### PR TITLE
Multiple VM updates and bugfixes

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -15,7 +15,7 @@
       "shutdown_command": "sudo shutdown -P now",
       "format": "ova",
       "headless": true,
-      "guest_additions_mode": "upload",
+      "guest_additions_mode": "disable",
       "http_directory": "files",
       "boot_command": [
         "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
@@ -47,6 +47,7 @@
         ["modifyvm", "{{ .Name }}", "--memory", "4096"]
       ],
       "vboxmanage_post": [
+        ["modifyhd", "output-cdap-sdk-vm/{{ .Name }}.vdi", "--compact"],
         ["modifyvm", "{{ .Name }}", "--clipboard", "bidirectional"],
         ["modifyvm", "{{ .Name }}", "--accelerate2dvideo", "on"],
         ["modifyvm", "{{ .Name }}", "--accelerate3d", "on"],
@@ -170,8 +171,7 @@
         "scripts/xorg.sh",
         "scripts/slim.sh",
         "scripts/fill-maven-cache.sh",
-        "scripts/lxde.sh",
-        "scripts/vbox-guest-additions.sh"
+        "scripts/lxde.sh"
       ],
       "only": ["cdap-sdk-vm"]
     },

--- a/cdap-distributions/src/packer/scripts/apt-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/apt-cleanup.sh
@@ -19,7 +19,7 @@
 #
 
 # Remove old kernels/headers
-apt-get remove --purge -y $(dpkg -l 'linux-image-*' | sed '/^ii/!d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d' | sort | tail -n +2)
+apt-get remove --purge -y $(dpkg -l 'linux-image-*' | grep -v linux-image-extra | grep -v linux-image-generic | sed '/^ii/!d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d' | sort | tail -n +2)
 apt-get remove --purge -y $(dpkg -l 'linux-headers-*' | sed '/^ii/!d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d' | sort | tail -n +2)
 
 # Remove build packages

--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@
 #
 
 # Install
-apt-get install -y lxde
+apt-get install -y --no-install-recommends lxde lxsession-logout chromium-browser openbox-gnome-session policykit-1 || exit 1
 
 # Symlink idea
 ln -sf /opt/idea* /opt/idea || (echo "Unable to symlink IDEA" && exit 1)

--- a/cdap-distributions/src/packer/scripts/xorg.sh
+++ b/cdap-distributions/src/packer/scripts/xorg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,8 @@
 #
 
 # Install xorg
-apt-get install -y xorg
+apt-get install -y --no-install-recommends xorg
+apt-get install -y --no-install-recommends linux-source xscreensaver xserver-xorg-video-vesa virtualbox-guest-dkms
 
 # Remove X11 video drivers
 for i in ati cirrus fbdev intel mach64 mga neomagic nouveau openchrome qxl r128 radeon s3 savage siliconmotion sis sisusb tdfx trident ; do 
@@ -30,5 +31,8 @@ done
 for i in mouse synaptics wacom ; do
   apt-get purge -y xserver-xorg-input-$i
 done
+
+# Remove linux-source
+apt-get purge -y linux-source
 
 exit 0


### PR DESCRIPTION
- Disable installing local version of VirtualBox Guest Additions
- Compact disk after zeroing it
- Update kernel image removal to skip aliases for current kernel
- Add select LXDE recommends packages by name
- Install VESA Xorg video driver for compatibility
- Install Ubuntu-provided VirtualBox Guest DMKS driver

Conflicts: (kept new code)
- cdap-distributions/src/packer/scripts/lxde.sh
- cdap-distributions/src/packer/scripts/xorg.sh