### PR TITLE
ProjectInfo version doesn't support plain -SNAPSHOT suffix without timestamp

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/UpgradeValueLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/UpgradeValueLoader.java
@@ -39,7 +39,7 @@ public class UpgradeValueLoader extends CacheLoader<byte[], Boolean> {
   public static final byte[] COLUMN = Bytes.toBytes('c');
   private static final Logger LOG = LoggerFactory.getLogger(UpgradeValueLoader.class);
   private static final Logger LIMITED_LOGGER = Loggers.sampling(LOG, LogSamplers.onceEvery(100));
-  private static final ProjectInfo.Version EXPECTED_VERSION = new ProjectInfo.Version("4.1.2-SNAPSHOT");
+  private static final ProjectInfo.Version EXPECTED_VERSION = new ProjectInfo.Version("4.1.1");
 
   private final String name;
   private final TransactionExecutorFactory factory;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -89,7 +89,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
   private static final String TYPE_WORKFLOW_NODE_STATE = "wns";
   private static final String TYPE_WORKFLOW_TOKEN = "wft";
   private static final String TYPE_NAMESPACE = "namespace";
-  private static final ProjectInfo.Version EXPECTED_VERSION = new ProjectInfo.Version("4.1.2-SNAPSHOT");
+  private static final ProjectInfo.Version EXPECTED_VERSION = new ProjectInfo.Version("4.1.1");
 
   private final CConfiguration cConf;
   private final AtomicBoolean upgradeComplete;


### PR DESCRIPTION
Expected Version should 4.1.1. Cleaner fix will be merged into release branch as part of PR #8649 