### PR TITLE
[CDAP-11342] Adds the ability to import pipelines with artifact ranges.

### DIFF
--- a/cdap-ui/app/common/cask-header.js
+++ b/cdap-ui/app/common/cask-header.js
@@ -26,6 +26,7 @@
  var VersionStore = require('../cdap/services/VersionStore').default;
  var VersionActions = require('../cdap/services/VersionStore/VersionActions').default;
  var Version = require('../cdap/services/VersionRange/Version').default;
+ var VersionRange = require('../cdap/services/VersionRange').default;
  export {
   Store,
   Header,
@@ -35,6 +36,7 @@
   ee,
   VersionStore,
   VersionActions,
+  VersionRange,
   Version,
   ResourceCenterButton
 };

--- a/cdap-ui/app/tracker/services/my-jump-factory.js
+++ b/cdap-ui/app/tracker/services/my-jump-factory.js
@@ -26,7 +26,7 @@ function myJumpFactory($state, myTrackerApi, $rootScope) {
   let corePluginsArtifacts = {
     name: 'core-plugins',
     scope: 'SYSTEM',
-    version: '1.7.0-SNAPSHOT'
+    version: '[1.5.0, 2.0.0]'
   };
 
   let batchSourceTemplate = {


### PR DESCRIPTION
- Adds the ability to have version ranges for system artifacts & plugin artifacts
- Modifies core plugins artifact version used in tracker to use version range (Have now set to 1.5.0 - 2.0.0)


### Note:
- Need to think about error handling. Unsupported parent artifacts? Plugin artifact not found? 