### PR TITLE
fix for changing behavior for fromString

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -164,9 +164,9 @@ public abstract class EntityId implements IdCompatible {
       List<String> idParts = Arrays.asList(IDSTRING_PART_SEPARATOR_PATTERN.split(idString));
       // special case for DatasetId, DatasetModuleId, DatasetTypeId since we allow . in the name
       if (EnumSet.of(EntityType.DATASET, EntityType.DATASET_MODULE, EntityType.DATASET_TYPE).contains(typeFromString)) {
-        idParts = new ArrayList<>();
         int namespaceSeparatorPos = idString.indexOf(IDSTRING_PART_SEPARATOR);
         if (namespaceSeparatorPos > 0) {
+          idParts = new ArrayList<>();
           idParts.add(idString.substring(0, namespaceSeparatorPos));
           idParts.add(idString.substring(namespaceSeparatorPos + 1));
         }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
@@ -240,6 +240,15 @@ public class EntityIdTest {
     } catch (IllegalArgumentException e) {
       // expected
     }
+
+    // test error message
+    try {
+      // missing dataset field
+      DatasetId.fromString("dataset:foo");
+      Assert.fail("Dataset Id creation should fail without dataset name");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Missing field: dataset", e.getCause().getMessage());
+    }
   }
 
   @Test


### PR DESCRIPTION
in #8894 , we changed the behavior for fromString for dataset, if we pass "dataset:foo" we will get missing field for namespace instead of dataset. This PR fixes it.