### PR TITLE
Add trailing slash

### DIFF
--- a/cdap-distributions/bin/build_docs_bucket.sh
+++ b/cdap-distributions/bin/build_docs_bucket.sh
@@ -86,7 +86,7 @@ function get_repo_version() {
 }
 
 function sync_from_s3() {
-  s3cmd sync s3://${S3_BUCKET}/${S3_REPO_PATH}/${__repo_version}/ ${TARGET_DIR}
+  s3cmd sync s3://${S3_BUCKET}/${S3_REPO_PATH}/${__repo_version}/ ${TARGET_DIR}/
 }
 
 function robots_tags() {


### PR DESCRIPTION
The trailing slash is missing and older versions of s3cmd require it when syncing multiple items.