### PR TITLE
Update certain cask.co URLs for SSL

### DIFF
--- a/cdap-distributions/bin/build_apt_repo.sh
+++ b/cdap-distributions/bin/build_apt_repo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright © 2015-2016 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -118,7 +118,7 @@ function create_definition_file() {
   echo "Create APT repository definition file"
   cd ${STAGE_DIR}/${__maj_min}
   cat <<EOF > cask.list
-deb [ arch=amd64 ] http://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min} precise cdap
+deb [ arch=amd64 ] https://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min} precise cdap
 EOF
 }
 

--- a/cdap-distributions/bin/build_yum_repo.sh
+++ b/cdap-distributions/bin/build_yum_repo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright © 2015-2016 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -130,7 +130,7 @@ function create_definition_file() {
   cat <<EOF > cask.repo
 [cask]
 name=Cask Packages
-baseurl=http://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min}
+baseurl=https://${S3_BUCKET}/${S3_REPO_PATH}/${__maj_min}
 enabled=1
 gpgcheck=1
 EOF

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -40,7 +40,7 @@ __gitdir="${__tmpdir}/cdap"
 __packerdir="${__gitdir}/cdap-distributions/src/packer/scripts"
 __cdap_site_template="${__gitdir}/cdap-distributions/src/emr/cdap-conf.json"
 
-__repo_url=${CDAP_YUM_REPO_URL:-http://repository.cask.co/centos/6/x86_64/cdap/MAJ_MIN}
+__repo_url=${CDAP_YUM_REPO_URL:-https://repository.cask.co/centos/6/x86_64/cdap/MAJ_MIN}
 
 die() { echo "ERROR: ${*}"; exit 1; };
 

--- a/cdap-docs/_common/_themes/cdap/casksites.html
+++ b/cdap-docs/_common/_themes/cdap/casksites.html
@@ -5,10 +5,10 @@
     
 #}
 <div role="note" aria-label="other links">
-    <h3><a href="http://docs.cask.co/" target="_blank">Documentation</a></h3>
+    <h3><a href="//docs.cask.co/" target="_blank">Documentation</a></h3>
     <ul class="this-page-menu">
-        <li><a href="http://docs.cask.co/cdap/index.html" target="_blank">CDAP</a></li>
-        <li><a href="http://docs.cask.co/coopr/index.html" target="_blank">Coopr</a></li>
-        <li><a href="http://docs.cask.co/tigon/index.html" target="_blank">Tigon</a></li>
+        <li><a href="//docs.cask.co/cdap/index.html" target="_blank">CDAP</a></li>
+        <li><a href="//docs.cask.co/coopr/index.html" target="_blank">Coopr</a></li>
+        <li><a href="//docs.cask.co/tigon/index.html" target="_blank">Tigon</a></li>
     </ul>
 </div>

--- a/cdap-docs/_common/_themes/cdap/downloads.html
+++ b/cdap-docs/_common/_themes/cdap/downloads.html
@@ -6,10 +6,10 @@
 #}
 {%- set zip_archive = "cdap-docs-" ~ release ~ "-web.zip" %}
   <div role="note" aria-label="downloads links">
-    <h3><a href="http://docs.cask.co/cdap/{{ release }}/{{ zip_archive }}"
+    <h3><a href="//docs.cask.co/cdap/{{ release }}/{{ zip_archive }}"
             rel="nofollow">Download</a></h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/cdap/{{ release }}/{{ zip_archive }}"
+      <li><a href="//docs.cask.co/cdap/{{ release }}/{{ zip_archive }}"
             rel="nofollow">Zip Archive of CDAP Documentation</a></li>
     </ul>
    </div>

--- a/cdap-docs/_common/_themes/cdap/layout.html
+++ b/cdap-docs/_common/_themes/cdap/layout.html
@@ -30,7 +30,7 @@
     <div class="related" role="navigation" aria-label="related navigation">
       <h3>{{ _('Navigation') }}</h3>
       <ul>
-        <li class="headerlogo"><a href="http://docs.cask.co/cdap"><img class="headerlogo" src="{{ pathto('_static/doc_logo.png', 1) }}" alt="Logo"/></a></li>
+        <li class="headerlogo"><a href="//docs.cask.co/cdap"><img class="headerlogo" src="{{ pathto('_static/doc_logo.png', 1) }}" alt="Logo"/></a></li>
         {%- block rootrellink %}
         <script type="text/javascript" src="{{ pathto('_static/version-menu.js', 1) }}"></script>
         <script src="{{ theme_json_versions_js }}"/></script>

--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -19,7 +19,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  * 
- * Requires a JSONP file at http://docs.cask.co/cdap/json-versions.js in the format:
+ * Requires a JSONP file at docs.cask.co/cdap/json-versions.js in the format:
  * 
  * versionscallback({
  *  'development': [['3.5.0-SNAPSHOT', '3.5.0', '', '1']], 
@@ -45,7 +45,7 @@
  */
 
 (function() {
-  var versionsURL = 'http://docs.cask.co/cdap/';
+  var versionsURL = '//docs.cask.co/cdap/';
   var versionID = 'select-version';
   var buildURL = (function(dir){
     var en = location.pathname.indexOf('/en/');

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -261,7 +261,7 @@ extlinks = {
     'cdap-java-source-github': (cdap_java_source_github_pattern , None),
     'cdap-security-extn-source-github': (cdap_security_extn_github_pattern, None),
     'cask-issue': ('https://issues.cask.co/browse/%s', ''),
-    'cask-repository-parcels-cdap': ("http://repository.cask.co/parcels/cdap/%s/%%s" % short_version, None),
+    'cask-repository-parcels-cdap': ("https://repository.cask.co/parcels/cdap/%s/%%s" % short_version, None),
     'cdap-guides': (cdap_guides_github_pattern, None),
     'spark-docs': ("https://spark.apache.org/docs/%s/%%s" % spark_version, None),
     'github-hydrator-plugins': (hydrator_plugins_github_pattern, None),

--- a/cdap-docs/_common/tabbed-parsed-literal.py
+++ b/cdap-docs/_common/tabbed-parsed-literal.py
@@ -80,14 +80,14 @@ Examples:
     $ cdap cli start flow HelloWorld.WhoFlow
     Successfully started flow 'WhoFlow' of application 'HelloWorld' with stored runtime arguments '{}'
     
-    $ curl -o /etc/yum.repos.d/cask.repo http://repository.cask.co/centos/6/x86_64/cdap/|short-version|/cask.repo
+    $ curl -o /etc/yum.repos.d/cask.repo https://repository.cask.co/centos/6/x86_64/cdap/|short-version|/cask.repo
     
     .. Windows
     
     > cdap.bat cli start flow HelloWorld.WhoFlow
     Successfully started flow 'WhoFlow' of application 'HelloWorld' with stored runtime arguments '{}'
 
-    > <CDAP-SDK-HOME>\libexec\bin\curl.exe -d c:\|release| -X POST 'http://repository.cask.co/centos/6/x86_64/cdap/|short-version|/cask.repo'
+    > <CDAP-SDK-HOME>\libexec\bin\curl.exe -d c:\|release| -X POST 'https://repository.cask.co/centos/6/x86_64/cdap/|short-version|/cask.repo'
 
 If you pass a single set of commands, without comments, the directive will create a
 two-tabbed "Linux" and "Windows" with a generated Windows-equivalent command set. Check
@@ -100,7 +100,7 @@ strings in the commands must be on a single line to convert successfully.
     $ cdap cli start flow HelloWorld.WhoFlow
     Successfully started flow 'WhoFlow' of application 'HelloWorld' with stored runtime arguments '{}'
     
-    $ curl -o /etc/yum.repos.d/cask.repo http://repository.cask.co/centos/6/x86_64/cdap/|short-version|/cask.repo
+    $ curl -o /etc/yum.repos.d/cask.repo https://repository.cask.co/centos/6/x86_64/cdap/|short-version|/cask.repo
     
 .. tabbed-parsed-literal::
     :copyable:

--- a/cdap-docs/admin-manual/source/_includes/installation/installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/installation.txt
@@ -41,7 +41,7 @@ This will create the file ``/etc/yum.repos.d/cask.repo`` with:
 .. parsed-literal::
   [cask]
   name=Cask Packages
-  baseurl=http://repository.cask.co/centos/6/x86_64/cdap/|short-version|
+  baseurl=https://repository.cask.co/centos/6/x86_64/cdap/|short-version|
   enabled=1
   gpgcheck=1
 

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -293,7 +293,7 @@ cm_ig_parcels.html>`__, but in summary these are the steps:
 
   .. parsed-literal::
 
-    \http://repository.cask.co/parcels/cdap/|short-version|\ /manifest.json
+    \https://repository.cask.co/parcels/cdap/|short-version|\ /manifest.json
 
 
 Installing CDAP Services

--- a/cdap-docs/admin-manual/source/installation/emr.rst
+++ b/cdap-docs/admin-manual/source/installation/emr.rst
@@ -100,7 +100,7 @@ Using the Create Cluster Wizard
    
      .. parsed-literal::
    
-       instance.isMaster=true "curl \http://downloads.cask.co/emr/install-|release|.sh | sudo bash -s"
+       instance.isMaster=true "curl \https://downloads.cask.co/emr/install-|release|.sh | sudo bash -s"
 
    .. figure:: ../_images/emr/emr-step3b-bootstrap-action-run-if.png
       :figwidth: 100%

--- a/cdap-docs/developers-manual/source/getting-started/quick-start.rst
+++ b/cdap-docs/developers-manual/source/getting-started/quick-start.rst
@@ -84,13 +84,13 @@ GitHub. If you download the zip file, then the artifact is already built and pac
   .. Linux
 
   $ cd <CDAP-SDK-HOME>
-  $ curl -w"\n" -O -X GET "http://repository.cask.co/downloads/co/cask/cdap/apps/|cdap-apps-version|/cdap-wise-|cdap-apps-version|.zip"
+  $ curl -w"\n" -O -X GET "https://repository.cask.co/downloads/co/cask/cdap/apps/|cdap-apps-version|/cdap-wise-|cdap-apps-version|.zip"
   $ unzip cdap-wise-|cdap-apps-version|.zip
 
   .. Windows
   
   > cd <CDAP-SDK-HOME>
-  > curl -O -X GET "http://repository.cask.co/downloads/co/cask/cdap/apps/|cdap-apps-version|/cdap-wise-|cdap-apps-version|.zip"
+  > curl -O -X GET "https://repository.cask.co/downloads/co/cask/cdap/apps/|cdap-apps-version|/cdap-wise-|cdap-apps-version|.zip"
   > jar xf cdap-wise-|cdap-apps-version|.zip
 
             

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -1250,7 +1250,7 @@ Building Real World Applications
          .. tabbed-parsed-literal::
       
             $ cd cdap-sdk-|release|/examples
-            $ curl -O http://repository.cask.co/downloads/co/cask/cdap/apps/|cdap-apps-version|/cdap-wise-|cdap-apps-version|.zip
+            $ curl -O https://repository.cask.co/downloads/co/cask/cdap/apps/|cdap-apps-version|/cdap-wise-|cdap-apps-version|.zip
             $ unzip cdap-wise-|cdap-apps-version|.zip
 
          From within the CDAP CLI:

--- a/cdap-docs/tools/docs-search-deprecated.py
+++ b/cdap-docs/tools/docs-search-deprecated.py
@@ -17,7 +17,7 @@
 #
 #
 # Reads in the Javadocs pages
-# (at http://docs.cask.co/cdap/<release-version>/en/reference-manual/javadocs/deprecated-list.html);
+# (at docs.cask.co/cdap/<release-version>/en/reference-manual/javadocs/deprecated-list.html);
 # extracts all of the listed deprecated items, and then searches in the Java, text, and
 # ReST files of the examples and the documentation for any usage. 
 #
@@ -44,15 +44,15 @@ def parse_options():
         usage="%prog [release]",
         description="Searches for deprecated items in documentation ('cdap-docs') and examples ('cdap-examples'). "
             "If no release is specified, 'current' is used instead. "
-            "Uses the lists at 'http://docs.cask.co/cdap/[release]/en/reference-manual/javadocs/deprecated-list.html' "
-            "and at 'http://docs.cask.co/cdap/json-versions.js'")
+            "Uses the lists at 'docs.cask.co/cdap/[release]/en/reference-manual/javadocs/deprecated-list.html' "
+            "and at 'docs.cask.co/cdap/json-versions.js'")
 
     (options, args) = parser.parse_args()
 
     return options, args, parser
 
 def load_json_versions(release):
-    json_versions_url = 'http://docs.cask.co/cdap/json-versions.js'
+    json_versions_url = '//docs.cask.co/cdap/json-versions.js'
     page = urllib2.urlopen(json_versions_url).read().strip()
     if page.startswith(r'versionscallback('):
         page = page[len(r'versionscallback('):]
@@ -77,7 +77,7 @@ def load_deprecated_items(release):
     deprecated_items = dict()
     longest = 0
     for version in versions:
-        deprecated_url = "http://docs.cask.co/cdap/%s/en/reference-manual/javadocs/deprecated-list.html" % version
+        deprecated_url = "//docs.cask.co/cdap/%s/en/reference-manual/javadocs/deprecated-list.html" % version
         deprecated_version = _load_deprecated_items(deprecated_url)
         for deprecated in deprecated_version:
             signatures = deprecated_version[deprecated]

--- a/cdap-docs/tools/sitemap-xml.py
+++ b/cdap-docs/tools/sitemap-xml.py
@@ -152,7 +152,7 @@ def write_sitemap(sitemap, output, version, compare=False):
     sitemap_urls = ''
     unique_files = []
     for fileURL in sitemap:
-        sitemap_urls += SITEMAP_URL_TEMPLATE % ("http://docs.cask.co/cdap/%s%s" % (version, fileURL.path_fragment))
+        sitemap_urls += SITEMAP_URL_TEMPLATE % ("//docs.cask.co/cdap/%s%s" % (version, fileURL.path_fragment))
         if compare and fileURL.path.endswith('.html'):
             md5_hash = fileURL.generate_md5()
             if md5_hash not in unique_files:

--- a/cdap-ui/README.rst
+++ b/cdap-ui/README.rst
@@ -57,29 +57,29 @@ Release Notes
 
 New Features
 ------------
-* `CDAP-9523 <http://issues.cask.co/browse/CDAP-9523>`__ - Added point-and-click interaction for extracting text from a column using Regex Groups
-* `CDAP-9515 <http://issues.cask.co/browse/CDAP-9515>`__ - Added point-and-click interaction for exploding data in a row into multiple rows
-* `CDAP-9514 <http://issues.cask.co/browse/CDAP-9514>`__ - Added point-and-click interaction for swapping and merging columns
-* `CDAP-9510 <http://issues.cask.co/browse/CDAP-9510>`__ - Added point-and-click interaction for changing column name
-* `CDAP-9507 <http://issues.cask.co/browse/CDAP-9507>`__ - Added point-and-click interaction for formatting data
+* `CDAP-9523 <https://issues.cask.co/browse/CDAP-9523>`__ - Added point-and-click interaction for extracting text from a column using Regex Groups
+* `CDAP-9515 <https://issues.cask.co/browse/CDAP-9515>`__ - Added point-and-click interaction for exploding data in a row into multiple rows
+* `CDAP-9514 <https://issues.cask.co/browse/CDAP-9514>`__ - Added point-and-click interaction for swapping and merging columns
+* `CDAP-9510 <https://issues.cask.co/browse/CDAP-9510>`__ - Added point-and-click interaction for changing column name
+* `CDAP-9507 <https://issues.cask.co/browse/CDAP-9507>`__ - Added point-and-click interaction for formatting data
 
 Improvements
 ------------
-* `CDAP-9541 <http://issues.cask.co/browse/CDAP-9541>`__ - Improved styling of column directive dropdown icon
-* `CDAP-9441 <http://issues.cask.co/browse/CDAP-9441>`__ - Rephrased message when a user is not authorized to access any namespace
-* `CDAP-9415 <http://issues.cask.co/browse/CDAP-9415>`__ - Switched from font icons to SVGs on the home page for better loading of images
-* `CDAP-9394 <http://issues.cask.co/browse/CDAP-9394>`__ - Added an exact/whole world match option for find and replace
-* `CDAP-9255 <http://issues.cask.co/browse/CDAP-9255>`__ - When there are no nodes on the studio, disabled certain actions
+* `CDAP-9541 <https://issues.cask.co/browse/CDAP-9541>`__ - Improved styling of column directive dropdown icon
+* `CDAP-9441 <https://issues.cask.co/browse/CDAP-9441>`__ - Rephrased message when a user is not authorized to access any namespace
+* `CDAP-9415 <https://issues.cask.co/browse/CDAP-9415>`__ - Switched from font icons to SVGs on the home page for better loading of images
+* `CDAP-9394 <https://issues.cask.co/browse/CDAP-9394>`__ - Added an exact/whole world match option for find and replace
+* `CDAP-9255 <https://issues.cask.co/browse/CDAP-9255>`__ - When there are no nodes on the studio, disabled certain actions
 
 Bug Fixes
 ---------
-* `CDAP-10488 <http://issues.cask.co/browse/CDAP-10488>`__ - Made it easier to delete an action plugin easily from Studio
-* `CDAP-10312 <http://issues.cask.co/browse/CDAP-10312>`__ - Fixed an issue where users could open multiple popovers in dataprep modal in Pipeline studio
-* `CDAP-9596 <http://issues.cask.co/browse/CDAP-9596>`__ - Fixed the parsing of search results in the metadata view
-* `CDAP-9445 <http://issues.cask.co/browse/CDAP-9445>`__ - Renaming a column to an existing column should show a warning to users
-* `CDAP-9175 <http://issues.cask.co/browse/CDAP-9175>`__ - Fixed the realtime stream source to have a view details button
-* `CDAP-9051 <http://issues.cask.co/browse/CDAP-9051>`__ - Fixed the help for parse-as-json
-* `CDAP-8963 <http://issues.cask.co/browse/CDAP-8963>`__ - Handled boolean values correctly while previewing explore results
+* `CDAP-10488 <https://issues.cask.co/browse/CDAP-10488>`__ - Made it easier to delete an action plugin easily from Studio
+* `CDAP-10312 <https://issues.cask.co/browse/CDAP-10312>`__ - Fixed an issue where users could open multiple popovers in dataprep modal in Pipeline studio
+* `CDAP-9596 <https://issues.cask.co/browse/CDAP-9596>`__ - Fixed the parsing of search results in the metadata view
+* `CDAP-9445 <https://issues.cask.co/browse/CDAP-9445>`__ - Renaming a column to an existing column should show a warning to users
+* `CDAP-9175 <https://issues.cask.co/browse/CDAP-9175>`__ - Fixed the realtime stream source to have a view details button
+* `CDAP-9051 <https://issues.cask.co/browse/CDAP-9051>`__ - Fixed the help for parse-as-json
+* `CDAP-8963 <https://issues.cask.co/browse/CDAP-8963>`__ - Handled boolean values correctly while previewing explore results
 
 
 
@@ -173,38 +173,38 @@ Release Notes
 
 New Features
 ------------
-* `HYDRATOR-163 <http://issues.cask.co/browse/HYDRATOR-163>`__ - Add Placeholders to input boxes in node configuration
-* `WRANGLER-77 <http://issues.cask.co/browse/WRANGLER-77>`__ - Added a dropdown on each column to provide click-through experience for directives in Data Preparation
-* `WRANGLER-49 <http://issues.cask.co/browse/WRANGLER-49>`__ - Added click-through experience for split column directive in Data Preparation
-* `WRANGLER-54 <http://issues.cask.co/browse/WRANGLER-54>`__ - Added click-through experience for filling null or empty cells in Data Preparation
+* `HYDRATOR-163 <https://issues.cask.co/browse/HYDRATOR-163>`__ - Add Placeholders to input boxes in node configuration
+* `WRANGLER-77 <https://issues.cask.co/browse/WRANGLER-77>`__ - Added a dropdown on each column to provide click-through experience for directives in Data Preparation
+* `WRANGLER-49 <https://issues.cask.co/browse/WRANGLER-49>`__ - Added click-through experience for split column directive in Data Preparation
+* `WRANGLER-54 <https://issues.cask.co/browse/WRANGLER-54>`__ - Added click-through experience for filling null or empty cells in Data Preparation
 
 Improvements
 ------------
-* `CDAP-8501 <http://issues.cask.co/browse/CDAP-8501>`__ - Disabled preview button on clusters since preview is not supported in distributed env
-* `CDAP-8861 <http://issues.cask.co/browse/CDAP-8861>`__ - Removed CDAP Version Range in market entities display
-* `CDAP-8430 <http://issues.cask.co/browse/CDAP-8430>`__ - Improved "No Entities Found" message in the Overview to show Call(s) to Action
-* `CDAP-8403 <http://issues.cask.co/browse/CDAP-8403>`__ - Added labels to CDAP Studio actions
-* `CDAP-8900 <http://issues.cask.co/browse/CDAP-8900>`__ - Added the ability to update to a newer version of data preparation libraries if available
-* `CDAP-7352 <http://issues.cask.co/browse/CDAP-7352>`__ - Made logviewer header row sticky
-* `CDAP-4798 <http://issues.cask.co/browse/CDAP-4798>`__ - Improved user experience in explore page
-* `CDAP-8964 <http://issues.cask.co/browse/CDAP-8964>`__ - Made Output Schema for sinks macro enabled
-* `HYDRATOR-1364 <http://issues.cask.co/browse/HYDRATOR-1364>`__ - Removed most of the "__ui__" field
-* `CDAP-8494 <http://issues.cask.co/browse/CDAP-8494>`__ - Fixed browser back button after switching to classic UI
-* `CDAP-8828 <http://issues.cask.co/browse/CDAP-8828>`__ - Removed dialog to select pipeline type upon pipeline creation
-* `CDAP-8396 <http://issues.cask.co/browse/CDAP-8396>`__ - Added call to action for namespace creation
+* `CDAP-8501 <https://issues.cask.co/browse/CDAP-8501>`__ - Disabled preview button on clusters since preview is not supported in distributed env
+* `CDAP-8861 <https://issues.cask.co/browse/CDAP-8861>`__ - Removed CDAP Version Range in market entities display
+* `CDAP-8430 <https://issues.cask.co/browse/CDAP-8430>`__ - Improved "No Entities Found" message in the Overview to show Call(s) to Action
+* `CDAP-8403 <https://issues.cask.co/browse/CDAP-8403>`__ - Added labels to CDAP Studio actions
+* `CDAP-8900 <https://issues.cask.co/browse/CDAP-8900>`__ - Added the ability to update to a newer version of data preparation libraries if available
+* `CDAP-7352 <https://issues.cask.co/browse/CDAP-7352>`__ - Made logviewer header row sticky
+* `CDAP-4798 <https://issues.cask.co/browse/CDAP-4798>`__ - Improved user experience in explore page
+* `CDAP-8964 <https://issues.cask.co/browse/CDAP-8964>`__ - Made Output Schema for sinks macro enabled
+* `HYDRATOR-1364 <https://issues.cask.co/browse/HYDRATOR-1364>`__ - Removed most of the "__ui__" field
+* `CDAP-8494 <https://issues.cask.co/browse/CDAP-8494>`__ - Fixed browser back button after switching to classic UI
+* `CDAP-8828 <https://issues.cask.co/browse/CDAP-8828>`__ - Removed dialog to select pipeline type upon pipeline creation
+* `CDAP-8396 <https://issues.cask.co/browse/CDAP-8396>`__ - Added call to action for namespace creation
 
 Bug Fixes
 ---------
-* `CDAP-8554 <http://issues.cask.co/browse/CDAP-8554>`__ - Fixed styling issues while showing Call(s) to actions in Application create wizard
-* `CDAP-8412 <http://issues.cask.co/browse/CDAP-8412>`__ - Fixed overflow in namespace creation confirmation modal
-* `CDAP-8433 <http://issues.cask.co/browse/CDAP-8433>`__ - Added units for memory for YARN stats on management page
-* `CDAP-8950 <http://issues.cask.co/browse/CDAP-8950>`__ - Fixed link from stream overview to stream deatils
-* `CDAP-8933 <http://issues.cask.co/browse/CDAP-8933>`__ - Added namespace name to the No entities found message
-* `CDAP-8461 <http://issues.cask.co/browse/CDAP-8461>`__ - Clicking back from the Detail page view now opens the overview page with the overview pane opened
-* `CDAP-8638 <http://issues.cask.co/browse/CDAP-8638>`__ - Opened each log in a new tab
-* `CDAP-8668 <http://issues.cask.co/browse/CDAP-8668>`__ - Fixed UI to show ERROR, WARN and INFO logs by default
-* `CDAP-8965 <http://issues.cask.co/browse/CDAP-8965>`__ - Removed Wrangle button from Wrangler Transform. Please use the Data Preparation UI for wrangling.
-* `HYDRATOR-1419 <http://issues.cask.co/browse/HYDRATOR-1419>`__ - Fixed browser back button behavior after switching namespace
+* `CDAP-8554 <https://issues.cask.co/browse/CDAP-8554>`__ - Fixed styling issues while showing Call(s) to actions in Application create wizard
+* `CDAP-8412 <https://issues.cask.co/browse/CDAP-8412>`__ - Fixed overflow in namespace creation confirmation modal
+* `CDAP-8433 <https://issues.cask.co/browse/CDAP-8433>`__ - Added units for memory for YARN stats on management page
+* `CDAP-8950 <https://issues.cask.co/browse/CDAP-8950>`__ - Fixed link from stream overview to stream deatils
+* `CDAP-8933 <https://issues.cask.co/browse/CDAP-8933>`__ - Added namespace name to the No entities found message
+* `CDAP-8461 <https://issues.cask.co/browse/CDAP-8461>`__ - Clicking back from the Detail page view now opens the overview page with the overview pane opened
+* `CDAP-8638 <https://issues.cask.co/browse/CDAP-8638>`__ - Opened each log in a new tab
+* `CDAP-8668 <https://issues.cask.co/browse/CDAP-8668>`__ - Fixed UI to show ERROR, WARN and INFO logs by default
+* `CDAP-8965 <https://issues.cask.co/browse/CDAP-8965>`__ - Removed Wrangle button from Wrangler Transform. Please use the Data Preparation UI for wrangling.
+* `HYDRATOR-1419 <https://issues.cask.co/browse/HYDRATOR-1419>`__ - Fixed browser back button behavior after switching namespace
 
 
 ======================


### PR DESCRIPTION
- docs
  - Remove protocol (use `//docs.cask.co`) in JavaScript/HTML in `cdap-docs`
- downloads/issues/repository
  - Switch all `http://` use to `https://`