### PR TITLE
Feature/fix sdk checksum

### DIFF
--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -10,7 +10,7 @@
     "version": "0.12.0",
     "binary": {
       "checksum": {
-        "linux_x64": "d4130512228439bf9115b7057fe145b095c1e49fa8e62c8d3e192b3dd3fe821b"
+        "linux_x64": "3bdb7267ca7ee24ac59c54ae146741f70a6ae3a8a8afd42d06204647fe9d4206"
       }
     }
   },

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -7,7 +7,7 @@
     "version": "0.12.0",
     "binary": {
       "checksum": {
-        "linux_x64": "d4130512228439bf9115b7057fe145b095c1e49fa8e62c8d3e192b3dd3fe821b"
+        "linux_x64": "3bdb7267ca7ee24ac59c54ae146741f70a6ae3a8a8afd42d06204647fe9d4206"
       }
     }
   },

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -26,7 +26,7 @@ for cb in cdap hadoop idea maven nodejs openssh; do
 done
 
 # need nodejs < 3.0.0 until CDAP UI nodeVersion is a version they provide *.xz downloads for
-knife cookbook site install nodejs 2.4.4 || die "Cannot fetch ark cookbook 2.1.0"
+knife cookbook site install nodejs 2.4.4 || die "Cannot fetch nodejs cookbook 2.4.4"
 
 # Do not change HOME for cdap user
 sed -i '/ home /d' /var/chef/cookbooks/cdap/recipes/sdk.rb


### PR DESCRIPTION
previous checksum was from wrong arch:

```
# curl -s https://nodejs.org/download/release/v0.12.0/SHASUMS256.txt | grep node-v0.12.0-linux*
3bdb7267ca7ee24ac59c54ae146741f70a6ae3a8a8afd42d06204647fe9d4206  node-v0.12.0-linux-x64.tar.gz
d4130512228439bf9115b7057fe145b095c1e49fa8e62c8d3e192b3dd3fe821b  node-v0.12.0-linux-x86.tar.gz
```