### PR TITLE
Fixing pipeline deployment

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -289,7 +289,7 @@ public class ArtifactStore {
 
       ArtifactData data = GSON.fromJson(Bytes.toString(columnEntry.getValue()), ArtifactData.class);
       ArtifactId artifactId = new ArtifactId(artifactKey.name, new ArtifactVersion(version),
-                                             artifactKey.namespace.equals(NamespaceId.SYSTEM) ?
+                                             artifactKey.namespace.equals(NamespaceId.SYSTEM.getNamespace()) ?
                                                ArtifactScope.SYSTEM : ArtifactScope.USER);
       queue.add(new ArtifactDetail(
         new ArtifactDescriptor(artifactId, Locations.getLocationFromAbsolutePath(locationFactory,


### PR DESCRIPTION
Namespace comparison was not being correctly handled after it
was changed from an entity to a string.