### PR TITLE
UI Regression fixes before power pack 3

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
@@ -132,4 +132,38 @@ body.state-hydrator-create.state-hydrator {
       min-width: auto;
     }
   }
+
+  .dataprep-parse-modal {
+    .dropdown-item {
+      display: block;
+      width: 100%;
+      padding: 3px 1.5rem;
+      clear: both;
+      font-weight: 400;
+      color: #373a3c;
+      text-align: inherit;
+      white-space: nowrap;
+      background: none;
+      border: 0;
+
+      &:focus,
+      &:hover {
+        color: #2b2d2f;
+        text-decoration: none;
+        background-color: #f5f5f5;
+      }
+    }
+
+    .dropdown-toggle:after {
+      display: inline-block;
+      width: 0;
+      height: 0;
+      margin-left: 0.3em;
+      vertical-align: middle;
+      content: "";
+      border-top: 0.3em solid;
+      border-right: 0.3em solid transparent;
+      border-left: 0.3em solid transparent;
+    }
+  }
 }

--- a/cdap-ui/app/hydrator/adapters.less
+++ b/cdap-ui/app/hydrator/adapters.less
@@ -382,36 +382,3 @@ body.theme-cdap {
     }
   }
 }
-
-// have to define these dropdown values here since styling for DropdownItem is in Bootstrap 4, but not in Bootstrap 3
-.dropdown-item {
-  display: block;
-  width: 100%;
-  padding: 3px 1.5rem;
-  clear: both;
-  font-weight: 400;
-  color: #373a3c;
-  text-align: inherit;
-  white-space: nowrap;
-  background: none;
-  border: 0;
-
-  &:focus,
-  &:hover {
-    color: #2b2d2f;
-    text-decoration: none;
-    background-color: #f5f5f5;
-  }
-}
-
-.dropdown-toggle::after {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  margin-left: .3em;
-  vertical-align: middle;
-  content: "";
-  border-top: .3em solid;
-  border-right: .3em solid transparent;
-  border-left: .3em solid transparent;
-}


### PR DESCRIPTION
- Fixes Log level dropdown icon to not appear twice. This is because of moving `.dropdown` css class to `adapter.less` (since its not available in bootstrap3).
- ~Fixes `z-index` of all modals in dataprep to be `1060` to make sure the modals go underneath the loading icon goes backdrop. (This is a bit risky change at the last minute).~ Not doing this change. Its too much of last minute change.