### PR TITLE
[CDAP-9541] Have directives popover always appear on the right of dropdown icon for consistency

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -195,8 +195,8 @@ export default class ColumnActionsDropdown extends Component {
     let tableContainer = document.getElementById('dataprep-table-id');
 
     const tetherOption = {
-      attachment: 'top right',
-      targetAttachment: 'bottom left',
+      attachment: 'top left',
+      targetAttachment: 'bottom right',
       constraints: [
         {
           to: tableContainer,

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Explode/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Explode/index.js
@@ -22,6 +22,9 @@ import UsingDelimiterModal from 'components/DataPrep/Directives/ExtractFields/Us
 import DataPrepStore from 'components/DataPrep/store';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import {setPopoverOffset} from 'components/DataPrep/helper';
+import debounce from 'lodash/debounce';
+
 require('./Explode.scss');
 export default class Explode extends Component {
   constructor(props) {
@@ -33,6 +36,20 @@ export default class Explode extends Component {
     this.preventPropagation = this.preventPropagation.bind(this);
     this.explodeByFlattening = this.explodeByFlattening.bind(this);
     this.handleUsingFilters = this.handleUsingFilters.bind(this);
+  }
+  componentDidMount() {
+    this.calculateOffset = setPopoverOffset.bind(this, document.getElementById('explode-fields-directive'));
+    this.offsetCalcDebounce = debounce(this.calculateOffset, 1000);
+  }
+
+  componentDidUpdate() {
+    if (this.props.isOpen && this.calculateOffset) {
+      this.calculateOffset();
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.offsetCalcDebounce);
   }
 
   execute(addDirective) {

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
@@ -23,6 +23,8 @@ import UsingDelimiterModal from 'components/DataPrep/Directives/ExtractFields/Us
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import {setPopoverOffset} from 'components/DataPrep/helper';
+import debounce from 'lodash/debounce';
 
 require('./ExtractFields.scss');
 export default class ExtractFields extends Component {
@@ -35,6 +37,21 @@ export default class ExtractFields extends Component {
     this.parseUsingDelimiters = this.parseUsingDelimiters.bind(this);
     this.preventPropagation = this.preventPropagation.bind(this);
     this.handleUsingDelimiters = this.handleUsingDelimiters.bind(this);
+  }
+
+  componentDidMount() {
+    this.calculateOffset = setPopoverOffset.bind(this, document.getElementById('extract-fields-directive'));
+    this.offsetCalcDebounce = debounce(this.calculateOffset, 1000);
+  }
+
+  componentDidUpdate() {
+    if (this.props.isOpen && this.calculateOffset) {
+      this.calculateOffset();
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.offsetCalcDebounce);
   }
 
   renderDetail() {

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
@@ -20,6 +20,8 @@ import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import T from 'i18n-react';
+import {setPopoverOffset} from 'components/DataPrep/helper';
+import debounce from 'lodash/debounce';
 
 const PREFIX = `features.DataPrep.Directives.FindAndReplace`;
 
@@ -41,6 +43,21 @@ export default class FindAndReplaceDirective extends Component {
     this.applyDirective = this.applyDirective.bind(this);
     this.handleExactMatchChange = this.handleExactMatchChange.bind(this);
     this.handleIgnoreCaseChange = this.handleIgnoreCaseChange.bind(this);
+  }
+
+  componentDidMount() {
+    this.calculateOffset = setPopoverOffset.bind(this, document.getElementById('find-and-replace-directive'));
+    this.offsetCalcDebounce = debounce(this.calculateOffset, 1000);
+  }
+
+  componentDidUpdate() {
+    if (this.props.isOpen && this.calculateOffset) {
+      this.calculateOffset();
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.offsetCalcDebounce);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -215,6 +232,7 @@ export default class FindAndReplaceDirective extends Component {
   render() {
     return (
       <div
+        id="find-and-replace-directive"
         className={classnames('fill-null-or-empty-directive clearfix action-item', {
           'active': this.state.isOpen
         })}

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Format/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Format/index.js
@@ -21,6 +21,8 @@ import SimpleDateModal from 'components/DataPrep/Directives/Parse/Modals/SimpleD
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import {setPopoverOffset} from 'components/DataPrep/helper';
+import debounce from 'lodash/debounce';
 
 const PREFIX = 'features.DataPrep.Directives.Format';
 
@@ -59,6 +61,20 @@ export default class Format extends Component {
         onClick: this.formatTitlecase
       }
     ];
+  }
+  componentDidMount() {
+    this.calculateOffset = setPopoverOffset.bind(this, document.getElementById('format-directive'));
+    this.offsetCalcDebounce = debounce(this.calculateOffset, 1000);
+  }
+
+  componentDidUpdate() {
+    if (this.props.isOpen && this.calculateOffset) {
+      this.calculateOffset();
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.offsetCalcDebounce);
   }
   toggleModal() {
     this.setState({

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/index.js
@@ -25,6 +25,7 @@ import T from 'i18n-react';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import debounce from 'lodash/debounce';
+import {setPopoverOffset} from 'components/DataPrep/helper';
 
 const SUFFIX = 'features.DataPrep.Directives.Parse';
 
@@ -64,44 +65,22 @@ export default class ParseDirective extends Component {
       'HL7'
     ];
 
-    this.calculateOffset = this.calculateOffset.bind(this);
-
-    this.offsetCalcDebounce = debounce(this.calculateOffset, 1000);
-
     window.addEventListener('resize', this.offsetCalcDebounce);
   }
 
   componentDidUpdate() {
-    if (this.props.isOpen) {
+    if (this.props.isOpen && this.calculateOffset) {
       this.calculateOffset();
     }
   }
 
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.offsetCalcDebounce);
+  componentDidMount() {
+    this.calculateOffset = setPopoverOffset.bind(this, document.getElementById('parse-directive'));
+    this.offsetCalcDebounce = debounce(this.calculateOffset, 1000);
   }
 
-  calculateOffset() {
-    let elem = document.getElementById('parse-directive');
-    let elemBounding = elem.getBoundingClientRect();
-
-    const HEADER_HEIGHT = 50;
-    const FOOTER_HEIGHT = 54;
-    let bodyHeight = document.documentElement.clientHeight - HEADER_HEIGHT - FOOTER_HEIGHT;
-
-    let popover = document.getElementsByClassName('second-level-popover');
-    let popoverHeight = popover[0].getBoundingClientRect().height;
-
-    let tableContainerScroll = document.getElementById('dataprep-table-id').scrollTop;
-
-    // out of bound check
-    let diff = bodyHeight - (elemBounding.top + popoverHeight) - tableContainerScroll;
-
-    if (diff < 0) {
-      popover[0].style.top = `${diff}px`;
-    } else {
-      popover[0].style.top = 0;
-    }
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.offsetCalcDebounce);
   }
 
   preventPropagation(e) {

--- a/cdap-ui/app/cdap/components/DataPrep/helper.js
+++ b/cdap-ui/app/cdap/components/DataPrep/helper.js
@@ -38,3 +38,25 @@ export function directiveRequestBodyCreator(directivesArray, wsId) {
 export function isCustomOption(selectedOption) {
   return selectedOption.substr(0, 6) === 'CUSTOM';
 }
+
+export function setPopoverOffset(element, header_height = 50, footer_height = 54) {
+  let elem = element;
+  let elemBounding = elem.getBoundingClientRect();
+
+  const FOOTER_HEIGHT = footer_height;
+
+  let popover = document.getElementsByClassName('second-level-popover');
+  let popoverHeight = popover[0].getBoundingClientRect().height;
+  let tableContainerScroll = document.getElementById('dataprep-table-id').scrollTop;
+  let popoverMenuItemTop = elemBounding.top;
+  let bodyBottom = document.body.getBoundingClientRect().bottom + FOOTER_HEIGHT; // Since we have footer absolutely positioned.
+
+  let diff = bodyBottom - (popoverMenuItemTop + popoverHeight) - tableContainerScroll;
+
+  if (diff < 0) {
+    diff = diff - 5; // Give that extra margin at the bottom just so that the menu doesn't stick to the bottom of the browser.
+    popover[0].style.top = `${diff}px`;
+  } else {
+    popover[0].style.top = 0;
+  }
+}


### PR DESCRIPTION
- Today we have popover menu always appear on the left of the dropdown icon (most overlapping the contents of the column in which it is being operated on). 
- This PR changes that to have the popover menu appear always on the right and adapt to columns on the far right (appear left of the dropdown icon) to be consistent with the popover menu that will appear on right click on column header (to be added in future PRs)

JIRA: https://issues.cask.co/browse/CDAP-9541
Bamboo build: https://builds.cask.co/browse/CDAP-DRC6413/latest