### PR TITLE
CDAP-9374 Add app version support for get/set runtime args api

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -491,7 +491,17 @@ public class CLIMainTest extends CLITestBase {
   public void testRuntimeArgs() throws Exception {
     String qualifiedServiceId = String.format("%s.%s", FakeApp.NAME, PrefixedEchoHandler.NAME);
     ServiceId service = NamespaceId.DEFAULT.app(FakeApp.NAME).service(PrefixedEchoHandler.NAME);
+    testServiceRuntimeArgs(qualifiedServiceId, service);
+  }
 
+  @Test
+  public void testVersionedRuntimeArgs() throws Exception {
+    String versionedServiceId = String.format("%s.%s version %s", FakeApp.NAME, PrefixedEchoHandler.NAME, V1_SNAPSHOT);
+    ServiceId service = FAKE_APP_ID_V_1.service(PrefixedEchoHandler.NAME);
+    testServiceRuntimeArgs(versionedServiceId, service);
+  }
+
+  public void testServiceRuntimeArgs(String qualifiedServiceId, ServiceId service) throws Exception {
     Map<String, String> runtimeArgs = ImmutableMap.of("sdf", "bacon");
     String runtimeArgsKV = Joiner.on(",").withKeyValueSeparator("=").join(runtimeArgs);
     testCommandOutputContains(cli, "start service " + qualifiedServiceId + " '" + runtimeArgsKV + "'",

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRuntimeArgsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRuntimeArgsCommand.java
@@ -55,8 +55,8 @@ public class GetProgramRuntimeArgsCommand extends AbstractAuthCommand {
 
   @Override
   public String getPattern() {
-    return String.format("get %s runtimeargs <%s>", elementType.getShortName(),
-                         elementType.getArgumentName());
+    return String.format("get %s runtimeargs <%s> [version <%s>]", elementType.getShortName(),
+                         elementType.getArgumentName(), ArgumentName.APP_VERSION);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
@@ -59,8 +59,8 @@ public class SetProgramRuntimeArgsCommand extends AbstractAuthCommand {
 
   @Override
   public String getPattern() {
-    return String.format("set %s runtimeargs <%s> <%s>", elementType.getShortName(),
-                         elementType.getArgumentName(), ArgumentName.RUNTIME_ARGS);
+    return String.format("set %s runtimeargs <%s> [version <%s>] <%s>", elementType.getShortName(),
+                         elementType.getArgumentName(), ArgumentName.APP_VERSION, ArgumentName.RUNTIME_ARGS);
   }
 
   @Override

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -966,8 +966,9 @@ public class ProgramClient {
   public Map<String, String> getRuntimeArgs(ProgramId program)
     throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
 
-    String path = String.format("apps/%s/%s/%s/runtimeargs",
-                                program.getApplication(), program.getType().getCategoryName(), program.getProgram());
+    String path = String.format("apps/%s/versions/%s/%s/%s/runtimeargs",
+                                program.getApplication(), program.getVersion(),
+                                program.getType().getCategoryName(), program.getProgram());
     URL url = config.resolveNamespacedURLV3(program.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -1006,8 +1007,9 @@ public class ProgramClient {
   public void setRuntimeArgs(ProgramId program, Map<String, String> runtimeArgs)
     throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
 
-    String path = String.format("apps/%s/%s/%s/runtimeargs",
-                                program.getApplication(), program.getType().getCategoryName(), program.getProgram());
+    String path = String.format("apps/%s/versions/%s/%s/%s/runtimeargs",
+                                program.getApplication(), program.getVersion(),
+                                program.getType().getCategoryName(), program.getProgram());
     URL url = config.resolveNamespacedURLV3(program.getNamespaceId(), path);
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(runtimeArgs)).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/ExceptedNumberOfAuditPolicyPaths.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/ExceptedNumberOfAuditPolicyPaths.java
@@ -21,5 +21,5 @@ package co.cask.cdap.gateway.router;
  * Expected number of paths annotated with {@link co.cask.cdap.common.security.AuditPolicy}
  */
 public final class ExceptedNumberOfAuditPolicyPaths {
-  public static final int EXPECTED_PATH_NUMBER = 94;
+  public static final int EXPECTED_PATH_NUMBER = 96;
 }


### PR DESCRIPTION
StartProgramCommand uses getRuntimeArgs API for report success to user. getRuntimeArgs did not have an implementation for app version causing this bug. Includes: 
- add REST endpoint 
- add CLI
- add test 