### PR TITLE
[CDAP-9432] enable cdap services on boot for hdinsight

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -22,7 +22,22 @@
       "tez_conf_dir": "/etc/tez/conf"
     },
     "fs_superuser": "root",
+    "kafka": {
+      "init_actions": [ "enable" ]
+    },
+    "master": {
+      "init_actions": [ "enable" ]
+    },
+    "router": {
+      "init_actions": [ "enable" ]
+    },
+    "security": {
+      "init_actions": [ "enable" ]
+    },
     "skip_prerequisites": "true",
+    "ui": {
+      "init_actions": [ "enable" ]
+    },
     "version": "{{CDAP_VERSION}}"
   },
   "hadoop": {


### PR DESCRIPTION
Fixes [CDAP-9432](https://issues.cask.co/browse/CDAP-9432) for HDInsight 3.5 (Ubuntu16).  Will need to test/backport for 3.4 (Ubuntu14) as well.  