### PR TITLE
Correct punctuation of messages.

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeletePreferencesDeprecatedCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeletePreferencesDeprecatedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -106,8 +106,8 @@ public class DeletePreferencesDeprecatedCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Deletes the preferences of %s (Deprecated as of CDAP 4.1.0. Use delete %s preferences <%s> " +
-                           "instead)", Fragment.of(Article.A, type.getName()), type.getShortName(),
+    return String.format("Deletes the preferences of %s. (Deprecated as of CDAP 4.1.0. Use delete %s preferences " +
+                           "<%s> instead.)", Fragment.of(Article.A, type.getName()), type.getShortName(),
                          type.getArgumentName());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetPreferencesDeprecatedCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetPreferencesDeprecatedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -43,7 +43,7 @@ public class GetPreferencesDeprecatedCommand extends AbstractGetPreferencesComma
 
   @Override
   public String getDescription() {
-    return String.format("Gets the preferences of %s (Deprecated as of CDAP 4.1.0. Use %s instead)",
+    return String.format("Gets the preferences of %s. (Deprecated as of CDAP 4.1.0. Use %s instead.)",
                          Fragment.of(Article.A, type.getName()), determinePattern());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetResolvedPreferencesDeprecatedCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetResolvedPreferencesDeprecatedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -43,7 +43,7 @@ public class GetResolvedPreferencesDeprecatedCommand extends AbstractGetPreferen
 
   @Override
   public String getDescription() {
-    return String.format("Gets the resolved preferences of %s (Deprecated as of CDAP 4.1.0. Use %s instead)",
+    return String.format("Gets the resolved preferences of %s. (Deprecated as of CDAP 4.1.0. Use %s instead.)",
                          Fragment.of(Article.A, type.getName()), determinePattern());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesDeprecatedCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesDeprecatedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -89,7 +89,7 @@ public class LoadPreferencesDeprecatedCommand extends AbstractSetPreferencesComm
 
   @Override
   public String getDescription() {
-    return String.format("Sets the preferences of %s from a local JSON config file (Deprecated as of CDAP 4.1.0. " +
-                           "Use %s instead)", Fragment.of(Article.A, type.getName()), determinePattern("load"));
+    return String.format("Sets the preferences of %s from a local JSON config file. (Deprecated as of CDAP 4.1.0. " +
+                           "Use %s instead.)", Fragment.of(Article.A, type.getName()), determinePattern("load"));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesDeprecatedCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesDeprecatedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -63,7 +63,7 @@ public class SetPreferencesDeprecatedCommand extends AbstractSetPreferencesComma
   @Override
   public String getDescription() {
     return String.format("Sets the preferences of %s. '<%s>' is specified in the format 'key1=v1 key2=v2'. " +
-                           "(Deprecated as of CDAP 4.1.0. Use %s instead)", Fragment.of(Article.A, type.getName()),
+                           "(Deprecated as of CDAP 4.1.0. Use %s instead.)", Fragment.of(Article.A, type.getName()),
                          ArgumentName.RUNTIME_ARGS, determinePattern("set"));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamDescriptionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamDescriptionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -58,6 +58,6 @@ public class SetStreamDescriptionCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Sets the description of %s.", Fragment.of(Article.A, ElementType.STREAM.getName()));
+    return String.format("Sets the description of %s", Fragment.of(Article.A, ElementType.STREAM.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
@@ -96,7 +96,7 @@ public class CreateAppCommand extends AbstractAuthCommand {
                            "containing the application config. For example, the file contents could contain: " +
                            "'{ \"config\": { \"stream\": \"purchases\" } }'. In this case, the application would " +
                            "receive '{ \"stream\": \"purchases\" }' as its config object. Finally, an optional " +
-                           "principal may be given",
+                           "principal may be given.",
       Fragment.of(Article.A, ElementType.APP.getName()), ApplicationId.DEFAULT_VERSION);
   }
 }


### PR DESCRIPTION
Fixes the punctuation of numerous messages in the CLI help.

Running as a Quick Build: https://builds.cask.co/browse/CDAP-DQB335-1 (passes)

Page of interest: https://builds.cask.co/artifact/CDAP-DQB335/shared/build-1/Docs-HTML/4.1.1-SNAPSHOT/en/reference-manual/cli-api.html