### PR TITLE
Fix Documentation Javadoc Build

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
@@ -71,7 +71,9 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
         <executions>
           <execution>
             <id>etl-tools-fat-jar</id>

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -45,13 +45,6 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-common</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-formats</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
Fix errors in pom-xml files. Revises documentation Javadoc build to use a local repo, and install
CDAP there. Split Javadocs from first part of command to aid debugging.

Modifies doc build script so that errors in Javadoc build are fatal and are surfaced immediately.

Passes a full doc build: https://builds.cask.co/browse/CDAP-DBT12-1

New Javadocs: https://builds.cask.co/artifact/CDAP-DBT12/shared/build-1/Current-Docs-HTML/3.5.5/en/reference-manual/javadocs/index.html

Once I fixed both of these warnings (see below) I was able to get the local repo to work, which kept failing until then.