### PR TITLE
disable git merge autoedit

### DIFF
--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -20,6 +20,8 @@
 
 die() { echo $*; exit 1; }
 
+export GIT_MERGE_AUTOEDIT=no
+
 # Grab cookbooks using knife
 for cb in cdap hadoop idea maven nodejs openssh; do
   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"


### PR DESCRIPTION
prevents git from prompting for merge commit message, and hanging the build.

