### PR TITLE
CDAP-9452 Fix: deleting namespace should not fail if Hive Tables or D…

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -828,7 +828,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
         try {
           sessionHandle = openHiveSession(sessionConf);
 
-          String statement = String.format("DROP DATABASE %s", database);
+          String statement = String.format("DROP DATABASE IF EXISTS %s", database);
           operationHandle = executeAsync(sessionHandle, statement);
           QueryHandle handle = saveReadOnlyOperation(operationHandle, sessionHandle, sessionConf, statement, database);
           LOG.info("Deleting database {} with handle {}", database, handle);

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceInvalidateTxTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceInvalidateTxTest.java
@@ -61,14 +61,8 @@ public class HiveExploreServiceInvalidateTxTest extends BaseHiveExploreServiceTe
       // Expected
     }
     Assert.assertEquals(1, transactionManager.getCurrentState().getInvalid().size());
-
-    try {
-      waitForCompletionStatus(exploreService.deleteNamespace(new NamespaceId("nonexistent")), 5, TimeUnit.SECONDS, 10);
-      Assert.fail("Expected HiveSQLException");
-    } catch (HiveSQLException e) {
-      // Expected
-    }
+    //Deleting a non-existing namespace should not fail for non-existing hive database
+    waitForCompletionStatus(exploreService.deleteNamespace(new NamespaceId("nonexistent")), 5, TimeUnit.SECONDS, 10);
     Assert.assertEquals(1, transactionManager.getCurrentState().getInvalid().size());
   }
-
 }


### PR DESCRIPTION
…B is not found

Tested on cluster:
1. CDAP namespace delete works if Hive databases not exist;
2. CDAP namespace delete works if Hive tables not exist;
Build: https://builds.cask.co/browse/CDAP-DUT5753-3