### PR TITLE
(CDAP-8167) Message caching in TMS

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -607,7 +607,9 @@ public final class Constants {
       public static final String PRODUCER = "pr";
       public static final String CONSUMER = "co";
 
+      // For TMS
       public static final String TABLE = "tbl";
+      public static final String TOPIC = "tpc";
     }
 
     /**
@@ -1172,6 +1174,8 @@ public final class Constants {
   public static final class MessagingSystem {
     public static final String LOCAL_DATA_DIR = "messaging.local.data.dir";
     public static final String LOCAL_DATA_CLEANUP_FREQUENCY = "messaging.local.data.cleanup.frequency.secs";
+
+    public static final String CACHE_SIZE_MB = "messaging.cache.size.mb";
 
     public static final String HBASE_MAX_SCAN_THREADS = "messaging.hbase.max.scan.threads";
     public static final String HBASE_SCAN_CACHE_ROWS = "messaging.hbase.scan.cache.rows";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -660,6 +660,15 @@
   </property>
 
   <property>
+    <name>data.tx.grace.period</name>
+    <value>86400</value>
+    <description>
+      The time in seconds used to pad transaction max lifetime while pruning.
+    </description>
+    <final>true</final>
+  </property>
+
+  <property>
     <name>data.tx.pruning.plugin.class</name>
     <value>co.cask.data2.txprune.DefaultHBaseTransactionPruningPlugin</value>
     <description>
@@ -1458,6 +1467,17 @@
 
 
   <!-- Messaging System Configuration -->
+
+  <property>
+    <name>messaging.cache.size.mb</name>
+    <value>30</value>
+    <description>
+      Memory in megabytes for the cache size used by the messaging service
+      for caching recently published messages. Currently, only topics listed
+      in the ${messaging.system.topics} configuration have caching enabled.
+      Set it to 0 to disable caching.
+    </description>
+  </property>
 
   <property>
     <name>messaging.container.instances</name>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="c393126937de6ace04d26dae9b44143e"
+DEFAULT_XML_MD5_HASH="4dc26eb36a2c0e9dcb969b2fdf108944"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/MessagingSystemCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/MessagingSystemCheck.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.messaging.MessagingServiceUtils;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Startup check for configurations used by the messaging system.
+ */
+@SuppressWarnings("unused")
+class MessagingSystemCheck extends AbstractMasterCheck {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MessagingSystemCheck.class);
+
+  @Inject
+  MessagingSystemCheck(CConfiguration cConf) {
+    super(cConf);
+  }
+
+  @Override
+  public void run() throws Exception {
+    MessagingServiceUtils.getSystemTopics(cConf, false);
+    LOG.info("Messaging System configurations verified.");
+  }
+}

--- a/cdap-master/src/test/java/co/cask/cdap/master/startup/MessagingSystemCheckTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/master/startup/MessagingSystemCheckTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import org.junit.Test;
+
+/**
+ * Unit-tests for {@link MessagingSystemCheck}.
+ */
+public class MessagingSystemCheckTest {
+
+  @Test
+  public void testValid() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    new MessagingSystemCheck(cConf).run();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testInvalidTopic() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.MessagingSystem.SYSTEM_TOPICS, "invalid.topic");
+    new MessagingSystemCheck(cConf).run();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testInvalidTopicNumber() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.MessagingSystem.SYSTEM_TOPICS, "topic:xyz");
+    new MessagingSystemCheck(cConf).run();
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testNegativeTopicNumber() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.MessagingSystem.SYSTEM_TOPICS, "topic:-10");
+    new MessagingSystemCheck(cConf).run();
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/MessagingServiceUtils.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/MessagingServiceUtils.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.TopicId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A util class for TMS.
+ */
+public final class MessagingServiceUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MessagingServiceUtils.class);
+
+  /**
+   * Returns a set of system {@link TopicId} as configured by the {@link Constants.MessagingSystem#SYSTEM_TOPICS}
+   * property.
+   *
+   * @param cConf the configuration to get the system topics
+   * @param ignoreInvalidTopic if {@code true}, invalid topics will be ignored; otherwise exception will be raised
+   * @return a set of valid system {@link TopicId}.
+   * @throws IllegalArgumentException if {@code ignoreInvalidTopic} is {@code true} and there is invalid topic being
+   *                                  configured
+   */
+  public static Set<TopicId> getSystemTopics(CConfiguration cConf, boolean ignoreInvalidTopic) {
+    Set<TopicId> systemTopics = new LinkedHashSet<>();
+
+    for (String topic : cConf.getTrimmedStringCollection(Constants.MessagingSystem.SYSTEM_TOPICS)) {
+      int idx = topic.lastIndexOf(':');
+      if (idx < 0) {
+        try {
+          systemTopics.add(NamespaceId.SYSTEM.topic(topic));
+        } catch (IllegalArgumentException e) {
+          if (ignoreInvalidTopic) {
+            LOG.warn("Ignore system topic '{}'. Reason: {}", topic, e.getMessage());
+          } else {
+            throw e;
+          }
+        }
+        continue;
+      }
+
+      // If the current topic matches the format <common.prefix>:<total.topic.number>, expands it to
+      // <total.topic.number> topics with the prefix <common.prefix> with numerical suffices
+      // ranging from 0 to (<total.topic.number> - 1)
+      try {
+        int totalTopicCount = Integer.parseInt(topic.substring(idx + 1));
+        if (totalTopicCount <= 0) {
+          if (ignoreInvalidTopic) {
+            LOG.warn("Ignore system topic '{}' because the total topic number {} in it is not positive integer.",
+                     topic, totalTopicCount);
+            continue;
+          } else {
+            throw new IllegalArgumentException("Total topic number must be positive for system topic '" + topic + "'.");
+          }
+        }
+
+        // Add it to a list first before adding to the result set to avoid any potential partial result.
+        List<TopicId> topics = new ArrayList<>(totalTopicCount);
+        String topicPrefix = topic.substring(0, idx);
+        for (int i = 0; i < totalTopicCount; i++) {
+          topics.add(NamespaceId.SYSTEM.topic(topicPrefix + i));
+        }
+        systemTopics.addAll(topics);
+      } catch (NumberFormatException e) {
+        if (ignoreInvalidTopic) {
+          LOG.warn("Ignore invalid system topic '{}' because of the invalid total topic number in it.", topic);
+        } else {
+          throw new IllegalArgumentException("Total topic number must be a positive number for system topic '"
+                                               + topic + "'.");
+        }
+      } catch (IllegalArgumentException e) {
+        if (ignoreInvalidTopic) {
+          LOG.warn("Ignore system topic '{}'. Reason: {}", topic, e.getMessage());
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    return Collections.unmodifiableSet(systemTopics);
+  }
+
+
+  private MessagingServiceUtils() {
+    // no-op
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/cache/MessageCache.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/cache/MessageCache.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.cache;
+
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.messaging.store.MessageFilter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.AbstractIterator;
+
+import java.util.Comparator;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.Nullable;
+
+/**
+ * An in-memory cache for messages. This cache is expected to be shared between publishers and fetchers of the same
+ * topic. This cache is specifically designed for the TMS operations, hence leveraging certain properties from TMS:
+ *
+ * - Single writer, concurrent fetchers
+ * - Ordered, unique entry (row key)
+ *
+ * This cache uses three memory limits to balance between publish and consume efficiency as well as
+ * bounding the memory usage. It uses a provided {@link Weigher} to compute the weight of each entry
+ * being stored inside the cache.
+ *
+ * - Hard limit. This is the upper bound weight for the cache and it won't grow beyond this.
+ * - Min retain. This is the minimum weight that the cache will try to maintain.
+ * - Reduce trigger. This is the cache weight that triggers the logic for reducing the cache size back to the
+ *   min retain weight. When the cache weight is larger than this limit, weight reduction logic will be executed
+ *   by the consumer. On adding entries to the cache, the cache can keep growing without blocking as long as
+ *   the hard limit is not hit so that the publisher doesn't need to be blocked.
+ *   The room between the reduce trigger and hard limits is basically the buffer for non-blocking addition.
+ *   - On addition, once the hard limit is reached, a blocking operation is needed to reduce the weight of the
+ *     cache back to min retain.
+ *   - On fetching entries from the cache, the fetcher will check whether it needs to reduce the cache weight and reduce
+ *     it if needed. This essentially is to amortize the cost of the blocking weight reduction operations among all
+ *     fetchers (which typically has multiple of them), without blocking the single publish as much as possible.
+ *
+ * @param <T> type of entry stored in the cache
+ */
+public class MessageCache<T> {
+
+  private static final String METRICS_WEIGHT = "cache.weight";
+  private static final String METRICS_ENTRIES_ADDED = "cache.entries.added";
+  private static final String METRICS_ENTRIES_REMOVED = "cache.entries.removed";
+  private static final String METRICS_ADD_REQUESTS = "cache.add.requests";
+  private static final String METRICS_ADD_REDUCE_WEIGHT = "cache.add.reduce.weight";
+  private static final String METRICS_SCAN_REQUESTS = "cache.scan.requests";
+  private static final String METRICS_SCAN_REDUCE_WEIGHT = "cache.scan.reduce.weight";
+
+  private final NavigableSet<CacheEntry<T>> cache;
+  private final Comparator<T> comparator;
+  private final AtomicReference<Limits> limits;
+  private final MetricsContext metricsContext;
+  private final AtomicLong currentWeight;
+  private final AtomicBoolean needReduceWeight;
+  private final AtomicBoolean adding;
+  private final Weigher<T> weigher;
+  private final ReadWriteLock cacheLock;
+
+  /**
+   * Creates a new instance of the cache.
+   *
+   * @param comparator a {@link Comparator} for ordering cache entries
+   * @param weigher a {@link Weigher} for computing the weight of each cache entry
+   * @param limits the limits for maintaining cache weight; see class description for more detail
+   * @param metricsContext a {@link MetricsContext} for emitting metrics about this cache.
+   */
+  public MessageCache(Comparator<T> comparator, Weigher<T> weigher, Limits limits, MetricsContext metricsContext) {
+    this.cache = new ConcurrentSkipListSet<>(new CacheEntryComparator<>(comparator));
+    this.comparator = comparator;
+    this.limits = new AtomicReference<>(limits);
+    this.metricsContext = metricsContext;
+    this.currentWeight = new AtomicLong();
+    this.needReduceWeight = new AtomicBoolean();
+    this.adding = new AtomicBoolean();
+    this.weigher = weigher;
+    this.cacheLock = new ReentrantReadWriteLock();
+  }
+
+  /**
+   * Returns the {@link Comparator} used by this cache.
+   */
+  public Comparator<T> getComparator() {
+    return comparator;
+  }
+
+  /**
+   * Adds a list of entries to the cache. The entries provided must be in strictly increasing order and should be
+   * larger than existing entries in the cache. Also, this method doesn't allow concurrent invocation.
+   *
+   * @param entries a {@link Iterator} to provide entries to be added to the cache
+   * @throws ConcurrentModificationException if called by multiple threads concurrently
+   * @throws IllegalArgumentException if the entries provided are not in strictly increasing order
+   *                                  or not larger existing cached entries
+   */
+  public void addAll(Iterator<T> entries) {
+    if (!adding.compareAndSet(false, true)) {
+      // This is to guard against bug, otherwise this shouldn't happen
+      throw new ConcurrentModificationException(
+        "The MessageCache.addAll method shouldn't be called concurrently by multiple threads.");
+    }
+
+    try {
+      long newWeight = 0L;
+      CacheEntry<T> largestCacheEntry = null;
+
+      int entriesAdded = 0;
+      while (entries.hasNext()) {
+        T entry = entries.next();
+        CacheEntry<T> cacheEntry = new CacheEntry<>(entry, weigher.weight(entry));
+        newWeight = currentWeight.addAndGet(cacheEntry.getWeight());
+        if (newWeight > limits.get().getHardLimit()) {
+          reduceWeight();
+          metricsContext.increment(METRICS_ADD_REDUCE_WEIGHT, 1L);
+          newWeight = currentWeight.get();
+        }
+
+        // Make sure new entries are also in increasing order.
+        // For the first entry from the provided iterator, it must be larger than everything in the cache, hence
+        // the ceiling call must be returning null.
+        // For sub-sequence entries in the iterator, they must be in strictly increasing order
+        largestCacheEntry = largestCacheEntry == null ? cache.ceiling(cacheEntry) : largestCacheEntry;
+        if (largestCacheEntry != null && comparator.compare(largestCacheEntry.getEntry(), cacheEntry.getEntry()) >= 0) {
+          // Entries must be in strictly increasing order
+          // Clear the cache to reset state. This is just for precaution, as this shouldn't happen,
+          // unless there is bug in the TMS system (from the caller side).
+          currentWeight.addAndGet(-1 * cacheEntry.getWeight());
+          clear();
+          throw new IllegalArgumentException("Cache entry must be in strictly increasing order. " +
+                                               "Entry " + entry + " is smaller than or equal to " +
+                                               largestCacheEntry.getEntry());
+        }
+
+        // It's ok to "leak" this to reader even if the new weight is larger than the hard limit
+        // The entry will get removed eventually and the read/write operations as a whole still give valid
+        // results
+        cache.add(cacheEntry);
+        entriesAdded++;
+        largestCacheEntry = cacheEntry;
+      }
+
+      metricsContext.increment(METRICS_ADD_REQUESTS, 1L);
+      metricsContext.increment(METRICS_ENTRIES_ADDED, entriesAdded);
+      metricsContext.gauge(METRICS_WEIGHT, newWeight);
+
+      if (newWeight > limits.get().getHardLimit()) {
+        reduceWeight();
+        metricsContext.increment(METRICS_ADD_REDUCE_WEIGHT, 1L);
+      } else if (newWeight > limits.get().getReduceTrigger()) {
+        needReduceWeight.compareAndSet(false, true);
+      }
+    } finally {
+      adding.set(false);
+    }
+  }
+
+  /**
+   * Creates a {@link Scanner} for fetching cached entries in ascending order.
+   *
+   * @param startEntry the entry to start fetching from
+   * @param includeStart {@code true} to include the startEntry in the resulting {@link Scanner}
+   *                                 if it exists in the cache
+   * @param limit maximum number of entries to fetch
+   * @return a {@link Scanner} for accessing to the fetched entries
+   */
+  public Scanner<T> scan(T startEntry, boolean includeStart, int limit, MessageFilter<T> filter) {
+    List<T> entries = new LinkedList<>();
+
+    // Acquire the read lock and copy the entries. This is to guard against weight reduction while the caller
+    // is iterating using the returned Scanner.
+    cacheLock.readLock().lock();
+    T firstInCache;
+    try {
+      firstInCache = cache.isEmpty() ? null : cache.first().getEntry();
+      for (CacheEntry<T> cacheEntry : cache.tailSet(new CacheEntry<>(startEntry, 0), includeStart)) {
+        if (entries.size() >= limit) {
+          break;
+        }
+
+        MessageFilter.Result result = filter.apply(cacheEntry.getEntry());
+        if (result == MessageFilter.Result.ACCEPT) {
+          entries.add(cacheEntry.getEntry());
+        } else if (result == MessageFilter.Result.HOLD) {
+          // Hold means not to scan more, so just break
+          break;
+        }
+      }
+    } finally {
+      cacheLock.readLock().unlock();
+    }
+
+    metricsContext.increment(METRICS_SCAN_REQUESTS, 1L);
+
+    return new AbstractScanner<T>(entries.iterator(), firstInCache) {
+      @Override
+      void doClose() {
+        // Use compareAndSet to check if need to reduce weight. There will only be
+        // one winner to proceed with the reduce weight call.
+        if (needReduceWeight.compareAndSet(true, false)) {
+          reduceWeight();
+          metricsContext.increment(METRICS_SCAN_REDUCE_WEIGHT, 1L);
+        }
+      }
+    };
+  }
+
+  /**
+   * Updates entries in the cache. Update to each entry shouldn't change the ordering of the entry based on the
+   * {@link Comparator} provided to this cache.
+   *
+   * @param startEntry the starting entry for the update to start (inclusive)
+   * @param endEntry the ending entry for the update to end (inclusive)
+   * @param updater a {@link EntryUpdater} to update the content of a entry
+   */
+  public void updateEntries(T startEntry, T endEntry, EntryUpdater<T> updater) {
+    CacheEntry<T> startCacheEntry = new CacheEntry<>(startEntry, 0);
+
+    cacheLock.writeLock().lock();
+    try {
+      CacheEntry<T> lower = cache.lower(startCacheEntry);
+      Iterator<CacheEntry<T>> iterator = cache.subSet(startCacheEntry, true,
+                                                      new CacheEntry<>(endEntry, 0), true).iterator();
+      CacheEntry<T> cacheEntry = iterator.hasNext() ? iterator.next() : null;
+      while (cacheEntry != null) {
+        CacheEntry<T> nextCacheEntry = iterator.hasNext() ? iterator.next() : null;
+        CacheEntry<T> higher = nextCacheEntry == null ? cache.higher(cacheEntry) : nextCacheEntry;
+
+        try {
+          updater.updateEntry(cacheEntry.getEntry());
+        } catch (RuntimeException e) {
+          clear();
+          throw e;
+        }
+
+        // A quick check that the ordering hasn't been altered.
+        // It doesn't cover all possible case though. This is just a quick catch for bug in the caller.
+        if ((lower != null && comparator.compare(lower.getEntry(), cacheEntry.getEntry()) >= 0)
+            || (higher != null && comparator.compare(higher.getEntry(), cacheEntry.getEntry()) <= 0)) {
+          // This shouldn't happen, unless there is bug in the caller.
+          clear();
+          throw new IllegalStateException("Entry order should not be altered after update.");
+        }
+
+        lower = cacheEntry;
+        cacheEntry = nextCacheEntry;
+      }
+
+    } finally {
+      cacheLock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * Clears the cache. The caller is responsible to make sure there is no concurrent call to the
+   * {@link #addAll(Iterator)} method.
+   */
+  public void clear() {
+    // To clear the cache, first set the limit to 0, the reset it back to proper limit
+    Limits oldLimits = limits.get();
+    resize(new Limits(0, 0, 0));
+    resize(oldLimits);
+  }
+
+  /**
+   * Resize the cache limits.
+   *
+   * @param limits the new limits for this cache.
+   */
+  public void resize(Limits limits) {
+    cacheLock.writeLock().lock();
+    try {
+      this.limits.set(limits);
+      reduceWeight();
+    } finally {
+      cacheLock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * Returns the current soft and hard limits of this cache.
+   */
+  public Limits getLimits() {
+    return limits.get();
+  }
+
+  /**
+   * Returns the current cache weight.
+   */
+  @VisibleForTesting
+  long getCurrentWeight() {
+    return currentWeight.get();
+  }
+
+  /**
+   * Reduces the cache weight. Cached entries will be removed until the cache weight is smaller than the soft limit.
+   */
+  private void reduceWeight() {
+    int entriesRemoved = 0;
+    cacheLock.writeLock().lock();
+    try {
+      long newWeight = currentWeight.get();
+      Iterator<CacheEntry<T>> iterator = cache.iterator();
+      while (iterator.hasNext()) {
+        CacheEntry<T> cacheEntry = iterator.next();
+        // If removing the next entry is smaller than the min weight, we are done with the reduce logic
+        if (newWeight - cacheEntry.getWeight() < limits.get().getMinRetain()) {
+          break;
+        }
+        iterator.remove();
+        entriesRemoved++;
+        newWeight = currentWeight.addAndGet(-1 * cacheEntry.getWeight());
+      }
+    } finally {
+      cacheLock.writeLock().unlock();
+    }
+    metricsContext.increment(METRICS_ENTRIES_REMOVED, entriesRemoved);
+  }
+
+  /**
+   * Carries the limits for the {@link MessageCache}.
+   */
+  public static final class Limits {
+    private final long minRetain;
+    private final long reduceTrigger;
+    private final long hardLimit;
+
+    public Limits(long minRetain, long reduceTrigger, long hardLimit) {
+      Preconditions.checkArgument(reduceTrigger <= hardLimit,
+                                  "The reduce trigger weight should not be larger than hard limit");
+      Preconditions.checkArgument(minRetain <= reduceTrigger,
+                                  "The minimum retain weight should not be larger than the reduce trigger weight");
+
+      this.minRetain = minRetain;
+      this.reduceTrigger = reduceTrigger;
+      this.hardLimit = hardLimit;
+    }
+
+    public long getMinRetain() {
+      return minRetain;
+    }
+
+    public long getReduceTrigger() {
+      return reduceTrigger;
+    }
+
+    public long getHardLimit() {
+      return hardLimit;
+    }
+  }
+
+  /**
+   * This interface is for calculating the weight of a cache entry.
+   *
+   * @param <T> type of the entry
+   */
+  public interface Weigher<T> {
+    int weight(T entry);
+  }
+
+  /**
+   * This interface is for accessing cached entries.
+   *
+   * @param <T> type of the entry
+   */
+  public interface Scanner<T> extends CloseableIterator<T> {
+
+    /**
+     * Returns the first (smallest) entry in the cache when this scanner was created.
+     *
+     * @return the first entry in the cache or {@code null} if the cache was empty
+     */
+    @Nullable
+    T getFirstInCache();
+  }
+
+  /**
+   * A updater for updating an entry.
+   *
+   * @param <T> type of the entry
+   */
+  public abstract static class EntryUpdater<T> {
+
+    /**
+     * Updates the entry.
+     *
+     * @param entry the entry to update
+     */
+    public abstract void updateEntry(T entry);
+  }
+
+
+  /**
+   * Abstract implementation of {@link Scanner}.
+   *
+   * @param <T> type of the entry
+   */
+  private abstract static class AbstractScanner<T> extends AbstractIterator<T> implements Scanner<T> {
+
+    private final Iterator<T> iterator;
+    private final T firstInCache;
+    private boolean closed;
+
+    private AbstractScanner(Iterator<T> iterator, @Nullable T firstInCache) {
+      this.iterator = iterator;
+      this.firstInCache = firstInCache;
+    }
+
+    @Override
+    protected final T computeNext() {
+      if (!closed && iterator.hasNext()) {
+        return iterator.next();
+      }
+      close();
+      return endOfData();
+    }
+
+    @Nullable
+    @Override
+    public final T getFirstInCache() {
+      return firstInCache;
+    }
+
+    @Override
+    public final void close() {
+      if (!closed) {
+        closed = true;
+        doClose();
+      }
+    }
+
+    /**
+     * Performs cleanup task.
+     */
+    abstract void doClose();
+  }
+
+  /**
+   * A private class that wraps a user provided entry of type {@code T} with an associated weight.
+   *
+   * @param <T> type of the entry
+   */
+  private static class CacheEntry<T> {
+    private final T entry;
+    private final int weight;
+
+    private CacheEntry(T entry, int weight) {
+      this.entry = entry;
+      this.weight = weight;
+    }
+
+    T getEntry() {
+      return entry;
+    }
+
+    int getWeight() {
+      return weight;
+    }
+
+    @Override
+    public String toString() {
+      return "CacheEntry{" +
+        "entry=" + entry +
+        ", weight=" + weight +
+        '}';
+    }
+  }
+
+  /**
+   * A {@link Comparator} for {@link CacheEntry} that only compares with the user entry of type {@code T},
+   * using the provided {@link Comparator}.
+   *
+   * @param <T> type of the user entry
+   */
+  private static final class CacheEntryComparator<T> implements Comparator<CacheEntry<T>> {
+
+    private final Comparator<T> comparator;
+
+    private CacheEntryComparator(Comparator<T> comparator) {
+      this.comparator = comparator;
+    }
+
+    @Override
+    public int compare(CacheEntry<T> entry1, CacheEntry<T> entry2) {
+      return comparator.compare(entry1.getEntry(), entry2.getEntry());
+    }
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/CoreMessagingService.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/CoreMessagingService.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.TimeProvider;
 import co.cask.cdap.messaging.MessageFetcher;
 import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.messaging.MessagingServiceUtils;
 import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.RollbackDetail;
 import co.cask.cdap.messaging.StoreRequest;
@@ -54,12 +55,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -92,8 +93,8 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
   }
 
   @VisibleForTesting
-  CoreMessagingService(CConfiguration cConf, TableFactory tableFactory, TimeProvider timeProvider,
-                       MetricsCollectionService metricsCollectionService) {
+  CoreMessagingService(CConfiguration cConf, TableFactory tableFactory,
+                       TimeProvider timeProvider, MetricsCollectionService metricsCollectionService) {
     this.cConf = cConf;
     this.tableFactory = tableFactory;
     this.topicCache = createTopicCache();
@@ -227,38 +228,9 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
   protected void startUp() throws Exception {
     Queue<TopicId> asyncCreationTopics = new LinkedList<>();
 
-    for (String topic : new HashSet<>(cConf.getTrimmedStringCollection(Constants.MessagingSystem.SYSTEM_TOPICS))) {
-      // If the current topic matches the format <common.prefix>:<total.topic.number>, create totally
-      // <total.topic.number> topics with the prefix <common.prefix> with numerical suffices
-      // ranging from 0 to (<total.topic.number> - 1)
-      if (topic.contains(":")) {
-        String[] topicParts = topic.split(":");
-        int totalTopicNum;
-        if (topicParts.length != 2) {
-          LOG.warn("Ignore creation of invalid topic '{}'. Expecting topic in the format " +
-                     "<common.prefix>:<total.topic.number>.", topic);
-          continue;
-        }
-        String topicPrefix = topicParts[0];
-        try {
-          totalTopicNum = Integer.parseInt(topicParts[1]);
-          if (totalTopicNum <= 0) {
-            LOG.warn("Ignore creation of invalid topic '{}' because " +
-                       "the total topics number {} in it is not positive integer.", topic, topicParts[1]);
-            continue;
-          }
-        } catch (NumberFormatException e) {
-          LOG.warn(String.format(
-            "Ignore creation of invalid topic '%s' because of the invalid total topics number in it.", topic), e);
-          continue;
-        }
-
-        for (int i = 0; i < totalTopicNum; i++) {
-          createSystemTopic(topicPrefix + i, asyncCreationTopics);
-        }
-      } else {
-        createSystemTopic(topic, asyncCreationTopics);
-      }
+    Set<TopicId> systemTopics = MessagingServiceUtils.getSystemTopics(cConf, true);
+    for (TopicId topic : systemTopics) {
+      createSystemTopic(topic, asyncCreationTopics);
     }
 
     if (!asyncCreationTopics.isEmpty()) {
@@ -272,22 +244,15 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
    * Creates the given topic if it is not yet created. Adds a topic to the {@code creationFailureTopics}
    * if creation fails.
    */
-  private void createSystemTopic(String topicName,  Queue<TopicId> creationFailureTopics) {
+  private void createSystemTopic(TopicId topicId, Queue<TopicId> creationFailureTopics) {
     try {
-      TopicId topicId = NamespaceId.SYSTEM.topic(topicName);
-      try {
-        createTopicIfNotExists(topicId);
-      } catch (Exception e) {
-        // If failed, add it to a list so that the retry will happen asynchronously
-        LOG.warn("Topic {} creation failed with exception {}. Will retry.", topicId, e.getMessage());
-        LOG.debug("Topic {} creation failure stacktrace", topicId, e);
-        creationFailureTopics.add(topicId);
-      }
-    } catch (IllegalArgumentException e) {
-      // Ignore invalid topic
-      LOG.warn(String.format("Ignore creation of invalid topic '%s'", topicName), e);
+      createTopicIfNotExists(topicId);
+    } catch (Exception e) {
+      // If failed, add it to a list so that the retry will happen asynchronously
+      LOG.warn("Topic {} creation failed with exception {}. Will retry.", topicId, e.getMessage());
+      LOG.debug("Topic {} creation failure stacktrace", topicId, e);
+      creationFailureTopics.add(topicId);
     }
-
   }
 
   @Override

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ForwardingTableFactory.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ForwardingTableFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store;
+
+import java.io.IOException;
+
+/**
+ * A {@link TableFactory} that forwards all operations to another {@link TableFactory}.
+ */
+public abstract class ForwardingTableFactory implements TableFactory {
+
+  /**
+   * Returns the {@link TableFactory} that this class forwards to.
+   */
+  public abstract TableFactory getDelegate();
+
+  @Override
+  public MetadataTable createMetadataTable(String tableName) throws IOException {
+    return getDelegate().createMetadataTable(tableName);
+  }
+
+  @Override
+  public MessageTable createMessageTable(String tableName) throws IOException {
+    return getDelegate().createMessageTable(tableName);
+  }
+
+  @Override
+  public PayloadTable createPayloadTable(String tableName) throws IOException {
+    return getDelegate().createPayloadTable(tableName);
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutableMessageTableEntry.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutableMessageTableEntry.java
@@ -35,15 +35,16 @@ public final class ImmutableMessageTableEntry implements MessageTable.Entry {
   private final short sequenceId;
 
   public ImmutableMessageTableEntry(byte[] row, @Nullable byte[] payload, @Nullable byte[] txPtr) {
+    this.topicId = MessagingUtils.toTopicId(row, 0,
+                                            row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG - Bytes.SIZEOF_INT);
+    this.generation = Bytes.toInt(row, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG - Bytes.SIZEOF_INT);
+
     int topicLength = MessagingUtils.getTopicLengthMessageEntry(row.length);
     this.publishTimestamp = Bytes.toLong(row, topicLength);
     this.sequenceId = Bytes.toShort(row, topicLength + Bytes.SIZEOF_LONG);
     this.transactional = (txPtr != null);
     // since we mark tx as negative when tx is rolled back, we return the absolute value of tx
     this.transactionWritePointer = txPtr == null ? -1 : Math.abs(Bytes.toLong(txPtr));
-    this.generation = Bytes.toInt(row, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG - Bytes.SIZEOF_INT);
-    this.topicId = MessagingUtils.toTopicId(row, 0, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG
-      - Bytes.SIZEOF_INT);
     this.payload = payload;
   }
 

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/MessageFilter.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/MessageFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store;
+
+import com.google.common.base.Function;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Filter messages read from {@link MessageTable}.
+ *
+ * @param <T>
+ */
+public abstract class MessageFilter<T> implements Function<T, MessageFilter.Result> {
+
+  /**
+   * The result of the filtering.
+   */
+  public enum Result {
+    ACCEPT,
+    SKIP,
+    HOLD
+  }
+
+  @Nonnull
+  @Override
+  public abstract Result apply(@Nullable T input);
+
+  /**
+   * Creates a {@link MessageFilter} that always accept.
+   *
+   * @param <T> type of input to filter on
+   * @return a {@link MessageFilter} that accepts on all input
+   */
+  public static <T> MessageFilter<T> alwaysAccept() {
+    return new MessageFilter<T>() {
+      @Override
+      public Result apply(@Nullable T input) {
+        return Result.ACCEPT;
+      }
+    };
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/TransactionMessageFilter.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/TransactionMessageFilter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store;
+
+import org.apache.tephra.Transaction;
+
+import java.util.Arrays;
+
+/**
+ * A {@link MessageFilter} that filter {@link MessageTable.Entry} based on a given transaction.
+ */
+public class TransactionMessageFilter extends MessageFilter<MessageTable.Entry> {
+
+  private final Transaction transaction;
+
+  public TransactionMessageFilter(Transaction transaction) {
+    this.transaction = transaction;
+  }
+
+  @Override
+  public Result apply(MessageTable.Entry entry) {
+    if (!entry.isTransactional()) {
+      return Result.ACCEPT;
+    }
+    return filter(entry.getTransactionWritePointer());
+  }
+
+  public Result filter(long txWritePtr) {
+    // This transaction has been rolled back and thus skip the entry
+    if (txWritePtr < 0) {
+      return Result.SKIP;
+    }
+
+    // This transaction is visible, hence accept the message
+    if (transaction.isVisible(txWritePtr)) {
+      return Result.ACCEPT;
+    }
+
+    // This transaction is an invalid transaction, so skip the entry and proceed to the next
+    if (Arrays.binarySearch(transaction.getInvalids(), txWritePtr) >= 0) {
+      return Result.SKIP;
+    }
+
+    // This transaction has not yet been committed, hence hold to ensure ordering
+    return Result.HOLD;
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/CachingMessageTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/CachingMessageTable.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store.cache;
+
+import co.cask.cdap.api.dataset.lib.AbstractCloseableIterator;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.utils.TimeProvider;
+import co.cask.cdap.messaging.RollbackDetail;
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.messaging.cache.MessageCache;
+import co.cask.cdap.messaging.data.MessageId;
+import co.cask.cdap.messaging.store.MessageFilter;
+import co.cask.cdap.messaging.store.MessageTable;
+import co.cask.cdap.messaging.store.TransactionMessageFilter;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import org.apache.tephra.Transaction;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link MessageTable} that uses {@link MessageCache} for caching recently published messages.
+ */
+final class CachingMessageTable implements MessageTable {
+
+  // Copied from TxConstants in Tephra because TMS doesn't depends on tephra-core.
+  @VisibleForTesting
+  static final String PRUNE_GRACE_PERIOD = "data.tx.grace.period";
+
+  private final long gracePeriod;
+  private final MessageTable messageTable;
+  private final MessageTableCacheProvider cacheProvider;
+  private final TimeProvider timeProvider;
+
+  CachingMessageTable(CConfiguration cConf, MessageTable messageTable, MessageTableCacheProvider cacheProvider) {
+    this(cConf, messageTable, cacheProvider, TimeProvider.SYSTEM_TIME);
+  }
+
+  @VisibleForTesting
+  CachingMessageTable(CConfiguration cConf, MessageTable messageTable,
+                      MessageTableCacheProvider cacheProvider, TimeProvider timeProvider) {
+    // Half the tx pruning grace period to be the grace period for scanning the message cache.
+    // This is to make sure we won't scan for cached entries that might be pruned.
+    this.gracePeriod = cConf.getLong(PRUNE_GRACE_PERIOD) / 2;
+    this.messageTable = messageTable;
+    this.cacheProvider = cacheProvider;
+    this.timeProvider = timeProvider;
+  }
+
+  @Override
+  public CloseableIterator<Entry> fetch(TopicMetadata metadata, long startTime,
+                                        int limit, @Nullable Transaction transaction) throws IOException {
+    MessageCache<Entry> messageCache = cacheProvider.getMessageCache(metadata.getTopicId());
+    if (messageCache == null) {
+      // If no caching for the given topic, just return result from table directly
+      return messageTable.fetch(metadata, startTime, limit, transaction);
+    }
+
+    // First scan from cache.
+    Entry lookupEntry = new CacheMessageTableEntry(metadata, startTime, (short) 0);
+    // Adjust the cache scan start time based on the pruning grace period if fetch with transaction
+    Entry adjustedEntry = transaction == null ? lookupEntry : adjustLookupEntry(metadata, lookupEntry);
+    MessageCache.Scanner<Entry> scanner = messageCache.scan(adjustedEntry, true,
+                                                            limit, createFilter(metadata, transaction));
+
+    // No need to scan the table if there is no adjustment on the start time and the cache has everything needed
+    if (lookupEntry == adjustedEntry && cacheHasAllEntries(lookupEntry, scanner, messageCache.getComparator())) {
+      return scanner;
+    }
+
+    // Otherwise scan the table and return a combine result.
+    CloseableIterator<Entry> tableIterator = messageTable.fetch(metadata, startTime, limit, transaction);
+    return new CombineMessageEntryIterator(tableIterator, scanner, messageCache.getComparator(), limit);
+  }
+
+  @Override
+  public CloseableIterator<Entry> fetch(TopicMetadata metadata, MessageId messageId, boolean inclusive,
+                                        int limit, @Nullable Transaction transaction) throws IOException {
+
+    MessageCache<Entry> messageCache = cacheProvider.getMessageCache(metadata.getTopicId());
+    if (messageCache == null) {
+      // If no caching for the given topic, just return result from table directly
+      return messageTable.fetch(metadata, messageId, inclusive, limit, transaction);
+    }
+
+    // First scan from cache, starting from the given message id
+    Entry lookupEntry = new CacheMessageTableEntry(metadata,
+                                                   messageId.getPublishTimestamp(), messageId.getSequenceId());
+
+    // Adjust the cache scan start time based on the pruning grace period if fetch with transaction
+    Entry adjustedEntry = transaction == null ? lookupEntry : adjustLookupEntry(metadata, lookupEntry);
+    MessageCache.Scanner<Entry> scanner = messageCache.scan(adjustedEntry, inclusive,
+                                                            limit, createFilter(metadata, transaction));
+
+    // No need to scan the table if there is no adjustment on the start messageId and the cache has everything needed
+    if (lookupEntry == adjustedEntry && cacheHasAllEntries(lookupEntry, scanner, messageCache.getComparator())) {
+      return scanner;
+    }
+
+    // Otherwise scan the table and return a combine result.
+    CloseableIterator<Entry> tableIterator = messageTable.fetch(metadata, messageId, inclusive, limit, transaction);
+    return new CombineMessageEntryIterator(tableIterator, scanner, messageCache.getComparator(), limit);
+  }
+
+  @Override
+  public void store(Iterator<? extends Entry> entries) throws IOException {
+    // Write it to the message table first
+    CopyingIterator iterator = new CopyingIterator(entries);
+    messageTable.store(iterator);
+
+    Multimap<TopicId, Entry> topicEntries = iterator.getEntries();
+    for (Map.Entry<TopicId, Collection<Entry>> entry : topicEntries.asMap().entrySet()) {
+      MessageCache<Entry> messageCache = cacheProvider.getMessageCache(entry.getKey());
+      // Write it to the cache if it is enabled for the topic
+      if (messageCache != null) {
+        messageCache.addAll(entry.getValue().iterator());
+      }
+    }
+  }
+
+  @Override
+  public void rollback(TopicMetadata metadata, RollbackDetail rollbackDetail) throws IOException {
+    MessageCache<Entry> messageCache = cacheProvider.getMessageCache(metadata.getTopicId());
+    if (messageCache != null) {
+      // Rollback from the cache first so that we don't have to worry about invalid list pruning for the cache,
+      // assuming the rollback from cache shouldn't fail.
+      Entry startEntry = new CacheMessageTableEntry(metadata,
+                                                    rollbackDetail.getStartTimestamp(),
+                                                    (short) rollbackDetail.getStartSequenceId());
+      Entry endEntry = new CacheMessageTableEntry(metadata,
+                                                  rollbackDetail.getEndTimestamp(),
+                                                  (short) rollbackDetail.getEndSequenceId());
+      messageCache.updateEntries(startEntry, endEntry, new MessageCache.EntryUpdater<Entry>() {
+        @Override
+        public void updateEntry(Entry entry) {
+          if (!(entry instanceof CacheMessageTableEntry)) {
+            // This shouldn't happen
+            throw new IllegalStateException("Entries in MessageCache must be of type "
+                                              + CacheMessageTableEntry.class.getName()
+                                              + ", but got type " + entry.getClass().getName() + " instead.");
+          }
+          ((CacheMessageTableEntry) entry).rollback();
+        }
+      });
+    }
+
+    // Rollback from the table
+    messageTable.rollback(metadata, rollbackDetail);
+  }
+
+  @Override
+  public void close() throws IOException {
+    messageTable.close();
+  }
+
+  /**
+   * Adjusts the given {@link Entry} based on the grace period.
+   *
+   * @param metadata the topic metadata
+   * @param entry the {@link Entry} to adjust
+   * @return the same {@link Entry} instance if no adjustment was made; otherwise return a new instance
+   *         with the publish timestamp adjusted base on the grace period.
+   */
+  private Entry adjustLookupEntry(TopicMetadata metadata, Entry entry) {
+    long minStartTime = timeProvider.currentTimeMillis() - gracePeriod;
+    if (entry.getPublishTimestamp() >= minStartTime) {
+      return entry;
+    }
+    return new CacheMessageTableEntry(metadata, minStartTime, (short) 0);
+  }
+
+  /**
+   * Returns {@code true} if the scanner created from the message cache contains all entries starting from the given
+   * start entry; otherwise return {@code false}.
+   */
+  private boolean cacheHasAllEntries(Entry startEntry, MessageCache.Scanner<Entry> scanner,
+                                     Comparator<MessageTable.Entry> comparator) {
+    Entry firstInCache = scanner.getFirstInCache();
+    return firstInCache != null && comparator.compare(firstInCache, startEntry) <= 0;
+  }
+
+  /**
+   * Creates a {@link MessageFilter} for scanning entries from the {@link MessageCache}.
+   */
+  private MessageFilter<Entry> createFilter(TopicMetadata metadata, @Nullable Transaction transaction) {
+    final int generation = metadata.getGeneration();
+
+    // If there is no transaction in reading, the filter just need to match with the topic generation
+    if (transaction == null) {
+      return new MessageFilter<Entry>() {
+        @Override
+        public Result apply(Entry entry) {
+          return generation ==  entry.getGeneration() ? Result.ACCEPT : Result.SKIP;
+        }
+      };
+    }
+
+    // If transaction is present, need to match the generation and skip entries that has been rollback.
+    return new TransactionMessageFilter(transaction) {
+      @Override
+      public Result apply(Entry entry) {
+        if (generation != entry.getGeneration()) {
+          return Result.SKIP;
+        }
+        if (entry instanceof CacheMessageTableEntry && ((CacheMessageTableEntry) entry).isRollback()) {
+          return Result.SKIP;
+        }
+        return super.apply(entry);
+      }
+    };
+  }
+
+  /**
+   * A {@link CloseableIterator} of {@link Entry} by combine entries scanned from {@link MessageTable}
+   * and from {@link MessageCache}.
+   */
+  private static final class CombineMessageEntryIterator extends AbstractCloseableIterator<Entry> {
+
+    private final CloseableIterator<Entry> tableIterator;
+    private final MessageCache.Scanner<Entry> scanner;
+    private final Comparator<Entry> comparator;
+    private boolean iterateCache;
+    private Entry firstCachedEntry;
+    private int count;
+
+    private CombineMessageEntryIterator(CloseableIterator<Entry> tableIterator,
+                                        MessageCache.Scanner<Entry> scanner,
+                                        Comparator<Entry> comparator,
+                                        int limit) {
+      this.tableIterator = tableIterator;
+      this.scanner = scanner;
+      this.comparator = comparator;
+      this.firstCachedEntry = scanner.hasNext() ? scanner.next() : null;
+      this.count = limit;
+    }
+
+
+    @Override
+    protected Entry computeNext() {
+      if (count <= 0) {
+        return endOfData();
+      }
+      count--;
+
+      if (iterateCache) {
+        return scanner.hasNext() ? scanner.next() : endOfData();
+      }
+
+      // If the table iterator is exhausted, doesn't matter what's in the cache, as the table is the source of truth
+      if (!tableIterator.hasNext()) {
+        return endOfData();
+      }
+
+      // If the table iterator return the same entry as the first one in the cache,
+      // switch to scan from the cache onward.
+      Entry entry = tableIterator.next();
+      if (firstCachedEntry != null && comparator.compare(entry, firstCachedEntry) == 0) {
+        entry = firstCachedEntry;
+        firstCachedEntry = null;
+        iterateCache = true;
+      }
+
+      return entry;
+    }
+
+    @Override
+    public void close() {
+      try {
+        tableIterator.close();
+      } finally {
+        scanner.close();
+      }
+    }
+  }
+
+  /**
+   * An {@link Iterator} of {@link Entry} that memorize the entries that have been iterated on.
+   */
+  private static final class CopyingIterator extends AbstractIterator<Entry> {
+
+    private final Iterator<? extends Entry> iterator;
+    private final Multimap<TopicId, Entry> entries;
+
+    private CopyingIterator(Iterator<? extends Entry> iterator) {
+      this.iterator = iterator;
+      this.entries = LinkedListMultimap.create();
+    }
+
+    @Override
+    protected Entry computeNext() {
+      if (!iterator.hasNext()) {
+        return endOfData();
+      }
+      Entry entry = iterator.next();
+      entries.put(entry.getTopicId(), copyEntry(entry));
+
+      return entry;
+    }
+
+    Multimap<TopicId, Entry> getEntries() {
+      return entries;
+    }
+
+    private Entry copyEntry(Entry other) {
+      return new CacheMessageTableEntry(other);
+    }
+  }
+
+  /**
+   * A {@link Entry} implementation used for entries in {@link MessageCache}, which allows
+   * altering the transaction write point for rollback purpose of messages that were published transactionally.
+   */
+  @VisibleForTesting
+  static final class CacheMessageTableEntry implements Entry {
+
+    private final boolean lookupOnly;
+    private final TopicId topicId;
+    private final int generation;
+    private final boolean transactional;
+    private final byte[] payload;
+    private final long publishTimestamp;
+    private final short sequenceId;
+    private long transactionWritePointer;
+    private boolean rollback;
+
+    CacheMessageTableEntry(TopicMetadata topicMetadata, long publishTimestamp, short sequenceId) {
+      this.lookupOnly = true;
+      this.topicId = topicMetadata.getTopicId();
+      this.generation = topicMetadata.getGeneration();
+      this.transactional = false;
+      this.payload = null;
+      this.publishTimestamp = publishTimestamp;
+      this.sequenceId = sequenceId;
+    }
+
+    CacheMessageTableEntry(Entry other) {
+      this.lookupOnly = false;
+      this.topicId = other.getTopicId();
+      this.generation = other.getGeneration();
+      this.transactional = other.isTransactional();
+      this.transactionWritePointer = other.getTransactionWritePointer();
+      this.payload = other.getPayload();
+      this.publishTimestamp = other.getPublishTimestamp();
+      this.sequenceId = other.getSequenceId();
+    }
+
+    void rollback() {
+      if (isTransactional()) {
+        rollback = true;
+      }
+    }
+
+    public boolean isRollback() {
+      return rollback;
+    }
+
+    @Override
+    public TopicId getTopicId() {
+      return topicId;
+    }
+
+    @Override
+    public int getGeneration() {
+      return generation;
+    }
+
+    @Override
+    public boolean isPayloadReference() {
+      return getPayload() == null;
+    }
+
+    @Override
+    public boolean isTransactional() {
+      if (lookupOnly) {
+        throw new UnsupportedOperationException();
+      }
+      return transactional;
+    }
+
+    @Override
+    public long getTransactionWritePointer() {
+      if (lookupOnly) {
+        throw new UnsupportedOperationException();
+      }
+      return transactionWritePointer;
+    }
+
+    @Nullable
+    @Override
+    public byte[] getPayload() {
+      if (lookupOnly) {
+        throw new UnsupportedOperationException();
+      }
+      return payload;
+    }
+
+    @Override
+    public long getPublishTimestamp() {
+      return publishTimestamp;
+    }
+
+    @Override
+    public short getSequenceId() {
+      return sequenceId;
+    }
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/CachingTableFactory.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/CachingTableFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store.cache;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.messaging.store.ForwardingTableFactory;
+import co.cask.cdap.messaging.store.MessageTable;
+import co.cask.cdap.messaging.store.MetadataTable;
+import co.cask.cdap.messaging.store.PayloadTable;
+import co.cask.cdap.messaging.store.TableFactory;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import java.io.IOException;
+
+/**
+ * A {@link TableFactory} with optional caching for {@link MessageTable} that it creates.
+ */
+public class CachingTableFactory extends ForwardingTableFactory {
+
+  public static final String DELEGATE_TABLE_FACTORY = "delegate.table.factory";
+
+  private final CConfiguration cConf;
+  private final TableFactory delegateTableFactory;
+  private final MessageTableCacheProvider cacheProvider;
+
+  @Inject
+  CachingTableFactory(CConfiguration cConf,
+                      @Named(DELEGATE_TABLE_FACTORY) TableFactory delegateTableFactory,
+                      MessageTableCacheProvider cacheProvider) {
+    this.cConf = cConf;
+    this.delegateTableFactory = delegateTableFactory;
+    this.cacheProvider = cacheProvider;
+  }
+
+  @Override
+  public TableFactory getDelegate() {
+    return delegateTableFactory;
+  }
+
+  @Override
+  public MetadataTable createMetadataTable(String tableName) throws IOException {
+    return delegateTableFactory.createMetadataTable(tableName);
+  }
+
+  @Override
+  public MessageTable createMessageTable(String tableName) throws IOException {
+    MessageTable messageTable = delegateTableFactory.createMessageTable(tableName);
+    return new CachingMessageTable(cConf, messageTable, cacheProvider);
+  }
+
+  @Override
+  public PayloadTable createPayloadTable(String tableName) throws IOException {
+    return delegateTableFactory.createPayloadTable(tableName);
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/DefaultMessageTableCacheProvider.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/DefaultMessageTableCacheProvider.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store.cache;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.messaging.MessagingServiceUtils;
+import co.cask.cdap.messaging.cache.MessageCache;
+import co.cask.cdap.messaging.store.MessageTable;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * The default implementation of {@link MessageTableCacheProvider}.
+ */
+public class DefaultMessageTableCacheProvider implements MessageTableCacheProvider {
+
+  private final CConfiguration cConf;
+  private final MetricsCollectionService metricsCollectionService;
+  private Map<TopicId, MessageCache<MessageTable.Entry>> topicMessageCaches;
+  private volatile boolean initialized;
+
+  @Inject
+  DefaultMessageTableCacheProvider(CConfiguration cConf, MetricsCollectionService metricsCollectionService) {
+    // Due to circular dependency (see CoreMessagingService), we can't use the MetricsCollectionService in the
+    // constructor, hence delay the cache initialization to later time.
+    this.cConf = cConf;
+    this.metricsCollectionService = metricsCollectionService;
+  }
+
+
+  @Nullable
+  @Override
+  public MessageCache<MessageTable.Entry> getMessageCache(TopicId topicId) {
+    if (!initialized) {
+      synchronized (this) {
+        if (!initialized) {
+          Map<TopicId, MessageCache<MessageTable.Entry>> caches = new HashMap<>();
+
+          long cacheSize = cConf.getInt(Constants.MessagingSystem.CACHE_SIZE_MB) * 1024 * 1024;
+          Set<TopicId> systemTopics = MessagingServiceUtils.getSystemTopics(cConf, true);
+          if (cacheSize > 0 && !systemTopics.isEmpty()) {
+            MessageTableEntryWeigher weigher = new MessageTableEntryWeigher();
+            MessageTableEntryComparator comparator = new MessageTableEntryComparator();
+
+            // Just evenly distributed the cache among all system topics.
+            // More sophisticated logic can be employed at runtime to monitor the metrics from MessageCache
+            // for each topic and adjust the soft/hard limit accordingly to maximize efficiency in
+            // memory usage and performance
+            long hardLimit = cacheSize / systemTopics.size();
+            if (hardLimit > 0) {
+              // Have reduce trigger as 70% of the hard limit and min retain as 50% of the hard limit
+              // In future, it can be adjusted dynamically based on metrics
+              MessageCache.Limits limits = new MessageCache.Limits(hardLimit / 2, hardLimit * 7 / 10, hardLimit);
+              for (TopicId topic : systemTopics) {
+                caches.put(topic, new MessageCache<>(comparator, weigher, limits,
+                                                     createMetricsContext(cConf, topic, metricsCollectionService)));
+              }
+            }
+          }
+
+          topicMessageCaches = caches;
+          initialized = true;
+        }
+      }
+    }
+
+    return topicMessageCaches.get(topicId);
+  }
+
+  /**
+   * Creates a {@link MetricsContext} for {@link MessageCache} to use for the given topic.
+   */
+  private MetricsContext createMetricsContext(CConfiguration cConf, TopicId topicId,
+                                              MetricsCollectionService metricsCollectionService) {
+    return metricsCollectionService.getContext(ImmutableMap.of(
+      Constants.Metrics.Tag.COMPONENT, Constants.Service.MESSAGING_SERVICE,
+      Constants.Metrics.Tag.INSTANCE_ID, cConf.get(Constants.MessagingSystem.CONTAINER_INSTANCE_ID, "0"),
+      Constants.Metrics.Tag.NAMESPACE, topicId.getNamespace(),
+      Constants.Metrics.Tag.TOPIC, topicId.getTopic()
+    ));
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/MessageTableCacheProvider.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/MessageTableCacheProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store.cache;
+
+import co.cask.cdap.messaging.cache.MessageCache;
+import co.cask.cdap.messaging.store.MessageTable;
+import co.cask.cdap.proto.id.TopicId;
+
+import javax.annotation.Nullable;
+
+/**
+ * A provider to provide {@link MessageCache} over {@link MessageTable.Entry} based on {@link TopicId}.
+ */
+public interface MessageTableCacheProvider {
+
+  /**
+   * Returns a {@link MessageCache} for the given topic.
+   *
+   * @param topicId the topic id
+   * @return a {@link MessageCache} or {@code null} if caching is not enabled for the given topic.
+   */
+  @Nullable
+  MessageCache<MessageTable.Entry> getMessageCache(TopicId topicId);
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/MessageTableEntryComparator.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/MessageTableEntryComparator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store.cache;
+
+import co.cask.cdap.messaging.store.MessageTable;
+
+import java.util.Comparator;
+
+/**
+ * A {@link Comparator} for {@link MessageTable.Entry}.
+ * The order is first by generation, followed by publish timestamp and sequence id.
+ */
+final class MessageTableEntryComparator implements Comparator<MessageTable.Entry> {
+
+  @Override
+  public int compare(MessageTable.Entry entry1, MessageTable.Entry entry2) {
+    int cmp = Integer.compare(entry1.getGeneration(), entry2.getGeneration());
+    if (cmp != 0) {
+      return cmp;
+    }
+    cmp = Long.compare(entry1.getPublishTimestamp(), entry2.getPublishTimestamp());
+    if (cmp != 0) {
+      return cmp;
+    }
+    return Integer.compare(entry1.getSequenceId() & 0xFFFF, entry2.getSequenceId() & 0xFFFF);
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/MessageTableEntryWeigher.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/cache/MessageTableEntryWeigher.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store.cache;
+
+import co.cask.cdap.messaging.cache.MessageCache;
+import co.cask.cdap.messaging.store.MessageTable;
+
+/**
+ * A {@link MessageCache.Weigher} for the {@link MessageTable.Entry}.
+ */
+final class MessageTableEntryWeigher implements MessageCache.Weigher<MessageTable.Entry> {
+
+  @Override
+  public int weight(MessageTable.Entry entry) {
+    // Some fixed overhead for the primitive and reference fields
+    int weight = 40;
+    byte[] payload = entry.getPayload();
+    weight += payload == null ? 0 : payload.length;
+    return weight;
+  }
+}

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/MessagingUtilsTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/MessagingUtilsTest.java
@@ -16,12 +16,18 @@
 
 package co.cask.cdap.messaging;
 
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.TopicId;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 /**
- * Tests for {@link MessagingUtils}.
+ * Tests for {@link MessagingUtils} and {@link MessagingServiceUtils}.
  */
 public class MessagingUtilsTest {
 
@@ -40,5 +46,21 @@ public class MessagingUtilsTest {
     Assert.assertFalse(MessagingUtils.isOlderGeneration(6, 5));
     Assert.assertFalse(MessagingUtils.isOlderGeneration(6, 6));
     Assert.assertFalse(MessagingUtils.isOlderGeneration(6, -5));
+  }
+
+  @Test
+  public void testSystemTopics() {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.MessagingSystem.SYSTEM_TOPICS, "  topic-1, topic_2 ,prefix:10,invalid.name");
+
+    Set<TopicId> topics = MessagingServiceUtils.getSystemTopics(cConf, true);
+    Set<TopicId> expected = new LinkedHashSet<>();
+    expected.add(NamespaceId.SYSTEM.topic("topic-1"));
+    expected.add(NamespaceId.SYSTEM.topic("topic_2"));
+    for (int i = 0; i < 10; i++) {
+      expected.add(NamespaceId.SYSTEM.topic("prefix" + i));
+    }
+
+    Assert.assertEquals(expected, topics);
   }
 }

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/cache/MessageCacheTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/cache/MessageCacheTest.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.cache;
+
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.metrics.NoopMetricsContext;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.messaging.store.MessageFilter;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit test for {@link MessageCache}.
+ */
+public class MessageCacheTest {
+
+  private static final MetricsContext NOOP_METRICS = new NoopMetricsContext();
+
+  @Test
+  public void testNoCache() {
+    // Create a cache with zero limits
+    MessageCache<String> cache = new MessageCache<>(String.CASE_INSENSITIVE_ORDER, new MessageCache.Weigher<String>() {
+      @Override
+      public int weight(String entry) {
+        return entry.length();
+      }
+    }, new MessageCache.Limits(0, 0, 0), NOOP_METRICS);
+    cache.addAll(Arrays.asList("111", "222", "333").iterator());
+    Assert.assertEquals(0L, cache.getCurrentWeight());
+
+    try (MessageCache.Scanner<String> scanner = cache.scan("0", true, 10, MessageFilter.<String>alwaysAccept())) {
+      Assert.assertNull(scanner.getFirstInCache());
+      Assert.assertFalse(scanner.hasNext());
+    }
+  }
+
+  @Test
+  public void testBasic() {
+    // Test basic operations for the cache from single thread
+    MessageCache<Integer> cache = new MessageCache<>(new IntComparator(), new UnitWeigher<Integer>(),
+                                                     new MessageCache.Limits(10, 14, 20), NOOP_METRICS);
+
+    cache.addAll(Arrays.asList(1, 2, 3, 4, 5, 11, 12, 13, 14, 15).iterator());
+    Assert.assertEquals(10, cache.getCurrentWeight());
+
+    MessageFilter<Integer> filter = MessageFilter.alwaysAccept();
+
+    // Scan with a start key that is not in cache
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5, 11, 12, 13, 14, 15), Lists.newArrayList(scanner));
+    }
+
+    // Scan with a limit
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 5, filter)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), Lists.newArrayList(scanner));
+    }
+
+    // Scan with a start key that is in the cache, inclusive
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(3, true, 5, filter)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(3, 4, 5, 11, 12), Lists.newArrayList(scanner));
+    }
+
+    // Scan with a start key that is in the cache, exclusive
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(3, false, 5, filter)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(4, 5, 11, 12, 13), Lists.newArrayList(scanner));
+    }
+
+    // Scan with a start key that is between keys in the cache
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(9, true, 5, filter)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(11, 12, 13, 14, 15), Lists.newArrayList(scanner));
+    }
+
+    // Scan with filter that only accept evens
+    MessageFilter<Integer> acceptEvens = new MessageFilter<Integer>() {
+      @Override
+      public Result apply(Integer input) {
+        return input % 2 == 0 ? Result.ACCEPT : Result.SKIP;
+      }
+    };
+    // Scan that takes all evens
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, acceptEvens)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(2, 4, 12, 14), Lists.newArrayList(scanner));
+    }
+    // Scan that takes evens with limit
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 3, acceptEvens)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(2, 4, 12), Lists.newArrayList(scanner));
+    }
+
+    // Scan with filter that hold when number 11
+    MessageFilter<Integer> holdAtEleven = new MessageFilter<Integer>() {
+      @Override
+      public Result apply(Integer input) {
+        return input == 11 ? Result.HOLD : Result.ACCEPT;
+      }
+    };
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, holdAtEleven)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), Lists.newArrayList(scanner));
+    }
+  }
+
+  @Test
+  public void testUpdate() {
+    MessageCache<Entry> cache = new MessageCache<>(new EntryComparator(), new UnitWeigher<Entry>(),
+                                                   new MessageCache.Limits(10, 14, 20), NOOP_METRICS);
+
+    // Try update that alter order at different element. Exception should be raised in all cases.
+    for (int i = 0; i < 3; i++) {
+      // Add some entries to the cache
+      cache.addAll(Arrays.asList(new Entry(0, "Name"), new Entry(1, "Name"),
+                                 new Entry(2, "Name"), new Entry(3, "Name")).iterator());
+
+      // Update entries that alter ordering. Exception should be raised
+      try {
+        final int idx = i;
+        cache.updateEntries(new Entry(0, "Name"), new Entry(2, "Name"), new MessageCache.EntryUpdater<Entry>() {
+          @Override
+          public void updateEntry(Entry entry) {
+            if (entry.getId() == idx) {
+              entry.setId(entry.getId() + 1);
+            }
+          }
+        });
+        Assert.fail("Expected exception of out of order update in iteration " + i);
+      } catch (IllegalStateException e) {
+        Assert.assertEquals(0, cache.getCurrentWeight());
+      }
+    }
+
+    // Repopulate the cache
+    cache.addAll(Arrays.asList(new Entry(0, "Name"), new Entry(1, "Name"),
+                               new Entry(2, "Name"), new Entry(3, "Name")).iterator());
+
+    // Update entries normally
+    cache.updateEntries(new Entry(0, null), new Entry(3, null), new MessageCache.EntryUpdater<Entry>() {
+      @Override
+      public void updateEntry(Entry entry) {
+        entry.setName("Name " + entry.getId());
+      }
+    });
+
+    try (MessageCache.Scanner<Entry> scanner = cache.scan(new Entry(0, null), true, 10,
+                                                          MessageFilter.<Entry>alwaysAccept())) {
+      int idx = 0;
+      while (scanner.hasNext()) {
+        Entry entry = scanner.next();
+        Assert.assertEquals(idx, entry.getId());
+        Assert.assertEquals("Name " + idx, entry.getName());
+        idx++;
+      }
+    }
+  }
+
+  @Test
+  public void testCacheReduction() {
+    // Test the cache reduction logic in single thread case.
+    MessageCache<Integer> cache = new MessageCache<>(new IntComparator(), new UnitWeigher<Integer>(),
+                                                     new MessageCache.Limits(5, 7, 10), NOOP_METRICS);
+
+    MessageFilter<Integer> filter = MessageFilter.alwaysAccept();
+
+    // Add some entries to the cache, without going over the reduce trigger
+    cache.addAll(Arrays.asList(1, 2, 3, 4, 5).iterator());
+
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+      Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), Lists.newArrayList(scanner));
+    }
+
+    // Add some more entries so that it goes over the reduce trigger limit, but not hitting hard limit
+    cache.addAll(Arrays.asList(6, 7, 8, 9).iterator());
+
+    // First scan of the cache should gives all cached entries, since reduction only performed at scanner close
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9), Lists.newArrayList(scanner));
+    }
+
+    // The second scan should only give the last 5 entries (min retain)
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+      Assert.assertEquals(Integer.valueOf(5), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(5, 6, 7, 8, 9), Lists.newArrayList(scanner));
+    }
+
+    // Add more entries so that it will hit the hard limit while adding
+    cache.addAll(Arrays.asList(10, 11, 12, 13, 14, 15, 16, 17, 18).iterator());
+
+    // Since weight reduction happened during adding of element 15 (5 - 15 has weight 11),
+    // it retains the latest 5 (11 to 15). Then adding 16 to 18 doesn't hit the hard limit, hence the cache
+    // will be holding 11 to 18.
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+      Assert.assertEquals(Integer.valueOf(11), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(11, 12, 13, 14, 15, 16, 17, 18), Lists.newArrayList(scanner));
+    }
+
+    // Since on previous scan closure will reduce the cache back to the min retain, scanning again would
+    // only give the last 5 elements
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+      Assert.assertEquals(Integer.valueOf(14), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(14, 15, 16, 17, 18), Lists.newArrayList(scanner));
+    }
+  }
+
+  @Test
+  public void testCacheResize() {
+    // Test resize the cache
+    MessageCache<Integer> cache = new MessageCache<>(new IntComparator(), new UnitWeigher<Integer>(),
+                                                     new MessageCache.Limits(2, 3, 4), NOOP_METRICS);
+
+    MessageFilter<Integer> filter = MessageFilter.alwaysAccept();
+
+    // Add entries to the cache up to the hard limit
+    cache.addAll(Arrays.asList(1, 2, 3, 4).iterator());
+
+    // Resize the the cache to double the size
+    cache.resize(new MessageCache.Limits(4, 6, 8));
+
+    // Scanning should get all entries
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+      Assert.assertEquals(Integer.valueOf(1), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(1, 2, 3, 4), Lists.newArrayList(scanner));
+    }
+
+    // Add more elements that passes the new hard limit
+    cache.addAll(Arrays.asList(5, 6, 7, 8, 9).iterator());
+
+    // Scanning should get the last four elements (new min retain)
+    try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+      Assert.assertEquals(Integer.valueOf(6), scanner.getFirstInCache());
+      Assert.assertEquals(Arrays.asList(6, 7, 8, 9), Lists.newArrayList(scanner));
+    }
+  }
+
+  @Test
+  public void testAddError() throws Exception {
+    // Test to verify various error situations are being safeguarded
+    final MessageCache<Integer> cache = new MessageCache<>(new IntComparator(), new UnitWeigher<Integer>(),
+                                                           new MessageCache.Limits(5, 7, 10), NOOP_METRICS);
+
+    // 1. Adding out of order should result in error
+    try {
+      cache.addAll(Arrays.asList(5, 2, 3, 4).iterator());
+      Assert.fail("Expected failure for adding out of order");
+    } catch (IllegalArgumentException e) {
+      // Expected. The cache should be cleared
+      Assert.assertEquals(0, cache.getCurrentWeight());
+    }
+
+    // 2. Adding entries that are smaller than the largest one in the cache
+    cache.addAll(Arrays.asList(5, 6, 7, 8).iterator());
+    try {
+      cache.addAll(Arrays.asList(1, 2, 3, 4).iterator());
+      Assert.fail("Expected failure for adding out of order");
+    } catch (IllegalArgumentException e) {
+      // Expected. The cache should be cleared
+      Assert.assertEquals(0, cache.getCurrentWeight());
+    }
+
+    // 3. Adding duplicate entry
+    try {
+      cache.addAll(Arrays.asList(1, 1).iterator());
+      Assert.fail("Expected failure for adding out of order");
+    } catch (IllegalArgumentException e) {
+      // Expected. The cache should be cleared
+      Assert.assertEquals(0, cache.getCurrentWeight());
+    }
+
+    // 4. Adding entry that is already exist in the cache
+    cache.addAll(Arrays.asList(1, 2).iterator());
+    try {
+      cache.addAll(Arrays.asList(2, 3).iterator());
+    } catch (IllegalArgumentException e) {
+      // Expected. The cache should be cleared
+      Assert.assertEquals(0, cache.getCurrentWeight());
+    }
+
+    // 5. Multiple threads calling addAll at the same time
+    final CyclicBarrier barrier = new CyclicBarrier(2);
+    final CountDownLatch produceLatch = new CountDownLatch(1);
+
+    // Starts the the first thread and block inside the addAll call
+    new Thread() {
+      @Override
+      public void run() {
+        cache.addAll(new AbstractIterator<Integer>() {
+          private boolean produced;
+
+          @Override
+          protected Integer computeNext() {
+            try {
+              barrier.await();
+            } catch (Exception e) {
+              // This shouldn't happen
+            }
+            Uninterruptibles.awaitUninterruptibly(produceLatch);
+            if (!produced) {
+              produced = true;
+              return 1;
+            }
+            return endOfData();
+          }
+        });
+      }
+    }.start();
+
+    // Starts the second thread that tries to call addAll after the first thread is blocked inside the addAll call
+    final BlockingQueue<Exception> exception = new ArrayBlockingQueue<>(1);
+    new Thread() {
+      @Override
+      public void run() {
+        try {
+          barrier.await();
+        } catch (Exception e) {
+          // This shouldn't happen
+        }
+        try {
+          cache.addAll(Arrays.asList(1, 2, 3).iterator());
+        } catch (Exception e) {
+          exception.add(e);
+        }
+      }
+    }.start();
+
+    Exception e = exception.poll(10, TimeUnit.SECONDS);
+    Assert.assertNotNull(e);
+    Assert.assertTrue(e instanceof ConcurrentModificationException);
+
+    // Unblock the first thread
+    produceLatch.countDown();
+
+    final MessageFilter<Integer> filter = MessageFilter.alwaysAccept();
+    Tasks.waitFor(Collections.singletonList(1), new Callable<List<Integer>>() {
+      @Override
+      public List<Integer> call() throws Exception {
+        try (MessageCache.Scanner<Integer> scanner = cache.scan(0, true, 10, filter)) {
+          return Lists.newArrayList(scanner);
+        }
+      }
+    }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+  }
+
+
+  /**
+   * A {@link Comparator} for {@link Integer}.
+   */
+  private static final class IntComparator implements Comparator<Integer> {
+
+    @Override
+    public int compare(Integer o1, Integer o2) {
+      return o1.compareTo(o2);
+    }
+  }
+
+  /**
+   * A {@link MessageCache.Weigher} that also return 1 for the weight
+   *
+   * @param <T> type of entry
+   */
+  private static final class UnitWeigher<T> implements MessageCache.Weigher<T> {
+
+    @Override
+    public int weight(T entry) {
+      return 1;
+    }
+  }
+
+  /**
+   * A cache entry for testing.
+   */
+  private static final class Entry {
+    private int id;
+    private String name;
+
+    public Entry(int id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+
+  /**
+   * A {@link Comparator} for {@link Entry} that only compare with the id.
+   */
+  private static final class EntryComparator implements Comparator<Entry> {
+
+    @Override
+    public int compare(Entry entry1, Entry entry2) {
+      return Integer.compare(entry1.getId(), entry2.getId());
+    }
+  }
+}

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/cache/CachingMessageTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/cache/CachingMessageTableTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store.cache;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.metrics.NoopMetricsContext;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.utils.TimeProvider;
+import co.cask.cdap.messaging.MessagingUtils;
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.messaging.cache.MessageCache;
+import co.cask.cdap.messaging.data.MessageId;
+import co.cask.cdap.messaging.store.ImmutableMessageTableEntry;
+import co.cask.cdap.messaging.store.MessageTable;
+import co.cask.cdap.messaging.store.leveldb.LevelDBMessageTableTest;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Lists;
+import org.apache.tephra.Transaction;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Unit test for {@link CachingMessageTable}.
+ */
+public class CachingMessageTableTest extends LevelDBMessageTableTest {
+
+  private static MessageTableCacheProvider cacheProvider;
+
+  @BeforeClass
+  public static void initCache() {
+    final LoadingCache<TopicId, MessageCache<MessageTable.Entry>> caches = CacheBuilder
+      .newBuilder().build(new CacheLoader<TopicId, MessageCache<MessageTable.Entry>>() {
+        @Override
+        public MessageCache<MessageTable.Entry> load(TopicId key) throws Exception {
+          return new MessageCache<>(new MessageTableEntryComparator(), new MessageTableEntryWeigher(),
+                                    new MessageCache.Limits(500, 700, 1000), new NoopMetricsContext());
+        }
+      });
+
+    cacheProvider = new MessageTableCacheProvider() {
+      @Override
+      public MessageCache<MessageTable.Entry> getMessageCache(TopicId topicId) {
+        return caches.getUnchecked(topicId);
+      }
+    };
+  }
+
+  @Override
+  protected MessageTable getMessageTable() throws Exception {
+    MessageTable messageTable = super.getMessageTable();
+    return new CachingMessageTable(cConf, messageTable, cacheProvider);
+  }
+
+  @Test
+  public void testCachePruning() throws Exception {
+    long txGracePeriod = 6;
+    CConfiguration cConf = CConfiguration.create();
+    cConf.setLong(CachingMessageTable.PRUNE_GRACE_PERIOD, txGracePeriod);
+
+    // Creates a CachingMessageTable with a controlled time provider
+    final AtomicLong currentTimeMillis = new AtomicLong(0);
+    MessageTable messageTable = new CachingMessageTable(cConf, super.getMessageTable(),
+                                                        cacheProvider, new TimeProvider() {
+      @Override
+      public long currentTimeMillis() {
+        return currentTimeMillis.get();
+      }
+    });
+
+    // Insert 10 entries, with different publish time
+    TopicMetadata metadata = new TopicMetadata(NamespaceId.DEFAULT.topic("test"),
+                                               TopicMetadata.GENERATION_KEY, 1,
+                                               TopicMetadata.TTL_KEY, 86400);
+    for (int i = 0; i < 10; i++) {
+      // Key is (topic, generation, publish time, sequence id)
+      byte[] key = Bytes.concat(MessagingUtils.toDataKeyPrefix(metadata.getTopicId(), metadata.getGeneration()),
+                                Bytes.toBytes((long) i), Bytes.toBytes((short) 0));
+      // Store a message with a write pointer
+      messageTable.store(
+        Collections.singleton(new ImmutableMessageTableEntry(key, Bytes.toBytes("Payload " + i),
+                                                             Bytes.toBytes((long) i))).iterator());
+    }
+
+    // Update the current time to 11
+    currentTimeMillis.set(11);
+
+    // Fetch from the table without transaction, should get all entries.
+    try (CloseableIterator<MessageTable.Entry> iter = messageTable.fetch(metadata, 0, 100, null)) {
+      List<MessageTable.Entry> entries = Lists.newArrayList(iter);
+      Assert.assertEquals(10, entries.size());
+      // All entries must be from the cache
+      for (MessageTable.Entry entry : entries) {
+        Assert.assertTrue(entry instanceof CachingMessageTable.CacheMessageTableEntry);
+      }
+    }
+
+    // Fetch with a transaction, with start time older than tx grace period / 2
+    Transaction tx = new Transaction(10, 11, new long[0], new long[0], 11);
+    long startTime = currentTimeMillis.get() - txGracePeriod / 2 - 1;
+    try (CloseableIterator<MessageTable.Entry> iter = messageTable.fetch(metadata, startTime, 100, tx)) {
+      List<MessageTable.Entry> entries = Lists.newArrayList(iter);
+
+      // Should get three entries (7, 8, 9)
+      Assert.assertEquals(3, entries.size());
+
+      // The first entry should be from the table, while the last two entries (timestamp 8 and 9) should be
+      // from cache (current time = 11, grace period = 3)
+      Iterator<MessageTable.Entry> iterator = entries.iterator();
+      Assert.assertFalse(iterator.next() instanceof CachingMessageTable.CacheMessageTableEntry);
+      Assert.assertTrue(iterator.next() instanceof CachingMessageTable.CacheMessageTableEntry);
+      Assert.assertTrue(iterator.next() instanceof CachingMessageTable.CacheMessageTableEntry);
+    }
+
+    // Fetch with a transaction, with start messageId publish time older than tx grace period / 2
+    byte[] rawId = new byte[MessageId.RAW_ID_SIZE];
+    MessageId.putRawId(startTime, (short) 0, 0L, (short) 0, rawId, 0);
+    MessageId messageId = new MessageId(rawId);
+    try (CloseableIterator<MessageTable.Entry> iter = messageTable.fetch(metadata, messageId, true, 100, tx)) {
+      List<MessageTable.Entry> entries = Lists.newArrayList(iter);
+
+      // Should get three entries (7, 8, 9)
+      Assert.assertEquals(3, entries.size());
+
+      // The first entry should be from the table, while the last two entries (timestamp 8 and 9) should be
+      // from cache (current time = 11, grace period = 3)
+      Iterator<MessageTable.Entry> iterator = entries.iterator();
+      Assert.assertFalse(iterator.next() instanceof CachingMessageTable.CacheMessageTableEntry);
+      Assert.assertTrue(iterator.next() instanceof CachingMessageTable.CacheMessageTableEntry);
+      Assert.assertTrue(iterator.next() instanceof CachingMessageTable.CacheMessageTableEntry);
+    }
+  }
+}

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/leveldb/LevelDBMessageTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/leveldb/LevelDBMessageTableTest.java
@@ -36,11 +36,12 @@ public class LevelDBMessageTableTest extends MessageTableTest {
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
+  protected static CConfiguration cConf;
   private static TableFactory tableFactory;
 
   @BeforeClass
   public static void init() throws IOException {
-    CConfiguration cConf = CConfiguration.create();
+    cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     tableFactory = new LevelDBTableFactory(cConf);
   }


### PR DESCRIPTION
Changes are organized into 4 commits. The most important changes are in the Part 1 and Part 3, which mostly are new code.

1. (CDAP-8167) (Part 1) Message caching for TMS
   * Added the MessageCache cache as a general message entry cache
2. (CDAP-8167) (Part 2) Refactor logic for getting system topics configuration
   * Separate out logic to get system topics to a util class
   * Also added startup check for the messaging system
3. CDAP-8167) (Part 3) Added CachingMessageTable implementation
   * A MessageTable implementation that combines MessageCache and MessageTable
4. (CDAP-8167) (Part 4) Enable message caching to TMS in distributed mode
   * Enable caching by configuration
   * Off for memory/local mode, enable for distributed mode
    

