### PR TITLE
[BACKPORT to release/4.1] add node-dir as a version dependencies

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -75,6 +75,7 @@
     "lodash-webpack-plugin": "0.10.0",
     "main-bower-files": "2.11.1",
     "merge-stream": "1.0.0",
+    "node-dir": "0.1.16",
     "node-sass": "4.3.0",
     "parallel-webpack": "1.6.0",
     "postcss-loader": "1.1.1",


### PR DESCRIPTION
Backport of https://github.com/caskdata/cdap/pull/8952