### PR TITLE
Move hadoop.metrics2 to error

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -36,6 +36,7 @@
   <logger name="SecurityLogger.org.apache.hadoop.ipc.Server" level="WARN"/>
   <!-- Because of HADOOP-11180 move this to Error -->
   <logger name="org.apache.hadoop.security.token.Token" level="ERROR"/>
+  <logger name="org.apache.hadoop.metrics2" level="ERROR"/>
   <logger name="akka" level="WARN"/>
   <logger name="Remoting" level="WARN"/>
   <logger name="org.quartz.core" level="WARN"/>

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -40,6 +40,7 @@
     <logger name="SecurityLogger.org.apache.hadoop.ipc.Server" level="WARN"/>
     <!-- Because of HADOOP-11180 move this to Error -->
     <logger name="org.apache.hadoop.security.token.Token" level="ERROR"/>
+    <logger name="org.apache.hadoop.metrics2" level="ERROR"/>
     <logger name="akka" level="WARN"/>
     <logger name="Remoting" level="WARN"/>
 

--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -41,6 +41,7 @@
   <logger name="SecurityLogger.org.apache.hadoop.ipc.Server" level="WARN"/>
   <!-- Because of HADOOP-11180 move this to Error -->
   <logger name="org.apache.hadoop.security.token.Token" level="ERROR"/>
+  <logger name="org.apache.hadoop.metrics2" level="ERROR"/>
   <logger name="org.quartz.core" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="io.netty.util.internal" level="WARN"/>


### PR DESCRIPTION
Move logger name="org.apache.hadoop.metrics2 to ERROR to avoid repeated errors: 
"Cannot locate configuration: tried hadoop-metrics2-mrappmaster.properties,hadoop-metrics2.properties"