### PR TITLE
CDAP-9178 logs for spark programs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -389,7 +389,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     // Shutdown will still get executed, but the service will notify failure after that.
     // However, if it's the job is requested to stop (via triggerShutdown, meaning it's a user action), don't throw
     if (!stopRequested) {
-      Preconditions.checkState(job.isSuccessful(), "MapReduce JobId {} failed", job.getStatus().getJobID());
+      Preconditions.checkState(job.isSuccessful(), "MapReduce JobId %s failed", job.getStatus().getJobID());
     }
   }
 

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -43,7 +43,8 @@
   <logger name="org.quartz.core" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="io.netty.util.internal" level="WARN"/>
-
+  <logger name="WriteAheadLogManager " level="WARN"/>
+  <logger name="org.apache.kafka.common.config.AbstractConfig" level="WARN"/>
   <logger name="org.apache.twill" level="INFO"/>
   <logger name="org.apache.twill.internal.kafka.client.SimpleKafkaConsumer" level="WARN"/>
   <logger name="co.cask.cdap" level="INFO"/>

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -45,6 +45,8 @@
     <logger name="Remoting" level="WARN"/>
     <logger name="com.sun.jersey" level="WARN"/>
 
+    <logger name="WriteAheadLogManager " level="WARN"/>
+    <logger name="org.apache.kafka.common.config.AbstractConfig" level="WARN"/>
 
     <!-- HttpRequestLog is not used and expects log4j logging or logs a WARN message -->
     <logger name="org.apache.hadoop.http.HttpRequestLog" level="ERROR"/>

--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -51,6 +51,9 @@
   <logger name="Remoting" level="WARN"/>
   <logger name="com.sun.jersey" level="WARN"/>
 
+  <logger name="WriteAheadLogManager " level="WARN"/>
+  <logger name="org.apache.kafka.common.config.AbstractConfig" level="WARN"/>
+
   <!-- HttpRequestLog is not used and expects log4j logging or logs a WARN message -->
   <logger name="org.apache.hadoop.http.HttpRequestLog" level="ERROR"/>
 


### PR DESCRIPTION
- Move unnecessary loggers to WARN. 
- Fix mapreduce error. 