### PR TITLE
Added back running of spark core modules tests

### DIFF
--- a/cdap-api-spark/pom.xml
+++ b/cdap-api-spark/pom.xml
@@ -227,4 +227,63 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <!-- This profile is just for Spark development in IDE, don't use it in normal Maven build -->
+      <id>spark1-dev</id>
+      <properties>
+        <spark.api.base.dir>${project.basedir}/../cdap-api-spark-base</spark.api.base.dir>
+      </properties>
+      <build>
+        <plugins>
+          <!-- Disable the copying of files from base -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+              <execution>
+                <id>copy-api-base</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Symlink the source from base -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+              <execution>
+                <id>mkdir-symlink-dir</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <mkdir dir="${project.build.directory}/generated-sources/cdap-api-spark-base/src"/>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>symlink-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <symlink link="${project.build.directory}/generated-sources/cdap-api-spark-base/src/main" resource="${spark.api.base.dir}/src/main" overwrite="true" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/cdap-api-spark2_2.11/pom.xml
+++ b/cdap-api-spark2_2.11/pom.xml
@@ -227,4 +227,63 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <!-- This profile is just for Spark development in IDE, don't use it in normal Maven build -->
+      <id>spark2-dev</id>
+      <properties>
+        <spark.api.base.dir>${project.basedir}/../cdap-api-spark-base</spark.api.base.dir>
+      </properties>
+      <build>
+        <plugins>
+          <!-- Disable the copying of files from base -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+              <execution>
+                <id>copy-api-base</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Symlink the source from base -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+              <execution>
+                <id>mkdir-symlink-dir</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <mkdir dir="${project.build.directory}/generated-sources/cdap-api-spark-base/src"/>
+                  </target>
+                </configuration>
+              </execution>
+              <execution>
+                <id>symlink-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <symlink link="${project.build.directory}/generated-sources/cdap-api-spark-base/src/main" resource="${spark.api.base.dir}/src/main" overwrite="true" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/cdap-spark-core/pom.xml
+++ b/cdap-spark-core/pom.xml
@@ -226,12 +226,77 @@
               </sources>
             </configuration>
           </execution>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-test-sources/cdap-spark-core-base/src/test/java</source>
+                <source>${project.build.directory}/generated-test-sources/cdap-spark-core-base/src/test/scala</source>
+              </sources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
 
   <profiles>
+    <profile>
+      <!-- This profile is just for Spark development in IDE, don't use it in normal Maven build -->
+      <id>spark1-dev</id>
+      <properties>
+        <spark.base.dir>${project.basedir}/../cdap-spark-core-base</spark.base.dir>
+      </properties>
+      <build>
+        <plugins>
+          <!-- Disable the copying of files from base -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+              <execution>
+                <id>copy-base</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>copy-base-test</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Symlink the source from base -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+              <execution>
+                <id>mkdir-symlink-dir</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <mkdir dir="${project.build.directory}/generated-sources/cdap-spark-core-base/src"/>
+                    <mkdir dir="${project.build.directory}/generated-test-sources/cdap-spark-core-base/src"/>
+                    <symlink link="${project.build.directory}/generated-sources/cdap-spark-core-base/src/main" resource="${spark.base.dir}/src/main" overwrite="true" />
+                    <symlink link="${project.build.directory}/generated-test-sources/cdap-spark-core-base/src/test" resource="${spark.base.dir}/src/test" overwrite="true" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>dist</id>
       <build>

--- a/cdap-spark-core2_2.11/pom.xml
+++ b/cdap-spark-core2_2.11/pom.xml
@@ -226,12 +226,77 @@
               </sources>
             </configuration>
           </execution>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-test-sources/cdap-spark-core-base/src/test/java</source>
+                <source>${project.build.directory}/generated-test-sources/cdap-spark-core-base/src/test/scala</source>
+              </sources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
 
   <profiles>
+    <profile>
+      <!-- This profile is just for Spark development in IDE, don't use it in normal Maven build -->
+      <id>spark2-dev</id>
+      <properties>
+        <spark.base.dir>${project.basedir}/../cdap-spark-core-base</spark.base.dir>
+      </properties>
+      <build>
+        <plugins>
+          <!-- Disable the copying of files from base -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+              <execution>
+                <id>copy-base</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>copy-base-test</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Symlink the source from base -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+              <execution>
+                <id>mkdir-symlink-dir</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <mkdir dir="${project.build.directory}/generated-sources/cdap-spark-core-base/src"/>
+                    <mkdir dir="${project.build.directory}/generated-test-sources/cdap-spark-core-base/src"/>
+                    <symlink link="${project.build.directory}/generated-sources/cdap-spark-core-base/src/main" resource="${spark.base.dir}/src/main" overwrite="true" />
+                    <symlink link="${project.build.directory}/generated-test-sources/cdap-spark-core-base/src/test" resource="${spark.base.dir}/src/test" overwrite="true" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>dist</id>
       <build>


### PR DESCRIPTION
Also added two new profiles for spark development in IDE
  - Use symlink instead of copy source so that there is single place to modify the common code.