### PR TITLE
Cleanup Spark Program Logs

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -36,6 +36,8 @@
   <logger name="SecurityLogger.org.apache.hadoop.ipc.Server" level="WARN"/>
   <!-- Because of HADOOP-11180 move this to Error -->
   <logger name="org.apache.hadoop.security.token.Token" level="ERROR"/>
+  <logger name="akka" level="WARN"/>
+  <logger name="Remoting" level="WARN"/>
   <logger name="org.quartz.core" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="io.netty.util.internal" level="WARN"/>

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -40,6 +40,8 @@
     <logger name="SecurityLogger.org.apache.hadoop.ipc.Server" level="WARN"/>
     <!-- Because of HADOOP-11180 move this to Error -->
     <logger name="org.apache.hadoop.security.token.Token" level="ERROR"/>
+    <logger name="akka" level="WARN"/>
+    <logger name="Remoting" level="WARN"/>
 
     <logger name="org.apache.twill" level="INFO"/>
     <logger name="org.apache.twill.internal.kafka.client.SimpleKafkaConsumer" level="WARN"/>

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkCredentialsUpdater.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkCredentialsUpdater.java
@@ -90,7 +90,7 @@ public class SparkCredentialsUpdater extends AbstractIdleService implements Runn
     scheduler = Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("credentials-updater"));
     scheduler.submit(this).get();
 
-    LOG.info("Credentials updater started");
+    LOG.debug("Credentials updater started");
   }
 
   @Override
@@ -100,7 +100,7 @@ public class SparkCredentialsUpdater extends AbstractIdleService implements Runn
       executor.shutdownNow();
     }
 
-    LOG.info("Credentials updater stopped");
+    LOG.debug("Credentials updater stopped");
   }
 
   @Override
@@ -127,7 +127,7 @@ public class SparkCredentialsUpdater extends AbstractIdleService implements Runn
         throw new IOException("Failed to rename from " + tempFile + " to " + credentialsFile);
       }
 
-      LOG.info("Credentials written to {}", credentialsFile);
+      LOG.debug("Credentials written to {}", credentialsFile);
 
       // Schedule the next update.
       // Use the same logic as the Spark executor to calculate the update time.

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -443,6 +443,10 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     // Setup configs from the default spark conf
     setSparkDefaultConfigs(configs);
 
+    // Setup app.id and executor.id for Metric System
+    configs.put("spark.app.id", context.getApplicationSpecification().getName());
+    configs.put("spark.executor.id", context.getApplicationSpecification().getName());
+
     // Setups the resources requirements for driver and executor. The user can override it with the SparkConf.
     configs.put("spark.driver.memory", context.getDriverResources().getMemoryMB() + "m");
     configs.put("spark.driver.cores", String.valueOf(context.getDriverResources().getVirtualCores()));

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionService.java
@@ -85,7 +85,7 @@ public final class SparkExecutionService extends AbstractIdleService {
   public SparkExecutionService(LocationFactory locationFactory, String host,
                                ProgramRunId programRunId, @Nullable WorkflowToken workflowToken) {
     this.locationFactory = locationFactory;
-    this.httpServer = NettyHttpService.builder(SparkExecutionService.class.getName())
+    this.httpServer = NettyHttpService.builder(programRunId.getProgram() + "-spark-exec-service")
       .addHttpHandlers(Collections.singletonList(new SparkControllerHandler()))
       .setHost(host)
       .setExceptionHandler(new HttpExceptionHandler())

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
@@ -67,6 +67,9 @@ public class DistributedSparkSubmitter extends AbstractSparkSubmitter {
     config.put("spark.yarn.appMasterEnv.CDAP_LOG_DIR",  ApplicationConstants.LOG_DIR_EXPANSION_VAR);
     config.put("spark.executorEnv.CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR);
 
+    config.put("spark.yarn.security.tokens.hbase.enabled", "false");
+    config.put("spark.yarn.security.tokens.hive.enabled", "false");
+
     return config;
   }
 

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkMainWrapper.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SparkMainWrapper.scala
@@ -214,7 +214,7 @@ object SparkMainWrapper {
           executor.awaitTermination(5L, TimeUnit.SECONDS)
           // Send the complete call
           client.completed(workflowToken)
-          LOG.info("Spark program execution completed: {}", programRunId)
+          LOG.info("Spark program {} completed. Program RunID: [{}]", programRunId.getProgram, programRunId.getRun)
         }
       }
     })

--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -46,6 +46,8 @@
   <logger name="io.netty.util.internal" level="WARN"/>
   <logger name="co.cask.cdap.operations.OperationalStats" level="ERROR"/>
   <logger name="co.cask.cdap.extension.AbstractExtensionLoader" level="ERROR"/>
+  <logger name="akka" level="WARN"/>
+  <logger name="Remoting" level="WARN"/>
 
   <appender name="Rolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>logs/cdap.log</file>


### PR DESCRIPTION
- Move debugs to debug level.
- Add missing Spark configurations that were causing WARN logs.
- Move chatty loggers to WARN. 