### PR TITLE
CDAP-9475 add a test module for spark2

### DIFF
--- a/cdap-examples/DecisionTreeRegression/src/test/java/co/cask/cdap/examples/dtree/DecisionTreeRegressionAppTest.java
+++ b/cdap-examples/DecisionTreeRegression/src/test/java/co/cask/cdap/examples/dtree/DecisionTreeRegressionAppTest.java
@@ -23,7 +23,7 @@ import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SparkManager;
-import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestBaseWithSpark2;
 import co.cask.cdap.test.TestConfiguration;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
@@ -45,12 +45,11 @@ import java.util.concurrent.TimeUnit;
 /**
  * Decision Tree Example tests.
  */
-public class DecisionTreeRegressionAppTest extends TestBase {
+public class DecisionTreeRegressionAppTest extends TestBaseWithSpark2 {
   private static final Gson GSON = new Gson();
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
-                                                                       Constants.AppFabric.SPARK_COMPAT, "spark2_2.11");
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void test() throws Exception {

--- a/cdap-examples/deploy_pom.xml
+++ b/cdap-examples/deploy_pom.xml
@@ -220,6 +220,10 @@
       <artifactId>cdap-unit-test</artifactId>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-unit-test-spark2_2.11</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -243,6 +247,12 @@
         <groupId>co.cask.cdap</groupId>
         <artifactId>cdap-unit-test</artifactId>
         <version>${cdap.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>co.cask.cdap</groupId>
+        <artifactId>cdap-unit-test-spark2_2.11</artifactId>
+        <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -474,12 +484,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>co.cask.cdap</groupId>
-        <artifactId>cdap-spark-core2_2.11</artifactId>
-        <version>${cdap.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/cdap-examples/pom.xml
+++ b/cdap-examples/pom.xml
@@ -172,6 +172,10 @@
       <artifactId>cdap-unit-test</artifactId>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-unit-test-spark2_2.11</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -205,6 +209,12 @@
       <dependency>
         <groupId>co.cask.cdap</groupId>
         <artifactId>cdap-unit-test</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>co.cask.cdap</groupId>
+        <artifactId>cdap-unit-test-spark2_2.11</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
@@ -386,12 +396,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.11</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>co.cask.cdap</groupId>
-        <artifactId>cdap-spark-core2_2.11</artifactId>
-        <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/cdap-unit-test-spark2_2.11/pom.xml
+++ b/cdap-unit-test-spark2_2.11/pom.xml
@@ -14,64 +14,28 @@
   License for the specific language governing permissions and limitations under
   the License.
   -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <artifactId>cdap-examples</artifactId>
-    <groupId>co.cask.cdap</groupId>
-    <version>4.2.0-SNAPSHOT</version>
-  </parent>
+
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>DecisionTreeRegression</artifactId>
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap</artifactId>
+    <version>4.2.0-SNAPSHOT</version>
+  </parent>
 
-  <properties>
-    <app.main.class>co.cask.cdap.examples.dtree.DecisionTreeRegressionApp</app.main.class>
-    <scala.version>2.11.8</scala.version>
-    <spark.version>2.1.0</spark.version>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>scala-tools.org</id>
-      <name>Scala-tools Maven2 Repository</name>
-      <url>http://scala-tools.org/repo-releases</url>
-    </repository>
-  </repositories>
+  <artifactId>cdap-unit-test-spark2_2.11</artifactId>
+  <name>CDAP Unit Test Framework with Spark2_2.11</name>
+  <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-api-spark2_2.11</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
-      <version>${spark.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.11</artifactId>
-      <version>${spark.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_2.11</artifactId>
-      <version>${spark.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-unit-test</artifactId>
-      <scope>test</scope>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>co.cask.cdap</groupId>
@@ -83,6 +47,26 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-spark-core2_2.11</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api-spark2_2.11</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -92,6 +76,20 @@
         <artifactId>scala-maven-plugin</artifactId>
         <version>3.2.2</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>test-jar</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
+
 </project>

--- a/cdap-unit-test-spark2_2.11/src/main/java/co/cask/cdap/test/TestBaseWithSpark2.java
+++ b/cdap-unit-test-spark2_2.11/src/main/java/co/cask/cdap/test/TestBaseWithSpark2.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import co.cask.cdap.app.runtime.spark.SparkCompat;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.test.TestRunner;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+/**
+ * Base class to inherit from for unit-test that need to run Spark2.
+ * It provides testing functionality for {@link co.cask.cdap.api.app.Application}.
+ * To clean App Fabric state, you can use the {@link #clear} method.
+ * <p>
+ * Custom configurations for CDAP can be set by using {@link ClassRule} and {@link TestConfiguration}.
+ * </p>
+ *
+ * @see TestConfiguration
+ */
+@RunWith(TestRunner.class)
+public class TestBaseWithSpark2 extends TestBase {
+
+  // Do not overwrite (create a TestConfiguration with the exact same name),
+  // otherwise Spark classes will not be available.
+  @ClassRule
+  public static final TestConfiguration DO_NOT_OVERWRITE_THIS_CONFIG =
+    new TestConfiguration(Constants.AppFabric.SPARK_COMPAT, SparkCompat.SPARK2_2_11.getCompat());
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2615,6 +2615,7 @@
         <module>cdap-explore-jdbc</module>
         <module>cdap-explore</module>
         <module>cdap-unit-test</module>
+        <module>cdap-unit-test-spark2_2.11</module>
         <module>cdap-kms</module>
         <module>cdap-master</module>
         <module>cdap-proto</module>


### PR DESCRIPTION
Add a dedicated module for unit tests on spark2 so that users
don't have to modify some internal configuration key and modify
their pom with cdap internal modules.