### PR TITLE
Ensure proper Node.js cookbook and binary are used

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -164,6 +164,15 @@
           "install_flavor": "openjdk",
           "jdk_version": 7
         },
+        "nodejs": {
+          "install_method": "binary",
+          "version": "0.12.0",
+          "binary": {
+            "checksum": {
+              "linux_x64": "3bdb7267ca7ee24ac59c54ae146741f70a6ae3a8a8afd42d06204647fe9d4206"
+            }
+          }
+        },
         "openssh": {
           "server": {
             "permit_root_login": "without-password",

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -5,6 +5,15 @@
       "url": "{{URI}}"
     }
   },
+  "nodejs": {
+    "install_method": "binary",
+    "version": "0.12.0",
+    "binary": {
+      "checksum": {
+        "linux_x64": "3bdb7267ca7ee24ac59c54ae146741f70a6ae3a8a8afd42d06204647fe9d4206"
+      }
+    }
+  },
   "java": {
     "install_flavor": "openjdk",
     "jdk_version": 7

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -2,6 +2,15 @@
   "cdap": {
     "version": "3.4.4-1"
   },
+  "nodejs": {
+    "install_method": "binary",
+    "version": "0.12.0",
+    "binary": {
+      "checksum": {
+        "linux_x64": "3bdb7267ca7ee24ac59c54ae146741f70a6ae3a8a8afd42d06204647fe9d4206"
+      }
+    }
+  },
   "java": {
     "install_flavor": "openjdk",
     "jdk_version": 7

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -20,10 +20,15 @@
 
 die() { echo $*; exit 1; }
 
+export GIT_MERGE_AUTOEDIT=no
+
 # Grab cookbooks using knife
-for cb in cdap hadoop idea maven nodejs openssh; do
+for cb in cdap hadoop idea maven openssh; do
   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
 done
+
+# need nodejs < 3.0.0 until CDAP UI nodeVersion is a version they provide *.xz downloads for
+knife cookbook site install nodejs 2.4.4 || die "Cannot fetch nodejs cookbook 2.4.4"
 
 # Do not change HOME for cdap user
 sed -i '/ home /d' /var/chef/cookbooks/cdap/recipes/sdk.rb


### PR DESCRIPTION
Conflicts:
- cdap-distributions/src/packer/scripts/cookbook-setup.sh

This is a cherry-pick from #8551 with the above conflict fixed by keeping the new code and adding the `export GIT_MERGE_AUTOEDIT=no`