### PR TITLE
parameterize packer vm name

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -1,5 +1,6 @@
 {
   "variables": {
+    "standalone_vm_name": "cdap-standalone-vm",
     "sdk_version": "DEFINE ME ON COMMAND LINE"
   },
   "builders": [
@@ -54,7 +55,7 @@
         ["modifyvm", "{{ .Name }}", "--accelerate3d", "on"],
         ["modifyvm", "{{ .Name }}", "--natpf1", "guest_ssh,tcp,127.0.0.1,2222,,22" ]
       ],
-      "vm_name": "cdap-standalone-vm-{{user `sdk_version`}}",
+      "vm_name": "{{user `standalone_vm_name`}}-{{user `sdk_version`}}",
       "name": "cdap-sdk-vm"
     },
     {


### PR DESCRIPTION
Conflicts:
	cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json

backport the packer changes from https://github.com/caskdata/cdap/pull/8917.  The BA build has been modified to pass this parameter, and so all branches need to use it