### PR TITLE
[CDAP-9310] Show warning modal on leaving studio + preview&logviewer improvements

### DIFF
--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewLogsApi, LOGVIEWERSTORE_ACTIONS, MyCDAPDataSource, $sce, myCdapUrl, $timeout, $q, moment, myAlertOnValium) {
+function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewLogsApi, LOGVIEWERSTORE_ACTIONS, MyCDAPDataSource, $sce, myCdapUrl, $timeout, $q, moment, myAlertOnValium, HydratorPlusPlusPreviewStore) {
   'ngInject';
 
   /**
@@ -128,6 +128,14 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
 
   vm.toggleExpandAll = false;
 
+  let previewPoll = HydratorPlusPlusPreviewStore.subscribe(() => {
+    let state = HydratorPlusPlusPreviewStore.getState().preview;
+    if (vm.previewId !== state.previewId) {
+      vm.previewId = state.previewId;
+      vm.getInitalPreviewStatus();
+    }
+  });
+
   let unsub = LogViewerStore.subscribe(() => {
     let logViewerState = LogViewerStore.getState();
 
@@ -204,34 +212,38 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
     }
   };
 
-  if (vm.previewId) {
-    // Get Initial Status
-    myPreviewLogsApi.getLogsStatus({
-      namespace : vm.namespaceId,
-      previewId : vm.previewId
-    }).$promise.then(
-      (statusRes) => {
-        LogViewerStore.dispatch({
-          type: LOGVIEWERSTORE_ACTIONS.SET_STATUS,
-          payload: {
-            status: statusRes.status,
+  vm.getInitalPreviewStatus = () => {
+    if (vm.previewId) {
+      // Get Initial Status
+      myPreviewLogsApi.getLogsStatus({
+        namespace : vm.namespaceId,
+        previewId : vm.previewId
+      }).$promise.then(
+        (statusRes) => {
+          LogViewerStore.dispatch({
+            type: LOGVIEWERSTORE_ACTIONS.SET_STATUS,
+            payload: {
+              status: statusRes.status,
+            }
+          });
+          vm.setProgramMetadata(statusRes.status);
+        },
+        (statusErr) => {
+          console.log('ERROR: ', statusErr);
+
+          if (statusErr.statusCode === 404) {
+            myAlertOnValium.show({
+              type: 'danger',
+              content: statusErr.data
+            });
           }
         });
-        vm.setProgramMetadata(statusRes.status);
-      },
-      (statusErr) => {
-        console.log('ERROR: ', statusErr);
+    } else {
+      vm.loading = false;
+    }
+  };
 
-        if (statusErr.statusCode === 404) {
-          myAlertOnValium.show({
-            type: 'danger',
-            content: statusErr.data
-          });
-        }
-      });
-  } else {
-    vm.loading = false;
-  }
+  vm.getInitalPreviewStatus();
 
   vm.filterSearch = () => {
     // Rerender data
@@ -759,6 +771,9 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
   $scope.$on('$destroy', function() {
     if (unsub) {
       unsub();
+    }
+    if (previewPoll) {
+      previewPoll();
     }
     if (timeout) {
       $timeout.cancel(timeout);

--- a/cdap-ui/app/directives/log-viewer/log-viewer.less
+++ b/cdap-ui/app/directives/log-viewer/log-viewer.less
@@ -115,6 +115,7 @@ body {
       border-radius: 3px;
       font-size: 11px;
       max-width: 600px;
+      white-space: pre-wrap;
       &.top {
         margin-top: -2px;
         .tooltip-arrow {
@@ -131,6 +132,8 @@ body {
 
 my-log-viewer,
 my-log-viewer-preview {
+  font-family: Helvetica, Arial, sans-serif;
+
   .empty-buffer {
     display: none;
   }
@@ -138,7 +141,7 @@ my-log-viewer-preview {
   .row-expanded {
     td,
     span {
-      white-space: normal;
+      white-space: pre-wrap;
     }
 
     td.source {
@@ -445,8 +448,16 @@ my-log-viewer-preview {
         height: ~"-moz-calc(100% - 47px)";
         height: ~"-webkit-calc(100% - 47px)";
         height: ~"calc(100% - 47px)";
+        background-color: @selected-row-color;
 
         .table { border-top: 0; }
+
+        td {
+          color: #333333;
+          font-size: 14px;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
       }
 
       .has-stack-trace {
@@ -499,12 +510,14 @@ my-log-viewer-preview {
         }
 
         td {
-          line-height: 18px;
+          line-height: 30px;
           border-top: 0;
           color: #666666;
           font-size: 11px;
           text-overflow: ellipsis;
           white-space: nowrap;
+          border-left: 0;
+          border-right: 0;
 
           .fa-chevron-right {
             color: #393939;
@@ -549,7 +562,7 @@ my-log-viewer-preview {
           padding-left: 5px;
           padding-right: 0;
           padding-top: 10px;
-          font-size: 12px;
+          font-size: 14px;
           font-family: inherit;
           background-color: @stack-trace-background-color;
           color: @stack-trace-font-color;
@@ -593,7 +606,7 @@ my-log-viewer-preview {
         line-height: 12px;
         height: 10px;
         overflow: hidden;
-        font-size: 12px;
+        font-size: 14px;
         border-color: @border-color;
       }
       td.time-stack-trace {
@@ -614,6 +627,10 @@ my-log-viewer-preview {
         th:hover,
         th:focus {
           cursor: default;
+          font-size: 14px;
+          border-left: 0;
+          border-right: 0;
+
           ul.dropdown-menu { width: 30px; }
 
           li {
@@ -621,7 +638,7 @@ my-log-viewer-preview {
           }
         }
         td {
-          line-height: 18px;
+          line-height: 30px;
         }
         .table-text-content {
           display: inline-block;
@@ -657,7 +674,7 @@ my-log-viewer-preview {
       }
 
       .time {
-        width: 130px;
+        width: 150px;
         max-width: initial;
         padding-left: 15px;
       }

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorPlusPlusNodeConfigCtrl {
-  constructor($scope, $timeout, $state, HydratorPlusPlusPluginConfigFactory, EventPipe, GLOBALS, HydratorPlusPlusConfigActions, myHelpers, NonStorePipelineErrorFactory, $uibModal, HydratorPlusPlusConfigStore, rPlugin, rDisabled, HydratorPlusPlusHydratorService, myPipelineApi, HydratorPlusPlusPreviewStore, rIsStudioMode, HydratorPlusPlusOrderingFactory, avsc) {
+  constructor($scope, $timeout, $state, HydratorPlusPlusPluginConfigFactory, EventPipe, GLOBALS, HydratorPlusPlusConfigActions, myHelpers, NonStorePipelineErrorFactory, $uibModal, HydratorPlusPlusConfigStore, rPlugin, rDisabled, HydratorPlusPlusHydratorService, myPipelineApi, HydratorPlusPlusPreviewStore, rIsStudioMode, HydratorPlusPlusOrderingFactory, avsc, LogViewerStore) {
     'ngInject';
     this.$scope = $scope;
     this.$timeout = $timeout;
@@ -36,6 +36,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.previewStore = HydratorPlusPlusPreviewStore;
     this.HydratorPlusPlusOrderingFactory = HydratorPlusPlusOrderingFactory;
     this.avsc = avsc;
+    this.LogViewerStore = LogViewerStore;
     this.setDefaults(rPlugin);
     this.tabs = [
       {
@@ -60,6 +61,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     if (rIsStudioMode && this.isPreviewMode) {
       this.previewLoading = false;
       this.previewData = null;
+      this.previewStatus = null;
       this.fetchPreview();
     }
 
@@ -399,6 +401,11 @@ class HydratorPlusPlusNodeConfigCtrl {
             }
           }
         });
+        let logViewerState = this.LogViewerStore.getState();
+        if (logViewerState.statusInfo) {
+          // TODO: Move preview status state info HydratorPlusPlusPreviewStore, then get from there
+          this.previewStatus = logViewerState.statusInfo.status;
+        }
         this.previewLoading = false;
       }, () => {
         this.previewLoading = false;

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -265,6 +265,12 @@
                 }
               }
 
+              .row.preview-no-data {
+                h3 {
+                  font-size: 16px;
+                }
+              }
+
               .row.preview-tab {
                 margin-left: 0;
                 margin-right: 0;
@@ -284,6 +290,11 @@
                   padding-left: 5px;
                   margin-top: 20px;
                   font-size: 18px;
+
+                  &.message {
+                    font-size: 16px;
+                    font-weight: 300;
+                  }
                 }
                 .schema-toggle {
                   padding-left: 15px;

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/preview-tab.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/preview-tab.html
@@ -14,15 +14,15 @@
   the License.
 -->
 
-<div class="row" ng-if="!HydratorPlusPlusNodeConfigCtrl.previewData && !HydratorPlusPlusNodeConfigCtrl.previewLoading">
+<div class="row preview-no-data" ng-if="!HydratorPlusPlusNodeConfigCtrl.previewData && !HydratorPlusPlusNodeConfigCtrl.previewLoading">
   <div class="col-xs-12">
     <h3 class="text-center">
-      No preview data.
+      Preview Data for stage "{{ HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label }}" is not available.
     </h3>
   </div>
 </div>
 
-<div class="row" ng-if="HydratorPlusPlusNodeConfigCtrl.previewLoading">
+<div class="row preview-no-data" ng-if="HydratorPlusPlusNodeConfigCtrl.previewLoading">
   <div class="col-xs-12">
     <h3 class="text-center">
       <span class="fa fa-spin fa-refresh"></span>
@@ -64,13 +64,39 @@
 
       <div class="text-center"
            ng-if="!value.records || value.records.length === 0">
-        <h4>No input records</h4>
+        <h4 class="message"
+            ng-if="HydratorPlusPlusNodeConfigCtrl.previewStatus &&
+            HydratorPlusPlusNodeConfigCtrl.previewStatus === 'RUNNING'">
+          Input records have not been generated yet. Please try again in some time.
+        </h4>
+        <h4 class="message"
+            ng-if="HydratorPlusPlusNodeConfigCtrl.previewStatus &&
+            HydratorPlusPlusNodeConfigCtrl.previewStatus !== 'RUNNING'">
+          Input records have not been generated. Please verify your logic, or try sending more data
+        </h4>
+        <h4 class="message"
+            ng-if="!HydratorPlusPlusNodeConfigCtrl.previewStatus">
+          Input records are not available. Please try running preview again.
+        </h4>
       </div>
     </div>
 
     <div class="text-center"
          ng-if="HydratorPlusPlusNodeConfigCtrl.previewData.numInputStages === 0">
-      <h4>No input records</h4>
+      <h4 class="message"
+          ng-if="HydratorPlusPlusNodeConfigCtrl.previewStatus &&
+          HydratorPlusPlusNodeConfigCtrl.previewStatus === 'RUNNING'">
+        Input records have not been generated for stage "{{ HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label }}" yet. Please try again in some time.
+      </h4>
+      <h4 class="message"
+          ng-if="HydratorPlusPlusNodeConfigCtrl.previewStatus &&
+          HydratorPlusPlusNodeConfigCtrl.previewStatus !== 'RUNNING'">
+        Input records have not been generated for stage "{{ HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label }}". Please verify your logic, or try sending more data
+      </h4>
+      <h4 class="message"
+          ng-if="!HydratorPlusPlusNodeConfigCtrl.previewStatus">
+        Input records are not available for stage "{{ HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label }}". Please try running preview again.
+      </h4>
     </div>
 
   </div>
@@ -102,7 +128,20 @@
 
     <div class="text-center"
          ng-if="!HydratorPlusPlusNodeConfigCtrl.previewData.output.records || HydratorPlusPlusNodeConfigCtrl.previewData.output.records.length === 0">
-      <h4>No output records</h4>
+      <h4 class="message"
+          ng-if="HydratorPlusPlusNodeConfigCtrl.previewStatus &&
+          HydratorPlusPlusNodeConfigCtrl.previewStatus === 'RUNNING'">
+        Output records have not been generated for stage "{{ HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label }}" yet. Please try again in some time.
+      </h4>
+      <h4 class="message"
+          ng-if="HydratorPlusPlusNodeConfigCtrl.previewStatus &&
+          HydratorPlusPlusNodeConfigCtrl.previewStatus !== 'RUNNING'">
+        Output records have not been generated for stage "{{ HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label }}". Please verify your logic, or try sending more data
+      </h4>
+      <h4 class="message"
+          ng-if="!HydratorPlusPlusNodeConfigCtrl.previewStatus">
+        Output records are not available for stage "{{ HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label }}". Please try running preview again.
+      </h4>
     </div>
 
   </div>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-9310

This PR is to fix a regression, where navigating away from the Studio doesn't prompt a warning modal. 

This was because we were overriding the `$window.onbeforeunload` event handler to stop the preview when page refreshes. Now we keep the preview going, and also display the correct duration of the ongoing/previous preview.