### PR TITLE
CDAP-11589 Bump Tephra version to 0.12.0-incubating

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/MultiThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/MultiThreadDatasetCache.java
@@ -168,6 +168,4 @@ public class MultiThreadDatasetCache extends DynamicDatasetCache {
     perThreadMap.cleanUp();
     return perThreadMap.asMap().keySet();
   }
-
 }
-

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCacheSupplier.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCacheSupplier.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.transaction.coprocessor;
 
+import com.google.common.base.Supplier;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
@@ -26,29 +27,14 @@ import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
  * coprocessors.
  */
 public class DefaultTransactionStateCacheSupplier extends TransactionStateCacheSupplier {
-  private final String sysConfigTablePrefix;
-
-  public DefaultTransactionStateCacheSupplier(String sysConfigTablePrefix, Configuration conf) {
-    super(conf);
-    this.sysConfigTablePrefix = sysConfigTablePrefix;
-  }
-
-  /**
-   * Returns a singleton instance of the transaction state cache, performing lazy initialization if necessary.
-   * @return A shared instance of the transaction state cache.
-   */
-  @Override
-  public TransactionStateCache get() {
-    if (instance == null) {
-      synchronized (lock) {
-        if (instance == null) {
-          instance = new DefaultTransactionStateCache(sysConfigTablePrefix);
-          instance.setConf(conf);
-          instance.start();
-        }
+  public DefaultTransactionStateCacheSupplier(final String sysConfigTablePrefix, final Configuration conf) {
+    super(new Supplier<TransactionStateCache>() {
+      @Override
+      public TransactionStateCache get() {
+        TransactionStateCache cache = new DefaultTransactionStateCache(sysConfigTablePrefix);
+        cache.setConf(conf);
+        return cache;
       }
-    }
-    return instance;
+    });
   }
-
 }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase96/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase96/DefaultTransactionProcessor.java
@@ -23,7 +23,6 @@ import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCache;
 import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCacheSupplier;
 import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.coprocessor.CellSkipFilter;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
@@ -180,7 +180,7 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+  protected CacheSupplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase98/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase98/DefaultTransactionProcessor.java
@@ -23,7 +23,6 @@ import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCache;
 import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCacheSupplier;
 import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.coprocessor.CellSkipFilter;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
@@ -180,7 +180,7 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+  protected CacheSupplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh/DefaultTransactionProcessor.java
@@ -23,7 +23,6 @@ import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCache;
 import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCacheSupplier;
 import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.coprocessor.CellSkipFilter;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
@@ -180,7 +180,7 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+  protected CacheSupplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh550/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh550/DefaultTransactionProcessor.java
@@ -23,7 +23,6 @@ import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCache;
 import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCacheSupplier;
 import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.coprocessor.CellSkipFilter;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
@@ -180,7 +180,7 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+  protected CacheSupplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10/DefaultTransactionProcessor.java
@@ -23,7 +23,6 @@ import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCache;
 import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCacheSupplier;
 import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.coprocessor.CellSkipFilter;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
@@ -180,7 +180,7 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+  protected CacheSupplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase11/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase11/DefaultTransactionProcessor.java
@@ -23,7 +23,6 @@ import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCache;
 import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCacheSupplier;
 import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.coprocessor.CellSkipFilter;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
@@ -180,7 +180,7 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+  protected CacheSupplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase12cdh570/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase12cdh570/DefaultTransactionProcessor.java
@@ -23,7 +23,6 @@ import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCache;
 import co.cask.cdap.data2.transaction.coprocessor.CConfigurationCacheSupplier;
 import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.coprocessor.CellSkipFilter;
 import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
@@ -180,7 +180,7 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+  protected CacheSupplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/feeds/service/MDSNotificationFeedStore.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/feeds/service/MDSNotificationFeedStore.java
@@ -70,7 +70,8 @@ public final class MDSNotificationFeedStore implements NotificationFeedStore {
     this.transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(datasetFramework), txClient,
-        NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)),
+        NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)
+      ),
       RetryStrategies.retryOnConflict(20, 100)
     );
   }
@@ -109,7 +110,7 @@ public final class MDSNotificationFeedStore implements NotificationFeedStore {
         @Override
         public NotificationFeedInfo call(DatasetContext context) throws Exception {
           MDSKey feedKey = getKey(TYPE_NOTIFICATION_FEED, feed.getNamespace(), feed.getCategory(), feed.getFeed());
-          return  getMetadataStore(context).getFirst(feedKey, NotificationFeedInfo.class);
+          return getMetadataStore(context).getFirst(feedKey, NotificationFeedInfo.class);
         }
       });
     } catch (TransactionFailureException e) {

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/DataCleanupTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/DataCleanupTest.java
@@ -170,7 +170,7 @@ public abstract class DataCleanupTest {
 
       metadataTable.deleteTopic(topicId);
       // Sleep so that the metadata cache in coprocessor expires
-      TimeUnit.SECONDS.sleep(1);
+      TimeUnit.SECONDS.sleep(3);
       forceFlushAndCompact(Table.MESSAGE);
       forceFlushAndCompact(Table.PAYLOAD);
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <snappy.version>1.1.1.7</snappy.version>
     <spark1.version>1.6.1</spark1.version>
     <spark2.version>2.1.0</spark2.version>
-    <tephra.version>0.11.0-incubating</tephra.version>
+    <tephra.version>0.12.0-incubating-SNAPSHOT</tephra.version>
     <tez.version>0.8.4</tez.version>
     <thrift.version>0.9.3</thrift.version>
     <twill.version>0.11.0</twill.version>


### PR DESCRIPTION
Also addresses CDAP-11579 by increasing sleep for testOldGenCleanup Test so that the cache expires.

Build : https://builds.cask.co/browse/CDAP-RUT982