### PR TITLE
CDAP-11429 fix register usage for streams

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunnerModule.java
@@ -25,7 +25,6 @@ import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
-import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
 import co.cask.cdap.data2.transaction.stream.inmemory.InMemoryStreamConsumerFactory;
 import co.cask.cdap.explore.client.ExploreClient;
@@ -73,20 +72,18 @@ public class PreviewRunnerModule extends PrivateModule {
   private final AuthorizerInstantiator authorizerInstantiator;
   private final AuthorizationEnforcer authorizationEnforcer;
   private final PrivilegesManager privilegesManager;
-  private final StreamAdmin streamAdmin;
   private final StreamCoordinatorClient streamCoordinatorClient;
   private final PreferencesStore preferencesStore;
 
   public PreviewRunnerModule(ArtifactRepository artifactRepository, ArtifactStore artifactStore,
                              AuthorizerInstantiator authorizerInstantiator, AuthorizationEnforcer authorizationEnforcer,
-                             PrivilegesManager privilegesManager, StreamAdmin streamAdmin,
+                             PrivilegesManager privilegesManager,
                              StreamCoordinatorClient streamCoordinatorClient, PreferencesStore preferencesStore) {
     this.artifactRepository = artifactRepository;
     this.artifactStore = artifactStore;
     this.authorizerInstantiator = authorizerInstantiator;
     this.authorizationEnforcer = authorizationEnforcer;
     this.privilegesManager = privilegesManager;
-    this.streamAdmin = streamAdmin;
     this.streamCoordinatorClient = streamCoordinatorClient;
     this.preferencesStore = preferencesStore;
   }
@@ -103,8 +100,6 @@ public class PreviewRunnerModule extends PrivateModule {
     expose(AuthorizationEnforcer.class);
     bind(PrivilegesManager.class).toInstance(privilegesManager);
     expose(PrivilegesManager.class);
-    bind(StreamAdmin.class).toInstance(streamAdmin);
-    expose(StreamAdmin.class);
     bind(StreamConsumerFactory.class).to(InMemoryStreamConsumerFactory.class).in(Scopes.SINGLETON);
     expose(StreamConsumerFactory.class);
     bind(StreamCoordinatorClient.class).toInstance(streamCoordinatorClient);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -38,6 +38,7 @@ import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.preview.PreviewDataModules;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
+import co.cask.cdap.data.stream.preview.PreviewStreamAdminModule;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -80,9 +81,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
@@ -209,11 +207,12 @@ public class DefaultPreviewManager implements PreviewManager {
       new AuthenticationContextModules().getMasterModule(),
       new SecurityModules().getStandaloneModules(),
       new PreviewSecureStoreModule(secureStore),
+      new PreviewStreamAdminModule(streamAdmin),
       new PreviewDiscoveryRuntimeModule(discoveryService),
       new LocationRuntimeModule().getStandaloneModules(),
       new ConfigStoreModule().getStandaloneModule(),
       new PreviewRunnerModule(artifactRepository, artifactStore, authorizerInstantiator, authorizationEnforcer,
-                              privilegesManager, streamAdmin, streamCoordinatorClient, preferencesStore),
+                              privilegesManager, streamCoordinatorClient, preferencesStore),
       new ProgramRunnerRuntimeModule().getStandaloneModules(),
       new PreviewDataModules().getDataFabricModule(transactionManager),
       new PreviewDataModules().getDataSetsModule(datasetFramework),

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/preview/PreviewDataModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/preview/PreviewDataModules.java
@@ -29,7 +29,7 @@ import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
-import co.cask.cdap.data2.registry.DefaultUsageRegistry;
+import co.cask.cdap.data2.registry.NoOpUsageRegistry;
 import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
@@ -45,8 +45,6 @@ import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import org.apache.tephra.TransactionManager;
-
-import java.util.Set;
 
 /**
  * Data fabric modules for preview
@@ -99,10 +97,10 @@ public class PreviewDataModules {
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
 
-        bind(RuntimeUsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
+        bind(RuntimeUsageRegistry.class).to(NoOpUsageRegistry.class).in(Scopes.SINGLETON);
         expose(RuntimeUsageRegistry.class);
 
-        bind(UsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
+        bind(UsageRegistry.class).to(NoOpUsageRegistry.class).in(Scopes.SINGLETON);
         expose(UsageRegistry.class);
       }
     };

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/preview/PreviewStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/preview/PreviewStreamAdmin.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream.preview;
+
+import co.cask.cdap.api.data.stream.StreamSpecification;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.data2.transaction.stream.StreamConfig;
+import co.cask.cdap.proto.StreamProperties;
+import co.cask.cdap.proto.ViewSpecification;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import javax.annotation.Nullable;
+
+/**
+ *  StreamAdmin to be used for preview. Any operation that modifies the stream will be no-op.
+ */
+public class PreviewStreamAdmin implements StreamAdmin {
+
+  private final StreamAdmin delegate;
+
+  public PreviewStreamAdmin(StreamAdmin delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void dropAllInNamespace(NamespaceId namespace) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void configureInstances(StreamId streamId, long groupId, int instances) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void configureGroups(StreamId streamId, Map<Long, Integer> groupInfo) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void upgrade() throws Exception {
+    // no-op
+  }
+
+  @Override
+  public List<StreamSpecification> listStreams(NamespaceId namespaceId) throws Exception {
+    return delegate.listStreams(namespaceId);
+  }
+
+  @Override
+  public StreamConfig getConfig(StreamId streamId) throws IOException {
+    return delegate.getConfig(streamId);
+  }
+
+  @Override
+  public StreamProperties getProperties(StreamId streamId) throws Exception {
+    return delegate.getProperties(streamId);
+  }
+
+  @Override
+  public void updateConfig(StreamId streamId, StreamProperties properties) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public boolean exists(StreamId streamId) throws Exception {
+    return delegate.exists(streamId);
+  }
+
+  @Nullable
+  @Override
+  public StreamConfig create(StreamId streamId) throws Exception {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public StreamConfig create(StreamId streamId, @Nullable Properties props) throws Exception {
+    return null;
+  }
+
+  @Override
+  public void truncate(StreamId streamId) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void drop(StreamId streamId) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public boolean createOrUpdateView(StreamViewId viewId, ViewSpecification spec) throws Exception {
+    return false;
+  }
+
+  @Override
+  public void deleteView(StreamViewId viewId) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public List<StreamViewId> listViews(StreamId streamId) throws Exception {
+    return delegate.listViews(streamId);
+  }
+
+  @Override
+  public ViewSpecification getView(StreamViewId viewId) throws Exception {
+    return delegate.getView(viewId);
+  }
+
+  @Override
+  public boolean viewExists(StreamViewId viewId) throws Exception {
+    return delegate.viewExists(viewId);
+  }
+
+  @Override
+  public void register(Iterable<? extends EntityId> owners, StreamId streamId) {
+    // no-op
+  }
+
+  @Override
+  public void addAccess(ProgramRunId run, StreamId streamId, AccessType accessType) {
+    // no-op
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/preview/PreviewStreamAdminModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/preview/PreviewStreamAdminModule.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream.preview;
+
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import com.google.inject.AbstractModule;
+
+/**
+ *  Provides Guice bindings for StreamAdmin in preview mode.
+ */
+public class PreviewStreamAdminModule extends AbstractModule {
+
+  private final StreamAdmin streamAdmin;
+
+  public PreviewStreamAdminModule(StreamAdmin streamAdmin) {
+    this.streamAdmin = streamAdmin;
+  }
+
+  @Override
+  protected void configure() {
+    PreviewStreamAdmin previewStreamAdmin = new PreviewStreamAdmin(streamAdmin);
+    bind(StreamAdmin.class).toInstance(previewStreamAdmin);
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-11429
Build: https://builds.cask.co/browse/CDAP-DUT5732-1

We are registering usage for mapreduce or spark at https://github.com/caskdata/cdap/blob/develop/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java#L819

Like SecureStore, we need to have no-op for registering usage for streams.