### PR TITLE
CDAP-5730 CDAP-11497 fix for now allowing . for dataset/type/module name

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -18,8 +18,11 @@ package co.cask.cdap.proto.id;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Vector;
 import java.util.regex.Pattern;
@@ -158,7 +161,17 @@ public abstract class EntityId implements IdCompatible {
     }
     String idString = typeAndId[1];
     try {
-      return typeFromString.fromIdParts(Arrays.asList(IDSTRING_PART_SEPARATOR_PATTERN.split(idString)));
+      List<String> idParts = Arrays.asList(IDSTRING_PART_SEPARATOR_PATTERN.split(idString));
+      // special case for DatasetId, DatasetModuleId, DatasetTypeId since we allow . in the name
+      if (EnumSet.of(EntityType.DATASET, EntityType.DATASET_MODULE, EntityType.DATASET_TYPE).contains(typeFromString)) {
+        idParts = new ArrayList<>();
+        int namespaceSeparatorPos = idString.indexOf(IDSTRING_PART_SEPARATOR);
+        if (namespaceSeparatorPos > 0) {
+          idParts.add(idString.substring(0, namespaceSeparatorPos));
+          idParts.add(idString.substring(namespaceSeparatorPos + 1));
+        }
+      }
+      return typeFromString.fromIdParts(idParts);
     } catch (IllegalArgumentException e) {
       String message = idClass == null ? String.format("Invalid ID: %s", string) :
         String.format("Invalid ID for type '%s': %s", idClass.getName(), string);

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
@@ -227,10 +227,15 @@ public class EntityIdTest {
 
   @Test
   public void testDatasetName() {
-    // TODO: CDAP-5730: Even though dots are allowed, if we use it here, id creation will fail.
     DatasetId.fromString("dataset:foo.Zo123_-$$_-");
+    DatasetId dataset = DatasetId.fromString("dataset:foo.app.meta");
+    Assert.assertEquals("foo", dataset.getNamespace());
+    Assert.assertEquals("app.meta", dataset.getDataset());
+    dataset = DatasetId.fromString("dataset:foo.app.meta.second");
+    Assert.assertEquals("app.meta.second", dataset.getDataset());
     try {
       DatasetId.fromString("dataset:i have a space in my name");
+      DatasetId.fromString("dataset:.should.have.a.namespace.name");
       Assert.fail("Dataset Id with space in its name was created successfully while it should have failed.");
     } catch (IllegalArgumentException e) {
       // expected


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-5730
https://issues.cask.co/browse/CDAP-11497
Build: https://builds.cask.co/browse/CDAP-RUT1000-1
Fix the fromString method for not allowing . in dataset/type/module names
