### PR TITLE
Remove @Nullable annotation from 'arguments' parameter of DatasetFramework

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
@@ -81,7 +81,7 @@ public final class DatasetServiceStore extends AbstractIdleService implements Se
         try {
           return DatasetsUtil.getOrCreateDataset(dsFramework, serviceStoreDatasetInstanceId,
                                                  NoTxKeyValueTable.class.getName(),
-                                                 DatasetProperties.EMPTY, null, null);
+                                                 DatasetProperties.EMPTY, null);
         } catch (Exception e) {
           // Throwing RetryableException here is just to make it retry getting the dataset
           // an exception here usually means there is an hbase problem

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
@@ -140,7 +140,7 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException {
     return super.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader);
@@ -148,7 +148,7 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader,
                                           DatasetClassLoaderProvider classLoaderProvider,
                                           @Nullable Iterable<? extends EntityId> owners, AccessType accessType)

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
@@ -195,7 +195,7 @@ public class AuthorizationBootstrapperTest {
     // ensure that system datasets can be created by the system user
     Dataset systemDataset = DatasetsUtil.getOrCreateDataset(
       dsFramework, NamespaceId.SYSTEM.dataset("system-dataset"), Table.class.getName(), DatasetProperties.EMPTY,
-      Collections.<String, String>emptyMap(), this.getClass().getClassLoader());
+      Collections.<String, String>emptyMap());
     Assert.assertNotNull(systemDataset);
     // as part of bootstrapping, admin users were also granted admin privileges on the CDAP instance, so they can
     // create namespaces

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -152,6 +152,6 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
     DatasetId metricsDatasetInstanceId = NamespaceId.SYSTEM.dataset(name);
     DatasetProperties props = TableProperties.builder().setReadlessIncrementSupport(true).build();
     return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId,
-                                           MetricsTable.class.getName(), props, null, null);
+                                           MetricsTable.class.getName(), props, null);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
@@ -64,11 +65,12 @@ public final class DatasetsUtil {
   public static <T extends Dataset> T getOrCreateDataset(DatasetFramework datasetFramework,
                                                          DatasetId datasetInstanceId, String typeName,
                                                          DatasetProperties props,
-                                                         Map<String, String> arguments,
-                                                         ClassLoader cl)
+                                                         @Nullable Map<String, String> arguments)
     throws DatasetManagementException, IOException {
-
     createIfNotExists(datasetFramework, datasetInstanceId, typeName, props);
+    if (arguments == null) {
+      arguments = Collections.emptyMap();
+    }
     return datasetFramework.getDataset(datasetInstanceId, arguments, null);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -243,7 +243,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(DatasetId id, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId id, Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader,
                                           DatasetClassLoaderProvider classLoaderProvider,
                                           @Nullable Iterable<? extends EntityId> owners, AccessType accessType)

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -310,7 +310,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @Nullable
-  <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
+  <T extends Dataset> T getDataset(DatasetId datasetInstanceId, Map<String, String> arguments,
                                    @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException;
 
@@ -331,7 +331,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @Nullable
-  <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
+  <T extends Dataset> T getDataset(DatasetId datasetInstanceId, Map<String, String> arguments,
                                    @Nullable ClassLoader classLoader,
                                    DatasetClassLoaderProvider classLoaderProvider,
                                    @Nullable Iterable<? extends EntityId> owners,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
@@ -156,7 +156,7 @@ public class ForwardingDatasetFramework implements DatasetFramework {
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException {
     return delegate.getDataset(datasetInstanceId, arguments, classLoader);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -455,7 +455,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, Map<String, String> arguments,
                                           @Nullable ClassLoader parentClassLoader,
                                           DatasetClassLoaderProvider classLoaderProvider,
                                           @Nullable Iterable<? extends EntityId> owners, AccessType accessType)

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDefinition.java
@@ -121,7 +121,6 @@ public class FileSetDefinition implements DatasetDefinition<FileSet, FileSetAdmi
   @Override
   public FileSet getDataset(DatasetContext datasetContext, DatasetSpecification spec, Map<String, String> arguments,
                             ClassLoader classLoader) throws IOException {
-    return new FileSetDataset(datasetContext, cConf, spec, locationFactory, namespacedLocationFactory,
-                              arguments == null ? Collections.<String, String>emptyMap() : arguments);
+    return new FileSetDataset(datasetContext, cConf, spec, locationFactory, namespacedLocationFactory, arguments);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetaTableUtil.java
@@ -42,7 +42,7 @@ public abstract class MetaTableUtil {
   public Table getMetaTable() throws IOException, DatasetManagementException {
     DatasetId metaTableInstanceId = NamespaceId.SYSTEM.dataset(getMetaTableName());
     return DatasetsUtil.getOrCreateDataset(dsFramework, metaTableInstanceId, Table.class.getName(),
-                                           DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
+                                           DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/preview/PreviewDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/preview/PreviewDatasetFramework.java
@@ -254,7 +254,7 @@ public class PreviewDatasetFramework implements DatasetFramework {
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException {
 
@@ -265,7 +265,7 @@ public class PreviewDatasetFramework implements DatasetFramework {
   @Nullable
   @Override
   public <T extends Dataset> T getDataset(final DatasetId datasetInstanceId,
-                                          @Nullable final Map<String, String> arguments,
+                                          final Map<String, String> arguments,
                                           @Nullable final ClassLoader classLoader,
                                           final DatasetClassLoaderProvider classLoaderProvider,
                                           @Nullable final Iterable<? extends EntityId> owners,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
@@ -234,7 +234,7 @@ public class LineageStore implements LineageStoreReader, LineageStoreWriter {
     try {
       return DatasetsUtil.getOrCreateDataset(
         datasetFramework, lineageDatasetId, LineageDataset.class.getName(),
-        DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
+        DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -649,7 +649,7 @@ public class DefaultMetadataStore implements MetadataStore {
       return DatasetsUtil.getOrCreateDataset(
         dsFramework, getMetadataDatasetInstance(scope), MetadataDataset.class.getName(),
         DatasetProperties.builder().add(MetadataDatasetDefinition.SCOPE_KEY, scope.name()).build(),
-        DatasetDefinition.NO_ARGUMENTS, null);
+        DatasetDefinition.NO_ARGUMENTS);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -145,7 +145,7 @@ public class LineageWriterDatasetFramework extends ForwardingDatasetFramework im
   @Override
   @Nullable
   public <T extends Dataset> T getDataset(final DatasetId datasetInstanceId,
-                                          @Nullable final Map<String, String> arguments,
+                                          final Map<String, String> arguments,
                                           @Nullable final ClassLoader classLoader)
     throws DatasetManagementException, IOException {
 
@@ -156,7 +156,7 @@ public class LineageWriterDatasetFramework extends ForwardingDatasetFramework im
   @Nullable
   @Override
   public <T extends Dataset> T getDataset(final DatasetId datasetInstanceId,
-                                          @Nullable final Map<String, String> arguments,
+                                          final Map<String, String> arguments,
                                           @Nullable final ClassLoader classLoader,
                                           final DatasetClassLoaderProvider classLoaderProvider,
                                           @Nullable final Iterable<? extends EntityId> owners,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DefaultUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DefaultUsageRegistry.java
@@ -70,7 +70,7 @@ public class DefaultUsageRegistry implements UsageRegistry {
     try {
       return DatasetsUtil.getOrCreateDataset(
         datasetFramework, USAGE_INSTANCE_ID, UsageDataset.class.getSimpleName(),
-        DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
+        DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
@@ -53,7 +53,7 @@ public class DatasetWithArgumentsTest {
 
   @Test
   public void testPrefixTable() throws Exception {
-    final PrefixedTable table = dsFrameworkUtil.getInstance(pret, null);
+    final PrefixedTable table = dsFrameworkUtil.getInstance(pret, Collections.<String, String>emptyMap());
     final PrefixedTable aTable = dsFrameworkUtil.getInstance(pret, Collections.singletonMap("prefix", "a"));
     final PrefixedTable bTable = dsFrameworkUtil.getInstance(pret, Collections.singletonMap("prefix", "b"));
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -69,6 +69,7 @@ import co.cask.cdap.security.impersonation.InMemoryOwnerStore;
 import co.cask.cdap.security.impersonation.OwnerAdmin;
 import co.cask.cdap.security.impersonation.OwnerStore;
 import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -610,7 +611,7 @@ public abstract class AbstractDatasetFrameworkTest {
                                         new AuthenticationTestContext(), new NoOpAuthorizer());
     lineageFramework.initContext(runId);
     lineageFramework.setAuditPublisher(inMemoryAuditPublisher);
-    lineageFramework.getDataset(MY_TABLE, null, getClass().getClassLoader());
+    lineageFramework.getDataset(MY_TABLE, ImmutableMap.<String, String>of(), getClass().getClassLoader());
     expectedMessages.add(new AuditMessage(0, MY_TABLE, "", AuditType.ACCESS,
                                           new AccessPayload(AccessType.UNKNOWN, runId)));
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
@@ -74,6 +74,6 @@ public class InMemoryMetricsTableTest extends MetricsTableTest {
   protected MetricsTable getTable(String name) throws Exception {
     DatasetId metricsDatasetInstanceId = NamespaceId.SYSTEM.dataset(name);
     return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId, MetricsTable.class.getName(),
-                                           DatasetProperties.EMPTY, null, null);
+                                           DatasetProperties.EMPTY, null);
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
@@ -74,6 +74,6 @@ public class LevelDBMetricsTableTest extends MetricsTableTest {
   protected MetricsTable getTable(String name) throws Exception {
     DatasetId metricsDatasetInstanceId = NamespaceId.SYSTEM.dataset(name);
     return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId, MetricsTable.class.getName(),
-                                           DatasetProperties.EMPTY, null, null);
+                                           DatasetProperties.EMPTY, null);
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -1502,7 +1502,7 @@ public class MetadataDatasetTest {
                                            DatasetProperties.builder()
                                              .add(MetadataDatasetDefinition.SCOPE_KEY, scope.name())
                                              .build(),
-                                           null, null);
+                                           null);
   }
 
   private static final class ReversingIndexer implements Indexer {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
@@ -191,7 +191,7 @@ public class LineageDatasetTest {
   private static LineageDataset getLineageDataset(String instanceId) throws Exception {
     DatasetId id = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset(instanceId);
     return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), id,
-                                           LineageDataset.class.getName(), DatasetProperties.EMPTY, null, null);
+                                           LineageDataset.class.getName(), DatasetProperties.EMPTY, null);
   }
 
   @SafeVarargs

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
@@ -268,6 +268,6 @@ public class UsageDatasetTest {
   protected static UsageDataset getUsageDataset(String instanceId) throws Exception {
     DatasetId id = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset(instanceId);
     return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), id,
-                                           UsageDataset.class.getSimpleName(), DatasetProperties.EMPTY, null, null);
+                                           UsageDataset.class.getSimpleName(), DatasetProperties.EMPTY, null);
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
@@ -55,7 +55,7 @@ public class UsageRegistryTest extends UsageDatasetTest {
       @Nullable
       @Override
       public <T extends Dataset> T getDataset(DatasetId datasetInstanceId,
-                                              @Nullable Map<String, String> arguments,
+                                              Map<String, String> arguments,
                                               @Nullable ClassLoader classLoader)
         throws DatasetManagementException, IOException {
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -107,7 +107,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
     MetricsTable table = null;
     try {
       table = DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId, MetricsTable.class.getName(),
-                                              props, null, null);
+                                              props, null);
     } catch (Exception e) {
       Throwables.propagate(e);
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsDataMigrator.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsDataMigrator.java
@@ -415,7 +415,7 @@ public class MetricsDataMigrator {
     DatasetId metricsDatasetInstanceId = NamespaceId.DEFAULT.dataset(tableName);
     try {
       table = DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId,
-                                              MetricsTable.class.getName(), empty, null, null);
+                                              MetricsTable.class.getName(), empty, null);
     } catch (DatasetManagementException | ServiceUnavailableException e) {
       String msg = String.format("Cannot access or create table %s.", tableName) + " " + e.getMessage();
       LOG.warn(msg);


### PR DESCRIPTION
Remove @Nullable annotation from 'arguments' parameter of DatasetFramework. It is passed to DatasetDefintion's getDataset method, on which the 'arguments' parameter is not @Nullable.

Otherwise, code can throw exceptions like this, since DatasetDefinition does not expect `arguments` to be null.

```
Caused by: java.lang.NullPointerException
     at co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable.<init>(HBaseTable.java:119)
     at co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableDefinition.getDataset(HBaseTableDefinition.java:50)
     at co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableDefinition.getDataset(HBaseTableDefinition.java:34)
     at co.cask.cdap.api.dataset.lib.CompositeDatasetDefinition.getDataset(CompositeDatasetDefinition.java:114)
     at co.cask.cdap.internal.app.runtime.schedule.queue.JobQueueDatasetDefinition.getDataset(JobQueueDatasetDefinition.java:41)
     at co.cask.cdap.internal.app.runtime.schedule.queue.JobQueueDatasetDefinition.getDataset(JobQueueDatasetDefinition.java:31)
     at co.cask.cdap.data2.datafabric.dataset.DatasetType.getDataset(DatasetType.java:73)
     at co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework.getDataset(RemoteDatasetFramework.java:258)
     at co.cask.cdap.data2.dataset2.ForwardingDatasetFramework.getDataset(ForwardingDatasetFramework.java:172)
     at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework.access$101(LineageWriterDatasetFramework.java:63)
     at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework$2.call(LineageWriterDatasetFramework.java:180)
     at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework$2.call(LineageWriterDatasetFramework.java:177)
     at co.cask.cdap.data2.dataset2.DefaultDatasetRuntimeContext.execute(DefaultDatasetRuntimeContext.java:120)
     at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework.getDataset(LineageWriterDatasetFramework.java:175)
     ... 11 more
```

https://builds.cask.co/browse/CDAP-DUT5747-1