### PR TITLE
use hdi4.2 tag

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -24,7 +24,7 @@ CDAP_BRANCH='release/4.1'
 # Optional tag to checkout - All released versions of this script should set this
 # like this: CDAP_TAG=${CDAP_TAG:+tag} as this allows setting tag to empty/null
 # otherwise, it should be CDAP_TAG=''
-CDAP_TAG=${CDAP_TAG:+v4.2.0}
+CDAP_TAG=${CDAP_TAG:+hdi4.2}
 # The CDAP package version passed to Chef
 CDAP_VERSION='4.2.0-1'
 # The version of Chef to install


### PR DESCRIPTION
Updates the HDInsight provisioning to use a git tag created specifically for HDInsight config.  This decouples it from the cdap release tag.

The git tag will need to be created prior to releasing HDInsight 4.2
