### PR TITLE
CDAP-7429 Cleanup shell output for spark-shell on HDP

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -503,20 +503,20 @@ cdap_set_spark() {
       # If there is no valid SPARK_HOME, we should unset the existing one if it is set
       # Otherwise the spark-shell won't run correctly
       unset SPARK_HOME
-      local __spark_shell=$(which spark-shell)
+      local __spark_shell=$(which spark-shell 2>/dev/null)
       local __spark_client_version=None
       for __dist in hdp iop; do
         if [[ $(which ${__dist}-select 2>/dev/null) ]]; then
           __spark_client_version=$(${__dist}-select status spark-client | awk '{print $3}')
-        fi
-        if [[ ${__spark_client_version} == 'None' ]]; then # defaults None, we're hoping for a version
-          logecho "$(date) Spark client not installed via ${__dist}-select detection"
-          return 1
-        elif [[ -x /usr/${__dist}/${__spark_client_version}/spark/bin/spark-shell ]]; then
-          __spark_shell=/usr/${__dist}/${__spark_client_version}/spark/bin/spark-shell
-        else
-          logecho "$(date) Spark client not installed via on-disk detection"
-          return 1
+          if [[ ${__spark_client_version} == 'None' ]]; then # defaults None, we're hoping for a version
+            logecho "$(date) Spark client not installed via ${__dist}-select detection"
+            return 1
+          elif [[ -x /usr/${__dist}/${__spark_client_version}/spark/bin/spark-shell ]]; then
+            __spark_shell=/usr/${__dist}/${__spark_client_version}/spark/bin/spark-shell
+          else
+            logecho "$(date) Spark client not installed via on-disk detection"
+            return 1
+          fi
         fi
       done
       ERR_FILE=$(mktemp)

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -503,15 +503,31 @@ cdap_set_spark() {
       # If there is no valid SPARK_HOME, we should unset the existing one if it is set
       # Otherwise the spark-shell won't run correctly
       unset SPARK_HOME
+      local __spark_shell=$(which spark-shell)
+      local __spark_client_version=None
+      for __dist in hdp iop; do
+        if [[ $(which ${__dist}-select 2>/dev/null) ]]; then
+          __spark_client_version=$(${__dist}-select status spark-client | awk '{print $3}')
+        fi
+        if [[ ${__spark_client_version} == 'None' ]]; then # defaults None, we're hoping for a version
+          logecho "$(date) Spark client not installed via ${__dist}-select detection"
+          return 1
+        elif [[ -x /usr/${__dist}/${__spark_client_version}/spark/bin/spark-shell ]]; then
+          __spark_shell=/usr/${__dist}/${__spark_client_version}/spark/bin/spark-shell
+        else
+          logecho "$(date) Spark client not installed via on-disk detection"
+          return 1
+        fi
+      done
       ERR_FILE=$(mktemp)
-      SPARK_VAR_OUT=$(echo '(sys.env ++ Map(("sparkVersion", org.apache.spark.SPARK_VERSION),("scalaVersion", scala.util.Properties.releaseVersion.get))).foreach { case (k, v) => println(s"$k=$v") }; sys.exit' | spark-shell --master local 2>${ERR_FILE})
+      SPARK_VAR_OUT=$(echo '(sys.env ++ Map(("sparkVersion", org.apache.spark.SPARK_VERSION),("scalaVersion", scala.util.Properties.releaseVersion.get))).foreach { case (k, v) => println(s"$k=$v") }; sys.exit' | ${__spark_shell} --master local 2>${ERR_FILE})
       __ret=$?
       # spark-shell invocation above does not properly restore the stty.
-      stty ${__saved_stty}
+      stty ${__saved_stty} 2>/dev/null
       SPARK_ERR_MSG=$(< ${ERR_FILE})
       rm ${ERR_FILE}
       if [[ ${__ret} -ne 0 ]]; then
-        echo "[ERROR] While determining Spark home, failed to get Spark settings using: spark-shell --master local"
+        echo "[ERROR] While determining Spark home, failed to get Spark settings using: ${__spark_shell} --master local"
         echo "  stderr:"
         echo "${SPARK_ERR_MSG}"
         return 1
@@ -724,7 +740,7 @@ cdap_start_java() {
   echo
   if [[ ${CDAP_SERVICE} == master ]]; then
     # Determine SPARK_HOME
-    cdap_set_spark || logecho "Could not determine SPARK_HOME! Spark support unavailable!"
+    cdap_set_spark || logecho "$(date) Could not determine SPARK_HOME! Spark support unavailable!"
     if [[ -n ${SPARK_COMPAT} ]]; then
       __defines+=" -Dapp.program.spark.compat=${SPARK_COMPAT}"
     fi
@@ -749,13 +765,13 @@ cdap_start_java() {
           local __conf_version=$(echo ${OPTS} | grep -oP "\-D${__dist}.version=\d+\.\d+\.\d+\.\d+-\d+" | cut -d= -f2)
           if [[ ${__conf_version} != ${__auto_version} ]]; then
             local __caps=$(echo ${__dist} | awk 'BEGIN { getline; print toupper($0) }')
-            logecho "[WARN] ${__caps} version mismatch! Detected: ${__auto_version}, Configured: ${__conf_version}"
-            logecho "[WARN] Using configured ${__caps} version: ${__conf_version}"
+            logecho "$(date) [WARN] ${__caps} version mismatch! Detected: ${__auto_version}, Configured: ${__conf_version}"
+            logecho "$(date) [WARN] Using configured ${__caps} version: ${__conf_version}"
           fi
         else
           # No version specified in OPTS or incorrect format, appending ours
           __defines+=" -D${__dist}.version=${__auto_version}"
-          logecho "Detected ${__dist} version ${__auto_version} and adding to CDAP Master command line"
+          logecho "$(date) Detected ${__dist} version ${__auto_version} and adding to CDAP Master command line"
         fi
       fi
     done
@@ -802,7 +818,7 @@ cdap_run_class() {
   cdap_set_classpath "${CDAP_HOME}"/master "${CDAP_CONF}"
   # Setup Java
   cdap_set_java || return 1
-  cdap_set_spark || logecho "[WARN] Could not determine SPARK_HOME! Spark support unavailable!"
+  cdap_set_spark || logecho "$(date) [WARN] Could not determine SPARK_HOME! Spark support unavailable!"
   cdap_set_hive_classpath || return 1
   # Add proper HBase compatibility to CLASSPATH
   cdap_set_hbase || exit 1


### PR DESCRIPTION
This attempts to use the distribution selection tool (`hdp-select` or `iop-select`) to determine if the `spark-client` is installed and configured or not. This prevents us from attempting to run `spark-shell` on these distributions when we're aware it's not installed and configured.

There are still extra logs from Spark detection, since we'll run it multiple times, now. I filed [CDAP-11622](https://issues.cask.co/browse/CDAP-11622) to take care of that in CDAP 4.3's release.