### PR TITLE
CDAP-9427 Develop and Current versions of the sitemap.xml

### DIFF
--- a/cdap-docs/tools/sitemap-xml.py
+++ b/cdap-docs/tools/sitemap-xml.py
@@ -19,7 +19,7 @@
 #
 # Generates a sitemap XML file for a web server.
 #
-# version 0.1
+# version 0.2
 
 from optparse import OptionParser
 
@@ -49,7 +49,7 @@ DEFAULT_INPUT_DIRECTORY = os.path.abspath(os.path.join(SCRIPT_DIR_PATH, "../targ
 DEFAULT_OUTPUT_SITEMAP_XML_FILE = os.path.abspath(os.path.join(DEFAULT_INPUT_DIRECTORY, 'sitemap.xml'))
 
 SITEMAP_XML_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> 
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 %s</urlset>
 """
 
@@ -61,13 +61,13 @@ SITEMAP_URL_TEMPLATE = """<url>
 def parse_options():
     """ Parses args options.
     """
-    
+
     description = """Reads either the default documentation directory
 (%(default_input)s) or a specified directory, walks the directory, generates a
-site-map.xml file, uses the CDAP version of either the default (%(default_version)s) or a
+sitemap.xml file, uses the CDAP version of either the default (%(default_version)s) or a
 specified version, and writes it to either the default (%(default_output)s) or a specified
-output.
-""" % {'default_input': DEFAULT_INPUT_DIRECTORY, 
+output. Also writes a 'current.xml' and 'develop.xml' version of the sitemap.xml.
+""" % {'default_input': DEFAULT_INPUT_DIRECTORY,
        'default_version': DEFAULT_CDAP_VERSION,
        'default_output': DEFAULT_OUTPUT_SITEMAP_XML_FILE,
        }
@@ -100,7 +100,7 @@ output.
     (options, args) = parser.parse_args()
 
     return options, args, parser
-    
+
 def build_sitemap(input):
     sitemap = []
     print "Using input directory: %s" % input
@@ -120,13 +120,13 @@ def write_sitemap(sitemap, output, version):
     if not os.path.dirname(output):
         print "Output file parent directory does not exist: %s" % output
         return 1
-    
+
     sitemap_urls = ''
     for path in sitemap:
         sitemap_urls += SITEMAP_URL_TEMPLATE % ("http://docs.cask.co/cdap/%s%s" % (version, path))
-    
+
     sitemap_xml = SITEMAP_XML_TEMPLATE % sitemap_urls
-    
+
     f = open(output, 'w')
     f.write(sitemap_xml)
     f.close()
@@ -140,18 +140,21 @@ def main():
     """ Main program entry point.
     """
     options, args, parser = parse_options()
-    
+
     if args:
         parser.print_help()
         sys.exit(1)
-        
+
     sitemap = build_sitemap(options.input)
-    
+
     if sitemap:
         return_code = write_sitemap(sitemap, options.output, options.version)
+        for v in ('current', 'develop'):
+            if not return_code:
+                return_code = write_sitemap(sitemap, "%s.%s.xml" % (options.output, v), v)
     else:
         return_code = 1
-        
+
     return return_code
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a 'current' and a 'develop' version of the sitemap.xml file.

In order to get correct indexes for the searching, we supply sitemap.xml files. However, we need a version for the `develop` and `current` directories; the simplest way is to create them at the time the builds are done (the files are tiny) and then simply rename them as required.

Aside from bumping the version of the tool that does this, this PR removes whitespace, and then adds three lines where it creates the two additional sitemap.xml files.

Fix for https://issues.cask.co/browse/CDAP-9427