### PR TITLE
[CDAP-11545] Opens up schedule pipeline modeless instead of run pipeline modeless, when user clicks Schedule

### DIFF
--- a/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.html
@@ -78,7 +78,7 @@
           class="btn btn-primary apply-run"
           ng-disabled="PipelineConfigCtrl.buttonsAreDisabled()"
           ng-click="PipelineConfigCtrl.applyAndRunPipeline()">
-          Apply &amp; Run
+          Apply &amp; {{PipelineConfigCtrl.actionLabel}}
         </button>
         <button
           class="btn btn-secondary"

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.js
@@ -19,6 +19,12 @@ class MyPipelineConfigurationsCtrl {
     this.uuid = uuid;
     this.HydratorPlusPlusHydratorService = HydratorPlusPlusHydratorService;
 
+    this.actionLabel = 'Run';
+
+    if (this.pipelineAction && this.pipelineAction === 'Scheduling') {
+      this.actionLabel = 'Schedule';
+    }
+
     this.checkForReset = (runtimeArguments) => {
       let runtimeArgumentsPairs = runtimeArguments.pairs;
       this.resettingFields = false;
@@ -90,6 +96,7 @@ MyPipelineConfigurationsCtrl.$inject = ['uuid', 'HydratorPlusPlusHydratorService
         resolvedMacros: '=',
         applyRuntimeArguments: '&',
         runPipeline: '&',
+        pipelineAction: '@',
         convertRuntimeArgsToMacros: '&',
         pipelineName: '@',
         onClose: '&',

--- a/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
@@ -373,6 +373,13 @@ class HydratorDetailTopPanelController {
           );
     }
   }
+  startOrSchedulePipeline() {
+    if (this.runPlayer.action === 'Starting') {
+      this.startPipeline();
+    } else if (this.runPlayer.action === 'Scheduling') {
+      this.schedulePipeline();
+    }
+  }
   startPipeline() {
     this.lastRunTime = 'N/A';
     this.lastFinished = null;
@@ -382,7 +389,7 @@ class HydratorDetailTopPanelController {
     this.HydratorPlusPlusDetailActions.startPipeline(
       this.HydratorPlusPlusDetailRunsStore.getApi(),
       this.HydratorPlusPlusDetailRunsStore.getParams(),
-      this.macrosMap
+      Object.assign({}, this.macrosMap, this.userRuntimeArgumentsMap)
     )
     .then(
       () => {},
@@ -421,7 +428,7 @@ class HydratorDetailTopPanelController {
     };
 
     this.myPreferenceApi
-      .setAppPreference(preferenceParams, this.macrosMap)
+      .setAppPreference(preferenceParams, Object.assign({}, this.macrosMap, this.userRuntimeArgumentsMap))
       .$promise
       .then(
         () => {

--- a/cdap-ui/app/hydrator/templates/detail/top-panel.html
+++ b/cdap-ui/app/hydrator/templates/detail/top-panel.html
@@ -242,8 +242,9 @@
       apply-runtime-arguments="TopPanelCtrl.applyRuntimeArguments()"
       resolved-macros="TopPanelCtrl.resolvedMacros"
       convert-runtime-args-to-macros="TopPanelCtrl.convertRuntimeArgsToMacros()"
-      run-pipeline="TopPanelCtrl.startPipeline()"
+      run-pipeline="TopPanelCtrl.startOrSchedulePipeline()"
       pipeline-name="{{TopPanelCtrl.app.name}}"
+      pipeline-action="{{TopPanelCtrl.runPlayer.action}}"
       on-close="TopPanelCtrl.runPlayer.view = false; TopPanelCtrl.runPlayer.action = null"
       namespace-id="{{TopPanelCtrl.$state.params.namespace}}">
     </my-pipeline-configurations>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-11545

Also sends both resolved macros and user-set runtime args as the runtime args for the pipeline, instead of just macros.