### PR TITLE
[CDAP-9328] Adds license step to One step deploy wizards

### DIFF
--- a/cdap-ui/app/cdap/components/CaskWizards/Informational/Informational.scss
+++ b/cdap-ui/app/cdap/components/CaskWizards/Informational/Informational.scss
@@ -22,35 +22,6 @@ body {
       &.modal-dialog {
         &.informational-wizard {
           margin-top: $wizard-modal-margin-top;
-          .modal-body {
-            .license-container {
-              background: white;
-              height: 100%;
-              padding: 20px;
-              h2 {
-                margin-top: 10px;
-                font-weight: bold;
-              }
-              .license-text {
-                height: calc(100% - 100px);
-                margin-bottom: 10px;
-                overflow-y: auto;
-              }
-              .agree-btn {
-                background: #ff6600;
-                border-color: #ff6600;
-                display: inline-block;
-                padding-right: 30px;
-                padding-left: 30px;
-              }
-              .back-to-cdap-link {
-                display: inline-block;
-                margin-left: 10px;
-                color: #ff6600;
-                cursor: pointer;
-              }
-            }
-          }
         }
       }
     }

--- a/cdap-ui/app/cdap/components/CaskWizards/Informational/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/Informational/index.js
@@ -19,7 +19,7 @@ import Wizard from 'components/Wizard';
 import InformationalWizardConfig from 'services/WizardConfigs/InformationalWizardConfig';
 import InformationalWizardStore from 'services/WizardStores/Informational/InformationalStore';
 import InformationalActions from 'services/WizardStores/Informational/InformationalActions';
-import {MyMarketApi} from 'api/market';
+import LicenseStep from 'components/CaskWizards/LicenseStep';
 require('./Informational.scss');
 
 import T from 'i18n-react';
@@ -29,27 +29,13 @@ export default class InformationalWizard extends Component {
     super(props);
     this.state = {
       showWizard: this.props.isOpen,
-      license: this.props.input.package.license ? true : false,
-      licenseAgreement: false
+      license: this.props.input.package.license ? true : false
     };
+    this.showWizardContents = this.showWizardContents.bind(this);
+    this.toggleWizard = this.toggleWizard.bind(this);
     this.prepareInputForSteps();
   }
-  componentDidMount() {
-    if (this.props.input.package.license) {
-      let params = {
-        entityName: this.props.input.package.name,
-        entityVersion: this.props.input.package.version,
-        filename: this.props.input.package.license
-      };
-      MyMarketApi
-        .getSampleData(params)
-        .subscribe(license => {
-          this.setState({
-            license
-          });
-        });
-    }
-  }
+
   prepareInputForSteps() {
     let actionSteps = this.props.input.action.arguments[0].value;
 
@@ -73,10 +59,9 @@ export default class InformationalWizard extends Component {
     });
   }
 
-
-  showWizard() {
+  showWizardContents() {
     this.setState({
-      licenseAgreement: true
+      license: false
     });
   }
   render() {
@@ -94,37 +79,6 @@ export default class InformationalWizard extends Component {
       );
     };
 
-    const getLicenseTemplate = () => {
-      if (typeof this.state.license === 'boolean') {
-        return (
-          <div className="fa fa-spin fa-spinner"></div>
-        );
-      }
-      if (this.state.licenseAgreement) {
-        return getWizardContent();
-      } else {
-        return (
-          <div className="license-container">
-            <h2>{T.translate('features.Wizard.Informational.termsandconditions')}</h2>
-            <div className="license-text">{this.state.license}</div>
-            <div>
-              <div
-                className="btn btn-primary agree-btn"
-                onClick={this.showWizard.bind(this)}
-              >
-                Agree and Download
-              </div>
-              <div
-                className="back-to-cdap-link"
-                onClick={this.toggleWizard.bind(this, false)}
-              >
-                Back to Cask Market
-              </div>
-            </div>
-          </div>
-        );
-      }
-    };
 
     let wizardModalTitle = (pkg.label ? pkg.label + " | " : '') + T.translate('features.Wizard.Informational.headerlabel');
     return (
@@ -136,7 +90,13 @@ export default class InformationalWizard extends Component {
       >
         {
           this.state.license ?
-            getLicenseTemplate()
+            <LicenseStep
+              entityName={this.props.input.package.name}
+              entityVersion={this.props.input.package.version}
+              licenseFileName={this.props.input.package.license}
+              onAgree={this.showWizardContents}
+              onReject={this.toggleWizard.bind(this, false)}
+            />
           :
             getWizardContent()
         }

--- a/cdap-ui/app/cdap/components/CaskWizards/LicenseStep/LicenseStep.scss
+++ b/cdap-ui/app/cdap/components/CaskWizards/LicenseStep/LicenseStep.scss
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@import '../../WizardModal/WizardModal.scss';
+
+body {
+  .modal {
+    .wizard-modal {
+      &.modal-dialog {
+        margin-top: $wizard-modal-margin-top;
+        .modal-body {
+          .spinner-container {
+            background: white;
+            height: 100%;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+          }
+          .license-container {
+            background: white;
+            height: 100%;
+            padding: 20px;
+            h2 {
+              margin-top: 10px;
+              font-weight: bold;
+            }
+            .license-text {
+              height: calc(100% - 100px);
+              margin-bottom: 10px;
+              overflow-y: auto;
+            }
+            .agree-btn {
+              background: #ff6600;
+              border-color: #ff6600;
+              display: inline-block;
+              padding-right: 30px;
+              padding-left: 30px;
+            }
+            .back-to-cdap-link {
+              display: inline-block;
+              margin-left: 10px;
+              color: #ff6600;
+              cursor: pointer;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/CaskWizards/LicenseStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/LicenseStep/index.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {PropTypes, Component} from 'react';
+import {MyMarketApi} from 'api/market';
+import T from 'i18n-react';
+require('./LicenseStep.scss');
+
+export default class LicenseStep extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      license: null
+    };
+  }
+  componentWillMount() {
+    let {entityName, entityVersion, licenseFileName} = this.props;
+    let params = {
+      entityName,
+      entityVersion,
+      filename: licenseFileName
+    };
+    MyMarketApi
+      .getSampleData(params)
+      .subscribe(license => {
+        this.setState({
+          license
+        });
+      });
+  }
+  render() {
+    if (!this.state.license) {
+      return (
+        <div className="spinner-container">
+          <div className="fa fa-spin fa-spinner fa-3x"></div>
+        </div>
+      );
+    }
+    return (
+      <div className="license-container">
+        <h2>{T.translate('features.Wizard.licenseStep.termsandconditions')}</h2>
+        <pre className="license-text">{this.state.license}</pre>
+        <div>
+          <div
+            className="btn btn-primary agree-btn"
+            onClick={this.props.onAgree.bind(this)}
+          >
+            {T.translate('features.Wizard.licenseStep.agreeAndActionBtnLabel')}
+          </div>
+          <div
+            className="back-to-cdap-link"
+            onClick={this.props.onReject.bind(this, false)}
+          >
+            {T.translate('features.Wizard.licenseStep.backToCaskBtnLabel')}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+LicenseStep.propTypes = {
+  entityName: PropTypes.string,
+  entityVersion: PropTypes.string,
+  licenseFileName: PropTypes.string,
+  onReject: PropTypes.func.required,
+  onAgree: PropTypes.func.required
+};

--- a/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/index.js
@@ -21,16 +21,26 @@ import OneStepDeployStore from 'services/WizardStores/OneStepDeploy/OneStepDeplo
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import T from 'i18n-react';
+import LicenseStep from 'components/CaskWizards/LicenseStep';
 
 export default class OneStepDeployWizard extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      showWizard: this.props.isOpen
+      showWizard: this.props.isOpen,
+      license: this.props.input.package.license ? true : false
     };
 
     this.publishApp = this.publishApp.bind(this);
+    this.showWizardContents = this.showWizardContents.bind(this);
+    this.toggleWizard = this.toggleWizard.bind(this);
+  }
+
+  showWizardContents() {
+    this.setState({
+      license: false
+    });
   }
 
   toggleWizard(returnResult) {
@@ -76,7 +86,18 @@ export default class OneStepDeployWizard extends Component {
         toggle={this.toggleWizard.bind(this, false)}
         className="one-step-deploy-wizard"
       >
-        {getWizardContent()}
+        {
+          this.state.license ?
+            <LicenseStep
+              entityName={this.props.input.package.name}
+              entityVersion={this.props.input.package.version}
+              licenseFileName={this.props.input.package.license}
+              onAgree={this.showWizardContents}
+              onReject={this.toggleWizard.bind(this, false)}
+            />
+          :
+            getWizardContent()
+        }
       </WizardModal>
     );
   }

--- a/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/index.js
@@ -27,7 +27,7 @@ import NamespaceStore from 'services/NamespaceStore';
 import {MyPipelineApi} from 'api/pipeline';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
-
+import LicenseStep from 'components/CaskWizards/LicenseStep';
 import T from 'i18n-react';
 
 export default class PublishPipelineWizard extends Component {
@@ -35,11 +35,12 @@ export default class PublishPipelineWizard extends Component {
     super(props);
     this.state = {
       showWizard: this.props.isOpen,
-      successInfo: {}
+      successInfo: {},
+      license: this.props.input.package.license ? true : false
     };
 
     this.setDefaultConfig();
-
+    this.showWizardContents = this.showWizardContents.bind(this);
     this.eventEmitter = ee(ee);
   }
   componentWillMount() {
@@ -59,6 +60,11 @@ export default class PublishPipelineWizard extends Component {
   componentWillUnmount() {
     PublishPipelineWizardStore.dispatch({
       type: PublishPipelineAction.onReset
+    });
+  }
+  showWizardContents() {
+    this.setState({
+      license: false
     });
   }
   setDefaultConfig() {
@@ -173,14 +179,26 @@ export default class PublishPipelineWizard extends Component {
               toggle={this.toggleWizard.bind(this, false)}
               className="create-stream-wizard"
             >
-              <Wizard
-                wizardConfig={PublishPipelineWizardConfig}
-                wizardType="PublishPipeline"
-                onSubmit={this.publishPipeline.bind(this)}
-                successInfo={this.state.successInfo}
-                onClose={this.toggleWizard.bind(this)}
-                store={PublishPipelineWizardStore}
-              />
+
+              {
+                this.state.license ?
+                  <LicenseStep
+                    entityName={this.props.input.package.name}
+                    entityVersion={this.props.input.package.version}
+                    licenseFileName={this.props.input.package.license}
+                    onAgree={this.showWizardContents}
+                    onReject={this.toggleWizard.bind(this, false)}
+                  />
+                :
+                  <Wizard
+                    wizardConfig={PublishPipelineWizardConfig}
+                    wizardType="PublishPipeline"
+                    onSubmit={this.publishPipeline.bind(this)}
+                    successInfo={this.state.successInfo}
+                    onClose={this.toggleWizard.bind(this)}
+                    store={PublishPipelineWizardStore}
+                  />
+              }
             </WizardModal>
           :
             null

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -757,12 +757,15 @@ features:
     Done: Done
     GoToHomePage: Go to Home Page
     Informational:
-      termsandconditions: Terms and Conditions
       Step1:
         description: Please follow the steps specified below to download and configure
         shorttitle: Download Information
         title: Information
       headerlabel: Download Information
+    licenseStep:
+      termsandconditions: Terms and Conditions
+      agreeAndActionBtnLabel: Agree
+      backToCaskBtnLabel: Back to Cask Market
     MarketHydratorPluginUpload:
       headerlabel: Add Hydrator Plugin
     OneStepDeploy:


### PR DESCRIPTION
#### Background:
- UIs assumption till today was that there would always be an Informational Step before a download step in all of the wizards in Cask Market.
- We have changed this recently (4.1.0) to have one step deploy where UI automatically downloads the necessary files and deploys to CDAP instead of user manually downloading it and uploading it to CDAP

#### Changes:
- Adds `LicenseStep` as a separate component to be reused in any wizard
- Modifies `Informational` & `OneStepDeploy` Wizards to  use `LicenseStep` to show license if necessary.