### PR TITLE
CDAP-11549 Proper Propagate TransactionFailureException

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/Transactionals.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Transactionals.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api;
+
+import co.cask.cdap.api.data.DatasetContext;
+import org.apache.tephra.TransactionFailureException;
+
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Helper class for interacting with {@link Transactional}
+ */
+public final class Transactionals {
+
+  private Transactionals() {
+  }
+
+  /**
+   * Executes the given {@link TxRunnable} using the given {@link Transactional}.
+   *
+   * @param transactional the {@link Transactional} to use for transactional execution.
+   * @param runnable the {@link TxRunnable} to be executed inside a transaction
+   * @throws RuntimeException if failed to execute the given {@link TxRunnable} in a transaction.
+   * If the TransactionFailureException has a cause in it, the cause is propagated.
+   */
+  public static void execute(Transactional transactional, final TxRunnable runnable) {
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          runnable.run(context);
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw propagate(e);
+    }
+  }
+
+  /**
+   * Executes the given {@link TxRunnable} using the given {@link Transactional}.
+   *
+   * @param transactional the {@link Transactional} to use for transactional execution.
+   * @param runnable the {@link TxRunnable} to be executed inside a transaction
+   * @param <X> exception type of propagate type
+   * @throws X if failed to execute the given {@link TxRunnable} in a transaction. If the TransactionFailureException
+   * has a cause in it, the cause is thrown as-is if it is an instance of X.
+   * @throws RuntimeException if cause is not an instance of X. The cause is wrapped with {@link RuntimeException}
+   * if it is not already a {@link RuntimeException}.
+   */
+  public static <X extends Throwable> void execute(Transactional transactional,
+                                                   final TxRunnable runnable, Class<X> exception) throws X {
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          runnable.run(context);
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw propagate(e, exception);
+    }
+  }
+
+  /**
+   * Executes the given {@link TxRunnable} using the given {@link Transactional}.
+   *
+   * @param transactional the {@link Transactional} to use for transactional execution.
+   * @param runnable the {@link TxRunnable} to be executed inside a transaction
+   * @param <X1> exception type of first propagate type
+   * @param <X2> exception type of second propagate type
+   * @throws X1 if failed to execute the given {@link TxRunnable} in a transaction. If the
+   * TransactionFailureException has a cause in it, the cause is thrown as-is if it is an instance of X1.
+   * @throws X2 if failed to execute the given {@link TxRunnable} in a transaction. If the
+   * TransactionFailureException has a cause in it, the cause is thrown as-is if it is an instance of X2.
+   * @throws RuntimeException if cause is not an instance of X1 or X2. The cause is wrapped with
+   * {@link RuntimeException} if it is not already a {@link RuntimeException}.
+   */
+  public static <X1 extends Throwable, X2 extends Throwable>
+  void execute(Transactional transactional, final TxRunnable runnable, Class<X1> exception1,
+               Class<X2> exception2) throws X1, X2 {
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          runnable.run(context);
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw propagate(e, exception1, exception2);
+    }
+  }
+
+  /**
+   * Executes the given {@link TxCallable} using the given {@link Transactional}.
+   * @param transactional the {@link Transactional} to use for transactional execution.
+   * @param callable the {@link TxCallable} to be executed inside a transaction
+   * @param <V> type of the result
+   * @return value returned by the given {@link TxCallable}.
+   * @throws  RuntimeException if failed to execute the given {@link TxRunnable} in a transaction.
+   * If the TransactionFailureException has a cause in it, the cause is propagated.
+   */
+  public static <V> V execute(Transactional transactional, final TxCallable<V> callable) {
+    final AtomicReference<V> result = new AtomicReference<>();
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          result.set(callable.call(context));
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw propagate(e);
+    }
+    return result.get();
+  }
+
+  /**
+   * Executes the given {@link TxCallable} using the given {@link Transactional}.
+   *
+   * @param transactional the {@link Transactional} to use for transactional execution.
+   * @param callable the {@link TxCallable} to be executed inside a transaction
+   * @param <V> type of the result
+   * @param <X> exception type of propagate type
+   * @return value returned by the given {@link TxCallable}.
+   * @throws X if failed to execute the given {@link TxRunnable} in a transaction. If the TransactionFailureException
+   * has a cause in it, the cause is thrown as-is if it is an instance of X.
+   * @throws RuntimeException if cause is not an instance of X. The cause is wrapped with {@link RuntimeException}
+   * if it is not already a {@link RuntimeException}.
+   */
+  public static <V, X extends Throwable> V execute(Transactional transactional,
+                              final TxCallable<V> callable, Class<X> exception) throws X {
+    final AtomicReference<V> result = new AtomicReference<>();
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          result.set(callable.call(context));
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw propagate(e, exception);
+    }
+    return result.get();
+  }
+
+  /**
+   * Executes the given {@link TxCallable} using the given {@link Transactional}.
+   *
+   * @param transactional the {@link Transactional} to use for transactional execution.
+   * @param callable the {@link TxCallable} to be executed inside a transaction
+   * @param <V> type of the result
+   * @param <X1> exception type of first propagate type
+   * @param <X2> exception type of second propagate type
+   * @return value returned by the given {@link TxCallable}.
+   * @throws X1 if failed to execute the given {@link TxRunnable} in a transaction. If the
+   * TransactionFailureException has a cause in it, the cause is thrown as-is if it is an instance of X1.
+   * @throws X2 if failed to execute the given {@link TxRunnable} in a transaction. If the
+   * TransactionFailureException has a cause in it, the cause is thrown as-is if it is an instance of X2.
+   * @throws RuntimeException if cause is not an instance of X1 or X2. The cause is wrapped with
+   * {@link RuntimeException} if it is not already a {@link RuntimeException}.
+   */
+  public static <V, X1 extends Throwable, X2 extends Throwable> V execute(
+    Transactional transactional, final TxCallable<V> callable,
+    Class<X1> exception1, Class<X2> exception2) throws X1, X2 {
+    final AtomicReference<V> result = new AtomicReference<>();
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          result.set(callable.call(context));
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw propagate(e, exception1, exception2);
+    }
+    return result.get();
+  }
+
+  /**
+   * Propagates {@code throwable} as-is if it is an instance of
+   * {@link RuntimeException} or {@link Error}, or else as a last resort, wraps
+   * it in a {@code RuntimeException} then propagates.
+   * @param throwable the Throwable to propagate
+   * @return nothing will ever be returned; this return type is only for convenience
+   */
+  private static RuntimeException propagate(Throwable throwable) {
+    propagateIfPossible(requireNonNull(throwable));
+    throw new RuntimeException(throwable);
+  }
+
+  /**
+   * Propagates the given {@link TransactionFailureException}. If the {@link TransactionFailureException#getCause()}
+   * doesn't return {@code null}, the cause will be used instead for the propagation. This method will
+   * throw the failure exception as-is the given propagated type if the type matches or as {@link RuntimeException}.
+   * This method will always throw exception and the returned exception is for satisfying Java static analysis only.
+   *
+   * @param e the {@link TransactionFailureException} to propagate
+   * @param propagateType if the exception is an instance of this type, it will be rethrown as is
+   * @param <X> exception type of propagate type
+   * @return a exception of type X.
+   */
+  public static <X extends Throwable> X propagate(TransactionFailureException e, Class<X> propagateType) throws X {
+    Throwable cause = firstNonNull(e.getCause(), e);
+    propagateIfPossible(cause, propagateType);
+    throw propagate(cause);
+  }
+
+  /**
+   * Propagates the given {@link TransactionFailureException}. If the {@link TransactionFailureException#getCause()}
+   * doesn't return {@code null}, the cause will be used instead for the propagation. This method will
+   * throw the failure exception as-is the given propagated types if the type matches or as {@link RuntimeException}.
+   * This method will always throw and the returned exception is for satisfying Java static analysis only.
+   *
+   * @param e the {@link TransactionFailureException} to propagate
+   * @param propagateType1 if the exception is an instance of this type, it will be rethrown as is
+   * @param propagateType2 if the exception is an instance of this type, it will be rethrown as is
+   * @param <X1> exception type of first propagate type
+   * @param <X2> exception type of second propagate type
+   * @return a exception of type X1,X2.
+   */
+  public static <X1 extends Throwable, X2 extends Throwable> X1 propagate(TransactionFailureException e,
+                                                                          Class<X1> propagateType1,
+                                                                          Class<X2> propagateType2) throws X1, X2 {
+    Throwable cause = firstNonNull(e.getCause(), e);
+    propagateIfPossible(cause, propagateType1, propagateType2);
+    throw propagate(cause);
+  }
+
+  /**
+   * Propagates {@code throwable} exactly as-is, if and only if it is an
+   * instance of {@link RuntimeException} or {@link Error}.
+   */
+  private static void propagateIfPossible(@Nullable Throwable throwable) {
+    propagateIfInstanceOf(throwable, Error.class);
+    propagateIfInstanceOf(throwable, RuntimeException.class);
+  }
+
+  /**
+   * Propagates {@code throwable} exactly as-is, if and only if it is an
+   * instance of {@link RuntimeException}, {@link Error}, or
+   * {@code declaredType}.
+   * @param throwable the Throwable to possibly propagate
+   * @param declaredType the single checked exception type declared by the calling method
+   */
+  private static <X extends Throwable> void propagateIfPossible(
+    @Nullable Throwable throwable, Class<X> declaredType) throws X {
+    propagateIfInstanceOf(throwable, declaredType);
+    propagateIfPossible(throwable);
+  }
+
+  /**
+   * Propagates {@code throwable} exactly as-is, if and only if it is an
+   * instance of {@link RuntimeException}, {@link Error}, {@code declaredType1},
+   * or {@code declaredType2}.
+   * @param throwable the Throwable to possibly propagate
+   * @param declaredType1 any checked exception type declared by the calling
+   *     method
+   * @param declaredType2 any other checked exception type declared by the
+   *     calling method
+   */
+  private static <X1 extends Throwable, X2 extends Throwable>
+  void propagateIfPossible(@Nullable Throwable throwable,
+                           Class<X1> declaredType1, Class<X2> declaredType2) throws X1, X2 {
+    requireNonNull(declaredType2);
+    propagateIfInstanceOf(throwable, declaredType1);
+    propagateIfPossible(throwable, declaredType2);
+  }
+
+  /**
+   * Propagates {@code throwable} exactly as-is, if and only if it is an
+   * instance of {@code declaredType}.
+   */
+  private static <X extends Throwable> void propagateIfInstanceOf(
+    @Nullable Throwable throwable, Class<X> declaredType) throws X {
+    if (throwable != null && declaredType.isInstance(throwable)) {
+      throw declaredType.cast(throwable);
+    }
+  }
+
+  /**
+   * Returns the first of two given parameters that is not {@code null}, if
+   * either is, or otherwise throws a {@link NullPointerException}.
+   */
+  private static <T> T firstNonNull(@Nullable T first, @Nullable T second) {
+    return first != null ? first : requireNonNull(second);
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/TxCallable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/TxCallable.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.Dataset;
+
+/**
+ * A callable that provides a {@link DatasetContext} to programs which may be used to get
+ * access to and use datasets.
+ *
+ * @param <V> type of the return value from the {@link #call(DatasetContext)}.
+ *
+ */
+public interface TxCallable<V> {
+  /**
+   * Provides a {@link DatasetContext} to get instances of {@link Dataset}s.
+   *
+   * <p>
+   *   Operations executed on a dataset within the execution of this method are committed as a single transaction.
+   *   The transaction is started before this method is invoked and is committed upon successful execution.
+   *   Exceptions thrown while committing the transaction or thrown by user-code result in a rollback of the
+   *   transaction.
+   * </p>
+   *
+   * @param context to get datasets from
+   * @return return value of the call method
+   */
+  V call(DatasetContext context) throws Exception;
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.datastreams;
 
+import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.schema.Schema;
@@ -93,13 +94,14 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
 
       // there isn't any way to instantiate the fileset except in a TxRunnable, so need to use a reference.
       final AtomicReference<Location> checkpointBaseRef = new AtomicReference<>();
-      sec.execute(new TxRunnable() {
+      Transactionals.execute(sec, new TxRunnable() {
         @Override
         public void run(DatasetContext context) throws Exception {
           FileSet checkpointFileSet = context.getDataset(DataStreamsApp.CHECKPOINT_FILESET);
           checkpointBaseRef.set(checkpointFileSet.getBaseLocation());
         }
-      });
+      }, Exception.class);
+
       Location pipelineCheckpointDir = checkpointBaseRef.get().append(pipelineName).append(relativeCheckpointDir);
       checkpointDir = pipelineCheckpointDir.toURI().toString();
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TxLookupProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TxLookupProvider.java
@@ -16,11 +16,11 @@
 package co.cask.cdap.etl.common;
 
 import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.etl.api.Lookup;
 import com.google.common.base.Function;
-import org.apache.tephra.TransactionFailureException;
 
 import java.util.Map;
 import java.util.Set;
@@ -83,18 +83,14 @@ public class TxLookupProvider extends AbstractLookupProvider {
   @Nullable
   private <T, R> R executeLookup(final String table, final Map<String, String> arguments,
                                  final Function<Lookup<T>, R> func) {
-    try {
-      final AtomicReference<R> result = new AtomicReference<>();
-      tx.execute(new TxRunnable() {
-        @Override
-        public void run(DatasetContext context) throws Exception {
-          Lookup<T> lookup = getLookup(table, context.getDataset(table, arguments));
-          result.set(func.apply(lookup));
-        }
-      });
-      return result.get();
-    } catch (TransactionFailureException e) {
-      throw new RuntimeException("Failed to execute transaction", e);
-    }
+    final AtomicReference<R> result = new AtomicReference<>();
+    Transactionals.execute(tx, new TxRunnable() {
+      @Override
+      public void run(DatasetContext context) throws Exception {
+        Lookup<T> lookup = getLookup(table, context.getDataset(table, arguments));
+        result.set(func.apply(lookup));
+      }
+    });
+    return result.get();
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.spark.batch;
 
+import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
@@ -43,6 +44,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.tephra.TransactionFailureException;
 import scala.Tuple2;
 
 import java.io.BufferedReader;
@@ -106,7 +108,7 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
     // Execution the whole pipeline in one long transaction. This is because the Spark execution
     // currently share the same contract and API as the MapReduce one.
     // The API need to expose DatasetContext, hence it needs to be executed inside a transaction
-    sec.execute(this);
+    Transactionals.execute(sec, this, Exception.class);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.spark.streaming;
 
+import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
@@ -41,6 +42,7 @@ import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.apache.spark.streaming.Durations;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.tephra.TransactionFailureException;
 import scala.Tuple2;
 
 import javax.annotation.Nullable;
@@ -108,7 +110,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   public <U> SparkCollection<U> compute(final StageInfo stageInfo, SparkCompute<T, U> compute) throws Exception {
     final SparkCompute<T, U> wrappedCompute =
       new DynamicSparkCompute<>(new DynamicDriverContext(stageInfo, sec), compute);
-    sec.execute(new TxRunnable() {
+    Transactionals.execute(sec, new TxRunnable() {
       @Override
       public void run(DatasetContext datasetContext) throws Exception {
         SparkExecutionPluginContext sparkPluginContext =
@@ -116,7 +118,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
                                                datasetContext, stageInfo);
         wrappedCompute.initialize(sparkPluginContext);
       }
-    });
+    }, Exception.class);
     return wrap(stream.transform(new ComputeTransformFunction<>(sec, stageInfo, wrappedCompute)));
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.spark.streaming;
 
 import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetManagementException;
@@ -73,12 +74,12 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
       LOG.debug("Dataset with name {} already created. Hence not creating the external dataset.", referenceName);
     }
 
-    sec.execute(new TxRunnable() {
+    Transactionals.execute(sec, new TxRunnable() {
       @Override
       public void run(DatasetContext context) throws Exception {
         context.getDataset(referenceName);
       }
-    });
+    }, DatasetManagementException.class);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicSparkCompute.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicSparkCompute.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.spark.streaming.function;
 
+import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
@@ -27,6 +28,7 @@ import co.cask.cdap.etl.spark.function.PluginFunctionContext;
 import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.tephra.TransactionFailureException;
 
 /**
  * This class is required to make sure that macro substitution occurs each time a pipeline is run instead of just
@@ -65,14 +67,14 @@ public class DynamicSparkCompute<T, U> extends SparkCompute<T, U> {
       delegate = pluginFunctionContext.createPlugin();
       final StageInfo stageInfo = pluginFunctionContext.getStageInfo();
       final JavaSparkExecutionContext sec = dynamicDriverContext.getSparkExecutionContext();
-      sec.execute(new TxRunnable() {
+      Transactionals.execute(sec, new TxRunnable() {
         @Override
         public void run(DatasetContext datasetContext) throws Exception {
           SparkExecutionPluginContext sparkPluginContext =
             new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageInfo);
           delegate.initialize(sparkPluginContext);
         }
-      });
+      }, Exception.class);
     }
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/FileMetaDataWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/FileMetaDataWriter.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.logging.meta;
 
 import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.DatasetContext;
@@ -58,15 +59,14 @@ public class FileMetaDataWriter {
                             final Location location) throws Exception {
     LOG.debug("Writing meta data for logging context {} with startTimeMs {} sequence Id {} and location {}",
               identifier.getRowkey(), eventTimeMs, currentTimeMs, location);
-
-    transactional.execute(new TxRunnable() {
+    Transactionals.execute(transactional, new TxRunnable() {
       @Override
       public void run(DatasetContext context) throws Exception {
         Table table = LoggingStoreTableUtil.getMetadataTable(context, datasetManager);
         table.put(getRowKey(identifier, eventTimeMs, currentTimeMs),
                   LoggingStoreTableUtil.META_TABLE_COLUMN_KEY, Bytes.toBytes(location.toURI().getPath()));
       }
-    });
+    }, Exception.class);
   }
 
   private byte[] getRowKey(LogPathIdentifier identifier, long eventTime, long currentTime) {

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/FileMetaDataManager.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/FileMetaDataManager.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.logging.write;
 
 import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.DatasetContext;
@@ -95,15 +96,14 @@ public class FileMetaDataManager {
                              final Location location) throws Exception {
     LOG.debug("Writing meta data for logging context {} as startTimeMs {} and location {}",
               logPartition, startTimeMs, location);
-
-    transactional.execute(new TxRunnable() {
+    Transactionals.execute(transactional, new TxRunnable() {
       @Override
       public void run(DatasetContext context) throws Exception {
         getMetaTable(context).put(getRowKey(logPartition),
                                   Bytes.toBytes(startTimeMs),
                                   Bytes.toBytes(location.toURI().getPath()));
       }
-    });
+    }, Exception.class);
   }
 
   private byte[] getRowKey(String logPartition) {


### PR DESCRIPTION
- Add Transactions methods to TransactionsUtility class in cdap-api.
- Avoid guava dependency because of conflicts with security-spi.
- Handle TransactionFailureException and propagate the cause inside. 