### PR TITLE
Fix sorting for determining current docs version

### DIFF
--- a/cdap-distributions/bin/docs_bucket_current_develop.sh
+++ b/cdap-distributions/bin/docs_bucket_current_develop.sh
@@ -19,7 +19,7 @@ S3_BUCKET=${S3_BUCKET:-docs.cask.co}
 
 # Get Docs versions
 echo "Getting Docs version from local directory: ${LOCAL_DIR}"
-__local=${VERSION:-$(ls -1F ${LOCAL_DIR}/ | grep '/$' | head -n 1 | sed -e 's:/$::')}
+__local=${VERSION:-$(ls -1F ${LOCAL_DIR}/ | sort -rn | grep '/$' | tail -n 1 | sed -e 's:/$::')}
 echo "Getting Docs versions from remote: ${S3_BUCKET}/${LOCAL_DIR}"
 __current=$(curl -sL http://s3.amazonaws.com/${S3_BUCKET}/${LOCAL_DIR}/version)
 __develop=$(curl -sL http://s3.amazonaws.com/${S3_BUCKET}/${LOCAL_DIR}/development)


### PR DESCRIPTION
Adding a sort to fix the version checking.

Broken:
```
$ ls -1 cdap/
4.1.0
4.1.1
$ ls -1F cdap/ | grep '/$' | head -n 1 | sed -e 's:/$::'
4.1.0
```

Fixed:
```
$ ls -1F cdap/ | grep '/$' | sort -rn | head -n 1 | sed -e 's:/$::'
4.1.1
```