### PR TITLE
[CDAP-11580] Make ScheduleClient backward-compatible

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/schedule/ScheduleSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/schedule/ScheduleSpecification.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.schedule;
 
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
+import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,7 +25,10 @@ import java.util.Map;
 
 /**
  * Specification for {@link Schedule}.
+ *
+ * @deprecated as of 4.2.0. Use {@link ScheduleCreationSpec} instead.
  */
+@Deprecated
 public final class ScheduleSpecification {
   private final Schedule schedule;
   private final ScheduleProgramInfo program;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/Schedulers.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/Schedulers.java
@@ -19,7 +19,6 @@ package co.cask.cdap.internal.app.runtime.schedule.store;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.api.schedule.RunConstraints;
 import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -34,7 +33,6 @@ import co.cask.cdap.internal.schedule.TimeSchedule;
 import co.cask.cdap.internal.schedule.constraint.Constraint;
 import co.cask.cdap.internal.schedule.trigger.Trigger;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.ProtoConstraint;
 import co.cask.cdap.proto.ProtoTrigger;
 import co.cask.cdap.proto.ScheduleDetail;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -50,7 +48,6 @@ import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -136,38 +133,6 @@ public class Schedulers {
         return input == null ? null : input.toScheduleDetail();
       }
     });
-  }
-
-  /**
-   * Convert a list of schedule details to a list of schedule specifications, for backward compatibility.
-   *
-   * Schedules with triggets other than time or stream size triggers are ignored, so are run constraints
-   * other than concurrency consraints (these were not supported by the legacy APIs).
-   */
-  public static List<ScheduleSpecification> toScheduleSpecs(List<ScheduleDetail> details) {
-    List<ScheduleSpecification> specs = new ArrayList<>();
-    for (ScheduleDetail detail : details) {
-      if (detail.getTrigger() instanceof ProtoTrigger.TimeTrigger) {
-        ProtoTrigger.TimeTrigger trigger = ((ProtoTrigger.TimeTrigger) detail.getTrigger());
-        RunConstraints constraints = RunConstraints.NONE;
-        if (detail.getConstraints() != null) {
-          for (Constraint runConstraint : detail.getConstraints()) {
-            if (runConstraint instanceof ProtoConstraint.ConcurrenyConstraint) {
-              constraints = new RunConstraints(
-                ((ProtoConstraint.ConcurrenyConstraint) runConstraint).getMaxConcurrency());
-            }
-          }
-        }
-        specs.add(new ScheduleSpecification(
-          new TimeSchedule(detail.getName(),
-                           detail.getDescription(),
-                           trigger.getCronExpression(),
-                           constraints),
-          detail.getProgram(),
-          detail.getProperties()));
-      }
-    }
-    return specs;
   }
 
   public static StreamSizeSchedule toStreamSizeSchedule(ProgramSchedule schedule) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -29,7 +29,6 @@ import co.cask.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
 import co.cask.cdap.gateway.handlers.WorkflowHttpHandler;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.internal.app.BufferFileInputStream;
-import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
 import co.cask.cdap.internal.schedule.constraint.Constraint;
 import co.cask.cdap.internal.schedule.trigger.Trigger;
 import co.cask.cdap.proto.ApplicationDetail;
@@ -315,7 +314,7 @@ public class AppFabricClient {
   @Deprecated
   public List<ScheduleSpecification> getSchedules(String namespace, String app, String workflow)
     throws NotFoundException {
-    return Schedulers.toScheduleSpecs(getProgramSchedules(namespace, app, workflow));
+    return ScheduleDetail.toScheduleSpecs(getProgramSchedules(namespace, app, workflow));
   }
 
   public WorkflowTokenDetail getWorkflowToken(String namespaceId, String appId, String wflowId, String runId,

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/ListWorkflowSchedulesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/ListWorkflowSchedulesCommand.java
@@ -60,7 +60,7 @@ public final class ListWorkflowSchedulesCommand extends AbstractCommand {
     String workflowName = programIdParts[1];
     WorkflowId workflowId = cliConfig.getCurrentNamespace().app(appId).workflow(workflowName);
 
-    List<ScheduleDetail> list = scheduleClient.list(workflowId);
+    List<ScheduleDetail> list = scheduleClient.listSchedules(workflowId);
     Table table = Table.builder()
       .setHeader("application", "program", "program type", "name", "description", "trigger", "properties")
       .setRows(list, new RowMaker<ScheduleDetail>() {

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
@@ -24,7 +24,6 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
 import co.cask.cdap.proto.ScheduleDetail;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.WorkflowTokenDetail;
@@ -61,13 +60,17 @@ public class RemoteWorkflowManager extends AbstractProgramManager<WorkflowManage
 
   @Override
   public List<ScheduleSpecification> getSchedules() {
-    return Schedulers.toScheduleSpecs(getProgramSchedules());
+    try {
+      return scheduleClient.list(workflowId);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   @Override
   public List<ScheduleDetail> getProgramSchedules() {
     try {
-      return scheduleClient.list(workflowId);
+      return scheduleClient.listSchedules(workflowId);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }


### PR DESCRIPTION
- moves toScheduleSpecs() from Schedulers to proto.ScheduleDetail (such that it is available in ScheduleClient)
- updates ScheduleClient to have both backward-compatible and new APIs for add, update, list
- adds a check to test case that both list() methods are equivalent