### PR TITLE
HYDRATOR-1156 disable speculation by default

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -163,6 +163,8 @@ public class ETLMapReduce extends AbstractMapReduce {
 
     Job job = context.getHadoopJob();
     Configuration hConf = job.getConfiguration();
+    hConf.setBoolean("mapreduce.map.speculative", false);
+    hConf.setBoolean("mapreduce.reduce.speculative", false);
 
     // plugin name -> runtime args for that plugin
     Map<String, Map<String, String>> runtimeArgs = new HashMap<>();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
@@ -107,6 +107,7 @@ public class ETLSpark extends AbstractSpark {
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.driver.extraJavaOptions", "-XX:MaxPermSize=256m");
     sparkConf.set("spark.executor.extraJavaOptions", "-XX:MaxPermSize=256m");
+    sparkConf.set("spark.speculation", "false");
     context.setSparkConf(sparkConf);
 
     Map<String, String> properties = context.getSpecification().getProperties();


### PR DESCRIPTION
Now that there is a way to set arbitrary values in the conf,
disabling speculation by default. This will make sure that the
metrics are not double counted. If the user wants, they can
always override it.