### PR TITLE
[CDAP-9395] Adds Sampler dropdown

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrep.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrep.scss
@@ -60,7 +60,9 @@ $panel-toggle-bg-color: #999999;
     }
 
     .top-section-content {
-      width: calc(100% - 26px);
+      // Width calculation:
+      // 100% - 25px for panel-toggle (left arrow for going back to file browser)
+      width: calc(100% - 25px);
     }
   }
 

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/SamplerDropdown.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/SamplerDropdown.scss
@@ -64,4 +64,7 @@
       }
     }
   }
+  .icon-refresh {
+    cursor: pointer;
+  }
 }

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/SamplerDropdown.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/SamplerDropdown.scss
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+.dataprep-sampler-dropdown {
+  display: flex;
+  align-items: center;
+  .collapsed-dropdown-toggle.dropdown {
+    margin-left: 10px;
+  }
+  .dropdown {
+    &.open {
+      .dropdown-toggle.active {
+        &:active,
+        &:focus {
+          outline: none;
+          background-color: transparent;
+        }
+      }
+    }
+    .dropdown-toggle {
+      background: transparent;
+
+      &:active,
+      &:focus {
+        outline: none;
+        background-color: transparent;
+      }
+    }
+    .dropdown-menu {
+      width: 100%;
+      .dropdown-item {
+        &:active,
+        &:focus {
+          outline: none;
+          background-color: transparent;
+        }
+        padding: 5px 0;
+        &:not(.selected) {
+          span {
+            padding-left: 25px;
+          }
+        }
+        &.selected {
+          span {
+            padding-left: 0;
+
+            &:nth-child(1) {
+              padding: 0 6px;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/__tests__/SamplerDropdown.test.js
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/__tests__/SamplerDropdown.test.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import {mount} from 'enzyme';
+import SamplerDropdown from 'components/DataPrep/SamplerDropdown';
+jest.mock('api/dataprep');
+console.warn = jest.genMockFunction();
+// console.trace = jest.genMockFunction();
+console.error = jest.genMockFunction();
+jest.useFakeTimers();
+import DataPrepStore from 'components/DataPrep/store';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import {objectQuery} from 'services/helpers';
+const workspaceObject = {
+  "version": 1,
+  "workspace": {
+    "name": "b65933228e4a873a4f354ee3bbeb594d",
+    "results": 100
+  },
+  "recipe": {
+    "directives": [
+      "parse-as-csv body , false"
+    ]
+  },
+  "sampling": {
+    "method": "FIRST",
+    "limit": 1000
+  },
+  "properties": {
+    "connection": "file",
+    "file": "CustomerStream.csv",
+    "path": "/Users/ajainarayanan/Desktop/CustomerStream.csv",
+    "uri": "file:/Users/ajainarayanan/Desktop/CustomerStream.csv",
+    "sampler": "poisson"
+  }
+};
+
+const setWorkspace = (workspaceInfo = workspaceObject) => {
+  let directives = objectQuery(workspaceInfo, 'recipe', 'directives') || [];
+  let workspaceUri = objectQuery(workspaceInfo, 'properties', 'path');
+  DataPrepStore.dispatch({
+    type: DataPrepActions.setWorkspace,
+    payload: {
+      headers: {},
+      data: [],
+      directives,
+      workspaceUri,
+      workspaceInfo
+    }
+  });
+};
+
+describe('Unit tests for SamplerDropdown', () => {
+  setWorkspace();
+  it('Should render', () => {
+    let samplerdropdown = mount(
+      <SamplerDropdown />
+    );
+    jest.runAllTimers();
+    expect(samplerdropdown.find('.dataprep-sampler-dropdown').length).toBe(1);
+    expect(samplerdropdown.find('.dataprep-sampler-dropdown .icon-refresh').length).toBe(1);
+    expect(samplerdropdown.find('.dropdown').length).toBe(1);
+    samplerdropdown.unmount();
+  });
+
+  it('Should choose right options', () => {
+    let samplerdropdown = mount(
+      <SamplerDropdown />
+    );
+    jest.runAllTimers();
+    let samplerMethod = samplerdropdown.state('samplerMethod');
+    expect(samplerdropdown.find('.dropdown').length).toBe(1);
+    expect(samplerdropdown.find('.dropdown .dropdown-item').length).toBe(3);
+    expect(samplerdropdown.find('.selected.dropdown-item').length).toBe(1);
+    expect(samplerMethod.name).toBe('poisson');
+
+    let newWorkspace = Object.assign({}, workspaceObject,{
+      properties: {
+        "connection": "file",
+        "file": "CustomerStream.csv",
+        "path": "/Users/ajainarayanan/Desktop/CustomerStream.csv",
+        "uri": "file:/Users/ajainarayanan/Desktop/CustomerStream.csv",
+        "sampler": "bernoulli"
+      }
+    });
+    setWorkspace(newWorkspace);
+    samplerMethod = samplerdropdown.state('samplerMethod');
+    expect(samplerMethod.name).toBe('bernoulli');
+  });
+});

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/__tests__/SamplerDropdown.test.js
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/__tests__/SamplerDropdown.test.js
@@ -19,7 +19,7 @@ import {mount} from 'enzyme';
 import SamplerDropdown from 'components/DataPrep/SamplerDropdown';
 jest.mock('api/dataprep');
 console.warn = jest.genMockFunction();
-// console.trace = jest.genMockFunction();
+console.trace = jest.genMockFunction();
 console.error = jest.genMockFunction();
 jest.useFakeTimers();
 import DataPrepStore from 'components/DataPrep/store';
@@ -43,8 +43,8 @@ const workspaceObject = {
   "properties": {
     "connection": "file",
     "file": "CustomerStream.csv",
-    "path": "/Users/ajainarayanan/Desktop/CustomerStream.csv",
-    "uri": "file:/Users/ajainarayanan/Desktop/CustomerStream.csv",
+    "path": "/path/CustomerStream.csv",
+    "uri": "file:/path/CustomerStream.csv",
     "sampler": "poisson"
   }
 };
@@ -92,8 +92,8 @@ describe('Unit tests for SamplerDropdown', () => {
       properties: {
         "connection": "file",
         "file": "CustomerStream.csv",
-        "path": "/Users/ajainarayanan/Desktop/CustomerStream.csv",
-        "uri": "file:/Users/ajainarayanan/Desktop/CustomerStream.csv",
+        "path": "/path/CustomerStream.csv",
+        "uri": "file:/path/CustomerStream.csv",
         "sampler": "bernoulli"
       }
     });

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/__tests__/SamplerDropdown.test.js
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/__tests__/SamplerDropdown.test.js
@@ -49,6 +49,7 @@ const workspaceObject = {
   }
 };
 
+
 const setWorkspace = (workspaceInfo = workspaceObject) => {
   let directives = objectQuery(workspaceInfo, 'recipe', 'directives') || [];
   let workspaceUri = objectQuery(workspaceInfo, 'properties', 'path');
@@ -84,7 +85,7 @@ describe('Unit tests for SamplerDropdown', () => {
     jest.runAllTimers();
     let samplerMethod = samplerdropdown.state('samplerMethod');
     expect(samplerdropdown.find('.dropdown').length).toBe(1);
-    expect(samplerdropdown.find('.dropdown .dropdown-item').length).toBe(3);
+    expect(samplerdropdown.find('.dropdown .dropdown-item').length).toBe(4);
     expect(samplerdropdown.find('.selected.dropdown-item').length).toBe(1);
     expect(samplerMethod.name).toBe('poisson');
 

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/index.js
@@ -30,10 +30,12 @@ require('./SamplerDropdown.scss');
 const samplerMethods = {
   first: 'first',
   bernoulli: 'bernoulli',
-  poisson: 'poisson'
+  poisson: 'poisson',
+  reservoir: 'reservoir'
 };
 const PREFIX = `features.DataPrep.SamplerDropdown`;
 const NUMLINES = 10000;
+const DEFAULT_FRACTION = 0.35;
 const CONTENT_TYPE = 'text/plain';
 
 export default class SamplerDropdown extends Component {
@@ -69,7 +71,8 @@ export default class SamplerDropdown extends Component {
     let params = {
       namespace,
       path,
-      lines: samplerMethod.name === samplerMethods.bernoulli ? 1 :  NUMLINES,
+      lines: NUMLINES,
+      fraction: DEFAULT_FRACTION,
       sampler: samplerMethod.name
     };
     const headers = {

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/index.js
@@ -26,7 +26,6 @@ import MyDataPrepApi from 'api/dataprep';
 import NamespaceStore from 'services/NamespaceStore';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import {setWorkspace} from 'components/DataPrep/store/DataPrepActionCreator';
-
 require('./SamplerDropdown.scss');
 const samplerMethods = {
   first: 'first',
@@ -40,12 +39,14 @@ const CONTENT_TYPE = 'text/plain';
 export default class SamplerDropdown extends Component {
   constructor(props) {
     super(props);
+    let samplerMethod = objectQuery(DataPrepStore.getState(), 'dataprep', 'workspaceInfo', 'properties', 'sampler');
     this.dropdownOptions = Object.keys(samplerMethods).map(method => ({
       name: method,
       label: T.translate(`${PREFIX}.${method}.label`)
     }));
+    let defaultValue = this.dropdownOptions.filter(option => option.name === samplerMethod);
     this.state = {
-      samplerMethod: this.dropdownOptions[0]
+      samplerMethod: defaultValue.length ? defaultValue[0] : this.dropdownOptions[0]
     };
     this.onSamplerChange = this.onSamplerChange.bind(this);
   }

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/index.js
@@ -75,6 +75,8 @@ export default class SamplerDropdown extends Component {
       fraction: DEFAULT_FRACTION,
       sampler: samplerMethod.name
     };
+    // FIXME: Right now CONTENT_TYPE is 'text/plain' and this is because UI doesn't have the info
+    // yet from backend. Will replace this with appropriate value when we get it from backend.
     const headers = {
       'Content-Type': CONTENT_TYPE
     };
@@ -121,7 +123,7 @@ export default class SamplerDropdown extends Component {
                     {
                       this.state.samplerMethod.name === option.name ?
                         <span>
-                          <IconSVG name="icon-check"/>
+                          <IconSVG name="icon-check" />
                         </span>
                       :
                         null

--- a/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/SamplerDropdown/index.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component} from 'react';
+import {UncontrolledDropdown} from 'components/UncontrolledComponents';
+import {DropdownToggle, DropdownMenu, DropdownItem} from 'reactstrap';
+import IconSVG from 'components/IconSVG';
+import DataPrepStore from 'components/DataPrep/store';
+import {objectQuery} from 'services/helpers';
+import T from 'i18n-react';
+import classnames from 'classnames';
+import MyDataPrepApi from 'api/dataprep';
+import NamespaceStore from 'services/NamespaceStore';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import {setWorkspace} from 'components/DataPrep/store/DataPrepActionCreator';
+
+require('./SamplerDropdown.scss');
+const samplerMethods = {
+  first: 'first',
+  bernoulli: 'bernoulli',
+  poisson: 'poisson'
+};
+const PREFIX = `features.DataPrep.SamplerDropdown`;
+const NUMLINES = 10000;
+const CONTENT_TYPE = 'text/plain';
+
+export default class SamplerDropdown extends Component {
+  constructor(props) {
+    super(props);
+    this.dropdownOptions = Object.keys(samplerMethods).map(method => ({
+      name: method,
+      label: T.translate(`${PREFIX}.${method}.label`)
+    }));
+    this.state = {
+      samplerMethod: this.dropdownOptions[0]
+    };
+    this.onSamplerChange = this.onSamplerChange.bind(this);
+  }
+  componentDidMount() {
+    this.storeSubscription = DataPrepStore.subscribe(() => {
+      let samplerMethod = objectQuery(DataPrepStore.getState(), 'dataprep', 'workspaceInfo', 'properties', 'sampler');
+      let match = this.dropdownOptions.filter(method => method.name === samplerMethod);
+      if (match.length && match[0].name !== this.state.samplerMethod.name) {
+        this.setState({
+          samplerMethod: match[0]
+        });
+      }
+    });
+  }
+  onSamplerChange(samplerMethod) {
+    let {selectedNamespace: namespace} = NamespaceStore.getState();
+    let path = objectQuery(DataPrepStore.getState(), 'dataprep', 'workspaceInfo', 'properties', 'path');
+    let workspaceId = objectQuery(DataPrepStore.getState(), 'dataprep', 'workspaceId');
+
+    let params = {
+      namespace,
+      path,
+      lines: samplerMethod.name === samplerMethods.bernoulli ? 1 :  NUMLINES,
+      sampler: samplerMethod.name
+    };
+    const headers = {
+      'Content-Type': CONTENT_TYPE
+    };
+    MyDataPrepApi
+      .readFile(params, null, headers)
+      .flatMap(() => {
+        return setWorkspace(workspaceId);
+      })
+      .subscribe(
+        () => {},
+        (err) => {
+          DataPrepStore.dispatch({
+            type: DataPrepActions.setError,
+            payload: {
+              message: err.message || err.response.message
+            }
+          });
+        }
+      );
+  }
+  render() {
+    return (
+      <div className="dataprep-sampler-dropdown">
+        <IconSVG
+          name="icon-refresh"
+          onClick={this.onSamplerChange.bind(this, this.state.samplerMethod)}
+        />
+        <UncontrolledDropdown
+          className="collapsed-dropdown-toggle"
+        >
+          <DropdownToggle caret>
+            {T.translate(`${PREFIX}.title`, {sampleMethod: this.state.samplerMethod.label})}
+          </DropdownToggle>
+          <DropdownMenu>
+            {
+              this.dropdownOptions.map(option => {
+                return (
+                  <DropdownItem
+                    className={classnames({
+                      'selected': this.state.samplerMethod.name === option.name
+                    })}
+                    onClick={this.onSamplerChange.bind(this, option)}
+                  >
+                    {
+                      this.state.samplerMethod.name === option.name ?
+                        <span>
+                          <IconSVG name="icon-check"/>
+                        </span>
+                      :
+                        null
+                    }
+                    <span>{option.label}</span>
+                  </DropdownItem>
+                );
+              })
+            }
+          </DropdownMenu>
+        </UncontrolledDropdown>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
 $top-panel-connection-color: #999999;
 
@@ -21,8 +21,14 @@ $top-panel-connection-color: #999999;
     height: 50px;
     border-bottom: 1px solid #cccccc;
 
+    .row,
+    .row [class*="col-xs"],
     .left-title {
-      width: calc(100% - 270px);
+      height: inherit;
+    }
+    .left-title {
+      display: flex;
+      justify-content: space-between;
 
       .data-prep-name,
       .upgrade-button {

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -24,6 +24,8 @@ import {getParsedSchemaForDataPrep} from 'components/SchemaEditor/SchemaHelpers'
 import {directiveRequestBodyCreator} from 'components/DataPrep/helper';
 import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
+import SamplerDropdown from 'components/DataPrep/SamplerDropdown';
+
 import T from 'i18n-react';
 
 require('./TopPanel.scss');
@@ -176,67 +178,76 @@ export default class DataPrepTopPanel extends Component {
 
   render() {
     return (
-      <div className="top-panel clearfix">
-        <div className="left-title float-xs-left">
-          <div className="upper-section">
-            {this.renderTopPanelDisplay()}
+      <div className="top-panel ">
+        <div className="row">
+          <div className="col-xs-9">
+            <div className="left-title ">
+              <div className="upper-section">
+                {this.renderTopPanelDisplay()}
 
-            <div className="upgrade-button">
-              {
-                this.state.higherVersion ? (
-                  <button
-                    className="btn btn-info btn-sm"
-                    onClick={this.toggleUpgradeModal}
-                  >
-                    <span className="fa fa-wrench fa-fw" />
-                    {T.translate('features.DataPrep.TopPanel.upgradeBtnLabel')}
-                  </button>
-                ) : null
-              }
-              {this.renderUpgradeModal()}
+                <div className="upgrade-button">
+                  {
+                    this.state.higherVersion ? (
+                      <button
+                        className="btn btn-info btn-sm"
+                        onClick={this.toggleUpgradeModal}
+                      >
+                        <span className="fa fa-wrench fa-fw" />
+                        {T.translate('features.DataPrep.TopPanel.upgradeBtnLabel')}
+                      </button>
+                    ) : null
+                  }
+                  {this.renderUpgradeModal()}
+                </div>
+              </div>
+              <SamplerDropdown />
             </div>
           </div>
-        </div>
 
-        <div className="action-buttons float-xs-right">
-          {
-            this.state.onSubmitError ?
-              <span className="text-danger">{this.state.onSubmitError}</span>
-            :
-              null
-          }
-          {
-            !this.props.singleWorkspaceMode ?
-              <button
-                className="btn btn-primary"
-                onClick={this.toggleAddToPipelineModal}
-              >
-                {T.translate('features.DataPrep.TopPanel.addToPipelineBtnLabel')}
-              </button>
-            :
-            <button
-              className="btn btn-primary"
-              onClick={this.onSubmit.bind(this)}
-              disabled={this.state.onSubmitLoading ? 'disabled' : null}
-            >
-              {
-                this.state.onSubmitLoading ?
-                  <span className="fa fa-spinner fa-spin"></span>
-                :
-                  null
-              }
-              <span>{T.translate('features.DataPrep.TopPanel.applyBtnLabel')}</span>
-            </button>
-          }
-          {this.renderAddToPipelineModal()}
+          <div className="col-xs-3">
+            <div className="clearfix">
+              <div className="action-buttons float-xs-right">
+                {
+                  this.state.onSubmitError ?
+                    <span className="text-danger">{this.state.onSubmitError}</span>
+                  :
+                    null
+                }
+                {
+                  !this.props.singleWorkspaceMode ?
+                    <button
+                      className="btn btn-primary"
+                      onClick={this.toggleAddToPipelineModal}
+                    >
+                      {T.translate('features.DataPrep.TopPanel.addToPipelineBtnLabel')}
+                    </button>
+                  :
+                  <button
+                    className="btn btn-primary"
+                    onClick={this.onSubmit.bind(this)}
+                    disabled={this.state.onSubmitLoading ? 'disabled' : null}
+                  >
+                    {
+                      this.state.onSubmitLoading ?
+                        <span className="fa fa-spinner fa-spin"></span>
+                      :
+                        null
+                    }
+                    <span>{T.translate('features.DataPrep.TopPanel.applyBtnLabel')}</span>
+                  </button>
+                }
+                {this.renderAddToPipelineModal()}
 
-          <button
-            className="btn btn-link"
-            onClick={this.toggleSchemaModal}
-          >
-            {T.translate('features.DataPrep.TopPanel.viewSchemaBtnLabel')}
-          </button>
-          {this.renderSchemaModal()}
+                <button
+                  className="btn btn-link"
+                  onClick={this.toggleSchemaModal}
+                >
+                  {T.translate('features.DataPrep.TopPanel.viewSchemaBtnLabel')}
+                </button>
+                {this.renderSchemaModal()}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -532,6 +532,14 @@ features:
       Swap:
         title: Swap Two Column Names
     pageTitle: CDAP | Data Preparation
+    SamplerDropdown:
+      title: Sample {sampleMethod}
+      first:
+        label: First N Records
+      bernoulli:
+        label: Bernoulli
+      poisson:
+        label: Poisson
     SidePanel:
       ColumnsTab:
         toggle:

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -538,6 +538,8 @@ features:
         label: First N Records
       bernoulli:
         label: Bernoulli
+      reservoir:
+        label: Reservoir
       poisson:
         label: Poisson
     SidePanel:

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -533,15 +533,15 @@ features:
         title: Swap Two Column Names
     pageTitle: CDAP | Data Preparation
     SamplerDropdown:
-      title: Sample {sampleMethod}
-      first:
-        label: First N Records
       bernoulli:
         label: Bernoulli
-      reservoir:
-        label: Reservoir
+      first:
+        label: First N Records
       poisson:
         label: Poisson
+      reservoir:
+        label: Reservoir
+      title: Sample {sampleMethod}
     SidePanel:
       ColumnsTab:
         toggle:


### PR DESCRIPTION
Branched off of https://github.com/caskdata/cdap/pull/8715.

#### Note:
- Right now all sampler methods seem to accept same query parameters and that doesn't seem to work correctly (atleast in the case of `bernoulli`).  Need to check with @nitinmotgi.
- Right now refreshing the sampling appears not to work. When we send a `readFile` with same sampler method, data doesn't seem to refresh 