### PR TITLE
CDAP-7217 Document creation of "cdap" user

### DIFF
--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -119,6 +119,18 @@ You can make these changes `using Cloudera Manager
 Please restart the stale services upon seeing a prompt to do so after making the above
 changes.
 
+Create the "cdap" User
+----------------------
+**The CDAP system user:** As Hadoop resolves users at the NameNode, the ``cdap`` user must
+be added there, or name resolution for the user will fail. With Cloudera Manager, the CDAP
+installation will create the ``cdap`` user on all nodes when it is distributed or
+activated on the cluster.
+
+Note that Cloudera Manager can be configured to not add users specified in a installation.
+This can be the case for installations whose IT policies or infrastructure do not allow
+local user creation. If this is the case, manual creation of the ``cdap`` user on nodes
+may be required.
+
 .. HDFS Permissions
 .. ----------------
 .. include:: /../target/_includes/cloudera-hdfs-permissions.rst
@@ -446,16 +458,6 @@ values for Cloudera may vary from the above appendix:
 .. include:: /../target/_includes/cloudera-starting.rst
     :start-after: .. _cloudera-starting-services-java-heapmax:
     :end-before: .. end_of_list
-
-**The CDAP system user:** As Hadoop resolves users at the NameNode, the ``cdap`` user must
-be added there, or name resolution for the user will fail. With Cloudera Manager, the CDAP
-installation will create the ``cdap`` user on all nodes when it is distributed or
-activated on the cluster.
-
-Note that Cloudera Manager can be configured to not add users specified in a installation.
-This can be the case for installations whose IT policies or infrastructure do not allow
-local user creation. If this is the case, manual creation of the ``cdap`` user on nodes
-may be required.
 
 **At this point, the CDAP installation is configured** and is ready to be installed. Review
 your settings before continuing to the next step, which will install and start CDAP.

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -447,7 +447,17 @@ values for Cloudera may vary from the above appendix:
     :start-after: .. _cloudera-starting-services-java-heapmax:
     :end-before: .. end_of_list
 
-At this point, the CDAP installation is configured and is ready to be installed. Review
+**The CDAP system user:** As Hadoop resolves users at the NameNode, the ``cdap`` user must
+be added there, or name resolution for the user will fail. With Cloudera Manager, the CDAP
+installation will create the ``cdap`` user on all nodes when it is distributed or
+activated on the cluster.
+
+Note that Cloudera Manager can be configured to not add users specified in a installation.
+This can be the case for installations whose IT policies or infrastructure do not allow
+local user creation. If this is the case, manual creation of the ``cdap`` user on nodes
+may be required.
+
+**At this point, the CDAP installation is configured** and is ready to be installed. Review
 your settings before continuing to the next step, which will install and start CDAP.
 
 .. _cloudera-starting-services:

--- a/cdap-docs/admin-manual/source/installation/mapr.rst
+++ b/cdap-docs/admin-manual/source/installation/mapr.rst
@@ -38,7 +38,7 @@ ResourceManager*, or *HBase Master*, then the client configurations will already
 A typical client node should have the ``mapr-client``, ``mapr-hbase``, and ``mapr-hive``
 packages installed, and can be configured using the MapR `configure.sh
 <http://doc.mapr.com/display/MapR/configure.sh>`__ utility.
- 
+
 .. Hadoop Configuration
 .. --------------------
 .. include:: ../_includes/installation/hadoop-configuration.txt
@@ -48,7 +48,7 @@ Create the "cdap" User
 ----------------------
 
 .. highlight:: console
-   
+
 To prepare your cluster for CDAP, manually create a ``cdap`` user on all nodes of the
 cluster. As *"...MapR uses each node's native operating system configuration to
 authenticate users and groups for access to the cluster...[MapR documentation]",* make
@@ -56,10 +56,14 @@ sure that the UID and GID for the ``cdap`` user is the same on each node of the 
 
   $ id cdap
   uid=503(cdap) gid=504(cdap) groups=504(cdap)
-  
+
 *Note:* The values returned by ``id cdap`` may differ from these shown depending on your system.
 
-See the MapR documentation (`Common Users 
+When installing CDAP on an edge node, the ``cdap`` system user is only created locally. As
+Hadoop resolves users at the NameNode, the ``cdap`` user must also be added there, or name
+resolution for the user will fail.
+
+See the MapR documentation (`Common Users
 <http://maprdocs.mapr.com/home/AdvancedInstallation/PreparingEachNode-connectivity.html>`__)
 for more information.
 
@@ -67,7 +71,7 @@ for more information.
 .. ----------------
 .. include:: /../target/_includes/mapr-hdfs-permissions.rst
 
-Ensure the Hive DB directory is configured properly to allow CDAP to create Hive tables. 
+Ensure the Hive DB directory is configured properly to allow CDAP to create Hive tables.
 The Hive DB directory (default ``/user/hive/``) by default is only accessible to the ``mapr`` user.
 Change the permissions on this directory::
 
@@ -135,7 +139,7 @@ Create Required Directories
 ---------------------------
 
 .. highlight:: console
-   
+
 To prepare your cluster so that CDAP can write to its default namespace,
 create a top-level ``/cdap`` directory in MapRFS, owned by the MapRFS user ``cdap``::
 
@@ -164,13 +168,13 @@ that value instead for ``/cdap/tx.snapshot``.
 .. include:: /../target/_includes/mapr-configuration.rst
     :end-before:   .. _mapr-configuration-options-may-need:
 
-#. Due to an issue with the version of the Kafka ZooKeeper client shipped with MapR, 
+#. Due to an issue with the version of the Kafka ZooKeeper client shipped with MapR,
    it is necessary to disable use of the embedded Kafka in CDAP by setting these properties:
-   
+
    .. highlight:: xml
 
    ::
-   
+
      <property>
         <name>master.collect.containers.log</name>
         <value>false</value>
@@ -180,11 +184,11 @@ that value instead for ``/cdap/tx.snapshot``.
         <name>master.collect.app.containers.log.level</name>
         <value>OFF</value>
       </property>
-      
+
    As a consequence of this setting, the container logs will not be streamed back to the
-   master process log file. This issue is due to a `known Kafka issue 
-   <https://issues.apache.org/jira/browse/TWILL-139?focusedCommentId=14598628>`__.   
-    
+   master process log file. This issue is due to a `known Kafka issue
+   <https://issues.apache.org/jira/browse/TWILL-139?focusedCommentId=14598628>`__.
+
 #. Depending on your installation, you may need to set these properties:
 
 .. include:: /../target/_includes/mapr-configuration.rst
@@ -196,24 +200,24 @@ that value instead for ``/cdap/tx.snapshot``.
 YARN Application Classpath
 --------------------------
 CDAP requires that an additional entry |---| ``/opt/mapr/lib/*`` |---| be appended to the
-``yarn.application.classpath`` setting of ``yarn-site.xml``. (This file is usually in 
+``yarn.application.classpath`` setting of ``yarn-site.xml``. (This file is usually in
 ``/opt/mapr/hadoop/hadoop-<hadoop-version>/etc/hadoop/yarn-site.xml``.) The default
 ``yarn.application.classpath`` for Linux with this additional entry appended is
 (reformatted to fit)::
 
-  $HADOOP_CONF_DIR, 
-  $HADOOP_COMMON_HOME/share/hadoop/common/*, 
-  $HADOOP_COMMON_HOME/share/hadoop/common/lib/*, 
-  $HADOOP_HDFS_HOME/share/hadoop/hdfs/*, 
-  $HADOOP_HDFS_HOME/share/hadoop/hdfs/lib/*, 
-  $HADOOP_YARN_HOME/share/hadoop/yarn/*, 
-  $HADOOP_YARN_HOME/share/hadoop/yarn/lib/*, 
-  $HADOOP_COMMON_HOME/share/hadoop/mapreduce/*, 
-  $HADOOP_COMMON_HOME/share/hadoop/mapreduce/lib/*, 
+  $HADOOP_CONF_DIR,
+  $HADOOP_COMMON_HOME/share/hadoop/common/*,
+  $HADOOP_COMMON_HOME/share/hadoop/common/lib/*,
+  $HADOOP_HDFS_HOME/share/hadoop/hdfs/*,
+  $HADOOP_HDFS_HOME/share/hadoop/hdfs/lib/*,
+  $HADOOP_YARN_HOME/share/hadoop/yarn/*,
+  $HADOOP_YARN_HOME/share/hadoop/yarn/lib/*,
+  $HADOOP_COMMON_HOME/share/hadoop/mapreduce/*,
+  $HADOOP_COMMON_HOME/share/hadoop/mapreduce/lib/*,
   /opt/mapr/lib/*
-    
-**Notes:** 
-   
+
+**Notes:**
+
 - Since MapR might not dereference the Hadoop variables (such as ``$HADOOP_CONF_DIR``)
   correctly, we recommend specifying their full paths instead of the variables we have
   included here.
@@ -229,8 +233,8 @@ CDAP requires that an additional entry |---| ``/opt/mapr/lib/*`` |---| be append
 
 .. include:: /../target/_includes/mapr-starting.rst
 
-.. _mapr-verification:
 
+.. _mapr-verification:
 
 Verification
 ============

--- a/cdap-docs/admin-manual/source/installation/packages.rst
+++ b/cdap-docs/admin-manual/source/installation/packages.rst
@@ -16,7 +16,7 @@ Manual Installation using Packages
 
 This section describes installing CDAP on Hadoop clusters that are:
 
-- Generic Apache Hadoop distributions; 
+- Generic Apache Hadoop distributions;
 - CDH (Cloudera Distribution of Apache Hadoop) clusters *not managed* with Cloudera Manager; or
 - HDP (Hortonworks Data Platform) clusters *not managed* with Apache Ambari.
 
@@ -24,21 +24,21 @@ Cloudera Manager (CDH), Apache Ambari (HDP), and MapR distributions should be in
 with our other :ref:`distribution instructions <installation-index>`.
 
 - As CDAP depends on HDFS, YARN, HBase, ZooKeeper, and (optionally) Hive and Spark, it must be installed
-  on cluster host(s) with full client configurations for these dependent services. 
+  on cluster host(s) with full client configurations for these dependent services.
 
 - The CDAP Master Service must be co-located on a cluster host with an HDFS client, a YARN
   client, an HBase client, and |---| optionally |---| Hive or Spark clients.
 
-- Note that these clients are redundant if you are co-locating the CDAP Master  
+- Note that these clients are redundant if you are co-locating the CDAP Master
   on a cluster host (or hosts, in the case of a deployment with high availability) with
-  actual services, such as the HDFS Namenode, the YARN resource manager, or the HBase
+  actual services, such as the HDFS NameNode, the YARN resource manager, or the HBase
   Master.
-  
-- You can download the `Hadoop client <http://hadoop.apache.org/releases.html#Download>`__ 
+
+- You can download the `Hadoop client <http://hadoop.apache.org/releases.html#Download>`__
   and `HBase client <http://www.apache.org/dyn/closer.cgi/hbase/>`__ libraries, and then
   install them on the hosts running CDAP services. No Hadoop or HBase services need be running.
 
-- All services run as the ``'cdap'`` user installed by the package manager.
+- All services run as the ``cdap`` user installed by the package manager.
 
 - If you are installing CDAP with the intention of using *replication,* see these
   instructions on :ref:`CDAP Replication <installation-replication>` *before* installing or starting CDAP.
@@ -46,19 +46,38 @@ with our other :ref:`distribution instructions <installation-index>`.
 
 Preparing the Cluster
 =============================
-Please review the :ref:`Software Prerequisites <admin-manual-software-requirements>`, 
+Please review the :ref:`Software Prerequisites <admin-manual-software-requirements>`,
 as a configured Hadoop, HBase, and Hive (plus an optional Spark client) needs to be configured on the
-node(s) where CDAP will run. 
+node(s) where CDAP will run.
 
 .. Hadoop Configuration
 .. --------------------
 .. include:: ../_includes/installation/hadoop-configuration.txt
 
+Create the "cdap" User
+----------------------
+
+.. highlight:: console
+
+To prepare your cluster for CDAP, manually create a ``cdap`` user on all nodes of the
+cluster. Make sure that the UID and GID for the ``cdap`` user is the same on each node of
+the cluster::
+
+  $ id cdap
+  uid=503(cdap) gid=504(cdap) groups=504(cdap)
+
+*Note:* The values returned by ``id cdap`` may differ from these shown depending on your
+system.
+
+When installing CDAP on an edge node, the ``cdap`` system user is only created locally. As
+Hadoop resolves users at the NameNode, the ``cdap`` user must also be added there, or name
+resolution for the user will fail.
+
 .. HDFS Permissions
 .. ----------------
 .. include:: /../target/_includes/packages-hdfs-permissions.rst
 
-  
+
 Downloading and Distributing Packages
 =====================================
 
@@ -92,8 +111,8 @@ Installing CDAP Services
 
 .. include:: /../target/_includes/packages-starting.rst
 
-.. _packages-verification:
 
+.. _packages-verification:
 
 Verification
 ============

--- a/cdap-docs/admin-manual/source/installation/packages.rst
+++ b/cdap-docs/admin-manual/source/installation/packages.rst
@@ -38,7 +38,7 @@ with our other :ref:`distribution instructions <installation-index>`.
   and `HBase client <http://www.apache.org/dyn/closer.cgi/hbase/>`__ libraries, and then
   install them on the hosts running CDAP services. No Hadoop or HBase services need be running.
 
-- All services run as the ``cdap`` user installed by the package manager.
+- All services run as the ``cdap`` user installed by the package manager. See `Create the "cdap" User`_ below.
 
 - If you are installing CDAP with the intention of using *replication,* see these
   instructions on :ref:`CDAP Replication <installation-replication>` *before* installing or starting CDAP.
@@ -59,6 +59,13 @@ Create the "cdap" User
 
 .. highlight:: console
 
+The base CDAP package will install ``cdap`` as a system user. However, in order to have a
+consistent UID for the ``cdap`` user across the cluster, or to ensure that it is created
+on the namenode when installing CDAP elsewhere, you need to check that the ``cdap`` user
+is installed |---| and installed consistently |---| on all nodes of the cluster.
+Though the base CDAP package will automatically install the ``cdap`` system user, it's
+best if the ``cdap`` user is manually created on all nodes of the cluster beforehand.
+
 To prepare your cluster for CDAP, manually create a ``cdap`` user on all nodes of the
 cluster. Make sure that the UID and GID for the ``cdap`` user is the same on each node of
 the cluster::
@@ -66,7 +73,7 @@ the cluster::
   $ id cdap
   uid=503(cdap) gid=504(cdap) groups=504(cdap)
 
-*Note:* The values returned by ``id cdap`` may differ from these shown depending on your
+*Note:* The values returned by ``id cdap`` may differ from these shown, depending on your
 system.
 
 When installing CDAP on an edge node, the ``cdap`` system user is only created locally. As


### PR DESCRIPTION
Adds paragraphs on installing the "cdap" user on all nodes to packages and CM.
Adds to existing paragraph on MapR. 
Removes trailing whitespace.

Running as a Quick Build: https://builds.cask.co/browse/CDAP-DQB343-1 (passed)
Pages of interest:
- https://builds.cask.co/artifact/CDAP-DQB343/shared/build-1/Docs-HTML/html/admin-manual/installation/cloudera.html#add-service-wizard-reviewing-configuration
- https://builds.cask.co/artifact/CDAP-DQB343/shared/build-1/Docs-HTML/html/admin-manual/installation/mapr.html#create-the-cdap-user
- https://builds.cask.co/artifact/CDAP-DQB343/shared/build-1/Docs-HTML/html/admin-manual/installation/packages.html#create-the-cdap-user