### PR TITLE
fix package iteration for 4.1.1

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -24,7 +24,7 @@ CDAP_BRANCH='release/4.1'
 # Optional tag to checkout - All released versions of this script should set this
 CDAP_TAG='v4.1.1'
 # The CDAP package version passed to Chef
-CDAP_VERSION='4.1.1-1'
+CDAP_VERSION='4.1.1-2'
 # The version of Chef to install
 CHEF_VERSION='12.10.24'
 # cdap-site.xml configuration parameters


### PR DESCRIPTION
The available 4.1.1 CDAP packages are iteration 2 and not 1.  Updating package version appropriately for HDInsight install