### PR TITLE
CDAP-9158 disabling escaping on macros by default

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Macro.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Macro.java
@@ -26,4 +26,16 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Macro {
+
+  /**
+   * Returns whether escaping is enabled. Default is false.
+   *
+   * When escaping is enabled, any character can be escaped with a backslash '\'. For example, with escaping enabled,
+   * '\${val}' would evaluate to '${val}'. With escaping disabled, '\${val}' would result in a lookup of 'val'.
+   * If the lookup for 'val' is 'xyz', the entire macro would evaluate to '\xyz'. Before enabling escaping on a field,
+   * keep in mind that an escape enabled macro field will behave differently than a non-macro field.
+   * In a non-macro field, '\n' will be evaluated as-is. In an escape enabled macro field, '\n' will evaluate
+   * to 'n'.
+   */
+  boolean escapingEnabled() default false;
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Macro.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Macro.java
@@ -36,6 +36,10 @@ public @interface Macro {
    * keep in mind that an escape enabled macro field will behave differently than a non-macro field.
    * In a non-macro field, '\n' will be evaluated as-is. In an escape enabled macro field, '\n' will evaluate
    * to 'n'.
+   *
+   * When escaping is disabled, certain values cannot be expressed. For example, a literal '${val}' cannot be used,
+   * since it will always be interpreted as a macro lookup. Similarly, '${${val}}' will not be a lookup on
+   * key '${val}', but will be a lookup on whatever '${val}' evaluates to.
    */
   boolean escapingEnabled() default false;
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginPropertyField.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginPropertyField.java
@@ -18,6 +18,8 @@ package co.cask.cdap.api.plugin;
 
 import co.cask.cdap.api.annotation.Beta;
 
+import java.util.Objects;
+
 /**
  * Contains information about a property used by a plugin.
  */
@@ -29,8 +31,10 @@ public class PluginPropertyField {
   private final String type;
   private final boolean required;
   private final boolean macroSupported;
+  private final boolean macroEscapingEnabled;
 
-  public PluginPropertyField(String name, String description, String type, boolean required, boolean macroSupported) {
+  public PluginPropertyField(String name, String description, String type, boolean required, boolean macroSupported,
+                             boolean macroEscapingEnabled) {
     if (name == null) {
       throw new IllegalArgumentException("Plugin property name cannot be null");
     }
@@ -46,6 +50,11 @@ public class PluginPropertyField {
     this.type = type;
     this.required = required;
     this.macroSupported = macroSupported;
+    this.macroEscapingEnabled = macroEscapingEnabled;
+  }
+
+  public PluginPropertyField(String name, String description, String type, boolean required, boolean macroSupported) {
+    this(name, description, type, required, macroSupported, false);
   }
 
   /**
@@ -77,6 +86,13 @@ public class PluginPropertyField {
   }
 
   /**
+   * Returns {@code true} if the macro escaping is enabled, {@code false} otherwise.
+   */
+  public boolean isMacroEscapingEnabled() {
+    return macroEscapingEnabled;
+  }
+
+  /**
    * Returns the type of the property.
    */
   public String getType() {
@@ -98,16 +114,12 @@ public class PluginPropertyField {
       && name.equals(that.name)
       && description.equals(that.description)
       && type.equals(that.type)
-      && macroSupported == that.macroSupported;
+      && macroSupported == that.macroSupported
+      && macroEscapingEnabled == that.macroEscapingEnabled;
   }
 
   @Override
   public int hashCode() {
-    int result = name.hashCode();
-    result = 31 * result + description.hashCode();
-    result = 31 * result + type.hashCode();
-    result = 31 * result + (required ? 1 : 0);
-    result = 31 * result + (macroSupported ? 1 : 0);
-    return result;
+    return Objects.hash(name, description, type, required, macroSupported, macroEscapingEnabled);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/FindPluginHelper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/FindPluginHelper.java
@@ -102,9 +102,8 @@ public final class FindPluginHelper {
   }
 
   private static Plugin getPlugin(Map.Entry<ArtifactDescriptor, PluginClass> pluginEntry, PluginProperties properties,
-                           String pluginType, String pluginName, PluginInstantiator pluginInstantiator) {
+                                  String pluginType, String pluginName, PluginInstantiator pluginInstantiator) {
     CollectMacroEvaluator collectMacroEvaluator = new CollectMacroEvaluator();
-    MacroParser parser = new MacroParser(collectMacroEvaluator);
 
     // Just verify if all required properties are provided.
     // No type checking is done for now.
@@ -113,6 +112,7 @@ public final class FindPluginHelper {
                                   "Required property '%s' missing for plugin of type %s, name %s.",
                                   field.getName(), pluginType, pluginName);
       if (field.isMacroSupported()) {
+        MacroParser parser = new MacroParser(collectMacroEvaluator, field.isMacroEscapingEnabled());
         parser.parse(properties.getProperties().get(field.getName()));
       }
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/MacroParser.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/MacroParser.java
@@ -32,9 +32,15 @@ public class MacroParser {
   private static final int MAX_SUBSTITUTION_DEPTH = 10;
 
   private final MacroEvaluator macroEvaluator;
+  private final boolean escapingEnabled;
 
   public MacroParser(MacroEvaluator macroEvaluator) {
+    this(macroEvaluator, true);
+  }
+
+  public MacroParser(MacroEvaluator macroEvaluator, boolean escapingEnabled) {
     this.macroEvaluator = macroEvaluator;
+    this.escapingEnabled = escapingEnabled;
   }
 
   /**
@@ -160,6 +166,9 @@ public class MacroParser {
    * @return if the character at the provided index is escaped
    */
   private boolean isEscaped(int index, String str) {
+    if (!escapingEnabled) {
+      return false;
+    }
     int numPrecedingParens = 0;
     for (int i = index - 1; i >= 0; i--) {
       if (str.charAt(i) == '\\') {
@@ -178,6 +187,9 @@ public class MacroParser {
    * @return the string with no escaped syntax
    */
   private String replaceEscapedSyntax(String str) {
+    if (!escapingEnabled) {
+      return str;
+    }
     StringBuilder syntaxRebuilder = new StringBuilder();
     boolean includeNextConsecutiveBackslash = false;
     for (int i = 0; i < str.length(); i++) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/plugin/MacroParserTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/plugin/MacroParserTest.java
@@ -43,6 +43,7 @@ public class MacroParserTest {
   @Test
   public void testContainsSimpleEscapedMacro() throws InvalidMacroException {
     assertContainsMacroParsing("$${{\\}}", true);
+    assertSubstitution("\\${val}", "${val}", ImmutableMap.<String, String>of(), ImmutableMap.<String, String>of());
   }
 
   @Test
@@ -486,6 +487,15 @@ public class MacroParserTest {
                        properties, new HashMap<String, String>());
   }
 
+  @Test
+  public void testNoEscape() {
+    MacroParser parser = new MacroParser(new TestMacroEvaluator(ImmutableMap.of("\\a\\b\\c\\", "123", "x", "xyz"),
+                                                                ImmutableMap.of("xyz", "321")),
+                                         false);
+    Assert.assertEquals("123", parser.parse("${\\a\\b\\c\\}"));
+    Assert.assertEquals("321", parser.parse("${test(${x})}"));
+    Assert.assertEquals("\\321", parser.parse("\\${test(xyz)}"));
+  }
 
   // Testing util methods
 

--- a/cdap-docs/developers-manual/source/pipelines/creating-pipelines.rst
+++ b/cdap-docs/developers-manual/source/pipelines/creating-pipelines.rst
@@ -507,16 +507,6 @@ expecting that it would be replaced with::
 
   my-demo-host.example.com:9991
 
-Escaping Macros
----------------
-Macro syntax can be escaped using a backslash (``\``) character. For example::
-
-  ${\${escaped-macro-literal\}}
-  
-will lookup the key ``${escaped-macro-literal}``, which includes the special characters of
-the macro syntax.
-
-
 Validation
 ==========
 From within the CDAP Studio, the validation button will examine the pipeline


### PR DESCRIPTION
In most use cases, escaping is not required or desired. Disabling
escaping by default on macro fields. It can still be enabled
if a plugin developer really wants.