### PR TITLE
CDAP 9297 fix lower case scope for preview

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/preview/PreviewHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/preview/PreviewHttpHandler.java
@@ -20,6 +20,7 @@ import co.cask.cdap.app.preview.PreviewManager;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.logging.context.LoggingContextHelper;
@@ -64,7 +65,8 @@ import javax.ws.rs.QueryParam;
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class PreviewHttpHandler extends AbstractLogHandler {
   private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec()).create();
+    .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec())
+    .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory(true)).create();
   private static final Type STRING_LIST_MAP_TYPE = new TypeToken<Map<String, List<String>>>() { }.getType();
 
   private final PreviewManager previewManager;

--- a/cdap-common/src/test/java/co/cask/cdap/common/io/CaseInsensitiveEnumTypeAdapterFactoryTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/io/CaseInsensitiveEnumTypeAdapterFactoryTest.java
@@ -24,20 +24,28 @@ import org.junit.Test;
 /**
  */
 public class CaseInsensitiveEnumTypeAdapterFactoryTest {
-  private static final Gson GSON = new GsonBuilder()
+  private static final Gson GSON_LOWER_CASE = new GsonBuilder()
     .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
     .create();
+  private static final Gson GSON_UPPER_CASE = new GsonBuilder()
+    .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory(true))
+    .create();
+
 
   @Test
   public void testDeserialization() {
-    Assert.assertEquals(Suit.CLUB, GSON.fromJson("club", Suit.class));
-    Assert.assertEquals(Suit.CLUB, GSON.fromJson("CLUB", Suit.class));
-    Assert.assertEquals(Suit.CLUB, GSON.fromJson("cLub", Suit.class));
+    Assert.assertEquals(Suit.CLUB, GSON_LOWER_CASE.fromJson("club", Suit.class));
+    Assert.assertEquals(Suit.CLUB, GSON_LOWER_CASE.fromJson("CLUB", Suit.class));
+    Assert.assertEquals(Suit.CLUB, GSON_LOWER_CASE.fromJson("cLub", Suit.class));
+    Assert.assertEquals(Suit.CLUB, GSON_UPPER_CASE.fromJson("club", Suit.class));
+    Assert.assertEquals(Suit.CLUB, GSON_UPPER_CASE.fromJson("CLUB", Suit.class));
+    Assert.assertEquals(Suit.CLUB, GSON_UPPER_CASE.fromJson("cLub", Suit.class));
   }
 
   @Test
   public void testSerialization() {
-    Assert.assertEquals("\"club\"", GSON.toJson(Suit.CLUB));
+    Assert.assertEquals("\"club\"", GSON_LOWER_CASE.toJson(Suit.CLUB));
+    Assert.assertEquals("\"CLUB\"", GSON_UPPER_CASE.toJson(Suit.CLUB));
   }
 
   private enum Suit {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-9297
Build: https://builds.cask.co/browse/CDAP-RUT880-1
Since Gson.fromJson will parse lower cased artifact scope to null, we will not be able to get the artifact, thus preview wont start.