### PR TITLE
CDAP-4887 Fix HBaseTableUtil#isCDAPTable

### DIFF
--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -606,7 +606,7 @@ public abstract class HBaseTableUtil {
 
       for (RegionLoad regionLoad : regionsLoad.values()) {
         TableName tableName = HRegionInfo.getTable(regionLoad.getName());
-        HTableDescriptor tableDescriptor = new HTableDescriptor(tableName);
+        HTableDescriptor tableDescriptor = admin.getTableDescriptor(tableName);
         if (!isCDAPTable(tableDescriptor)) {
           continue;
         }

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -178,12 +178,7 @@ public abstract class HBaseTableUtil {
   }
 
   protected boolean isCDAPTable(HTableDescriptor hTableDescriptor) {
-    // TODO: Once all system tables are upgraded to have CDAP_VERSION in their descriptor, we can then solely rely on
-    // that key being present in the descriptor to identify a CDAP Table
-    String tableName = hTableDescriptor.getNameAsString();
-    String value = hTableDescriptor.getValue(CDAP_VERSION);
-    return tableName.startsWith(tablePrefix + ".") || tableName.startsWith(tablePrefix + "_") ||
-      !Strings.isNullOrEmpty(value);
+    return !Strings.isNullOrEmpty(hTableDescriptor.getValue(CDAP_VERSION));
   }
 
   public HTableDescriptor setVersion(HTableDescriptor tableDescriptor) {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-4887
Fix HBaseTableUtil#isCDAPTable to not consider tables that are simply prefixed by 'cdap' as cdap tables.

This change is possible due to https://issues.cask.co/browse/CDAP-2963 and https://issues.cask.co/browse/CDAP-6450.

https://builds.cask.co/browse/CDAP-RUT1015-6