### PR TITLE
CDAP-11425 setup classloader to build MR job.jar

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -1041,7 +1041,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     }
 
     ClassLoader oldCLassLoader = ClassLoaders.setContextClassLoader(new CombineClassLoader(
-      job.getConfiguration().getClassLoader(), Collections.singleton(ddlExecutorClass.getClassLoader())));
+      getClass().getClassLoader(), Collections.singleton(ddlExecutorClass.getClassLoader())));
 
     try {
       appBundler.createBundle(Locations.toLocation(jobJar), classes);


### PR DESCRIPTION
Logs like this one are sent to stderr and hence show with as WARN logs in the program log. This fixes the issue by setting the jcl over slf4 bridge correctly. 

May 08, 2017 6:23:27 PM org.apache.hadoop.mapreduce.v2.app.MRAppMaster initAndStartAppMaster INFO: Executing with tokens: