### PR TITLE
Add Sphinx Error Handling

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -187,7 +187,7 @@ function add_html_redirect() {
 </html>
 EOF
 )
-  echo_set_message "Adding redirect"
+  echo "Adding redirect"
   echo ${redirect_text} >> ${TARGET}/redirect.html
 }
 
@@ -501,7 +501,7 @@ function consolidate_messages() {
   if [[ -z ${TMP_MESSAGES_FILE} ]]; then
     return
   fi
-  local m="Warning Messages for \"${MANUAL}\":"
+  local m="Messages for \"${MANUAL}\":"
   local l="--------------------------------------------------------"
   if [[ -n ${MESSAGES} ]]; then
     echo_red_bold "Consolidating messages"
@@ -531,7 +531,7 @@ function display_messages() {
   if [[ -n ${TMP_MESSAGES_FILE} && -s ${TMP_MESSAGES_FILE} ]]; then
     echo
     echo "--------------------------------------------------------"
-    echo_red_bold "Warning Messages: $(basename ${TMP_MESSAGES_FILE})"
+    echo_red_bold "Messages: $(basename ${TMP_MESSAGES_FILE})"
     echo "--------------------------------------------------------"
     echo
     cat ${TMP_MESSAGES_FILE} | while read line
@@ -540,7 +540,7 @@ function display_messages() {
     done
     echo
     echo "--------------------------------------------------------"
-    echo_red_bold "End Warning Messages"
+    echo_red_bold "End Messages"
     echo "--------------------------------------------------------"
     echo
     warnings=1 # Indicates warning messages present

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -116,6 +116,7 @@ function clean() {
 }
 
 function build_docs() {
+  local errors=0
   local google_tag
   if [[ -n ${1} ]] ; then
     google_tag="-A html_google_tag_manager_code=${1}"
@@ -126,6 +127,8 @@ function build_docs() {
   errors=$?
   if [[ ${errors} -ne 0 ]]; then
     echo_set_message "Error in check_includes: ${errors}"
+    consolidate_messages
+    return ${errors}
   fi
   if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
     echo "Not building using Sphinx."
@@ -135,13 +138,14 @@ function build_docs() {
     ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_tag} ${SOURCE} ${TARGET}/${HTML}
     errors=$?
     if [[ ${errors} -ne 0 ]]; then
-        echo "Could not build using Sphinx."
+        echo_set_message "Could not build using Sphinx."
+        consolidate_messages
         return ${errors}
     fi
   fi
   build_extras
-  consolidate_messages
   add_html_redirect
+  consolidate_messages
 }
 
 function build_docs_local() {
@@ -204,6 +208,7 @@ function check_build_rst() {
 }
 
 function check_includes() {
+  local errors
   if [[ ${DOCS_LOCAL} == ${TRUE} ]]; then
     LOCAL_INCLUDES="${TRUE}"
   fi
@@ -548,6 +553,7 @@ function rewrite() {
   # or if $4=='', substitutes text in-place in file $1, replacing text $2 with text $3
   # or if $3 & $4=='', substitutes text in-place in file $1, using sed command $2
   local rewrite_source=${1}
+  local errors
   pushd ${SCRIPT_PATH} > /dev/null
   echo "Re-writing"
   echo "    $rewrite_source"

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -1,17 +1,17 @@
 # Copyright © 2014-2017 Cask Data, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-  
+
 # Common code for Build script for docs
 # Not called directly; included in either the main build.sh or the individual manual's build.sh
 #
@@ -133,7 +133,12 @@ function build_docs() {
   else
     echo "Building using Sphinx."
     ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_tag} ${SOURCE} ${TARGET}/${HTML}
-  fi  
+    errors=$?
+    if [[ ${errors} -ne 0 ]]; then
+        echo "Could not build using Sphinx."
+        return ${errors}
+    fi
+  fi
   build_extras
   consolidate_messages
   add_html_redirect
@@ -243,20 +248,20 @@ function test_an_include() {
   local location=${3}
   local new_md5_hash
   local m
-  local m_display  
-  
+  local m_display
+
   if [[ -n ${target} ]]; then
     local file_name=$(basename ${target})
-  
+
     if [[ ${OSTYPE} == "darwin"* ]]; then
       new_md5_hash=$(md5 -q ${target})
     else
       new_md5_hash=$(md5sum ${target} | awk '{print $1}')
     fi
-    
+
     # If the new_md5_hash is in the NOT_FOUND_HASHES, it will set as the not_found_hash
     local not_found_hash=`echo ${NOT_FOUND_HASHES[@]} | grep -o "${new_md5_hash}"`
-  
+
     if [[ ${new_md5_hash} == ${not_found_hash} ]]; then
       m="${WARNING} ${RED_BOLD}${file_name} not found!${NO_COLOR}"
       m="${m}\nfile: ${target}"
@@ -268,7 +273,7 @@ function test_an_include() {
         m="${m}\nHash location: ${location}"
       fi
     fi
-  else  
+  else
     m="No target is set for test_an_include"
   fi
   if [[ -n ${m} ]]; then
@@ -296,7 +301,7 @@ function download_file() {
   else
     local target=${includes_dir}/${file_name}
   fi
-  
+
   if [[ ! -d ${includes_dir} ]]; then
     mkdir ${includes_dir}
     echo "Creating Includes Directory: ${includes_dir}"
@@ -392,7 +397,7 @@ function set_version() {
   fi
   popd > /dev/null
   IFS="${OIFS}"
-  
+
   if [[ ${GIT_BRANCH_TYPE:0:7} == "develop" ]]; then
     GIT_BRANCH_CDAP_PIPELINES="develop"
     GIT_BRANCH_CDAP_METADATA_MANAGEMENT="develop"
@@ -453,7 +458,7 @@ function get_cdap_metadata_management_version() {
     CDAP_METADATA_MANAGEMENT_VERSION="0.2.0-SNAPSHOT"
     echo "Using default CDAP_METADATA_MANAGEMENT_VERSION ${CDAP_METADATA_MANAGEMENT_VERSION}"
   fi
-  export CDAP_METADATA_MANAGEMENT_VERSION 
+  export CDAP_METADATA_MANAGEMENT_VERSION
 }
 
 function clear_messages_file() {
@@ -494,7 +499,7 @@ function consolidate_messages() {
   local m="Warning Messages for \"${MANUAL}\":"
   local l="--------------------------------------------------------"
   if [[ -n ${MESSAGES} ]]; then
-    echo_red_bold "Consolidating messages" 
+    echo_red_bold "Consolidating messages"
     echo >> ${TMP_MESSAGES_FILE}
     echo_red_bold "${m}" >> ${TMP_MESSAGES_FILE}
     echo ${l} >> ${TMP_MESSAGES_FILE}
@@ -503,7 +508,7 @@ function consolidate_messages() {
     unset -v MESSAGES
   fi
   if [[ -s ${TARGET}/${SPHINX_MESSAGES} ]]; then
-    echo_red_bold "Consolidating Sphinx messages" 
+    echo_red_bold "Consolidating Sphinx messages"
     m="Sphinx ${m}"
     echo >> ${TMP_MESSAGES_FILE}
     echo_red_bold "${m}" >> ${TMP_MESSAGES_FILE}
@@ -519,16 +524,16 @@ function consolidate_messages() {
 function display_messages() {
   local warnings=0
   if [[ -n ${TMP_MESSAGES_FILE} && -s ${TMP_MESSAGES_FILE} ]]; then
-    echo 
+    echo
     echo "--------------------------------------------------------"
     echo_red_bold "Warning Messages: $(basename ${TMP_MESSAGES_FILE})"
     echo "--------------------------------------------------------"
-    echo 
+    echo
     cat ${TMP_MESSAGES_FILE} | while read line
     do
       echo "${line}"
     done
-    echo 
+    echo
     echo "--------------------------------------------------------"
     echo_red_bold "End Warning Messages"
     echo "--------------------------------------------------------"
@@ -557,7 +562,7 @@ function rewrite() {
     errors=$?
     if [[ ${errors} -ne 0 ]]; then
         echo "Could not sed ${sub_string} ${rewrite_source}"
-        return ${errors}   
+        return ${errors}
     fi
     if [[ $(uname) == "Darwin" ]]; then
       rm ${rewrite_source}.bak
@@ -574,7 +579,7 @@ function rewrite() {
     errors=$?
     if [[ ${errors} -ne 0 ]]; then
         echo "Could not sed ${sub_string} ${rewrite_source}"
-        return ${errors}   
+        return ${errors}
     fi
     if [[ $(uname) == "Darwin" ]]; then
       rm ${rewrite_source}.bak
@@ -590,7 +595,7 @@ function rewrite() {
     errors=$?
     if [[ ${errors} -ne 0 ]]; then
         echo "Could not sed ${sub_string} ${rewrite_source} ${rewrite_target}"
-        return ${errors}   
+        return ${errors}
     fi
   fi
   popd  > /dev/null

--- a/cdap-docs/admin-manual/source/conf.py
+++ b/cdap-docs/admin-manual/source/conf.py
@@ -91,7 +91,6 @@ hdinsight_path = os.path.join(os.getcwd(), '../../..', 'cdap-distributions/src/h
 try:
     with open(hdinsight_path) as json_data:
         d = json.load(json_data)
-        d = None
         v_list = d['clusterFilters']['versions']
         if not v_list:
             raise

--- a/cdap-docs/admin-manual/source/conf.py
+++ b/cdap-docs/admin-manual/source/conf.py
@@ -91,6 +91,7 @@ hdinsight_path = os.path.join(os.getcwd(), '../../..', 'cdap-distributions/src/h
 try:
     with open(hdinsight_path) as json_data:
         d = json.load(json_data)
+        d = None
         v_list = d['clusterFilters']['versions']
         if not v_list:
             raise

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -224,8 +224,8 @@ function build_javadocs() {
   export USING_JAVADOCS
   local javadoc_type=${1}
   local title="Building Javadocs: '${javadoc_type}'"
+  local errors
   display_start_title "${title}"
-  local warnings
   check_build_rst
   set_environment
   if [[ ${DEBUG} == ${TRUE} ]]; then
@@ -260,13 +260,13 @@ function build_javadocs() {
     echo "Error building Javadocs"
   fi
   display_end_title ${title}
-  return ${warnings}
+  return ${errors}
 }
 
 function build_docs_cli() {
   local title="Building CLI Input File for docs"
   display_start_title "${title}"
-  local warnings
+  local errors
   if [[ -n ${NO_CLI_DOCS} ]]; then
     echo_red_bold "Building CLI input file disabled. '${NO_CLI_DOCS}'"
   else
@@ -276,13 +276,13 @@ function build_docs_cli() {
     set_environment
     cd ${PROJECT_PATH}
     mvn package -pl cdap-docs-gen -am -DskipTests
-    warnings=$?
-    if [[ ${warnings} -eq 0 ]]; then
+    errors=$?
+    if [[ ${errors} -eq 0 ]]; then
       ${JAVA} -cp cdap-docs-gen/target/cdap-docs-gen-${PROJECT_VERSION}.jar:cdap-cli/target/cdap-cli-${PROJECT_VERSION}.jar co.cask.cdap.docgen.cli.GenerateCLIDocsTable > ${target_txt}
       warnings=$?
       echo
       echo "Completed building of CLI"
-      if [[ ${warnings} -eq 0 ]]; then
+      if [[ ${errors} -eq 0 ]]; then
         echo "CLI input file written to ${target_txt}"
         USING_CLI_DOCS="true"
       else
@@ -294,43 +294,46 @@ function build_docs_cli() {
     export USING_CLI_DOCS
   fi
   display_end_title ${title}
-  return ${warnings}
+  return ${errors}
 }
 
 function cache_docs_cli() {
   local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
   local cache=${SCRIPT_PATH}/target
+  local errors
   cp ${target_txt} ${cache}
-  warnings=$?
-  if [[ ${warnings} -eq 0 ]]; then
+  errors=$?
+  if [[ ${errors} -eq 0 ]]; then
     echo "Caching CLI output file from '${target_txt}'"
   else
     echo "Error caching CLI output file: ${warnings}"
     echo "From: ${target_txt}"
     echo "To: ${cache}"
   fi
-  return ${warnings}
+  return ${errors}
 }
 
 function restore_cached_docs_cli() {
   local target=${SCRIPT_PATH}/../cdap-docs-gen/target
   local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
+  local errors
   cp ${cache_txt} ${target}
-  warnings=$?
-  if [[ ${warnings} -eq 0 ]]; then
+  errors=$?
+  if [[ ${errors} -eq 0 ]]; then
     echo "Restored CLI output file from '${cache_txt}'"
   else
     echo "Error restoring CLI output file: ${warnings}"
     echo "From: ${cache_txt}"
     echo "To: ${target}"
   fi
-  return ${warnings}
+  return ${errors}
 }
 
 function build_docs_inner_level() {
   # Change to each manual, and run the local ./build.sh from there.
   # Each manual can (and does) have a customised build script, using the common-build.sh as a base.
   local build_target=${1}
+  local errors
   if [[ ${LOCAL_INCLUDES} == ${TRUE} ]]; then
     echo "Using local builds."
     build_target="${1}-local"
@@ -343,9 +346,15 @@ function build_docs_inner_level() {
     echo
     cd ${SCRIPT_PATH}/${i}
     ./build.sh ${build_target}
+    errors=$?
+    if [[ ${errors} -ne 0 ]]; then
+        echo_set_message "Could not build manual \"${i}\"."
+        break
+    fi
     echo
   done
   popd > /dev/null
+  return ${errors}
 }
 
 function build_docs_outer_level() {
@@ -378,7 +387,7 @@ function build_docs_outer_level() {
     ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
     errors=$?
     if [[ ${errors} -ne 0 ]]; then
-        echo "Could not build using Sphinx."
+        echo_set_message "Could not build using Sphinx."
         return ${errors}
     fi
   fi

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -376,6 +376,11 @@ function build_docs_outer_level() {
   else
     echo "Building using Sphinx."
     ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
+    errors=$?
+    if [[ ${errors} -ne 0 ]]; then
+        echo "Could not build using Sphinx."
+        return ${errors}
+    fi
   fi
   consolidate_messages
   add_html_redirect


### PR DESCRIPTION
Our current doc builds ignore any errors or exceptions that are generated by the Sphinx build, and instead keeps going.

This set of changes adds to each invocation of Sphinx a test for the return code, and adds appropriate messages, and terminates the build if there is a non-zero error code from Sphinx.

You can see the results in this build: an error has been introduced in the build that triggers an exception, and the message is then surfaced in the log: https://builds.cask.co/browse/CDAP-DQB340-3 . The log page (https://builds.cask.co/browse/CDAP-DQB340-3/log) shows that it occurs in the `admin-manual`. It still requires some digging (the message doesn't appear at the very end of the log, so you would need to go to the end and scroll back to it), but it's a step up from swallowing exceptions.

The last commit removes the error, and https://builds.cask.co/browse/CDAP-DQB340-4 passes.