### PR TITLE
CDAP-11504 Configurable per-service JVM flags

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-env.sh
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-env.sh
@@ -43,3 +43,9 @@ TEMP_DIR="/tmp"
 # export KAFKA_JAVA_HEAPMAX="-Xmx1024m"
 # export MASTER_JAVA_HEAPMAX="-Xmx1024m"
 # export ROUTER_JAVA_HEAPMAX="-Xmx1024m"
+
+# Service-specific Java options (added to OPTS, before other options)
+# export AUTH_JAVA_OPTS=""
+# export KAFKA_JAVA_OPTS=""
+# export MASTER_JAVA_OPTS=""
+# export ROUTER_JAVA_OPTS=""


### PR DESCRIPTION
This allows setting a per-service configuration variable, which gets loaded into the Java command line before other options, allowing it to override them.