### PR TITLE
Update to JDK8 and use Flume Agent from HDP 2.5.3

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -149,11 +149,11 @@
         },
         "hadoop": {
           "distribution": "hdp",
-          "distribution_version": "2.1.7.0"
+          "distribution_version": "2.5.3.0"
         },
         "java": {
           "install_flavor": "openjdk",
-          "jdk_version": 7
+          "jdk_version": 8
         }
       },
       "only": ["cdap-sdk-vm"]

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -16,6 +16,6 @@
   },
   "java": {
     "install_flavor": "openjdk",
-    "jdk_version": 7
+    "jdk_version": 8
   }
 }

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -13,6 +13,6 @@
   },
   "java": {
     "install_flavor": "openjdk",
-    "jdk_version": 7
+    "jdk_version": 8
   }
 }


### PR DESCRIPTION
Switches the VM and Docker to use JDK8 (they use the same configuration). This is needed due to #8801 and upgrading Eclipse to Neon 3.

Also, bumping Flume Agent to HDP 2.5.3 version, for JDK8 support.