### PR TITLE
[CDAP-9025] Instead of admin users support admin groups, so that users can be add…

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -909,7 +909,7 @@ public final class Constants {
       public static final String CACHE_TTL_SECS = "security.authorization.cache.ttl.secs";
       /** Maximum number of entries the authorization cache will hold */
       public static final String CACHE_MAX_ENTRIES = "security.authorization.cache.max.entries";
-      public static final String ADMIN_USERS = "security.authorization.admin.users";
+      public static final String ADMIN_GROUPS = "security.authorization.admin.groups";
       /** Enable hierarchical privilege propagation, i.e. privilege on a parent will propagate to all descendants */
       public static final String PROPAGATE_PRIVILEGES = "security.authorization.propagate.privileges";
     }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authentication/SecurityRequestContext.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authentication/SecurityRequestContext.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 public final class SecurityRequestContext {
   private static final ThreadLocal<String> userId = new InheritableThreadLocal<>();
   private static final ThreadLocal<String> userIP = new InheritableThreadLocal<>();
+  private static final ThreadLocal<Principal.PrincipalType> principalType = new InheritableThreadLocal<>();
 
   private SecurityRequestContext() {
   }
@@ -64,9 +65,26 @@ public final class SecurityRequestContext {
   }
 
   /**
+   * @return the principal type set on the current thread or PrincipalType.USER if not set
+   */
+  public static Principal.PrincipalType getPrincipalType() {
+    Principal.PrincipalType type = principalType.get();
+    return type == null ? Principal.PrincipalType.USER : type;
+  }
+
+  /**
+   * Set the principalType on the current thread.
+   *
+   * @param type principalType to be set
+   */
+  public static void setPrincipalType(Principal.PrincipalType type) {
+    principalType.set(type);
+  }
+
+  /**
    * Returns a {@link Principal} for the user set on the current thread
    */
   public static Principal toPrincipal() {
-    return new Principal(userId.get(), Principal.PrincipalType.USER);
+    return new Principal(getUserId(), getPrincipalType());
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/context/MasterAuthenticationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/context/MasterAuthenticationContext.java
@@ -53,6 +53,6 @@ public class MasterAuthenticationContext implements AuthenticationContext {
         throw Throwables.propagate(e);
       }
     }
-    return new Principal(userId, Principal.PrincipalType.USER);
+    return new Principal(userId, SecurityRequestContext.getPrincipalType());
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -483,6 +483,7 @@ public class AuthorizationTest extends TestBase {
     // delete should fail
     try {
       appManager.delete();
+      Assert.fail("Delete should have failed");
     } catch (Exception expected) {
       // expected
     }


### PR DESCRIPTION
…ed to the admin group to gain privileges and removed from the group if privilege revocation is required.