### PR TITLE
CDAP-9400 Document upgrade status endpoint API

### DIFF
--- a/cdap-docs/admin-manual/source/upgrading/cloudera.rst
+++ b/cdap-docs/admin-manual/source/upgrading/cloudera.rst
@@ -34,7 +34,7 @@ in the Cloudera Manager UI.
 
 Upgrading CDAP Major/Minor Release Versions
 -------------------------------------------
-Upgrading between major versions of CDAP (for example, from a |previous-short-version|\.x version 
+Upgrading between major versions of CDAP (for example, from a |previous-short-version|\.x version
 to |short-version|\.x) involves the additional step of upgrading the
 CSD. Upgrades between multiple Major/Minor
 versions must be done consecutively, and a version cannot be skipped unless otherwise
@@ -65,15 +65,25 @@ CDAP:
    the CSD.  For example, if new CDAP services were added or removed, you must add or
    remove role instances as necessary. Check the :ref:`release-specific upgrade notes
    <cloudera-release-specific-upgrade-notes>` below for any specific instructions.
-   
+
 #. After CDAP services have started, run the *CDAP Post-Upgrade Tasks* to perform any necessary
    upgrade steps against the running services.  From the CDAP Service page, select "Run CDAP
    Post-Upgrade Tasks."
 
-#. To upgrade existing pipeline applications created using the |previous-short-version|\.x versions of 
+#. To upgrade existing pipeline applications created using the |previous-short-version|\.x versions of
    the system artifacts, there are :ref:`separate instructions <cdap-pipelines-operating-upgrading-pipeline>`.
 
 #. You must recompile and then redeploy your applications prior to using them.
+
+#. Once CDAP has restarted, you can check the :ref:`status of the upgrade
+   <http-restful-api-monitor-status-system-upgrade>` using the :ref:`Monitor
+   HTTP RESTful API <http-restful-api-monitor>`::
+
+      $ curl -w"\n" -X GET "http://<cdap-host>:11015/v3/system/upgrade/status"
+
+   Returning::
+
+      {"defaultStore":true,"streamSizeScheduleStore":true,"timeScheduleStore":true }
 
 
 Upgrading CDH
@@ -96,7 +106,7 @@ goes wrong, see these troubleshooting instructions for :ref:`problems while upgr
 .. highlight:: console
 
 1. Upgrade CDAP to a version that will support the new CDH version, following the usual
-   :ref:`CDAP-Cloudera Manager upgrade procedure <admin-upgrading-cloudera-upgrading-cdap>`. 
+   :ref:`CDAP-Cloudera Manager upgrade procedure <admin-upgrading-cloudera-upgrading-cdap>`.
 
 #. After upgrading CDAP, start CDAP and check that it is working correctly.
 
@@ -105,17 +115,17 @@ goes wrong, see these troubleshooting instructions for :ref:`problems while upgr
 #. Disable all CDAP tables; from an HBase shell, run the command::
 
     > disable_all 'cdap.*'
-    
+
 #. Upgrade to the new version of CDH, following Cloudera's `documentation on upgrading
    <http://www.cloudera.com/documentation/enterprise/latest/topics/cm_mc_upgrading_cdh.html>`__.
 
 #. Stop all CDAP services, as CM may have auto-started CDAP.
 
-#. Run the *Post-CDH Upgrade Tasks* to upgrade CDAP for the new version of CDH. From the CDAP Service 
+#. Run the *Post-CDH Upgrade Tasks* to upgrade CDAP for the new version of CDH. From the CDAP Service
    page, select "Run Post-CDH Upgrade Tasks" from the Actions menu.
 
 #. Enable all CDAP tables; from an HBase shell, run this command::
 
     > enable_all 'cdap.*'
-    
+
 #. Start CDAP using Cloudera Manager.

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -50,16 +50,16 @@ and then restart CDAP:
      $ for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i stop ; done
 
 #. Update the CDAP repository definition by running either of these methods:
- 
+
    - On RPM using Yum:
 
-     .. include:: ../_includes/installation/installation.txt 
+     .. include:: ../_includes/installation/installation.txt
         :start-after: Download the Cask Yum repo definition file:
         :end-before:  .. end_install-rpm-using-yum
 
    - On Debian using APT:
 
-     .. include:: ../_includes/installation/installation.txt 
+     .. include:: ../_includes/installation/installation.txt
         :start-after: Download the Cask APT repo definition file:
         :end-before:  .. end_install-debian-using-apt
 
@@ -76,17 +76,17 @@ and then restart CDAP:
 #. Run the upgrade tool, as the user that runs CDAP Master (the CDAP user, indicated by ``<cdap-user>``)::
 
      $ sudo -u <cdap-user> /opt/cdap/master/bin/cdap run co.cask.cdap.data.tools.UpgradeTool upgrade
-     
+
    Note that once you have upgraded an instance of CDAP, you cannot reverse the process; down-grades
    to a previous version are not possible. Also, note that authorization is disabled in the *UpgradeTool*
    so that the ``cdap`` user can upgrade all users' data.
-   
+
    The *UpgradeTool* will produce output similar to the following, prompting you to continue with the upgrade:
-   
+
     .. container:: highlight
 
-      .. parsed-literal::    
-    
+      .. parsed-literal::
+
         UpgradeTool - version |version|-<build timestamp>.
 
         upgrade - Upgrades CDAP to |version|
@@ -103,15 +103,25 @@ and then restart CDAP:
 
    You can run the tool in a non-interactive fashion by using the ``force`` flag, in which case
    it will run unattended and not prompt for continuing::
-   
+
      $ sudo -u <cdap-user> /opt/cdap/master/bin/cdap run co.cask.cdap.data.tools.UpgradeTool upgrade force
-     
+
 #. Restart the CDAP processes::
 
      $ for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done
 
 #. To upgrade existing pipeline applications created using the |previous-short-version|\.x versions of
    system artifacts, there are :ref:`separate instructions on doing so <cdap-pipelines-operating-upgrading-pipeline>`.
+
+#. Once CDAP has restarted, you can check the :ref:`status of the upgrade
+   <http-restful-api-monitor-status-system-upgrade>` using the :ref:`Monitor
+   HTTP RESTful API <http-restful-api-monitor>`::
+
+      $ curl -w"\n" -X GET "http://<cdap-host>:11015/v3/system/upgrade/status"
+
+   Returning::
+
+      {"defaultStore":true,"streamSizeScheduleStore":true,"timeScheduleStore":true }
 
 
 .. _admin-upgrading-packages-upgrading-hadoop:
@@ -162,18 +172,18 @@ version. The steps below will, if required, update the coprocessors appropriatel
 get upgraded correctly and HBase regionservers may crash.**
 
 1. Upgrade CDAP to a version that will support the new Hadoop version, following the usual
-   :ref:`CDAP upgrade procedure for packages <admin-upgrading-packages-upgrading-cdap>`. 
+   :ref:`CDAP upgrade procedure for packages <admin-upgrading-packages-upgrading-cdap>`.
 
 #. After upgrading CDAP, start CDAP and check that it is working correctly.
 
 #. Stop all CDAP applications and services::
-   
+
     $ for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i stop ; done
 
 #. Disable all CDAP tables; from an HBase shell, run the command::
 
     > disable_all 'cdap.*'
-    
+
 #. Upgrade to the new version of Hadoop.
 
 #. Run the *Post-Hadoop Upgrade Tasks* |---| to upgrade CDAP for the new version of Hadoop |---| by running
@@ -184,7 +194,7 @@ get upgraded correctly and HBase regionservers may crash.**
 #. Enable all CDAP tables; from an HBase shell, run this command::
 
     > enable_all 'cdap.*'
-    
+
 #. Restart CDAP::
 
     $ for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done

--- a/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
@@ -143,6 +143,37 @@ The status of these CDAP system services can be checked:
      - Returns the status of the metrics service
 
 
+.. _http-restful-api-monitor-status-system-upgrade:
+
+Checking the Status of a System Upgrade
+==========================================
+To check the status of a :ref:`CDAP system upgrade <upgrading-index>`, use::
+
+  GET /v3/system/upgrade/status
+
+**Note:** This returns useful information only for Distributed CDAP installation upgrades.
+
+.. rubric:: HTTP Responses
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Status Codes
+     - Description
+   * - ``200 OK``
+     - The event successfully called the method, and the body contains the results
+
+.. rubric:: Example
+
+The response body will contain a JSON-formatted list of upgraded tables::
+
+  {
+      "defaultStore":false,
+      "streamSizeScheduleStore":false,
+      "timeScheduleStore":false
+  }
+
+
 Container Information of a System Service
 =========================================
 If you are trying to debug a CDAP system service, you can retrieve container info for a


### PR DESCRIPTION
Adding system upgrade status endpoint.

Running as a Quick Build: https://builds.cask.co/browse/CDAP-DQB344-1
Pages of interest:
- Cloudera Manager (see step 10): https://builds.cask.co/artifact/CDAP-DQB344/shared/build-1/Docs-HTML/4.2.0-SNAPSHOT/en/admin-manual/upgrading/cloudera.html#upgrading-cdap-major-minor-release-versions
- Packages (see step 8) https://builds.cask.co/artifact/CDAP-DQB344/shared/build-1/Docs-HTML/4.2.0-SNAPSHOT/en/admin-manual/upgrading/packages.html#upgrade-steps
- Monitor RESTful API: Checking the Status of a System Upgrade https://builds.cask.co/artifact/CDAP-DQB344/shared/build-1/Docs-HTML/4.2.0-SNAPSHOT/en/reference-manual/http-restful-api/monitor.html#http-restful-api-monitor-status-system-upgrade