### PR TITLE
Increase the default thread pool size for Dataset Service

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -339,9 +339,9 @@ public final class Constants {
 
       // Defaults
       public static final int DEFAULT_BACKLOG = 20000;
-      public static final int DEFAULT_EXEC_THREADS = 300;
+      public static final int DEFAULT_EXEC_THREADS = 10;
       public static final int DEFAULT_BOSS_THREADS = 1;
-      public static final int DEFAULT_WORKER_THREADS = 30;
+      public static final int DEFAULT_WORKER_THREADS = 4;
     }
 
     /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -339,9 +339,9 @@ public final class Constants {
 
       // Defaults
       public static final int DEFAULT_BACKLOG = 20000;
-      public static final int DEFAULT_EXEC_THREADS = 10;
+      public static final int DEFAULT_EXEC_THREADS = 300;
       public static final int DEFAULT_BOSS_THREADS = 1;
-      public static final int DEFAULT_WORKER_THREADS = 4;
+      public static final int DEFAULT_WORKER_THREADS = 30;
     }
 
     /**

--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml
@@ -22,7 +22,7 @@
 
   <property>
     <name>dataset.service.exec.threads</name>
-    <value>300</value>
+    <value>100</value>
     <description>
       Set size of executor ThreadPool in netty for Dataset Service.
     </description>

--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml
@@ -20,5 +20,21 @@
     Your site level configuration goes here 
   -->
 
+  <property>
+    <name>dataset.service.exec.threads</name>
+    <value>300</value>
+    <description>
+      Set size of executor ThreadPool in netty for Dataset Service.
+    </description>
+  </property>
+
+  <property>
+    <name>dataset.service.worker.threads</name>
+    <value>30</value>
+    <description>
+      Set size of worker ThreadPool in netty for Dataset Service.
+    </description>
+  </property>
+
 </configuration>
 


### PR DESCRIPTION
[CDAP-11402](https://issues.cask.co/browse/CDAP-11402) Increase the default thread pool size for Dataset Service, for increased throughput on a fresh CDAP install.

Several times, we've recommended increasing to these values whenever there are performance issues on a CDAP cluster. I feel that its better to increase them by default.