### PR TITLE
Fix/cdap 8911 fix executor stream

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/AbstractStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/AbstractStreamService.java
@@ -85,7 +85,6 @@ public abstract class AbstractStreamService extends AbstractScheduledService imp
   protected final void startUp() throws Exception {
     streamCoordinatorClient.startAndWait();
     janitorService.startAndWait();
-    sizeCollector.startAndWait();
     initialize();
   }
 
@@ -97,7 +96,6 @@ public abstract class AbstractStreamService extends AbstractScheduledService imp
       executor.shutdownNow();
     }
 
-    sizeCollector.stopAndWait();
     janitorService.stopAndWait();
     streamCoordinatorClient.stopAndWait();
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/BasicStreamWriterSizeCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/BasicStreamWriterSizeCollector.java
@@ -18,14 +18,10 @@ package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.AbstractIdleService;
-import org.apache.twill.common.Cancellable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -33,27 +29,13 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Basic implementation of a {@link StreamWriterSizeCollector}.
  */
-public class BasicStreamWriterSizeCollector extends AbstractIdleService implements StreamWriterSizeCollector {
+public class BasicStreamWriterSizeCollector implements StreamWriterSizeCollector {
   private static final Logger LOG = LoggerFactory.getLogger(BasicStreamWriterSizeCollector.class);
 
   private final ConcurrentMap<StreamId, AtomicLong> streamSizes;
-  private final List<Cancellable> truncationSubscriptions;
 
   public BasicStreamWriterSizeCollector() {
     this.streamSizes = Maps.newConcurrentMap();
-    this.truncationSubscriptions = Lists.newArrayList();
-  }
-
-  @Override
-  protected void startUp() throws Exception {
-    // No-op
-  }
-
-  @Override
-  protected void shutDown() throws Exception {
-    for (Cancellable subscription : truncationSubscriptions) {
-      subscription.cancel();
-    }
   }
 
   public Map<StreamId, AtomicLong> getStreamSizes() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriter.java
@@ -41,6 +41,7 @@ import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.Service;
 import org.apache.twill.common.Cancellable;
+import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -130,6 +133,12 @@ public final class ConcurrentStreamWriter implements Closeable {
             LOG.error("Error while refreshing event queue.", t);
           }
         }
+      }
+
+      @Override
+      protected ScheduledExecutorService executor() {
+        return Executors.newSingleThreadScheduledExecutor(
+          Threads.createDaemonThreadFactory("concurrent-stream-writer"));
       }
 
       @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamWriterSizeCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamWriterSizeCollector.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Keep track of the sizes of the files written by one {@link StreamHandler}.
  */
-public interface StreamWriterSizeCollector extends Service {
+public interface StreamWriterSizeCollector {
 
   // TODO have one implementation of this
 


### PR DESCRIPTION
When Extending `AbstractScheduledService` we have to implement `executor` along with `scheduler`.  
Otherwise it creates a non-daemon thread and this causes the stream container to be not shutdown cleanly and the stream container gets killed by AM after a timeout.  

`BasicStreamWriterSizeCollector` extends a service but the start and stop doesn't do anything meaningful, so removing the extends service. 