### PR TITLE
CDAP-11645 exclude netty-all from sdk lib directory

### DIFF
--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -200,6 +200,12 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <version>${sdk.hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
It doesn't appear like it is needed, and it causes conflicts
when using spark.