### PR TITLE
CDAP-11609 fixes for spark2 on cdh

### DIFF
--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkPackageUtils.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkPackageUtils.java
@@ -415,11 +415,14 @@ public final class SparkPackageUtils {
     String sparkYarnJar = sparkConf.getProperty(SPARK_YARN_JAR);
 
     if (sparkYarnJar != null) {
-      Location frameworkLocation = locationFactory.create(URI.create(sparkYarnJar));
-      if (frameworkLocation.exists()) {
-        return new SparkFramework(new LocalizeResource(resolveURI(frameworkLocation), false), SPARK_YARN_JAR);
+      URI sparkYarnJarURI = URI.create(sparkYarnJar);
+      if (locationFactory.getHomeLocation().toURI().getScheme().equals(sparkYarnJarURI.getScheme())) {
+        Location frameworkLocation = locationFactory.create(sparkYarnJarURI);
+        if (frameworkLocation.exists()) {
+          return new SparkFramework(new LocalizeResource(resolveURI(frameworkLocation), false), SPARK_YARN_JAR);
+        }
+        LOG.warn("The location {} set by '{}' does not exist.", frameworkLocation, SPARK_YARN_JAR);
       }
-      LOG.warn("The location {} set by '{}' does not exist.", frameworkLocation, SPARK_YARN_JAR);
     }
 
     // If spark.yarn.jar is not defined or doesn't exists, get the spark-assembly jar from local FS and upload it
@@ -452,11 +455,14 @@ public final class SparkPackageUtils {
     String sparkYarnArchive = sparkConf.getProperty(SPARK_YARN_ARCHIVE);
 
     if (sparkYarnArchive != null) {
-      Location frameworkLocation = locationFactory.create(URI.create(sparkYarnArchive));
-      if (frameworkLocation.exists()) {
-        return new SparkFramework(new LocalizeResource(resolveURI(frameworkLocation), true), SPARK_YARN_ARCHIVE);
+      URI sparkYarnArchiveURI = URI.create(sparkYarnArchive);
+      if (locationFactory.getHomeLocation().toURI().getScheme().equals(sparkYarnArchiveURI.getScheme())) {
+        Location frameworkLocation = locationFactory.create(URI.create(sparkYarnArchive));
+        if (frameworkLocation.exists()) {
+          return new SparkFramework(new LocalizeResource(resolveURI(frameworkLocation), true), SPARK_YARN_ARCHIVE);
+        }
+        LOG.warn("The location {} set by '{}' does not exist.", frameworkLocation, SPARK_YARN_ARCHIVE);
       }
-      LOG.warn("The location {} set by '{}' does not exist.", frameworkLocation, SPARK_YARN_ARCHIVE);
     }
 
     // If spark.yarn.archive is not defined or doesn't exists, build a archive zip from local FS and upload it

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -49,6 +49,7 @@ import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hive.service.auth.HiveAuthFactory;
 import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
@@ -124,6 +125,7 @@ public final class DistributedSparkProgramRunner extends DistributedProgramRunne
 
     // Update the container hConf
     hConf.setBoolean(SparkRuntimeContextConfig.HCONF_ATTR_CLUSTER_MODE, true);
+    hConf.set("hive.metastore.token.signature", HiveAuthFactory.HS2_CLIENT_TOKEN);
 
     if (SecurityUtil.isKerberosEnabled(cConf)) {
       // Need to divide the interval by 0.8 because Spark logic has a 0.8 discount on the interval

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/AbstractSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/AbstractSparkSubmitter.java
@@ -126,9 +126,9 @@ public abstract class AbstractSparkSubmitter implements SparkSubmitter {
   }
 
   /**
-   * Returns the value for the {@code --master} argument for the Spark submission.
+   * Add the {@code --master} argument for the Spark submission.
    */
-  protected abstract String getMaster(Map<String, String> configs);
+  protected abstract void addMaster(Map<String, String> configs, ImmutableList.Builder<String> argBuilder);
 
   /**
    * Invoked for stopping the Spark job explicitly.
@@ -185,7 +185,7 @@ public abstract class AbstractSparkSubmitter implements SparkSubmitter {
                                              List<LocalizeResource> resources, File jobJar) {
     ImmutableList.Builder<String> builder = ImmutableList.builder();
 
-    builder.add("--master").add(getMaster(configs));
+    addMaster(configs, builder);
     builder.add("--class").add(SparkMainWrapper.class.getName());
     builder.add("--conf").add("spark.app.name=" + spec.getName());
 

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
@@ -24,6 +24,7 @@ import co.cask.cdap.app.runtime.spark.distributed.SparkExecutionService;
 import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.twill.filesystem.LocationFactory;
@@ -74,8 +75,9 @@ public class DistributedSparkSubmitter extends AbstractSparkSubmitter {
   }
 
   @Override
-  protected String getMaster(Map<String, String> configs) {
-    return "yarn-cluster";
+  protected void addMaster(Map<String, String> configs, ImmutableList.Builder<String> argBuilder) {
+    argBuilder.add("--master").add("yarn")
+      .add("--deploy-mode").add("cluster");
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/LocalSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/LocalSparkSubmitter.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.runtime.spark.submit;
 
 import co.cask.cdap.app.runtime.spark.SparkMainWrapper;
+import com.google.common.collect.ImmutableList;
 
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -30,16 +31,19 @@ public class LocalSparkSubmitter extends AbstractSparkSubmitter {
   private static final Pattern LOCAL_MASTER_PATTERN = Pattern.compile("local\\[([0-9]+|\\*)\\]");
 
   @Override
-  protected String getMaster(Map<String, String> configs) {
+  protected void addMaster(Map<String, String> configs, ImmutableList.Builder<String> argBuilder) {
+    // Use at least two threads for Spark Streaming
+    String masterArg = "local[2]";
+
     String master = configs.get("spark.master");
     if (master != null) {
       Matcher matcher = LOCAL_MASTER_PATTERN.matcher(master);
       if (matcher.matches()) {
-        return "local[" + matcher.group(1) + "]";
+        masterArg = "local[" + matcher.group(1) + "]";
       }
     }
-    // Use at least two threads for Spark Streaming
-    return "local[2]";
+
+    argBuilder.add("--master").add(masterArg);
   }
 
   @Override


### PR DESCRIPTION
Modified spark submit to include deploy-mode as 'cluster' and
master as 'yarn', instead of master as 'yarn-cluster'.
This is to prevent issues that arise when an environment has a
spark default of 'client' set for deploy mode, which
clashes with the cluster in 'yarn-cluster'.

Also setting a property in hConf to make Hive use delegation tokens
instead of kerberos for auth in cdh environments.

Also explicitly filtering out the spark-yarn-shuffle jar that cdh
packages in their yarn lib directory, since it causes wrong classes
to be loaded.