### PR TITLE
cdap apply-pack option for linux scripts

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -75,6 +75,7 @@ test -f "${CDAP_CONF}"/cdap-env.sh && source "${CDAP_CONF}"/cdap-env.sh
 
 # Main script, handles options and Does the Right Thing™
 case ${1} in
+  apply-pack) shift; cdap_apply_pack ${@}; __ret=${?} ;;
   auth-server|kafka-server|master|router|ui) CDAP_SERVICE=${1}; shift; cdap_service ${CDAP_SERVICE} ${@}; __ret=${?} ;;
   classpath) cdap_service master classpath; __ret=${?} ;;
   cli) shift; cdap_cli "${@}"; __ret=${?} ;;
@@ -108,6 +109,7 @@ case ${1} in
     echo "    sdk          - Sends the arguments (start/stop/etc.) to the Standalone CDAP service on this host"
     echo
     fi
+    echo "    apply-pack   - Installs the UI Pack specified as an argument"
     echo "    cli          - Starts an interactive CDAP CLI session"
     echo "    debug        - Runs CDAP debug functions"
     echo

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -75,6 +75,7 @@ test -f "${CDAP_CONF}"/cdap-env.sh && source "${CDAP_CONF}"/cdap-env.sh
 
 # Main script, handles options and Does the Right Thing™
 case ${1} in
+  apply-pack) shift; cdap_apply_pack ${@}; __ret=${?} ;;
   auth-server|kafka-server|master|router|ui) CDAP_SERVICE=${1}; shift; cdap_service ${CDAP_SERVICE} ${@}; __ret=${?} ;;
   classpath) cdap_service master classpath; __ret=${?} ;;
   cli) shift; cdap_cli "${@}"; __ret=${?} ;;
@@ -108,6 +109,7 @@ case ${1} in
     echo "    sdk          - Sends the arguments (start/stop/etc.) to the Standalone CDAP service on this host"
     echo
     fi
+    echo "    apply-pack   - Installs a CDAP Pack specified as an argument"
     echo "    cli          - Starts an interactive CDAP CLI session"
     echo "    debug        - Runs CDAP debug functions"
     echo

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -636,6 +636,20 @@ cdap_start_bin() {
 }
 
 #
+# cdap_run_bin [args]
+# Runs a non-Java application with arguments in the foreground
+#
+cdap_run_bin() {
+  local readonly __bin=${1}
+  shift
+  local readonly __args=${@}
+  local readonly __ret
+  ${__bin} ${__args}
+  __ret=${?}
+  return ${__ret}
+}
+
+#
 # cdap_start_java [args]
 # Start a Java application from class name with arguments in the background
 #
@@ -1102,6 +1116,25 @@ cdap_upgrade_tool() {
   cdap_run_class ${__class} ${@}
   __ret=${?}
   return ${__ret}
+}
+
+#
+# cdap_apply_pack [arguments]
+#
+cdap_apply_pack() {
+  local __ui_pack=${1}
+  local __ext=${__ui_pack##*.}
+
+  if [[ -f ${__ui_pack} ]] && [[ -r ${__ui_pack} ]] && [[ ${__ext} == zip ]]; then
+    # ui upgrade script must be run from subdirectory
+    cd ${CDAP_HOME}/ui/cdap-ui-upgrade
+
+    cdap_run_bin "npm" "run" "upgrade" "--" "--new-ui-zip-path=${__ui_pack}"
+    __ret=${?}
+    return ${__ret}
+  else
+    die "UI pack must be an absolute path to a zip file"
+  fi
 }
 
 #


### PR DESCRIPTION
linux portion of [CDAP-9077](https://issues.cask.co/browse/CDAP-9077).  windows to follow

updates to linux scripts to upgrade ui-pack via ``cdap apply-pack [zip]``.  

```
mac[17:19:19] derek:cdap-sdk-4.1.1-SNAPSHOT$ ./bin/cdap

Usage: ./bin/cdap <command> [arguments]

  Commands:

    sdk          - Sends the arguments (start/stop/etc.) to the Standalone CDAP service on this host

    apply-pack   - Installs the UI Pack specified as an argument
    cli          - Starts an interactive CDAP CLI session
    debug        - Runs CDAP debug functions

 Get more help for each command by executing:
 ./bin/cdap <command> --help


mac[17:19:21] derek:cdap-sdk-4.1.1-SNAPSHOT$ ./bin/cdap apply-pack
[ERROR] UI pack must be an absolute path to a zip file

mac[17:19:26] derek:cdap-sdk-4.1.1-SNAPSHOT$ ./bin/cdap apply-pack foo.zip
[ERROR] UI pack must be an absolute path to a zip file

mac[17:19:29] derek:cdap-sdk-4.1.1-SNAPSHOT$ ./bin/cdap apply-pack /tmp/cdap-ui-pack-4.1.1-SNAPSHOT_p1.zip 

> cdap-ui-upgrade@1.0.0 upgrade /Users/derek/9077-apply-pack/cdap-sdk-4.1.1-SNAPSHOT/ui/cdap-ui-upgrade
> node index.js "--new-ui-zip-path=/tmp/cdap-ui-pack-4.1.1-SNAPSHOT_p1.zip"

 ✔ Verifying environment before upgrading UI Pack
 ✔ Backing existing UI : </Users/derek/9077-apply-pack/cdap-sdk-4.1.1-SNAPSHOT>
 ✔ Updating with new UI Pack
mac[17:21:01] derek:cdap-sdk-4.1.1-SNAPSHOT$ 
```