### PR TITLE
CDAP-8942 property to enable/disable update schedule in cdap-site

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -74,7 +74,7 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
   public static final String APP_CONFIG_HEADER = "X-App-Config";
 
   public static final String PRINCIPAL_HEADER = "X-Principal";
-  public static final String SCHEDULES_HEADER = "X-Update-Schedules";
+  public static final String SCHEDULES_HEADER = "X-App-Deploy-Update-Schedules";
 
   protected int getInstances(HttpRequest request) throws BadRequestException {
     Instances instances;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -39,6 +39,7 @@ import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.common.CannotBeDeletedException;
 import co.cask.cdap.common.InvalidArtifactException;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.kerberos.OwnerAdmin;
 import co.cask.cdap.common.kerberos.SecurityUtil;
@@ -138,9 +139,11 @@ ApplicationLifecycleService extends AbstractIdleService {
   private final AuthenticationContext authenticationContext;
   private final Impersonator impersonator;
   private final RouteStore routeStore;
+  private final boolean appUpdateSchedules;
 
   @Inject
-  ApplicationLifecycleService(ProgramRuntimeService runtimeService, Store store,
+  ApplicationLifecycleService(CConfiguration cConfiguration,
+                              ProgramRuntimeService runtimeService, Store store,
                               Scheduler scheduler, QueueAdmin queueAdmin,
                               StreamConsumerFactory streamConsumerFactory, UsageRegistry usageRegistry,
                               PreferencesStore preferencesStore, MetricStore metricStore, OwnerAdmin ownerAdmin,
@@ -149,6 +152,8 @@ ApplicationLifecycleService extends AbstractIdleService {
                               MetadataStore metadataStore, PrivilegesManager privilegesManager,
                               AuthorizationEnforcer authorizationEnforcer, AuthenticationContext authenticationContext,
                               Impersonator impersonator, RouteStore routeStore) {
+    this.appUpdateSchedules = cConfiguration.getBoolean(Constants.AppFabric.APP_UPDATE_SCHEDULES,
+                                                        Constants.AppFabric.DEFAULT_APP_UPDATE_SCHEDULES);
     this.runtimeService = runtimeService;
     this.store = store;
     this.scheduler = scheduler;
@@ -418,15 +423,37 @@ ApplicationLifecycleService extends AbstractIdleService {
     return deployApp(namespace, appName, appVersion, artifactId, configStr, programTerminator, null, true);
   }
 
+  /**
+   * Deploy an application using the specified artifact and configuration. When an app is deployed, the Application
+   * class is instantiated and configure() is called in order to generate an {@link ApplicationSpecification}.
+   * Programs, datasets, and streams are created based on the specification before the spec is persisted in the
+   * {@link Store}. This method can create a new application as well as update an existing one.
+   *
+   * @param namespace the namespace to deploy the app to
+   * @param appName the name of the app. If null, the name will be set based on the application spec
+   * @param artifactId the id of the artifact to create the application from
+   * @param configStr the configuration to send to the application when generating the application specification
+   * @param programTerminator a program terminator that will stop programs that are removed when updating an app.
+   *                          For example, if an update removes a flow, the terminator defines how to stop that flow.
+   * @param ownerPrincipal the kerberos principal of the application owner
+   * @param updateSchedules specifies if schedules of the workflow have to be updated,
+   *                        if null value specified by the property "app.deploy.update.schedules" will be used.
+   * @return information about the deployed application
+   * @throws InvalidArtifactException if the artifact does not contain any application classes
+   * @throws ArtifactNotFoundException if the specified artifact does not exist
+   * @throws IOException if there was an IO error reading artifact detail from the meta store
+   * @throws Exception if there was an exception during the deployment pipeline. This exception will often wrap
+   *                   the actual exception
+   */
   public ApplicationWithPrograms deployApp(NamespaceId namespace, @Nullable String appName, @Nullable String appVersion,
                                            Id.Artifact artifactId,
                                            @Nullable String configStr,
                                            ProgramTerminator programTerminator,
                                            @Nullable KerberosPrincipalId ownerPrincipal,
-                                           boolean updateSchedules) throws Exception {
+                                           @Nullable Boolean updateSchedules) throws Exception {
     ArtifactDetail artifactDetail = artifactRepository.getArtifact(artifactId);
     return deployApp(namespace, appName, appVersion, configStr, programTerminator, artifactDetail, ownerPrincipal,
-                     updateSchedules);
+                     updateSchedules == null ? appUpdateSchedules : updateSchedules);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -249,6 +249,10 @@ public abstract class AppFabricTestBase {
     cConf.set(Constants.AppFabric.OUTPUT_DIR, System.getProperty("java.io.tmpdir"));
     cConf.set(Constants.AppFabric.TEMP_DIR, System.getProperty("java.io.tmpdir"));
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
+    String updateSchedules = System.getProperty(Constants.AppFabric.APP_UPDATE_SCHEDULES);
+    if (updateSchedules != null) {
+      cConf.set(Constants.AppFabric.APP_UPDATE_SCHEDULES, updateSchedules);
+    }
     return cConf;
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppScheduleUpdateTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppScheduleUpdateTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services.http.handlers;
+
+import co.cask.cdap.AppWithSchedule;
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+
+import java.util.List;
+
+public class AppScheduleUpdateTest extends AppFabricTestBase {
+  @ClassRule
+  public static final ExternalResource RESOURCE = new ExternalResource() {
+    @Override
+    protected void before() throws Throwable {
+      // Set app schedule update to be false
+      System.setProperty(Constants.AppFabric.APP_UPDATE_SCHEDULES, "false");
+    }
+  };
+
+  @Test
+  public void testUpdateSchedulesFlag() throws Exception {
+    // deploy an app with schedule
+    AppWithSchedule.AppConfig config = new AppWithSchedule.AppConfig(true, true, true);
+
+    Id.Artifact artifactId = Id.Artifact.from(TEST_NAMESPACE_META2.getNamespaceId().toId(),
+                                              AppWithSchedule.NAME, VERSION1);
+    addAppArtifact(artifactId, AppWithSchedule.class);
+    AppRequest<? extends Config> request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config);
+
+    ApplicationId defaultAppId = TEST_NAMESPACE_META2.getNamespaceId().app(AppWithSchedule.NAME);
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    List<ScheduleSpecification> actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                                               defaultAppId.getApplication(),
+                                                               defaultAppId.getVersion());
+
+    // none of the schedules will be added - by default we have set update schedules to be false as system property.
+    Assert.assertEquals(0, actualSchSpecs.size());
+
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, true);
+
+
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                                               defaultAppId.getApplication(),
+                                                               defaultAppId.getVersion());
+
+    // both the schedules will be added as now,
+    // we have provided update schedules property to be true manually in appRequest
+    Assert.assertEquals(2, actualSchSpecs.size());
+
+    config = new AppWithSchedule.AppConfig(true, true, false);
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config);
+
+
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                   defaultAppId.getApplication(),
+                                   defaultAppId.getVersion());
+
+    // no changes will be made, as default behavior is dont update schedules, so both the schedules should be there
+    Assert.assertEquals(2, actualSchSpecs.size());
+
+    config = new AppWithSchedule.AppConfig(false, false, false);
+    request = new AppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config);
+
+
+    Assert.assertEquals(200, deploy(defaultAppId, request).getStatusLine().getStatusCode());
+
+    actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
+                                   defaultAppId.getApplication(),
+                                   defaultAppId.getVersion());
+
+    // workflow is deleted, so the schedules will be deleted now
+    Assert.assertEquals(0, actualSchSpecs.size());
+  }
+
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.cli.util.FilePathResolver;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.artifact.preview.PreviewConfig;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.common.cli.Arguments;
 import com.google.gson.Gson;
@@ -66,6 +67,8 @@ public class CreateAppCommand extends AbstractAuthCommand {
 
     JsonObject config = new JsonObject();
     String ownerPrincipal = null;
+    Boolean updateSchedules = null;
+    PreviewConfig previewConfig = null;
     String configPath = arguments.getOptional(ArgumentName.APP_CONFIG_FILE.toString());
     if (configPath != null) {
       File configFile = resolver.resolvePathToFile(configPath);
@@ -73,10 +76,13 @@ public class CreateAppCommand extends AbstractAuthCommand {
         AppRequest<JsonObject> appRequest = GSON.fromJson(reader, configType);
         config = appRequest.getConfig();
         ownerPrincipal = appRequest.getOwnerPrincipal();
+        previewConfig = appRequest.getPreview();
+        updateSchedules = appRequest.canUpdateSchedules();
       }
     }
 
-    AppRequest<JsonObject> appRequest = new AppRequest<>(artifact, config, ownerPrincipal);
+    AppRequest<JsonObject> appRequest = new AppRequest<>(artifact, config, previewConfig,
+                                                         ownerPrincipal, updateSchedules);
     applicationClient.deploy(appId, appRequest);
     output.println("Successfully created application");
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -177,6 +177,7 @@ public final class Constants {
     public static final int DEFAULT_EXEC_THREADS = 20;
     public static final int DEFAULT_BOSS_THREADS = 1;
     public static final int DEFAULT_WORKER_THREADS = 10;
+    public static final boolean DEFAULT_APP_UPDATE_SCHEDULES = true;
 
     /**
      * Query parameter to indicate start time.
@@ -215,6 +216,8 @@ public final class Constants {
      * added to classpaths of CDAP programs.
      */
     public static final String PROGRAM_CONTAINER_DIST_JARS = "program.container.dist.jars";
+
+    public static final String APP_UPDATE_SCHEDULES = "app.deploy.update.schedules";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -422,6 +422,18 @@
   </property>
 
   <property>
+    <name>app.deploy.update.schedules</name>
+    <value>true</value>
+    <description>
+      If true, redeploying an application will modify any schedules that currently exist
+      for the application; if false, redeploying an application does not create any new
+      schedules and existing schedules are neither deleted nor updated. This property only
+      affects the redeployment of an application; all related actions or endpoints are
+      unaffected.
+    </description>
+  </property>
+
+  <property>
     <name>master.services.bind.address</name>
     <value>0.0.0.0</value>
     <description>

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -66,7 +66,8 @@ and an optional application configuration. For example:
       "config": {
         "stream": "purchaseStream"
       },
-      "principal":"user/example.net@examplekdc.net"
+      "principal":"user/example.net@examplekdc.net",
+      "app.deploy.update.schedules":"true"
     }
 
 will create an application named ``purchaseWordCount`` from the example ``WordCount`` artifact.
@@ -76,6 +77,11 @@ to create a stream named ``purchaseStream`` instead of using the default stream 
 Optionally, you can specify a Kerberos principal with which the application should be deployed.
 If a Kerberos principal is specified, then all the streams and datasets created by the
 application will be created with the application's Kerberos principal.
+
+Optionally, you can set or reset the flag "app.deploy.update.schedules". If true,
+redeploying an application will modify any schedules that currently exist for the application;
+if false, redeploying an application does not create any new schedules and existing schedules
+are neither deleted nor updated.
 
 Update an Application
 ---------------------
@@ -126,6 +132,10 @@ and Kerberos principal with which the application is to be deployed (if required
 
   X-Principal: <Kerberos Principal>
 
+and enable or disable updating schedules of the existing workflows using the header::
+
+  X-App-Deploy-Update-Schedules: <Update Schedules>
+
 This will add the JAR file as an artifact and then create an application from that artifact.
 The archive name must be in the form ``<artifact-name>-<artifact-version>.jar``.
 An optional header can supply a configuration object as a serialized JSON string::
@@ -151,6 +161,7 @@ We can deploy it with this RESTful call::
   POST /v3/namespaces/<namespace-id>/apps
   -H "X-Archive-Name: <jar-name>" \
   -H "X-Principal: <kerberos-principal>" \
+  -H "X-App-Deploy-Update-Schedules: true" \
   -H 'X-App-Config: "{\"streamName\" : \"newStream\", \"datasetName\" : \"newDataset\" }" ' \
   --data-binary "@<jar-location>"
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/AppRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/AppRequest.java
@@ -32,7 +32,7 @@ public class AppRequest<T> {
   private final PreviewConfig preview;
   @SerializedName("principal")
   private final String ownerPrincipal;
-  @SerializedName("update-schedules")
+  @SerializedName("app.deploy.update.schedules")
   private final Boolean updateSchedules;
 
 
@@ -41,19 +41,19 @@ public class AppRequest<T> {
   }
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config) {
-    this(artifact, config, null, null, true);
+    this(artifact, config, null, null, null);
   }
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable PreviewConfig preview) {
-    this(artifact, config, preview, null, true);
+    this(artifact, config, preview, null, null);
   }
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable String ownerPrincipal) {
-    this(artifact, config, null, ownerPrincipal, true);
+    this(artifact, config, null, ownerPrincipal, null);
   }
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable PreviewConfig preview,
-                    @Nullable String ownerPrincipal, boolean updateSchedules) {
+                    @Nullable String ownerPrincipal, @Nullable Boolean updateSchedules) {
     this.artifact = artifact;
     this.config = config;
     this.preview = preview;
@@ -80,7 +80,8 @@ public class AppRequest<T> {
     return ownerPrincipal;
   }
 
+  @Nullable
   public Boolean canUpdateSchedules() {
-    return updateSchedules == null || updateSchedules;
+    return updateSchedules;
   }
 }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/artifact/AppRequestTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/artifact/AppRequestTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto.artifact;
+
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AppRequestTest {
+  private static final Gson GSON = new Gson();
+
+  /**
+   * Test {@link AppRequest} deserialization
+   */
+  @Test
+  public void testAppRequestDeserialize() throws Exception {
+    String appRequestWithSchedules = "{\n" +
+      "  \"artifact\": {\n" +
+      "     \"name\": \"cdap-notifiable-workflow\",\n" +
+      "     \"version\": \"1.0.0\",\n" +
+      "     \"scope\": \"system\"\n" +
+      "  },\n" +
+      "  \"config\": {\n" +
+      "     \"plugin\": {\n" +
+      "        \"name\": \"WordCount\",\n" +
+      "        \"type\": \"sparkprogram\",\n" +
+      "        \"artifact\": {\n" +
+      "           \"name\": \"word-count-program\",\n" +
+      "           \"scope\": \"user\",\n" +
+      "           \"version\": \"1.0.0\"\n" +
+      "        }\n" +
+      "     },\n" +
+      "\n" +
+      "     \"notificationEmailSender\": \"sender@example.domain.com\",\n" +
+      "     \"notificationEmailIds\": [\"recipient@example.domain.com\"],\n" +
+      "     \"notificationEmailSubject\": \"[Critical] Workflow execution failed.\",\n" +
+      "     \"notificationEmailBody\": \"Execution of Workflow running the WordCount program failed.\"\n" +
+      "  },\n" +
+      "  \"preview\" : {\n" +
+      "    \"programName\" : \"WordCount\",\n" +
+      "    \"programType\" : \"spark\"\n" +
+      "    },\n" +
+      "  \"principal\" : \"test2\",\n" +
+      "  \"app.deploy.update.schedules\":\"false\"\n" +
+      "}";
+    AppRequest appRequest = GSON.fromJson(appRequestWithSchedules, AppRequest.class);
+    Assert.assertNotNull(appRequest.getArtifact());
+    Assert.assertEquals("cdap-notifiable-workflow", appRequest.getArtifact().getName());
+    Assert.assertNotNull(appRequest.getPreview());
+    Assert.assertEquals("WordCount", appRequest.getPreview().getProgramName());
+    Assert.assertNotNull(appRequest.canUpdateSchedules());
+    Assert.assertFalse(appRequest.canUpdateSchedules());
+  }
+}


### PR DESCRIPTION
Add "app.update.schedules" to cdap-site and corresponding changes in AppLifecycle handler and AppRequest.
Missed adding this property changes in last PR.