### PR TITLE
Update to JDK8 and use Flume Agent from HDP 2.5.3

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -124,14 +124,11 @@
         },
         "hadoop": {
           "distribution": "hdp",
-          "distribution_version": "2.1.7.0"
+          "distribution_version": "2.5.3.0"
         },
         "java": {
-          "install_flavor": "oracle",
-          "jdk_version": 7,
-          "oracle": {
-            "accept_oracle_download_terms": true
-          }
+          "install_flavor": "openjdk",
+          "jdk_version": 8
         }
       },
       "only": ["cdap-sdk-vm"]

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -4,5 +4,18 @@
     "sdk": {
       "url": "{{URI}}"
     }
+  },
+  "nodejs": {
+    "install_method": "binary",
+    "version": "4.5.0",
+    "binary": {
+      "checksum": {
+        "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
+      }
+    }
+  },
+  "java": {
+    "install_flavor": "openjdk",
+    "jdk_version": 8
   }
 }

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -1,5 +1,18 @@
 {
   "cdap": {
     "version": "3.1.1-2"
+  },
+  "nodejs": {
+    "install_method": "binary",
+    "version": "4.5.0",
+    "binary": {
+      "checksum": {
+        "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
+      }
+    }
+  },
+  "java": {
+    "install_flavor": "openjdk",
+    "jdk_version": 8
   }
 }


### PR DESCRIPTION
This is a cherry-pick of #8835

Conflicts:
- cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
- cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
- cdap-distributions/src/packer/files/cdap-sdk.json