### PR TITLE
CDAP-7874 Support Hive 2.1

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/hive/ExploreUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/hive/ExploreUtils.java
@@ -105,11 +105,25 @@ public final class ExploreUtils {
       throw new RuntimeException("System property " + EXPLORE_CLASSPATH + " is not set.");
     }
 
+    Iterable<File> classpathJarFiles = getClasspathJarFiles(property, extraExtensions);
+    LOG.trace("Explore classpath jar files: {}", classpathJarFiles);
+    return classpathJarFiles;
+  }
+
+  /**
+   * Returns the set of jars in Java classpath. Only jar files will be included in the result set and paths
+   * ended with a '*' will be expanded to include all jars under the given path.
+   *
+   * @param classpath java classpath separated by the {@link File#pathSeparatorChar}
+   * @param extraExtensions if provided, the set of file extensions that is also accepted when resolving the
+   *                        classpath wildcard
+   */
+  public static Iterable<File> getClasspathJarFiles(String classpath, String...extraExtensions) {
     Set<String> acceptedExts = Sets.newHashSet(extraExtensions);
     acceptedExts.add("jar");
 
     Set<File> result = new LinkedHashSet<>();
-    for (String path : Splitter.on(File.pathSeparator).split(property)) {
+    for (String path : Splitter.on(File.pathSeparator).split(classpath)) {
       List<File> jarFiles;
       // The path has to either ends with "*" or is a jar file. This is because we are only interested in JAR files
       // in the hive classpath.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreRenewer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreRenewer.java
@@ -31,7 +31,6 @@ import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
-import org.apache.hadoop.hive.thrift.HadoopThriftAuthBridge;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -175,10 +174,10 @@ public class TokenSecureStoreRenewer extends SecureStoreRenewer {
       // Renewal interval for Hive. Also see: https://issues.apache.org/jira/browse/HIVE-9214
       Configuration hiveConf = getHiveConf();
       if (hiveConf != null) {
-        renewalTimes.add(hiveConf.getLong(HadoopThriftAuthBridge.Server.DELEGATION_TOKEN_RENEW_INTERVAL_KEY,
-                                          HadoopThriftAuthBridge.Server.DELEGATION_TOKEN_RENEW_INTERVAL_DEFAULT));
+        renewalTimes.add(hiveConf.getLong("hive.cluster.delegation.token.renew-interval",
+                                          TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS)));
       } else {
-        renewalTimes.add(HadoopThriftAuthBridge.Server.DELEGATION_TOKEN_RENEW_INTERVAL_DEFAULT);
+        renewalTimes.add(TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS));
       }
 
       // Renewal interval for JHS

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/HiveUtilities.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/HiveUtilities.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore;
+
+import co.cask.cdap.explore.service.ExploreException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hive.service.cli.thrift.TColumnValue;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Utility methods to invoke corresponding Hive methods in a compatible manner
+ */
+public class HiveUtilities {
+  private HiveUtilities() {
+    // to prevent object creation
+  }
+
+  /**
+   * Deserialize the Hive expression by invoking the right method based on the Hive version used.
+   * This is needed for compatibility across various Hive versions.
+   */
+  public static ExprNodeGenericFuncDesc deserializeExpression(String serializedExpr, Configuration conf) {
+    // Hack to deal with the fact that older versions of Hive 1.x use
+    // Utilities.deserializeExpression(String, Configuration),
+    // whereas newer versions of Hive 1.x use Utilities.deserializeExpression(String).
+    // Hive 2.x uses SerializationUtilities.deserializeExpression(serializedExpr)
+    ExprNodeGenericFuncDesc expr;
+    try {
+      // If SerializationUtilities class is present, use that
+      Class<?> serializationUtilitiesClass =
+        HiveUtilities.class.getClassLoader().loadClass("org.apache.hadoop.hive.ql.exec.SerializationUtilities");
+      expr = (ExprNodeGenericFuncDesc) serializationUtilitiesClass.getMethod("deserializeExpression", String.class)
+        .invoke(null, serializedExpr);
+    } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      try {
+        // Else try Utilities.deserializeExpression(String)
+        expr = Utilities.deserializeExpression(serializedExpr);
+      } catch (NoSuchMethodError e2) {
+        try {
+          // Else try SerializationUtilities.deserializeExpression(serializedExpr)
+          expr = (ExprNodeGenericFuncDesc) Utilities.class.getMethod(
+            "deserializeExpression", String.class, Configuration.class).invoke(null, serializedExpr, conf);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e1) {
+          throw new IllegalStateException("Not able to deserialize expression. The Hive version is not supported.", e1);
+        }
+      }
+    }
+    return expr;
+  }
+
+  /**
+   * Converts TColumnValue objects into their corresponding objects. This is needed for compatibility across
+   * various Hive versions
+   */
+  public static Object tColumnToObject(TColumnValue tColumnValue) throws ExploreException {
+    if (tColumnValue.isSetBoolVal()) {
+      return tColumnValue.getBoolVal().isValue();
+    } else if (tColumnValue.isSetByteVal()) {
+      return tColumnValue.getByteVal().getValue();
+    } else if (tColumnValue.isSetDoubleVal()) {
+      return tColumnValue.getDoubleVal().getValue();
+    } else if (tColumnValue.isSetI16Val()) {
+      return tColumnValue.getI16Val().getValue();
+    } else if (tColumnValue.isSetI32Val()) {
+      return tColumnValue.getI32Val().getValue();
+    } else if (tColumnValue.isSetI64Val()) {
+      return tColumnValue.getI64Val().getValue();
+    } else if (tColumnValue.isSetStringVal()) {
+      return tColumnValue.getStringVal().getValue();
+    }
+    throw new ExploreException("Unknown column value encountered: " + tColumnValue);
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -166,6 +166,8 @@ public class ExploreServiceUtils {
       return HiveSupport.HIVE_1_1;
     }  else if (hiveVersion.startsWith(("1.2"))) {
       return HiveSupport.HIVE_1_2;
+    } else if (hiveVersion.startsWith(("2.1"))) {
+      return HiveSupport.HIVE_1_2;
     }
 
     throw new RuntimeException("Hive distribution not supported. Set the configuration '" +

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -92,7 +92,6 @@ import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.SessionHandle;
 import org.apache.hive.service.cli.TableSchema;
-import org.apache.hive.service.cli.thrift.TColumnValue;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.thrift.TException;
@@ -1559,24 +1558,5 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       throw e;
     }
     throw new ExploreException(e);
-  }
-
-  protected Object tColumnToObject(TColumnValue tColumnValue) throws ExploreException {
-    if (tColumnValue.isSetBoolVal()) {
-      return tColumnValue.getBoolVal().isValue();
-    } else if (tColumnValue.isSetByteVal()) {
-      return tColumnValue.getByteVal().getValue();
-    } else if (tColumnValue.isSetDoubleVal()) {
-      return tColumnValue.getDoubleVal().getValue();
-    } else if (tColumnValue.isSetI16Val()) {
-      return tColumnValue.getI16Val().getValue();
-    } else if (tColumnValue.isSetI32Val()) {
-      return tColumnValue.getI32Val().getValue();
-    } else if (tColumnValue.isSetI64Val()) {
-      return tColumnValue.getI64Val().getValue();
-    } else if (tColumnValue.isSetStringVal()) {
-      return tColumnValue.getStringVal().getValue();
-    }
-    throw new ExploreException("Unknown column value encountered: " + tColumnValue);
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
@@ -22,6 +22,7 @@ import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.explore.HiveUtilities;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.proto.QueryResult;
@@ -99,7 +100,7 @@ public class Hive12CDH5ExploreService extends BaseHiveExploreService {
     for (TRow tRow : tRowSet.getRows()) {
       List<Object> cols = Lists.newArrayList();
       for (TColumnValue tColumnValue : tRow.getColVals()) {
-        cols.add(tColumnToObject(tColumnValue));
+        cols.add(HiveUtilities.tColumnToObject(tColumnValue));
       }
       rowsBuilder.add(new QueryResult(cols));
     }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
@@ -22,6 +22,7 @@ import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.explore.HiveUtilities;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.proto.QueryResult;
@@ -109,7 +110,7 @@ public class Hive12ExploreService extends BaseHiveExploreService {
     for (TRow tRow : tRowSet.getRows()) {
       List<Object> cols = Lists.newArrayList();
       for (TColumnValue tColumnValue : tRow.getColVals()) {
-        cols.add(tColumnToObject(tColumnValue));
+        cols.add(HiveUtilities.tColumnToObject(tColumnValue));
       }
       rowsBuilder.add(new QueryResult(cols));
     }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/HiveStreamInputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/HiveStreamInputFormat.java
@@ -21,13 +21,13 @@ import co.cask.cdap.data.stream.StreamInputSplitFactory;
 import co.cask.cdap.data.stream.StreamInputSplitFinder;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
+import co.cask.cdap.explore.HiveUtilities;
 import co.cask.cdap.hive.context.ContextManager;
 import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.index.IndexPredicateAnalyzer;
 import org.apache.hadoop.hive.ql.index.IndexSearchCondition;
 import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
@@ -126,16 +126,7 @@ public class HiveStreamInputFormat implements InputFormat<Void, ObjectWritable> 
     }
 
     try {
-      ExprNodeGenericFuncDesc expr;
-      // Hack to deal with the fact that older versions of Hive use
-      // Utilities.deserializeExpression(String, Configuration),
-      // whereas newer versions use Utilities.deserializeExpression(String).
-      try {
-        expr = Utilities.deserializeExpression(serializedExpr);
-      } catch (NoSuchMethodError e) {
-        expr = (ExprNodeGenericFuncDesc) Utilities.class.getMethod(
-          "deserializeExpression", String.class, Configuration.class).invoke(null, serializedExpr, conf);
-      }
+      ExprNodeGenericFuncDesc expr = HiveUtilities.deserializeExpression(serializedExpr, conf);
 
       // Analyze the query to extract predicates that can be used for indexing (i.e. setting start/end time)
       IndexPredicateAnalyzer analyzer = new IndexPredicateAnalyzer();


### PR DESCRIPTION
It would be easier to review commit by commit. The first commit makes the code compatible with Hive 2.1 code and the second commit changes how Explore classpath is determined.

JIRA - https://issues.cask.co/browse/CDAP-7874
Build - https://builds.cask.co/browse/CDAP-DUT5741-1