### PR TITLE
[CDAP-7138] fix duplicate log on log polling

### DIFF
--- a/cdap-ui/app/directives/log-viewer/log-viewer.js
+++ b/cdap-ui/app/directives/log-viewer/log-viewer.js
@@ -766,7 +766,6 @@ const link = (scope) => {
 };
 
 angular.module(PKG.name + '.commons')
-  .value('THROTTLE_MILLISECONDS', 250) // throttle infinite scroll
   .directive('myLogViewer', function () {
     return {
       templateUrl: 'log-viewer/log-viewer.html',

--- a/cdap-ui/app/directives/log-viewer/log-viewer.js
+++ b/cdap-ui/app/directives/log-viewer/log-viewer.js
@@ -437,7 +437,23 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
           res[index].log.stackTrace = res[index].log.stackTrace.trim();
         });
 
-        vm.data = vm.data.concat(res);
+        // xor vm.data with res, add the xor value to vm.data
+        // Calculating xor is not very optimal, however since the
+        // limit would be iterating through 100 items, we should be fine
+        // Uniqueness is identied by the offset
+        let xor = {};
+        let xorData = [];
+        angular.forEach(vm.data, (logItem) => {
+          xor[logItem.offset] = true;
+        });
+
+        angular.forEach(res, (logItem) => {
+          if (!xor[logItem.offset]) {
+            xorData.push(logItem);
+          }
+        });
+
+        vm.data = vm.data.concat(xorData);
         vm.renderData();
       }
 

--- a/cdap-ui/app/hydrator/main.js
+++ b/cdap-ui/app/hydrator/main.js
@@ -83,6 +83,7 @@ angular
 
     'angular-loading-bar'
   ])
+  .value('THROTTLE_MILLISECONDS', 500) // throttle infinite scroll
 
   .run(function ($rootScope, $state, $stateParams) {
     // It's very handy to add references to $state and $stateParams to the $rootScope

--- a/cdap-ui/app/logviewer/main.js
+++ b/cdap-ui/app/logviewer/main.js
@@ -82,6 +82,7 @@ angular
 
     'angular-loading-bar'
   ])
+  .value('THROTTLE_MILLISECONDS', 500) // throttle infinite scroll
 
   .run(function ($rootScope, $state, $stateParams) {
     // It's very handy to add references to $state and $stateParams to the $rootScope


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-7138

Root Cause:
On log entry, the viewer do a `startTimeRequest()` to get initial set of logs, then the poll starts. During the poll, the response from the poll is concatenated to the data array, therefore causing duplicates. 

To reproduce this issue, program should be running and log is less than 10 (making sure all the logs fit in 1 screen). Then switch to a different tab, and go back. The poll will restart, and the logs will get duplicated.

