### PR TITLE
CDAP-8806 get rid of getSnapshot

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -579,6 +579,10 @@ public final class Constants {
       ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
                       Constants.Metrics.Tag.COMPONENT, Constants.Service.METRICS_PROCESSOR);
 
+    public static final Map<String, String> TRANSACTION_MANAGER_CONTEXT =
+      ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
+                      Constants.Metrics.Tag.COMPONENT, Constants.Service.TRANSACTION);
+
     /**
      * Metric's dataset related constants.
      */

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/metrics/TransactionManagerMetricsCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/metrics/TransactionManagerMetricsCollector.java
@@ -32,9 +32,7 @@ public class TransactionManagerMetricsCollector extends TxMetricsCollector {
 
   @Inject
   public TransactionManagerMetricsCollector(MetricsCollectionService service) {
-    this.metricsContext = service.getContext(
-      ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getEntityName(),
-                      Constants.Metrics.Tag.COMPONENT, "transactions"));
+    this.metricsContext = service.getContext(Constants.Metrics.TRANSACTION_MANAGER_CONTEXT);
   }
 
   // todo: change TxMetricsCollector in Tephra

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/AbstractCDAPStats.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/AbstractCDAPStats.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.operations.cdap;
 
+import co.cask.cdap.api.dataset.lib.cube.TimeValue;
+import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.operations.AbstractOperationalStats;
 import co.cask.cdap.operations.OperationalStats;
 import com.google.common.annotations.VisibleForTesting;
@@ -30,5 +32,13 @@ public abstract class AbstractCDAPStats extends AbstractOperationalStats {
   @Override
   public String getServiceName() {
     return SERVICE_NAME;
+  }
+
+  protected long aggregateMetricValue(MetricTimeSeries metricTimeSery) {
+    long aggregateValue = 0L;
+    for (TimeValue timeValue : metricTimeSery.getTimeValues()) {
+      aggregateValue += timeValue.getValue();
+    }
+    return aggregateValue;
   }
 }

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPLoad.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPLoad.java
@@ -140,14 +140,6 @@ public class CDAPLoad extends AbstractCDAPStats implements CDAPConnectionsMXBean
     }
   }
 
-  private long aggregateMetricValue(MetricTimeSeries metricTimeSery) {
-    long aggregateValue = 0L;
-    for (TimeValue timeValue : metricTimeSery.getTimeValues()) {
-      aggregateValue += timeValue.getValue();
-    }
-    return aggregateValue;
-  }
-
   private void reset() {
     totalRequests = 0;
     successful = 0;

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPTransactionsMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPTransactionsMXBean.java
@@ -24,11 +24,6 @@ import javax.management.MXBean;
 public interface CDAPTransactionsMXBean {
 
   /**
-   * Returns the time when the transaction snapshot was taken.
-   */
-  long getSnapshotTime();
-
-  /**
    * Returns the read pointer at the time of the snapshot.
    */
   long getReadPointer();
@@ -57,11 +52,4 @@ public interface CDAPTransactionsMXBean {
    * Returns the number of committed change sets across all write pointers.
    */
   int getNumCommittedChangeSets();
-
-  /**
-   * Returns a transaction id {@code X} such that any of the transactions newer than {@code X} might be invisible to
-   * some of the currently in-progress transactions or to those that will be started
-   * NOTE: the returned tx id can be invalid.
-   */
-  long getVisibilityUpperBound();
 }

--- a/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/cdap/CDAPOperationalStatsTest.java
+++ b/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/cdap/CDAPOperationalStatsTest.java
@@ -20,12 +20,12 @@ import co.cask.cdap.AllProgramsApp;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.operations.OperationalStats;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.scheduler.Scheduler;
-import com.google.common.util.concurrent.Service;
 import com.google.inject.Injector;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionSystemClient;
@@ -35,6 +35,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link OperationalStats} for CDAP
@@ -86,11 +88,19 @@ public class CDAPOperationalStatsTest {
     Assert.assertEquals(4, entities.getDatasets());
     Assert.assertEquals(1, entities.getStreams());
     Assert.assertEquals(0, entities.getStreamViews());
-    CDAPTransactions transactions = new CDAPTransactions();
+    final CDAPTransactions transactions = new CDAPTransactions();
     transactions.initialize(injector);
     Assert.assertEquals(AbstractCDAPStats.SERVICE_NAME, transactions.getServiceName());
     Assert.assertEquals("transactions", transactions.getStatType());
-    transactions.collect();
+    // wait for some time to make sure the metrics get gauged
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        transactions.collect();
+        return transactions.getNumCommittingChangeSets() > 0 && transactions.getNumInProgressTransactions() > 0 &&
+          transactions.getNumInvalidTransactions() > 0;
+      }
+    }, 1, TimeUnit.MINUTES, 3, TimeUnit.SECONDS);
     Assert.assertTrue(transactions.getNumInProgressTransactions() >= 1);
     Assert.assertTrue(transactions.getNumInvalidTransactions() >= 1);
     Assert.assertTrue(transactions.getNumCommittingChangeSets() >= 1);
@@ -98,8 +108,6 @@ public class CDAPOperationalStatsTest {
     // app making the committed transaction 1 here. We assert for 0 or greater because we might add other such calls
     // which will cause a transaction to be completed.
     Assert.assertTrue(transactions.getNumCommittedChangeSets() >= 0);
-    Assert.assertTrue(transactions.getVisibilityUpperBound() > TEST_START_TIME);
-    Assert.assertTrue(transactions.getSnapshotTime() > TEST_START_TIME);
     Assert.assertTrue(transactions.getReadPointer() > TEST_START_TIME);
     Assert.assertTrue(transactions.getWritePointer() > TEST_START_TIME);
     CDAPLoad requests = new CDAPLoad();

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -184,7 +184,6 @@ features:
         Running: Running
         ServerErrors: Server Errors
         Snapshots: Snapshots
-        SnapshotTime: Last Snapshot Time
         Stopped: Stopped
         Streams: Streams
         StreamViews: Stream Views
@@ -205,7 +204,6 @@ features:
         UsedVCores: Used Virtual Cores
         UnusableNodes: Unusable Nodes
         UnusableContainers: Unusable Containers
-        VisibilityUpperBound: Visibility Upper Bound
         WarnLogs: Warnings in Logs
         WritePointer: Write Pointer
     PageTitle: CDAP | Management


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8806
Build: https://builds.cask.co/browse/CDAP-RUT989-2

Replaced getSnapshotInputStream(), the stats are getting from metrics and a short transaction.