### PR TITLE
use hdi4.0 tag

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -22,7 +22,7 @@
 # The git branch to clone
 CDAP_BRANCH='release/4.0'
 # Optional tag to checkout - All released versions of this script should set this
-CDAP_TAG='v4.0.2'
+CDAP_TAG='hdi4.0'
 # The CDAP package version passed to Chef
 CDAP_VERSION='4.0.2-1'
 # The version of Chef to install


### PR DESCRIPTION
Updates the HDInsight provisioning to use a [git tag](https://github.com/caskdata/cdap/tree/hdi4.0) created specifically for HDInsight config.  This decouples it from the cdap release tag, and allows resolution of [CDAP-9432](https://issues.cask.co/browse/CDAP-9432) without requiring a new cdap release.

This install script will need to be updated via s3 update/azure publishing portal.  It then uses this tag to retrieve hdi-version-specific cdap configuration and packer build scripts.