### PR TITLE
Clean up MR Program Logs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -199,7 +199,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
 
       final ProgramController controller = new MapReduceProgramController(mapReduceRuntimeService, context);
 
-      LOG.info("Starting MapReduce Job: {}", context.toString());
+      LOG.debug("Starting MapReduce Job: {}", context);
       // if security is not enabled, start the job as the user we're using to access hdfs with.
       // if this is not done, the mapred job will be launched as the user that runs the program
       // runner, which is probably the yarn user. This may cause permissions issues if the program

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -95,6 +95,7 @@ import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tephra.Transaction;
@@ -339,7 +340,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
         // submits job and returns immediately. Shouldn't need to set context ClassLoader.
         job.submit();
         // log after the job.submit(), because the jobId is not assigned before then
-        LOG.info("Submitted MapReduce Job: {}.", context);
+        LOG.debug("Submitted MapReduce Job: {}.", context);
 
         this.job = job;
         this.transaction = tx;
@@ -375,7 +376,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       TimeUnit.SECONDS.sleep(1);
     }
 
-    LOG.info("MapReduce Job is complete, status: {}, job: {}", job.isSuccessful(), context);
+    LOG.info("MapReduce Job completed{}. Job details: [{}]", job.isSuccessful() ? " successfully" : "", context);
     // NOTE: we want to report the final stats (they may change since last report and before job completed)
     metricsWriter.reportStats();
     // If we don't sleep, the final stats may not get sent before shutdown.
@@ -396,7 +397,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
 
     try {
       if (success) {
-        LOG.info("Committing MapReduce Job transaction: {}", context);
+        LOG.debug("Committing MapReduce Job transaction: {}", context);
         // committing long running tx: no need to commit datasets, as they were committed in external processes
         // also no need to rollback changes if commit fails, as these changes where performed by mapreduce tasks
         // NOTE: can't call afterCommit on datasets in this case: the changes were made by external processes.
@@ -484,9 +485,14 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       jobConf.setBoolean(Job.JOB_AM_ACCESS_DISABLED, false);
 
       Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
-      LOG.info("Running in secure mode; adding all user credentials: {}", credentials.getAllTokens());
+      LOG.debug("Running in secure mode; adding all user credentials: {}", credentials.getAllTokens());
       job.getCredentials().addAll(credentials);
     }
+
+    // Command-line arguments are not supported here, but do this anyway to avoid warning log
+    GenericOptionsParser genericOptionsParser = new GenericOptionsParser(jobConf, null);
+    genericOptionsParser.getRemainingArgs();
+
     return job;
   }
 
@@ -995,7 +1001,6 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     if (cConf.getBoolean(Constants.AppFabric.MAPREDUCE_INCLUDE_CUSTOM_CLASSES)) {
       try {
         Class<? extends InputFormat<?, ?>> inputFormatClass = job.getInputFormatClass();
-        LOG.info("InputFormat class: {} {}", inputFormatClass, inputFormatClass.getClassLoader());
         classes.add(inputFormatClass);
 
         // If it is StreamInputFormat, also add the StreamEventCodec class as well.
@@ -1007,15 +1012,14 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
           }
         }
       } catch (Throwable t) {
-        LOG.info("InputFormat class not found: {}", t.getMessage(), t);
+        LOG.debug("InputFormat class not found: {}", t.getMessage(), t);
         // Ignore
       }
       try {
         Class<? extends OutputFormat<?, ?>> outputFormatClass = job.getOutputFormatClass();
-        LOG.info("OutputFormat class: {} {}", outputFormatClass, outputFormatClass.getClassLoader());
         classes.add(outputFormatClass);
       } catch (Throwable t) {
-        LOG.info("OutputFormat class not found: {}", t.getMessage(), t);
+        LOG.debug("OutputFormat class not found: {}", t.getMessage(), t);
         // Ignore
       }
     }
@@ -1045,7 +1049,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       ClassLoaders.setContextClassLoader(oldCLassLoader);
     }
 
-    LOG.info("Built MapReduce Job Jar at {}", jobJar.toURI());
+    LOG.debug("Built MapReduce Job Jar at {}", jobJar.toURI());
     return jobJar;
   }
 
@@ -1223,7 +1227,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     Location programJarCopy = targetDir.append("program.jar");
 
     ByteStreams.copy(Locations.newInputSupplier(programJarLocation), Locations.newOutputSupplier(programJarCopy));
-    LOG.info("Copied Program Jar to {}, source: {}", programJarCopy, programJarLocation);
+    LOG.debug("Copied Program Jar to {}, source: {}", programJarCopy, programJarLocation);
     return programJarCopy;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/inmemory/LocalClientProtocolProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/inmemory/LocalClientProtocolProvider.java
@@ -39,7 +39,7 @@ public class LocalClientProtocolProvider extends ClientProtocolProvider {
   public ClientProtocol create(Configuration conf) throws IOException {
     String framework =
       conf.get(MRConfig.FRAMEWORK_NAME, MRConfig.LOCAL_FRAMEWORK_NAME);
-    LOG.info("Using framework: " + framework);
+    LOG.debug("Using framework: " + framework);
     if (!MRConfig.LOCAL_FRAMEWORK_NAME.equals(framework)) {
       return null;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -321,7 +321,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
     try {
       state.get();
-      LOG.info("Program {} stopped.", name);
+      LOG.debug("Program {} stopped.", name);
     } catch (InterruptedException e) {
       LOG.warn("Program {} interrupted.", name, e);
     } catch (ExecutionException e) {
@@ -341,7 +341,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
   @Override
   public void destroy() {
-    LOG.info("Releasing resources: {}", name);
+    LOG.debug("Releasing resources: {}", name);
     try {
       if (program != null) {
         Closeables.closeQuietly(program);
@@ -351,7 +351,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       Futures.getUnchecked(
         Services.chainStop(services.get(0),
                            services.subList(1, services.size()).toArray(new Service[services.size() - 1])));
-      LOG.info("Runnable stopped: {}", name);
+      LOG.debug("Runnable stopped: {}", name);
     } finally {
       if (logAppenderInitializer != null) {
         logAppenderInitializer.close();

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/LocationRuntimeModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/LocationRuntimeModule.java
@@ -89,7 +89,7 @@ public final class LocationRuntimeModule extends RuntimeModule {
     @Singleton
     private LocationFactory providesLocationFactory(Configuration hConf, CConfiguration cConf, FileContext fc) {
       final String namespace = cConf.get(Constants.CFG_HDFS_NAMESPACE);
-      LOG.info("HDFS namespace is {}",  namespace);
+      LOG.debug("HDFS namespace is {}", namespace);
 
       if (UserGroupInformation.isSecurityEnabled()) {
         return new FileContextLocationFactory(hConf, namespace);

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -30,6 +30,12 @@
   <logger name="org.spark-project" level="WARN"/>
   <logger name="org.apache.hadoop" level="WARN"/>
   <logger name="org.apache.hive" level="WARN"/>
+  <logger name="org.apache.tephra.distributed.AbstractClientProvider" level="WARN"/>
+  <logger name="org.mortbay.log" level="WARN"/>
+  <logger name="SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager" level="WARN"/>
+  <logger name="SecurityLogger.org.apache.hadoop.ipc.Server" level="WARN"/>
+  <!-- Because of HADOOP-11180 move this to Error -->
+  <logger name="org.apache.hadoop.security.token.Token" level="ERROR"/>
   <logger name="org.quartz.core" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="io.netty.util.internal" level="WARN"/>

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -34,6 +34,12 @@
     <logger name="org.quartz.core" level="WARN"/>
     <logger name="org.eclipse.jetty" level="WARN"/>
     <logger name="io.netty.util.internal" level="WARN"/>
+    <logger name="org.apache.tephra.distributed.AbstractClientProvider" level="WARN"/>
+    <logger name="org.mortbay.log" level="WARN"/>
+    <logger name="SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager" level="WARN"/>
+    <logger name="SecurityLogger.org.apache.hadoop.ipc.Server" level="WARN"/>
+    <!-- Because of HADOOP-11180 move this to Error -->
+    <logger name="org.apache.hadoop.security.token.Token" level="ERROR"/>
 
     <logger name="org.apache.twill" level="INFO"/>
     <logger name="org.apache.twill.internal.kafka.client.SimpleKafkaConsumer" level="WARN"/>

--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -35,6 +35,12 @@
   <logger name="org.apache.hive" level="WARN"/>
   <!-- TODO Remove suppressing of Tephra logs once CDAP-8806 is fixed. -->
   <logger name="org.apache.tephra.TransactionManager" level="WARN"/>
+  <logger name="org.apache.tephra.distributed.AbstractClientProvider" level="WARN"/>
+  <logger name="org.mortbay.log" level="WARN"/>
+  <logger name="SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager" level="WARN"/>
+  <logger name="SecurityLogger.org.apache.hadoop.ipc.Server" level="WARN"/>
+  <!-- Because of HADOOP-11180 move this to Error -->
+  <logger name="org.apache.hadoop.security.token.Token" level="ERROR"/>
   <logger name="org.quartz.core" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="io.netty.util.internal" level="WARN"/>

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/LogAppenderInitializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/LogAppenderInitializer.java
@@ -89,9 +89,9 @@ public class LogAppenderInitializer implements Closeable {
   @Override
   public void close() {
     if (logAppender != null) {
-      LOG.info("Stopping log appender {}", logAppender.getName());
+      LOG.debug("Stopping log appender {}", logAppender.getName());
       logAppender.stop();
-      LOG.info("Done stopping log appender {}", logAppender.getName());
+      LOG.debug("Done stopping log appender {}", logAppender.getName());
     }
   }
   


### PR DESCRIPTION
This PR covers following changes for MR logs:
1. Move certain logs to debug that are not directly useful for the User.
2. Move certain org.apache loggers to WARN
3. Add genericOptionsParser for MR jobs. 