### PR TITLE
add update-schedules flag to configure schedule update on app redeploy

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -83,6 +83,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -161,14 +162,15 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @PathParam("namespace-id") final String namespaceId,
                              @HeaderParam(ARCHIVE_NAME_HEADER) final String archiveName,
                              @HeaderParam(APP_CONFIG_HEADER) String configString,
-                             @HeaderParam(PRINCIPAL_HEADER) String ownerPrincipal)
+                             @HeaderParam(PRINCIPAL_HEADER) String ownerPrincipal,
+                             @DefaultValue("true") @HeaderParam(SCHEDULES_HEADER) boolean  updateSchedules)
     throws BadRequestException, NamespaceNotFoundException {
 
     NamespaceId namespace = validateNamespace(namespaceId);
 
     // null means use name provided by app spec
     try {
-      return deployApplication(responder, namespace, null, archiveName, configString, ownerPrincipal);
+      return deployApplication(responder, namespace, null, archiveName, configString, ownerPrincipal, updateSchedules);
     } catch (Exception ex) {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Deploy failed: " + ex.getMessage());
       return null;
@@ -386,7 +388,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
           // if we don't null check, it gets serialized to "null"
           String configString = appRequest.getConfig() == null ? null : GSON.toJson(appRequest.getConfig());
           applicationLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
-                                                artifactId, configString, createProgramTerminator(), ownerPrincipalId);
+                                                artifactId, configString, createProgramTerminator(), ownerPrincipalId,
+                                                appRequest.canUpdateSchedules());
           responder.sendString(HttpResponseStatus.OK, "Deploy Complete");
         } catch (ArtifactNotFoundException e) {
           responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());
@@ -413,7 +416,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                          final String appId,
                                          final String archiveName,
                                          final String configString,
-                                         @Nullable final String ownerPrincipal) throws IOException {
+                                         @Nullable final String ownerPrincipal,
+                                         final boolean updateSchedules) throws IOException {
 
     Id.Namespace idNamespace = namespace.toId();
     Location namespaceHomeLocation = namespacedLocationFactory.get(idNamespace);
@@ -465,7 +469,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
           // deploy app
           ApplicationWithPrograms app =
             applicationLifecycleService.deployAppAndArtifact(namespace, appId, artifactId, uploadedFile, configString,
-                                                             finalOwnerPrincipalId, createProgramTerminator());
+                                                             finalOwnerPrincipalId, createProgramTerminator(),
+                                                             updateSchedules);
           LOG.info("Successfully deployed app {} in namespace {} from artifact {} with configuration {} and " +
                      "principal {}", app.getApplicationId().getApplication(), namespace.getNamespace(), artifactId,
                    configString, finalOwnerPrincipalId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -74,6 +74,7 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
   public static final String APP_CONFIG_HEADER = "X-App-Config";
 
   public static final String PRINCIPAL_HEADER = "X-Principal";
+  public static final String SCHEDULES_HEADER = "X-Update-Schedules";
 
   protected int getInstances(HttpRequest request) throws BadRequestException {
     Instances instances;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -42,16 +42,19 @@ public class AppDeploymentInfo {
   private final String configString;
   @SerializedName("principal")
   private final KerberosPrincipalId ownerPrincipal;
+  @SerializedName("update-schedules")
+  private final boolean updateSchedules;
 
   public AppDeploymentInfo(ArtifactDescriptor artifactDescriptor, NamespaceId namespaceId,
                            String appClassName, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString) {
-    this(artifactDescriptor, namespaceId, appClassName, appName, appVersion, configString, null);
+    this(artifactDescriptor, namespaceId, appClassName, appName, appVersion, configString, null, true);
   }
 
   public AppDeploymentInfo(ArtifactDescriptor artifactDescriptor, NamespaceId namespaceId,
                            String appClassName, @Nullable String appName, @Nullable String appVersion,
-                           @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal) {
+                           @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
+                           boolean updateSchedules) {
     this.artifactId = Artifacts.toArtifactId(namespaceId, artifactDescriptor.getArtifactId());
     this.artifactLocation = artifactDescriptor.getLocation();
     this.namespaceId = namespaceId;
@@ -60,6 +63,7 @@ public class AppDeploymentInfo {
     this.appVersion = appVersion;
     this.configString = configString;
     this.ownerPrincipal = ownerPrincipal;
+    this.updateSchedules = updateSchedules;
   }
 
   /**
@@ -120,5 +124,12 @@ public class AppDeploymentInfo {
   @Nullable
   public KerberosPrincipalId getOwnerPrincipal() {
     return ownerPrincipal;
+  }
+
+  /**
+   * return true if we can update the schedules of the app
+   */
+  public boolean canUpdateSchedules() {
+    return updateSchedules;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -38,19 +38,23 @@ public class ApplicationDeployable {
   private final ApplicationDeployScope applicationDeployScope;
   @SerializedName("principal")
   private final KerberosPrincipalId ownerPrincipal;
+  @SerializedName("update-schedules")
+  private final boolean updateSchedules;
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
                                ApplicationId applicationId, ApplicationSpecification specification,
                                @Nullable ApplicationSpecification existingAppSpec,
                                ApplicationDeployScope applicationDeployScope) {
-    this(artifactId, artifactLocation, applicationId, specification, existingAppSpec, applicationDeployScope, null);
+    this(artifactId, artifactLocation, applicationId, specification, existingAppSpec, applicationDeployScope,
+         null, true);
   }
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
                                ApplicationId applicationId, ApplicationSpecification specification,
                                @Nullable ApplicationSpecification existingAppSpec,
                                ApplicationDeployScope applicationDeployScope,
-                               @Nullable KerberosPrincipalId ownerPrincipal) {
+                               @Nullable KerberosPrincipalId ownerPrincipal,
+                               boolean updateSchedules) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.applicationId = applicationId;
@@ -58,6 +62,7 @@ public class ApplicationDeployable {
     this.existingAppSpec = existingAppSpec;
     this.applicationDeployScope = applicationDeployScope;
     this.ownerPrincipal = ownerPrincipal;
+    this.updateSchedules = updateSchedules;
   }
 
   /**
@@ -110,5 +115,12 @@ public class ApplicationDeployable {
   @Nullable
   public KerberosPrincipalId getOwnerPrincipal() {
     return ownerPrincipal;
+  }
+
+  /**
+   * @return true if we can update the schedules of the app
+   */
+  public boolean canUpdateSchedules() {
+    return updateSchedules;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
@@ -21,21 +21,32 @@ import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.FlowletConnection;
 import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
 import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.kerberos.OwnerAdmin;
 import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.internal.app.DefaultApplicationSpecification;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  *
@@ -55,10 +66,14 @@ public class ApplicationRegistrationStage extends AbstractStage<ApplicationWithP
 
   @Override
   public void process(ApplicationWithPrograms input) throws Exception {
+    ApplicationSpecification applicationSpecification = input.getSpecification();
+    if (!input.canUpdateSchedules()) {
+      applicationSpecification = getApplicationSpecificationWithExistingSchedules(input);
+    }
     Collection<ApplicationId> allAppVersionsAppIds = store.getAllAppVersionsAppIds(input.getApplicationId());
     boolean ownerAdded = addOwnerIfRequired(input, allAppVersionsAppIds);
     try {
-      store.addApplication(input.getApplicationId(), input.getSpecification());
+      store.addApplication(input.getApplicationId(), applicationSpecification);
     } catch (Exception e) {
       // if we failed to store the app spec cleanup the owner if it was added in this call
       if (ownerAdded) {
@@ -69,6 +84,45 @@ public class ApplicationRegistrationStage extends AbstractStage<ApplicationWithP
     }
     registerDatasets(input);
     emit(input);
+  }
+
+  /**
+   * uses the existing app spec schedules, however if workflows are deleted in the new app spec,
+   * we want to remove the schedules assigned to those deleted workflow from the existing app spec schedules.
+   * construct and return a app spec based on this filtered schedules and programs from new app spec.
+   * @param input
+   * @return {@link ApplicationSpecification} updated spec.
+   */
+  private ApplicationSpecification getApplicationSpecificationWithExistingSchedules(ApplicationWithPrograms input) {
+    Map<String, ScheduleSpecification> filteredExistingSchedules = new HashMap<>();
+
+    if (input.getExistingAppSpec() != null) {
+      final Set<String> deletedWorkflows =
+        Maps.difference(input.getExistingAppSpec().getWorkflows(), input.getSpecification().getWorkflows()).
+          entriesOnlyOnLeft().keySet();
+
+      // predicate to filter schedules if their workflow is deleted
+      Predicate<Map.Entry<String, ScheduleSpecification>> byScheduleProgramStatus =
+        new Predicate<Map.Entry<String, ScheduleSpecification>>() {
+          @Override
+          public boolean apply(Map.Entry<String, ScheduleSpecification> input) {
+            return !deletedWorkflows.contains(input.getValue().getProgram().getProgramName());
+          }
+        };
+
+      filteredExistingSchedules = Maps.filterEntries(input.getExistingAppSpec().getSchedules(),
+                                                     byScheduleProgramStatus);
+    }
+
+    ApplicationSpecification newSpecification = input.getSpecification();
+    return new DefaultApplicationSpecification(newSpecification.getName(), newSpecification.getAppVersion(),
+                                               newSpecification.getDescription(), newSpecification.getConfiguration(),
+                                               newSpecification.getArtifactId(), newSpecification.getStreams(),
+                                               newSpecification.getDatasetModules(), newSpecification.getDatasets(),
+                                               newSpecification.getFlows(), newSpecification.getMapReduce(),
+                                               newSpecification.getSpark(), newSpecification.getWorkflows(),
+                                               newSpecification.getServices(), filteredExistingSchedules,
+                                               newSpecification.getWorkers(), newSpecification.getPlugins());
   }
 
   // adds owner information for the application if this is the first version of the application

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
@@ -33,7 +33,7 @@ public class ApplicationWithPrograms extends ApplicationDeployable {
     super(applicationDeployable.getArtifactId(), applicationDeployable.getArtifactLocation(),
           applicationDeployable.getApplicationId(), applicationDeployable.getSpecification(),
           applicationDeployable.getExistingAppSpec(), applicationDeployable.getApplicationDeployScope(),
-          applicationDeployable.getOwnerPrincipal());
+          applicationDeployable.getOwnerPrincipal(), applicationDeployable.canUpdateSchedules());
     this.programDescriptors = ImmutableList.copyOf(programDescriptors);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateSchedulesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateSchedulesStage.java
@@ -52,6 +52,13 @@ public class CreateSchedulesStage extends AbstractStage<ApplicationWithPrograms>
 
   @Override
   public void process(ApplicationWithPrograms input) throws Exception {
+
+    if (!input.canUpdateSchedules()) {
+      // if we cant update schedules, emit and return
+      emit(input);
+      return;
+    }
+
     ApplicationId appId = input.getApplicationId();
     Map<String, ScheduleSpecification> existingSchedulesMap = input.getExistingAppSpec() != null ?
       input.getExistingAppSpec().getSchedules() : ImmutableMap.<String, ScheduleSpecification>of();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -115,6 +115,7 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
     }
     emit(new ApplicationDeployable(deploymentInfo.getArtifactId(), deploymentInfo.getArtifactLocation(),
                                    applicationId, specification, store.getApplication(applicationId),
-                                   ApplicationDeployScope.USER, deploymentInfo.getOwnerPrincipal()));
+                                   ApplicationDeployScope.USER, deploymentInfo.getOwnerPrincipal(),
+                                   deploymentInfo.canUpdateSchedules()));
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithSchedule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithSchedule.java
@@ -16,10 +16,17 @@
 
 package co.cask.cdap;
 
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.annotation.ProcessInput;
+import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.customaction.AbstractCustomAction;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.lib.ObjectStores;
+import co.cask.cdap.api.flow.AbstractFlow;
+import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.api.workflow.AbstractWorkflow;
 import com.google.common.base.Preconditions;
@@ -29,15 +36,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Application with workflow scheduling.
  */
-public class AppWithSchedule extends AbstractApplication {
+public class AppWithSchedule extends AbstractApplication<AppWithSchedule.AppConfig> {
 
   public static final String NAME = "AppWithSchedule";
   public static final String WORKFLOW_NAME = "SampleWorkflow";
   public static final String SCHEDULE = "SampleSchedule";
+  public static final String SCHEDULE_2 = "SampleSchedule2";
 
   @Override
   public void configure() {
@@ -46,20 +55,60 @@ public class AppWithSchedule extends AbstractApplication {
       setDescription("Sample application");
       ObjectStores.createObjectStore(getConfigurer(), "input", String.class);
       ObjectStores.createObjectStore(getConfigurer(), "output", String.class);
-      addWorkflow(new SampleWorkflow());
+      AppConfig config = getConfig();
+      // if add workflow is false, we want to add a flow, so the app will have at least one program, for testing deploy
+      if (!config.addWorkflow) {
+        addFlow(new AllProgramsApp.NoOpFlow());
+      }
+
+      if (config.addWorkflow) {
+        addWorkflow(new SampleWorkflow());
+      }
 
       Map<String, String> scheduleProperties = Maps.newHashMap();
       scheduleProperties.put("oneKey", "oneValue");
       scheduleProperties.put("anotherKey", "anotherValue");
       scheduleProperties.put("someKey", "someValue");
 
-      scheduleWorkflow(Schedules.builder(SCHEDULE)
-                         .setDescription("Sample schedule")
-                         .createTimeSchedule("0/15 * * * * ?"),
-                       WORKFLOW_NAME,
-                       scheduleProperties);
+      if (config.addWorkflow && config.addSchedule1) {
+        scheduleWorkflow(Schedules.builder(SCHEDULE)
+                           .setDescription("Sample schedule")
+                           .createTimeSchedule("0/15 * * * * ?"),
+                         WORKFLOW_NAME,
+                         scheduleProperties);
+      }
+      if (config.addWorkflow && config.addSchedule2) {
+        scheduleWorkflow(Schedules.builder(SCHEDULE_2)
+                           .setDescription("Sample schedule")
+                           .createTimeSchedule("0/30 * * * * ?"),
+                         WORKFLOW_NAME,
+                         scheduleProperties);
+      }
     } catch (UnsupportedTypeException e) {
       throw Throwables.propagate(e);
+    }
+  }
+
+
+
+  /**
+   * Application Config Class to control schedule creation
+   */
+  public static class AppConfig extends Config {
+    private final boolean addWorkflow;
+    private final boolean addSchedule1;
+    private final boolean addSchedule2;
+
+    public AppConfig() {
+      this.addSchedule1 = true;
+      this.addSchedule2 = false;
+      this.addWorkflow = true;
+    }
+
+    public AppConfig(boolean addWorkflow, boolean addSchedule1, boolean addSchedule2) {
+      this.addWorkflow = addWorkflow;
+      this.addSchedule1 = addSchedule1;
+      this.addSchedule2 = addSchedule2;
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -431,7 +431,7 @@ public class AppFabricClient {
     }
     MockResponder mockResponder = new MockResponder();
     BodyConsumer bodyConsumer = appLifecycleHttpHandler.deploy(request, mockResponder, namespace.getId(), archiveName,
-                                                               config, owner);
+                                                               config, owner, true);
     Preconditions.checkNotNull(bodyConsumer, "BodyConsumer from deploy call should not be null");
 
     try (BufferFileInputStream is = new BufferFileInputStream(deployedJar.getInputStream(), 100 * 1024)) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -92,7 +92,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
           public void stop(ProgramId programId) throws Exception {
             // no-op
           }
-        });
+        }, true);
       Assert.fail("expected application deployment to fail.");
     } catch (Exception e) {
       // expected
@@ -225,7 +225,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
       public void stop(ProgramId programId) throws Exception {
         // no-op
       }
-    });
+    }, true);
 
     ApplicationId appId = NamespaceId.DEFAULT.app("appName");
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1097,6 +1097,95 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     testUpdateSchedule(appV2Id);
   }
 
+  @Test
+  public void testUpdateSchedulesFlag() throws Exception {
+    // deploy an app with schedule
+    AppWithSchedule.AppConfig config = new AppWithSchedule.AppConfig(true, true, true);
+
+    Id.Artifact artifactId = Id.Artifact.from(TEST_NAMESPACE_META2.getNamespaceId().toId(),
+                                              AppWithSchedule.NAME, VERSION1);
+    addAppArtifact(artifactId, AppWithSchedule.class);
+    AppRequest<? extends Config> request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, false);
+
+    ApplicationId defaultAppId = TEST_NAMESPACE_META2.getNamespaceId().app(AppWithSchedule.NAME);
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    List<ScheduleSpecification> actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                                               defaultAppId.getApplication(),
+                                                               defaultAppId.getVersion());
+
+    // none of the schedules will be added as we have set update schedules to be false
+    Assert.assertEquals(0, actualSchSpecs.size());
+
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, true);
+
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                                               defaultAppId.getApplication(),
+                                                               defaultAppId.getVersion());
+    Assert.assertEquals(2, actualSchSpecs.size());
+
+    // with workflow, without schedule
+    config = new AppWithSchedule.AppConfig(true, false, false);
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, false);
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    // schedule should not be updated
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                   defaultAppId.getApplication(),
+                                   defaultAppId.getVersion());
+    Assert.assertEquals(2, actualSchSpecs.size());
+
+    // without workflow and schedule, schedule should be deleted
+    config = new AppWithSchedule.AppConfig(false, false, false);
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, false);
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                   defaultAppId.getApplication(),
+                                   defaultAppId.getVersion());
+    Assert.assertEquals(0, actualSchSpecs.size());
+
+    // with workflow and  one schedule, schedule should be added
+    config = new AppWithSchedule.AppConfig(true, true, false);
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, true);
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                   defaultAppId.getApplication(),
+                                   defaultAppId.getVersion());
+    Assert.assertEquals(1, actualSchSpecs.size());
+    Assert.assertEquals("SampleSchedule", actualSchSpecs.get(0).getSchedule().getName());
+
+    // with workflow and two schedules, but update-schedules is false, so 2nd schedule should not get added
+    config = new AppWithSchedule.AppConfig(true, true, true);
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, false);
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                   defaultAppId.getApplication(),
+                                   defaultAppId.getVersion());
+    Assert.assertEquals(1, actualSchSpecs.size());
+    Assert.assertEquals("SampleSchedule", actualSchSpecs.get(0).getSchedule().getName());
+
+    // same config, but update-schedule flag is true now, so 2 schedules should be available now
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, true);
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                   defaultAppId.getApplication(),
+                                   defaultAppId.getVersion());
+    Assert.assertEquals(2, actualSchSpecs.size());
+  }
+
   private void testAddSchedule(ApplicationId appV2Id, String scheduleName) throws Exception {
     TimeSchedule timeSchedule = (TimeSchedule) Schedules.builder(scheduleName)
       .setDescription("Something")

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
@@ -132,7 +132,7 @@ public class ScheduleClientTestRun extends ClientTestBase {
 
   @Test
   public void testScheduleChanges() throws Exception {
-    // deploy the app without time and stream size schedule
+    // deploy the app with time and stream size schedule
     FakeApp.AppConfig config = new FakeApp.AppConfig(true, true, null, null, null);
     appClient.deploy(namespace, createAppJarFile(FakeApp.class), config);
     // now there should be two schedule

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterAuditLookUpTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterAuditLookUpTest.java
@@ -60,7 +60,8 @@ public class RouterAuditLookUpTest {
                   new AuditLogContent(HttpMethod.POST, false, true,
                                       ImmutableList.of(AbstractAppFabricHttpHandler.ARCHIVE_NAME_HEADER,
                                                        AbstractAppFabricHttpHandler.APP_CONFIG_HEADER,
-                                                       AbstractAppFabricHttpHandler.PRINCIPAL_HEADER)));
+                                                       AbstractAppFabricHttpHandler.PRINCIPAL_HEADER,
+                                                       AbstractAppFabricHttpHandler.SCHEDULES_HEADER)));
     // endpoints from ArtifactHttpHandler
     assertContent("/v3/namespaces/default/artifacts/myArtifact/versions/1.0/properties", DEFAULT_AUDIT);
     assertContent("/v3/namespaces/default/artifacts/myArtifact",

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/AppRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/AppRequest.java
@@ -32,29 +32,33 @@ public class AppRequest<T> {
   private final PreviewConfig preview;
   @SerializedName("principal")
   private final String ownerPrincipal;
+  @SerializedName("update-schedules")
+  private final Boolean updateSchedules;
+
 
   public AppRequest(ArtifactSummary artifact) {
     this(artifact, null);
   }
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config) {
-    this(artifact, config, null, null);
+    this(artifact, config, null, null, true);
   }
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable PreviewConfig preview) {
-    this(artifact, config, preview, null);
+    this(artifact, config, preview, null, true);
   }
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable String ownerPrincipal) {
-    this(artifact, config, null, ownerPrincipal);
+    this(artifact, config, null, ownerPrincipal, true);
   }
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable PreviewConfig preview,
-                    @Nullable String ownerPrincipal) {
+                    @Nullable String ownerPrincipal, boolean updateSchedules) {
     this.artifact = artifact;
     this.config = config;
     this.preview = preview;
     this.ownerPrincipal = ownerPrincipal;
+    this.updateSchedules = updateSchedules;
   }
 
   public ArtifactSummary getArtifact() {
@@ -74,5 +78,9 @@ public class AppRequest<T> {
   @Nullable
   public String getOwnerPrincipal() {
     return ownerPrincipal;
+  }
+
+  public Boolean canUpdateSchedules() {
+    return updateSchedules == null || updateSchedules;
   }
 }


### PR DESCRIPTION
update schedule if update-schedule flag is set to true, by default update-schedule is always true.
if update-schedule is set to false, we wont delete the schedules, however if the workflow itself is deleted, the schedules belonging to the workflow will be deleted even if update-schedule is set to false. 

More information is available in the JIRA : https://issues.cask.co/browse/CDAP-8942