### PR TITLE
CDAP-8895 Update the Schedule HTTP RESTful API docs

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/schedules.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/schedules.rst
@@ -21,7 +21,7 @@ be used in different applications.
 Schedules can be controlled by the :ref:`CDAP CLI <cli>` and the :ref:`Lifecycle HTTP
 RESTful API <http-restful-api-lifecycle>`. The :ref:`status of a schedule
 <http-restful-api-lifecycle-status>` can be retrieved, and individual schedules
-:ref:`resumed or suspended <http-restful-api-lifecycle-schedules-suspend-resume>`. 
+:ref:`resumed or suspended <http-restful-api-lifecycle-schedule-suspend-resume>`. 
 
 When a schedule is initially deployed, it is in a *suspended* state; a *resume* command needs to be
 issued to change it to *scheduled* before it will begin.

--- a/cdap-docs/developers-manual/source/building-blocks/schedules.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/schedules.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2015-2017 Cask Data, Inc.
 
 .. _schedules:
 
@@ -25,6 +25,8 @@ RESTful API <http-restful-api-lifecycle>`. The :ref:`status of a schedule
 
 When a schedule is initially deployed, it is in a *suspended* state; a *resume* command needs to be
 issued to change it to *scheduled* before it will begin.
+
+.. _schedules-time:
 
 Time Schedules
 ==============
@@ -56,6 +58,7 @@ Optionally, you can specify the properties for the schedule::
 Every time the ``FiveHourSchedule`` triggers, it passes the ``scheduleProperties`` as runtime arguments to the ``MyWorkflow``.
 
 
+.. _schedules-stream-size:
 .. _stream-size-schedules:
 
 Stream-size Schedules

--- a/cdap-docs/developers-manual/source/building-blocks/schedules.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/schedules.rst
@@ -18,10 +18,11 @@ class contains a builder to create schedules based on time, or schedules based o
 The name of a schedule must be unique in the application that it is in; the same name can
 be used in different applications.
 
-Schedules can be controlled by the :ref:`CDAP CLI <cli>` and the :ref:`Lifecycle HTTP
+Schedules can be added and controlled by the :ref:`CDAP CLI <cli>` and the :ref:`Lifecycle HTTP
 RESTful API <http-restful-api-lifecycle>`. The :ref:`status of a schedule
-<http-restful-api-lifecycle-status>` can be retrieved, and individual schedules
-:ref:`resumed or suspended <http-restful-api-lifecycle-schedule-suspend-resume>`. 
+<http-restful-api-lifecycle-status>` can be retrieved, and individual schedules can be 
+:ref:`added <http-restful-api-lifecycle-schedule-add>`, 
+:ref:`resumed, or suspended <http-restful-api-lifecycle-schedule-suspend-resume>`. 
 
 When a schedule is initially deployed, it is in a *suspended* state; a *resume* command needs to be
 issued to change it to *scheduled* before it will begin.
@@ -121,11 +122,11 @@ These actions can be performed on a schedule:
   already-active schedule has no effect. If |---| while the schedule was suspended, and since the last time the
   schedule was triggered |---| the Stream has ingested more than the increment of data defined by the schedule,
   the workflow will be immediately executed upon resume.
-- *Update*: this action is triggered when an application which contains a stream-size schedule is redeployed in CDAP.
+- *Update*: this action is triggered when an application which contains a schedule is redeployed in CDAP.
   If the schedule name has not been modified and one of its parameters has changed |---| such as the `dataTrigger` |---| the
   *update* action will be called. If the `dataTrigger` is updated, and the Stream has ingested more data than defined
   by the `dataTrigger` since the last time the schedule was triggered, then the workflow will be executed upon
-  update.
+  update. A similar behaviour triggers a time schedule, if the time has passed for when it should have been executed.
 
 .. rubric:: Special Runtime Arguments
 

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -847,19 +847,21 @@ request with the version specified::
      - Version of the application, typically following `semantic versioning
        <http://semver.org>`__
 
-The request body is a JSON object specifying the schedule configurations to be updated, and follows the same form
-as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
+The request body is a JSON object specifying the schedule configurations to be updated, and follows
+the same form as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
 
-- For example to update a :ref:`time schedule <schedules-time>`, use::
+- To update a :ref:`time schedule <schedules-time>`, use::
 
     {
       "scheduleDescription": "updatedDescription",
       "maxConcurrentRuns": 1,
-      "properties": {},
+      "properties": {
+         "key": "value"
+      },
       "cronExpression": "0 4 * * *"
     }
 
-- For :ref:`stream-sized schedule <schedules-stream-size>`, use::
+- For a :ref:`stream-sized schedule <schedules-stream-size>`, use::
 
     {
       "scheduleDescription": "updatedDescription",
@@ -871,10 +873,11 @@ as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
       "dataTriggerMB": 50
     }
 
-Only changes to the schedule configurations are supported; changes to the schedule name, its type or the program
-associated with it are not allowed. If a property is not given, the current property will be used.
-If the property is present, the current property will be overwritten by the property specified in the request. To
-remove the value of an existing property, use an empty value for the property.
+Only changes to the schedule configurations are supported; changes to the schedule name,
+its type, or the program associated with it are not allowed. If a property is not given,
+the current property will be used. If the property is present, the current property will
+be overwritten by the property specified in the request. To remove the value of an
+existing property, use an empty value for the property.
 
 .. rubric:: HTTP Responses
 
@@ -893,10 +896,9 @@ remove the value of an existing property, use an empty value for the property.
 
 Retrieving a Schedule
 ---------------------
-To get a schedule in an application, submit an HTTP GET request::
+To retrieve a schedule in an application, submit an HTTP GET request::
 
   GET /v3/namespaces/<namespace-id>/apps/<app-id>/schedules/<schedule-name>
-
 
 .. list-table::
 :widths: 20 80
@@ -911,49 +913,47 @@ To get a schedule in an application, submit an HTTP GET request::
    * - ``schedule-name``
      - Name of the schedule
 
-
 .. container:: table-block-example
 
    .. list-table::
       :widths: 99 1
       :stub-columns: 1
 
-         * - Example: Retrieving a Schedule
-           -
+      * - Example: Retrieving a Schedule
+        -
 
    .. list-table::
       :widths: 15 85
       :class: triple-table
 
       * - Description
-         - Retrieves the schedule *DailySchedule* of the application *PurchaseHistory*
+        - Retrieves the schedule *DailySchedule* of the application *PurchaseHistory*
 
       * - HTTP Method
-         - ``GET /v3/namespaces/default/apps/PurchaseHistory/schedules/DailySchedule``
+        - ``GET /v3/namespaces/default/apps/PurchaseHistory/schedules/DailySchedule``
 
       * - Returns
-         - | ``[{"schedule":{"name":"DailySchedule","description":"DailySchedule with crontab 0 4 * * *","cronEntry":"0 4 * * *"},``
-           | `` "program":{"programName":"PurchaseHistoryWorkflow","programType":"WORKFLOW"},"properties":{}}]``
+        - | ``[{"schedule":{"name":"DailySchedule","description":"DailySchedule with crontab 0 4 * * *","cronEntry":"0 4 * * *"},``
+          | `` "program":{"programName":"PurchaseHistoryWorkflow","programType":"WORKFLOW"},"properties":{}}]``
 
 
 List Schedules
 --------------
-To list all the schedules for an application, submit an HTTP GET request::
+To list all of the schedules for an application, use an HTTP GET request::
 
   GET /v3/namespaces/<namespace-id>/apps/<app-id>/schedules
 
-
-As schedules are created for a workflow, you can also list schedules for a workflow of an application. You can use the
-:ref:`http-restful-api-lifecycle-app-deployed-details` to obtain the workflows of an
+As schedules are created for a workflow, you can also list schedules for a workflow of an application.
+You can use the :ref:`http-restful-api-lifecycle-app-deployed-details` to obtain the workflows of an
 application.
 
-To list all of the schedules of a workflow of an application, issue an HTTP GET request::
+To list all of the schedules of a workflow of an application, use an HTTP GET request::
 
   GET /v3/namespaces/<namespace-id>/apps/<app-id>/workflows/<workflow-id>/schedules
 
 To list the next time that the workflow is scheduled to run, use the parameter ``nextruntime``::
 
-    GET /v3/namespaces/<namespace-id>/apps/<app-id>/workflows/<workflow-id>/nextruntime
+  GET /v3/namespaces/<namespace-id>/apps/<app-id>/workflows/<workflow-id>/nextruntime
     
 .. list-table::
    :widths: 20 80

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -847,12 +847,33 @@ request with the version specified::
      - Version of the application, typically following `semantic versioning
        <http://semver.org>`__
 
-The request body is a JSON object specifying the schedule to be updated, and follows the same form
+The request body is a JSON object specifying the schedule configurations to be updated, and follows the same form
 as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
 
-Only changes to the schedule are supported; changes to the schedule name are not allowed.
-If a property is not given, the current property will be used. If the property is present,
-the current property will be overwritten by the property specified in the request. To
+- For example to update a :ref:`time schedule <schedules-time>`, use::
+
+    {
+      "scheduleDescription": "updatedDescription",
+      "maxConcurrentRuns": 1,
+      "properties": {},
+      "cronExpression": "0 4 * * *"
+    }
+
+- For :ref:`stream-sized schedule <schedules-stream-size>`, use::
+
+    {
+      "scheduleDescription": "updatedDescription",
+      "maxConcurrentRuns": 2,
+      "properties": {
+         "key": "value"
+      },
+      "streamName": "myStream",
+      "dataTriggerMB": 50
+    }
+
+Only changes to the schedule configurations are supported; changes to the schedule name, its type or the program
+associated with it are not allowed. If a property is not given, the current property will be used.
+If the property is present, the current property will be overwritten by the property specified in the request. To
 remove the value of an existing property, use an empty value for the property.
 
 .. rubric:: HTTP Responses
@@ -870,10 +891,59 @@ remove the value of an existing property, use an empty value for the property.
 
 .. _http-restful-api-lifecycle-schedule-list:
 
+Retrieving a Schedule
+---------------------
+To get a schedule in an application, submit an HTTP GET request::
+
+  GET /v3/namespaces/<namespace-id>/apps/<app-id>/schedules/<schedule-name>
+
+
+.. list-table::
+:widths: 20 80
+:header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``namespace-id``
+     - Namespace ID
+   * - ``app-id``
+     - Name of the application
+   * - ``schedule-name``
+     - Name of the schedule
+
+
+.. container:: table-block-example
+
+   .. list-table::
+      :widths: 99 1
+      :stub-columns: 1
+
+         * - Example: Retrieving a Schedule
+           -
+
+   .. list-table::
+      :widths: 15 85
+      :class: triple-table
+
+      * - Description
+         - Retrieves the schedule *DailySchedule* of the application *PurchaseHistory*
+
+      * - HTTP Method
+         - ``GET /v3/namespaces/default/apps/PurchaseHistory/schedules/DailySchedule``
+
+      * - Returns
+         - | ``[{"schedule":{"name":"DailySchedule","description":"DailySchedule with crontab 0 4 * * *","cronEntry":"0 4 * * *"},``
+           | `` "program":{"programName":"PurchaseHistoryWorkflow","programType":"WORKFLOW"},"properties":{}}]``
+
+
 List Schedules
 --------------
-As schedules are created for a workflow, you need to know the workflows of an application
-in order to retrieve the application's schedules. You can use the
+To list all the schedules for an application, submit an HTTP GET request::
+
+  GET /v3/namespaces/<namespace-id>/apps/<app-id>/schedules
+
+
+As schedules are created for a workflow, you can also list schedules for a workflow of an application. You can use the
 :ref:`http-restful-api-lifecycle-app-deployed-details` to obtain the workflows of an
 application.
 

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -817,43 +817,87 @@ Update a Schedule
 -----------------
 To update a schedule, submit an HTTP POST request::
 
-  POST /v3/namespaces/<namespace-id>/apps/<app-id>/update
+  POST /v3/namespaces/<namespace-id>/apps/<app-id>/schedules/<schedule-id>/update
 
-To update a schedule to an application with a non-default version, submit an HTTP POST
+To update a schedule of an application with a non-default version, submit an HTTP POST
 request with the version specified::
 
-  POST /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/schedules/<schedule-id>
+  POST /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/schedules/<schedule-id>/update
 
-The request body is a JSON object specifying the updated artifact version and the updated application
-config. For example, a request body of:
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
 
-.. container:: highlight
+   * - Parameter
+     - Description
+   * - ``namespace-id``
+     - Namespace ID
+   * - ``app-id``
+     - Name of the application
+   * - ``schedule-id``
+     - Name of the schedule; it is unique to the application and, if specified, the
+       application version 
+   * - ``version-id``
+     - Version of the application, typically following `semantic versioning
+       <http://semver.org>`__
 
-  .. parsed-literal::
-    |$| POST /v3/namespaces/default/apps/purchaseWordCount/update -d
-    {
-      "artifact": {
-        "name": "WordCount",
-        "version": "|release|",
-        "scope": "user"
-      },
-      "config": {
-        "stream": "logStream";
-      },
-      "principal":"user/example.net@examplekdc.net"
-    }
+The request body is a JSON object specifying the schedule to be updated, and follows the same form
+as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
 
-will update the ``purchaseWordCount`` application to use version |release| of the ``WordCount`` artifact,
-and update the name of the stream to ``logStream``. If no artifact is given, the current artifact will be
-used. 
+Only changes to the schedule are supported; changes to the schedule name are not allowed.
+If a property is not given, the current property will be used. If the property is present,
+the current property will be overwritten by the property specified in the request. To
+remove the value of an existing property, use an empty value for the property.
 
-Only changes to artifact version are supported; changes to the artifact name are not allowed. If no
-``config`` is given, the current ``config`` will be used. If the ``config`` key is present, the current
-``config`` will be overwritten by the ``config`` specified in the request. As the principal of an
-application cannot be updated, during an update the principal should either be the same or absent.
+.. rubric:: HTTP Responses
 
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
 
+   * - Status Codes
+     - Description
+   * - ``400 Bad Request``
+     - If the new schedule type does not match the existing schedule type or there are
+       other client errors
 
+Delete a Schedule
+-----------------
+To delete a schedule, submit an HTTP DELETE::
+
+  DELETE /v3/namespaces/<namespace-id>/apps/<app-id>/schedules/<schedule-id>
+
+To delete a schedule of an application with a non-default version, submit an HTTP DELETE
+request with the version specified::
+
+  DELETE /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/schedules/<schedule-id>
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``namespace-id``
+     - Namespace ID
+   * - ``app-id``
+     - Name of the application to be deleted
+   * - ``schedule-id``
+     - Name of the schedule; it is unique to the application and, if specified, the
+       application version 
+   * - ``version-id``
+     - Version of the application to be deleted
+
+.. rubric:: HTTP Responses
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Status Codes
+     - Description
+   * - ``404 Bad Request``
+     - If the schedule given by ``schedule-id`` was not found
 
 
 .. _http-restful-api-lifecycle-container-information:

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -883,7 +883,7 @@ the same form as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
 
 Only changes to the schedule configurations are supported; changes to the schedule name,
 type, or the program associated with it are not allowed. If *any* properties are provided,
-it will overwrite all existing properties with what is provided. You must return all
+it will overwrite all existing properties with what is provided. You must include all
 properties, even ones you are are not altering.
 
 .. rubric:: HTTP Responses

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -861,8 +861,7 @@ the same form as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
         "cronExpression": "0 4 * * *"
       },
       "properties": {
-        "twoKey": "twoValue",
-        "someKey": "newValue"
+        "aKey": "aValue"
       }
     }
 
@@ -878,14 +877,14 @@ the same form as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
         "dataTriggerMB": 256
       },
       "properties": {
-        "twoKey": "twoValue",
-        "someKey": "newValue"
+        "aKey": "aValue"
       }
     }
 
 Only changes to the schedule configurations are supported; changes to the schedule name,
-type, or the program associated with it are not allowed. If properties are provided then it will overwrite all existing
-properties.
+type, or the program associated with it are not allowed. If *any* properties are provided,
+it will overwrite all existing properties with what is provided. You must return all
+properties, even ones you are are not altering.
 
 .. rubric:: HTTP Responses
 

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -756,50 +756,101 @@ request with the version specified::
 
 The request body is a JSON object specifying the schedule to be created. Two different schedule
 types are currently supported: :ref:`time schedules <schedules-time>` and
-:ref:`stream-size schedules schedules-stream-size`.
+:ref:`stream-size schedules schedules-stream-size`:
 
-To specify a :ref:`time schedule <schedules-time>`, use ``"scheduleType": "TIME"``, as
-shown in this example for scheduling the *PurchaseHistoryWorkflow* of the :ref:`Purchase
-application <examples-purchase>`, to trigger daily::
+- To specify a :ref:`time schedule <schedules-time>`, use ``"scheduleType": "TIME"``, as
+  shown in this example for scheduling the *PurchaseHistoryWorkflow* of the :ref:`Purchase
+  application <examples-purchase>` to trigger daily::
     
-  {
-    "scheduleType": "TIME",
-    "schedule":{
-      "cronExpression":"0 4 * * *",
-      "description":"Daily schedule",
-      "runConstraints":{
-        "maxConcurrentRuns":1
-      }
-    },
-    "program":{
-      "programName": "PurchaseHistoryWorkflow",
-      "programType": "WORKFLOW"
-    },
-    "properties":{
-    }
-  }
-
-To specify a :ref:`stream-sized schedule <schedules-stream-size>`, use ``"scheduleType":
-"STREAM"``, as shown in this example for scheduling the *PurchaseHistoryWorkflow* of the
-:ref:`Purchase application <examples-purchase>`, to trigger after ingesting 1 MB of data or more::
-    
-  {
-    "scheduleType":"STREAM",
-    "schedule":{
-      "dataTriggerMB":1,
-      "description":"Schedule execution when 1 MB or more of data is ingested in the purchaseStream",
-      "runConstraints":{
-        "maxConcurrentRuns":1
+    {
+      "scheduleType": "TIME",
+      "schedule":{
+        "cronExpression":"0 4 * * *",
+        "description":"Daily schedule",
+        "runConstraints":{
+          "maxConcurrentRuns":1
+        }
       },
-      "streamName":"purchaseStream"
-    },
-    "program":{
-      "programName":"PurchaseHistoryWorkflow",
-      "programType":"WORKFLOW"
-    },
-    "properties":{
+      "program":{
+        "programName": "PurchaseHistoryWorkflow",
+        "programType": "WORKFLOW"
+      },
+      "properties":{
+      }
     }
-  }
+
+- To specify a :ref:`stream-sized schedule <schedules-stream-size>`, use ``"scheduleType":
+  "STREAM"``, as shown in this example for scheduling the *PurchaseHistoryWorkflow* of the
+  :ref:`Purchase application <examples-purchase>` to trigger after ingesting 1 MB of data or more::
+    
+    {
+      "scheduleType":"STREAM",
+      "schedule":{
+        "dataTriggerMB":1,
+        "description":"Schedule execution when 1 MB or more of data is ingested in the purchaseStream",
+        "runConstraints":{
+          "maxConcurrentRuns":1
+        },
+        "streamName":"purchaseStream"
+      },
+      "program":{
+        "programName":"PurchaseHistoryWorkflow",
+        "programType":"WORKFLOW"
+      },
+      "properties":{
+      }
+    }
+
+
+.. rubric:: HTTP Responses
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Status Codes
+     - Description
+   * - ``409 Conflict``
+     - Schedule with the same name already exists
+
+Update a Schedule
+-----------------
+To update a schedule, submit an HTTP POST request::
+
+  POST /v3/namespaces/<namespace-id>/apps/<app-id>/update
+
+To update a schedule to an application with a non-default version, submit an HTTP POST
+request with the version specified::
+
+  POST /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/schedules/<schedule-id>
+
+The request body is a JSON object specifying the updated artifact version and the updated application
+config. For example, a request body of:
+
+.. container:: highlight
+
+  .. parsed-literal::
+    |$| POST /v3/namespaces/default/apps/purchaseWordCount/update -d
+    {
+      "artifact": {
+        "name": "WordCount",
+        "version": "|release|",
+        "scope": "user"
+      },
+      "config": {
+        "stream": "logStream";
+      },
+      "principal":"user/example.net@examplekdc.net"
+    }
+
+will update the ``purchaseWordCount`` application to use version |release| of the ``WordCount`` artifact,
+and update the name of the stream to ``logStream``. If no artifact is given, the current artifact will be
+used. 
+
+Only changes to artifact version are supported; changes to the artifact name are not allowed. If no
+``config`` is given, the current ``config`` will be used. If the ``config`` key is present, the current
+``config`` will be overwritten by the ``config`` specified in the request. As the principal of an
+application cannot be updated, during an update the principal should either be the same or absent.
 
 
 

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -853,31 +853,39 @@ the same form as documented in :ref:`http-restful-api-lifecycle-schedule-add`.
 - To update a :ref:`time schedule <schedules-time>`, use::
 
     {
-      "scheduleDescription": "updatedDescription",
-      "maxConcurrentRuns": 1,
-      "properties": {
-         "key": "value"
+      "schedule": {
+        "description": "updatedDescription",
+        "runConstraints": {
+          "maxConcurrentRuns": 5
+        },
+        "cronExpression": "0 4 * * *"
       },
-      "cronExpression": "0 4 * * *"
+      "properties": {
+        "twoKey": "twoValue",
+        "someKey": "newValue"
+      }
     }
 
 - For a :ref:`stream-sized schedule <schedules-stream-size>`, use::
 
     {
-      "scheduleDescription": "updatedDescription",
-      "maxConcurrentRuns": 2,
-      "properties": {
-         "key": "value"
+      "schedule": {
+        "description": "updatedDescription",
+        "runConstraints": {
+          "maxConcurrentRuns": 5
+        },
+        "streamName": "myStream",
+        "dataTriggerMB": 256
       },
-      "streamName": "myStream",
-      "dataTriggerMB": 50
+      "properties": {
+        "twoKey": "twoValue",
+        "someKey": "newValue"
+      }
     }
 
 Only changes to the schedule configurations are supported; changes to the schedule name,
-its type, or the program associated with it are not allowed. If a property is not given,
-the current property will be used. If the property is present, the current property will
-be overwritten by the property specified in the request. To remove the value of an
-existing property, use an empty value for the property.
+type, or the program associated with it are not allowed. If properties are provided then it will overwrite all existing
+properties.
 
 .. rubric:: HTTP Responses
 


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-8895

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB321-1 (passes)

Page of interest: 
- Dev Manual: BB: Schedules http://builds.cask.co/artifact/CDAP-DQB321/shared/build-1/Docs-HTML/4.1.0/en/developers-manual/building-blocks/schedules.html
- Ref Manual: RESTful API: Schedules http://builds.cask.co/artifact/CDAP-DQB321/shared/build-1/Docs-HTML/4.1.0/en/reference-manual/http-restful-api/lifecycle.html#schedule-lifecycle