### PR TITLE
Use version of Node.js from cdap-ui/pom.xml

### DIFF
--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -5,6 +5,15 @@
       "url": "{{URI}}"
     }
   },
+  "nodejs": {
+    "install_method": "binary",
+    "version": "0.12.0",
+    "binary": {
+      "checksum": {
+        "linux_x64": "d4130512228439bf9115b7057fe145b095c1e49fa8e62c8d3e192b3dd3fe821b"
+      }
+    }
+  },
   "java": {
     "install_flavor": "openjdk",
     "jdk_version": 7

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -2,6 +2,15 @@
   "cdap": {
     "version": "3.5.5-1"
   },
+  "nodejs": {
+    "install_method": "binary",
+    "version": "0.12.0",
+    "binary": {
+      "checksum": {
+        "linux_x64": "d4130512228439bf9115b7057fe145b095c1e49fa8e62c8d3e192b3dd3fe821b"
+      }
+    }
+  },
   "java": {
     "install_flavor": "openjdk",
     "jdk_version": 7


### PR DESCRIPTION
Override the `nodejs` cookbook's default method of installation and use same version as defined in `cdap-ui/pom.xml` for Docker/VM.