### PR TITLE
Fixes Dataprep - Pipeline communication via localStorage

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -30,7 +30,7 @@ import DropColumn from 'components/DataPrep/Directives/DropColumn';
 import FilterDirective from 'components/DataPrep/Directives/Filter';
 import FindAndReplaceDirective from 'components/DataPrep/Directives/FindAndReplace';
 import CopyColumnDirective from 'components/DataPrep/Directives/CopyColumn';
-
+import ee from 'event-emitter';
 require('./ColumnActionsDropdown.scss');
 
 export default class ColumnActionsDropdown extends Component {
@@ -74,10 +74,13 @@ export default class ColumnActionsDropdown extends Component {
         tag: ParseDirective
       }
     ];
+    this.eventEmitter = ee(ee);
+    this.eventEmitter.on('CLOSE_POPOVER', this.toggleDropdown.bind(this, false));
   }
 
   componentWillMount() {
     this.dropdownId = shortid.generate();
+    this.eventEmitter.off('CLOSE_POPOVER', this.toggleDropdown.bind(this, false));
   }
 
   componentWillUnmount() {
@@ -87,8 +90,8 @@ export default class ColumnActionsDropdown extends Component {
     Mousetrap.unbind('esc');
   }
 
-  toggleDropdown() {
-    let newState = !this.state.dropdownOpen;
+  toggleDropdown(toggleState) {
+    let newState = typeof toggleState === 'boolean' ? toggleState : !this.state.dropdownOpen;
 
     this.setState({
       dropdownOpen: newState,
@@ -109,7 +112,9 @@ export default class ColumnActionsDropdown extends Component {
 
       Mousetrap.bind('esc', this.toggleDropdown);
     } else {
-      this.documentClick$.dispose();
+      if (this.documentClick$) {
+        this.documentClick$.dispose();
+      }
       Mousetrap.unbind('esc');
     }
   }
@@ -155,7 +160,7 @@ export default class ColumnActionsDropdown extends Component {
                   >
                     <Tag
                       column={this.props.column}
-                      onComplete={this.toggleDropdown}
+                      onComplete={this.toggleDropdown.bind(this, false)}
                       isOpen={this.state.open === directive.id}
                       close={this.directiveClick.bind(this, null)}
                     />

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/index.js
@@ -38,6 +38,7 @@ export default class DataPrepTable extends Component {
 
     this.eventEmitter = ee(ee);
     this.openUploadData = this.openUploadData.bind(this);
+    this.openCreateWorkspaceModal = this.openCreateWorkspaceModal.bind(this);
 
     this.sub = DataPrepStore.subscribe(() => {
       let state = DataPrepStore.getState().dataprep;
@@ -53,6 +54,10 @@ export default class DataPrepTable extends Component {
 
   componentWillUnmount() {
     this.sub();
+  }
+
+  openCreateWorkspaceModal() {
+    this.eventEmitter.emit('DATAPREP_CREATE_WORKSPACE');
   }
 
   openUploadData() {
@@ -72,6 +77,24 @@ export default class DataPrepTable extends Component {
 
     let headers = this.state.headers;
     let data = this.state.data;
+
+    if (!this.state.workspaceId) {
+      return (
+        <div className="dataprep-table empty">
+          <div>
+            <h5 className="text-xs-center">Please create a workspace to wrangle data</h5>
+            <div className="button-container text-xs-center">
+              <button
+                className="btn btn-primary"
+                onClick={this.openCreateWorkspaceModal}
+              >
+                Create
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
 
     if (data.length === 0 || headers.length === 0) {
       return (

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
@@ -51,7 +51,10 @@ export default class AddToHydratorModal extends Component {
       loading: true,
       batchUrl: null,
       realtimeUrl: null,
-      error: null
+      error: null,
+      workspaceId: null,
+      realtimeConfig: null,
+      batchConfig: null
     };
   }
 
@@ -143,7 +146,10 @@ export default class AddToHydratorModal extends Component {
         };
 
         let properties = {
-          workspaceId
+          workspaceId,
+          directives: directives.join('\n'),
+          schema: JSON.stringify(tempSchema),
+          field: '*'
         };
 
         try {
@@ -182,7 +188,8 @@ export default class AddToHydratorModal extends Component {
           stateName: 'hydrator.create',
           stateParams: {
             namespace,
-            configParams: realtimeConfig
+            workspaceId,
+            artifactType: realtimeArtifact.name
           }
         });
 
@@ -190,14 +197,18 @@ export default class AddToHydratorModal extends Component {
           stateName: 'hydrator.create',
           stateParams: {
             namespace,
-            configParams: batchConfig
+            workspaceId,
+            artifactType: batchArtifact.name
           }
         });
 
         this.setState({
           loading: false,
           realtimeUrl,
-          batchUrl
+          batchUrl,
+          workspaceId,
+          realtimeConfig,
+          batchConfig
         });
 
       }, (err) => {
@@ -245,6 +256,9 @@ export default class AddToHydratorModal extends Component {
             <a
               href={this.state.batchUrl}
               className="btn btn-secondary"
+              onClick={(() => {
+                window.localStorage.setItem(this.state.workspaceId, JSON.stringify(this.state.batchConfig));
+              }).bind(this)}
             >
               <i className="fa icon-ETLBatch"/>
               <span>Batch Pipeline</span>
@@ -252,6 +266,9 @@ export default class AddToHydratorModal extends Component {
             <a
               href={this.state.realtimeUrl}
               className="btn btn-secondary"
+              onClick={(() => {
+                window.localStorage.setItem(this.state.workspaceId, JSON.stringify(this.state.realtimeConfig));
+              }).bind(this)}
             >
               <i className="fa icon-sparkstreaming"/>
               <span>Realtime Pipeline</span>

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceTabs/WorkspaceModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceTabs/WorkspaceModal.js
@@ -225,6 +225,10 @@ export default class WorkspaceModal extends Component {
   }
 
   attemptModalClose() {
+    if (this.props.singleWorkspaceMode) {
+      this.props.toggle();
+      return;
+    }
     if (!this.state.activeWorkspace || this.props.isEmpty) { return; }
 
     this.props.toggle();
@@ -287,5 +291,6 @@ export default class WorkspaceModal extends Component {
 WorkspaceModal.propTypes = {
   toggle: PropTypes.func.isRequired,
   onCreate: PropTypes.func,
-  isEmpty: PropTypes.bool
+  isEmpty: PropTypes.bool,
+  singleWorkspaceMode: PropTypes.bool
 };

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceTabs/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceTabs/index.js
@@ -51,7 +51,7 @@ export default class WorkspaceTabs extends Component {
     this.eventEmitter = ee(ee);
 
     this.eventEmitter.on('DATAPREP_OPEN_UPLOAD', this.toggleWorkspacePropertiesModal);
-
+    this.eventEmitter.on('DATAPREP_CREATE_WORKSPACE', this.toggleCreateWorkspace);
     this.sub = DataPrepStore.subscribe(() => {
       this.setState({
         activeWorkspace: DataPrepStore.getState().dataprep.workspaceId
@@ -69,6 +69,7 @@ export default class WorkspaceTabs extends Component {
     }
 
     this.eventEmitter.off('DATAPREP_OPEN_UPLOAD', this.toggleWorkspacePropertiesModal);
+    this.eventEmitter.off('DATAPREP_CREATE_WORKSPACE', this.toggleCreateWorkspace);
   }
 
   getWorkspaceList() {
@@ -142,6 +143,7 @@ export default class WorkspaceTabs extends Component {
       <WorkspaceModal
         toggle={this.toggleCreateWorkspace}
         onCreate={this.getWorkspaceList}
+        singleWorkspaceMode={this.props.singleWorkspaceMode}
         isEmpty={this.state.workspaceList.length === 0}
       />
     );

--- a/cdap-ui/app/cdap/components/DataPrep/store/DataPrepActionCreator.js
+++ b/cdap-ui/app/cdap/components/DataPrep/store/DataPrepActionCreator.js
@@ -21,8 +21,11 @@ import NamespaceStore from 'services/NamespaceStore';
 import Rx from 'rx';
 import {directiveRequestBodyCreator} from 'components/DataPrep/helper';
 import {objectQuery} from 'services/helpers';
+import ee from 'event-emitter';
 
 export function execute(addDirective, shouldReset) {
+  let eventEmitter = ee(ee);
+  eventEmitter.emit('CLOSE_POPOVER');
   DataPrepStore.dispatch({
     type: DataPrepActions.enableLoading
   });

--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/widget-wrangler-directives.js
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/widget-wrangler-directives.js
@@ -23,39 +23,9 @@
         properties: '='
       },
       templateUrl: 'widget-container/widget-wrangler-directives/widget-wrangler-directives.html',
-      controller: function($scope, myHelpers, $stateParams, myDataprepApi, EventPipe, $uibModal) {
+      controller: function($scope, myHelpers, $uibModal) {
         $scope.rows = myHelpers.objectQuery($scope, 'config', 'widget-attributes', 'rows');
         $scope.placeholder = myHelpers.objectQuery($scope, 'config', 'widget-attributes', 'rows') || '';
-        $scope.fetchWorkspaceDetails = function() {
-          if ($scope.properties.workspaceId) {
-            let workspaceId =  $scope.properties.workspaceId;
-            let requestObj = {
-              namespace: $stateParams.namespace,
-              workspaceId: $scope.properties.workspaceId
-            };
-            myDataprepApi.getWorkspace(requestObj)
-              .$promise
-              .then(res => {
-                let directives = myHelpers.objectQuery(res, 'values', 0, 'recipe', 'directives');
-                $scope.model = directives.join('\n');
-                let requestBody = window.CaskCommon.DataPrepHelper.directiveRequestBodyCreator(directives, workspaceId);
-
-                myDataprepApi
-                  .getSchema(requestObj, requestBody)
-                  .$promise
-                  .then(fields => {
-                    let schemaValue = {
-                      name: 'avroSchema',
-                      type: 'record',
-                      fields
-                    };
-                    EventPipe.emit('schema.import', JSON.stringify(schemaValue));
-                  });
-              });
-          }
-        };
-        EventPipe.on('wrangler.updateworkspace', $scope.fetchWorkspaceDetails);
-        $scope.fetchWorkspaceDetails();
 
         $scope.openWranglerModal = function() {
           $uibModal.open({

--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal-ctrl.js
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal-ctrl.js
@@ -22,6 +22,12 @@ class WranglerModalController {
     this.EventPipe = EventPipe;
     this.onSubmit = this.onSubmit.bind(this);
     this.modalClosed = false;
+    $scope.$on('modal.closing', (e, reason) => {
+      if (reason === 'ADD_TO_PIPELINE') { return; }
+
+      let shouldClose = confirm('Are you sure you want to exit Wrangler?');
+      if (!shouldClose) { e.preventDefault(); }
+    });
   }
 
   onSubmit ({workspaceId, directives, schema}) {
@@ -30,7 +36,6 @@ class WranglerModalController {
     }
     if (!directives || !schema) {
       this.node.properties.workspaceId = workspaceId;
-      this.EventPipe.emit('wrangler.updateworkspace');
       this.$uibModalInstance.close('ADD_TO_PIPELINE');
       this.modalClosed = true;
       return;

--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
@@ -76,21 +76,16 @@ body.state-hydrator-create.state-hydrator {
     }
   }
   dataprep .dataprep-container {
+    .dataprep-loading {
+      z-index: 1063;
+    }
     .top-panel {
       .left-title {
-        width: ~"calc(100% - 210px)";
+        width: auto;
         margin-top: 5px;
         .workspace-tab {
           padding: 0 10px;
           cursor: pointer;
-
-          span:not(.fa) {
-            max-width: ~"calc(100% - 20px)";
-            display: inline-block;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            vertical-align: top;
-          }
           .fa.fa-pencil {
             margin-left: 5px;
           }

--- a/cdap-ui/app/hydrator/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/create-studio-ctrl.js
@@ -41,7 +41,7 @@ class HydratorPlusPlusStudioCtrl {
     };
     let artifact = getValidArtifact();
     if (rConfig) {
-      if (!rConfig.artifact){
+      if (!rConfig.artifact) {
         rConfig.artifact = artifact;
       }
       HydratorPlusPlusConfigActions.initializeConfigStore(rConfig);
@@ -67,7 +67,7 @@ class HydratorPlusPlusStudioCtrl {
       HydratorPlusPlusConfigActions.initializeConfigStore(config);
     }
 
-    function customConfirm(message){
+    function customConfirm(message) {
       var start = Date.now();
       var result = confirm(message);
       var timeDifference = Date.now() - start;
@@ -82,12 +82,12 @@ class HydratorPlusPlusStudioCtrl {
 
          The reasoning behind this is the user has selected 'Prevent this page from showing any additional dialogs' while clicking OK in the popup and so any dirty state checks are inherently skipped based on that choice.
       */
-      for(var i=0; i < 10 && !result && timeDifference < 50; i++){
+      for (var i=0; i < 10 && !result && timeDifference < 50; i++) {
         start = Date.now();
         result = confirm(message);
         timeDifference = Date.now() - start;
       }
-      if(timeDifference < 50) {
+      if (timeDifference < 50) {
         return true;
       }
       return result;

--- a/cdap-ui/app/hydrator/routes.js
+++ b/cdap-ui/app/hydrator/routes.js
@@ -49,7 +49,7 @@ angular.module(PKG.name + '.feature.hydrator')
         }
       })
         .state('hydrator.create', {
-          url: '/studio?artifactType&draftId&configParams',
+          url: '/studio?artifactType&draftId&workspaceId',
           onEnter: function() {
             document.title = 'CDAP | Studio';
           },
@@ -62,7 +62,7 @@ angular.module(PKG.name + '.feature.hydrator')
             highlightTab: 'hydratorStudioPlusPlus'
           },
           resolve: {
-            rConfig: function($stateParams, mySettings, $q, myHelpers) {
+            rConfig: function($stateParams, mySettings, $q, myHelpers, $window) {
               var defer = $q.defer();
               if ($stateParams.draftId) {
                 mySettings.get('hydratorDrafts', true)
@@ -74,16 +74,17 @@ angular.module(PKG.name + '.feature.hydrator')
                       defer.resolve(false);
                     }
                   });
-              } else if ($stateParams.data){
+              } else if ($stateParams.data) {
                 defer.resolve($stateParams.data);
-              } else if ($stateParams.configParams) {
+              } else if ($stateParams.workspaceId) {
                 try {
-                  var config = JSON.parse($stateParams.configParams);
-
+                  let configParams = $window.localStorage.getItem($stateParams.workspaceId);
+                  var config = JSON.parse(configParams);
                   defer.resolve(config);
                 } catch (e) {
                   defer.resolve(false);
                 }
+                $window.localStorage.removeItem($stateParams.workspaceId);
               }
               else {
                 defer.resolve(false);
@@ -129,7 +130,7 @@ angular.module(PKG.name + '.feature.hydrator')
                 };
 
                 let chooseDefaultArtifact = () => {
-                  if(!isArtifactValid(artifactsFromBackend, GLOBALS.etlDataPipeline)) {
+                  if (!isArtifactValid(artifactsFromBackend, GLOBALS.etlDataPipeline)) {
                     if (!isAnyUISupportedArtifactPresent(artifactsFromBackend).length) {
                       return showWarningAndNavigateAway();
                     } else {
@@ -142,11 +143,11 @@ angular.module(PKG.name + '.feature.hydrator')
                   }
                 };
 
-                if(!artifactsFromBackend.length) {
+                if (!artifactsFromBackend.length) {
                   return showWarningAndNavigateAway();
                 }
 
-                if(!isArtifactValid(artifactsFromBackend, $stateParams.artifactType)) {
+                if (!isArtifactValid(artifactsFromBackend, $stateParams.artifactType)) {
                   chooseDefaultArtifact();
                 } else {
                   defer.resolve($stateParams.artifactType);
@@ -236,7 +237,7 @@ angular.module(PKG.name + '.feature.hydrator')
                     let config = pipelineDetail.configuration;
                     try {
                       config = JSON.parse(config);
-                    } catch(e) {
+                    } catch (e) {
                       myAlertOnValium.show({
                         type: 'danger',
                         content: 'Invalid configuration JSON.'
@@ -247,7 +248,7 @@ angular.module(PKG.name + '.feature.hydrator')
                       $state.go('hydrator.list');
                       return;
                     }
-                    if(!config.stages) {
+                    if (!config.stages) {
                       myAlertOnValium.show({
                         type: 'danger',
                         content: 'Pipeline is created using older version of hydrator. Please upgrage the pipeline to newer version(3.4) to view in UI.'

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
@@ -61,7 +61,7 @@
             {{::HydratorPlusPlusNodeConfigCtrl.tabs[0].label}}
           </li>
           <li role="presentation"
-              ng-click="!HydratorPlusPlusNodeConfigCtrl.state.isAction && HydratorPlusPlusNodeConfigCtrl.activeTab = 2"
+              ng-click="!HydratorPlusPlusNodeConfigCtrl.state.isAction ? HydratorPlusPlusNodeConfigCtrl.activeTab = 2 : null"
               ng-class="{active: HydratorPlusPlusNodeConfigCtrl.activeTab === 2, disabled: HydratorPlusPlusNodeConfigCtrl.state.isAction}"
               ng-if="HydratorPlusPlusNodeConfigCtrl.isPreviewMode"
               uib-tooltip="Preview data is not supported for action plugins"


### PR DESCRIPTION
#### Goal:
 - Detach DataPrep and Wrangler transform in pipeline studio from each other and have the data flow one way from data prep to pipeline (rather than pulling data from pipeline directly).
 - ***Experienced user*** : Avoid querying data prep service from hydrator studio. This provides the ability for the user to edit directive in pipeline studio without being affected by changes in the Dataprep.
 - ***Beginner User***: In addition to the above point we also provide a wrangle button to allow the user to sync if he/she wants to use the data prep
