### PR TITLE
Allow disabling of CDAP_TAG on published install scripts

### DIFF
--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -24,7 +24,7 @@ CDAP_BRANCH=${CDAP_BRANCH:-release/4.1}
 # Optional tag to checkout - All released versions of this script should set this
 # like this: CDAP_TAG=${CDAP_TAG:+tag} as this allows setting tag to empty/null
 # otherwise, it should be CDAP_TAG=''
-CDAP_TAG=''
+CDAP_TAG=${CDAP_TAG:+v4.2.0}
 # The CDAP package version passed to Chef
 CDAP_VERSION=${CDAP_VERSION:-4.1.1-1}
 # The version of Chef to install

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -22,6 +22,8 @@
 # The git branch to clone
 CDAP_BRANCH=${CDAP_BRANCH:-release/4.1}
 # Optional tag to checkout - All released versions of this script should set this
+# like this: CDAP_TAG=${CDAP_TAG:+tag} as this allows setting tag to empty/null
+# otherwise, it should be CDAP_TAG=''
 CDAP_TAG=''
 # The CDAP package version passed to Chef
 CDAP_VERSION=${CDAP_VERSION:-4.1.1-1}

--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -22,7 +22,9 @@
 # The git branch to clone
 CDAP_BRANCH='release/4.1'
 # Optional tag to checkout - All released versions of this script should set this
-CDAP_TAG='v4.2.0'
+# like this: CDAP_TAG=${CDAP_TAG:+tag} as this allows setting tag to empty/null
+# otherwise, it should be CDAP_TAG=''
+CDAP_TAG=${CDAP_TAG:+v4.2.0}
 # The CDAP package version passed to Chef
 CDAP_VERSION='4.2.0-1'
 # The version of Chef to install


### PR DESCRIPTION
If release versions set `CDAP_TAG=${CDAP_TAG:+tag}` then it can be overridden for testing.