### PR TITLE
Use --no-preserve so we exit cleanly

### DIFF
--- a/cdap-distributions/bin/build_docs_bucket.sh
+++ b/cdap-distributions/bin/build_docs_bucket.sh
@@ -86,7 +86,7 @@ function get_repo_version() {
 }
 
 function sync_from_s3() {
-  s3cmd sync s3://${S3_BUCKET}/${S3_REPO_PATH}/${__repo_version}/ ${TARGET_DIR}/${__repo_version}/
+  s3cmd sync --no-preserve s3://${S3_BUCKET}/${S3_REPO_PATH}/${__repo_version}/ ${TARGET_DIR}/${__repo_version}/
 }
 
 function robots_tags() {


### PR DESCRIPTION
Otherwise, s3cmd will attempt to change the extended attributes of the files on sync and this will fail as a non-root user, and though it's not fatal to s3cmd or the sync, it causes a non-zero exit code, which will fail our script.