### PR TITLE
CDAP-9476 spark2 split compat

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>cdap-data-pipeline</artifactId>
-  <name>CDAP Data Pipeline Application</name>
+  <name>CDAP Data Pipeline Application Spark1 Scala 2.10</name>
   <packaging>jar</packaging>
 
   <properties>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -59,6 +59,7 @@ import co.cask.cdap.etl.proto.Engine;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.etl.spark.Compat;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.WorkflowTokenDetail;
@@ -115,7 +116,9 @@ public class DataPipelineTest extends HydratorTestBase {
   
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
-                                                                       Constants.Security.Store.PROVIDER, "file");
+                                                                       Constants.Security.Store.PROVIDER, "file",
+                                                                       Constants.AppFabric.SPARK_COMPAT,
+                                                                       Compat.SPARK_COMPAT);
   private static final String WORDCOUNT_PLUGIN = "wordcount";
   private static final String FILTER_PLUGIN = "filterlines";
   private static final String SPARK_TYPE = co.cask.cdap.etl.common.Constants.SPARK_PROGRAM_PLUGIN_TYPE;
@@ -147,8 +150,15 @@ public class DataPipelineTest extends HydratorTestBase {
 
     File input = new File(testDir, "poem.txt");
     try (PrintWriter writer = new PrintWriter(input.getAbsolutePath())) {
-      writer.println("this is a poem");
-      writer.println("it is a bad poem");
+      writer.println("this");
+      writer.println("is");
+      writer.println("a");
+      writer.println("poem");
+      writer.println("it");
+      writer.println("is");
+      writer.println("a");
+      writer.println("bad");
+      writer.println("poem");
     }
     File wordCountOutput = new File(testDir, "poem_counts");
     File filterOutput = new File(testDir, "poem_filtered");
@@ -207,7 +217,7 @@ public class DataPipelineTest extends HydratorTestBase {
     // check filter output
     files = filterOutput.listFiles();
     Assert.assertNotNull("No output files for filter program found.", files);
-    List<String> expectedLines = ImmutableList.of("this is a poem");
+    List<String> expectedLines = ImmutableList.of("this", "is", "a", "poem", "it", "is", "a", "poem");
     List<String> actualLines = new ArrayList<>();
     for (File file : files) {
       String fileName = file.getName();

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/spark/WordCount.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/spark/WordCount.java
@@ -19,13 +19,10 @@ package co.cask.cdap.datapipeline.spark;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFunction;
 import scala.Tuple2;
-
-import java.util.Arrays;
 
 /**
  * Spark Word count program in java
@@ -38,15 +35,8 @@ public class WordCount {
     // Create a Java Spark Context.
     SparkConf conf = new SparkConf().setAppName("wordCount");
     JavaSparkContext sc = new JavaSparkContext(conf);
-    // Load our input data.
-    JavaRDD<String> input = sc.textFile(inputFile);
-    // Split up into words.
-    JavaRDD<String> words = input.flatMap(
-      new FlatMapFunction<String, String>() {
-        public Iterable<String> call(String x) {
-          return Arrays.asList(x.split(" "));
-        }
-      });
+    // Load our input data, assuming each line is one word
+    JavaRDD<String> words = sc.textFile(inputFile);
     // Transform into word and count.
     JavaRDD<String> counts = words.mapToPair(
       new PairFunction<String, String, Integer>() {

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>cdap-data-streams</artifactId>
-  <name>CDAP Data Streams Application</name>
+  <name>CDAP Data Streams Application Spark1 Scala 2.10</name>
   <packaging>jar</packaging>
 
   <properties>

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
@@ -37,6 +37,7 @@ import co.cask.cdap.etl.mock.transform.SleepTransform;
 import co.cask.cdap.etl.mock.transform.StringValueFilterTransform;
 import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
 import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.etl.spark.Compat;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -74,7 +75,9 @@ public class DataStreamsTest extends HydratorTestBase {
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
   private static int startCount = 0;
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
+                                                                       Constants.AppFabric.SPARK_COMPAT,
+                                                                       Compat.SPARK_COMPAT);
 
   @BeforeClass
   public static void setupTest() throws Exception {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/PairDStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/PairDStreamCollection.java
@@ -17,9 +17,9 @@
 package co.cask.cdap.etl.spark.streaming;
 
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
-import co.cask.cdap.etl.spark.Compat;
 import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPairCollection;
+import co.cask.cdap.etl.spark.StreamingCompat;
 import com.google.common.base.Optional;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
@@ -72,27 +72,29 @@ public class PairDStreamCollection<K, V> implements SparkPairCollection<K, V> {
   @SuppressWarnings("unchecked")
   @Override
   public <T> SparkPairCollection<K, Tuple2<V, Optional<T>>> leftOuterJoin(SparkPairCollection<K, T> other) {
-    return wrap(Compat.leftOuterJoin(pairStream, (JavaPairDStream<K, T>) other.getUnderlying()));
+    return wrap(StreamingCompat.leftOuterJoin(pairStream, (JavaPairDStream<K, T>) other.getUnderlying()));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public <T> SparkPairCollection<K, Tuple2<V, Optional<T>>> leftOuterJoin(SparkPairCollection<K, T> other,
                                                                           int numPartitions) {
-    return wrap(Compat.leftOuterJoin(pairStream, (JavaPairDStream<K, T>) other.getUnderlying(), numPartitions));
+    return wrap(
+      StreamingCompat.leftOuterJoin(pairStream, (JavaPairDStream<K, T>) other.getUnderlying(), numPartitions));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public <T> SparkPairCollection<K, Tuple2<Optional<V>, Optional<T>>> fullOuterJoin(SparkPairCollection<K, T> other) {
-    return wrap(Compat.fullOuterJoin(pairStream, (JavaPairDStream<K, T>) other.getUnderlying()));
+    return wrap(StreamingCompat.fullOuterJoin(pairStream, (JavaPairDStream<K, T>) other.getUnderlying()));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public <T> SparkPairCollection<K, Tuple2<Optional<V>, Optional<T>>> fullOuterJoin(SparkPairCollection<K, T> other,
                                                                                     int numPartitions) {
-    return wrap(Compat.fullOuterJoin(pairStream, (JavaPairDStream<K, T>) other.getUnderlying(), numPartitions));
+    return wrap(
+      StreamingCompat.fullOuterJoin(pairStream, (JavaPairDStream<K, T>) other.getUnderlying(), numPartitions));
   }
 
   private <T, U> PairDStreamCollection<T, U> wrap(JavaPairDStream<T, U> pairStream) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/Compat.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/Compat.java
@@ -26,23 +26,21 @@ import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.apache.spark.streaming.Time;
 import org.apache.spark.streaming.api.java.JavaDStream;
-import org.apache.spark.streaming.api.java.JavaPairDStream;
 import scala.Tuple2;
 
 /**
  * Utility class to handle incompatibilities between Spark1 and Spark2. All hydrator-spark-core modules must have this
- * class with the exact same method signatures. Incompatibilities are in a few places.
+ * class with the exact same method signatures. Incompatibilities are in a few places. Should not contain any
+ * classes from Spark streaming.
  *
  * FlatMapFunction and PairFlatMapFunction in Spark2 was changed to return an Iterator instead of an Iterable
  * This class contains convert methods to change a FlatMapFunc and PairFlatMapFunc into the corresponding Spark version
  * specific class.
  *
- * DStream.foreachRDD() no longer takes a Function2 in Spark2 in favor of VoidFunction2.
- * In Spark1, a Function2 must be used because Spark1.2 does not have VoidFunction2.
- *
  * Outer join methods in Spark1 use guava's Optional whereas Spark2 uses its own Optional.
  */
 public final class Compat {
+  public static final String SPARK_COMPAT = "spark1_2.10";
 
   private Compat() {
 
@@ -89,27 +87,6 @@ public final class Compat {
   public static <K, V1, V2> JavaPairRDD<K, Tuple2<Optional<V1>, Optional<V2>>> fullOuterJoin(JavaPairRDD<K, V1> left,
                                                                                              JavaPairRDD<K, V2> right,
                                                                                              int numPartitions) {
-    return left.fullOuterJoin(right, numPartitions);
-  }
-
-  public static <K, V1, V2> JavaPairDStream<K, Tuple2<V1, Optional<V2>>> leftOuterJoin(JavaPairDStream<K, V1> left,
-                                                                                       JavaPairDStream<K, V2> right) {
-    return left.leftOuterJoin(right);
-  }
-
-  public static <K, V1, V2> JavaPairDStream<K, Tuple2<V1, Optional<V2>>> leftOuterJoin(JavaPairDStream<K, V1> left,
-                                                                                       JavaPairDStream<K, V2> right,
-                                                                                       int numPartitions) {
-    return left.leftOuterJoin(right, numPartitions);
-  }
-
-  public static <K, V1, V2> JavaPairDStream<K, Tuple2<Optional<V1>, Optional<V2>>> fullOuterJoin(
-    JavaPairDStream<K, V1> left, JavaPairDStream<K, V2> right) {
-    return left.fullOuterJoin(right);
-  }
-
-  public static <K, V1, V2> JavaPairDStream<K, Tuple2<Optional<V1>, Optional<V2>>> fullOuterJoin(
-    JavaPairDStream<K, V1> left, JavaPairDStream<K, V2> right, int numPartitions) {
     return left.fullOuterJoin(right, numPartitions);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/StreamingCompat.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/StreamingCompat.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark;
+
+import com.google.common.base.Optional;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function0;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.streaming.Time;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import scala.Tuple2;
+
+/**
+ * Utility class to handle incompatibilities between Spark1 and Spark2 streaming.
+ * All hydrator-spark-core modules must have this class with the exact same method signatures.
+ * Incompatibilities are in a few places.
+ *
+ * DStream.foreachRDD() no longer takes a Function2 in Spark2 in favor of VoidFunction2.
+ * In Spark1.2, a Function2 must be used because VoidFunction2 was not yet introduced.
+ *
+ * Outer join methods in Spark1 use guava's Optional whereas Spark2 uses its own Optional.
+ *
+ * JavaStreamingContext.getOrCreate() does not use a JavaStreamingContextFactory in Spark2, but requires it in Spark1.2.
+ */
+public final class StreamingCompat {
+
+  private StreamingCompat() {
+
+  }
+
+  public static JavaStreamingContext getOrCreate(String checkpointDir, Function0<JavaStreamingContext> contextFunc) {
+    return JavaStreamingContext.getOrCreate(checkpointDir, contextFunc);
+  }
+
+  public static <T> void foreachRDD(JavaDStream<T> stream, final Function2<JavaRDD<T>, Time, Void> func) {
+    stream.foreachRDD(func);
+  }
+
+  public static <K, V1, V2> JavaPairDStream<K, Tuple2<V1, Optional<V2>>> leftOuterJoin(JavaPairDStream<K, V1> left,
+                                                                                       JavaPairDStream<K, V2> right) {
+    return left.leftOuterJoin(right);
+  }
+
+  public static <K, V1, V2> JavaPairDStream<K, Tuple2<V1, Optional<V2>>> leftOuterJoin(JavaPairDStream<K, V1> left,
+                                                                                       JavaPairDStream<K, V2> right,
+                                                                                       int numPartitions) {
+    return left.leftOuterJoin(right, numPartitions);
+  }
+
+  public static <K, V1, V2> JavaPairDStream<K, Tuple2<Optional<V1>, Optional<V2>>> fullOuterJoin(
+    JavaPairDStream<K, V1> left, JavaPairDStream<K, V2> right) {
+    return left.fullOuterJoin(right);
+  }
+
+  public static <K, V1, V2> JavaPairDStream<K, Tuple2<Optional<V1>, Optional<V2>>> fullOuterJoin(
+    JavaPairDStream<K, V1> left, JavaPairDStream<K, V2> right, int numPartitions) {
+    return left.fullOuterJoin(right, numPartitions);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/co/cask/cdap/etl/spark/StreamingCompat.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/co/cask/cdap/etl/spark/StreamingCompat.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark;
+
+import com.google.common.base.Optional;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.Function0;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.VoidFunction2;
+import org.apache.spark.streaming.Time;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import scala.Tuple2;
+
+/**
+ * Utility class to handle incompatibilities between Spark1 and Spark2 streaming.
+ * All hydrator-spark-core modules must have this class with the exact same method signatures.
+ * Incompatibilities are in a few places.
+ *
+ * DStream.foreachRDD() no longer takes a Function2 in Spark2 in favor of VoidFunction2.
+ * In Spark1.2, a Function2 must be used because VoidFunction2 was not yet introduced.
+ *
+ * Outer join methods in Spark1 use guava's Optional whereas Spark2 uses its own Optional.
+ *
+ * JavaStreamingContext.getOrCreate() does not use a JavaStreamingContextFactory in Spark2, but requires it in Spark1.2.
+ */
+public final class StreamingCompat {
+
+  private StreamingCompat() {
+
+  }
+
+  public static JavaStreamingContext getOrCreate(String checkpointDir, Function0<JavaStreamingContext> contextFunc) {
+    return JavaStreamingContext.getOrCreate(checkpointDir, contextFunc);
+  }
+
+  public static <T> void foreachRDD(JavaDStream<T> stream, final Function2<JavaRDD<T>, Time, Void> func) {
+    stream.foreachRDD(new VoidFunction2<JavaRDD<T>, Time>() {
+      @Override
+      public void call(JavaRDD<T> v1, Time v2) throws Exception {
+        func.call(v1, v2);
+      }
+    });
+  }
+
+  public static <K, V1, V2> JavaPairDStream<K, Tuple2<V1, Optional<V2>>> leftOuterJoin(JavaPairDStream<K, V1> left,
+                                                                                       JavaPairDStream<K, V2> right) {
+    return left.leftOuterJoin(right).mapValues(new Compat.ConvertOptional<V1, V2>());
+  }
+
+  public static <K, V1, V2> JavaPairDStream<K, Tuple2<V1, Optional<V2>>> leftOuterJoin(JavaPairDStream<K, V1> left,
+                                                                                       JavaPairDStream<K, V2> right,
+                                                                                       int numPartitions) {
+    return left.leftOuterJoin(right, numPartitions).mapValues(new Compat.ConvertOptional<V1, V2>());
+  }
+
+  public static <K, V1, V2> JavaPairDStream<K, Tuple2<Optional<V1>, Optional<V2>>> fullOuterJoin(
+    JavaPairDStream<K, V1> left, JavaPairDStream<K, V2> right) {
+    return left.fullOuterJoin(right).mapValues(new Compat.ConvertOptional2<V1, V2>());
+  }
+
+  public static <K, V1, V2> JavaPairDStream<K, Tuple2<Optional<V1>, Optional<V2>>> fullOuterJoin(
+    JavaPairDStream<K, V1> left, JavaPairDStream<K, V2> right, int numPartitions) {
+    return left.fullOuterJoin(right, numPartitions).mapValues(new Compat.ConvertOptional2<V1, V2>());
+  }
+}


### PR DESCRIPTION
Some minor refactoring to move Spark Streaming classes
out of the Compat class, since cdap-data-pipeline does not include
Spark Streaming as a dependency. Added a new StreamingCompat class
to handle Spark Streaming compatibility related code. Also added
a method there for JavaStreamingContext differences in Spark.

Also changing the WordCount test app to remove usage of flatMap,
since that will cause problems once we add Spark2 versions of the
existing apps