### PR TITLE
[CDAP-9319] Adds Database browser for dataprep

### DIFF
--- a/cdap-ui/app/cdap/api/dataprep.js
+++ b/cdap-ui/app/cdap/api/dataprep.js
@@ -46,7 +46,11 @@ const MyDataPrepApi = {
   // File System Browser
   explorer: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/explorer/fs`),
   readFile: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/explorer/fs/read`),
-  getSpecification: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/explorer/fs/specification`)
+  getSpecification: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/explorer/fs/specification`),
+
+  // Database Browser
+  listTables: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/methods/list`),
+  readTable: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/methods/execute`)
 };
 
 export default MyDataPrepApi;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
+
+const setDatabaseInfoLoading = () => {
+  DataPrepBrowserStore.dispatch({
+    type: BrowserStoreActions.SET_DATABASE_LOADING,
+    payload: {
+      loading: !DataPrepBrowserStore.getState().database.loading
+    }
+  });
+};
+const setActiveBrowser = (payload) => {
+  DataPrepBrowserStore.dispatch({
+    type: BrowserStoreActions.SET_ACTIVEBROWSER,
+    payload
+  });
+};
+
+const setDatabaseProperties = (payload) => {
+  setDatabaseInfoLoading();
+  DataPrepBrowserStore.dispatch({
+    type: BrowserStoreActions.SET_DATABASE_PROPERTIES,
+    payload
+  });
+};
+
+export {
+  setActiveBrowser,
+  setDatabaseProperties
+};

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {createStore, combineReducers} from 'redux';
+import {defaultAction} from 'services/helpers';
+import {objectQuery} from 'services/helpers';
+const Actions = {
+  SET_DATABASE_PROPERTIES: 'SET_DATABASE_PROPERTIES',
+  SET_DATABASE_LOADING: 'SET_DATABASE_LOADING',
+  SET_ACTIVEBROWSER: 'SET_ACTIVE_BROWSER'
+};
+
+export {Actions} ;
+
+const defaultDatabaseValue = {
+  properties: {
+    connectionString: '',
+    userName: '',
+    password: '',
+    databasename: ''
+  },
+  loading: false
+};
+
+const defaultActiveBrowser = {
+  name: 'database'
+};
+
+const database = (state = defaultDatabaseValue, action = defaultAction) => {
+  switch (action.type) {
+    case Actions.SET_DATABASE_PROPERTIES:
+      return Object.assign({}, state, {
+        properties: objectQuery(action, 'payload', 'properties') || state.properties
+      });
+    case Actions.SET_DATABASE_LOADING:
+      return Object.assign({}, state, {
+        loading: action.payload.loading
+      });
+    default:
+      return state;
+  }
+};
+
+const activeBrowser = (state = defaultActiveBrowser, action = defaultAction) => {
+  switch (action.type) {
+    case Actions.SET_ACTIVEBROWSER:
+      return Object.assign({}, state, {
+        name: action.payload.name
+      });
+    default:
+      return state;
+  }
+};
+
+const DataPrepBrowserStore = createStore(
+  combineReducers({
+    database,
+    activeBrowser
+  }),
+  {
+    database: defaultDatabaseValue,
+    activeBrowser: defaultActiveBrowser
+  },
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+export default DataPrepBrowserStore;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/DatabaseBrowser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/DatabaseBrowser.scss
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import '../../../../styles/variables.scss';
+
+$header-border: #cccccc;
+$header-bg: #eeeeee;
+$content-font-color: #333333;
+
+.database-browser {
+  padding: 10px;
+  height: calc(100vh - 50px - 54px);
+  .database-content-table {
+    padding: 0;
+    margin-top: 10px;
+    height: calc(100% - 56px - 46px);
+    .row {
+      margin: 0;
+    }
+    .database-content-header {
+      border-bottom: 1px solid $header-border;
+      border-top: 1px solid $header-border;
+      background-color: $header-bg;
+      line-height: 36px;
+      font-weight: 600;
+    }
+    .database-content-body {
+      height: calc(100% - 38px);
+      overflow-y: auto;
+      .content-row {
+        border-bottom: 1px solid $header-border;
+        line-height: 36px;
+        color: $content-font-color;
+        cursor: pointer;
+        &:hover {
+          background: $header-border;
+        }
+      }
+    }
+  }
+  .tables-count {
+    color: gray;
+    font-size: 12px;
+  }
+  .database-browser-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    .database-metadata {
+      padding-left: 5px;
+    }
+    .table-name-search {
+      padding-right: 5px;
+    }
+  }
+  .empty-search-container {
+    display: flex;
+    flex-wrap: wrap;
+    flex: 1;
+    width: 100%;
+
+    .empty-search {
+      font-size: 18px;
+      font-weight: 500;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 25vh;
+      max-width: 80%;
+      word-wrap: break-word;
+
+      hr {
+        color: #999999;
+        background-color: #999999;
+      }
+      span {
+        font-size: 14px;
+      }
+      ul {
+        padding: 0;
+        list-style: none;
+        font-size: 14px;
+        .link-text {
+          cursor: pointer;
+          color: $cdap-orange;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component} from 'react';
+import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
+import isEqual from 'lodash/isEqual';
+import DataPrepApi from 'api/dataprep';
+import isNil from 'lodash/isNil';
+import NamespaceStore from 'services/NamespaceStore';
+import T from 'i18n-react';
+import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import {Input} from 'reactstrap';
+
+require('./DatabaseBrowser.scss');
+
+const PREFIX = `features.DataPrep.DataPrepBrowser.DatabaseBrowser`;
+
+export default class DatabaseBrowser extends Component {
+  constructor(props) {
+    super(props);
+    let store = DataPrepBrowserStore.getState();
+    this.state = {
+      properties: store.database.properties,
+      tables: [],
+      loading: true,
+      search: '',
+      searchFocus: true,
+      error: null
+    };
+    this.fetchTables = this.fetchTables.bind(this);
+    this.handleSearch = this.handleSearch.bind(this);
+    this.prepTable = this.prepTable.bind(this);
+    this.fetchTables();
+  }
+  componentDidMount() {
+    this.storeSubscription = DataPrepBrowserStore.subscribe(() => {
+      let {database} = DataPrepBrowserStore.getState();
+      if (database.loading) {
+        this.setState({
+          loading: true
+        });
+        return;
+      }
+      if (!isEqual(this.state.properties, database.properties)) {
+        this.setState({
+          properties: database.properties,
+          loading: false
+        }, this.fetchTables);
+      }
+    });
+  }
+  handleSearch(e) {
+    this.setState({
+      search: e.target.value
+    });
+  }
+  prepTable(tableName) {
+     let {userName, password, connectionString} = this.state.properties;
+     let {selectedNamespace: namespace} = NamespaceStore.getState();
+     let params = {
+      namespace
+    };
+     let requestBody = {
+       userName,
+       password,
+       connectionString,
+       query: `SELECT * FROM ${tableName}`
+     };
+    DataPrepApi
+      .readTable(params, requestBody)
+      .subscribe(
+        (res) => {
+          let workspaceId = res.values[0].id;
+          window.location.href = `${window.location.origin}/cdap/ns/${namespace}/dataprep/${workspaceId}`;
+        },
+        (err) => {
+          console.log('ERROR: ', err);
+        }
+      );
+  }
+  fetchTables() {
+    let {userName, password, connectionString} = this.state.properties;
+    if (isNil(userName) || isNil(password) || isNil(connectionString)) {
+      return;
+    }
+    let {selectedNamespace: namespace} = NamespaceStore.getState();
+    let params = {
+      namespace
+    };
+    DataPrepApi
+      .listTables(params, {userName, password, connectionString})
+      .subscribe(
+        (res) => {
+          this.setState({
+            tables: res,
+            loading: false
+          });
+        },
+        (err) => {
+          this.setState({
+            error: typeof err === 'object' ? err.response : err,
+            loading: false
+          });
+        }
+      );
+  }
+  render() {
+    // FIXME: This should be going away as user wouldn't even be reaching here if plugin is not installed
+    const renderNoPluginMessage = () => {
+      return (
+         <div className="empty-search-container">
+            <div className="empty-search">
+              <strong>{T.translate(`${PREFIX}.NoPlugin.title`)}</strong>
+              <hr />
+              <span>{T.translate(`${PREFIX}.NoPlugin.suggestion1`)}</span>
+            </div>
+          </div>
+      );
+    };
+    const renderContents = (tables) => {
+      if (this.state.error) {
+        return renderNoPluginMessage();
+      }
+      if (!tables.length) {
+        return (
+          <div className="empty-search-container">
+            <div className="empty-search">
+              <strong>
+                {T.translate(`${PREFIX}.EmptyMessage.title`, {searchText: this.state.search})}
+              </strong>
+              <hr />
+              <span> {T.translate(`${PREFIX}.EmptyMessage.suggestionTitle`)} </span>
+              <ul>
+                <li>
+                  <span
+                    className="link-text"
+                    onClick={() => {
+                      this.setState({
+                        search: '',
+                        searchFocus: true
+                      });
+                    }}
+                  >
+                    {T.translate(`${PREFIX}.EmptyMessage.clearLabel`)}
+                  </span>
+                  <span> {T.translate(`${PREFIX}.EmptyMessage.suggestion1`)} </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        );
+      }
+      return (
+        <div className="database-content-table">
+          <div className="database-content-header">
+            <div className="row">
+              <div className="col-xs-8">
+                <span>{T.translate(`${PREFIX}.table.namecollabel`)}</span>
+              </div>
+              <div className="col-xs-4">
+                <span>{T.translate(`${PREFIX}.table.colcountlabel`)}</span>
+              </div>
+            </div>
+          </div>
+          <div className="database-content-body">
+            {
+              filteredTables.map(table => {
+                return (
+                  <div
+                    className="row content-row"
+                    onClick={this.prepTable.bind(this, table.tableName)}
+                  >
+                    <div className="col-xs-8">
+                      <span>{table.tableName}</span>
+                    </div>
+                    <div className="col-xs-4">
+                      <span>{table.columnCount}</span>
+                    </div>
+                  </div>
+                );
+              })
+            }
+          </div>
+        </div>
+      );
+    };
+
+    if (this.state.loading) {
+      return (
+        <LoadingSVGCentered />
+      );
+    }
+    let filteredTables = this.state.tables;
+    if (this.state.search) {
+      filteredTables = this.state.tables.filter(table => table.tableName.indexOf(this.state.search) !== -1);
+    }
+    return (
+      <div className="database-browser">
+        {
+          isNil(this.state.error) ?
+            <div>
+              <h4>
+                <strong>
+                  {T.translate(`${PREFIX}.title`)}
+                </strong>
+              </h4>
+              <div className="database-browser-header">
+                <div className="database-metadata">
+                  <h5>{this.state.properties.databasename}</h5>
+                  <span className="tables-count">
+                    {
+                      T.translate(`${PREFIX}.tableCount`, {
+                        context: {
+                          count: this.state.tables.length
+                        }
+                      })
+                    }
+                  </span>
+                </div>
+                <div className="table-name-search">
+                  <Input
+                    placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
+                    value={this.state.search}
+                    onChange={this.handleSearch}
+                    autoFocus={this.state.searchFocus}
+                  />
+                </div>
+              </div>
+            </div>
+          :
+            null
+        }
+          {
+            renderContents(filteredTables)
+          }
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component, PropTypes} from 'react';
+import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
+import DatabaseBrowser from 'components/DataPrep/DataPrepBrowser/DatabaseBrowser';
+import FileBrowser from 'components/FileBrowser';
+
+const browserMap = {
+  database: DatabaseBrowser,
+  file: FileBrowser
+};
+
+export default class DataPrepBrowser extends Component {
+  constructor(props) {
+    super(props);
+    let store = DataPrepBrowserStore.getState();
+    this.state = {
+      activeBrowser: store.activeBrowser
+    };
+  }
+  componentWillMount() {
+    DataPrepBrowserStore.subscribe(() => {
+      let {activeBrowser} = DataPrepBrowserStore.getState();
+      if (this.state.activeBrowser.name !== activeBrowser.name) {
+        this.setState({
+          activeBrowser
+        });
+      }
+    });
+  }
+  render() {
+    if (browserMap.hasOwnProperty(this.state.activeBrowser.name)) {
+      let Tag = browserMap[this.state.activeBrowser.name];
+      return (
+        <Tag
+          {...this.props}
+        />
+      );
+    }
+
+    return null; // FIXME: Should this be 404? Would we even end up in this state?
+  }
+}
+DataPrepBrowser.propTypes = {
+  location: PropTypes.object,
+  match: PropTypes.object
+};

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -18,7 +18,8 @@ import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';
 import {Route, NavLink, Redirect} from 'react-router-dom';
-import FileBrowser from 'components/FileBrowser';
+import DataPrepBrowser from 'components/DataPrep/DataPrepBrowser';
+import {setActiveBrowser} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import NamespaceStore from 'services/NamespaceStore';
 import T from 'i18n-react';
 import LoadingSVG from 'components/LoadingSVG';
@@ -60,6 +61,9 @@ export default class DataPrepConnections extends Component {
 
   componentWillMount() {
     this.checkBackendUp();
+    // FIXME: This is temporary. Based on standalone or cluster we will have this default
+    // to different things. For now it defaults to browser.
+    setActiveBrowser({name: 'file'});
   }
 
   checkBackendUp() {
@@ -184,7 +188,7 @@ export default class DataPrepConnections extends Component {
           <Route path={`${BASEPATH}/browser`}
             render={({match, location}) => {
               return (
-                <FileBrowser
+                <DataPrepBrowser
                   match={match}
                   location={location}
                   toggle={this.toggleSidePanel}

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -25,7 +25,8 @@ import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
 import DataPrepHome from 'components/DataPrepHome';
 import FileBrowser from 'components/FileBrowser';
 import DataPrepConnections from 'components/DataPrepConnections';
-
+import DataPrepBrowser from 'components/DataPrep/DataPrepBrowser';
+import {setActiveBrowser, setDatabaseProperties} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 export default class Home extends Component {
   componentWillMount() {
     NamespaceStore.dispatch({
@@ -46,6 +47,20 @@ export default class Home extends Component {
           <Route exact path="/ns/:namespace/dataprep" component={DataPrepHome} />
           <Route exact path="/ns/:namespace/dataprep/:workspaceId" component={DataPrepHome} />
           <Route path="/ns/:namespace/file" component={FileBrowser} />
+          <Route path="/ns/:namespace/databasebrowser" render={() => {
+            setActiveBrowser({ name: 'database' });
+            setDatabaseProperties({
+              properties: {
+                connectionString: 'jdbc:mysql://localhost:3306/test',
+                userName: 'root',
+                password: 'root',
+                databasename: 'test'
+              }
+            });
+            return (
+              <DataPrepBrowser />
+            );
+          }} />
           <Route path="/ns/:namespace/connections" component={DataPrepConnections} />
           <Route component={Page404} />
         </Switch>

--- a/cdap-ui/app/cdap/components/LoadingSVGCentered/LoadingSVGCentered.scss
+++ b/cdap-ui/app/cdap/components/LoadingSVGCentered/LoadingSVGCentered.scss
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+.loading-svg-centered {
+  position: absolute;
+  top: 50px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(255, 255, 255, 0.7);
+  color: #666666;
+  font-size: 72px;
+  z-index: 1000;
+
+  > .loading-bar {
+    position: absolute;
+    top: 35%;
+    transform: translateY(-50%) scale(1.7);
+
+    rect {
+      fill: #ff6600;
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/LoadingSVGCentered/index.js
+++ b/cdap-ui/app/cdap/components/LoadingSVGCentered/index.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import LoadingSVG from 'components/LoadingSVG';
+
+require('./LoadingSVGCentered.scss');
+
+export default function LoadingSVGCentered () {
+  return (
+    <div className="loading-svg-centered text-xs-center">
+        <LoadingSVG />
+    </div>
+  );
+}

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -189,6 +189,11 @@ function preventPropagation(e = defaultEventObject) {
   e.preventDefault();
 }
 
+const defaultAction = {
+  action : '',
+  payload : {}
+};
+
 export {
   objectQuery,
   convertBytesToHumanReadable,
@@ -200,5 +205,6 @@ export {
   humanReadableDate,
   contructUrl,
   getIcon,
-  preventPropagation
+  preventPropagation,
+  defaultAction
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -360,6 +360,25 @@ features:
       noColumns: No Columns
     DataPrepTable:
       columnEditWarningMessage: 'A column with the same name already exists. Pick a new name, or click "Apply" to overwrite'
+    DataPrepBrowser:
+      DatabaseBrowser:
+        EmptyMessage:
+          clearLabel: Clear
+          suggestionTitle: "You can try to:"
+          suggestion1: your search
+          title: 'No match found for "{searchText}"'
+        NoPlugin:
+          title: '"mysql" Plugin not installed'
+          suggestion1: Please install "mysql" plugin manually or via market.
+        searchPlaceholder: Search table name
+        table:
+          colcountlabel: NUMBER OF COLUMMNS
+          namecollabel: NAME
+        tableCount:
+          0: No Tables
+          1: '{count} Table'
+          _: "{context.count} Tables"
+        title: Select Table
     Directives:
       apply: Apply
       cancel: Cancel


### PR DESCRIPTION
#### Things added in this PR:
- Generic `DataPrepBrowser` that can be used to render different browsers based on the connections chosen from the left panel
- `DatabaseBrowser` that will handle rendering the list of tables in a database.
- Replaces `FileBrowser` with `DataPrepBrowser` in `/connections/browser` route in UI. `DataPrepBrowser` now renders the file browser.

#### Things to do:
- Need to add singleTabMode to all the components to be able to browser connections and prep data from pipeline studio view.
- Integrate with Edwin's connections changes for end-to-end usecase.

#### Assumptions:
- mysql driver with wrangler as parent artifacts installed.
- There is a mysql server running in the system having `test` database (`root` as username and password) with some tables.

#### Sequence of steps to setup environment:
- Download the mysql driver (5.1.39) from the url available in market.
- Install the driver using the following curl command
```
curl -v -X POST "localhost:11015/v3/namespaces/default/artifacts/mysql"  \
  -H 'Artifact-Plugins: [ { "name": "mysql", "type": "jdbc", "className": "com.mysql.jdbc.Driver" } ]' \
  -H "Artifact-Version: 5.1.38"  \
  -H "Artifact-Extends: default:wrangler-service[1.0.1-SNAPSHOT, 1.4.1-SNAPSHOT], default:wrangler-transform[1.0.1-SNAPSHOT, 1.4.1-SNAPSHOT), default:wrangler-core[1.0.1-SNAPSHOT, 1.4.1-SNAPSHOT) "  \
  --data-binary @mysql-connector-java-5.1.39/mysql-connector-java-5.1.39-bin.jar -v
```
- Build dataprep app from this branch `feature/db-wrangler` and deploy dataprep app 
- Start the service
- hit `http://localhost:11011/cdap/ns/default/databasebrowser` url in the browser.


JIRA: https://issues.cask.co/browse/CDAP-9319
Bamboo build: https://builds.cask.co/browse/CDAP-DRC6510-4