### PR TITLE
CDAP-7185 Remove deprecated method: EntityId#getEntity.

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -121,14 +121,6 @@ public abstract class EntityId implements IdCompatible {
 
   protected abstract Iterable<String> toIdParts();
 
-  /**
-   *  Deprecated method to rename to getEntityType(). Use {@link #getEntityType()}
-   */
-  @Deprecated
-  public final EntityType getEntity() {
-    return entity;
-  }
-
   public abstract String getEntityName();
 
   public final EntityType getEntityType() {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-7185
https://builds.cask.co/browse/CDAP-DUT5723