### PR TITLE
CDAP-11649 add sonatype snapshot repo to examples pom

### DIFF
--- a/cdap-examples/deploy_pom.xml
+++ b/cdap-examples/deploy_pom.xml
@@ -48,6 +48,10 @@
 
   <repositories>
     <repository>
+      <id>sonatype.snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+    <repository>
       <id>apache.snapshots</id>
       <url>https://repository.apache.org/content/repositories/snapshots</url>
     </repository>


### PR DESCRIPTION
This is to allow users to build the examples using a snapshot sdk.