### PR TITLE
CDAP-11444 Upgrade IntelliJ to 2017.1.3 in VM

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -144,7 +144,7 @@
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "2016.2.5",
+          "version": "2017.1.3",
           "url": "file:///tmp/idea.tar.gz"
         },
         "hadoop": {


### PR DESCRIPTION
This requires coordination with Ops to update the local file on the build agents that is used to prevent internet downloads of these files.