### PR TITLE
constrain nodejs cookbook for docker/vm build

### DIFF
--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -25,6 +25,9 @@ for cb in cdap hadoop idea maven nodejs openssh; do
   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
 done
 
+# need nodejs < 3.0.0 until CDAP UI nodeVersion is a version they provide *.xz downloads for
+knife cookbook site install nodejs 2.4.4 || die "Cannot fetch ark cookbook 2.1.0"
+
 # Do not change HOME for cdap user
 sed -i '/ home /d' /var/chef/cookbooks/cdap/recipes/sdk.rb
 


### PR DESCRIPTION
constrains the nodejs cookbook due to the desired version of node not being available as an xz pkg