### PR TITLE
Update DataCleansing and PurchaseApp to use new Scheduler APIs.

### DIFF
--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingWorkflow.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingWorkflow.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.examples.datacleansing;
+
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+
+/**
+ * Implements a simple Workflow with to run the DataCleansingMapReduce MapReduce.
+ */
+public class DataCleansingWorkflow extends AbstractWorkflow {
+
+  @Override
+  public void configure() {
+    setName("DataCleansingWorkflow");
+    setDescription("Workflow that runs the DataCleansingMapReduce");
+    addMapReduce("DataCleansingMapReduce");
+  }
+}

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
@@ -68,11 +68,9 @@ public class PurchaseApp extends AbstractApplication {
     addService(new CatalogLookupService());
 
     // Schedule the workflow
-    scheduleWorkflow(
-      Schedules.builder("DailySchedule")
-        .setMaxConcurrentRuns(1)
-        .createTimeSchedule("0 4 * * *"),
-      "PurchaseHistoryWorkflow");
+    configureWorkflowSchedule("DailySchedule", "PurchaseHistoryWorkflow")
+      .limitConcurrentRuns(1)
+      .triggerByTime("0 4 * * *");
 
     // Schedule the workflow based on the data coming in the purchaseStream stream
     scheduleWorkflow(


### PR DESCRIPTION
Update DataCleansing and PurchaseApp to use new Scheduler APIs.

Similar PR as https://github.com/caskdata/cdap/pull/8802, but that was reverted as it caused failing test cases then.

https://builds.cask.co/browse/CDAP-RUT979-1

Pending: update after the following PR is merged: https://github.com/caskdata/cdap/pull/8886