### PR TITLE
CDAP-8777 Stopping Queue Config Cache Refresh Thread

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCacheSupplier.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCacheSupplier.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase.coprocessor;
+
+import co.cask.cdap.data2.transaction.coprocessor.CacheSupplier;
+import co.cask.cdap.data2.util.ReferenceCountedSupplier;
+import com.google.common.base.Supplier;
+import com.google.common.io.InputSupplier;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.tephra.persist.TransactionVisibilityState;
+
+/**
+ * Supplies instances of {@link ConsumerConfigCache} implementations.
+ */
+public class ConsumerConfigCacheSupplier implements CacheSupplier<ConsumerConfigCache> {
+  private final ReferenceCountedSupplier<ConsumerConfigCache> referenceCountedSupplier;
+  private final Supplier<ConsumerConfigCache> supplier;
+
+  public ConsumerConfigCacheSupplier(final TableName tableName, final CConfigurationReader cConfReader,
+                                     final Supplier<TransactionVisibilityState> transactionSnapshotSupplier,
+                                     final InputSupplier<HTableInterface> hTableSupplier) {
+    this.supplier = new Supplier<ConsumerConfigCache>() {
+      @Override
+      public ConsumerConfigCache get() {
+        return new ConsumerConfigCache(tableName, cConfReader, transactionSnapshotSupplier, hTableSupplier);
+      }
+    };
+    this.referenceCountedSupplier = new ReferenceCountedSupplier<>(
+      String.format("%s-%s:%s", ConsumerConfigCache.class.getSimpleName(), tableName.getNamespaceAsString(),
+                    tableName.getNameAsString()));
+  }
+
+  @Override
+  public ConsumerConfigCache get() {
+    return referenceCountedSupplier.getOrCreate(supplier);
+  }
+
+  @Override
+  public void release() {
+    referenceCountedSupplier.release();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/TableNameAwareCacheSupplier.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/TableNameAwareCacheSupplier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase.coprocessor;
+
+import co.cask.cdap.data2.util.ReferenceCountedSupplier;
+import com.google.common.base.Supplier;
+import com.google.common.io.InputSupplier;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.tephra.persist.TransactionVisibilityState;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Provides {@link ReferenceCountedSupplier} of {@link ConsumerConfigCache} for a given {@link TableName}.
+ */
+public class TableNameAwareCacheSupplier {
+  private static final ConcurrentMap<TableName, ConsumerConfigCacheSupplier> SUPPLIER_MAP =
+    new ConcurrentHashMap<>();
+
+  private TableNameAwareCacheSupplier() {
+    // no default constructor
+  }
+
+  public static ConsumerConfigCacheSupplier getSupplier(TableName tableName, CConfigurationReader cConfReader,
+                                                        Supplier<TransactionVisibilityState> snapshotSupplier,
+                                                        InputSupplier<HTableInterface> hTableSuplpier) {
+    ConsumerConfigCacheSupplier supplier = SUPPLIER_MAP.get(tableName);
+    if (supplier == null) {
+      supplier = new ConsumerConfigCacheSupplier(tableName, cConfReader, snapshotSupplier, hTableSuplpier);
+      if (SUPPLIER_MAP.putIfAbsent(tableName, supplier) != null) {
+        // discard our instance and re-retrieve, since someone else has set it
+        supplier = SUPPLIER_MAP.get(tableName);
+      }
+    }
+    return supplier;
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -50,6 +50,7 @@ import co.cask.cdap.data2.transaction.queue.QueueMetrics;
 import co.cask.cdap.data2.transaction.queue.QueueTest;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.TableNameAwareCacheSupplier;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.ConfigurationTable;
 import co.cask.cdap.data2.util.hbase.HBaseDDLExecutorFactory;
@@ -668,8 +669,8 @@ public abstract class HBaseQueueTest extends QueueTest {
       String prefix = htd.getValue(Constants.Dataset.TABLE_PREFIX);
       CConfigurationReader cConfReader
         = new CConfigurationReader(hConf, HTableNameConverter.getSysConfigTablePrefix(prefix));
-      return ConsumerConfigCache.getInstance(configTableName,
-                                             cConfReader, new Supplier<TransactionVisibilityState>() {
+      return TableNameAwareCacheSupplier.getSupplier(configTableName,
+                                                     cConfReader, new Supplier<TransactionVisibilityState>() {
           @Override
           public TransactionVisibilityState get() {
             try {
@@ -683,7 +684,7 @@ public abstract class HBaseQueueTest extends QueueTest {
           public HTableInterface getInput() throws IOException {
             return new HTable(hConf, configTableName);
           }
-        });
+        }).get();
     }
   }
 

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -19,7 +19,6 @@ package co.cask.cdap.data2.increment.hbase96;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.increment.hbase.TimestampOracle;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.Cell;
@@ -89,6 +88,13 @@ public class IncrementHandler extends BaseRegionObserver {
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
         state.initFamily(columnDesc.getName(), convertFamilyValues(columnDesc.getValues()));
       }
+    }
+  }
+
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (state != null) {
+      state.stop();
     }
   }
 

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase96/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase96/MessageTableRegionObserver.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.TopicMetadataCache;
 import co.cask.cdap.messaging.TopicMetadataCacheSupplier;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.coprocessor.TransactionStateCache;
+import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
 
@@ -77,6 +77,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   private static final Log LOG = LogFactory.getLog(MessageTableRegionObserver.class);
 
   private int prefixLength;
+  private TransactionStateCacheSupplier txStateCacheSupplier;
   private TransactionStateCache txStateCache;
   private TopicMetadataCache topicMetadataCache;
 
@@ -97,9 +98,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
       CConfigurationReader cConfReader = new CConfigurationReader(env.getConfiguration(), sysConfigTablePrefix);
 
-      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix,
-                                                                                       env.getConfiguration());
-      txStateCache = cacheSupplier.get();
+      txStateCacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix, env.getConfiguration());
+      txStateCache = txStateCacheSupplier.get();
       topicMetadataCacheSupplier = new TopicMetadataCacheSupplier(env, cConfReader, hbaseNamespacePrefix,
                                                                   metadataTableNamespace, new DefaultScanBuilder());
       topicMetadataCache = topicMetadataCacheSupplier.get();
@@ -108,10 +108,11 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
 
   @Override
   public void stop(CoprocessorEnvironment e) {
-    topicMetadataCacheSupplier.release();
     if (compactionState != null) {
       compactionState.stop();
     }
+    topicMetadataCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -231,7 +232,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     }
   }
 
-  private Supplier<TransactionStateCache> getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
+  private TransactionStateCacheSupplier getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
     String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(tablePrefix);
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
   }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/HBaseQueueRegionObserver.java
@@ -25,8 +25,10 @@ import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCacheSupplier;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.TableNameAwareCacheSupplier;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.base.Supplier;
@@ -51,6 +53,7 @@ import org.apache.hadoop.hbase.regionserver.StoreFile;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
@@ -76,9 +79,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   private TableName configTableName;
   private CConfigurationReader cConfReader;
   private Supplier<TransactionVisibilityState> txSnapshotSupplier;
+
+  private CacheSupplier<TransactionStateCache> txStateCacheSupplier;
+  private ConsumerConfigCacheSupplier configCacheSupplier;
+  private CompactionState compactionState;
+
   private TransactionStateCache txStateCache;
   private ConsumerConfigCache configCache;
-  private CompactionState compactionState;
   private Boolean pruneEnable;
 
   private int prefixBytes;
@@ -110,7 +117,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
       final String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txStateCacheSupplier = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
+      txStateCache = txStateCacheSupplier.get();
       txSnapshotSupplier = new Supplier<TransactionVisibilityState>() {
         @Override
         public TransactionVisibilityState get() {
@@ -121,7 +129,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configTableName = HTableNameConverter.toTableName(hbaseNamespacePrefix,
                                                         TableId.from(namespaceId, queueConfigTableId));
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = createConfigCache(env);
+      configCacheSupplier = createConfigCache(env);
+      configCache = configCacheSupplier.get();
     }
   }
 
@@ -130,6 +139,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     if (compactionState != null) {
       compactionState.stop();
     }
+    configCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -202,7 +213,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       // If prune enable has never been initialized, try to do so now
       initializePruneState(env);
     } else {
-      CConfiguration conf = getConfigCache(env).getCConf();
+      CConfiguration conf = configCache.getCConf();
       if (conf != null) {
         boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                                  TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -220,7 +231,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   private void initializePruneState(RegionCoprocessorEnvironment env) {
-    CConfiguration conf = getConfigCache(env).getCConf();
+    CConfiguration conf = configCache.getCConf();
     if (conf != null) {
       pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -254,22 +265,14 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   // needed for queue unit-test
   @SuppressWarnings("unused")
   private void updateCache() throws IOException {
-    ConsumerConfigCache configCache = this.configCache;
     if (configCache != null) {
       configCache.updateCache();
     }
   }
 
-  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
-    if (!configCache.isAlive()) {
-      configCache = createConfigCache(env);
-    }
-    return configCache;
-  }
-
-  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
-    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
-                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+  private ConsumerConfigCacheSupplier createConfigCache(final CoprocessorEnvironment env) {
+    return TableNameAwareCacheSupplier.getSupplier(configTableName, cConfReader,
+                                                   txSnapshotSupplier, new InputSupplier<HTableInterface>() {
         @Override
         public HTableInterface getInput() throws IOException {
           return env.getTable(configTableName);
@@ -341,7 +344,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
+          consumerConfig = configCache.getConsumerConfig(currentQueue);
         }
 
         invalidTxData = false;

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -19,7 +19,6 @@ package co.cask.cdap.data2.increment.hbase98;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.increment.hbase.TimestampOracle;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hbase.Cell;
@@ -88,6 +87,13 @@ public class IncrementHandler extends BaseRegionObserver {
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
         state.initFamily(columnDesc.getName(), convertFamilyValues(columnDesc.getValues()));
       }
+    }
+  }
+
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (state != null) {
+      state.stop();
     }
   }
 

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/MessageTableRegionObserver.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.TopicMetadataCache;
 import co.cask.cdap.messaging.TopicMetadataCacheSupplier;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.coprocessor.TransactionStateCache;
+import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
 
@@ -77,6 +77,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   private static final Log LOG = LogFactory.getLog(MessageTableRegionObserver.class);
 
   private int prefixLength;
+  private TransactionStateCacheSupplier txStateCacheSupplier;
   private TransactionStateCache txStateCache;
   private TopicMetadataCache topicMetadataCache;
 
@@ -97,9 +98,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
       CConfigurationReader cConfReader = new CConfigurationReader(env.getConfiguration(), sysConfigTablePrefix);
 
-      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix,
-                                                                                       env.getConfiguration());
-      txStateCache = cacheSupplier.get();
+      txStateCacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix, env.getConfiguration());
+      txStateCache = txStateCacheSupplier.get();
       topicMetadataCacheSupplier = new TopicMetadataCacheSupplier(env, cConfReader, hbaseNamespacePrefix,
                                                                   metadataTableNamespace, new DefaultScanBuilder());
       topicMetadataCache = topicMetadataCacheSupplier.get();
@@ -108,10 +108,11 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
 
   @Override
   public void stop(CoprocessorEnvironment e) {
-    topicMetadataCacheSupplier.release();
     if (compactionState != null) {
       compactionState.stop();
     }
+    topicMetadataCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -231,7 +232,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     }
   }
 
-  private Supplier<TransactionStateCache> getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
+  private TransactionStateCacheSupplier getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
     String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(tablePrefix);
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
   }

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/HBaseQueueRegionObserver.java
@@ -25,8 +25,10 @@ import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCacheSupplier;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.TableNameAwareCacheSupplier;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.base.Supplier;
@@ -51,6 +53,7 @@ import org.apache.hadoop.hbase.regionserver.StoreFile;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
@@ -76,9 +79,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   private TableName configTableName;
   private CConfigurationReader cConfReader;
   private Supplier<TransactionVisibilityState> txSnapshotSupplier;
+
+  private CacheSupplier<TransactionStateCache> txStateCacheSupplier;
+  private ConsumerConfigCacheSupplier configCacheSupplier;
+  private CompactionState compactionState;
+
   private TransactionStateCache txStateCache;
   private ConsumerConfigCache configCache;
-  private CompactionState compactionState;
   private Boolean pruneEnable;
 
   private int prefixBytes;
@@ -110,7 +117,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
       final String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txStateCacheSupplier = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
+      txStateCache = txStateCacheSupplier.get();
       txSnapshotSupplier = new Supplier<TransactionVisibilityState>() {
         @Override
         public TransactionVisibilityState get() {
@@ -121,7 +129,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configTableName = HTableNameConverter.toTableName(hbaseNamespacePrefix,
                                                         TableId.from(namespaceId, queueConfigTableId));
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = createConfigCache(env);
+      configCacheSupplier = createConfigCache(env);
+      configCache = configCacheSupplier.get();
     }
   }
 
@@ -130,6 +139,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     if (compactionState != null) {
       compactionState.stop();
     }
+    configCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -202,7 +213,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       // If prune enable has never been initialized, try to do so now
       initializePruneState(env);
     } else {
-      CConfiguration conf = getConfigCache(env).getCConf();
+      CConfiguration conf = configCache.getCConf();
       if (conf != null) {
         boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                                  TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -220,7 +231,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   private void initializePruneState(RegionCoprocessorEnvironment env) {
-    CConfiguration conf = getConfigCache(env).getCConf();
+    CConfiguration conf = configCache.getCConf();
     if (conf != null) {
       pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -254,22 +265,14 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   // needed for queue unit-test
   @SuppressWarnings("unused")
   private void updateCache() throws IOException {
-    ConsumerConfigCache configCache = this.configCache;
     if (configCache != null) {
       configCache.updateCache();
     }
   }
 
-  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
-    if (!configCache.isAlive()) {
-      configCache = createConfigCache(env);
-    }
-    return configCache;
-  }
-
-  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
-    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
-                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+  private ConsumerConfigCacheSupplier createConfigCache(final CoprocessorEnvironment env) {
+    return TableNameAwareCacheSupplier.getSupplier(configTableName, cConfReader,
+                                                   txSnapshotSupplier, new InputSupplier<HTableInterface>() {
         @Override
         public HTableInterface getInput() throws IOException {
           return env.getTable(configTableName);
@@ -341,7 +344,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
+          consumerConfig = configCache.getConsumerConfig(currentQueue);
         }
 
         invalidTxData = false;

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandler.java
@@ -90,6 +90,13 @@ public class IncrementHandler extends BaseRegionObserver {
     }
   }
 
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (state != null) {
+      state.stop();
+    }
+  }
+
   @VisibleForTesting
   void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10cdh/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10cdh/MessageTableRegionObserver.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.TopicMetadataCache;
 import co.cask.cdap.messaging.TopicMetadataCacheSupplier;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.coprocessor.TransactionStateCache;
+import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
 
@@ -77,6 +77,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   private static final Log LOG = LogFactory.getLog(MessageTableRegionObserver.class);
 
   private int prefixLength;
+  private TransactionStateCacheSupplier txStateCacheSupplier;
   private TransactionStateCache txStateCache;
   private TopicMetadataCache topicMetadataCache;
 
@@ -97,9 +98,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
       CConfigurationReader cConfReader = new CConfigurationReader(env.getConfiguration(), sysConfigTablePrefix);
 
-      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix,
-                                                                                       env.getConfiguration());
-      txStateCache = cacheSupplier.get();
+      txStateCacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix, env.getConfiguration());
+      txStateCache = txStateCacheSupplier.get();
       topicMetadataCacheSupplier = new TopicMetadataCacheSupplier(env, cConfReader, hbaseNamespacePrefix,
                                                                   metadataTableNamespace, new DefaultScanBuilder());
       topicMetadataCache = topicMetadataCacheSupplier.get();
@@ -108,10 +108,11 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
 
   @Override
   public void stop(CoprocessorEnvironment e) {
-    topicMetadataCacheSupplier.release();
     if (compactionState != null) {
       compactionState.stop();
     }
+    topicMetadataCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -231,7 +232,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     }
   }
 
-  private Supplier<TransactionStateCache> getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
+  private TransactionStateCacheSupplier getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
     String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(tablePrefix);
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
   }

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/HBaseQueueRegionObserver.java
@@ -25,8 +25,10 @@ import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCacheSupplier;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.TableNameAwareCacheSupplier;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.base.Supplier;
@@ -51,6 +53,7 @@ import org.apache.hadoop.hbase.regionserver.StoreFile;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
@@ -76,9 +79,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   private TableName configTableName;
   private CConfigurationReader cConfReader;
   private Supplier<TransactionVisibilityState> txSnapshotSupplier;
+
+  private CacheSupplier<TransactionStateCache> txStateCacheSupplier;
+  private ConsumerConfigCacheSupplier configCacheSupplier;
+  private CompactionState compactionState;
+
   private TransactionStateCache txStateCache;
   private ConsumerConfigCache configCache;
-  private CompactionState compactionState;
   private Boolean pruneEnable;
 
   private int prefixBytes;
@@ -110,7 +117,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
       final String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txStateCacheSupplier = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
+      txStateCache = txStateCacheSupplier.get();
       txSnapshotSupplier = new Supplier<TransactionVisibilityState>() {
         @Override
         public TransactionVisibilityState get() {
@@ -121,7 +129,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configTableName = HTableNameConverter.toTableName(hbaseNamespacePrefix,
                                                         TableId.from(namespaceId, queueConfigTableId));
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = createConfigCache(env);
+      configCacheSupplier = createConfigCache(env);
+      configCache = configCacheSupplier.get();
     }
   }
 
@@ -130,6 +139,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     if (compactionState != null) {
       compactionState.stop();
     }
+    configCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -202,7 +213,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       // If prune enable has never been initialized, try to do so now
       initializePruneState(env);
     } else {
-      CConfiguration conf = getConfigCache(env).getCConf();
+      CConfiguration conf = configCache.getCConf();
       if (conf != null) {
         boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                                  TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -220,7 +231,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   private void initializePruneState(RegionCoprocessorEnvironment env) {
-    CConfiguration conf = getConfigCache(env).getCConf();
+    CConfiguration conf = configCache.getCConf();
     if (conf != null) {
       pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -254,22 +265,14 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   // needed for queue unit-test
   @SuppressWarnings("unused")
   private void updateCache() throws IOException {
-    ConsumerConfigCache configCache = this.configCache;
     if (configCache != null) {
       configCache.updateCache();
     }
   }
 
-  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
-    if (!configCache.isAlive()) {
-      configCache = createConfigCache(env);
-    }
-    return configCache;
-  }
-
-  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
-    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
-                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+  private ConsumerConfigCacheSupplier createConfigCache(final CoprocessorEnvironment env) {
+    return TableNameAwareCacheSupplier.getSupplier(configTableName, cConfReader,
+                                                   txSnapshotSupplier, new InputSupplier<HTableInterface>() {
         @Override
         public HTableInterface getInput() throws IOException {
           return env.getTable(configTableName);
@@ -341,7 +344,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
+          consumerConfig = configCache.getConsumerConfig(currentQueue);
         }
 
         invalidTxData = false;

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementHandler.java
@@ -90,6 +90,13 @@ public class IncrementHandler extends BaseRegionObserver {
     }
   }
 
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (state != null) {
+      state.stop();
+    }
+  }
+
   @VisibleForTesting
   void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh550/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh550/HBaseQueueRegionObserver.java
@@ -25,8 +25,10 @@ import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCacheSupplier;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.TableNameAwareCacheSupplier;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.base.Supplier;
@@ -52,6 +54,7 @@ import org.apache.hadoop.hbase.regionserver.StoreFile;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
@@ -77,9 +80,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   private TableName configTableName;
   private CConfigurationReader cConfReader;
   private Supplier<TransactionVisibilityState> txSnapshotSupplier;
+
+  private CacheSupplier<TransactionStateCache> txStateCacheSupplier;
+  private ConsumerConfigCacheSupplier configCacheSupplier;
+  private CompactionState compactionState;
+
   private TransactionStateCache txStateCache;
   private ConsumerConfigCache configCache;
-  private CompactionState compactionState;
   private Boolean pruneEnable;
 
   private int prefixBytes;
@@ -111,7 +118,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
       final String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txStateCacheSupplier = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
+      txStateCache = txStateCacheSupplier.get();
       txSnapshotSupplier = new Supplier<TransactionVisibilityState>() {
         @Override
         public TransactionVisibilityState get() {
@@ -122,7 +130,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configTableName = HTableNameConverter.toTableName(hbaseNamespacePrefix,
                                                         TableId.from(namespaceId, queueConfigTableId));
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = createConfigCache(env);
+      configCacheSupplier = createConfigCache(env);
+      configCache = configCacheSupplier.get();
     }
   }
 
@@ -131,6 +140,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     if (compactionState != null) {
       compactionState.stop();
     }
+    configCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -203,7 +214,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       // If prune enable has never been initialized, try to do so now
       initializePruneState(env);
     } else {
-      CConfiguration conf = getConfigCache(env).getCConf();
+      CConfiguration conf = configCache.getCConf();
       if (conf != null) {
         boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                                  TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -221,7 +232,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   private void initializePruneState(RegionCoprocessorEnvironment env) {
-    CConfiguration conf = getConfigCache(env).getCConf();
+    CConfiguration conf = configCache.getCConf();
     if (conf != null) {
       pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -254,22 +265,14 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   // needed for queue unit-test
   @SuppressWarnings("unused")
   private void updateCache() throws IOException {
-    ConsumerConfigCache configCache = this.configCache;
     if (configCache != null) {
       configCache.updateCache();
     }
   }
 
-  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
-    if (!configCache.isAlive()) {
-      configCache = createConfigCache(env);
-    }
-    return configCache;
-  }
-
-  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
-    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
-                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+  private ConsumerConfigCacheSupplier createConfigCache(final CoprocessorEnvironment env) {
+    return TableNameAwareCacheSupplier.getSupplier(configTableName, cConfReader,
+                                                   txSnapshotSupplier, new InputSupplier<HTableInterface>() {
         @Override
         public HTableInterface getInput() throws IOException {
           return env.getTable(configTableName);
@@ -341,7 +344,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
+          consumerConfig = configCache.getConsumerConfig(currentQueue);
         }
 
         invalidTxData = false;

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementHandler.java
@@ -90,6 +90,13 @@ public class IncrementHandler extends BaseRegionObserver {
     }
   }
 
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (state != null) {
+      state.stop();
+    }
+  }
+
   @VisibleForTesting
   void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10/MessageTableRegionObserver.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.TopicMetadataCache;
 import co.cask.cdap.messaging.TopicMetadataCacheSupplier;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.coprocessor.TransactionStateCache;
+import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
 
@@ -77,6 +77,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   private static final Log LOG = LogFactory.getLog(MessageTableRegionObserver.class);
 
   private int prefixLength;
+  private TransactionStateCacheSupplier txStateCacheSupplier;
   private TransactionStateCache txStateCache;
   private TopicMetadataCache topicMetadataCache;
 
@@ -97,9 +98,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
       CConfigurationReader cConfReader = new CConfigurationReader(env.getConfiguration(), sysConfigTablePrefix);
 
-      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix,
-                                                                                       env.getConfiguration());
-      txStateCache = cacheSupplier.get();
+      txStateCacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix, env.getConfiguration());
+      txStateCache = txStateCacheSupplier.get();
       topicMetadataCacheSupplier = new TopicMetadataCacheSupplier(env, cConfReader, hbaseNamespacePrefix,
                                                                   metadataTableNamespace, new HBase10ScanBuilder());
       topicMetadataCache = topicMetadataCacheSupplier.get();
@@ -108,10 +108,11 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
 
   @Override
   public void stop(CoprocessorEnvironment e) {
-    topicMetadataCacheSupplier.release();
     if (compactionState != null) {
       compactionState.stop();
     }
+    topicMetadataCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -231,7 +232,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     }
   }
 
-  private Supplier<TransactionStateCache> getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
+  private TransactionStateCacheSupplier getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
     String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(tablePrefix);
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
   }

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/increment/hbase11/IncrementHandler.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/increment/hbase11/IncrementHandler.java
@@ -90,6 +90,13 @@ public class IncrementHandler extends BaseRegionObserver {
     }
   }
 
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (state != null) {
+      state.stop();
+    }
+  }
+
   @VisibleForTesting
   void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase11/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase11/MessageTableRegionObserver.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.TopicMetadataCache;
 import co.cask.cdap.messaging.TopicMetadataCacheSupplier;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -51,6 +50,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.coprocessor.TransactionStateCache;
+import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
 
@@ -78,6 +78,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   private static final Log LOG = LogFactory.getLog(MessageTableRegionObserver.class);
 
   private int prefixLength;
+  private TransactionStateCacheSupplier txStateCacheSupplier;
   private TransactionStateCache txStateCache;
   private TopicMetadataCache topicMetadataCache;
 
@@ -98,9 +99,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
       CConfigurationReader cConfReader = new CConfigurationReader(env.getConfiguration(), sysConfigTablePrefix);
 
-      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix,
-                                                                                       env.getConfiguration());
-      txStateCache = cacheSupplier.get();
+      txStateCacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix, env.getConfiguration());
+      txStateCache = txStateCacheSupplier.get();
       topicMetadataCacheSupplier = new TopicMetadataCacheSupplier(env, cConfReader, hbaseNamespacePrefix,
                                                                   metadataTableNamespace, new HBase11ScanBuilder());
       topicMetadataCache = topicMetadataCacheSupplier.get();
@@ -109,10 +109,11 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
 
   @Override
   public void stop(CoprocessorEnvironment e) {
-    topicMetadataCacheSupplier.release();
     if (compactionState != null) {
       compactionState.stop();
     }
+    topicMetadataCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -231,7 +232,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     }
   }
 
-  private Supplier<TransactionStateCache> getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
+  private TransactionStateCacheSupplier getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
     String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(tablePrefix);
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
   }

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase11/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase11/HBaseQueueRegionObserver.java
@@ -25,8 +25,10 @@ import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCacheSupplier;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.TableNameAwareCacheSupplier;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.base.Supplier;
@@ -52,6 +54,7 @@ import org.apache.hadoop.hbase.regionserver.StoreFile;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
@@ -77,9 +80,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   private TableName configTableName;
   private CConfigurationReader cConfReader;
   private Supplier<TransactionVisibilityState> txSnapshotSupplier;
+
+  private CacheSupplier<TransactionStateCache> txStateCacheSupplier;
+  private ConsumerConfigCacheSupplier configCacheSupplier;
+  private CompactionState compactionState;
+
   private TransactionStateCache txStateCache;
   private ConsumerConfigCache configCache;
-  private CompactionState compactionState;
   private Boolean pruneEnable;
 
   private int prefixBytes;
@@ -111,7 +118,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
       final String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txStateCacheSupplier = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
+      txStateCache = txStateCacheSupplier.get();
       txSnapshotSupplier = new Supplier<TransactionVisibilityState>() {
         @Override
         public TransactionVisibilityState get() {
@@ -122,7 +130,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configTableName = HTableNameConverter.toTableName(hbaseNamespacePrefix,
                                                         TableId.from(namespaceId, queueConfigTableId));
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = createConfigCache(env);
+      configCacheSupplier = createConfigCache(env);
+      configCache = configCacheSupplier.get();
     }
   }
 
@@ -131,6 +140,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     if (compactionState != null) {
       compactionState.stop();
     }
+    configCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -203,7 +214,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       // If prune enable has never been initialized, try to do so now
       initializePruneState(env);
     } else {
-      CConfiguration conf = getConfigCache(env).getCConf();
+      CConfiguration conf = configCache.getCConf();
       if (conf != null) {
         boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                                  TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -221,7 +232,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   private void initializePruneState(RegionCoprocessorEnvironment env) {
-    CConfiguration conf = getConfigCache(env).getCConf();
+    CConfiguration conf = configCache.getCConf();
     if (conf != null) {
       pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -254,27 +265,19 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   // needed for queue unit-test
   @SuppressWarnings("unused")
   private void updateCache() throws IOException {
-    ConsumerConfigCache configCache = this.configCache;
     if (configCache != null) {
       configCache.updateCache();
     }
   }
 
-  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
-    if (!configCache.isAlive()) {
-      configCache = createConfigCache(env);
-    }
-    return configCache;
-  }
-
-  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
-    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
-                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
-      @Override
-      public HTableInterface getInput() throws IOException {
-        return env.getTable(configTableName);
-      }
-    });
+  private ConsumerConfigCacheSupplier createConfigCache(final CoprocessorEnvironment env) {
+    return TableNameAwareCacheSupplier.getSupplier(configTableName, cConfReader,
+                                                   txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+        @Override
+        public HTableInterface getInput() throws IOException {
+          return env.getTable(configTableName);
+        }
+      });
   }
 
   // need for queue unit-test
@@ -341,7 +344,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
+          consumerConfig = configCache.getConsumerConfig(currentQueue);
         }
 
         invalidTxData = false;

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandler.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandler.java
@@ -90,6 +90,13 @@ public class IncrementHandler extends BaseRegionObserver {
     }
   }
 
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (state != null) {
+      state.stop();
+    }
+  }
+
   @VisibleForTesting
   void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase12cdh570/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase12cdh570/MessageTableRegionObserver.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.TopicMetadataCache;
 import co.cask.cdap.messaging.TopicMetadataCacheSupplier;
-import com.google.common.base.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -51,6 +50,7 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
 import org.apache.tephra.coprocessor.TransactionStateCache;
+import org.apache.tephra.coprocessor.TransactionStateCacheSupplier;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
 
@@ -78,6 +78,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   private static final Log LOG = LogFactory.getLog(MessageTableRegionObserver.class);
 
   private int prefixLength;
+  private TransactionStateCacheSupplier txStateCacheSupplier;
   private TransactionStateCache txStateCache;
   private TopicMetadataCache topicMetadataCache;
 
@@ -98,9 +99,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
       CConfigurationReader cConfReader = new CConfigurationReader(env.getConfiguration(), sysConfigTablePrefix);
 
-      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix,
-                                                                                       env.getConfiguration());
-      txStateCache = cacheSupplier.get();
+      txStateCacheSupplier = getTransactionStateCacheSupplier(hbaseNamespacePrefix, env.getConfiguration());
+      txStateCache = txStateCacheSupplier.get();
       topicMetadataCacheSupplier = new TopicMetadataCacheSupplier(
         env, cConfReader, hbaseNamespacePrefix, metadataTableNamespace, new HBase12CDH570ScanBuilder());
       topicMetadataCache = topicMetadataCacheSupplier.get();
@@ -109,10 +109,11 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
 
   @Override
   public void stop(CoprocessorEnvironment e) {
-    topicMetadataCacheSupplier.release();
     if (compactionState != null) {
       compactionState.stop();
     }
+    topicMetadataCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -231,7 +232,7 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     }
   }
 
-  private Supplier<TransactionStateCache> getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
+  private TransactionStateCacheSupplier getTransactionStateCacheSupplier(String tablePrefix, Configuration conf) {
     String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(tablePrefix);
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
   }

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/HBaseQueueRegionObserver.java
@@ -25,8 +25,10 @@ import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCacheSupplier;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
 import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.TableNameAwareCacheSupplier;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.base.Supplier;
@@ -52,6 +54,7 @@ import org.apache.hadoop.hbase.regionserver.StoreFile;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.TxConstants;
+import org.apache.tephra.coprocessor.CacheSupplier;
 import org.apache.tephra.coprocessor.TransactionStateCache;
 import org.apache.tephra.hbase.txprune.CompactionState;
 import org.apache.tephra.persist.TransactionVisibilityState;
@@ -77,9 +80,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   private TableName configTableName;
   private CConfigurationReader cConfReader;
   private Supplier<TransactionVisibilityState> txSnapshotSupplier;
+
+  private CacheSupplier<TransactionStateCache> txStateCacheSupplier;
+  private ConsumerConfigCacheSupplier configCacheSupplier;
+  private CompactionState compactionState;
+
   private TransactionStateCache txStateCache;
   private ConsumerConfigCache configCache;
-  private CompactionState compactionState;
   private Boolean pruneEnable;
 
   private int prefixBytes;
@@ -111,7 +118,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
       final String sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txStateCacheSupplier = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf);
+      txStateCache = txStateCacheSupplier.get();
       txSnapshotSupplier = new Supplier<TransactionVisibilityState>() {
         @Override
         public TransactionVisibilityState get() {
@@ -122,7 +130,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configTableName = HTableNameConverter.toTableName(hbaseNamespacePrefix,
                                                         TableId.from(namespaceId, queueConfigTableId));
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = createConfigCache(env);
+      configCacheSupplier = createConfigCache(env);
+      configCache = configCacheSupplier.get();
     }
   }
 
@@ -131,6 +140,8 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     if (compactionState != null) {
       compactionState.stop();
     }
+    configCacheSupplier.release();
+    txStateCacheSupplier.release();
   }
 
   @Override
@@ -203,7 +214,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       // If prune enable has never been initialized, try to do so now
       initializePruneState(env);
     } else {
-      CConfiguration conf = getConfigCache(env).getCConf();
+      CConfiguration conf = configCache.getCConf();
       if (conf != null) {
         boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                                  TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -221,7 +232,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   private void initializePruneState(RegionCoprocessorEnvironment env) {
-    CConfiguration conf = getConfigCache(env).getCConf();
+    CConfiguration conf = configCache.getCConf();
     if (conf != null) {
       pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
@@ -254,22 +265,14 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   // needed for queue unit-test
   @SuppressWarnings("unused")
   private void updateCache() throws IOException {
-    ConsumerConfigCache configCache = this.configCache;
     if (configCache != null) {
       configCache.updateCache();
     }
   }
 
-  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
-    if (!configCache.isAlive()) {
-      configCache = createConfigCache(env);
-    }
-    return configCache;
-  }
-
-  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
-    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
-                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+  private ConsumerConfigCacheSupplier createConfigCache(final CoprocessorEnvironment env) {
+    return TableNameAwareCacheSupplier.getSupplier(configTableName, cConfReader,
+                                                   txSnapshotSupplier, new InputSupplier<HTableInterface>() {
         @Override
         public HTableInterface getInput() throws IOException {
           return env.getTable(configTableName);
@@ -341,7 +344,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
+          consumerConfig = configCache.getConsumerConfig(currentQueue);
         }
 
         invalidTxData = false;


### PR DESCRIPTION
Also enable TxState cache reference counting in MessageTableRegionObserver, HBaseQueueRegionObserver, IncrementHandler. It was previously done only in DefaultTransactionProcessor.

JIRA: https://issues.cask.co/browse/CDAP-8777

Build: https://builds.cask.co/browse/CDAP-RUT997

Verified on a cluster.