### PR TITLE
Consolidate a property in the cdap-default.xml

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -242,6 +242,14 @@
   </property>
 
   <property>
+    <name>upgrade.thread.pool.size</name>
+    <value>10</value>
+    <description>
+      Number of threads to be used running operations concurrently during a CDAP upgrade
+    </description>
+  </property>
+
+  <property>
     <name>zookeeper.client.startup.timeout.millis</name>
     <value>60000</value>
     <description>
@@ -3054,17 +3062,6 @@
     <value>60000</value>
     <description>
       Read timeout in milliseconds for internal HTTP requests
-    </description>
-  </property>
-
-
-  <!-- Upgrade configuration -->
-
-  <property>
-    <name>upgrade.thread.pool.size</name>
-    <value>10</value>
-    <description>
-      Number of threads used to run operations concurrently during an upgrade
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="c28808754c4256b278c69122fcdcec34"
+DEFAULT_XML_MD5_HASH="67c7183c9007d60e2df46fc18398d970"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Removes an extra section not really required, and adjusts the description and MD5 hash.

Running as a Quick Build: https://builds.cask.co/browse/CDAP-DQB333-1 (passed)