### PR TITLE
split ssh config into azure and non-azure

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -172,44 +172,11 @@
     {
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
-      "run_list": "recipe[openssh]",
-      "skip_install": true,
-      "json": {
-        "openssh": {
-          "server": {
-            "permit_root_login": "without-password",
-            "password_authentication": "no",
-            "use_dns": "no"
-          }
-        }
-      },
-      "except": ["cdap-cloud-sandbox-azure"]
-    },
-    {
-      "type": "chef-solo",
-      "remote_cookbook_paths": "/var/chef/cookbooks",
-      "run_list": "recipe[openssh]",
-      "skip_install": true,
-      "json": {
-        "openssh": {
-          "server": {
-            "client_alive_interval": "120",
-            "permit_root_login": "without-password",
-            "password_authentication": "no",
-            "use_dns": "no"
-          }
-        }
-      },
-      "only": ["cdap-cloud-sandbox-azure"]
-    },
-    {
-      "type": "chef-solo",
-      "remote_cookbook_paths": "/var/chef/cookbooks",
-      "run_list": "recipe[cdap::sdk]",
+      "run_list": "recipe[openssh],recipe[cdap::sdk]",
       "skip_install": true,
       "json": {
         "cdap": {
-          "comment": "DO NOT PUT SNAPSHOT IN THE VERSION BELOW, THIS CONTROLS CDAP COOKBOOK CODE",
+          "comment": "DO NOT PUT SNAPHOT IN THE VERSION BELOW, THIS CONTROLS CDAP COOKBOOK CODE",
           "version": "4.2.0-1",
           "sdk": {
             "comment": "COPY SDK ZIP TO files/cdap-sdk.zip BEFORE RUNNING ME",
@@ -227,6 +194,13 @@
             "checksum": {
               "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
             }
+          }
+        },
+        "openssh": {
+          "server": {
+            "permit_root_login": "without-password",
+            "password_authentication": "no",
+            "use_dns": "no"
           }
         }
       }

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -172,11 +172,44 @@
     {
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
-      "run_list": "recipe[openssh],recipe[cdap::sdk]",
+      "run_list": "recipe[openssh]",
+      "skip_install": true,
+      "json": {
+        "openssh": {
+          "server": {
+            "permit_root_login": "without-password",
+            "password_authentication": "no",
+            "use_dns": "no"
+          }
+        }
+      },
+      "except": ["cdap-cloud-sandbox-azure"]
+    },
+    {
+      "type": "chef-solo",
+      "remote_cookbook_paths": "/var/chef/cookbooks",
+      "run_list": "recipe[openssh]",
+      "skip_install": true,
+      "json": {
+        "openssh": {
+          "server": {
+            "client_alive_interval": "120",
+            "permit_root_login": "without-password",
+            "password_authentication": "no",
+            "use_dns": "no"
+          }
+        }
+      },
+      "only": ["cdap-cloud-sandbox-azure"]
+    },
+    {
+      "type": "chef-solo",
+      "remote_cookbook_paths": "/var/chef/cookbooks",
+      "run_list": "recipe[cdap::sdk]",
       "skip_install": true,
       "json": {
         "cdap": {
-          "comment": "DO NOT PUT SNAPHOT IN THE VERSION BELOW, THIS CONTROLS CDAP COOKBOOK CODE",
+          "comment": "DO NOT PUT SNAPSHOT IN THE VERSION BELOW, THIS CONTROLS CDAP COOKBOOK CODE",
           "version": "4.2.0-1",
           "sdk": {
             "comment": "COPY SDK ZIP TO files/cdap-sdk.zip BEFORE RUNNING ME",
@@ -194,13 +227,6 @@
             "checksum": {
               "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
             }
-          }
-        },
-        "openssh": {
-          "server": {
-            "permit_root_login": "without-password",
-            "password_authentication": "no",
-            "use_dns": "no"
           }
         }
       }

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -198,6 +198,7 @@
         },
         "openssh": {
           "server": {
+            "client_alive_interval": "180",
             "permit_root_login": "without-password",
             "password_authentication": "no",
             "use_dns": "no"
@@ -247,14 +248,14 @@
       "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
       "scripts": "scripts/ssh-cleanup.sh"
     },
-   {
-     "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
-     "inline": [
-       "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
-     ],
-     "inline_shebang": "/bin/sh -x",
-     "type": "shell",
-     "only": ["cdap-cloud-sandbox-azure"]
-   }
+    {
+      "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+      "inline": [
+        "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+      ],
+      "inline_shebang": "/bin/sh -x",
+      "type": "shell",
+      "only": ["cdap-cloud-sandbox-azure"]
+    }
   ]
 }


### PR DESCRIPTION
- [x] splits the ``recipe[openssh],recipe[cdap::sdk]`` chef-solo provisioner into two, and the openssh side further split into azure and non-azure versions :
   - [x] ``recipe[openssh]`` with ``"except": ["cdap-cloud-sandbox-azure"]``: same attributes for existing builds
   - [x] ``recipe[openssh]`` with ``"only": ["cdap-cloud-sandbox-azure"]`` only for azure, with the required ``sshd_config`` attribute ``ClientAliveInterval``.  Value of ``120`` matches HDInsight clusters.
   - [x] ``recipe[cdap::sdk]``, common and relevant attributes unchanged