### PR TITLE
CDAP-9321 Move HttpRequestLog logger to Error

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -47,6 +47,9 @@
   <logger name="org.apache.twill.internal.kafka.client.SimpleKafkaConsumer" level="WARN"/>
   <logger name="co.cask.cdap" level="INFO"/>
 
+  <!-- HttpRequestLog is not used and expects log4j logging or logs a WARN message -->
+  <logger name="org.apache.hadoop.http.HttpRequestLog" level="ERROR"/>
+
   <!-- Redirected stdout and stderr of Hive operations -->
   <logger name="Explore.stdout" level="INFO"/>
   <logger name="Explore.stderr" level="INFO"/>

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -44,6 +44,9 @@
     <logger name="akka" level="WARN"/>
     <logger name="Remoting" level="WARN"/>
 
+    <!-- HttpRequestLog is not used and expects log4j logging or logs a WARN message -->
+    <logger name="org.apache.hadoop.http.HttpRequestLog" level="ERROR"/>
+
     <logger name="org.apache.twill" level="INFO"/>
     <logger name="org.apache.twill.internal.kafka.client.SimpleKafkaConsumer" level="WARN"/>
     <logger name="co.cask.cdap" level="INFO"/>

--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -50,6 +50,9 @@
   <logger name="akka" level="WARN"/>
   <logger name="Remoting" level="WARN"/>
 
+  <!-- HttpRequestLog is not used and expects log4j logging or logs a WARN message -->
+  <logger name="org.apache.hadoop.http.HttpRequestLog" level="ERROR"/>
+
   <appender name="Rolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>logs/cdap.log</file>
     <encoder>


### PR DESCRIPTION
HttpRequestLog is not used and expects log4j logging or logs a WARN message for all MR and Spark Programs on both CDH and HDP distros. 
2017-05-08 23:47:44,979 - WARN  [main:o.a.h.h.HttpRequestLog@100] - Jetty request log can only be enabled using Log4j
