### PR TITLE
[CDAP-11481] Fixes call-to-action modal showing outline in pipeline detail view

### DIFF
--- a/cdap-ui/app/cdap/components/Wizard/Wizard.scss
+++ b/cdap-ui/app/cdap/components/Wizard/Wizard.scss
@@ -60,6 +60,13 @@
       &.LOADING {
         border-top-color: gray;
       }
+
+      .stack-trace {
+        // should be at least tall enough to show the resizable icon
+        min-height: 45px;
+        // 75vh (full height of modal) - 40px (modal header) - 360px (max modal body height) - 35px (error header)
+        max-height: calc(75vh - 40px - 360px - 35px);
+      }
     }
     &.success {
       width: 100%;

--- a/cdap-ui/app/cdap/components/WizardModal/WizardModal.scss
+++ b/cdap-ui/app/cdap/components/WizardModal/WizardModal.scss
@@ -16,7 +16,7 @@
 
 @import '../../styles/variables.scss';
 $wizard-header-color: #464a57;
-$wizard-modal-height: 82vh;
+$wizard-modal-height: 75vh;
 $wizard-modal-width: 60vw;
 $wizard-modal-margin-top: 12.5vh;
 $wizard-modal-body-max-height: 360px;

--- a/cdap-ui/app/hydrator/bottompanel.less
+++ b/cdap-ui/app/hydrator/bottompanel.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -81,12 +81,6 @@ body.theme-cdap.state-hydrator {
       }
       &.maximized {
         top: 93px;
-      }
-    }
-
-    .modal {
-      .modal-dialog {
-        margin-top: 119px;
       }
     }
   }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-11481

Have tested and checked that this change doesn't break anything in pipeline detail view, and actually also fixes the problem of the system services down modal being way too low on the screen. Removing this hard-coded rule defaults the modal to use `margin-top: 12.5vh` defined higher up in the hierarchy.

Since this CSS snippet was added a long time ago, I wasn't sure about its purpose, since it didn't seem to address any particular styling issue. Maybe there were other styling code changes that made this code obsolete.