### PR TITLE
Fix sync previous version from S3 to local

### DIFF
--- a/cdap-distributions/bin/build_docs_bucket.sh
+++ b/cdap-distributions/bin/build_docs_bucket.sh
@@ -86,7 +86,7 @@ function get_repo_version() {
 }
 
 function sync_from_s3() {
-  s3cmd sync s3://${S3_BUCKET}/${S3_REPO_PATH}/${__repo_version}/ ${TARGET_DIR}/
+  s3cmd sync s3://${S3_BUCKET}/${S3_REPO_PATH}/${__repo_version}/ ${TARGET_DIR}/${__repo_version}/
 }
 
 function robots_tags() {


### PR DESCRIPTION
We need to specify the version when we sync it locally, otherwise it'll sync the contents of the S3 version directly into TARGET_DIR, and we need it versioned.