### PR TITLE
CDAP-11398 Upgrade Eclipse to Neon 3 in VM

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -134,10 +134,10 @@
       "skip_install": true,
       "json": {
         "eclipse": {
-          "version": "Luna",
-          "release_code": "SR2",
+          "version": "Neon",
+          "release_code": "3",
           "plugins": [
-            { "http://download.eclipse.org/releases/luna": "org.eclipse.egit.feature.group" },
+            { "http://download.eclipse.org/releases/neon": "org.eclipse.egit.feature.group" },
             { "http://download.eclipse.org/technology/m2e/releases": "org.eclipse.m2e.feature.feature.group" }
           ],
           "url": "file:///tmp/eclipse.tar.gz"


### PR DESCRIPTION
This requires coordination with Ops to update the local file on the build agents that is used to prevent internet downloads of these files.