### PR TITLE
Reverts changes related to handling multiple popover open fix.

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -99,10 +99,10 @@ export default class ColumnActionsDropdown extends Component {
     });
 
     if (newState) {
-
-      this.documentClick$ = Rx.Observable.fromEvent(document.body, 'click')
+      let element = document.getElementById('app-container');
+      this.documentClick$ = Rx.Observable.fromEvent(element, 'click')
         .subscribe((e) => {
-          if (isDescendant(this.popover, e.target) || this.menuCaretSpanRef === e.target) {
+          if (isDescendant(this.popover, e.target) || !this.state.dropdownOpen) {
             return;
           }
 
@@ -145,10 +145,6 @@ export default class ColumnActionsDropdown extends Component {
         target={`dataprep-action-${this.dropdownId}`}
         className="dataprep-columns-action-dropdown"
         tether={tetherOption}
-        tetherRef={(ref) => {
-          if (!ref) {return;}
-          this.popover = ref.element;
-        }}
       >
         <PopoverContent>
           <div>
@@ -181,12 +177,12 @@ export default class ColumnActionsDropdown extends Component {
     return (
       <span
         className="column-actions-dropdown-container"
+        ref={(ref) => this.popover = ref}
       >
         <span
           className={classnames('fa fa-caret-down', {
             'expanded': this.state.dropdownOpen
           })}
-          ref={(ref) => this.menuCaretSpanRef = ref}
           onClick={this.toggleDropdown}
           id={`dataprep-action-${this.dropdownId}`}
         />


### PR DESCRIPTION
### Cause:
- Tried to fix the problem of avoiding multiple popovers opened at a time
- The solution was to listen to `document.body` click and close if the click target is not a descendant of the menu popover.
- The above solution was working until the user had to open a modal and type into it something.
- Clicking on, say input box, caused a click on `document.body` & since the click target is not a descendant of menu popover, we closed the popover menu which closed the modal.

### Fix:
- Revert back the document.body click change. This will cause multiple popovers to be opened in dataprep modal for now. 
- We need to take a step back and move out the directive modals out of the menu popover and make it independent. This way we can avoid having issues with closing popover (which shouldn't close the modal).

