### PR TITLE
[CDAP-9339] Fixes parsing name & version while installing plugins for pipelines

### DIFF
--- a/cdap-ui/app/cdap/services/__tests__/helpers.test.js
+++ b/cdap-ui/app/cdap/services/__tests__/helpers.test.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {getArtifactNameAndVersion} from 'services/helpers';
+
+describe('Unit Tests for Helpers: "getArtifactNameAndVersion"', () => {
+
+  it('Usecase 1 - Valid: Should return correct name & version', () => {
+    var jarfileName = 'wrangler-service-1.3.0-SNAPSHOT';
+    let {name, version} = getArtifactNameAndVersion(jarfileName);
+    expect(name).toBe('wrangler-service');
+    expect(version).toBe('1.3.0-SNAPSHOT');
+  });
+
+  it('Usecase 2 - Invalid: Should return undefined for version if it could not find', () => {
+    var jarfileName = 'invalid-file-name-without-a-version';
+    let {name, version} = getArtifactNameAndVersion(jarfileName);
+    expect(name).toBe(jarfileName);
+    expect(version).toBe(undefined);
+  });
+
+  it('Usecase 3: Should ignore unnecessary patterns & return correct name, version', () => {
+    var jarfileName = 'redshifttos3-action-plugin-1.0.0-SNAPSHOT';
+    let {name, version} = getArtifactNameAndVersion(jarfileName);
+    expect(name).toBe('redshifttos3-action-plugin');
+    expect(version).toBe('1.0.0-SNAPSHOT');
+  });
+
+  it('Usecase 4: Should return undefined for name & version if provided with an undefined input', () => {
+    let {name, version} = getArtifactNameAndVersion();
+    expect(name).toBe(undefined);
+    expect(version).toBe(undefined);
+  });
+
+  it('Usecase 5: Should return "" for name & undefined for version if provided with an undefined input', () => {
+    let {name, version} = getArtifactNameAndVersion('');
+    expect(name).toBe('');
+    expect(version).toBe(undefined);
+  });
+
+  it('Usecase 6: Should return null for name & undefined for version if provided with an undefined input', () => {
+    let {name, version} = getArtifactNameAndVersion(null);
+    expect(name).toBe(null);
+    expect(version).toBe(undefined);
+  });
+
+});

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -17,6 +17,8 @@
 import isObject from 'lodash/isObject';
 import numeral from 'numeral';
 import moment from 'moment';
+import isNil from 'lodash/isNil';
+import isEmpty from 'lodash/isEmpty';
 
 /*
   Purpose: Query a json object or an array of json objects
@@ -126,8 +128,16 @@ function isDescendant(parent, child) {
 function getArtifactNameAndVersion (nameWithVersion) {
   // core-plugins-3.4.0-SNAPSHOT.jar
   // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning up to version beginning)
-  let regExpRule = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
-  let version = regExpRule.exec(nameWithVersion)[0];
+  // Fixed it to use a suffix pattern. Added `\\-` to detect versions from names such as `redshifttos3-action-plugin-1.0.0.json`
+  if (isNil(nameWithVersion) || isEmpty(nameWithVersion)) {
+    return {name: nameWithVersion, version: undefined};
+  }
+  let regExpRule = new RegExp('\\-(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
+  let version = regExpRule.exec(nameWithVersion);
+  if (!version) {
+    return {name: nameWithVersion, version: undefined};
+  }
+  version = version[0].slice(1);
   let name = nameWithVersion.substr(0, nameWithVersion.indexOf(version) -1);
   return { version, name };
 }


### PR DESCRIPTION
- UI used a regexp that detects incorrect name & version from plugin jar names. (Eg: `redshifttos3-action-plugin-1.0.0.json`).
- Fixed to use the same regexp pattern used in the backend for now.
- Right fix probably would be to expose an API in the backend which the UI can hit to determine the name and version from a plugin jar's name.

JIRA: https://issues.cask.co/browse/CDAP-9339
Bamboo build: https://builds.cask.co/browse/CDAP-DRC6266-1