### PR TITLE
[CDAP-9092][CDAP-9093][CDAP-9273] New pipeline schedule modeless, with more basic scheduling options

### DIFF
--- a/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.html
@@ -78,18 +78,15 @@
           class="btn btn-primary apply-run"
           ng-disabled="PipelineConfigCtrl.buttonsAreDisabled()"
           ng-click="PipelineConfigCtrl.applyAndRunPipeline()">
-          Apply &amp; {{PipelineConfigCtrl.actionLabel}}
+          Apply &amp; Run
         </button>
         <button
           class="btn btn-secondary"
           ng-disabled="PipelineConfigCtrl.buttonsAreDisabled()"
-          ng-click="PipelineConfigCtrl.applyWithMessage()">
+          ng-click="PipelineConfigCtrl.applyRuntimeArguments()">
           Apply
         </button>
-        <span class="applied-message text-success"
-              ng-show="PipelineConfigCtrl.showAppliedMessage">
-          Runtime Arguments Applied
-        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.js
@@ -15,7 +15,7 @@
   */
 
 class MyPipelineConfigurationsCtrl {
-  constructor(uuid, HydratorPlusPlusHydratorService, $timeout) {
+  constructor(uuid, HydratorPlusPlusHydratorService) {
     this.uuid = uuid;
     this.HydratorPlusPlusHydratorService = HydratorPlusPlusHydratorService;
 
@@ -55,14 +55,6 @@ class MyPipelineConfigurationsCtrl {
       this.runtimeArguments = this.checkForReset(newRuntimeArguments);
     };
 
-    this.applyWithMessage = () => {
-      this.applyRuntimeArguments();
-      this.showAppliedMessage = true;
-      $timeout(() => {
-        this.showAppliedMessage = false;
-      }, 3000);
-    };
-
     this.applyAndRunPipeline = () => {
       this.applyRuntimeArguments();
       this.runPipeline();
@@ -82,7 +74,7 @@ class MyPipelineConfigurationsCtrl {
   }
 }
 
-MyPipelineConfigurationsCtrl.$inject = ['uuid', 'HydratorPlusPlusHydratorService', '$timeout'];
+MyPipelineConfigurationsCtrl.$inject = ['uuid', 'HydratorPlusPlusHydratorService'];
   angular.module(PKG.name + '.commons')
   .directive('keyValuePairs', function(reactDirective) {
     return reactDirective(window.CaskCommon.KeyValuePairs);
@@ -95,10 +87,9 @@ MyPipelineConfigurationsCtrl.$inject = ['uuid', 'HydratorPlusPlusHydratorService
         runtimeArguments: '=',
         resolvedMacros: '=',
         applyRuntimeArguments: '&',
-        runPipeline: '&',
-        pipelineAction: '@',
         convertRuntimeArgsToMacros: '&',
         pipelineName: '@',
+        runPipeline: '&',
         onClose: '&',
         namespace: '@namespaceId'
       },

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.less
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.less
@@ -33,7 +33,7 @@ body.theme-cdap {
     .pipeline-configurations-content {
       background: @modeless-bg-color;
       position: fixed;
-      top: 96px;
+      top: 95px;
       overflow: auto;
       right: 15px;
       z-index: 999;
@@ -194,10 +194,6 @@ body.theme-cdap {
               &.apply-run {
                 margin-right: 16px;
               }
-            }
-
-            .applied-message {
-              margin-left: 10px;
             }
           }
         }

--- a/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.html
+++ b/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.html
@@ -1,0 +1,338 @@
+<!--
+  Copyright © 2017 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<div class="pipeline-scheduler-content">
+  <div class="pipeline-scheduler-header">
+    <h3 class="modeless-title">
+      Configure Schedule for Pipeline
+      <span ng-if="SchedulerCtrl.pipelineName.length > 0">
+        "{{SchedulerCtrl.pipelineName}}"
+      </span>
+    </h3>
+    <div class="btn-group">
+      <a class="btn" ng-click="SchedulerCtrl.onClose()">
+        <span class="fa fa-remove"></span>
+      </a>
+    </div>
+  </div>
+  <div class="pipeline-scheduler-body">
+    <div class="schedule-content">
+      <fieldset ng-disabled="SchedulerCtrl._isDisabled">
+        <div class="schedule-types row">
+          <span class="col-xs-3 schedule-type schedule-type-basic"
+                ng-class="{'active': SchedulerCtrl.scheduleType === 'basic'}"
+                ng-click="SchedulerCtrl.selectType('basic')">
+            Basic
+          </span>
+          <span class="col-xs-4 schedule-type schedule-type-advanced">
+            <span class="separator">
+              |
+            </span>
+            <span ng-class="{'active': SchedulerCtrl.scheduleType === 'advanced'}"
+                  ng-click="SchedulerCtrl.selectType('advanced')">
+              Advanced
+            </span>
+          </span>
+        </div>
+        <div class="schedule-type-content">
+          <div ng-if="SchedulerCtrl.scheduleType === 'basic'">
+            <div class="form-group row">
+              <label class="col-xs-3 control-label">
+                Pipeline run repeats
+              </label>
+              <div class="col-xs-4 schedule-values-container">
+                <select class="form-control"
+                        ng-change="SchedulerCtrl.switchToDefault()"
+                        ng-model="SchedulerCtrl.intervalOptionKey"
+                        ng-options="optionKey as optionVal for (optionKey,optionVal) in SchedulerCtrl.INTERVAL_OPTIONS">
+                </select>
+              </div>
+            </div>
+            <div class="form-group row"
+                  ng-class="{'invisible': ['Hourly', 'Daily', 'Weekly', 'Monthly', 'Yearly'].indexOf(SchedulerCtrl.intervalOptionKey) === -1}">
+              <label class="col-xs-3 control-label">
+                Repeats every
+              </label>
+              <div class="col-xs-4 schedule-values-container">
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Hourly'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.repeatEvery.numHours"
+                          ng-options="option as option for option in SchedulerCtrl.HOUR_OPTIONS">
+                  </select>
+                  <span>hour(s)</span>
+                </span>
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Daily'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.repeatEvery.numDays"
+                          ng-options="option as option for option in SchedulerCtrl.DAY_OF_MONTH_OPTIONS">
+                  </select>
+                  <span>day(s)</span>
+                </span>
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Weekly'">
+                  <div class="day-of-week"
+                        ng-repeat="(day, selected) in SchedulerCtrl.timeSelections.repeatEvery.daysOfWeekObj">
+                    <label>
+                      <input ng-model="SchedulerCtrl.timeSelections.repeatEvery.daysOfWeekObj[day]"
+                              ng-change="SchedulerCtrl.updateSelectedDaysInWeek()"
+                              type="checkbox"/>
+                      <span>{{ day | cronDayName | getFirstLetter}}</span>
+                    </label>
+                  </div>
+                </span>
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Monthly'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.repeatEvery.dayOfMonth"
+                          ng-options="option as (option | cronDayOfMonth) for option in SchedulerCtrl.DAY_OF_MONTH_OPTIONS">
+                  </select>
+                  <span>day of the month</span>
+                </span>
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Yearly'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.repeatEvery.month"
+                          ng-options="option as (option | cronMonthName) for option in SchedulerCtrl.MONTH_OPTIONS">
+                  </select>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.repeatEvery.dayOfMonth"
+                          ng-options="option as (option | cronDayOfMonth) for option in SchedulerCtrl.DAY_OF_MONTH_OPTIONS">
+                  </select>
+                </span>
+              </div>
+            </div>
+            <div class="form-group row"
+                  ng-class="{'invisible': ['Hourly', 'Daily', 'Weekly', 'Monthly', 'Yearly'].indexOf(SchedulerCtrl.intervalOptionKey) === -1}">
+              <label class="col-xs-3 control-label">
+                Starting at
+              </label>
+              <div class="col-xs-4 schedule-values-container">
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Hourly'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.min"
+                          ng-options="option as (option | displayTwoDigitNumber) for option in SchedulerCtrl.MINUTE_OPTIONS">
+                  </select>
+                  <span>past the hour</span>
+                </span>
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Daily'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.hour"
+                          ng-options="option as option for option in SchedulerCtrl.HOUR_OPTIONS_CLOCK">
+                  </select>
+                  <span class="separator"> : </span>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.min"
+                          ng-options="option as (option | displayTwoDigitNumber) for option in SchedulerCtrl.MINUTE_OPTIONS">
+                  </select>
+                  <span>&nbsp;</span>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.am_pm"
+                          ng-options="option as option for option in SchedulerCtrl.AM_PM_OPTIONS">
+                  </select>
+                </span>
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Weekly'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.hour"
+                          ng-options="option as option for option in SchedulerCtrl.HOUR_OPTIONS_CLOCK">
+                  </select>
+                  <span class="separator"> : </span>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.min"
+                          ng-options="option as (option | displayTwoDigitNumber) for option in SchedulerCtrl.MINUTE_OPTIONS">
+                  </select>
+                  <span>&nbsp;</span>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.am_pm"
+                          ng-options="option as option for option in SchedulerCtrl.AM_PM_OPTIONS">
+                  </select>
+                </span>
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Monthly'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.hour"
+                          ng-options="option as option for option in SchedulerCtrl.HOUR_OPTIONS_CLOCK">
+                  </select>
+                  <span class="separator"> : </span>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.min"
+                          ng-options="option as (option | displayTwoDigitNumber) for option in SchedulerCtrl.MINUTE_OPTIONS">
+                  </select>
+                  <span>&nbsp;</span>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.am_pm"
+                          ng-options="option as option for option in SchedulerCtrl.AM_PM_OPTIONS">
+                  </select>
+                </span>
+                <span class="schedule-values"
+                      ng-if="SchedulerCtrl.intervalOptionKey === 'Yearly'">
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.hour"
+                          ng-options="option as option for option in SchedulerCtrl.HOUR_OPTIONS_CLOCK">
+                  </select>
+                  <span class="separator"> : </span>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.min"
+                          ng-options="option as (option | displayTwoDigitNumber) for option in SchedulerCtrl.MINUTE_OPTIONS">
+                  </select>
+                  <span>&nbsp;</span>
+                  <select class="form-control small-dropdown"
+                          ng-model="SchedulerCtrl.timeSelections.startingAt.am_pm"
+                          ng-options="option as option for option in SchedulerCtrl.AM_PM_OPTIONS">
+                  </select>
+                </span>
+              </div>
+            </div>
+            <div class="form-group row summary">
+              <label class="col-xs-3 control-label">
+                Summary
+              </label>
+              <div class="col-xs-8 schedule-values-container">
+                <div>
+                  <span>This pipeline is scheduled to run </span>
+                  <span ng-if="SchedulerCtrl.intervalOptionKey === '5min'">
+                    every 5 minutes
+                  </span>
+                  <span ng-if="SchedulerCtrl.intervalOptionKey === '10min'">
+                    every 10 minutes
+                  </span>
+                  <span ng-if="SchedulerCtrl.intervalOptionKey === '30min'">
+                    every 30 minutes
+                  </span>
+                  <span ng-if="SchedulerCtrl.intervalOptionKey === 'Hourly'">
+                    every
+                    <span ng-if="SchedulerCtrl.timeSelections.repeatEvery.numHours === 1">
+                      hour,
+                    </span>
+                    <span ng-if="SchedulerCtrl.timeSelections.repeatEvery.numHours !== 1">
+                      {{ SchedulerCtrl.timeSelections.repeatEvery.numHours }} hours,
+                    </span>
+                    <span ng-if="SchedulerCtrl.timeSelections.startingAt.min === 0">
+                      on the hour
+                    </span>
+                    <span ng-if="SchedulerCtrl.timeSelections.startingAt.min !== 0">
+                      {{ SchedulerCtrl.timeSelections.startingAt.min | displayTwoDigitNumber }} minutes past the hour
+                    </span>
+                  </span>
+                  <span ng-if="SchedulerCtrl.intervalOptionKey === 'Daily'">
+                    <span ng-if="SchedulerCtrl.timeSelections.repeatEvery.numDays === 1">
+                      everyday,
+                    </span>
+                    <span ng-if="SchedulerCtrl.timeSelections.repeatEvery.numDays !== 1">
+                      every {{ SchedulerCtrl.timeSelections.repeatEvery.numDays }} days,
+                    </span>
+                    <span>
+                      at {{ SchedulerCtrl.timeSelections.startingAt.hour }}:{{ SchedulerCtrl.timeSelections.startingAt.min | displayTwoDigitNumber }}{{ SchedulerCtrl.timeSelections.startingAt.am_pm | lowercase }}
+                    </span>
+                  </span>
+                  <span ng-if="SchedulerCtrl.intervalOptionKey === 'Weekly'">
+                    <span ng-if="SchedulerCtrl.timeSelections.repeatEvery.daysOfWeek.length === 7">
+                      everyday,
+                    </span>
+                    <span ng-if="SchedulerCtrl.timeSelections.repeatEvery.daysOfWeek.length !== 7">
+                      every
+                      <span ng-repeat="day in SchedulerCtrl.timeSelections.repeatEvery.daysOfWeek">
+                        {{ day | cronDayName }},
+                      </span>
+                    </span>
+                    <span>
+                      at {{ SchedulerCtrl.timeSelections.startingAt.hour }}:{{ SchedulerCtrl.timeSelections.startingAt.min | displayTwoDigitNumber }}{{ SchedulerCtrl.timeSelections.startingAt.am_pm | lowercase }}
+                    </span>
+                  </span>
+                  <span ng-if="SchedulerCtrl.intervalOptionKey === 'Monthly'">
+                    <span>
+                      every {{ SchedulerCtrl.timeSelections.repeatEvery.dayOfMonth | cronDayOfMonth }} day of the month,
+                    </span>
+                    <span>
+                      at {{ SchedulerCtrl.timeSelections.startingAt.hour }}:{{ SchedulerCtrl.timeSelections.startingAt.min | displayTwoDigitNumber }}{{ SchedulerCtrl.timeSelections.startingAt.am_pm | lowercase }}
+                    </span>
+                  </span>
+                  <span ng-if="SchedulerCtrl.intervalOptionKey === 'Yearly'">
+                    <span>
+                      every year on {{ SchedulerCtrl.timeSelections.repeatEvery.month | cronMonthName }} {{ SchedulerCtrl.timeSelections.repeatEvery.dayOfMonth | cronDayOfMonth }},
+                    </span>
+                    <span>
+                      at {{ SchedulerCtrl.timeSelections.startingAt.hour }}:{{ SchedulerCtrl.timeSelections.startingAt.min | displayTwoDigitNumber }}{{ SchedulerCtrl.timeSelections.startingAt.am_pm | lowercase }}
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div ng-if="SchedulerCtrl.scheduleType === 'advanced'">
+            <div class="schedule-advanced-header">
+              Schedule this pipeline by using Cron syntax
+            </div>
+            <div class="schedule-advanced-values">
+              <div class="form-group col-xs-2 schedule-advanced-input">
+                <label>Min</label>
+                <input type="text"
+                      ng-model="SchedulerCtrl.advancedScheduleValues.min"
+                      class="form-control"
+                />
+              </div>
+              <div class="form-group col-xs-2 schedule-advanced-input">
+                <label>Hour</label>
+                <input type="text"
+                      ng-model="SchedulerCtrl.advancedScheduleValues.hour"
+                      class="form-control"
+                />
+              </div>
+              <div class="form-group col-xs-2 schedule-advanced-input">
+                <label>Day</label>
+                <input type="text"
+                      ng-model="SchedulerCtrl.advancedScheduleValues.day"
+                      class="form-control"
+                />
+              </div>
+              <div class="form-group col-xs-2 schedule-advanced-input">
+                <label>Month</label>
+                <input type="text"
+                      ng-model="SchedulerCtrl.advancedScheduleValues.month"
+                      class="form-control"
+                />
+              </div>
+              <div class="form-group col-xs-3 schedule-advanced-input">
+                <label>Day of the Week</label>
+                <input type="text"
+                      ng-model="SchedulerCtrl.advancedScheduleValues.daysOfWeek"
+                      class="form-control"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+      <div class="schedule-navigation">
+        <button
+          ng-if="SchedulerCtrl._isDisabled"
+          class="btn btn-primary start-schedule-btn"
+          ng-click="SchedulerCtrl.startSchedule()">
+          Start Schedule
+        </button>
+        <button
+          ng-if="!SchedulerCtrl._isDisabled"
+          class="btn btn-primary save-schedule-btn"
+          ng-click="SchedulerCtrl.saveSchedule()">
+          Save Schedule
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.js
+++ b/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.js
@@ -1,0 +1,260 @@
+  /*
+  * Copyright © 2017 Cask Data, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  * use this file except in compliance with the License. You may obtain a copy of
+  * the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  * License for the specific language governing permissions and limitations under
+  * the License.
+  */
+
+class MyPipelineSchedulerCtrl {
+  constructor(moment, myHelpers, CronConverter) {
+    this.moment = moment;
+    this._isDisabled = this.isDisabled === 'true';
+
+    this.INTERVAL_OPTIONS = {
+      '5min': 'Every 5 min',
+      '10min': 'Every 10 min',
+      '30min': 'Every 30 min',
+      'Hourly': 'Hourly',
+      'Daily': 'Daily',
+      'Weekly': 'Weekly',
+      'Monthly': 'Monthly',
+      'Yearly': 'Yearly',
+    };
+
+    let minuteOptions = [];
+    for (let i = 0; i < 60; i++) {
+      minuteOptions.push(i);
+    }
+
+    this.MINUTE_OPTIONS = minuteOptions;
+    this.HOUR_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23];
+    this.HOUR_OPTIONS_CLOCK = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    this.DAY_OF_MONTH_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31];
+    this.MONTH_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    this.AM_PM_OPTIONS = ['AM', 'PM'];
+
+    this.initialCron = this.store.getSchedule();
+    this.cron = this.initialCron;
+
+    this.intervalOptionKey = 'Hourly';
+
+    let defaulTimeOptions = {
+      'startingAt': {
+        'min': this.MINUTE_OPTIONS[0],
+        'hour': this.HOUR_OPTIONS[0],
+        'am_pm': this.AM_PM_OPTIONS[0]
+      },
+      'repeatEvery': {
+        'numMins': 5,
+        'numHours': this.HOUR_OPTIONS_CLOCK[0],
+        'numDays': this.DAY_OF_MONTH_OPTIONS[0],
+        'daysOfWeek': [1],
+        'daysOfWeekObj': CronConverter.convertSelectedDaysToObj([1]),
+        'dayOfMonth': this.DAY_OF_MONTH_OPTIONS[0],
+        'month': this.MONTH_OPTIONS[0]
+      }
+    };
+
+    this.timeSelections = Object.assign({}, defaulTimeOptions);
+
+    this.advancedScheduleValues = {
+      'min': 0,
+      'hour': '*',
+      'day': '*',
+      'month': '*',
+      'daysOfWeek': '*'
+    };
+
+    this.scheduleType = 'basic';
+
+    // '0 * * * *' is default cron
+    if (this.cron !== '0 * * * *') {
+      let convertedCronValues = CronConverter.convert(this.cron);
+      this.advancedScheduleValues = convertedCronValues.cronObj;
+      this.intervalOptionKey = convertedCronValues.intervalOption;
+      this.timeSelections = convertedCronValues.humanReadableObj;
+      this.scheduleType = convertedCronValues.scheduleType;
+    }
+
+    this.switchToDefault = () => {
+      this.timeSelections = Object.assign({}, defaulTimeOptions);
+    };
+
+    this.saveSchedule = () => {
+      this.getUpdatedCron();
+      this.actionCreator.setSchedule(this.cron);
+      this.onClose();
+    };
+
+    this.selectType = (type) => {
+      this.scheduleType = type;
+    };
+
+    this.updateSelectedDaysInWeek = () => {
+      for (let key in this.timeSelections.repeatEvery.daysOfWeekObj) {
+        if (this.timeSelections.repeatEvery.daysOfWeekObj.hasOwnProperty(key)) {
+          let keyInt = parseInt(key, 10);
+          if (this.timeSelections.repeatEvery.daysOfWeekObj[key] && this.timeSelections.repeatEvery.daysOfWeek.indexOf(keyInt) === -1) {
+            this.timeSelections.repeatEvery.daysOfWeek.push(keyInt);
+          } else if (!this.timeSelections.repeatEvery.daysOfWeekObj[key] && this.timeSelections.repeatEvery.daysOfWeek.indexOf(keyInt) !== -1) {
+            this.timeSelections.repeatEvery.daysOfWeek.splice(this.timeSelections.repeatEvery.daysOfWeek.indexOf(keyInt));
+          }
+        }
+      }
+      this.timeSelections.repeatEvery.daysOfWeek.sort();
+    };
+
+    this.getUpdatedCron = () => {
+      if (this.scheduleType === 'basic') {
+        let convertedHour;
+        switch(this.intervalOptionKey) {
+          case '5min':
+            this.cron = '*/5 * * * *';
+            break;
+          case '10min':
+            this.cron = '*/10 * * * *';
+            break;
+          case '30min':
+            this.cron = '*/30 * * * *';
+            break;
+          case 'Hourly':
+            this.cron = `${this.timeSelections.startingAt.min} */${this.timeSelections.repeatEvery.numHours} * * *`;
+            break;
+          case 'Daily':
+            convertedHour = this.moment(this.timeSelections.startingAt.hour.toString() + this.timeSelections.startingAt.am_pm, 'hA').format('H');
+            this.cron = `${this.timeSelections.startingAt.min} ${convertedHour} */${this.timeSelections.repeatEvery.numDays} * *`;
+            break;
+          case 'Weekly':
+            convertedHour = this.moment(this.timeSelections.startingAt.hour.toString() + this.timeSelections.startingAt.am_pm, 'hA').format('H');
+            this.cron = `${this.timeSelections.startingAt.min} ${convertedHour} * * ${this.timeSelections.repeatEvery.daysOfWeek.toString()}`;
+            break;
+          case 'Monthly':
+            convertedHour = this.moment(this.timeSelections.startingAt.hour.toString() + this.timeSelections.startingAt.am_pm, 'hA').format('H');
+            this.cron = `${this.timeSelections.startingAt.min} ${convertedHour} ${this.timeSelections.repeatEvery.dayOfMonth} * *`;
+            break;
+          case 'Yearly':
+            convertedHour = this.moment(this.timeSelections.startingAt.hour.toString() + this.timeSelections.startingAt.am_pm, 'hA').format('H');
+            this.cron = `${this.timeSelections.startingAt.min} ${convertedHour} ${this.timeSelections.repeatEvery.dayOfMonth} ${this.timeSelections.repeatEvery.month} *`;
+            break;
+        }
+      } else {
+        this.cron = `${this.advancedScheduleValues.min} ${this.advancedScheduleValues.hour} ${this.advancedScheduleValues.day} ${this.advancedScheduleValues.month} ${this.advancedScheduleValues.daysOfWeek}`;
+      }
+    };
+  }
+}
+
+MyPipelineSchedulerCtrl.$inject = ['moment', 'myHelpers', 'CronConverter'];
+  angular.module(PKG.name + '.commons')
+  .controller('MyPipelineSchedulerCtrl', MyPipelineSchedulerCtrl)
+  .filter('cronDayOfMonth', () => {
+    return (input) => {
+      switch (input) {
+        case 1:
+          return '1st';
+        case 2:
+          return '2nd';
+        case 3:
+          return '3rd';
+        case 21:
+          return '21st';
+        case 22:
+          return '22nd';
+        case 23:
+          return '23rd';
+        case 31:
+          return '31st';
+        case null:
+          return null;
+        default:
+          return input + 'th';
+      }
+    };
+  })
+  .filter('cronMonthName', () => {
+    return (input) => {
+      let months = {
+        1: 'Jan',
+        2: 'Feb',
+        3: 'Mar',
+        4: 'Apr',
+        5: 'May',
+        6: 'Jun',
+        7: 'Jul',
+        8: 'Aug',
+        9: 'Sep',
+        10: 'Oct',
+        11: 'Nov',
+        12: 'Dec'
+      };
+
+      if (input !== null && angular.isDefined(months[input])) {
+        return months[input];
+      } else {
+        return null;
+      }
+    };
+  })
+  .filter('cronDayName', () => {
+    return (input) => {
+      let days = {
+        0: 'Sunday',
+        1: 'Monday',
+        2: 'Tuesday',
+        3: 'Wednesday',
+        4: 'Thursday',
+        5: 'Friday',
+        6: 'Saturday',
+      };
+
+      if (input !== null && angular.isDefined(days[input])) {
+        return days[input];
+      } else {
+        return null;
+      }
+    };
+  })
+  .filter('getFirstLetter', () => {
+    return (input) => {
+      if (input !== null && input.length > 0) {
+        return input.charAt(0);
+      } else {
+        return null;
+      }
+    };
+  })
+  .filter('displayTwoDigitNumber', () => {
+    return (number) => {
+      if (number !== null && !isNaN(number)) {
+        return ('0' + number).slice(-2);
+      } else {
+        return null;
+      }
+    };
+  })
+  .directive('myPipelineScheduler', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        store: '=',
+        actionCreator: '=',
+        pipelineName: '@',
+        onClose: '&',
+        startSchedule: '&',
+        isDisabled: '@'
+      },
+      bindToController: true,
+      controller: 'MyPipelineSchedulerCtrl',
+      controllerAs: 'SchedulerCtrl',
+      templateUrl: 'my-pipeline-scheduler/my-pipeline-scheduler.html'
+    };
+  });

--- a/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.less
+++ b/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.less
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@text-color: #333333;
+@border-color: #cccccc;
+@modeless-bg-color: lightgray;
+@modeless-header-bg-color: #f5f5f5;
+@modeless-width: 730px;
+@modeless-height: 400px;
+@regular-font: 14px;
+
+body.theme-cdap {
+  &.state-hydrator {
+    .pipeline-scheduler-content {
+      background: @modeless-bg-color;
+      position: fixed;
+      top: 95px;
+      overflow: auto;
+      right: 15px;
+      z-index: 999;
+      box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.5);
+      color: @text-color;
+      background-color: white;
+      width: @modeless-width;
+      height: @modeless-height;
+
+      .pipeline-scheduler-header {
+        background-color: @modeless-header-bg-color;
+        height: 60px;
+        padding: 0;
+        border-radius: 4px 4px 0 0;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        .modeless-title {
+          color: @text-color;
+          padding-left: 15px;
+          max-width: 80%;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          overflow: hidden;
+          font-weight: 500;
+          margin: 0 auto 0 0;
+          font-size: 16px;
+          line-height: 20px;
+        }
+
+        .btn .fa-remove {
+          color: @text-color;
+          font-size: 16px;
+        }
+      }
+
+      .pipeline-scheduler-body {
+        display: flex;
+
+        /* 60px: height of modeless box header */
+        height: ~"calc(100% - 60px)";
+        height: ~"-moz-calc(100% - 60px)";
+        height: ~"-webkit-calc(100% - 60px)";
+
+        .schedule-content {
+          width: 100%;
+          margin: 16px 45px 40px 45px;
+          font-size: @regular-font;
+          position: relative;
+
+          .separator {
+            margin-right: 5px;
+          }
+
+          .schedule-type,
+          .control-label,
+          .schedule-values-container {
+            padding: 0;
+          }
+
+          .schedule-type,
+          .control-label {
+            margin-right: 15px;
+          }
+
+          fieldset {
+            /* 50px: height from bottom of buttons to horizontal line */
+            height: ~"calc(100% - 50px)";
+            height: ~"-moz-calc(100% - 50px)";
+            height: ~"-webkit-calc(100% - 50px)";
+
+            .schedule-types {
+              display: flex;
+              align-items: center;
+              height: 30px;
+
+              .schedule-type {
+                cursor: pointer;
+
+                &.schedule-type-basic {
+                  display: inline-block;
+                  text-align: right;
+                }
+              }
+
+              .active {
+                font-weight: bold;
+                text-decoration: underline;
+                pointer-events: none;
+              }
+            }
+
+            .schedule-type-content {
+              border-bottom: 1px solid @border-color;
+
+              /*  30px: height of Basic | Advanced options */
+              height: ~"calc(100% - 30px)";
+              height: ~"-moz-calc(100% - 30px)";
+              height: ~"-webkit-calc(100% - 30px)";
+
+              label {
+                font-weight: initial;
+                margin-bottom: 0;
+              }
+
+              .form-group {
+                display: flex;
+                align-items: center;
+                height: 45px;
+                margin-bottom: 0;
+
+                &.invisible {
+                  visibility: hidden;
+                }
+
+                &.summary {
+                  margin-top: 10px;
+                }
+
+                .control-label {
+                  text-align: right;
+                }
+
+                .schedule-values-container {
+                  .schedule-values {
+                    display: flex;
+                    align-items: center;
+
+                    .day-of-week {
+                      margin-right: 10px;
+                      text-align: center;
+                    }
+                  }
+
+                  .small-dropdown {
+                    width: 30%;
+                    margin-right: 5px;
+                    padding-right: 0;
+                    padding-left: 5px;
+                  }
+                }
+              }
+
+              .schedule-advanced-header {
+                margin-bottom: 20px;
+                padding-top: 10px;
+                padding-left: 20px;
+              }
+
+              .schedule-advanced-values {
+                display: table;
+
+                .schedule-advanced-input {
+                  display: table-cell;
+                  text-align: center;
+                }
+              }
+            }
+          }
+
+          .schedule-navigation {
+            position: absolute;
+            bottom: 0;
+
+            .btn {
+              font-size: @regular-font;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/directives/my-pipeline-settings/my-batch-pipeline-settings/my-batch-pipeline-settings-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-settings/my-batch-pipeline-settings/my-batch-pipeline-settings-ctrl.js
@@ -15,47 +15,20 @@
  */
 
 class MyBatchPipelineSettingsCtrl {
-  constructor(GLOBALS, $scope, MY_CONFIG) {
+  constructor(GLOBALS, MY_CONFIG) {
     this.GLOBALS = GLOBALS;
     this.isDistributed = MY_CONFIG.isEnterprise ? true : false;
     this._isDisabled = this.isDisabled === 'true';
     this.templateType = this.store.getArtifact().name;
-    this.scheduleWidget = {
-      type: 'basic'
-    };
-    this.initialCron = this.store.getSchedule();
-    this.cron = this.initialCron;
-    if (!this.checkCron(this.initialCron)) {
-      this.scheduleWidget.type = 'advanced';
-    }
+
     this.engine = this.store.getEngine();
-    if (!this._isDisabled) {
-      // Debounce method for setting schedule
-      var setSchedule = _.debounce(() => this.actionCreator.setSchedule(this.cron), 1000);
-      var unsub = $scope.$watch('MyBatchPipelineSettingsCtrl.cron', setSchedule);
-      $scope.$on('$destroy', unsub);
-    }
-  }
-  checkCron(cron) {
-    var pattern = /^[0-9\*\s]*$/g;
-    var parse = cron.split('');
-    for (var i = 0; i < parse.length; i++) {
-      if (!parse[i].match(pattern)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   onEngineChange() {
     this.actionCreator.setEngine(this.engine);
   }
-  changeScheduler () {
-    this.initialCron = this.store.getDefaultSchedule();
-    this.cron = this.initialCron;
-  }
 }
 
-MyBatchPipelineSettingsCtrl.$inject = ['GLOBALS', '$scope', 'MY_CONFIG'];
+MyBatchPipelineSettingsCtrl.$inject = ['GLOBALS', 'MY_CONFIG'];
 angular.module(PKG.name + '.commons')
   .controller('MyBatchPipelineSettingsCtrl', MyBatchPipelineSettingsCtrl);

--- a/cdap-ui/app/directives/my-pipeline-settings/my-batch-pipeline-settings/my-batch-pipeline-settings.html
+++ b/cdap-ui/app/directives/my-pipeline-settings/my-batch-pipeline-settings/my-batch-pipeline-settings.html
@@ -17,39 +17,6 @@
   <div class="pipeline-settings-content">
 
     <div>
-      <my-card data-title="Schedule" class="schedule">
-        <div class="radio-inline" ng-if="!MyBatchPipelineSettingsCtrl._isDisabled">
-          <label>
-            <input type="radio"
-                   ng-change="MyBatchPipelineSettingsCtrl.changeScheduler()"
-                   ng-model="MyBatchPipelineSettingsCtrl.scheduleWidget.type"
-                   value="basic"/>
-            Basic
-          </label>
-        </div>
-        <div class="radio-inline" ng-if="!MyBatchPipelineSettingsCtrl._isDisabled">
-          <label>
-            <input type="radio"
-                 ng-change="MyBatchPipelineSettingsCtrl.changeScheduler()"
-                 ng-model="MyBatchPipelineSettingsCtrl.scheduleWidget.type"
-                 value="advanced"/>
-            Advanced
-          </label>
-        </div>
-        <cron-selection
-          ng-if="MyBatchPipelineSettingsCtrl.scheduleWidget.type === 'basic'"
-          class="select-wrapper"
-          output="MyBatchPipelineSettingsCtrl.cron"
-          init="MyBatchPipelineSettingsCtrl.initialCron">
-        </cron-selection>
-        <div data-name="field"
-           ng-if="MyBatchPipelineSettingsCtrl.scheduleWidget.type === 'advanced'"
-           class="my-widget-container"
-           data-model="MyBatchPipelineSettingsCtrl.cron"
-           data-myconfig="{properties: {}, widget: 'schedule'}"
-           widget-container>
-        </div>
-      </my-card>
       <my-card data-title="Engine" class="engine">
         <form role="form" class="form-inline">
           <label class="radio-inline">

--- a/cdap-ui/app/hydrator/routes.js
+++ b/cdap-ui/app/hydrator/routes.js
@@ -68,18 +68,18 @@ angular.module(PKG.name + '.feature.hydrator')
                 mySettings.get('hydratorDrafts', true)
                   .then(function(res) {
                     var draft = myHelpers.objectQuery(res, $stateParams.namespace, $stateParams.draftId);
-                    let isVersionInRange = HydratorPlusPlusHydratorService
-                      .isVersionInRange({
-                        supportedVersion: $rootScope.cdapVersion,
-                        versionRange: draft.artifact.version
-                      });
-                    if (isVersionInRange) {
-                      draft.artifact.version = $rootScope.cdapVersion;
-                    } else {
-                      defer.resolve(false);
-                      return;
-                    }
                     if (angular.isObject(draft)) {
+                      let isVersionInRange = HydratorPlusPlusHydratorService
+                        .isVersionInRange({
+                          supportedVersion: $rootScope.cdapVersion,
+                          versionRange: draft.artifact.version
+                        });
+                      if (isVersionInRange) {
+                        draft.artifact.version = $rootScope.cdapVersion;
+                      } else {
+                        defer.resolve(false);
+                        return;
+                      }
                       defer.resolve(draft);
                     } else {
                       defer.resolve(false);

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -115,15 +115,17 @@
       <div class="button-label">Save</div>
     </div>
     <div class="btn"
-         ng-click="!HydratorPlusPlusTopPanelCtrl.hasNodes ||HydratorPlusPlusTopPanelCtrl.onValidate()"
-         uib-tooltip="Start building a pipeline before validating"
+         ng-if="HydratorPlusPlusTopPanelCtrl.state.artifact.name === HydratorPlusPlusTopPanelCtrl.GLOBALS.etlDataPipeline"
+         ng-class="{'active': HydratorPlusPlusTopPanelCtrl.viewScheduler}"
+         ng-click="!HydratorPlusPlusTopPanelCtrl.hasNodes || HydratorPlusPlusTopPanelCtrl.toggleScheduler()"
+         uib-tooltip="Start building a pipeline before scheduling"
          tooltip-placement="bottom auto"
          tooltip-enable="!HydratorPlusPlusTopPanelCtrl.hasNodes"
          tooltip-class="toppanel-tooltip"
          tooltip-append-to-body="true"
          ng-disabled="!HydratorPlusPlusTopPanelCtrl.hasNodes">
-      <span class="fa icon-validate"></span>
-      <div class="button-label">Validate</div>
+      <span class="fa icon-runtimestarttime"></span>
+      <div class="button-label">Schedule</div>
     </div>
     <div class="btn"
          ng-click="!HydratorPlusPlusTopPanelCtrl.hasNodes || HydratorPlusPlusTopPanelCtrl.onPublish()"
@@ -147,29 +149,38 @@
       <div class="button-label">Preview</div>
     </div>
     <div class="btn"
-         ng-class="{'btn-select': HydratorPlusPlusTopPanelCtrl.showRunTimeArguments}"
-         ng-click="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.toggleRuntimeArguments()"
-         ng-disabled="HydratorPlusPlusTopPanelCtrl.previewLoading">
-      <span class="fa fa-play text-success"
-            ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && !HydratorPlusPlusTopPanelCtrl.previewRunning">
-      </span>
-      <div class="button-label"
-           ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && !HydratorPlusPlusTopPanelCtrl.previewRunning">
-           Start
+         ng-click="HydratorPlusPlusTopPanelCtrl.toggleConfig()"
+         ng-class="{'btn-select': HydratorPlusPlusTopPanelCtrl.viewConfig}">
+      <span class="fa fa-sliders"></span>
+      <div class="button-label">Configure</div>
+    </div>
+    <div class="btn"
+          ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && !HydratorPlusPlusTopPanelCtrl.previewRunning"
+          ng-click="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.validToStartPreview && HydratorPlusPlusTopPanelCtrl.startOrStopPreview()"
+          uib-tooltip="Please provide values for runtime arguments {{ HydratorPlusPlusTopPanelCtrl.notValidRuntimeArgsString }}, before running the pipeline"
+          tooltip-placement="bottom"
+          tooltip-class="toppanel-tooltip"
+          tooltip-enable="!HydratorPlusPlusTopPanelCtrl.validToStartPreview"
+          ng-disabled="HydratorPlusPlusTopPanelCtrl.previewLoading || !HydratorPlusPlusTopPanelCtrl.validToStartPreview">
+      <span class="fa fa-play text-success"></span>
+      <div class="button-label">
+         Run
       </div>
-      <span class="fa fa-stop text-danger"
-            ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.previewRunning">
-      </span>
-      <div class="button-label"
-           ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.previewRunning">
-           Stop
+    </div>
+    <div class="btn"
+          ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.previewRunning"
+          ng-click="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.startOrStopPreview()"
+          ng-disabled="HydratorPlusPlusTopPanelCtrl.previewLoading">
+      <span class="fa fa-stop text-danger"></span>
+      <div class="button-label">
+        Stop
       </div>
-      <span ng-if="HydratorPlusPlusTopPanelCtrl.previewLoading">
-        <span class="fa fa-refresh fa-spin"></span>
-      </span>
-      <div class="button-label"
-           ng-if="HydratorPlusPlusTopPanelCtrl.previewLoading">
-           {{HydratorPlusPlusTopPanelCtrl.loadingLabel}}
+    </div>
+    <div class="btn"
+          ng-if="HydratorPlusPlusTopPanelCtrl.previewLoading">
+      <span class="fa fa-refresh fa-spin"></span>
+      <div class="button-label">
+        {{HydratorPlusPlusTopPanelCtrl.loadingLabel}}
       </div>
     </div>
     <div class="btn run-time">
@@ -191,10 +202,12 @@
 <div class="pipeline-settings-backdrop"
      ng-if="HydratorPlusPlusTopPanelCtrl.state.viewSettings ||
      HydratorPlusPlusTopPanelCtrl.viewLogs ||
-     HydratorPlusPlusTopPanelCtrl.showRunTimeArguments"
+     HydratorPlusPlusTopPanelCtrl.viewConfig ||
+     HydratorPlusPlusTopPanelCtrl.viewScheduler"
      ng-click="HydratorPlusPlusTopPanelCtrl.state.viewSettings =
      HydratorPlusPlusTopPanelCtrl.viewLogs =
-     HydratorPlusPlusTopPanelCtrl.showRunTimeArguments = false">
+     HydratorPlusPlusTopPanelCtrl.viewConfig =
+     HydratorPlusPlusTopPanelCtrl.viewScheduler = false">
 </div>
 <div class="pipeline-settings">
   <div
@@ -206,18 +219,25 @@
     my-pipeline-settings>
   </div>
 </div>
-<div class="pipeline-configurations" ng-if="HydratorPlusPlusTopPanelCtrl.showRunTimeArguments">
-  </my-pipeline-configurations> -->
-    <my-pipeline-configurations
-      runtime-arguments="HydratorPlusPlusTopPanelCtrl.runtimeArguments"
-      apply-runtime-arguments="HydratorPlusPlusTopPanelCtrl.applyRuntimeArguments()"
-      convert-runtime-args-to-macros="HydratorPlusPlusTopPanelCtrl.convertRuntimeArgsToMacros()"
-      resolved-macros="HydratorPlusPlusTopPanelCtrl.resolvedMacros"
-      run-pipeline="HydratorPlusPlusTopPanelCtrl.onPreviewStart()"
-      pipeline-name="{{HydratorPlusPlusTopPanelCtrl.state.metadata['name']}}"
-      on-close="HydratorPlusPlusTopPanelCtrl.showRunTimeArguments = false"
-      namespace-id="{{HydratorPlusPlusTopPanelCtrl.$state.params.namespace}}">
-    </my-pipeline-configurations>
+<div class="pipeline-configurations" ng-if="HydratorPlusPlusTopPanelCtrl.viewConfig">
+  <my-pipeline-configurations
+    runtime-arguments="HydratorPlusPlusTopPanelCtrl.runtimeArguments"
+    apply-runtime-arguments="HydratorPlusPlusTopPanelCtrl.applyRuntimeArguments()"
+    convert-runtime-args-to-macros="HydratorPlusPlusTopPanelCtrl.convertRuntimeArgsToMacros()"
+    resolved-macros="HydratorPlusPlusTopPanelCtrl.resolvedMacros"
+    run-pipeline="HydratorPlusPlusTopPanelCtrl.startOrStopPreview()"
+    pipeline-name="{{HydratorPlusPlusTopPanelCtrl.state.metadata['name']}}"
+    on-close="HydratorPlusPlusTopPanelCtrl.viewConfig = false"
+    namespace-id="{{HydratorPlusPlusTopPanelCtrl.$state.params.namespace}}">
+  </my-pipeline-configurations>
+</div>
+<div class="pipeline-scheduler" ng-if="HydratorPlusPlusTopPanelCtrl.viewScheduler">
+  <my-pipeline-scheduler
+    store="HydratorPlusPlusTopPanelCtrl.HydratorPlusPlusConfigStore"
+    action-creator="HydratorPlusPlusTopPanelCtrl.HydratorPlusPlusConfigActions"
+    pipeline-name="{{HydratorPlusPlusTopPanelCtrl.state.metadata['name']}}"
+    on-close="HydratorPlusPlusTopPanelCtrl.viewScheduler = false">
+  </my-pipeline-scheduler>
 </div>
 <div class="pipeline-settings pipeline-logs-section" ng-if="HydratorPlusPlusTopPanelCtrl.viewLogs">
   <my-log-viewer-preview

--- a/cdap-ui/app/hydrator/templates/detail/top-panel.html
+++ b/cdap-ui/app/hydrator/templates/detail/top-panel.html
@@ -56,16 +56,25 @@
     </div>
 
     <div class="app-status-container">
+      <div class="btn"
+           ng-class="{'btn-select': TopPanelCtrl.viewConfig}"
+           ng-click="TopPanelCtrl.do('Config')">
+        <span class="fa fa-sliders"></span>
+        <div class="button-label">Configure</div>
+      </div>
       <!-- IF ETL BATCH -->
       <div ng-if="TopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(TopPanelCtrl.app.type) !== -1">
         <div ng-if="['Starting', 'Succeeded', 'Failed', 'Stopped', 'Deployed'].indexOf(TopPanelCtrl.appStatus) !== -1">
-          <div ng-click="TopPanelCtrl.do('Start')"
+          <div ng-click="!TopPanelCtrl.validToStartOrSchedule || TopPanelCtrl.do('Start')"
                class="btn"
-               ng-class="{'btn-select': TopPanelCtrl.runPlayer.action === 'Starting'}"
-               ng-disabled="TopPanelCtrl.appStatus === 'Starting'">
+               uib-tooltip="Please provide values for runtime arguments {{ TopPanelCtrl.notValidRuntimeArgsString }}, before running the pipeline"
+               tooltip-placement="bottom"
+               tooltip-class="toppanel-tooltip"
+               tooltip-enable="!TopPanelCtrl.validToStartOrSchedule"
+               ng-disabled="TopPanelCtrl.appStatus === 'Starting' || !TopPanelCtrl.validToStartOrSchedule">
             <span ng-if="TopPanelCtrl.appStatus !== 'Starting'">
               <span class="fa fa-play text-success"></span>
-              <div class="button-label">Start</div>
+              <div class="button-label">Run</div>
             </span>
             <span ng-if="TopPanelCtrl.appStatus === 'Starting'">
               <span class="fa fa-spinner fa-spin"></span>
@@ -89,10 +98,13 @@
       <div ng-if="TopPanelCtrl.GLOBALS.etlBatchPipelines.indexOf(TopPanelCtrl.app.type) !== -1">
         <div ng-if="['Deployed', 'Scheduling'].indexOf(TopPanelCtrl.scheduleStatus) !== -1 || TopPanelCtrl.scheduleStatus.error">
 
-          <div ng-click="TopPanelCtrl.do('Schedule')"
+          <div ng-click="!TopPanelCtrl.validToStartOrSchedule || TopPanelCtrl.do('Schedule')"
               class="btn scheduler"
-              ng-class="{'btn-select': TopPanelCtrl.runPlayer.action === 'Scheduling'}"
-            ng-disabled="TopPanelCtrl.scheduleStatus === 'Scheduling' || TopPanelCtrl.scheduleStatus.error">
+              uib-tooltip="Please provide values for runtime arguments {{ TopPanelCtrl.notValidRuntimeArgsString }}, before scheduling the pipeline"
+              tooltip-placement="bottom"
+              tooltip-class="toppanel-tooltip"
+              tooltip-enable="!TopPanelCtrl.validToStartOrSchedule"
+              ng-disabled="TopPanelCtrl.scheduleStatus === 'Scheduling' || TopPanelCtrl.scheduleStatus.error || !TopPanelCtrl.validToStartOrSchedule">
             <span class="double-line" ng-if="(TopPanelCtrl.scheduleStatus === 'Deployed' || TopPanelCtrl.scheduleStatus.error) && !TopPanelCtrl.scheduleLoading">
               <span class="fa icon-runtimestarttime"></span>
               <div class="button-label">
@@ -125,12 +137,15 @@
       <div ng-if="[TopPanelCtrl.GLOBALS.etlRealtime, TopPanelCtrl.GLOBALS.etlDataStreams].indexOf(TopPanelCtrl.app.type) !== -1">
         <div ng-if="['Stopped', 'Succeeded', 'Failed', 'Starting', 'Deployed'].indexOf(TopPanelCtrl.appStatus) !== -1">
           <div class="btn"
-            ng-class="{'btn-select': TopPanelCtrl.runPlayer.action === 'Starting'}"
-            ng-click="TopPanelCtrl.do('Start')"
-            ng-disabled="TopPanelCtrl.appStatus === 'Starting'">
+            ng-click="!TopPanelCtrl.validToStartOrSchedule || TopPanelCtrl.do('Start')"
+            uib-tooltip="Configure the pipeline before running"
+            tooltip-placement="bottom"
+            tooltip-class="toppanel-tooltip"
+            tooltip-enable="!TopPanelCtrl.validToStartOrSchedule"
+            ng-disabled="TopPanelCtrl.appStatus === 'Starting' || !TopPanelCtrl.validToStartOrSchedule">
             <span ng-if="TopPanelCtrl.appStatus !== 'Starting'">
               <span class="fa fa-play text-success"></span>
-              <div class="button-label">Start</div>
+              <div class="button-label">Run</div>
             </span>
             <span ng-if="TopPanelCtrl.appStatus === 'Starting'">
               <span class="fa fa-spinner fa-spin"></span>
@@ -223,8 +238,8 @@
   </div>
   <cask-resource-center-button></cask-resource-center-button>
   <div class="pipeline-settings-backdrop"
-       ng-if="TopPanelCtrl.viewSettings || TopPanelCtrl.viewSummary || TopPanelCtrl.viewLogs || TopPanelCtrl.runPlayer.view"
-       ng-click="TopPanelCtrl.viewSettings = false; TopPanelCtrl.viewSummary = false; TopPanelCtrl.runPlayer.view = false; TopPanelCtrl.viewLogs = false; TopPanelCtrl.runPlayer.action = null">
+       ng-if="TopPanelCtrl.viewSettings || TopPanelCtrl.viewSummary || TopPanelCtrl.viewLogs || TopPanelCtrl.viewScheduler || TopPanelCtrl.viewConfig"
+       ng-click="TopPanelCtrl.viewSettings = false; TopPanelCtrl.viewSummary = false; TopPanelCtrl.viewLogs = false; TopPanelCtrl.viewScheduler = false; TopPanelCtrl.viewConfig = false">
   </div>
   <div class="pipeline-settings">
     <div
@@ -236,16 +251,25 @@
       my-pipeline-settings>
     </div>
   </div>
-  <div class="pipeline-configurations" ng-if="TopPanelCtrl.runPlayer.view">
+  <div class="pipeline-scheduler" ng-if="TopPanelCtrl.viewScheduler">
+    <my-pipeline-scheduler
+      store="TopPanelCtrl.HydratorPlusPlusDetailNonRunsStore"
+      action-creator="TopPanelCtrl.HydratorPlusPlusDetailActions"
+      pipeline-name="{{TopPanelCtrl.app.name}}"
+      on-close="TopPanelCtrl.viewScheduler = false"
+      is-disabled="true"
+      start-schedule="TopPanelCtrl.schedulePipeline()">
+    </my-pipeline-scheduler>
+  </div>
+  <div class="pipeline-configurations" ng-if="TopPanelCtrl.viewConfig">
     <my-pipeline-configurations
       runtime-arguments="TopPanelCtrl.runtimeArguments"
       apply-runtime-arguments="TopPanelCtrl.applyRuntimeArguments()"
       resolved-macros="TopPanelCtrl.resolvedMacros"
       convert-runtime-args-to-macros="TopPanelCtrl.convertRuntimeArgsToMacros()"
-      run-pipeline="TopPanelCtrl.startOrSchedulePipeline()"
       pipeline-name="{{TopPanelCtrl.app.name}}"
-      pipeline-action="{{TopPanelCtrl.runPlayer.action}}"
-      on-close="TopPanelCtrl.runPlayer.view = false; TopPanelCtrl.runPlayer.action = null"
+      run-pipeline="TopPanelCtrl.startPipeline()"
+      on-close="TopPanelCtrl.viewConfig = false"
       namespace-id="{{TopPanelCtrl.$state.params.namespace}}">
     </my-pipeline-configurations>
   </div>

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -429,6 +429,12 @@ body.theme-cdap {
             left: 32px;
             line-height: 1;
           }
+
+          span.icon-runtimestarttime {
+            font-size: 21px;
+            line-height: 11px;
+            transform: translateY(3px);
+          }
         }
       }
     }
@@ -682,6 +688,12 @@ body.theme-cdap {
     .pipeline-configurations {
       .pipeline-configurations-content {
         left: 119px;
+      }
+    }
+
+    .pipeline-scheduler {
+      .pipeline-scheduler-content {
+        left: 140px;
       }
     }
   }

--- a/cdap-ui/app/services/cron-converter/cron-converter.js
+++ b/cdap-ui/app/services/cron-converter/cron-converter.js
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.services')
+  .factory('CronConverter', function(moment, myHelpers) {
+
+    function convert(cron) {
+      let cronValues = cron.split(' ');
+
+      let cronObj = {
+        'min': cronValues[0],
+        'hour': cronValues[1],
+        'day': cronValues[2],
+        'month': cronValues[3],
+        'daysOfWeek': cronValues[4]
+      };
+
+      let intervalOption = 'Hourly';
+      let scheduleType = 'basic';
+
+      let humanReadableObj = {
+        'startingAt': {
+          'min': '',
+          'hour': '',
+          'am_pm': ''
+        },
+        'repeatEvery': {
+          'numMins': '',
+          'numHours': '',
+          'numDays': '',
+          'daysOfWeek': [],
+          'daysOfWeekObj': {},
+          'dayOfMonth': '',
+          'month': ''
+        }
+      };
+
+      // Every 5 min
+      if (cronValues[0] === '*/5' && cronValues[1] === '*' && cronValues[2] === '*' && cronValues[3] === '*' && cronValues[4] === '*') {
+        intervalOption = '5min';
+        humanReadableObj.repeatEvery.numMins = 5;
+      }
+
+      // Every 10 min
+      else if (cronValues[0] === '*/10' && cronValues[1] === '*' && cronValues[2] === '*' && cronValues[3] === '*' && cronValues[4] === '*') {
+        intervalOption = '10min';
+        humanReadableObj.repeatEvery.numMins = 10;
+      }
+
+      // Every 30 min
+      else if (cronValues[0] === '*/30' && cronValues[1] === '*' && cronValues[2] === '*' && cronValues[3] === '*' && cronValues[4] === '*') {
+        intervalOption = '30min';
+        humanReadableObj.repeatEvery.numMins = 30;
+      }
+
+      // Hourly
+      else if (myHelpers.isNumeric(cronValues[0]) && cronValues[1].indexOf('/') !== -1 && cronValues[2] === '*' && cronValues[3] === '*' && cronValues[4] === '*') {
+        intervalOption = 'Hourly';
+        humanReadableObj.startingAt.min = parseInt(cronValues[0], 10);
+        humanReadableObj.repeatEvery.numHours = parseInt(cronValues[1].split('/')[1], 10);
+      }
+
+      // Daily
+      else if (myHelpers.isNumeric(cronValues[0]) && myHelpers.isNumeric(cronValues[1]) && cronValues[2].indexOf('/') !== -1 && cronValues[3] === '*' && cronValues[4] === '*') {
+        intervalOption = 'Daily';
+        humanReadableObj.startingAt.min = parseInt(cronValues[0], 10);
+        let convertedHour = moment().hour(parseInt(cronValues[1]), 10);
+        humanReadableObj.startingAt.hour = parseInt(convertedHour.format('h'), 10);
+        humanReadableObj.startingAt.am_pm = convertedHour.format('A');
+        humanReadableObj.repeatEvery.numDays = parseInt(cronValues[2].split('/')[1], 10);
+      }
+
+      // Weekly
+      else if (myHelpers.isNumeric(cronValues[0]) && myHelpers.isNumeric(cronValues[1]) && cronValues[2] === '*' && cronValues[3] === '*' && (cronValues[4].indexOf(',') !== -1 || myHelpers.isNumeric(cronValues[4]))) {
+        intervalOption = 'Weekly';
+        humanReadableObj.startingAt.min = parseInt(cronValues[0], 10);
+        let convertedHour = moment().hour(parseInt(cronValues[1]), 10);
+        humanReadableObj.startingAt.hour = parseInt(convertedHour.format('h'), 10);
+        humanReadableObj.startingAt.am_pm = convertedHour.format('A');
+        humanReadableObj.repeatEvery.daysOfWeek = cronValues[4].split(',').map(val => parseInt(val), 10);
+        humanReadableObj.repeatEvery.daysOfWeekObj = convertSelectedDaysToObj(humanReadableObj.repeatEvery.daysOfWeek);
+      }
+
+      // Monthly
+      else if (myHelpers.isNumeric(cronValues[0]) && myHelpers.isNumeric(cronValues[1]) && myHelpers.isNumeric(cronValues[2]) && cronValues[3] === '*' && cronValues[4] === '*') {
+        intervalOption = 'Monthly';
+        humanReadableObj.startingAt.min = parseInt(cronValues[0], 10);
+        let convertedHour = moment().hour(parseInt(cronValues[1]), 10);
+        humanReadableObj.startingAt.hour = parseInt(convertedHour.format('h'), 10);
+        humanReadableObj.startingAt.am_pm = convertedHour.format('A');
+        humanReadableObj.repeatEvery.dayOfMonth = parseInt(cronValues[2], 10);
+      }
+
+      // Yearly
+      else if (myHelpers.isNumeric(cronValues[0]) && myHelpers.isNumeric(cronValues[1]) && myHelpers.isNumeric(cronValues[2]) && myHelpers.isNumeric(cronValues[3]) && cronValues[4] === '*') {
+        intervalOption = 'Yearly';
+        humanReadableObj.startingAt.min = parseInt(cronValues[0], 10);
+        let convertedHour = moment().hour(parseInt(cronValues[1]), 10);
+        humanReadableObj.startingAt.hour = parseInt(convertedHour.format('h'), 10);
+        humanReadableObj.startingAt.am_pm = convertedHour.format('A');
+        humanReadableObj.repeatEvery.dayOfMonth = parseInt(cronValues[2], 10);
+        humanReadableObj.repeatEvery.month = parseInt(cronValues[3], 10);
+      }
+
+      // Not handled in basic mode
+      else {
+        scheduleType = 'advanced';
+      }
+
+      return {
+        cronObj: cronObj,
+        intervalOption: intervalOption,
+        humanReadableObj: humanReadableObj,
+        scheduleType: scheduleType
+      };
+    }
+
+    function convertSelectedDaysToObj(selectedDaysArr) {
+      let checkboxObj = {};
+      for (let i = 0; i < 7; i++) {
+        if (selectedDaysArr.indexOf(i) !== -1) {
+          checkboxObj[i] = true;
+        } else {
+          checkboxObj[i] = false;
+        }
+      }
+      return checkboxObj;
+    }
+
+    return {
+      convert: convert,
+      convertSelectedDaysToObj: convertSelectedDaysToObj
+    };
+  });

--- a/cdap-ui/app/services/helpers.js
+++ b/cdap-ui/app/services/helpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -172,6 +172,36 @@ angular.module(PKG.name+'.services')
 
   /* ----------------------------------------------------------------------- */
 
+  function isNumeric(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+  }
+
+  /* ----------------------------------------------------------------------- */
+
+  function objHasMissingValues(obj) {
+    if (Object.keys(obj).length === 0) {
+      return false;
+    }
+
+    let res = false;
+    let keysWithMissingValue = [];
+    for(let key in obj){
+      if (obj.hasOwnProperty(key) &&
+        (typeof obj[key] === 'undefined' ||
+        typeof obj[key] === 'string' && obj[key].length === 0 ||
+        obj[key] === null)) {
+        res = true;
+        keysWithMissingValue.push(key);
+      }
+    }
+    return {
+      res: res,
+      keysWithMissingValue: keysWithMissingValue
+    };
+  }
+
+  /* ----------------------------------------------------------------------- */
+
   return {
     deepSet: deepSet,
     objectSetter: objectSetter,
@@ -179,6 +209,8 @@ angular.module(PKG.name+'.services')
     objectQuery: objectQuery,
     getConfig: getConfig,
     getConfigNs: getConfigNs,
-    getAbsUIUrl: $window.getAbsUIUrl
+    getAbsUIUrl: $window.getAbsUIUrl,
+    isNumeric: isNumeric,
+    objHasMissingValues: objHasMissingValues
   };
 });


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-9273

This new schedule modeless comes with a new look, and allows for more basic options (e.g. every x hours instead of just every hour). All the basic options can also be converted to advanced options and vice versa, when the user saves the schedule, as long as the basic view can handle the user's cron expression.

Also removed the Validate button in Studio to make place for the Schedule button, as the former will be removed anyways as part of https://issues.cask.co/browse/CDAP-11550.

This PR will also resolve [CDAP-9092](https://issues.cask.co/browse/CDAP-9092) and [CDAP-9093](https://issues.cask.co/browse/CDAP-9093).

**TODO**:
- ~~Figure out how to set the "Max concurrent runs" input as part of the schedule config.~~ Will remove this for now, as this config is not implemented in the backend yet.
- ~~Figure out how to allow for editing the schedule after the pipeline has been deployed. Currently in detail view, editing is disabled, but the user can still start the schedule.~~ Talked with @bdmogal, we decided that we can keep this behavior for this PR, then will discuss later how/when we should implement the editing behavior.