### PR TITLE
CDAP-8636 Avoid attempting to rewrite obtainTokenForHiveMetastore

### DIFF
--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
@@ -537,8 +537,8 @@ public class SparkClassRewriter implements ClassRewriter {
    * delegation tokens causes a spark program submission failure.
    */
   private byte[] rewriteSparkHadoopUtil(String name, InputStream byteCodeStream) throws IOException {
-    Set<String> methods =
-      ImmutableSet.of("obtainTokensForNamenodes", "obtainTokenForHiveMetastore", "obtainTokenForHBase");
+    // we can't rewrite 'obtainTokenForHiveMetastore', because it doesn't have Void return type
+    Set<String> methods = ImmutableSet.of("obtainTokensForNamenodes", "obtainTokenForHBase");
     return Classes.rewriteMethodToNoop(name, byteCodeStream, methods);
   }
 


### PR DESCRIPTION
[CDAP-8636](https://issues.cask.co/browse/CDAP-8636) Avoid attempting to rewrite obtainTokenForHiveMetastore, because it does not have Void return type, so won't actually be rewritten as noop anyways.

Otherwise, you'll see this WARN in the Spark logs:
```
2017-05-02 22:31:32,851 - WARN  [spark-submitter-PageRankSpark-f1807425-2f86-11e7-9a57-42010afa000f:c.c.c.i.a.Classes@125] - Cannot patch method obtainTokenForHiveMetastore in org.apache.spark.deploy.yarn.YarnSparkHadoopUtil due to non-void return type: (Lorg/apache/hadoop/conf/Configuration;)Lscala/Option;
```

https://builds.cask.co/browse/CDAP-DUT5696-2