### PR TITLE
HYDRATOR-1312 fix disable checkpoints flag

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -149,6 +149,7 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
       }
     };
 
-    return JavaStreamingContext.getOrCreate(checkpointDir, contextFactory);
+    return checkpointDir == null ? contextFactory.create() :
+      JavaStreamingContext.getOrCreate(checkpointDir, contextFactory);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
@@ -362,6 +362,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("source2", "agg2")
       .addConnection("agg1", "sink1")
       .addConnection("agg2", "sink2")
+      .disableCheckpoints()
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, pipelineConfig);


### PR DESCRIPTION
Fixed a bug where streaming pipelines could not be started
when checkpoints are disabled, due to a null pointer from a null
checkpoint path.