### PR TITLE
Restore xserver-xorg preseed configuration for VM

### DIFF
--- a/cdap-distributions/src/packer/files/preseed.cfg
+++ b/cdap-distributions/src/packer/files/preseed.cfg
@@ -70,6 +70,9 @@ d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean false
 d-i finish-install/keep-consoles boolean true
 d-i finish-install/reboot_in_progress note
+xserver-xorg xserver-xorg/autodetect_monitor boolean true
+xserver-xorg xserver-xorg/config/monitor/selection-method select medium
+xserver-xorg xserver-xorg/config/monitor/mode-list select 1024x768 @ 60 Hz
 
 # Hack-fu to get passwordless sudo
 d-i preseed/late_command string \


### PR DESCRIPTION
This restores the preseed configuration for xserver-xorg which was accidentally removed with caskdata/cdap#8355