### PR TITLE
CDAP-11678 Fix flaky WorkflowHttpHandlerTest#testStreamSizeSchedules.

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -86,7 +86,7 @@ import javax.annotation.Nullable;
 /**
  * Tests for {@link WorkflowHttpHandler}
  */
-public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
+public class WorkflowHttpHandlerTest extends AppFabricTestBase {
 
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
@@ -828,9 +828,9 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // 6. Resume the schedule
     // 7. Verify there are runs after the resume by looking at the history
 
-    String appName = "AppWithSchedule";
-    String workflowName = "SampleWorkflow";
-    String sampleSchedule = "SampleSchedule";
+    String appName = AppWithSchedule.NAME;
+    String workflowName = AppWithSchedule.WORKFLOW_NAME;
+    String sampleSchedule = AppWithSchedule.SCHEDULE;
 
     // deploy app with schedule in namespace 2
     HttpResponse response = deploy(AppWithSchedule.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
@@ -1019,10 +1019,11 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     Assert.assertEquals(200, resumeSchedule(TEST_NAMESPACE2, appName, scheduleName1));
 
-    assertRunHistory(programId, "completed", workflowRunsAfterSuspend, 60, TimeUnit.SECONDS);
-
     //check scheduled state
     assertSchedule(programId, scheduleName1, true, 30, TimeUnit.SECONDS);
+
+    // an additional run should execute and complete after resuming the schedule
+    assertRunHistory(programId, "completed", 1 + workflowRunsAfterSuspend, 60, TimeUnit.SECONDS);
 
     //Check status of a non existing schedule
     try {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-11678
https://builds.cask.co/browse/CDAP-RUT1044-1

The failure was happening because a second workflow run is started after resuming the schedule, but the test case doesn't wait for it to complete.
The test case had an assumption that no workflow was being executed after the schedule was resumed.