### PR TITLE
set tag for hdinsight 4.1.1 deploy

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -22,7 +22,7 @@
 # The git branch to clone
 CDAP_BRANCH='release/4.1'
 # Optional tag to checkout - All released versions of this script should set this
-CDAP_TAG=''
+CDAP_TAG='v4.1.1'
 # The CDAP package version passed to Chef
 CDAP_VERSION='4.1.1-1'
 # The version of Chef to install


### PR DESCRIPTION
sets the tag to lockdown the HDInsight configuration for 4.1.1: https://github.com/caskdata/cdap/blob/v4.1.1/cdap-distributions/src/hdinsight/cdap-conf.json