### PR TITLE
UI Pipelines Enable Macro Schema & JSON Editor Widget Fix

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -88,6 +88,7 @@ angular.module(PKG.name + '.commons')
         element: '<my-json-textbox></my-json-textbox>',
         attributes: {
           'ng-model': 'model',
+          'disabled': 'disabled',
           placeholder: 'myconfig.properties.default || myconfig["widget-attributes"].default'
         }
       },

--- a/cdap-ui/app/directives/widget-container/widget-json-editor/widget-json-editor.html
+++ b/cdap-ui/app/directives/widget-container/widget-json-editor/widget-json-editor.html
@@ -1,0 +1,38 @@
+<!--
+  Copyright © 2017 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="widget-json-editor">
+  <div ng-if="JsonEditor.warning && !JsonEditor.disabled">
+    <span class="text-warning">
+      {{ JsonEditor.warning }}
+    </span>
+  </div>
+
+  <div class="textarea-container">
+    <textarea class="form-control"
+              data-ng-trim="false"
+              ng-model="JsonEditor.internalModel"
+              placeholder="{{placeholder}}">
+    </textarea>
+
+    <button ng-if="!JsonEditor.disabled"
+            class="tidy-button btn btn-default"
+            ng-click="JsonEditor.tidy()">
+      Tidy
+    </button>
+  </div>
+
+</div>

--- a/cdap-ui/app/directives/widget-container/widget-json-editor/widget-json-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-json-editor/widget-json-editor.js
@@ -20,25 +20,47 @@ angular.module(PKG.name + '.commons')
       restrict: 'EA',
       scope: {
         model: '=ngModel',
-        placeholder: '='
+        placeholder: '=',
+        disabled: '='
       },
-      template: '<textarea class="form-control" data-ng-trim="false" cask-json-edit="internalModel" placeholder="placeholder"></textarea>',
+      controllerAs: 'JsonEditor',
+      bindToController: true,
+      templateUrl: 'widget-container/widget-json-editor/widget-json-editor.html',
       controller: function($scope) {
-        function initialize () {
+        var vm = this;
+        vm.warning = null;
+
+        function attemptParse(input) {
           try {
-            $scope.internalModel = JSON.parse($scope.model);
-          } catch(e) {
-            $scope.internalModel = '';
+            let parsedModel = angular.fromJson(input);
+
+            vm.internalModel = angular.toJson(parsedModel, true);
+            vm.warning = null;
+          } catch (e) {
+            vm.internalModel = input;
+            vm.warning = 'Value is not a JSON';
           }
+        }
+
+        function initialize () {
+          attemptParse(vm.model);
         }
 
         initialize();
 
-        $scope.$watch('model', initialize);
+        vm.tidy = function() {
+          attemptParse(vm.internalModel);
+        };
 
-        $scope.$watch('internalModel', function(newVal, oldVal) {
-          if (newVal !== oldVal) {
-            $scope.model = angular.toJson($scope.internalModel);
+        $scope.$watch('JsonEditor.internalModel', function(oldVal, newVal) {
+          if (oldVal !== newVal) {
+            // removing newlines
+            try {
+              let parsed = angular.fromJson(vm.internalModel);
+              vm.model = angular.toJson(parsed);
+            } catch (e) {
+              vm.model = vm.internalModel;
+            }
           }
         });
       }

--- a/cdap-ui/app/directives/widget-container/widget-json-editor/widget-json-editor.less
+++ b/cdap-ui/app/directives/widget-container/widget-json-editor/widget-json-editor.less
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+my-json-textbox {
+  .widget-json-editor {
+    .textarea-container {
+      position: relative;
+
+      textarea {
+        padding-right: 55px;
+        font-family: monospace;
+      }
+
+      .tidy-button {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -127,7 +127,7 @@ class HydratorPlusPlusNodeConfigCtrl {
       schemaAdvance: false
     };
 
-    if (this.state.isSink && this.state.node.outputSchema && this.state.node.outputSchema.length > 0) {
+    if (this.state.node.outputSchema && this.state.node.outputSchema.length > 0) {
       try {
         this.avsc.parse(this.state.node.outputSchema);
       } catch (e) {

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,7 +15,7 @@
  */
 
 class HydratorPlusPlusConfigStore {
-  constructor(HydratorPlusPlusConfigDispatcher, HydratorPlusPlusCanvasFactory, GLOBALS, mySettings, HydratorPlusPlusConsoleActions, $stateParams, NonStorePipelineErrorFactory, HydratorPlusPlusHydratorService, $q, HydratorPlusPlusPluginConfigFactory, uuid, $state, HYDRATOR_DEFAULT_VALUES, myHelpers){
+  constructor(HydratorPlusPlusConfigDispatcher, HydratorPlusPlusCanvasFactory, GLOBALS, mySettings, HydratorPlusPlusConsoleActions, $stateParams, NonStorePipelineErrorFactory, HydratorPlusPlusHydratorService, $q, HydratorPlusPlusPluginConfigFactory, uuid, $state, HYDRATOR_DEFAULT_VALUES, myHelpers, avsc){
     this.state = {};
     this.mySettings = mySettings;
     this.myHelpers = myHelpers;
@@ -30,6 +30,7 @@ class HydratorPlusPlusConfigStore {
     this.uuid = uuid;
     this.$state = $state;
     this.HYDRATOR_DEFAULT_VALUES = HYDRATOR_DEFAULT_VALUES;
+    this.avsc = avsc;
 
     this.changeListeners = [];
     this.setDefaults();
@@ -472,10 +473,29 @@ class HydratorPlusPlusConfigStore {
       if (nodesMap[node] && nodesMap[node].implicitSchema) {
         return;
       }
+
+      // Stop propagating if outputSchema is a macro schema
+      if (outputSchema && outputSchema.length > 0) {
+        try {
+          this.avsc.parse(outputSchema);
+        } catch (e) {
+          return;
+        }
+      }
+
       node.forEach( n => {
         // If we encounter an implicit schema down the stream while propagation stop there and return.
         if (nodesMap[n].implicitSchema) {
           return;
+        }
+
+        // If we encounter a macro schema, stop propagataion
+        if (nodesMap[n].outputSchema && nodesMap[n].outputSchema.length > 0) {
+          try {
+            this.avsc.parse(this.state.node.outputSchema);
+          } catch (e) {
+            return;
+          }
         }
 
         let schemaToPropagate = outputSchema;
@@ -802,6 +822,6 @@ class HydratorPlusPlusConfigStore {
   }
 }
 
-HydratorPlusPlusConfigStore.$inject = ['HydratorPlusPlusConfigDispatcher', 'HydratorPlusPlusCanvasFactory', 'GLOBALS', 'mySettings', 'HydratorPlusPlusConsoleActions', '$stateParams', 'NonStorePipelineErrorFactory', 'HydratorPlusPlusHydratorService', '$q', 'HydratorPlusPlusPluginConfigFactory', 'uuid', '$state', 'HYDRATOR_DEFAULT_VALUES', 'myHelpers'];
+HydratorPlusPlusConfigStore.$inject = ['HydratorPlusPlusConfigDispatcher', 'HydratorPlusPlusCanvasFactory', 'GLOBALS', 'mySettings', 'HydratorPlusPlusConsoleActions', '$stateParams', 'NonStorePipelineErrorFactory', 'HydratorPlusPlusHydratorService', '$q', 'HydratorPlusPlusPluginConfigFactory', 'uuid', '$state', 'HYDRATOR_DEFAULT_VALUES', 'myHelpers', 'avsc'];
 angular.module(`${PKG.name}.feature.hydrator`)
   .service('HydratorPlusPlusConfigStore', HydratorPlusPlusConfigStore);

--- a/cdap-ui/app/hydrator/templates/create/popovers/viewconfig.html
+++ b/cdap-ui/app/hydrator/templates/create/popovers/viewconfig.html
@@ -20,7 +20,7 @@
 </div>
 <div class="modal-body config-modal">
   <fieldset disabled="true" class="view-plugin-json">
-    <my-json-textbox ng-model="config"></my-json-textbox>
+    <my-json-textbox ng-model="config" disabled="true"></my-json-textbox>
   </fieldset>
   <br/>
 </div>

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
@@ -35,8 +35,8 @@
 
       <ul class="output-schema-actions" uib-dropdown-menu>
         <!-- If node is a sink and it's macro enabled -->
-        <li ng-if="!isDisabled && HydratorPlusPlusNodeConfigCtrl.state.isSink && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties['schema'] && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties['schema'].macroSupported">
-          <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.toggleAdvance()">Advance</a>
+        <li ng-if="!isDisabled && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties['schema'] && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties['schema'].macroSupported">
+          <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.toggleAdvance()">Advanced</a>
         </li>
 
         <li ng-if="(!HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)">

--- a/cdap-ui/app/services/pipeline-export-modal/pipeline-export-modal-template.html
+++ b/cdap-ui/app/services/pipeline-export-modal/pipeline-export-modal-template.html
@@ -24,7 +24,7 @@
 </div>
 <div class="modal-body config-modal">
   <fieldset disabled="true" class="view-plugin-json">
-    <my-json-textbox ng-model="config"></my-json-textbox>
+    <my-json-textbox ng-model="config" disabled="true"></my-json-textbox>
   </fieldset>
   <br/>
 </div>


### PR DESCRIPTION
### Changes
- Make source, transform, sink schema macro enabled option. Schema propagation will stop for macro schema.
- JSON editor widget modified to have a `Tidy` button, which will prettify the input. If it is not a JSON, a warning will show up.