### PR TITLE
CDAP_DOCS: Removing SDK in all its variations and replacing with Local Sandbox

### DIFF
--- a/cdap-docs/_common/_source/guides.rst
+++ b/cdap-docs/_common/_source/guides.rst
@@ -141,7 +141,7 @@ Guides
 
 - |examples-manual|_
 
-  - |ex-man-e-black|_ Included with the :ref:`CDAP SDK <getting-started-index>`, they range from a simple introductory to more elaborate examples
+  - |ex-man-e-black|_ Included with the :ref:`CDAP Local Sandbox <getting-started-index>`, they range from a simple introductory to more elaborate examples
   - |ex-man-htg-black|_ Designed to be completed in 15-30 minutes, these guides provide quick, hands-on instructions
   - |ex-man-t-black|_ Designed to be completed in 2-3 hours, these tutorials provide deeper, in-context explorations
   - |ex-man-capr-black|_ data applications built using CDAP and useful building blocks for your data applications

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -33,7 +33,7 @@ import subprocess
 import sys
 from datetime import datetime
 
-def get_sdk_version():
+def get_cdap_version():
     # Sets the Build Version
     version = None
     short_version = None
@@ -68,12 +68,12 @@ def get_sdk_version():
         pass
     return version, short_version, full_version, version_tuple
 
-def print_sdk_version():
-    version, short_version, full_version = get_sdk_version()
+def print_cdap_version():
+    version, short_version, full_version = get_cdap_version()
     if version == full_version:
-        print "SDK Version: %s" % version
+        print "CDAP Version: %s" % version
     elif version and full_version:
-        print "SDK Version: %s (%s)" % (version, full_version)
+        print "CDAP Version: %s (%s)" % (version, full_version)
         print "Version tuple: %s" % (version_tuple)
     else:
         print "Could not get version (%s), full version (%s) from grep" % (version, full_version)
@@ -207,7 +207,7 @@ locale_dirs = ['_locale/', '../../_common/_locale']
 # The X.Y.Z version
 # The X.Y short-version
 # The "full" version, which includes any alpha/beta/rc/SNAPSHOT tags, also called the "release" version.
-version, short_version, release, version_tuple = get_sdk_version()
+version, short_version, release, version_tuple = get_cdap_version()
 spark_version = get_spark_version()
 
 # The GIT info and GIT environment variables for the build

--- a/cdap-docs/_common/tabbed-parsed-literal.py
+++ b/cdap-docs/_common/tabbed-parsed-literal.py
@@ -87,7 +87,7 @@ Examples:
     > cdap.bat cli start flow HelloWorld.WhoFlow
     Successfully started flow 'WhoFlow' of application 'HelloWorld' with stored runtime arguments '{}'
 
-    > <CDAP-SDK-HOME>\libexec\bin\curl.exe -d c:\|release| -X POST 'http://repository.cask.co/centos/6/x86_64/cdap/|short-version|/cask.repo'
+    > <CDAP-HOME>\libexec\bin\curl.exe -d c:\|release| -X POST 'http://repository.cask.co/centos/6/x86_64/cdap/|short-version|/cask.repo'
 
 If you pass a single set of commands, without comments, the directive will create a
 two-tabbed "Linux" and "Windows" with a generated Windows-equivalent command set. Check

--- a/cdap-docs/admin-manual/source/appendices/cdap-site.rst
+++ b/cdap-docs/admin-manual/source/appendices/cdap-site.rst
@@ -18,7 +18,7 @@ and should not be altered.
 
 Any of the default values (with the exception of those marked :ref:`[Final]
 <cdap-site-xml-note-final>`) can be over-ridden by defining a modifying value in the
-``cdap-site.xml`` file, located (by default) either in ``<CDAP-SDK-HOME>/conf/cdap-site.xml``
+``cdap-site.xml`` file, located (by default) either in ``<CDAP-HOME>/conf/cdap-site.xml``
 (CDAP Local Sandbox) or ``/etc/cdap/conf/cdap-site.xml`` (Distributed CDAP).
 
 The section below are the parameters that can be defined in the ``cdap-site.xml`` file, their default

--- a/cdap-docs/admin-manual/source/cdap-components.rst
+++ b/cdap-docs/admin-manual/source/cdap-components.rst
@@ -32,7 +32,7 @@ to configure CDAP to your specific requirements prior to starting CDAP services.
 
 CDAP generates log files, following the settings in the configuration file ``logback.xml``, using
 `Logback <http://logback.qos.ch/>`__. Logs (for Distributed CDAP) are located in ``/var/log/cdap``.
-For CDAP Local Sandbox, they are located in ``<CDAP-SDK-HOME>/logs``.
+For CDAP Local Sandbox, they are located in ``<CDAP-HOME>/logs``.
 
 If you have :ref:`CDAP Security <admin-security>` enabled, then you will have an
 additional file, ``cdap-security.xml`` (documented in :ref:`an appendix

--- a/cdap-docs/admin-manual/source/operations/logging.rst
+++ b/cdap-docs/admin-manual/source/operations/logging.rst
@@ -165,7 +165,7 @@ only affect programs that are started after the change; existing running program
 be affected.
 
 - For **CDAP Local Sandbox:** As the entire CDAP Local Sandbox runs in a single JVM, the
-  ``logback.xml`` file, located in  ``<cdap-sdk-home>/conf``, configures both "container"
+  ``logback.xml`` file, located in  ``<CDAP-HOME>/conf``, configures both "container"
   and CDAP system service logging.
 - For **Distributed CDAP:** the ``logback-container.xml`` file is located in ``/etc/cdap/conf``.
 
@@ -256,7 +256,7 @@ System Service Log File Locations
 The location of CDAP system service logs depends on the mode of CDAP (Local Sandbox or
 Distributed) and the Hadoop distribution:
 
-- For **CDAP Local Sandbox:** system logs are located in ``<CDAP-SDK-HOME>/logs``.
+- For **CDAP Local Sandbox:** system logs are located in ``<CDAP-HOME>/logs``.
 
 - For **Distributed CDAP:** system logs are located in ``/var/log/cdap`` (with the
   exception of Cloudera Manager-based clusters). With Cloudera Manager installations, system
@@ -277,7 +277,7 @@ Configuring System Service Logs
 
   - For **CDAP Local Sandbox:** the ``logback.xml`` file is located in ``/etc/cdap/conf``.
   - For **Distributed CDAP:** the file ``logback.xml`` file, located in
-    ``<cdap-sdk-home>/conf``, configures both "container" and CDAP system service logging.
+    ``<CDAP-HOME>/conf``, configures both "container" and CDAP system service logging.
 
 Changing System Service Log Levels
 ----------------------------------
@@ -488,7 +488,7 @@ CDAP looks for "logback" files located in a directory as set by the property
 ``log.process.pipeline.config.dir`` in the :ref:`cdap-site.xml
 <appendix-cdap-default-logging>` file. In the default configuration, this is:
 
-- For **CDAP Local Sandbox:** ``<cdap-sdk-home>/ext/logging/config``
+- For **CDAP Local Sandbox:** ``<CDAP-HOME>/ext/logging/config``
 - For **Distributed CDAP:** ``/opt/cdap/master/ext/logging/config``
 
 .. _logging-monitoring-custom-logging-example:

--- a/cdap-docs/admin-manual/source/security/index.rst
+++ b/cdap-docs/admin-manual/source/security/index.rst
@@ -54,7 +54,7 @@ CDAP Security is configured in the files ``cdap-site.xml`` and ``cdap-security.x
 These files are shown in :ref:`appendix-cdap-site.xml` and :ref:`appendix-cdap-security.xml`.
 
 File paths shown in this section are either absolute paths or, in the case of :ref:`CDAP Local Sandbox
-<local-sandbox-index>`, can be relative to the CDAP SDK installation directory.
+<local-sandbox-index>`, can be relative to the CDAP Local Sandbox installation directory.
 
 
 - :ref:`admin-perimeter-security`

--- a/cdap-docs/admin-manual/source/verification.rst
+++ b/cdap-docs/admin-manual/source/verification.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. _admin-manual-verification:
 
@@ -9,11 +9,10 @@ Verification
 ============
 
 To verify that the CDAP software is successfully installed and you are able to use your
-Hadoop cluster, run an example application. We provide in our SDK pre-built JAR files for
-convenience.
+Hadoop cluster, run an example application. We provide, in our CDAP Local Sandbox,
+pre-built JAR files for convenience.
 
-#. Download and install the latest `CDAP Software Development Kit (SDK)
-   <http://cask.co/downloads/#cdap>`__.
+#. Download and install the latest `CDAP Local Sandbox <http://cask.co/downloads/#cdap>`__.
 #. Extract to a folder (``CDAP_HOME``).
 #. Open a command prompt and navigate to ``CDAP_HOME/examples``.
 #. Each example folder has a ``.jar`` file in its ``target`` directory.
@@ -22,7 +21,7 @@ convenience.
    It is located on port ``11011`` of the box where you installed the CDAP UI service.
 #. On the UI, click the button *Add App*.
 #. Find the pre-built |literal-Wordcount-release-jar| using the dialog box to navigate to
-   ``CDAP_HOME/examples/WordCount/target/``. 
+   ``CDAP_HOME/examples/WordCount/target/``.
 #. Once the application is deployed, instructions on running the example can be found at the
    :ref:`WordCount example <examples-word-count>`.
 #. You should be able to start the application, inject sentences, and retrieve results.
@@ -34,5 +33,5 @@ convenience.
 
 .. rubric:: Getting a Health Check
 
-.. include:: operations/index.rst 
+.. include:: operations/index.rst
    :start-after: .. _operations-health-check:

--- a/cdap-docs/developers-manual/source/_includes/building-apps.txt
+++ b/cdap-docs/developers-manual/source/_includes/building-apps.txt
@@ -3,5 +3,5 @@
    :end-line:   10
 
 See :ref:`Building and Running CDAP Applications <cdap-building-running>` for information
-on accessing the CDAP CLI and CDAP SDK bin utilities, building examples, starting CDAP,
-and deploying, starting, and stopping applications.
+on accessing the CDAP CLI and CDAP Local Sandbox ``bin`` utilities, building examples,
+starting CDAP, and deploying, starting, and stopping applications.

--- a/cdap-docs/developers-manual/source/_includes/plugins/index.rst
+++ b/cdap-docs/developers-manual/source/_includes/plugins/index.rst
@@ -12,7 +12,7 @@ Plugin Reference
 
 .. toctree::
    :maxdepth: 1
-   
+
     Action Plugins <actions/index>
     Source Plugins <sources/index>
     Transform Plugins <transforms/index>
@@ -23,7 +23,7 @@ Plugin Reference
 
 
 These plugins (from CDAP Pipelines Version |cdap-pipelines-version|) are shipped with CDAP, both in the
-SDK and Distributed CDAP:
+CDAP Local Sandbox and Distributed CDAP:
 
 - :doc:`Action Plugins <actions/index>`
 - :doc:`Source Plugins <sources/index>`
@@ -33,7 +33,7 @@ SDK and Distributed CDAP:
 - :doc:`Shared Plugins <shared-plugins/index>`
 
   - :doc:`CoreValidator Plugin <shared-plugins/core>`
-  
+
 - :doc:`Post-run Plugins <post-run-plugins/index>`
 
 .. rubric:: Plugin Notes
@@ -46,8 +46,8 @@ SDK and Distributed CDAP:
 - The *batch sources* can write to any *batch sinks* that are available and *real-time sources*
   can write to any *real-time sinks*. *Transformations* work with either *sinks* or *sources*.
   Transformations can use *validators* to test data and check that it follows user-specified
-  rules. 
-  
+  rules.
+
   Other plugin types may be restricted as to which plugin (and artifact) that they work
   with, depending on the particular functionality they provide. For instance, certain
   *model* (the *NaiveBayesTrainer*) and *compute* (the *NaiveBayesClassifier*) plugins

--- a/cdap-docs/developers-manual/source/advanced/application-logback.rst
+++ b/cdap-docs/developers-manual/source/advanced/application-logback.rst
@@ -17,7 +17,7 @@ running, these policies will apply. (As the lifetime of many containers is often
 14 days, these limits may never be reached.)
 
 **Note:** In the case of the CDAP Local Sandbox, the logback file used is ``logback.xml``, located
-in the ``<cdap-sdk-home>/conf`` directory.
+in the ``<CDAP-HOME>/conf`` directory.
 
 You can specify a custom ``logback.xml`` for a CDAP application by packaging
 it with the application in the application's ``src/main/resources`` directory.

--- a/cdap-docs/developers-manual/source/building-blocks/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/index.rst
@@ -12,7 +12,7 @@ Building Blocks
 
 .. toctree::
    :maxdepth: 1
-   
+
     Core Abstractions <core>
     Applications <applications>
     Streams <streams>
@@ -65,7 +65,7 @@ write data through the data abstraction layer in CDAP.
 **Additional abstractions** include:
 
 - An :doc:`Artifact <artifacts>` is a jar file that packages the Java Application class, as well
-  as any other classes and libraries needed to create and run an Application. 
+  as any other classes and libraries needed to create and run an Application.
 
 - All of the program building blocks follow a :doc:`Program Lifecycle <program-lifecycle>`.
 
@@ -73,10 +73,10 @@ write data through the data abstraction layer in CDAP.
   or **tags** (a list of keys) |---| can be set for artifacts, applications, programs, datasets, streams, and views.
   These can be retrieved and searched, and the metadata used to discover CDAP entities.
   Access of these entities is tracked, and you can view the :ref:`lineage <metadata-lineage>` of datasets and streams.
-  With a lineage diagram, you can then drill down into the metadata of its nodes. 
+  With a lineage diagram, you can then drill down into the metadata of its nodes.
 
 - :ref:`Audit Logging <audit-logging>` provides a chronological ledger containing evidence of operations or
-  changes on CDAP entities. This information can be used to capture a trail of the activities that 
+  changes on CDAP entities. This information can be used to capture a trail of the activities that
   determined the state of an entity at a given point in time.
 
 - A :doc:`Namespace <namespaces>` is a logical grouping of application and data in CDAP.
@@ -89,7 +89,7 @@ write data through the data abstraction layer in CDAP.
 
 - The :doc:`Transactional Messaging System <transactional-messaging-system>` is a CDAP service
   that provides a "publish-and-subscribe" messaging system that understands transactions.
-  
+
 - :doc:`Secure Keys <secure-keys>` allows users to store and retrieve sensitive information such
   as passwords from secure and encrypted storage.
 
@@ -98,5 +98,5 @@ platform :doc:`overview. </overview/index>`
 
 For information beyond this section, see the :ref:`Javadocs <reference:javadocs>` and
 the code in the :ref:`examples <examples-index>` directory, both of which are available at the
-`Cask.co resources page, <http://cask.co/resources>`_ as well as in your CDAP SDK
+`Cask.co resources page, <http://cask.co/resources>`_ as well as in your CDAP Local Sandbox
 installation directory.

--- a/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. _custom-dataset-exploration:
 
@@ -273,7 +273,7 @@ defining::
     return Scannables.valueRecordScanner(table.createSplitReader(split));
   }
 
-An example demonstrating an implementation of ``RecordScannable`` is included in the Cask Data Application Platform SDK in the
+An example demonstrating an implementation of ``RecordScannable`` is included in the CDAP Local Sandbox in the
 directory ``examples/Purchase``, namely the ``PurchaseHistoryStore``.
 
 Writing to Datasets with SQL

--- a/cdap-docs/developers-manual/source/getting-started/building-apps.rst
+++ b/cdap-docs/developers-manual/source/getting-started/building-apps.rst
@@ -45,18 +45,18 @@ to use the namespace *my_namespace*, you would replace ``default`` with ``my_nam
 	http://localhost:11015/v3/namespaces/my_namespace/apps...
 
 
-Accessing CLI, curl, and the SDK bin
-------------------------------------
+Accessing CLI, curl, and the CDAP Local Sandbox bin
+---------------------------------------------------
 
 - For brevity in the commands given below, we will simply use ``cdap cli`` for the CDAP
-  Command Line Interface. Substitute the actual path of ``./<CDAP-SDK-HOME>/bin/cdap cli``,
-  or ``<CDAP-SDK-HOME>\bin\cdap.bat cli`` on Windows, as appropriate.
+  Command Line Interface. Substitute the actual path of ``./<CDAP-HOME>/bin/cdap cli``,
+  or ``<CDAP-HOME>\bin\cdap.bat cli`` on Windows, as appropriate.
 
-- A Windows-version of the application ``curl`` is included in the CDAP SDK as
+- A Windows-version of the application ``curl`` is included in the CDAP Local Sandbox as
   ``libexec\bin\curl.exe``; use it as a substitute for ``curl`` in examples.
 
-- If you add the SDK bin directory to your path, you can simplify the commands. From within
-  the ``<CDAP-SDK-HOME>`` directory, enter:
+- If you add the CDAP Local Sandbox ``bin`` directory to your path, you can simplify the commands. From within
+  the ``<CDAP-HOME>`` directory, enter:
 
   .. tabbed-parsed-literal::
 
@@ -68,7 +68,7 @@ Accessing CLI, curl, and the SDK bin
 
     > set path=%PATH%;%CD%\bin;%CD%\libexec\bin
 
-  The Windows path has been augmented with a directory where the SDK includes
+  The Windows path has been augmented with a directory where the CDAP Local Sandbox includes
   Windows-versions of commands such as ``curl``.
 
 .. include:: /_includes/windows-note.txt
@@ -95,7 +95,7 @@ To build all the examples, switch to the main examples directory and run the Mav
 
 .. tabbed-parsed-literal::
 
-  $ cd <CDAP-SDK-HOME>/examples
+  $ cd <CDAP-HOME>/examples
   $ mvn clean package -DskipTests
 
 
@@ -147,7 +147,7 @@ Once CDAP is started, you can deploy an application using an example JAR by any 
 
   The CLI can be accessed under Windows using the ``bin\cdap.bat cli`` script.
 
-- Use an application such as ``curl`` (a Windows-version is included in the CDAP SDK in
+- Use an application such as ``curl`` (a Windows-version is included in the CDAP Local Sandbox in
   ``libexec\bin\curl.exe``):
 
   .. tabbed-parsed-literal::

--- a/cdap-docs/developers-manual/source/getting-started/local-sandbox/zip.rst
+++ b/cdap-docs/developers-manual/source/getting-started/local-sandbox/zip.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :description: CDAP SDK Zip
+    :description: CDAP Local Sandbox, Binary Zip File
     :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. highlight:: console

--- a/cdap-docs/developers-manual/source/getting-started/quick-start.rst
+++ b/cdap-docs/developers-manual/source/getting-started/quick-start.rst
@@ -8,7 +8,8 @@
 Quick Start
 ===========
 
-These instructions will take you from downloading the CDAP SDK through the running of an application.
+These instructions will take you from downloading the CDAP Local Sandbox through the
+running of an application.
 
 Download, Install and Start CDAP
 ================================

--- a/cdap-docs/developers-manual/source/getting-started/start-stop-cdap.rst
+++ b/cdap-docs/developers-manual/source/getting-started/start-stop-cdap.rst
@@ -1,5 +1,7 @@
-.. :author: Cask Data, Inc.
-   :copyright: Copyright © 2014-2017 Cask Data, Inc.
+.. meta::
+    :author: Cask Data, Inc.
+    :description: Starting and Stopping CDAP Local Sandbox
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 ========================================
 Starting and Stopping CDAP Local Sandbox
@@ -11,9 +13,9 @@ Starting and Stopping CDAP Local Sandbox
 
 .. highlight:: console
 
-Use the ``cdap sandbox`` script (or, if you are using Windows, use ``cdap.bat sandbox``) to start and
-stop the CDAP Local Sandbox (the location will vary depending on where the CDAP SDK is
-installed):
+Use the ``cdap sandbox`` script (or, if you are using Windows, use ``cdap.bat sandbox``)
+to start and stop the CDAP Local Sandbox (the location will vary depending on where the
+CDAP Local Sandbox is installed):
 
 .. tabbed-parsed-literal::
 

--- a/cdap-docs/developers-manual/source/index.rst
+++ b/cdap-docs/developers-manual/source/index.rst
@@ -13,7 +13,7 @@ CDAP Developer’s Manual
 .. _getting-started: getting-started/index.html
 
 - |getting-started|_ **A quick, hands-on introduction to developing with CDAP,**  which guides you through
-  installing the CDAP SDK, setting up your development environment, starting and stopping CDAP,
+  installing the CDAP Local Sandbox, setting up your development environment, starting and stopping CDAP,
   and building and running example applications.
 
 

--- a/cdap-docs/developers-manual/source/overview/modes.rst
+++ b/cdap-docs/developers-manual/source/overview/modes.rst
@@ -51,8 +51,8 @@ Machine on your local machine and includes a local version of the CDAP UI. The
 underlying Big Data infrastructure is emulated on top of your local file system. All data
 is persisted.
 
-See :ref:`Getting Started Developing <getting-started-index>` and the *Cask Data Application Platform
-SDK* for information on how to start and manage your CDAP Local Sandbox.
+See :ref:`Getting Started Developing <getting-started-index>` and :ref:`CDAP Local Sandbox
+<local-sandbox-index>` for information on how to start and manage your CDAP Local Sandbox.
 
 **Features:**
 

--- a/cdap-docs/examples-manual/source/examples/index.rst
+++ b/cdap-docs/examples-manual/source/examples/index.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Examples
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 :hide-toc: true
 
@@ -32,8 +32,8 @@ Examples
    Wikipedia Pipeline <wikipedia-data-pipeline>
    Word Count <word-count>
 
-In addition to the :ref:`Getting Started's <getting-started-index>` 
-:ref:`Quick Start/Web Log Analytics example, <quick-start>` the SDK includes these examples:
+In addition to the :ref:`Getting Started's <getting-started-index>`
+:ref:`Quick Start/Web Log Analytics example, <quick-start>` the CDAP Local Sandbox includes these examples:
 
 .. list-table::
   :widths: 15 60
@@ -103,7 +103,7 @@ You can learn more about developing data application using CDAP by:
 - Look at our :ref:`How-To Guides<guides-index>` and
   :ref:`Tutorials<tutorials>`, with a collection of quick how-to-guides and
   longer tutorials covering a complete range of Big Data application topics.
-- Exploring the web analytics application :doc:`source code.<web-analytics>` It includes 
+- Exploring the web analytics application :doc:`source code.<web-analytics>` It includes
   test cases that show unit-testing an application.
-- For a detailed understanding of what CDAP is capable of, read our :ref:`Overview <cdap-overview>` and 
+- For a detailed understanding of what CDAP is capable of, read our :ref:`Overview <cdap-overview>` and
   :ref:`Building Blocks <building-blocks>` sections.

--- a/cdap-docs/examples-manual/source/examples/user-profiles.rst
+++ b/cdap-docs/examples-manual/source/examples/user-profiles.rst
@@ -115,7 +115,7 @@ and build this example twice:
    - Start CDAP, deploy and start the application and its component.
      Make sure you start the flow and service as described below.
    - Once the application has been deployed and started, you can run the example by `starting the flow and service. <#starting-the-flow>`__
-   - You should observe errors as described below, in the ``<CDAP-SDK-home>/logs/cdap-debug.log``.
+   - You should observe errors as described below, in the ``<CDAP-HOME>/logs/cdap-debug.log``.
 
 #. Re-build the Application with Column-level Conflict Detection
 
@@ -196,7 +196,7 @@ For example, such a conflict would show as (reformatted to fit)::
   co.cask.tephra.TransactionContext.finish(TransactionContext.java:79) ~[co.cask.tephra.tephra-core-0.4.1.jar:na] at
   . . .
 
-(The log file is located at ``<CDAP-SDK-HOME>/logs/cdap-debug.log``. You should also see
+(The log file is located at ``<CDAP-HOME>/logs/cdap-debug.log``. You should also see
 an error in the CDAP UI, in the :cdap-ui-apps:`UserProfileService error log
 <UserProfiles/programs/services/UserProfileService/logs?filter=error>`.)
 

--- a/cdap-docs/examples-manual/source/index.rst
+++ b/cdap-docs/examples-manual/source/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. _examples-introduction-index:
 
@@ -12,7 +12,7 @@ CDAP Examples, How-To Guides, and Tutorials
 .. |examples| replace:: **Examples:**
 .. _examples: examples/index.html
 
-- |examples|_ Included with the :ref:`CDAP SDK, <getting-started-index>` they range from a
+- |examples|_ Included with the :ref:`CDAP Local Sandbox, <getting-started-index>` they range from a
   simple introductory :ref:`Hello World <examples-hello-world>` to more elaborate examples
   such as the :ref:`Purchase application <examples-purchase>` that uses many of the CDAP
   components.
@@ -28,7 +28,7 @@ CDAP Examples, How-To Guides, and Tutorials
 .. |tutorials| replace:: **Tutorials:**
 .. _tutorials: tutorials/index.html
 
-- |tutorials|_ Designed to be completed an hour or more, these tutorials provide deeper, in-context explorations of 
+- |tutorials|_ Designed to be completed an hour or more, these tutorials provide deeper, in-context explorations of
   big data application development topics, leaving you ready to implement real-world solutions.
 
 

--- a/cdap-docs/faqs/source/general.rst
+++ b/cdap-docs/faqs/source/general.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Frequently Asked Questions about the Cask Data Application Platform
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 :titles-only-global-toc: true
 
@@ -11,20 +11,20 @@
 FAQs: General Questions
 =======================
 
-What is available in the CDAP SDK?
-----------------------------------
-The CDAP SDK includes:
+What is available in the CDAP Local Sandbox?
+--------------------------------------------
+The CDAP Local Sandbox includes:
 
 - Local instance of the CDAP Server;
 - CDAP APIs for building applications;
-- CDAP UI and CDAP CLI for interacting with CDAP; and
+- The CDAP UI and CDAP CLI for interacting with CDAP; and
 - Examples for getting started with CDAP.
 
 
-What platforms are supported by the Cask Data Application Platform SDK?
------------------------------------------------------------------------
-The CDAP SDK has been extensively tested on Mac OS X and Linux. CDAP on Windows has not
-been extensively tested. If you have any issues with CDAP on Windows, help us by 
+What platforms are supported by the CDAP Local Sandbox?
+-------------------------------------------------------
+The CDAP Local Sandbox has been extensively tested on Mac OS X and Linux. CDAP on Windows
+has not been as extensively tested. If you have any issues with CDAP on Windows, help us by
 `filing a ticket <https://issues.cask.co/browse/CDAP>`__.
 
 What programming languages are supported by CDAP?
@@ -34,7 +34,7 @@ CDAP currently supports Java for developing applications.
 What version of Java SDK is required by CDAP?
 ---------------------------------------------
 The latest version of the JDK or JRE version 7 or version 8 must be installed in your
-environment. CDAP is tested on both the `Oracle JDK <http://www.java.com/en/download/manual.jsp>`__ 
+environment. CDAP is tested on both the `Oracle JDK <http://www.java.com/en/download/manual.jsp>`__
 and the `OpenJDK <http://openjdk.java.net/>`__.
 
 What version of Node.js is required by CDAP?
@@ -49,11 +49,11 @@ Yes. You can install Distributed CDAP on your Hadoop cluster. See the :ref:`Inst
 
 What Hadoop distributions can CDAP run on?
 ------------------------------------------
-CDAP |version| has been tested on and supports CDH |cdh-versions|, HDP |hdp-versions|, 
-MapR |mapr-versions|, Amazon Hadoop (EMR) |emr-versions|, and Apache Bigtop 1.0. 
+CDAP |version| has been tested on and supports CDH |cdh-versions|, HDP |hdp-versions|,
+MapR |mapr-versions|, Amazon Hadoop (EMR) |emr-versions|, and Apache Bigtop 1.0.
 
-I'm seeing log messages about the failure to send audit log message while running the SDK. What's wrong?
---------------------------------------------------------------------------------------------------------
+I'm seeing log messages about the failure to send audit log message while running the Local Sandbox. What's wrong?
+------------------------------------------------------------------------------------------------------------------
 If your computer goes into sleep mode, then you may see these messages after the machine
 is restored from sleep mode, as the audit logs are not getting delivered while the machine
 sleeps. You may need to restart CDAP to restore its state depending on how long it has

--- a/cdap-docs/integrations/source/jdbc.rst
+++ b/cdap-docs/integrations/source/jdbc.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2015-2017 Cask Data, Inc.
 
 .. _cdap-jdbc:
 
@@ -13,15 +13,15 @@ Overview
 CDAP provides a JDBC driver to make integrations with external programs and third-party BI
 (business intelligence) tools easier.
 
-The JDBC driver is a JAR that is bundled with the CDAP SDK. You can find it in the ``libexec``
-directory of your SDK installation at::
+The JDBC driver is a JAR that is bundled with the CDAP Local Sandbox. You can find it in the ``libexec``
+directory of your Local Sandbox installation at::
 
   libexec/co.cask.cdap.cdap-explore-jdbc-<version>.jar
 
-If you don't have a CDAP SDK and only want to connect to an existing instance of CDAP, 
-you can download the CDAP JDBC driver from `this link 
+If you don't have a CDAP Local Sandbox and only want to connect to an existing instance of CDAP,
+you can download the CDAP JDBC driver from `this link
 <https://repo1.maven.org/maven2/co/cask/cdap/cdap-explore-jdbc/>`__.
-Go to the directory matching the version of your running CDAP instance, and download the file 
+Go to the directory matching the version of your running CDAP instance, and download the file
 with the matching version number::
 
   cdap-explore-jdbc-<version>.jar
@@ -61,7 +61,7 @@ and executes a query over a CDAP dataset ``mydataset``::
   ...
 
 Here are the parameters that can be used in the connection URL:
-  
+
 - ``namespace``: CDAP namespace to run in
 - ``auth.token``: authentication token for the connection
 - ``ssl.enabled``: boolean; whether SSL is enabled or not

--- a/cdap-docs/reference-manual/build.sh
+++ b/cdap-docs/reference-manual/build.sh
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
 
 # Copyright © 2014-2017 Cask Data, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-  
+
 # Build script for docs
 # Builds the docs (all except javadocs and PDFs) from the .rst source files using Sphinx
 # Builds the javadocs and copies them into place
 # Zips everything up so it can be staged
-# REST PDF is built as a separate target and checked in, as it is only used in SDK and not website
-# Target for building the SDK
+# REST PDF is built as a separate target and checked in, as it is only used in the Local Sandbox and not website
+# Target for building the Local Sandbox
 # Targets for both a limited and complete set of javadocs
 # Targets not included in usage are intended for internal usage by script
 
@@ -37,7 +37,7 @@ function download_includes() {
     echo "Not building using Sphinx: skipping building rst file from cli-docs results."
   else
     local target_includes_dir=${1}
-    echo "Copying CLI Docs: building rst file from cli-docs results..." 
+    echo "Copying CLI Docs: building rst file from cli-docs results..."
     python "${CLI_DOC_TOOL}" "${CLI_INPUT_TXT}" "${target_includes_dir}/${CLI_TABLE_RST}"
     warnings=$?
     if [[ ${warnings} -eq 0 ]]; then
@@ -77,7 +77,7 @@ function build_extras() {
   if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
     echo "Not building using Sphinx: creating license directory."
     mkdir -p ${TARGET_PATH}/html/licenses
-  fi  
+  fi
 
   if [ -d ${TARGET_PATH}/html/licenses ]; then
     cp ${SCRIPT_PATH}/licenses-pdf/*.pdf ${TARGET_PATH}/html/licenses
@@ -97,7 +97,7 @@ function build_extras() {
     return ${warnings}
   fi
 
-  python "${PROJECT_PATH}/cdap-docs/tools/github-release-notes.py" --version ${PROJECT_VERSION} 
+  python "${PROJECT_PATH}/cdap-docs/tools/github-release-notes.py" --version ${PROJECT_VERSION}
   warnings=$?
   if [[ ${warnings} -eq 0 ]]; then
     echo "Created GitHub version of release notes."

--- a/cdap-docs/reference-manual/source/cli-api.rst
+++ b/cdap-docs/reference-manual/source/cli-api.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. _cli:
 .. _cdap-cli:
@@ -13,7 +13,7 @@ Introduction
 ============
 
 The Command Line Interface (CLI, or CDAP CLI) provides methods to interact with the CDAP server from within a shell,
-similar to the HBase or ``bash`` shells. It is located within the SDK, at ``bin/cdap-cli`` as either a bash
+similar to the HBase or ``bash`` shells. It is located within the CDAP Local Sandbox, at ``bin/cdap-cli`` as either a bash
 script or a Windows ``.bat`` file.
 
 It can be :ref:`installed on Distributed CDAP <packages-cli-package-installation>`, in
@@ -42,13 +42,13 @@ To run the CLI in interactive mode, run the ``cdap cli`` executable with no argu
   .. Windows
 
   > .\bin\cdap.bat cli
-  
+
   .. Distributed CDAP
 
   $ /opt/cdap/cli/bin/cdap cli
-  
+
   .. Cloudera Manager Clusters
-  
+
   $ /opt/cloudera/parcels/cdap/cli/bin/cdap cli
 
 
@@ -57,7 +57,7 @@ The executable should bring you into a shell, with a prompt similar to:
 .. container:: highlight
 
   .. parsed-literal::
-  
+
     cdap (http://localhost:11015/namespace:default)>
 
 This indicates that the CLI is currently set to interact with the CDAP server at ``localhost``.
@@ -74,15 +74,15 @@ a CDAP instance at ``example.com``, port ``11015``::
 To list all of the available commands, enter the CLI command ``help``::
 
   cdap (http://localhost:11015/namespace:default)> help
-  
+
 In this documentation, to save space, this prompt is abbreviated to:
 
 .. container:: highlight
 
   .. parsed-literal::
-  
+
     |cdap >|
-  
+
 
 Non-Interactive Mode
 --------------------
@@ -170,7 +170,7 @@ Certain commands (``cli render as``, ``connect``, and ``use namespace``) affect 
 
       app id,description
       PurchaseApp,Some description
-      
+
 - The command ``connect`` (from the `General`_ commands) allows you to connect to a CDAP
   instance.
 

--- a/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. _http-restful-api-introduction:
 
@@ -54,7 +54,7 @@ This means you would use::
 
   PUT http://<host>:<port>/v3/namespaces/<namespace-id>/streams/<new-stream-id>
 
-If you are using the CDAP SDK, running on your local machine, you might make a ``curl`` call such as:
+If you are using the CDAP Local Sandbox, running on your local machine, you might make a ``curl`` call such as:
 
 .. tabbed-parsed-literal::
 
@@ -78,7 +78,7 @@ the stream *mystream*::
 Reserved and Unsafe Characters
 ------------------------------
 In path parameters, reserved and unsafe characters must be replaced with their equivalent
-percent-encoded format, using the "``%hh``" syntax, as described in 
+percent-encoded format, using the "``%hh``" syntax, as described in
 `RFC3986: Uniform Resource Identifier (URI): Generic Syntax <http://tools.ietf.org/html/rfc3986#section-2.1>`__.
 
 In general, any character that is not a letter, a digit, or one of ``$-_.+!*'()`` should be encoded.
@@ -163,8 +163,8 @@ in CDAP. Example::
 can be replaced with::
 
   PUT http://<host>:<port>/v3/namespaces/default/streams/<new-stream-id>
-  
-However, you will need to test your code, as many APIs have changed as a result of the 
+
+However, you will need to test your code, as many APIs have changed as a result of the
 addition of namespaces.
 
 .. _http-restful-api-working-with-cdap-security:


### PR DESCRIPTION
Removing SDK in all its variations, updating copyrights, and minor fixes.

Running a Quick Build: https://builds.cask.co/browse/CDAP-DQB356-1