### PR TITLE
CDAP-11643 fix purchase app to avoid possible data clobbering

### DIFF
--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.UUID;
 
 /**
  * Store the incoming Purchase objects in the purchases dataset.
@@ -58,7 +59,7 @@ public class PurchaseStore extends AbstractFlowlet {
 
     LOG.info("Purchase info: Customer {}, ProductId {}, CatalogId {}",
              purchase.getCustomer(), purchase.getProduct(), purchase.getCatalogId());
-    store.write(Bytes.toBytes(purchase.getPurchaseTime()), purchase);
+    store.write(Bytes.toBytes(UUID.randomUUID()), purchase);
   }
 
   @Override

--- a/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
+++ b/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
@@ -31,7 +31,6 @@ import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;


### PR DESCRIPTION
The app was using the readtime of a purchase as the table key.
This is bad because it means purchases read at the same time will
clobber each other.