### PR TITLE
CDAP-11442 filter scala resources from extensions

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/extension/AbstractExtensionLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/extension/AbstractExtensionLoader.java
@@ -84,6 +84,7 @@ public abstract class AbstractExtensionLoader<EXTENSION_TYPE, EXTENSION> {
   private final ServiceLoader<EXTENSION> systemExtensionLoader;
   private final LoadingCache<EXTENSION_TYPE, AtomicReference<EXTENSION>> extensionsCache;
   private final LoadingCache<File, ServiceLoader<EXTENSION>> serviceLoaderCache;
+  private final ClassLoader parentClassLoader;
   private Map<EXTENSION_TYPE, EXTENSION> allExtensions;
 
   @SuppressWarnings("unchecked")
@@ -99,6 +100,7 @@ public abstract class AbstractExtensionLoader<EXTENSION_TYPE, EXTENSION> {
     this.systemExtensionLoader = ServiceLoader.load(this.extensionClass);
     this.serviceLoaderCache = createServiceLoaderCache();
     this.extensionsCache = createExtensionsCache();
+    this.parentClassLoader = new ScalaFilterClassLoader(getClass().getClassLoader());
   }
 
   /**
@@ -271,7 +273,7 @@ public abstract class AbstractExtensionLoader<EXTENSION_TYPE, EXTENSION> {
       }
     }), URL.class);
 
-    URLClassLoader classLoader = new URLClassLoader(urls, getClass().getClassLoader());
+    URLClassLoader classLoader = new URLClassLoader(urls, parentClassLoader);
     return ServiceLoader.load(extensionClass, classLoader);
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/extension/ScalaFilterClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/extension/ScalaFilterClassLoader.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.extension;
+
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.lang.FilterClassLoader;
+
+import java.net.URL;
+
+/**
+ * Filters scala resources. This includes any classes that start with 'scala', and any resources from the scala-library
+ * jar. This is used as the parent of extensions classloaders to allow different extensions to package different
+ * versions of scala than the scala packaged with CDAP. For example, Spark1 uses scala 2.10 (same as CDAP),
+ * but Spark2 uses 2.11.
+ */
+public class ScalaFilterClassLoader extends ClassLoader {
+
+  public ScalaFilterClassLoader(ClassLoader parent) {
+    super(new FilterClassLoader(parent, new FilterClassLoader.Filter() {
+      @Override
+      public boolean acceptResource(String resource) {
+        return !resource.startsWith("scala/") && !"scala.class".equals(resource);
+      }
+
+      @Override
+      public boolean acceptPackage(String packageName) {
+        return !packageName.startsWith("scala/");
+      }
+    }));
+  }
+
+  @Override
+  public URL getResource(String name) {
+    URL resource = super.getResource(name);
+    if (resource == null) {
+      return null;
+    }
+    // resource = jar:file:/path/to/cdap/lib/org.scala-lang.scala-library-2.10.4.jar!/library.properties
+    // baseClasspath = /path/to/cdap/lib/org.scala-lang.scala-library-2.10.4.jar
+    String baseClasspath = ClassLoaders.getClassPathURL(name, resource).getPath();
+    String jarName = baseClasspath.substring(baseClasspath.lastIndexOf('/') + 1, baseClasspath.length());
+    return jarName.startsWith("org.scala-lang") ? null : resource;
+  }
+}

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -773,6 +773,11 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
           LOG.warn("BeanIntrospector.ctorParamNamesCache is not a LoadingCache, may lead to memory leak in SDK." +
                      "Field type is {}", field.getType());
       }
+    } catch (NoSuchFieldException e) {
+      // If there is no ctorParamNamesCache field, there is nothing to invalidate.
+      // This is the case in jackson-module-scala_2.11-2.6.5 used by Spark 2.1.0
+      LOG.trace("No ctorParamNamesCache field in BeanIntrospector. " +
+                  "The current Spark version is not using a BeanIntrospector that has a param names loading cache.");
     } catch (ClassNotFoundException e) {
       // Catch the case when there is no BeanIntrospector class. It is ok since some Spark version may not be using it.
       LOG.debug("No BeanIntrospector class found. The current Spark version is not using BeanIntrospector.");

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -278,7 +278,7 @@
                   <overWriteSnapshots>false</overWriteSnapshots>
                   <overWriteIfNewer>true</overWriteIfNewer>
                   <excludeGroupIds>org.apache.hbase,asm</excludeGroupIds>
-                  <excludeArtifactIds>zkclient,servlet-api,cdap-cli,cdap-explore-jdbc,kafka_2.10,scala-library</excludeArtifactIds>
+                  <excludeArtifactIds>zkclient,servlet-api,cdap-cli,cdap-explore-jdbc</excludeArtifactIds>
                   <prependGroupId>true</prependGroupId>
                   <silent>true</silent>
                   <includeScope>runtime</includeScope>


### PR DESCRIPTION
Adding a filter to the classloader for extensions so that scala
resources from CDAP are not visible to extensions. If an extension
uses scala, it must include the relevant scala library. This is
to support runtimes of Spark that compiled against different scala.