### PR TITLE
Revert "Bump tracker version to 0.4.1."

### DIFF
--- a/cdap-ui/server/config/cdap-ui-config.json
+++ b/cdap-ui/server/config/cdap-ui-config.json
@@ -2,7 +2,7 @@
   "tracker": {
     "artifact": {
       "name": "tracker",
-      "version": "0.4.1",
+      "version": "0.4.0",
       "scope": "SYSTEM"
     },
     "appId": "_Tracker",


### PR DESCRIPTION
Reverts caskdata/cdap#8672

This is because UI Package is built from release/4.1. The UI Pack needs to work with CDAP 4.1.1, which packages Tracker 0.4.0.