### PR TITLE
[CDAP-11593] Add a backward-compatible option to schedule REST APIs

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -849,6 +849,12 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     String scheduleName = schedules.get(0).getName();
     Assert.assertFalse(scheduleName.isEmpty());
 
+    // get schedules in backward-compatible ScheduleSpecification form
+    List<ScheduleSpecification> specs = getScheduleSpecs(TEST_NAMESPACE2, appName, workflowName);
+    Assert.assertEquals(1, specs.size());
+    String specName = specs.get(0).getSchedule().getName();
+    Assert.assertEquals(scheduleName, specName);
+
     // TODO [CDAP-2327] Sagar Investigate why following check fails sometimes. Mostly test case issue.
     // List<ScheduledRuntime> previousRuntimes = getScheduledRunTime(programId, scheduleName, "previousruntime");
     // Assert.assertTrue(previousRuntimes.size() == 0);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -87,6 +87,7 @@ import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.id.ScheduleId;
 import co.cask.cdap.proto.id.ServiceId;
 import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.WorkflowId;
 import co.cask.cdap.scheduler.Scheduler;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.HttpResponder;
@@ -157,6 +158,13 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private static final Gson GSON = ApplicationSpecificationAdapter
     .addTypeAdapters(new GsonBuilder())
     .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
+    .registerTypeAdapter(Trigger.class, new TriggerCodec())
+    .registerTypeAdapter(Constraint.class, new ConstraintCodec())
+    .create();
+
+  // the CaseInsensitiveEnumTypeAdapterFactory breaks schedule deserialization in clients
+  private static final Gson GSON_FOR_SCHEDULES = ApplicationSpecificationAdapter
+    .addTypeAdapters(new GsonBuilder())
     .registerTypeAdapter(Trigger.class, new TriggerCodec())
     .registerTypeAdapter(Constraint.class, new ConstraintCodec())
     .create();
@@ -611,9 +619,10 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void getSchedule(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId,
                           @PathParam("app-name") String appName,
-                          @PathParam("schedule-name") String scheduleName)
-    throws NotFoundException, SchedulerException {
-    doGetSchedule(responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, scheduleName);
+                          @PathParam("schedule-name") String scheduleName,
+                          @QueryParam("format") String format)
+    throws NotFoundException, SchedulerException, BadRequestException {
+    doGetSchedule(responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, scheduleName, format);
   }
 
   @GET
@@ -622,25 +631,40 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                           @PathParam("namespace-id") String namespaceId,
                           @PathParam("app-name") String appName,
                           @PathParam("app-version") String appVersion,
-                          @PathParam("schedule-name") String scheduleName)
-    throws NotFoundException, SchedulerException {
-    doGetSchedule(responder, namespaceId, appName, appVersion, scheduleName);
+                          @PathParam("schedule-name") String scheduleName,
+                          @QueryParam("format") String format)
+    throws NotFoundException, SchedulerException, BadRequestException {
+    doGetSchedule(responder, namespaceId, appName, appVersion, scheduleName, format);
   }
 
-  private void doGetSchedule(HttpResponder responder, String namespace, String app, String version, String scheduleName)
-    throws NotFoundException {
+  private void doGetSchedule(HttpResponder responder, String namespace,
+                             String app, String version, String scheduleName, String format)
+    throws NotFoundException, BadRequestException {
+
+    boolean asScheduleSpec = returnScheduleAsSpec(format);
     ScheduleId scheduleId = new ApplicationId(namespace, app, version).schedule(scheduleName);
     ProgramSchedule schedule = programScheduler.getSchedule(scheduleId);
-    responder.sendJson(HttpResponseStatus.OK, schedule.toScheduleDetail(), ScheduleDetail.class, GSON);
+    ScheduleDetail detail = schedule.toScheduleDetail();
+    if (asScheduleSpec) {
+      ScheduleSpecification spec = detail.toScheduleSpec();
+      if (spec == null) {
+        // this is for supporting old-style schedules. If the schedule has a trigger that can't be expressed
+        // then this application must be using new APIs and the schedule can't be returned in old form.
+        throw new NotFoundException(scheduleId);
+      }
+      responder.sendJson(HttpResponseStatus.OK, spec, ScheduleSpecification.class, GSON);
+    } else {
+      responder.sendJson(HttpResponseStatus.OK, detail, ScheduleDetail.class, GSON);
+    }
   }
 
   @GET
   @Path("apps/{app-name}/schedules")
   public void getAllSchedules(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
-                              @PathParam("app-name") String appName)
-    throws NotFoundException, SchedulerException {
-    doGetAllSchedules(responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION);
+                              @PathParam("app-name") String appName,
+                              @QueryParam("format") String format) throws NotFoundException, BadRequestException {
+    doGetSchedules(responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, null, format);
   }
 
   @GET
@@ -648,17 +672,37 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void getAllSchedules(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("app-name") String appName,
-                              @PathParam("app-version") String appVersion)
-    throws NotFoundException, SchedulerException {
-    doGetAllSchedules(responder, namespaceId, appName, appVersion);
+                              @PathParam("app-version") String appVersion,
+                              @QueryParam("format") String format) throws NotFoundException, BadRequestException {
+    doGetSchedules(responder, namespaceId, appName, appVersion, null, format);
   }
 
-  private void doGetAllSchedules(HttpResponder responder, String namespace, String app, String version)
-    throws NotFoundException {
+  protected void doGetSchedules(HttpResponder responder, String namespace, String app, String version,
+                                @Nullable String workflow, @Nullable String format)
+    throws NotFoundException, BadRequestException {
+    boolean asScheduleSpec = returnScheduleAsSpec(format);
     ApplicationId applicationId = new ApplicationId(namespace, app, version);
-    List<ProgramSchedule> schedules = programScheduler.listSchedules(applicationId);
+    ApplicationSpecification appSpec = store.getApplication(applicationId);
+    if (appSpec == null) {
+      throw new NotFoundException(applicationId);
+    }
+    List<ProgramSchedule> schedules;
+    if (workflow != null) {
+      WorkflowId workflowId = applicationId.workflow(workflow);
+      if (appSpec.getWorkflows().get(workflow) == null) {
+        throw new NotFoundException(workflowId);
+      }
+      schedules = programScheduler.listSchedules(workflowId);
+    } else {
+      schedules = programScheduler.listSchedules(applicationId);
+    }
     List<ScheduleDetail> details = Schedulers.toScheduleDetails(schedules);
-    responder.sendJson(HttpResponseStatus.OK, details, Schedulers.SCHEDULE_DETAILS_TYPE, GSON);
+    if (asScheduleSpec) {
+      List<ScheduleSpecification> specs = ScheduleDetail.toScheduleSpecs(details);
+      responder.sendJson(HttpResponseStatus.OK, specs, Schedulers.SCHEDULE_SPECS_TYPE, GSON_FOR_SCHEDULES);
+    } else {
+      responder.sendJson(HttpResponseStatus.OK, details, Schedulers.SCHEDULE_DETAILS_TYPE, GSON_FOR_SCHEDULES);
+    }
   }
 
   @PUT
@@ -1876,4 +1920,19 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
     return namespaceId;
   }
+
+  /**
+   * Parses the URL parameter "format" to determine whether schedules should be returned as {@link ScheduleDetail}
+   * or as {@link ScheduleSpecification}, for backward-compatible response format.
+   */
+  protected boolean returnScheduleAsSpec(@Nullable String format) throws BadRequestException {
+    if (format == null || "detail".equals(format)) {
+      return false;
+    }
+    if ("spec".equals(format)) {
+      return true;
+    }
+    throw new BadRequestException("Parameter 'format' must be 'spec' or 'detail' but is '" + format + "'");
+  }
+
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/Schedulers.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/Schedulers.java
@@ -67,6 +67,7 @@ public class Schedulers {
   public static final DatasetId JOB_QUEUE_DATASET_ID = NamespaceId.SYSTEM.dataset("job.queue");
 
   public static final Type SCHEDULE_DETAILS_TYPE = new TypeToken<List<ScheduleDetail>>() { }.getType();
+  public static final Type SCHEDULE_SPECS_TYPE = new TypeToken<List<ScheduleSpecification>>() { }.getType();
 
   public static String triggerKeyForPartition(DatasetId datasetId) {
     return "partition:" + datasetId.getNamespace() + '.' + datasetId.getDataset();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
@@ -58,6 +59,7 @@ import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.http.BodyConsumer;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -299,7 +301,12 @@ public class AppFabricClient {
     String uri = String.format("%s/apps/%s/workflows/%s/schedules",
                                getNamespacePath(namespace), app, workflow);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    workflowHttpHandler.getWorkflowSchedules(request, responder, namespace, app, workflow);
+    try {
+      workflowHttpHandler.getWorkflowSchedules(request, responder, namespace, app, workflow, null);
+    } catch (BadRequestException e) {
+      // cannot happen
+      throw Throwables.propagate(e);
+    }
 
     List<ScheduleDetail> schedules = responder.decodeResponseContent(SCHEDULE_DETAILS_TYPE, GSON);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Getting workflow schedules failed");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -45,6 +45,7 @@ import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
@@ -57,7 +58,6 @@ import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProtoConstraintCodec;
-import co.cask.cdap.proto.ProtoTriggerCodec;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ScheduleDetail;
 import co.cask.cdap.proto.ScheduleUpdateDetail;
@@ -151,7 +151,6 @@ public abstract class AppFabricTestBase {
   protected static final Type LIST_JSON_OBJECT_TYPE = new TypeToken<List<JsonObject>>() { }.getType();
   protected static final Type LIST_MAP_STRING_STRING_TYPE = new TypeToken<List<Map<String, String>>>() { }.getType();
   protected static final Type LIST_RUNRECORD_TYPE = new TypeToken<List<RunRecord>>() { }.getType();
-  protected static final Type LIST_SCHEDULE_DETAIL_TYPE = new TypeToken<List<ScheduleDetail>>() { }.getType();
   protected static final Type SET_TRING_TYPE = new TypeToken<Set<String>>() { }.getType();
 
   protected static final String NONEXISTENT_NAMESPACE = "12jr0j90jf3foieoi33";
@@ -872,23 +871,61 @@ public abstract class AppFabricTestBase {
     return response.getStatusLine().getStatusCode();
   }
 
+  protected List<ScheduleDetail> listSchedules(String namespace, String appName,
+                                               @Nullable String appVersion) throws Exception {
+    String schedulesUrl = String.format("apps/%s/versions/%s/schedules", appName,
+                                        appVersion == null ? ApplicationId.DEFAULT_VERSION : appVersion);
+    return goGetSchedules(namespace, schedulesUrl);
+  }
+
   protected List<ScheduleDetail> getSchedules(String namespace, String appName,
                                               String workflowName) throws Exception {
     String schedulesUrl = String.format("apps/%s/workflows/%s/schedules", appName, workflowName);
-    String versionedUrl = getVersionedAPIPath(schedulesUrl, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
-    HttpResponse response = doGet(versionedUrl);
-    String json = EntityUtils.toString(response.getEntity());
-    return GSON.fromJson(json, LIST_SCHEDULE_DETAIL_TYPE);
+    return goGetSchedules(namespace, schedulesUrl);
   }
 
   protected List<ScheduleDetail> getSchedules(String namespace, String appName, String appVersion,
                                               String workflowName) throws Exception {
     String schedulesUrl = String.format("apps/%s/versions/%s/workflows/%s/schedules", appName, appVersion,
                                         workflowName);
-    String versionedUrl = getVersionedAPIPath(schedulesUrl, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
+    return goGetSchedules(namespace, schedulesUrl);
+  }
+
+  private List<ScheduleDetail> goGetSchedules(String namespace, String schedulesUrl) throws Exception {
+    String versionedUrl = getVersionedAPIPath(schedulesUrl, namespace);
     HttpResponse response = doGet(versionedUrl);
-    String json = EntityUtils.toString(response.getEntity());
-    return GSON.fromJson(json, LIST_SCHEDULE_DETAIL_TYPE);
+    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
+    return readResponse(response, Schedulers.SCHEDULE_DETAILS_TYPE);
+  }
+
+  @Deprecated
+  protected List<ScheduleSpecification> listScheduleSpecs(String namespace, String appName,
+                                                          @Nullable String appVersion) throws Exception {
+    String schedulesUrl = String.format("apps/%s/versions/%s/schedules", appName,
+                                        appVersion == null ? ApplicationId.DEFAULT_VERSION : appVersion);
+    return goGetScheduleSpecs(namespace, schedulesUrl);
+  }
+
+  @Deprecated
+  protected List<ScheduleSpecification> getScheduleSpecs(String namespace, String app,
+                                                         String workflow) throws Exception {
+    String schedulesUrl = String.format("apps/%s/workflows/%s/schedules", app, workflow);
+    return goGetScheduleSpecs(namespace, schedulesUrl);
+  }
+
+  @Deprecated
+  protected List<ScheduleSpecification> getScheduleSpecs(String namespace, String app, String version,
+                                                         String workflow) throws Exception {
+    String schedulesUrl = String.format("apps/%s/versions/%s/workflows/%s/schedules", app, version, workflow);
+    return goGetScheduleSpecs(namespace, schedulesUrl);
+  }
+
+  @Deprecated
+  private List<ScheduleSpecification> goGetScheduleSpecs(String namespace, String schedulesUrl) throws Exception {
+    String versionedUrl = getVersionedAPIPath(schedulesUrl + "?format=spec", namespace);
+    HttpResponse response = doGet(versionedUrl);
+    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
+    return readResponse(response, Schedulers.SCHEDULE_SPECS_TYPE);
   }
 
   protected HttpResponse addSchedule(String namespace, String appName, @Nullable String appVersion, String scheduleName,
@@ -929,7 +966,7 @@ public abstract class AppFabricTestBase {
   }
 
   protected ScheduleDetail getSchedule(String namespace, String appName, @Nullable String appVersion,
-                                              String scheduleName) throws Exception {
+                                       String scheduleName) throws Exception {
     appVersion = appVersion == null ? ApplicationId.DEFAULT_VERSION : appVersion;
     String path = String.format("apps/%s/versions/%s/schedules/%s", appName, appVersion, scheduleName);
     HttpResponse response = doGet(getVersionedAPIPath(path, namespace));
@@ -937,13 +974,14 @@ public abstract class AppFabricTestBase {
     return readResponse(response, ScheduleDetail.class);
   }
 
-  protected List<ScheduleDetail> listSchedules(String namespace, String appName,
-                                               @Nullable String appVersion) throws Exception {
+  @Deprecated
+  protected ScheduleSpecification getScheduleSpec(String namespace, String appName, @Nullable String appVersion,
+                                                  String scheduleName) throws Exception {
     appVersion = appVersion == null ? ApplicationId.DEFAULT_VERSION : appVersion;
-    String path = String.format("apps/%s/versions/%s/schedules", appName, appVersion);
+    String path = String.format("apps/%s/versions/%s/schedules/%s?format=spec", appName, appVersion, scheduleName);
     HttpResponse response = doGet(getVersionedAPIPath(path, namespace));
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
-    return readResponse(response, LIST_SCHEDULE_DETAIL_TYPE);
+    return readResponse(response, ScheduleSpecification.class);
   }
 
   protected void verifyNoRunWithStatus(final Id.Program program, final String status) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -984,12 +984,18 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     deleteApp(appDefault, 200);
 
-    // Schedule spec of app1 from versioned API
+    // Schedule of app1 from versioned API
     List<ScheduleDetail> someSchedules1 = getSchedules(TEST_NAMESPACE2, APP_WITH_MULTIPLE_WORKFLOWS_APP_NAME,
                                                        VERSION1, APP_WITH_MULTIPLE_WORKFLOWS_SOMEWORKFLOW);
     Assert.assertEquals(2, someSchedules1.size());
     Assert.assertEquals(APP_WITH_MULTIPLE_WORKFLOWS_SOMEWORKFLOW, someSchedules1.get(0).getProgram().getProgramName());
     Assert.assertEquals(APP_WITH_MULTIPLE_WORKFLOWS_SOMEWORKFLOW, someSchedules1.get(1).getProgram().getProgramName());
+    // validate backward-compatible API
+    List<ScheduleSpecification> someSpecs1 = getScheduleSpecs(TEST_NAMESPACE2, APP_WITH_MULTIPLE_WORKFLOWS_APP_NAME,
+                                                              VERSION1, APP_WITH_MULTIPLE_WORKFLOWS_SOMEWORKFLOW);
+    Assert.assertEquals(2, someSpecs1.size());
+    Assert.assertEquals(APP_WITH_MULTIPLE_WORKFLOWS_SOMEWORKFLOW, someSpecs1.get(0).getProgram().getProgramName());
+    Assert.assertEquals(APP_WITH_MULTIPLE_WORKFLOWS_SOMEWORKFLOW, someSpecs1.get(1).getProgram().getProgramName());
 
     deleteApp(app1, 200);
 
@@ -1128,6 +1134,13 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     List<ScheduleDetail> schedulesForApp = listSchedules(TEST_NAMESPACE1, AppWithSchedule.NAME, null);
     Assert.assertEquals(1, schedulesForApp.size());
     Assert.assertEquals(schedules, schedulesForApp);
+    // validate backward compatible api
+    List<ScheduleSpecification> specsForApp = listScheduleSpecs(TEST_NAMESPACE1, AppWithSchedule.NAME, null);
+    Assert.assertEquals(1, specsForApp.size());
+    ScheduleSpecification spec = specsForApp.get(0);
+    Assert.assertEquals(AppWithSchedule.WORKFLOW_NAME, spec.getProgram().getProgramName());
+    Assert.assertTrue(spec.getSchedule() instanceof TimeSchedule);
+    Assert.assertEquals("0/15 * * * * ?", ((TimeSchedule) spec.getSchedule()).getCronEntry());
 
     List<ScheduleDetail> schedules2 =
       getSchedules(TEST_NAMESPACE1, AppWithSchedule.NAME, VERSION2, AppWithSchedule.WORKFLOW_NAME);
@@ -1312,6 +1325,9 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
     ScheduleDetail detail100 = getSchedule(TEST_NAMESPACE1, AppWithSchedule.NAME, VERSION2, "schedule-100");
     Assert.assertEquals("schedule-100", detail100.getName());
+    // test backward-compatible api
+    ScheduleSpecification spec100 = getScheduleSpec(TEST_NAMESPACE1, AppWithSchedule.NAME, VERSION2, "schedule-100");
+    Assert.assertEquals(detail100.toScheduleSpec(), spec100);
   }
 
   private void testDeleteSchedule(ApplicationId appV2Id, String scheduleName) throws Exception {


### PR DESCRIPTION
- adds an optional ?format=spec to get/list schedule URLs 
- adds tests for these
- minor refactoring of HTTP handlers and test helpers
- major refactoring of HTTP handlers: ProgramLifecycleHTTPHandler serializes enums in lower case, which breaks schedule de/serialization in clients and CLI. Factored out the schedule endpoints into a new handler that is tolerant to lower case when deserializing but serializes in upper case. 