### PR TITLE
Remove c3p0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1027,11 +1027,23 @@
         <groupId>org.quartz-scheduler</groupId>
         <artifactId>quartz</artifactId>
         <version>${quartz.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>c3p0</groupId>
+            <artifactId>c3p0</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.quartz-scheduler</groupId>
         <artifactId>quartz-jobs</artifactId>
         <version>${quartz.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>c3p0</groupId>
+            <artifactId>c3p0</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.ning</groupId>


### PR DESCRIPTION
c3p0 is used for JDBC connections from quartz, CDAP doesn't use this functionality and this jar brings in a lgpl dependency. So adding an exclude

Tested that we can still run schedules and this is not packaged during the build