### PR TITLE
[HYDRATOR-1488] Fixes multiple popovers in DataPrep (Wrangler) modal in Pipeline studio

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -21,6 +21,7 @@ import Rx from 'rx';
 import shortid from 'shortid';
 import classnames from 'classnames';
 import Mousetrap from 'mousetrap';
+import DataPrepStore from 'components/DataPrep/store';
 
 // Directives List
 import SplitColumn from 'components/DataPrep/Directives/SplitColumn';
@@ -81,6 +82,7 @@ export default class ColumnActionsDropdown extends Component {
   componentWillMount() {
     this.dropdownId = shortid.generate();
     this.eventEmitter.off('CLOSE_POPOVER', this.toggleDropdown.bind(this, false));
+    this.singleWorkspaceMode = DataPrepStore.getState().dataprep.singleWorkspaceMode;
   }
 
   componentWillUnmount() {
@@ -100,6 +102,9 @@ export default class ColumnActionsDropdown extends Component {
 
     if (newState) {
       let element = document.getElementById('app-container');
+      if (this.singleWorkspaceMode) {
+        element = document.getElementsByClassName('wrangler-modal')[0];
+      }
       this.documentClick$ = Rx.Observable.fromEvent(element, 'click')
         .subscribe((e) => {
           if (isDescendant(this.popover, e.target) || !this.state.dropdownOpen) {

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -98,6 +98,15 @@ export default class DataPrep extends Component {
             }
           });
         }
+
+        if (this.props.singleWorkspaceMode) {
+          DataPrepStore.dispatch({
+            type: DataPrepActions.setWorkspaceMode,
+            payload: {
+              singleWorkspaceMode: true
+            }
+          });
+        }
       });
       this.setCurrentWorkspace(workspaceId);
   }

--- a/cdap-ui/app/cdap/components/DataPrep/store/DataPrepActions.js
+++ b/cdap-ui/app/cdap/components/DataPrep/store/DataPrepActions.js
@@ -20,6 +20,7 @@ const DataPrepActions = {
   setWorkspace: 'DATAPREP_SET_WORKSPACE',
   setInitialized: 'DATAPREP_SET_INITIALIZED',
   setHigherVersion: 'DATAPREP_SET_HIGHER_VERSION',
+  setWorkspaceMode: 'DATAPREP_SET_WORKSPACE_MODE',
   enableLoading: 'DATAPREP_ENABLE_LOADING',
   disableLoading: 'DATAPREP_DISABLE_LOADING',
   reset: 'DATAPREP_RESET',

--- a/cdap-ui/app/cdap/components/DataPrep/store/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/store/index.js
@@ -29,7 +29,8 @@ const defaultInitialState = {
   headers: [],
   directives: [],
   higherVersion: null,
-  loading: false
+  loading: false,
+  singleWorkspaceMode: false
 };
 
 const errorInitialState = {
@@ -72,6 +73,11 @@ const dataprep = (state = defaultInitialState, action = defaultAction) => {
     case DataPrepActions.setHigherVersion:
       stateCopy = Object.assign({}, state, {
         higherVersion: action.payload.higherVersion
+      });
+      break;
+    case DataPrepActions.setWorkspaceMode:
+      stateCopy = Object.assign({}, state, {
+        singleWorkspaceMode: action.payload.singleWorkspaceMode
       });
       break;
     case DataPrepActions.enableLoading:


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/HYDRATOR-1488

### Cause:
- In `ColumnActionsDropdown` component, we were listening to clicks on the element with id `app-container`, and if the click target is not a child of the popover, then we close it.
- However, the dataprep modal that opens up in Hydrator doesn't have the `app-container` element as the container, so the behavior described above is ignored.

### Fix:
- We know `DataPrep` component is used in Hydrator when the `single-workspace-mode` property is set to `true` for the `dataprep` directive. So when this property is true, then we add the click listener to the element with the class `wrangler-modal` instead, which is the right container element.
- To avoid unnecessarily passing too many props, I have added the property to the DataPrep store state. 