### PR TITLE
[CDAP-11424] Adds one time copy of data to CDAP Dataset in dataprep

### DIFF
--- a/cdap-ui/app/cdap/api/app.js
+++ b/cdap-ui/app/cdap/api/app.js
@@ -22,6 +22,7 @@ let appPath = `${basepath}/:appId`;
 
 export const MyAppApi = {
   list: apiCreator(dataSrc, 'GET', 'REQUEST', basepath),
+  deployApp: apiCreator(dataSrc, 'PUT', 'REQUEST', appPath),
   get: apiCreator(dataSrc, 'GET', 'REQUEST', appPath),
   getVersions: apiCreator(dataSrc, 'GET', 'REQUEST', `${appPath}/versions`),
   getDeployedApp: apiCreator(dataSrc, 'GET', 'REQUEST', basepath),

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/CreateDatasetBtn/CreateDatasetBtn.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/CreateDatasetBtn/CreateDatasetBtn.scss
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+$info-icon-fill-color: #5a84e4;
+$disabled-color: #cccccc;
+$error-bg-color: #2c3e50;
+$error-font-color: #cdcdcd;
+$max_height_error_container: 200px;
+
+.dataprep-parse-modal {
+  &.create-dataset-modal {
+    form {
+      input.form-control,
+      select.form-control {
+        width: calc(100% - 20px); // 20px for the info icon.
+        display: inline-block;
+        margin-right: 5px;
+      }
+      .icon-info-circle {
+        fill: $info-icon-fill-color;
+        cursor: pointer;
+      }
+      .dataset-name-group {
+        position: relative;
+        .required-label {
+          position: absolute;
+          top: -21px;
+        }
+      }
+      .col-form-label {
+        .text-danger {
+          margin-left: 3px;
+        }
+      }
+      .input-type-group {
+        button {
+          &:focus,
+          &:active {
+            outline: none;
+          }
+        }
+      }
+    }
+    .modal-header {
+      .close-section {
+        &.disabled {
+          color: $disabled-color;
+          cursor: not-allowed;
+        }
+      }
+    }
+    .modal-body {
+      min-height: 200px;
+
+      &.copying-steps-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 18px;
+        .steps-container {
+          .step-container {
+            > span {
+              &:first-child {
+                margin-right: 5px;
+              }
+            }
+          }
+          .btn.btn-primary {
+            margin-top: 15px;
+          }
+        }
+      }
+    }
+    .modal-footer {
+      &.dataset-copy-error-container {
+        padding: 0;
+        .step-error-container {
+          background: $error-bg-color;
+          color: $error-font-color;
+          padding: 5px 15px;
+          width: 100%;
+          text-align: left;
+          max-height: $max_height_error_container;
+          overflow-y: auto;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/CreateDatasetBtn/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/CreateDatasetBtn/index.js
@@ -1,0 +1,702 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import T from 'i18n-react';
+import {Modal, ModalHeader, ModalBody, ModalFooter, Button, ButtonGroup, Form, FormGroup, Label, Col, Input} from 'reactstrap';
+import {UncontrolledTooltip} from 'components/UncontrolledComponents';
+import classnames from 'classnames';
+import IconSVG from 'components/IconSVG';
+import {preventPropagation} from 'services/helpers';
+import DataPrepStore from 'components/DataPrep/store/';
+import GetPipelineConfig from 'components/DataPrep/TopPanel/PipelineConfigHelper';
+import {MyArtifactApi} from 'api/artifact';
+import {MyDatasetApi} from 'api/dataset';
+import {MyAppApi} from 'api/app';
+import {MyProgramApi} from 'api/program';
+import NamespaceStore from 'services/NamespaceStore';
+import find from 'lodash/find';
+import {objectQuery} from 'services/helpers';
+import isNil from 'lodash/isNil';
+import isEmpty from 'lodash/isEmpty';
+import cloneDeep from 'lodash/cloneDeep';
+import Rx from 'rx';
+
+require('./CreateDatasetBtn.scss');
+
+const PREFIX = `features.DataPrep.TopPanel.copyToCDAPDatasetBtn`;
+const fielsetDataType = [
+  {
+    id: 'TPFSAvro',
+    label: T.translate(`${PREFIX}.Formats.avro`)
+  },
+  {
+    id: 'TPFSOrc',
+    label: T.translate(`${PREFIX}.Formats.orc`)
+  },
+  {
+    id: 'TPFSParquet',
+    label: T.translate(`${PREFIX}.Formats.parquet`)
+  }
+];
+const copyingSteps = [
+  {
+    message: T.translate(`${PREFIX}.copyingSteps.Step1`),
+    error: T.translate(`${PREFIX}.copyingSteps.Step1Error`),
+    status: null
+  },
+  {
+    message: T.translate(`${PREFIX}.copyingSteps.Step2`),
+    error: T.translate(`${PREFIX}.copyingSteps.Step2Error`),
+    status: null
+  }
+];
+export default class CreateDatasetBtn extends Component {
+  constructor(props) {
+    super(props);
+    this.state = this.getDefaultState();
+    this.toggleModal = this.toggleModal.bind(this);
+    this.handleOnSubmit = this.handleOnSubmit.bind(this);
+    this.handleRowkeyChange = this.handleRowkeyChange.bind(this);
+    this.submitForm = this.submitForm.bind(this);
+    this.handleFormatChange = this.handleFormatChange.bind(this);
+    this.handleDatasetNameChange = this.handleDatasetNameChange.bind(this);
+  }
+
+  getDefaultState() {
+    let {headers} = DataPrepStore.getState().dataprep;
+    return {
+      showModal: false,
+      inputType: 'fileset',
+      rowKey: headers.length ? headers[0] : null,
+      format: fielsetDataType[0].id,
+      sinkPluginsForDataset: {},
+      batchPipelineConfig: {},
+      datasetName: '',
+      copyingSteps: [...copyingSteps],
+      copyInProgress: false,
+      datasetUrl: null,
+      error: null
+    };
+  }
+
+  componentWillMount() {
+    let {selectedNamespace: namespace} = NamespaceStore.getState();
+    let corePlugins;
+    MyArtifactApi
+      .list({ namespace })
+      .subscribe(res => {
+        corePlugins = find(res, { 'name': 'core-plugins' });
+        const getPluginConfig = (pluginName) => {
+          return {
+            name: pluginName,
+            plugin: {
+              name: pluginName,
+              label: pluginName,
+              type: 'batchsink',
+              artifact: corePlugins,
+              properties: {}
+            }
+          };
+        };
+        let sinks = {
+          TPFSAvro: getPluginConfig('TPFSAvro'),
+          TPFSParquet: getPluginConfig('TPFSParquet'),
+          TPFSOrc: getPluginConfig('TPFSOrc'),
+          Table: getPluginConfig('Table'),
+        };
+        this.setState({
+          sinkPluginsForDataset: sinks
+        });
+      });
+  }
+
+  toggleModal() {
+    let state = Object.assign(this.getDefaultState(), {
+      showModal: !this.state.showModal,
+      sinkPluginsForDataset: this.state.sinkPluginsForDataset,
+      batchPipelineConfig: this.state.batchPipelineConfig
+    });
+    this.setState(state);
+    if (!this.state.showModal) {
+      GetPipelineConfig().subscribe(
+        (res) => {
+          this.setState({
+            batchPipelineConfig: res.batchConfig
+          });
+        },
+        (err) => {
+          this.setState({
+            error: err
+          });
+        }
+      );
+    }
+  }
+
+  handleDatasetNameChange(e) {
+    this.setState({
+      datasetName: e.target.value
+    });
+  }
+
+  handleRowkeyChange(e) {
+    this.setState({
+      rowKey: e.target.value
+    });
+  }
+
+  handleFormatChange(e) {
+    this.setState({
+      format: e.target.value
+    });
+  }
+
+  handleOnSubmit(e) {
+    preventPropagation(e);
+    return false;
+  }
+
+  getAppConfigMacros () {
+    let {workspaceInfo, directives, headers} = DataPrepStore.getState().dataprep;
+    let pipelineConfig = cloneDeep(this.state.batchPipelineConfig);
+    let wranglerStage = pipelineConfig.config.stages.find(stage => stage.name === 'Wrangler');
+    let databaseConfig = objectQuery(workspaceInfo, 'properties', 'databaseConfig');
+    let macroMap = {};
+    if (databaseConfig) {
+      try {
+        databaseConfig = JSON.parse(databaseConfig);
+      } catch (e) {
+        databaseConfig = {};
+      }
+      macroMap = Object.assign(macroMap, databaseConfig);
+    }
+    return Object.assign({}, macroMap, {
+      datasetName: this.state.datasetName,
+      filename: workspaceInfo.properties.path,
+      directives: directives.join('\n'),
+      schema: wranglerStage.plugin.properties.schema,
+      schemaRowField: isNil(this.state.rowKey) ? headers[0] : this.state.rowKey
+    });
+  }
+
+  addMacrosToPipelineConfig(pipelineConfig) {
+    let macroMap = this.getAppConfigMacros();
+    let dataFormatProperties = {
+      schema: '${schema}',
+      name: '${datasetName}'
+    };
+    let pluginsMap = {
+      'Wrangler': {
+        directives: '${directives}',
+        schema: '${schema}',
+        field: '*',
+        precondition: 'false',
+        'threshold': '1',
+      },
+      'File': {
+        path: '${filename}',
+        referenceName: 'FileNode',
+        schema: "{\"name\":\"fileRecord\",\"type\":\"record\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}"
+      },
+      'Table': {
+        'schema.row.field': '${schemaRowField}',
+        name: '${datasetName}',
+        schema: '${schema}'
+      },
+      'Database': {
+        connectionString: '${connectionString}',
+        user: '${userName}',
+        password: '${password}',
+        jdbcPluginName: 'mysql',
+        jdbcPluginType: 'jdbc',
+        importQuery: '${query}'
+      },
+      'TPFSOrc': dataFormatProperties,
+      'TPFSParquet': dataFormatProperties,
+      'TPFSAvro': dataFormatProperties
+    };
+    pipelineConfig.config.stages = pipelineConfig.config.stages.map(stage => {
+      if (!isNil(pluginsMap[stage.name])) {
+        stage.plugin.properties = Object.assign({}, pluginsMap[stage.name]);
+      }
+      return stage;
+    });
+    return {pipelineConfig, macroMap};
+  }
+
+  preparePipelineConfig() {
+    let sink;
+    let {workspaceInfo} = DataPrepStore.getState().dataprep;
+    let {name: pipelineName} = workspaceInfo.properties;
+    let pipelineconfig = cloneDeep(this.state.batchPipelineConfig);
+    if (this.state.inputType === 'fileset') {
+      sink = fielsetDataType.find(dataType => dataType.id === this.state.format);
+      if (sink) {
+        sink = this.state.sinkPluginsForDataset[sink.id];
+      }
+    }
+    if (this.state.inputType === 'table') {
+      sink = this.state.sinkPluginsForDataset['Table'];
+    }
+    pipelineconfig.config.stages.push(sink);
+    let {pipelineConfig: appConfig, macroMap} = this.addMacrosToPipelineConfig(pipelineconfig);
+    let connections = this.state.batchPipelineConfig.config.connections;
+    let sinkConnection = [
+      {
+        from: connections[0].to,
+        to: sink.name
+      }
+    ];
+    appConfig.config.connections = connections.concat(sinkConnection);
+    appConfig.config.schedule = '0 * * * *';
+    appConfig.config.engine = 'mapreduce';
+    appConfig.description = `Pipeline to create dataset for workspace ${pipelineName} from dataprep`;
+    return {appConfig, macroMap};
+  }
+
+  submitForm() {
+    let steps = cloneDeep(copyingSteps);
+    steps[0].status = 'running';
+    this.setState({
+      copyInProgress: true,
+      copyingSteps: steps
+    });
+    let {selectedNamespace: namespace} = NamespaceStore.getState();
+    let pipelineName;
+    if (this.state.inputType === 'fileset') {
+      pipelineName = `one_time_copy_to_fs_${this.state.format}`;
+    } else {
+      pipelineName = `one_time_copy_to_table`;
+    }
+    pipelineName = pipelineName.replace('TPFS', '');
+    pipelineName = pipelineName.toLowerCase();
+    let pipelineconfig, macroMap;
+
+    // Get list of pipelines to check if the pipeline is already published
+    MyAppApi.list({namespace})
+      .flatMap(res => {
+        let appAlreadyDeployed = res.find(app => app.id === pipelineName);
+        if (!appAlreadyDeployed) {
+          let appConfigWithMacros= this.preparePipelineConfig();
+          pipelineconfig = appConfigWithMacros.appConfig;
+          macroMap = appConfigWithMacros.macroMap;
+          pipelineconfig.name = pipelineName;
+          let params = {
+            namespace,
+            appId: pipelineName
+          };
+          // If it doesn't exist create a new pipeline with macros.
+          return MyAppApi.deployApp(params, pipelineconfig);
+        }
+        // If it already exists just move to next step.
+        return Rx.Observable.create( observer => {
+          observer.next();
+        });
+      })
+      .flatMap(
+        () => {
+          let copyingSteps = [...this.state.copyingSteps];
+          copyingSteps[0].status = 'success';
+          copyingSteps[1].status = 'running';
+          this.setState({
+            copyingSteps
+          });
+          if (!macroMap) {
+            macroMap = this.getAppConfigMacros();
+          }
+          // Once the pipeline is published start the workflow. Pass run time arguments for macros.
+          return MyProgramApi.action({
+            namespace,
+            appId: pipelineName,
+            programType: 'workflows',
+            programId: 'DataPipelineWorkflow',
+            action: 'start'
+          }, macroMap);
+        }
+      )
+      .flatMap(
+        () => {
+          let count = 1;
+          const getDataset = (callback, errorCallback, count) => {
+            let params = {
+              namespace,
+              datasetId: this.state.datasetName
+            };
+            MyDatasetApi
+              .get(params)
+              .subscribe(
+                callback,
+                () => {
+                  if (count < 120) {
+                    count += count;
+                    setTimeout(() => {
+                      getDataset(callback, errorCallback, count);
+                    }, count * 1000);
+                  } else {
+                    errorCallback();
+                  }
+                }
+              );
+          };
+          return Rx.Observable.create((observer) => {
+            let successCallback = () => {
+              observer.onNext();
+            };
+            let errorCallback = () => {
+              observer.onError('Copy task timed out after 2 mins. Please check logs for more information.');
+            };
+            getDataset(successCallback, errorCallback, count);
+          });
+        }
+      )
+      .subscribe(
+        () => {
+          // Once workflow started successfully create a link to pipeline datasets tab for user reference.
+          let copyingSteps = [...this.state.copyingSteps];
+          let {selectedNamespace: namespaceId} = NamespaceStore.getState();
+          copyingSteps[1].status = 'success';
+          let datasetUrl = window.getAbsUIUrl({
+            namespaceId,
+            entityType: 'datasets',
+            entityId: this.state.datasetName
+          });
+          datasetUrl = `${datasetUrl}?modalToOpen=explore`;
+          this.setState({
+            copyingSteps,
+            datasetUrl
+          });
+        },
+        (err) => {
+          let copyingSteps = this.state.copyingSteps.map((step) => {
+            if (step.status === 'running') {
+              return Object.assign({}, step, {status: 'failure'});
+            }
+            return step;
+          });
+          let state = {
+            copyingSteps
+          };
+          if (!this.state.error) {
+            state.error = typeof err === 'object' ? err.response : err;
+          }
+          this.setState(state);
+        }
+      ); // FIXME: Need to handle the failure case here as well.
+  }
+
+  setType(type) {
+    this.setState({
+      inputType: type
+    });
+  }
+
+  renderDatasetSpecificContent() {
+    if (this.state.inputType === 'table') {
+      let {headers} = DataPrepStore.getState().dataprep;
+      return (
+        <FormGroup row>
+          <Label
+            xs="4"
+            className="text-xs-right"
+          >
+            {T.translate(`${PREFIX}.Form.rowKeyLabel`)}
+            <span className="text-danger">*</span>
+          </Label>
+          <Col xs="6">
+            <Input
+              type="select"
+              onChange={this.handleRowkeyChange}
+              value={this.state.rowKey}
+            >
+              {
+                headers.map(header => {
+                  return (
+                    <option value={header}>{header}</option>
+                  );
+                })
+              }
+            </Input>
+            <IconSVG
+              id="row-key-info-icon"
+              name="icon-info-circle"
+            />
+            <UncontrolledTooltip target="row-key-info-icon" delay={{show: 250, hide: 0}}>
+              {T.translate(`${PREFIX}.Form.rowKeyTooltip`)}
+            </UncontrolledTooltip>
+          </Col>
+        </FormGroup>
+      );
+    }
+    if (this.state.inputType === 'fileset') {
+      return (
+        <FormGroup row>
+          <Label
+            xs="4"
+            className="text-xs-right"
+          >
+            {T.translate(`${PREFIX}.Form.formatLabel`)}
+            <span className="text-danger">*</span>
+          </Label>
+          <Col xs="6">
+            <Input
+              type="select"
+              onChange={this.handleFormatChange}
+              value={this.state.format}
+            >
+              {
+                fielsetDataType.map(datatype => {
+                  return (
+                    <option value={datatype.id}>{datatype.label}</option>
+                  );
+                })
+              }
+            </Input>
+            <IconSVG
+              id="row-key-info-icon"
+              name="icon-info-circle"
+            />
+            <UncontrolledTooltip target="row-key-info-icon" delay={{show: 250, hide: 0}}>
+              {T.translate(`${PREFIX}.Form.formatTooltip`)}
+            </UncontrolledTooltip>
+          </Col>
+        </FormGroup>
+      );
+    }
+  }
+
+  renderSteps() {
+    if (!this.state.copyInProgress) {
+      return null;
+    }
+    const statusContainer = (status) => {
+      let icon, className;
+      if (status === 'running') {
+        icon="icon-spinner";
+        className="fa-spin";
+      }
+      if (status === 'success') {
+        icon="icon-check-circle";
+      }
+      if (status === 'failure') {
+        icon="icon-times-circle";
+      }
+      return (
+        <IconSVG
+          name={icon}
+          className={className}
+        />
+      );
+    };
+    return (
+      <div className="text-xs-left steps-container">
+        {
+          this.state.copyingSteps.map(step => {
+            return (
+              <div className={classnames("step-container", {
+                "text-success": step.status === 'success',
+                "text-danger": step.status === 'failure',
+                "text-info": step.status === 'running',
+                "text-muted": step.status === null
+              })}>
+                <span>
+                  {statusContainer(step.status)}
+                </span>
+                <span>
+                  {
+                    step.status === 'failure' ? step.error : step.message
+                  }
+                </span>
+              </div>
+            );
+          })
+        }
+        {
+          this.state.copyingSteps[1].status === 'success' ?
+            <a
+              className="btn btn-primary"
+              href={`${this.state.datasetUrl}`}
+            >
+              {T.translate(`${PREFIX}.monitorBtnLabel`)}
+            </a>
+          :
+            null
+        }
+      </div>
+    );
+  }
+
+  renderForm() {
+    let {dataprep} = DataPrepStore.getState();
+    let isTableOptionDisabled = objectQuery(dataprep, 'workspaceInfo', 'properties', 'databaseConfig');
+    return (
+      <div>
+        <p>{T.translate(`${PREFIX}.description`)}</p>
+        <Form onSubmit={this.handleOnSubmit}>
+          <FormGroup row>
+            <Label
+              xs={4}
+              className="text-xs-right"
+            >
+              {T.translate(`${PREFIX}.Form.typeLabel`)}
+            </Label>
+            <Col xs={8}>
+              <ButtonGroup className="input-type-group">
+                <Button
+                  color="secondary"
+                  onClick={this.setType.bind(this, 'fileset')}
+                  active={this.state.inputType === 'fileset'}
+                >
+                  {T.translate(`${PREFIX}.Form.fileSetBtnlabel`)}
+                </Button>
+                <Button
+                  color="secondary"
+                  onClick={this.setType.bind(this, 'table')}
+                  active={this.state.inputType === 'table'}
+                  disabled={isNil(isTableOptionDisabled) ? false : true}
+                >
+                  {T.translate(`${PREFIX}.Form.tableBtnlabel`)}
+                </Button>
+              </ButtonGroup>
+            </Col>
+          </FormGroup>
+          <FormGroup row>
+            <Col xs="4"></Col>
+            <Col xs="8"></Col>
+          </FormGroup>
+          <FormGroup row>
+            <Label
+              xs="4"
+              className="text-xs-right"
+            >
+              {T.translate(`${PREFIX}.Form.datasetNameLabel`)}
+              <span className="text-danger">*</span>
+            </Label>
+            <Col xs="6" className="dataset-name-group">
+              <p className="required-label">
+                {T.translate(`${PREFIX}.Form.requiredLabel`)}
+                <span className="text-danger">*</span>
+              </p>
+              <Input
+                value={this.state.datasetName}
+                onChange={this.handleDatasetNameChange}
+              />
+              <IconSVG
+                id="dataset-name-info-icon"
+                name="icon-info-circle"
+              />
+              <UncontrolledTooltip target="dataset-name-info-icon" delay={{show: 250, hide: 0}}>
+                {T.translate(`${PREFIX}.Form.datasetTooltip`)}
+              </UncontrolledTooltip>
+            </Col>
+          </FormGroup>
+          {this.renderDatasetSpecificContent()}
+        </Form>
+      </div>
+    );
+  }
+
+  renderFooter() {
+    if (!this.state.copyInProgress) {
+      return (
+        <ModalFooter>
+          <button
+            className="btn btn-primary"
+            onClick={this.submitForm}
+            disabled={isEmpty(this.state.datasetName)}
+          >
+            {T.translate(`${PREFIX}.createBtnLabel`)}
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={this.toggleModal}
+          >
+            {T.translate('features.DataPrep.Directives.cancel')}
+          </button>
+          {
+            this.renderSteps()
+          }
+        </ModalFooter>
+      );
+    }
+    if (this.state.error) {
+      return (
+        <ModalFooter className="dataset-copy-error-container">
+          <div className="step-error-container">
+            {
+              this.state.error
+            }
+          </div>
+        </ModalFooter>
+      );
+    }
+  }
+  render() {
+    return (
+      <span className="create-dataset-btn" title={this.props.title}>
+        <button
+          className={classnames("btn btn-link", this.props.className)}
+          onClick={this.toggleModal}
+          disabled={this.props.disabledState}
+        >
+          {T.translate(`${PREFIX}.btnLabel`)}
+        </button>
+        <Modal
+          toggle={this.toggleModal}
+          isOpen={this.state.showModal}
+          size="md"
+          backdrop="static"
+          keyboard={false}
+          zIndex="1061"
+          className="dataprep-parse-modal create-dataset-modal"
+        >
+          <ModalHeader>
+            <span>
+              {T.translate(`${PREFIX}.modalTitle`)}
+            </span>
+
+            <div
+              className={classnames("close-section float-xs-right", {
+                "disabled": this.state.copyInProgress && !this.state.datasetUrl && !this.state.error
+              })}
+              onClick={this.state.copyInProgress && !this.state.datasetUrl && !this.state.error? () => {} : this.toggleModal}
+            >
+              <span className="fa fa-times" />
+            </div>
+          </ModalHeader>
+          <ModalBody className={classnames({
+            "copying-steps-container": this.state.copyInProgress
+          })}>
+            {
+              this.state.copyInProgress ?
+                this.renderSteps()
+              :
+                this.renderForm()
+            }
+          </ModalBody>
+          {
+            this.renderFooter()
+          }
+        </Modal>
+      </span>
+    );
+  }
+}
+CreateDatasetBtn.propTypes = {
+  className: PropTypes.string,
+  disabledState: PropTypes.bool,
+  title: PropTypes.string
+};

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/PipelineConfigHelper.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/PipelineConfigHelper.js
@@ -1,0 +1,283 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import NamespaceStore from 'services/NamespaceStore';
+import MyDataPrepApi from 'api/dataprep';
+import DataPrepStore from 'components/DataPrep/store';
+import {directiveRequestBodyCreator} from 'components/DataPrep/helper';
+import {MyArtifactApi} from 'api/artifact';
+import {getParsedSchemaForDataPrep} from 'components/SchemaEditor/SchemaHelpers';
+import {objectQuery} from 'services/helpers';
+import {findHighestVersion} from 'services/VersionRange/VersionUtilities';
+import T from 'i18n-react';
+import Rx from 'rx';
+import find from 'lodash/find';
+
+export default function GetPipelineConfig() {
+  let workspaceInfo = DataPrepStore.getState().dataprep.workspaceInfo;
+  let namespace = NamespaceStore.getState().selectedNamespace;
+
+  return MyDataPrepApi.getInfo({ namespace })
+    .flatMap((res) => {
+      if (res.statusCode === 404) {
+        console.log(`can't find method; use latest wrangler-transform`);
+        return constructProperties(workspaceInfo);
+      }
+      let pluginVersion = res.values[0]['plugin.version'];
+      return constructProperties(workspaceInfo, pluginVersion);
+    });
+}
+
+function findWranglerArtifacts(artifacts, pluginVersion) {
+  let wranglerArtifacts = artifacts.filter((artifact) => {
+    if (pluginVersion) {
+      return artifact.name === 'wrangler-transform' && artifact.version === pluginVersion;
+    }
+
+    return artifact.name === 'wrangler-transform';
+  });
+
+  if (wranglerArtifacts.length === 0) {
+    // cannot find plugin. Error out
+    throw 'Cannot find wrangler-transform plugin. Please load wrangler transform from Cask Market';
+  }
+
+  let filteredArtifacts = wranglerArtifacts;
+
+  if (!pluginVersion) {
+    let highestVersion = findHighestVersion(wranglerArtifacts.map((artifact) => {
+      return artifact.version;
+    }), true);
+
+    filteredArtifacts = wranglerArtifacts.filter((artifact) => {
+      return artifact.version === highestVersion;
+    });
+  }
+
+  let returnArtifact = filteredArtifacts[0];
+
+  if (filteredArtifacts.length > 1) {
+    returnArtifact.scope = 'USER';
+  }
+
+  return returnArtifact;
+}
+
+function constructFileSource(artifactsList, properties) {
+  if (!properties) { return null; }
+
+  let plugin = objectQuery(properties, 'values', '0');
+
+  let pluginName = Object.keys(plugin)[0];
+
+  plugin = plugin[pluginName];
+  let batchArtifact = find(artifactsList, { 'name': 'core-plugins' });
+  let realtimeArtifact = find(artifactsList, { 'name': 'spark-plugins' });
+
+  let batchPluginInfo = {
+    name: plugin.name,
+    label: plugin.name,
+    type: 'batchsource',
+    artifact: batchArtifact,
+    properties: plugin.properties
+  };
+
+  let realtimePluginInfo = Object.assign({}, batchPluginInfo, {
+    type: 'streamingsource',
+    artifact: realtimeArtifact
+  });
+
+  let batchStage = {
+    name: 'File',
+    plugin: batchPluginInfo
+  };
+
+  let realtimeStage = {
+    name: 'File',
+    plugin: realtimePluginInfo
+  };
+
+  return {
+    batchSource: batchStage,
+    realtimeSource: realtimeStage,
+    connections: [{
+      from: 'File',
+      to: 'Wrangler'
+    }]
+  };
+}
+
+// Need to be modified once backend is complete
+function constructDatabaseSource(artifactsList, dbInfo) {
+  if (!dbInfo) { return null; }
+
+  let batchArtifact = find(artifactsList, { 'name': 'database-plugins' });
+  let pluginName = 'Database';
+
+  try {
+    let parsedProperties = JSON.parse(dbInfo.databaseConfig);
+
+    let pluginInfo = {
+      name: pluginName,
+      label: pluginName,
+      type: 'batchsource',
+      artifact: batchArtifact,
+      properties: {
+        referenceName: pluginName,
+        jdbcPluginName: 'mysql',
+        jdbcPluginType: 'jdbc',
+        connectionString: parsedProperties.connectionString,
+        user: parsedProperties.userName,
+        password: parsedProperties.password,
+        importQuery: dbInfo.name
+      }
+    };
+
+    let batchStage = {
+      name: pluginName,
+      plugin: pluginInfo
+    };
+
+    return {
+      batchSource: batchStage,
+      connections: [{
+        from: pluginName,
+        to: 'Wrangler'
+      }]
+    };
+  } catch (e) {
+    console.log('properties parse error', e);
+  }
+}
+
+function constructProperties(workspaceInfo, pluginVersion) {
+  let  observable = new Rx.Subject();
+  let namespace = NamespaceStore.getState().selectedNamespace;
+  let state = DataPrepStore.getState().dataprep;
+  let workspaceId = state.workspaceId;
+
+  let requestObj = {
+    namespace,
+    workspaceId
+  };
+
+  let directives = state.directives;
+
+  let requestBody = directiveRequestBodyCreator(directives);
+
+  let rxArray = [
+    MyDataPrepApi.getSchema(requestObj, requestBody)
+  ];
+
+  if (state.workspaceUri && state.workspaceUri.length > 0) {
+    let specParams = {
+      namespace,
+      path: state.workspaceUri
+    };
+
+    rxArray.push(MyDataPrepApi.getSpecification(specParams));
+  }
+
+  try {
+    MyArtifactApi.list({ namespace })
+    .combineLatest(rxArray)
+    .subscribe((res) => {
+      let batchArtifact = find(res[0], { 'name': 'cdap-data-pipeline' });
+      let realtimeArtifact = find(res[0], { 'name': 'cdap-data-streams' });
+      let wranglerArtifact;
+      try {
+        wranglerArtifact = findWranglerArtifacts(res[0], pluginVersion);
+      } catch (e) {
+        observable.onError(e);
+      }
+
+      let tempSchema = {
+        name: 'avroSchema',
+        type: 'record',
+        fields: res[1]
+      };
+
+      let properties = {
+        workspaceId,
+        directives: directives.join('\n'),
+        schema: JSON.stringify(tempSchema),
+        field: '*',
+        precondition: "false",
+        threshold: "1"
+      };
+
+      try {
+        getParsedSchemaForDataPrep(tempSchema);
+      } catch (e) {
+        observable.onError(objectQuery(e, 'message'));
+      }
+
+      let wranglerStage = {
+        name: 'Wrangler',
+        plugin: {
+          name: 'Wrangler',
+          label: 'Wrangler',
+          type: 'transform',
+          artifact: wranglerArtifact,
+          properties
+        }
+      };
+
+      let connections = [];
+
+      let realtimeStages = [wranglerStage];
+      let batchStages = [wranglerStage];
+
+      let sourceConfigs;
+      if (state.workspaceInfo.properties.connection === 'file') {
+        sourceConfigs = constructFileSource(res[0], res[2]);
+      } else if (state.workspaceInfo.properties.databaseConfig) {
+        sourceConfigs = constructDatabaseSource(res[0], state.workspaceInfo.properties);
+      }
+
+      if (sourceConfigs) {
+        realtimeStages.push(sourceConfigs.realtimeSource);
+        batchStages.push(sourceConfigs.batchSource);
+        connections = sourceConfigs.connections;
+      }
+
+      let realtimeConfig = {
+        artifact: realtimeArtifact,
+        config: {
+          stages: realtimeStages,
+          batchInterval: '10s',
+          connections
+        }
+      };
+
+      let batchConfig = {
+        artifact: batchArtifact,
+        config: {
+          stages: batchStages,
+          connections
+        }
+      };
+
+      observable.onNext({realtimeConfig, batchConfig});
+
+    }, (err) => {
+      observable.onError(objectQuery(err, 'response', 'message')  || T.translate('features.DataPrep.TopPanel.PipelineModal.defaultErrorMessage'));
+    });
+  } catch (e) {
+    observable.onError(objectQuery(e, 'message') || e);
+  }
+  return observable;
+}

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -23,9 +23,20 @@ $action-btn-inactive-color: #aaaaaa;
   .top-panel {
     height: 50px;
     border-bottom: 1px solid #cccccc;
+    margin-left: 0;
+    display: flex;
 
     .left-title {
-      width: calc(100% - 270px);
+      padding-left: 0;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      .upper-section {
+        height: 100%;
+        align-items: center;
+        display: flex;
+      }
 
       .data-prep-name,
       .upgrade-button {
@@ -35,6 +46,16 @@ $action-btn-inactive-color: #aaaaaa;
       .data-prep-name {
         font-size: 18px;
         padding: 0 10px;
+        width: 100%;
+
+        &.upgrade {
+          width: calc(100% - 100px);
+        }
+
+        .title {
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
 
         .connection-type {
           font-size: 13px;
@@ -44,7 +65,8 @@ $action-btn-inactive-color: #aaaaaa;
 
       .upgrade-button {
         margin-top: 2px;
-        margin-left: 15px;
+        margin-right: 10px;
+        margin-left: 10px;
         vertical-align: top;
 
         .fa.fa-wrench {
@@ -70,10 +92,23 @@ $action-btn-inactive-color: #aaaaaa;
     }
 
     .action-buttons {
-      padding-right: 15px;
+      padding: 0;
       margin-top: 10px;
+      margin-right: 30px;
 
-      .btn { margin-left: 10px; }
+      .secondary-actions {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        vertical-align: top;
+        line-height: 1;
+
+        .btn.btn-link {
+          padding: 0;
+          margin-left: 10px;
+          font-size: 12px;
+        }
+      }
     }
   }
 }

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -26,6 +26,8 @@ import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
 import T from 'i18n-react';
 import isNil from 'lodash/isNil';
+import CreateDatasetBtn from 'components/DataPrep/TopPanel/CreateDatasetBtn';
+import classnames from 'classnames';
 
 require('./TopPanel.scss');
 
@@ -153,7 +155,7 @@ export default class DataPrepTopPanel extends Component {
     if (info) {
       if (info.properties.connection === 'file') {
         return (
-          <div className="data-prep-name">
+          <div className={classnames("data-prep-name", {"upgrade": this.state.higherVersion})}>
             <div className="connection-type">
               {T.translate('features.DataPrep.TopPanel.file')}
             </div>
@@ -164,7 +166,7 @@ export default class DataPrepTopPanel extends Component {
         );
       } else if (info.properties.connection === 'database') {
         return (
-          <div className="data-prep-name">
+          <div className={classnames("data-prep-name", {"upgrade": this.state.higherVersion})}>
             <div className="connection-type">
               {T.translate('features.DataPrep.TopPanel.database')}
             </div>
@@ -188,8 +190,8 @@ export default class DataPrepTopPanel extends Component {
 
   render() {
     return (
-      <div className="top-panel clearfix">
-        <div className="left-title float-xs-left">
+      <div className="row top-panel clearfix">
+        <div className="left-title">
           <div className="upper-section">
             {this.renderTopPanelDisplay()}
 
@@ -210,7 +212,7 @@ export default class DataPrepTopPanel extends Component {
           </div>
         </div>
 
-        <div className="action-buttons float-xs-right">
+        <div className="action-buttons">
           {
             this.state.onSubmitError ?
               <span className="text-danger">{this.state.onSubmitError}</span>
@@ -242,13 +244,24 @@ export default class DataPrepTopPanel extends Component {
           }
           {this.renderAddToPipelineModal()}
 
-          <button
-            className="btn btn-link"
-            onClick={this.toggleSchemaModal}
-            disabled={isNil(this.state.workspaceInfo) ? 'disabled' : false}
-          >
-            {T.translate('features.DataPrep.TopPanel.viewSchemaBtnLabel')}
-          </button>
+          <div className="secondary-actions">
+            {
+              this.props.singleWorkspaceMode ?
+                null
+              :
+                <CreateDatasetBtn
+                  disabledState={isNil(this.state.workspaceInfo) || !objectQuery(this.state, 'workspaceInfo', 'properties', 'path')}
+                  title={!objectQuery(this.state, 'workspaceInfo', 'properties', 'path') ? T.translate('features.DataPrep.TopPanel.copyToCDAPDatasetBtn.uploadDisabledMessage') : null}
+                />
+            }
+            <button
+              className="btn btn-link"
+              onClick={this.toggleSchemaModal}
+              disabled={isNil(this.state.workspaceInfo) ? 'disabled' : false}
+            >
+              {T.translate('features.DataPrep.TopPanel.viewSchemaBtnLabel')}
+            </button>
+          </div>
           {this.renderSchemaModal()}
         </div>
       </div>

--- a/cdap-ui/app/cdap/components/LoadingIndicator/index.js
+++ b/cdap-ui/app/cdap/components/LoadingIndicator/index.js
@@ -58,6 +58,7 @@ export default class LoadingIndicator extends Component {
         <Modal
           isOpen={this.state.showLoading}
           toggle={() =>{}}
+          zIndex={2000}
           className="loading-indicator"
         >
 

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -589,7 +589,7 @@ features:
       expand: Expand the side panel
     TopPanel:
       applyBtnLabel: Apply
-      addToPipelineBtnLabel: Add to Pipeline
+      addToPipelineBtnLabel: Create Pipeline
       database: Database
       file: File System
       invalidFieldNameMessage: Invalid column name "{fieldName}"
@@ -605,6 +605,33 @@ features:
       title: Data Preparation
       upgradeBtnLabel: Upgrade
       viewSchemaBtnLabel: View Schema
+      copyToCDAPDatasetBtn:
+        uploadDisabledMessage: Copying to a dataset is not supported for uploaded files.
+        btnLabel: Make a Copy
+        createBtnLabel: Copy Data
+        copyingSteps:
+          Step1: 'Preparing to copy...'
+          Step1Error: 'Unable to copy data.'
+          Step2: 'Submitting copy task...'
+          Step2Error: 'Unable to submit copy task.'
+        description: You are creating a new Dataset, select a type and enter information about this new entity
+        Form:
+          datasetNameLabel: Dataset Name
+          datasetTooltip: Name of the dataset to copy to
+          fileSetBtnlabel: Fileset
+          formatLabel: Format
+          formatTooltip: Format of data
+          requiredLabel: Required
+          rowKeyLabel: Row Key
+          rowKeyTooltip: Its a rowkey
+          typeLabel: Type
+          tableBtnlabel: Table
+        Formats:
+          avro: Avro
+          orc: ORC
+          parquet: Parquet
+        modalTitle: Make a Copy
+        monitorBtnLabel: Monitor Data Copy
       WorkspaceModal:
         create: Create
         createModalTitle: Create Workspace

--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
@@ -73,6 +73,9 @@ body.state-hydrator-create.state-hydrator {
           }
           .action-buttons {
             min-width: auto;
+            .secondary-actions {
+              vertical-align: middle;
+            }
           }
         }
         .dataprep-main {


### PR DESCRIPTION
Merged to : https://github.com/caskdata/cdap/pull/8847
- Adds `CreateDatasetBtn` component to be able to copy data from dataprep to CDAP Dataset
- Adds generic `PipelineConfigHelper` to generate pipeline configuration to create dataset.

#### Approach:
- Under the hood UI creates a generic pipeline for each fileset type(avro, orc and parquet) or table type with macros to create a different dataset every time the user runs it in UI.

#### Things to do:
- Right now this PR is waiting on backend to fix an issue with publishing a pipeline with macros in wrangler.
- Based on connections integration with backend the database properties sent as part of the macros will need to be updated.