### PR TITLE
[CDAP-9445] Show warning message when editing column name in dataprep table

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/DataPrepTable.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/DataPrepTable.scss
@@ -13,6 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+$th-bg-color: #bcbcbc;
+$warning-container-border-color: #cccccc;
+$selected-header-bg-color: #3498db;
 
 $border-and-selected-color: #dbdbdb;
 $header-bg-color: #eeeeee;
@@ -74,9 +77,38 @@ $header-bg-color: #eeeeee;
             width: auto;
             height: 20px;
           }
+
+          .warning-container-wrapper {
+            width: 100%;
+            position: relative;
+            .warning-container {
+              position: absolute;
+              top: 32px;
+              width: calc(100% + 62px);
+              left: -10px;
+              background: white;
+              padding: 10px;
+              border: 1px solid $warning-container-border-color;
+              border-top: 0;
+              padding-bottom: 0;
+              .warning-title-container {
+                margin-left: -10px;
+                margin-right: -10px;
+                margin-top: -10px;
+              }
+              .warning-btns-container {
+                margin-left: -10px;
+                margin-right: -10px;
+                border-top: 1px solid $warning-container-border-color;
+                margin-top: 10px;
+                padding: 10px;
+              }
+            }
+          }
           > span:first-child {
             cursor: initial;
           }
+
         }
 
         &:first-child { border-left: 0; }

--- a/cdap-ui/app/cdap/components/TextboxOnValium/index.js
+++ b/cdap-ui/app/cdap/components/TextboxOnValium/index.js
@@ -34,9 +34,22 @@ export default class TextboxOnValium extends Component {
   updateTextValue(e) {
     this.setState({
       textValue: e.target.value
+    }, () => {
+      if (this.state.originalValue !== this.state.textValue && this.props.onWarning) {
+        let isWarning = this.props.onWarning(this.state.textValue);
+        if (isWarning || (!isWarning && this.state.isWarning)) {
+          this.setState({
+            isWarning
+          });
+          return;
+        }
+      }
     });
   }
   onBlur() {
+    if (this.state.isWarning) {
+      return;
+    }
     this.props.onChange(this.state.textValue, this.state.originalValue === this.state.textValue);
   }
   handleKeyPress(e) {
@@ -62,5 +75,6 @@ export default class TextboxOnValium extends Component {
 }
 TextboxOnValium.propTypes = {
   onChange: PropTypes.func,
-  value: PropTypes.string
+  value: PropTypes.string,
+  onWarning: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/WarningContainer/index.js
+++ b/cdap-ui/app/cdap/components/WarningContainer/index.js
@@ -19,7 +19,7 @@ import T from 'i18n-react';
 
 require('./WarningContainer.scss');
 
-export default function WarningContainer({title, message}) {
+export default function WarningContainer({title, message, children}) {
   return (
     <div className="warning-container">
       <div className="warning-title-container">
@@ -36,6 +36,7 @@ export default function WarningContainer({title, message}) {
       <div className="warning-message-container">
         {message}
       </div>
+      {children}
     </div>
   );
 }
@@ -47,5 +48,6 @@ WarningContainer.defaultProps = {
 
 WarningContainer.propTypes = {
   title: PropTypes.string,
-  message: PropTypes.string
+  message: PropTypes.string,
+  children: PropTypes.node
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -333,6 +333,8 @@ features:
       welcomeMessage2: User Experience
     Title: CDAP | Overview
   DataPrep:
+    DataPrepTable:
+      columnEditWarningMessage: 'A column with the same name already exists. Pick a new name, or click "Apply" to overwrite'
     Directives:
       apply: Apply
       cancel: Cancel


### PR DESCRIPTION
- When editing a column name in dataprep table, if the user ends up with a name that is already present then show a warning message about overwriting behavior.

JIRA: https://issues.cask.co/browse/CDAP-9445
Bamboo build: https://builds.cask.co/browse/CDAP-DRC6393-1