### PR TITLE
(CDAP-11409) Compile and interpret Spark

### DIFF
--- a/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContextBase.java
+++ b/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContextBase.java
@@ -31,6 +31,7 @@ import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter;
 import co.cask.cdap.api.stream.GenericStreamEventData;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
@@ -41,6 +42,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.tephra.TransactionFailureException;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
@@ -496,4 +498,11 @@ public abstract class JavaSparkExecutionContextBase implements RuntimeContext, T
    */
   public abstract void execute(int timeoutInSeconds, TxRunnable runnable) throws TransactionFailureException;
 
+  /**
+   * Creates a new instance of {@link SparkInterpreter} for Scala code compilation and interpretation.
+   *
+   * @return a new instance of {@link SparkInterpreter}
+   * @throws IOException if failed to create a local directory for storing the compiled class files
+   */
+  public abstract SparkInterpreter createInterpreter() throws IOException;
 }

--- a/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/dynamic/BindingException.java
+++ b/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/dynamic/BindingException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.spark.dynamic;
+
+import java.util.Arrays;
+
+/**
+ * Exception to indicate there is an error in binding variable.
+ */
+public class BindingException extends Exception {
+
+  public BindingException(String name, String type, Object value, String...modifies) {
+    super(String.format("Failed to bind variable %s with type %s to value %s%s.",
+                        name, type, value, modifies.length == 0 ? "" : " with modifiers " + Arrays.asList(modifies)));
+  }
+}

--- a/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/dynamic/CompilationFailureException.java
+++ b/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/dynamic/CompilationFailureException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.spark.dynamic;
+
+/**
+ * Exception to indicate there is a code compilation error.
+ */
+public class CompilationFailureException extends Exception {
+
+  public CompilationFailureException(String message) {
+    super(message);
+  }
+}

--- a/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/dynamic/InterpretFailureException.java
+++ b/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/dynamic/InterpretFailureException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.spark.dynamic;
+
+/**
+ * Exception to indicate there is a code interpretation error.
+ */
+public class InterpretFailureException extends Exception {
+
+  public InterpretFailureException(String message) {
+    super(message);
+  }
+}

--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContextBase.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContextBase.scala
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api.spark
 
+import java.io.IOException
+
 import co.cask.cdap.api._
 import co.cask.cdap.api.annotation.Beta
 import co.cask.cdap.api.data.batch.Split
@@ -25,6 +27,7 @@ import co.cask.cdap.api.messaging.MessagingContext
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.security.store.SecureStore
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter
 import co.cask.cdap.api.stream.GenericStreamEventData
 import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
 import org.apache.spark.SparkContext
@@ -274,4 +277,14 @@ trait SparkExecutionContextBase extends RuntimeContext with Transactional {
     * @throws TransactionFailureException always
     */
   def execute(timeoutInSeconds: Int, runnable: TxRunnable): Unit
+
+  /**
+    * Creates a new instance of [[co.cask.cdap.api.spark.dynamic.SparkInterpreter]] for Scala code compilation and
+    * interpretation.
+    *
+    * @return a new instance of [[co.cask.cdap.api.spark.dynamic.SparkInterpreter]]
+    * @throws java.io.IOException if failed to create a local directory for storing the compiled class files
+    */
+  @throws(classOf[IOException])
+  def createInterpreter(): SparkInterpreter
 }

--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkMain.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkMain.scala
@@ -106,7 +106,7 @@ trait SparkMain extends Serializable {
     * @tparam K key type
     * @tparam V value type
     */
-  protected implicit class SparkProgramRDDFunctions[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)]) {
+  implicit class SparkProgramRDDFunctions[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)]) {
 
     /**
       * Saves the given [[org.apache.spark.rdd.RDD]] to the given [[co.cask.cdap.api.dataset.Dataset]].
@@ -166,7 +166,7 @@ trait SparkMain extends Serializable {
     *
     * @param sc the [[org.apache.spark.SparkContext]]
     */
-  protected implicit class SparkProgramContextFunctions(sc: SparkContext) {
+  implicit class SparkProgramContextFunctions(sc: SparkContext) {
 
     /**
       * Creates a [[org.apache.spark.rdd.RDD]] from the given [[co.cask.cdap.api.dataset.Dataset]].
@@ -440,7 +440,7 @@ trait SparkMain extends Serializable {
   /**
     * Provides functional syntax to execute a function with a Transaction.
     */
-  protected object Transaction extends Serializable {
+  object Transaction extends Serializable {
 
     /**
       * Executes the given function in a single transaction.
@@ -472,13 +472,13 @@ trait SparkMain extends Serializable {
     * An implicit object that transforms [[co.cask.cdap.api.flow.flowlet.StreamEvent]] to a
     * [[scala.Tuple2]] of (eventTimestamp, UTF-8 decoded body string).
     */
-  protected implicit val timestampStringStreamDecoder: (StreamEvent) => (Long, String) = (e: StreamEvent) => {
+  implicit val timestampStringStreamDecoder: (StreamEvent) => (Long, String) = (e: StreamEvent) => {
     (e.getTimestamp, Charset.forName("UTF-8").decode(e.getBody).toString)
   }
 
   /**
     * An implicit object that transforms [[co.cask.cdap.api.flow.flowlet.StreamEvent]] body to a UTF-8 string.
     */
-  protected implicit val stringStreamDecoder: (StreamEvent) => String = (e: StreamEvent) =>
+  implicit val stringStreamDecoder: (StreamEvent) => String = (e: StreamEvent) =>
     timestampStringStreamDecoder(e)._2
 }

--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/dynamic/SparkCompiler.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/dynamic/SparkCompiler.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.spark.dynamic
+
+import java.io.{File, IOException, OutputStream}
+
+import co.cask.cdap.api.annotation.Beta
+
+import scala.tools.nsc.interpreter.IMain
+
+/**
+  * A compiler for compiling Spark code in Scala
+  */
+@Beta
+trait SparkCompiler extends AutoCloseable {
+
+  /**
+    * Adds dependency to the compiler. Classes loadable from the given file are usable by the code to be compiled
+    * by this compiler.
+    *
+    * @param file a directory or a jar file.
+    */
+  def addDependency(file: File): Unit
+
+  /**
+    * Compiles the given source code. The source code must have content the same as a valid scala source file.
+    *
+    * @param source the source string to compile
+    * @throws co.cask.cdap.api.spark.dynamic.CompilationFailureException if compilation failed
+    */
+  @throws(classOf[CompilationFailureException])
+  def compile(source: String): Unit
+
+  /**
+    * Compiles the given scala source file.
+    *
+    * @param file the file to compile
+    * @throws co.cask.cdap.api.spark.dynamic.CompilationFailureException if compilation failed
+    */
+  @throws(classOf[CompilationFailureException])
+  def compile(file: File): Unit
+
+  /**
+    * Saves all compiled classes to a JAR file.
+    *
+    * @param file the location of the JAR file
+    * @throws java.io.IOException if failed to save to the JAR file
+    */
+  @throws(classOf[IOException])
+  def saveAsJar(file: File): Unit
+
+  /**
+    * Saves all compiled classes to a JAR.
+    *
+    * @param outputStream the [[java.io.OutputStream]] for writing out the JAR content
+    * @throws java.io.IOException if failed to write out the JAR
+    */
+  @throws(classOf[IOException])
+  def saveAsJar(outputStream: OutputStream): Unit
+
+  /**
+    * Releases resources used by the compiler.
+    */
+  override def close(): Unit
+
+  /**
+    * Gets the underlying Scala [[scala.tools.nsc.interpreter.IMain]] for advanced control over code compilation
+    * and interpretation
+    *
+    * @return a [[scala.tools.nsc.interpreter.IMain]] instance
+    */
+  def getIMain(): IMain
+}

--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/dynamic/SparkInterpreter.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/dynamic/SparkInterpreter.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.spark.dynamic
+
+import co.cask.cdap.api.annotation.Beta
+
+import scala.reflect.{ClassTag, runtime}
+
+/**
+  * An interpreter for running Spark code in Scala.
+  */
+@Beta
+trait SparkInterpreter extends SparkCompiler {
+
+  /**
+    * Binds a variable to a specific value.
+    *
+    * @param name name of the variable
+    * @param value value to bind to
+    * @tparam T type of the variable, derived from the value type
+    * @throws co.cask.cdap.api.spark.dynamic.BindingException if failed to bind the variable
+    */
+  @throws(classOf[BindingException])
+  def bind[T: runtime.universe.TypeTag : ClassTag](name: String, value: T): Unit
+
+  /**
+    * Binds a variable of a specific type to a specific value.
+    *
+    * @param name name of the variable
+    * @param bindType type of the variable
+    * @param value value to bind to
+    * @param modifiers a list of modifies for the variable, such as `private`, `implicit`, etc.
+    * @throws co.cask.cdap.api.spark.dynamic.BindingException if failed to bind the variable
+    */
+  @throws(classOf[BindingException])
+  def bind(name: String, bindType: String, value: Any, modifiers: String*): Unit
+
+  /**
+    * Interprets a line of source code.
+    *
+    * @param line the source line to interpret
+    * @throws co.cask.cdap.api.spark.dynamic.InterpretFailureException if the interpretation failed
+    */
+  @throws(classOf[InterpretFailureException])
+  def interpret(line: String): Unit
+
+  /**
+    * Gets the value of the given variable if it exists in the context.
+    *
+    * @param name name of the variable
+    * @return an [[scala.Option]] that will content [[scala.Some]] value if it exists, or [[scala.None]] otherwise.
+    */
+  def getValue(name: String): Option[Any]
+}

--- a/cdap-api-spark/pom.xml
+++ b/cdap-api-spark/pom.xml
@@ -63,6 +63,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_2.10</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>

--- a/cdap-api-spark2_2.11/pom.xml
+++ b/cdap-api-spark2_2.11/pom.xml
@@ -63,6 +63,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_2.11</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -393,6 +393,13 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   }
 
   /**
+   * Returns the {@link ProgramRunId} of the running program.
+   */
+  public ProgramRunId getProgramRunId() {
+    return programRunId;
+  }
+
+  /**
    * Release all resources held by this context, for example, datasets. Subclasses should override this
    * method to release additional resources.
    */

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkClassLoader.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkClassLoader.java
@@ -106,7 +106,7 @@ public class SparkClassLoader extends CombineClassLoader {
     SparkConf sparkConf = new SparkConf();
     File resourcesDir = new File(sparkConf.get("spark.local.dir", System.getProperty("user.dir")));
     sparkExecutionContext = new DefaultSparkExecutionContext(
-      runtimeContext, SparkRuntimeUtils.getLocalizedResources(resourcesDir, sparkConf));
+      this, SparkRuntimeUtils.getLocalizedResources(resourcesDir, sparkConf));
     return sparkExecutionContext;
   }
 

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkDriverHttpService.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkDriverHttpService.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.http.HttpHandler;
+import co.cask.http.NettyHttpService;
+import com.google.common.util.concurrent.AbstractIdleService;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Arrays;
+
+/**
+ * An HTTP service that runs in the Spark driver process for providing various functionalities to executors,
+ * such as transaction and file services.
+ */
+final class SparkDriverHttpService extends AbstractIdleService {
+
+  private final NettyHttpService httpServer;
+
+  SparkDriverHttpService(String programName, String hostname, HttpHandler...handlers) {
+    this.httpServer = NettyHttpService.builder(programName + "-http-service")
+      .addHttpHandlers(Arrays.asList(handlers))
+      .setHost(hostname)
+      .build();
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    httpServer.startAndWait();
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    httpServer.stopAndWait();
+  }
+
+  /**
+   * Returns the base {@link URI} for talking to this service remotely through HTTP.
+   */
+  URI getBaseURI() {
+    InetSocketAddress bindAddress = httpServer.getBindAddress();
+    if (bindAddress == null) {
+      throw new IllegalStateException("SparkDriverHttpService hasn't been started");
+    }
+    return URI.create(String.format("http://%s:%d", bindAddress.getHostName(), bindAddress.getPort()));
+  }
+}

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkDriverHttpService.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkDriverHttpService.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.app.runtime.spark;
 
+import co.cask.cdap.common.HttpExceptionHandler;
 import co.cask.http.HttpHandler;
 import co.cask.http.NettyHttpService;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -35,6 +36,7 @@ final class SparkDriverHttpService extends AbstractIdleService {
   SparkDriverHttpService(String programName, String hostname, HttpHandler...handlers) {
     this.httpServer = NettyHttpService.builder(programName + "-http-service")
       .addHttpHandlers(Arrays.asList(handlers))
+      .setExceptionHandler(new HttpExceptionHandler())
       .setHost(hostname)
       .build();
   }

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -57,6 +57,7 @@ import javax.annotation.Nullable;
  */
 public final class SparkRuntimeContext extends AbstractContext implements Metrics, Closeable {
 
+  private final CConfiguration cConf;
   private final Configuration hConf;
   private final String hostname;
   private final TransactionSystemClient txClient;
@@ -82,7 +83,7 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
     super(program, programOptions, cConf, getSparkSpecification(program).getDatasets(), datasetFramework, txClient,
           discoveryServiceClient, true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
           secureStore, secureStoreManager, messagingService, pluginInstantiator);
-
+    this.cConf = cConf;
     this.hConf = hConf;
     this.hostname = hostname;
     this.txClient = txClient;
@@ -152,6 +153,13 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
    */
   TransactionSystemClient getTransactionSystemClient() {
     return txClient;
+  }
+
+  /**
+   * Returns the CDAP {@link CConfiguration} used for the execution.
+   */
+  CConfiguration getCConfiguration() {
+    return cConf;
   }
 
   /**

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -19,6 +19,7 @@ package co.cask.cdap.app.runtime.spark;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter;
 import co.cask.cdap.app.guice.DistributedProgramRunnableModule;
 import co.cask.cdap.app.program.DefaultProgram;
 import co.cask.cdap.app.program.Program;
@@ -61,9 +62,13 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.internal.Services;
 import org.apache.twill.kafka.client.KafkaClientService;
 import org.apache.twill.zookeeper.ZKClientService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
@@ -77,6 +82,8 @@ import javax.annotation.Nullable;
  */
 public final class SparkRuntimeContextProvider {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SparkRuntimeContextProvider.class);
+
   // Constants defined for file names used for files localization done by the SparkRuntimeService.
   // They are needed for recreating the SparkRuntimeContext in this class.
   static final String CCONF_FILE_NAME = "cConf.xml";
@@ -84,6 +91,7 @@ public final class SparkRuntimeContextProvider {
   // The suffix has to be .jar, otherwise YARN don't expand it
   static final String PROGRAM_JAR_EXPANDED_NAME = "program.expanded.jar";
   static final String PROGRAM_JAR_NAME = "program.jar";
+  static final String EXECUTOR_CLASSLOADER_NAME = "org.apache.spark.repl.ExecutorClassLoader";
 
   private static volatile SparkRuntimeContext sparkRuntimeContext;
 
@@ -96,8 +104,26 @@ public final class SparkRuntimeContextProvider {
     }
 
     // Try to find it from the context classloader
-    SparkClassLoader sparkClassLoader = ClassLoaders.find(Thread.currentThread().getContextClassLoader(),
-                                                          SparkClassLoader.class);
+    ClassLoader runtimeClassLoader = Thread.currentThread().getContextClassLoader();
+
+    // For interactive Spark, it uses ExecutorClassLoader, which doesn't follow normal classloader hierarchy.
+    // Since the presence of ExecutorClassLoader is optional in Spark, use reflection to gain access to the parentLoader
+    if (EXECUTOR_CLASSLOADER_NAME.equals(runtimeClassLoader.getClass().getName())) {
+      try {
+        Method getParentLoader = runtimeClassLoader.getClass().getDeclaredMethod("parentLoader");
+        if (!getParentLoader.isAccessible()) {
+          getParentLoader.setAccessible(true);
+        }
+        runtimeClassLoader = ((ClassLoader) getParentLoader.invoke(runtimeClassLoader)).getParent();
+      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassCastException e) {
+        LOG.warn("Unable to get the CDAP runtime classloader from {}. " +
+                   "Spark program may not be running correctly if {} is being used.",
+                 EXECUTOR_CLASSLOADER_NAME, SparkInterpreter.class.getName(), e);
+      }
+    }
+
+    SparkClassLoader sparkClassLoader = ClassLoaders.find(runtimeClassLoader, SparkClassLoader.class);
+
     if (sparkClassLoader != null) {
       // Shouldn't set the sparkContext field. It is because in Standalone, the SparkContext instance will be different
       // for different runs, hence it shouldn't be cached in the static field.

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionClient.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionClient.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
 /**
- * Client class to interact with {@link SparkTransactionService} through HTTP. It is used by tasks executed inside
+ * Client class to interact with {@link SparkTransactionHandler} through HTTP. It is used by tasks executed inside
  * executor processes.
  */
 final class SparkTransactionClient {

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
@@ -66,6 +66,8 @@ public class SparkClassRewriter implements ClassRewriter {
   private static final Type SPARK_SUBMIT_TYPE = Type.getObjectType("org/apache/spark/deploy/SparkSubmit$");
   private static final Type SPARK_YARN_CLIENT_TYPE = Type.getObjectType("org/apache/spark/deploy/yarn/Client");
   private static final Type SPARK_DSTREAM_GRAPH_TYPE = Type.getObjectType("org/apache/spark/streaming/DStreamGraph");
+  private static final Type SPARK_EXECUTOR_CLASSLOADER_TYPE =
+    Type.getObjectType("org/apache/spark/repl/ExecutorClassLoader");
   private static final Type YARN_SPARK_HADOOP_UTIL_TYPE =
     Type.getObjectType("org/apache/spark/deploy/yarn/YarnSparkHadoopUtil");
   private static final Type KRYO_TYPE = Type.getObjectType("com/esotericsoftware/kryo/Kryo");
@@ -123,6 +125,11 @@ public class SparkClassRewriter implements ClassRewriter {
     if (className.equals(SPARK_DSTREAM_GRAPH_TYPE.getClassName())) {
       // Rewrite DStreamGraph to set TaskSupport on parallel array usage to avoid Thread leak
       return rewriteDStreamGraph(input);
+    }
+    if (className.equals(SPARK_EXECUTOR_CLASSLOADER_TYPE.getClassName())) {
+      // Rewrite the Spark repl ExecutorClassLoader to call `super(null)` so that it won't use the system classloader
+      // as parent
+      return rewriteExecutorClassLoader(input);
     }
     if (className.equals(AKKA_REMOTING_TYPE.getClassName())) {
       // Define the akka.remote.Remoting class to avoid thread leakage
@@ -194,6 +201,61 @@ public class SparkClassRewriter implements ClassRewriter {
               && returnType.getClassName().equals("scala.collection.parallel.mutable.ParArray")) {
               super.visitMethodInsn(Opcodes.INVOKESTATIC, SPARK_RUNTIME_UTILS_TYPE.getInternalName(),
                                     "setTaskSupport", Type.getMethodDescriptor(returnType, returnType), false);
+            }
+          }
+        };
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    return cw.toByteArray();
+  }
+
+  /**
+   * Rewrites the ExecutorClassLoader so that it won't use system classloader as parent.
+   */
+  private byte[] rewriteExecutorClassLoader(InputStream byteCodeStream) throws IOException {
+    ClassReader cr = new ClassReader(byteCodeStream);
+    ClassWriter cw = new ClassWriter(0);
+
+    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+
+      private final Type classloaderType = Type.getType(ClassLoader.class);
+      private boolean needRewrite;
+
+      @Override
+      public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        // Only generate
+        if (classloaderType.getInternalName().equals(superName)) {
+          needRewrite = true;
+        }
+        super.visit(version, access, name, signature, superName, interfaces);
+      }
+
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+        if (!needRewrite) {
+          return mv;
+        }
+
+        if (!"<init>".equals(name)) {
+          return mv;
+        }
+        return new GeneratorAdapter(Opcodes.ASM5, mv, access, name, desc) {
+
+          @Override
+          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            // If there is a call to `super()`, skip that instruction and have the onMethodEnter generate the call
+            if (opcode == Opcodes.INVOKESPECIAL
+                && Type.getObjectType(owner).equals(classloaderType)
+                && name.equals("<init>")
+                && Type.getArgumentTypes(desc).length == 0
+                && Type.getReturnType(desc).equals(Type.VOID_TYPE)) {
+              // Generate `super(null)`. The `this` is already in the stack, so no need to `loadThis()`
+              push((Type) null);
+              invokeConstructor(classloaderType, new Method("<init>", Type.VOID_TYPE, new Type[] { classloaderType }));
+            } else {
+              super.visitMethodInsn(opcode, owner, name, desc, itf);
             }
           }
         };

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
@@ -89,12 +89,15 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
     // We also need to define the org.spark-project., fastxml and akka classes in this ClassLoader
     // to avoid reference/thread leakage due to Spark assumption on process terminating after execution
     // Also need to define Kryo class as it is for rewriting the Kryo class to add extra default serializers
+    // Also need to define janino class for code compilation to avoid leaking classloader
     if (API_CLASSES.contains(name) || (!name.startsWith("co.cask.cdap.api.spark.")
         && !name.startsWith("co.cask.cdap.app.runtime.spark.")
         && !name.startsWith("org.apache.spark.") && !name.startsWith("org.spark-project.")
         && !name.startsWith("com.fasterxml.jackson.module.scala.")
         && !name.startsWith("akka.") && !name.startsWith("com.typesafe.")
-        && !name.startsWith("com.esotericsoftware.kryo.") && !name.startsWith("com.twitter.chill."))) {
+        && !name.startsWith("com.esotericsoftware.kryo.") && !name.startsWith("com.twitter.chill."))
+        && !name.startsWith("org.codehaus.janino.")
+      ) {
       return super.loadClass(name, resolve);
     }
 

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/dynamic/SparkClassFileHandler.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/dynamic/SparkClassFileHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic;
+
+import co.cask.cdap.common.NotFoundException;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.common.collect.ImmutableMultimap;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.io.File;
+import java.net.URLDecoder;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * A {@link HttpHandler} to serve class file to Spark executor.
+ */
+public final class SparkClassFileHandler extends AbstractHttpHandler {
+
+  private final Set<File> classDirs;
+
+  public SparkClassFileHandler() {
+    this.classDirs = Collections.synchronizedSet(new LinkedHashSet<File>());
+  }
+
+  /**
+   * Adds a directory to the class file search path.
+   */
+  public void addClassDir(File classDir) {
+    classDirs.add(classDir);
+  }
+
+  /**
+   * Removes a directory to the class file search path.
+   */
+  public void removeClassDir(File classDir) {
+    classDirs.remove(classDir);
+  }
+
+  @GET
+  @Path("/.*")
+  public void getClassFile(HttpRequest request, HttpResponder responder) throws Exception {
+    String requestURI = URLDecoder.decode(request.getUri(), "UTF-8");
+    requestURI = requestURI.isEmpty() ? requestURI : requestURI.substring(1);
+
+    for (File dir : classDirs) {
+      File classFile = new File(dir, requestURI);
+      if (classFile.isFile()) {
+        responder.sendByteArray(HttpResponseStatus.OK, Files.readAllBytes(classFile.toPath()),
+                                ImmutableMultimap.of("Content-Type", "application/octet-stream"));
+        return;
+      }
+    }
+    throw new NotFoundException(requestURI);
+  }
+}

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/BatchReadableRDD.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/BatchReadableRDD.scala
@@ -29,18 +29,19 @@ import org.apache.spark.executor.InputMetrics
 import org.apache.spark.rdd.RDD
 import org.apache.tephra.TransactionAware
 
+import scala.annotation.meta.param
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
 
 /**
   * A [[org.apache.spark.rdd.RDD]] implementation that reads data through [[co.cask.cdap.api.data.batch.BatchReadable]].
   */
-class BatchReadableRDD[K: ClassTag, V: ClassTag](@transient sc: SparkContext,
-                                                 @transient batchReadable: BatchReadable[K, V],
+class BatchReadableRDD[K: ClassTag, V: ClassTag](@(transient @param) sc: SparkContext,
+                                                 @(transient @param) batchReadable: BatchReadable[K, V],
                                                  namespace: String,
                                                  datasetName: String,
                                                  arguments: Map[String, String],
-                                                 @transient splits: Option[Iterable[_ <: Split]],
+                                                 @(transient @param) splits: Option[Iterable[_ <: Split]],
                                                  txServiceBaseURI: Broadcast[URI]) extends RDD[(K, V)](sc, Nil) {
 
   override protected def getPartitions: Array[Partition] = {

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DatasetRDD.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DatasetRDD.scala
@@ -29,18 +29,19 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 
+import scala.annotation.meta.param
 import scala.reflect.ClassTag
 
 /**
   * A [[org.apache.spark.rdd.RDD]] for reading data from [[co.cask.cdap.api.dataset.Dataset]].
   */
-class DatasetRDD[K: ClassTag, V: ClassTag](@transient sc: SparkContext,
-                                           @transient datasetCompute: DatasetCompute,
-                                           @transient hConf: Configuration,
+class DatasetRDD[K: ClassTag, V: ClassTag](@(transient @param) sc: SparkContext,
+                                           @(transient @param) datasetCompute: DatasetCompute,
+                                           @(transient @param) hConf: Configuration,
                                            namespace: String,
                                            datasetName: String,
                                            arguments: Map[String, String],
-                                           @transient splits: Option[Iterable[_ <: Split]],
+                                           @(transient @param) splits: Option[Iterable[_ <: Split]],
                                            txServiceBaseURI: Broadcast[URI]) extends RDD[(K, V)](sc, Nil) {
 
   var delegateRDD: Option[RDD[(K, V)]] = None

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -28,6 +28,7 @@ import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.preview.DataTracer
 import co.cask.cdap.api.security.store.{SecureStore, SecureStoreData}
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter
 import co.cask.cdap.api.spark.{JavaSparkExecutionContext, SparkExecutionContext, SparkSpecification}
 import co.cask.cdap.api.stream.{GenericStreamEventData, StreamEventDecoder}
 import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
@@ -86,6 +87,8 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
   override def execute(runnable: TxRunnable): Unit = sec.execute(runnable)
 
   override def execute(timeout: Int, runnable: TxRunnable): Unit = sec.execute(timeout, runnable)
+
+  override def createInterpreter(): SparkInterpreter = sec.createInterpreter()
 
   override def fromDataset[K, V](datasetName: String, arguments: util.Map[String, String],
                                  splits: java.lang.Iterable[_ <: Split]): JavaPairRDD[K, V] = {

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.preview.DataTracer
 import co.cask.cdap.api.spark.SparkExecutionContext
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -58,6 +59,8 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
   override def execute(runnable: TxRunnable) = delegate.execute(runnable)
 
   override def execute(timeout: Int, runnable: TxRunnable) = delegate.execute(timeout, runnable)
+
+  override def createInterpreter(): SparkInterpreter = delegate.createInterpreter()
 
   override def saveAsDataset[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)], namespace: String,
                                                        datasetName: String, arguments: Map[String, String]) =

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SparkRuntimeEnv.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SparkRuntimeEnv.scala
@@ -16,8 +16,9 @@
 
 package co.cask.cdap.app.runtime.spark
 
+import java.util
 import java.util.Properties
-import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 import javax.annotation.Nullable
 
 import com.google.common.reflect.TypeToken
@@ -27,6 +28,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 /**
@@ -44,6 +46,7 @@ object SparkRuntimeEnv {
   private val properties = new Properties
   private var sparkContext: Option[SparkContext] = None
   private var streamingContext: Option[StreamingContext] = None
+  private val batchedWALs = new mutable.ListBuffer[AnyRef]
   private val sparkListeners = new ConcurrentLinkedQueue[SparkListener]()
 
   /**
@@ -106,6 +109,19 @@ object SparkRuntimeEnv {
 
       // Spark doesn't allow multiple StreamingContext instances concurrently, hence we don't need to check in here
       streamingContext = Some(context)
+    }
+  }
+
+  /**
+    * Adds the refernce to BatchedWriteAheadLog instance.
+    */
+  def addBatchedWriteAheadLog(batchedWAL: AnyRef): Unit = {
+    this.synchronized {
+      if (stopped) {
+        stopBatchedWAL(batchedWAL)
+        throw new IllegalStateException("Spark program is already stopped")
+      }
+      batchedWALs += batchedWAL
     }
   }
 
@@ -180,7 +196,7 @@ object SparkRuntimeEnv {
       })
     } finally {
       sc.foreach(context => {
-        val cleanup = createCleanup(context);
+        val cleanup = createCleanup(context, batchedWALs.toList);
         try {
           context.stop
         } finally {
@@ -201,7 +217,7 @@ object SparkRuntimeEnv {
     * Creates a function that will stop and cleanup up all http servers and thread pools
     * associated with the given SparkContext.
     */
-  private def createCleanup(sc: SparkContext): () => Unit = {
+  private def createCleanup(sc: SparkContext, batchedWALs: List[AnyRef]): () => Unit = {
     val closers = ArrayBuffer.empty[Option[() => Unit]]
 
     // Create a closer function for the file server in Spark
@@ -233,6 +249,9 @@ object SparkRuntimeEnv {
       case _ => None
     })
 
+    // Create a closer function for stopping the thead in BatchedWriteAheadLog
+    closers += Some(() => batchedWALs.foreach(stopBatchedWAL))
+
     // Creates a function that calls all closers
     () => closers.foreach(_.foreach(_()))
   }
@@ -249,6 +268,26 @@ object SparkRuntimeEnv {
           threadPool.callMethod("stop")
         }
       )
+    })
+  }
+
+  /**
+    * Stops the thread in the given BatchedWriteAheadLog instance
+    */
+  private def stopBatchedWAL(batchedWAL: AnyRef) = {
+    // Get the internal record queue
+    batchedWAL.getField("walWriteQueue").flatMap(queue => queue match {
+      case c: util.Collection[Any] => Some(c)
+      case _ => None
+    }).foreach(queue => {
+      // Wait until the queue is empty and the WAL is still active
+      while (!queue.isEmpty &&
+        batchedWAL.getField("active").filter(_.isInstanceOf[Boolean]).map(_.asInstanceOf[Boolean]).exists(b => b)) {
+        TimeUnit.MILLISECONDS.sleep(100)
+      }
+
+      // Now call BatchedWriteAheadLog.close()
+      batchedWAL.callMethod("close")
     })
   }
 

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkCompiler.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkCompiler.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+
+import java.io._
+import java.net.URL
+import java.util.jar.{JarEntry, JarOutputStream}
+
+import co.cask.cdap.api.spark.dynamic.{CompilationFailureException, SparkCompiler}
+import co.cask.cdap.common.lang.ClassLoaders
+import co.cask.cdap.common.lang.jar.BundleJarUtil
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+import scala.reflect.internal.util.{BatchSourceFile, SourceFile}
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interpreter.IMain
+import scala.tools.nsc.io.{AbstractFile, PlainFile}
+
+/**
+  * Abstract common base for implementation [[co.cask.cdap.api.spark.dynamic.SparkCompiler]] for different
+  * Spark version.
+  */
+abstract class AbstractSparkCompiler(settings: Settings, onClose: () => Unit) extends SparkCompiler {
+
+  import AbstractSparkCompiler._
+
+  private val errorReporter = new ErrorReporter()
+  private lazy val iMain = createIMain(settings, errorReporter)
+  private var compileCount = 0
+
+  /**
+    * Creates a new instance of [[scala.tools.nsc.interpreter.IMain]].
+    *
+    * @param settings the settings for the IMain
+    * @param errorReporter a [[co.cask.cdap.app.runtime.spark.dynamic.AbstractSparkCompiler.ErrorReporter]] for
+    *                      error reporting from the IMain
+    * @return a new instance of IMain
+    */
+  protected def createIMain(settings: Settings, errorReporter: ErrorReporter): IMain with URLAdder
+
+  /**
+    * Returns the directory where the compiler writes out compiled class files.
+    *
+    * @return a [[scala.tools.nsc.io.AbstractFile]] represeting output directory
+    */
+  protected def getOutputDir(): AbstractFile
+
+  override def compile(source: String): Unit = {
+    compileCount += 1
+    compile(new BatchSourceFile(s"<source-string-$compileCount>", source));
+  }
+
+  override def compile(file: File): Unit = {
+    compile(new BatchSourceFile(new PlainFile(file)))
+  }
+
+  override def saveAsJar(file: File): Unit = {
+    val output = new BufferedOutputStream(new FileOutputStream(file))
+    try {
+      saveAsJar(output)
+    } finally {
+      output.close()
+    }
+  }
+
+  override def saveAsJar(outputStream: OutputStream): Unit = {
+    val outputDir = getOutputDir()
+    val jarOutput = new JarOutputStream(outputStream)
+    try {
+      // If it is file, use the BundleJarUtil to handle it
+      if (outputDir.isInstanceOf[PlainFile]) {
+        BundleJarUtil.addToArchive(outputDir.file, jarOutput)
+        return
+      }
+
+      // Otherwise, iterate the AbstractFile recursively and create the jar
+      val queue = new mutable.Queue[AbstractFile]()
+      outputDir.foreach(f => queue.enqueue(f))
+      while (queue.nonEmpty) {
+        val entry = queue.dequeue()
+        val name = entry.path.substring(outputDir.path.length + 1)
+        if (entry.isDirectory) {
+          // If it is directory, add the entry with name ended with "/". Also add all children entries to the queue.
+          jarOutput.putNextEntry(new JarEntry(name + "/"))
+          jarOutput.closeEntry()
+          entry.foreach(f => queue.enqueue(f))
+        } else {
+          jarOutput.putNextEntry(new JarEntry(name))
+          copyStreams(entry.input, jarOutput)
+          jarOutput.closeEntry()
+        }
+      }
+    } finally {
+      jarOutput.close()
+    }
+  }
+
+  override def addDependency(file: File): Unit = {
+    iMain.addURLs(file.toURI.toURL)
+  }
+
+  override def getIMain(): IMain = {
+    return iMain
+  }
+
+  override def close(): Unit = {
+    iMain.reset()
+    iMain.close()
+    onClose()
+  }
+
+  /**
+    * Compiles using content defined by the given [[scala.reflect.internal.util.SourceFile]].
+    */
+  private def compile(sourceFile: SourceFile): Unit = {
+    if (!iMain.compileSources(sourceFile)) {
+      throw new CompilationFailureException(errorReporter.toString)
+    }
+  }
+
+  /**
+    * Class for reporting errors generated from [[scala.tools.nsc.interpreter.IMain]].
+    */
+  protected final class ErrorReporter {
+
+    private val errors = new mutable.ListBuffer[String]
+
+    def report(msg: String): Unit = {
+      errors += msg
+    }
+
+    def clear(): Unit = {
+      errors.clear()
+    }
+
+    override def toString: String = {
+      errors.mkString(System.getProperty("line.separator"))
+    }
+  }
+
+  /**
+    * Trait for the ability to add [[java.net.URL]]s.
+    */
+  trait URLAdder {
+    def addURLs(urls: URL*): Unit
+  }
+}
+
+/**
+  * Companion object to provide helper methods.
+  */
+object AbstractSparkCompiler {
+
+  /**
+    * Setup the [[scala.tools.nsc.settings]] user classpath based on the give [[java.lang.ClassLoader]].
+    *
+    * @param settings the settings to modify
+    * @param classLoader the classloader to use to determine the set of URLs to generate the user classpath
+    * @return the same settings instance from the argument
+    */
+  def setClassPath(settings: Settings, classLoader: ClassLoader): Settings = {
+    settings.classpath.value =
+      ClassLoaders.getClassLoaderURLs(classLoader, true, new java.util.LinkedHashSet[URL])
+                  .mkString(File.pathSeparator)
+    settings
+  }
+
+  /**
+    * Copying data from one stream to another.
+    */
+  private def copyStreams(from: InputStream, to: OutputStream): Unit = {
+    val buf = new Array[Byte](8192)
+    var len = from.read(buf)
+    while (len >= 0) {
+      to.write(buf, 0, len)
+      len = from.read(buf)
+    }
+  }
+}

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkCompiler.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkCompiler.scala
@@ -152,13 +152,6 @@ abstract class AbstractSparkCompiler(settings: Settings, onClose: () => Unit) ex
       errors.mkString(System.getProperty("line.separator"))
     }
   }
-
-  /**
-    * Trait for the ability to add [[java.net.URL]]s.
-    */
-  trait URLAdder {
-    def addURLs(urls: URL*): Unit
-  }
 }
 
 /**

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkInterpreter.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkInterpreter.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+
+import co.cask.cdap.api.spark.dynamic.{BindingException, InterpretFailureException, SparkInterpreter}
+
+import scala.reflect.{ClassTag, runtime}
+import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
+
+/**
+  * A trait to provide implementation of [[co.cask.cdap.api.spark.dynamic.SparkInterpreter]] that uses
+  * [[scala.tools.nsc.interpreter.IMain]] exposed by [[co.cask.cdap.api.spark.dynamic.SparkCompiler]].
+  */
+trait AbstractSparkInterpreter extends SparkInterpreter {
+
+  override def bind[T: runtime.universe.TypeTag : ClassTag](name: String, value: T): Unit = {
+    val valueType = implicitly[runtime.universe.TypeTag[T]].tpe
+    val iMain = getIMain()
+    iMain.reporter.reset()
+    iMain.bind(name, value) match {
+      case Error | Incomplete =>
+        throw new BindingException(name, valueType.toString(), value)
+      case Success =>
+    }
+  }
+
+  override def bind(name: String, bindType: String, value: Any, modifiers: String*): Unit = {
+    val iMain = getIMain()
+
+    iMain.reporter.reset()
+    iMain.bind(name, bindType, value, modifiers.toList) match {
+      case Error | Incomplete =>
+        throw new BindingException(name, bindType, value, modifiers: _*)
+      case Success =>
+    }
+  }
+
+  override def interpret(line: String): Unit = {
+    getIMain().interpret(line) match {
+      case Error => throw new InterpretFailureException(getIMain().reporter.toString)
+      case Incomplete => throw new InterpretFailureException("Source line is incomplete: " + line)
+      case Success =>
+    }
+  }
+
+  override def getValue(name: String): Option[Any] = {
+    getIMain().valueOfTerm(name)
+  }
+}

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/URLAdder.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/URLAdder.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+
+import java.net.URL
+
+/**
+  * Trait for the ability to add [[java.net.URL]]s.
+  */
+trait URLAdder {
+
+  /**
+    * Adds a set of [[java.net.URL]]s.
+    */
+  def addURLs(urls: URL*): Unit
+}

--- a/cdap-spark-core-base/src/test/java/co/cask/cdap/app/runtime/spark/dynamic/SparkCompilerTestBase.java
+++ b/cdap-spark-core-base/src/test/java/co/cask/cdap/app/runtime/spark/dynamic/SparkCompilerTestBase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic;
+
+import co.cask.cdap.api.spark.dynamic.CompilationFailureException;
+import co.cask.cdap.api.spark.dynamic.InterpretFailureException;
+import co.cask.cdap.api.spark.dynamic.SparkCompiler;
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter;
+import com.google.common.base.Joiner;
+import com.google.common.io.Files;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import scala.collection.JavaConversions;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+/**
+ * Unit test base for {@link SparkCompiler}.
+ */
+public abstract class SparkCompilerTestBase {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testCompiler() throws Exception {
+    // Jar file for saving the TestClass
+    File testClassJar = new File(TEMP_FOLDER.newFolder(), "testClass.jar");
+
+    try (SparkCompiler compiler = createCompiler()) {
+      StringWriter writer = new StringWriter();
+
+      // Compile a class that write out array to a file
+      try (PrintWriter sourceWriter = new PrintWriter(writer, true)) {
+        sourceWriter.println("package co.cask.cdap.test");
+        sourceWriter.println("import java.io._");
+        sourceWriter.println("class TestClass(outputFile: File) {");
+        sourceWriter.println("  def write(args: Array[String]): Unit = {");
+        sourceWriter.println("    val writer = new PrintWriter(new FileWriter(outputFile), true)");
+        sourceWriter.println("    try {");
+        sourceWriter.println("      args.foreach(writer.println)");
+        sourceWriter.println("    } finally {");
+        sourceWriter.println("      writer.close()");
+        sourceWriter.println("    }");
+        sourceWriter.println("  }");
+        sourceWriter.println("}");
+      }
+      compiler.compile(writer.toString());
+      compiler.saveAsJar(testClassJar);
+    }
+
+    // Jar file for saving the TestMain
+    File mainClassJar = new File(TEMP_FOLDER.newFolder(), "testMain.jar");
+    try (SparkCompiler compiler = createCompiler()) {
+      // Add the TestClass jar as dependency
+      compiler.addDependency(testClassJar);
+
+      // Compile a main class
+      StringWriter writer = new StringWriter();
+      try (PrintWriter sourceWriter = new PrintWriter(writer, true)) {
+        sourceWriter.println("package co.cask.cdap.test");
+        sourceWriter.println("import java.io._");
+        sourceWriter.println("object TestMain {");
+        sourceWriter.println("  def main(args: Array[String]): Unit = {");
+        sourceWriter.println("    new TestClass(new File(args(0))).write(args.slice(1, args.length))");
+        sourceWriter.println("  }");
+        sourceWriter.println("}");
+      }
+      compiler.compile(writer.toString());
+      compiler.saveAsJar(mainClassJar);
+    }
+
+    // Create an Interpreter
+    SparkInterpreter interpreter = createInterpreter();
+    interpreter.addDependency(testClassJar);
+    interpreter.addDependency(mainClassJar);
+
+    // Call the `TestMain.main` method
+    File outputFile = TEMP_FOLDER.newFile();
+    interpreter.bind("output", File.class.getName(), outputFile,
+                     JavaConversions.asScalaBuffer(Collections.<String>emptyList()));
+    interpreter.interpret("co.cask.cdap.test.TestMain.main(Array(output.getAbsolutePath(), \"a\", \"b\", \"c\"))");
+
+    // The main method will write to output file with the rest of the arguments, each on a new line
+    String content = Files.toString(outputFile, StandardCharsets.UTF_8).trim();
+    Assert.assertEquals(content, Joiner.on(System.getProperty("line.separator")).join("a", "b", "c"));
+
+    interpreter.interpret("val num = 10 + 10");
+    Assert.assertEquals(20, interpreter.getValue("num").get());
+    Assert.assertTrue(interpreter.getValue("num1").isEmpty());
+  }
+
+  @Test(expected = CompilationFailureException.class)
+  public void testCompilationFailure() throws Exception {
+    try (SparkCompiler compiler = createCompiler()) {
+      compiler.compile("something random");
+    }
+  }
+
+  @Test(expected = InterpretFailureException.class)
+  public void testInterpretFailure() throws Exception {
+    try (SparkInterpreter interpreter = createInterpreter()) {
+      interpreter.interpret("String str = \"abc\";");   // this is Java code, not valid Scala
+    }
+  }
+
+  protected abstract SparkCompiler createCompiler() throws Exception;
+
+  protected abstract SparkInterpreter createInterpreter() throws Exception;
+}

--- a/cdap-spark-core/pom.xml
+++ b/cdap-spark-core/pom.xml
@@ -89,6 +89,10 @@
       <artifactId>spark-mllib_2.10</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_2.10</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -19,15 +19,20 @@ package co.cask.cdap.app.runtime.spark
 import java.io.File
 import java.util
 
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter
+import co.cask.cdap.app.runtime.spark.dynamic.DefaultSparkInterpreter
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
+import scala.reflect.io.PlainFile
+import scala.tools.nsc.Settings
+
 /**
   * Spark1 SparkExecutionContext
   */
-class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext, localizeResources: util.Map[String, File])
-  extends AbstractSparkExecutionContext(runtimeContext, localizeResources) {
+class DefaultSparkExecutionContext(sparkClassLoader: SparkClassLoader, localizeResources: util.Map[String, File])
+  extends AbstractSparkExecutionContext(sparkClassLoader, localizeResources) {
 
   override protected def saveAsNewAPIHadoopDataset[K: ClassManifest, V: ClassManifest](sc: SparkContext,
                                                                                        conf: Configuration,
@@ -39,5 +44,10 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext, localize
     } else {
       rdd.saveAsNewAPIHadoopDataset(conf)
     }
+  }
+
+  override protected def createInterpreter(settings: Settings,
+                                           classDir: File, onClose: () => Unit): SparkInterpreter = {
+    new DefaultSparkInterpreter(settings, new PlainFile(classDir), onClose)
   }
 }

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/DefaultSparkCompiler.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/DefaultSparkCompiler.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+
+import java.io._
+import java.net.{URL, URLClassLoader}
+
+import scala.tools.nsc.backend.JavaPlatform
+import scala.tools.nsc.interpreter.{AbstractFileClassLoader, IMain, ReplGlobal, ReplReporter}
+import scala.tools.nsc.io.AbstractFile
+import scala.tools.nsc.reporters.Reporter
+import scala.tools.nsc.util.MergedClassPath
+import scala.tools.nsc.{Global, Settings, io}
+
+/**
+  * A default implementation of [[co.cask.cdap.api.spark.dynamic.SparkCompiler]] for Scala 2.10 that uses Scala
+  * [[scala.tools.nsc.interpreter.IMain]] for the compilation.
+  */
+class DefaultSparkCompiler(settings: Settings,
+                           outputDir: AbstractFile,
+                           onClose: () => Unit) extends AbstractSparkCompiler(settings, onClose) {
+
+  override protected def createIMain(settings: Settings, errorReporter: ErrorReporter): IMain with URLAdder = {
+    // Override couple methods so that
+    // 1. Compiled classes can be write out to custom directory instead of always in memory
+    // 2. Allow adding dependencies to the compiler
+    // 3. Collect errors instead of just getting printed to console.
+    new IMain(settings) with URLAdder {
+
+      private lazy val runtimeParentClassLoader = new MutableURLClassLoader(Array(), super.parentClassLoader)
+      private var runtimeClassLoader: Option[AbstractFileClassLoader] = None
+
+      override protected def parentClassLoader: ClassLoader = {
+        runtimeParentClassLoader
+      }
+
+      override def classLoader: AbstractFileClassLoader = {
+        runtimeClassLoader = runtimeClassLoader.orElse(Some(createClassLoader()))
+        runtimeClassLoader.get
+      }
+
+      override def resetClassLoader(): Unit = {
+        runtimeClassLoader = None
+      }
+
+      override protected def newCompiler(settings: Settings, reporter: Reporter): ReplGlobal = {
+        settings.outputDirs setSingleOutput outputDir
+        settings.exposeEmptyPackage.value = true
+        new Global(settings, reporter) with ReplGlobal {
+          override def toString: String = "<global>"
+        }
+      }
+
+      override lazy val reporter: ReplReporter = {
+        new ReplReporter(this) {
+          override def printMessage(msg: String): Unit = {
+            errorReporter.report(msg)
+          }
+
+          override def reset(): Unit = {
+            super.reset()
+            errorReporter.clear()
+          }
+
+          override def toString: String = {
+            errorReporter.toString
+          }
+        }
+      }
+
+      override def addURLs(urls: URL*): Unit = {
+        updateCompilerClassPath(urls: _*)
+        urls.foreach(runtimeParentClassLoader.addURL)
+      }
+
+      /**
+        * Updates the classpath used by the Scala compiler.
+        */
+      private def updateCompilerClassPath(urls: URL*): Unit = {
+        require(global.platform.isInstanceOf[JavaPlatform], "Only JavaPlatform is supported")
+
+        val platform = global.platform.asInstanceOf[JavaPlatform]
+
+        val newClassPath = mergeUrlsIntoClassPath(platform, urls: _*)
+
+        // NOTE: Must use reflection until this is exposed/fixed upstream in Scala
+        val fieldSetter = platform.getClass.getMethods
+          .find(_.getName.endsWith("currentClassPath_$eq")).get
+        fieldSetter.invoke(platform, Some(newClassPath))
+
+        // Reload all jars specified into our compiler
+        global.invalidateClassPathEntries(urls.map(_.getPath): _*)
+      }
+
+      /**
+        * Creates a new [[scala.tools.nsc.util.MergedClassPath]] by merging the existing classpath
+        * used by the platform with the given set of URLs.
+        */
+      private def mergeUrlsIntoClassPath(platform: JavaPlatform, urls: URL*): MergedClassPath[AbstractFile] = {
+        // Collect our new jars/directories and add them to the existing set of classpaths
+        val allClassPaths = (
+          platform.classPath.asInstanceOf[MergedClassPath[AbstractFile]].entries ++
+            urls.map(url => {
+              platform.classPath.context.newClassPath(
+                if (url.getProtocol == "file") {
+                  val f = new File(url.getPath)
+                  if (f.isDirectory)
+                    io.AbstractFile.getDirectory(f)
+                  else
+                    io.AbstractFile.getFile(f)
+                } else {
+                  io.AbstractFile.getURL(url)
+                }
+              )
+            })
+          ).distinct
+
+        // Combine all of our classpaths (old and new) into one merged classpath
+        new MergedClassPath(allClassPaths, platform.classPath.context)
+      }
+
+      /**
+        * Creates a new classloader used for runtime classloading.
+        */
+      private def createClassLoader(): AbstractFileClassLoader = {
+        // This is copied from Scala IMain in order to use a different AbstractFile instead of the virtualDirectory.
+        new AbstractFileClassLoader(outputDir, parentClassLoader) {
+          /** Overridden here to try translating a simple name to the generated
+            *  class name if the original attempt fails.  This method is used by
+            *  getResourceAsStream as well as findClass.
+            */
+          override protected def findAbstractFile(name: String): AbstractFile = {
+            super.findAbstractFile(name) match {
+              // deadlocks on startup if we try to translate names too early
+              case null if isInitializeComplete => generatedName(name) map (x => super.findAbstractFile(x)) orNull
+              case file => file
+            }
+          }
+        }
+      }
+    }
+  }
+
+  override protected def getOutputDir(): AbstractFile = {
+    outputDir
+  }
+
+  /**
+    * A [[java.net.URLClassLoader]] that exposes the addURL method.
+    */
+  private class MutableURLClassLoader(urls: Array[URL], parent: ClassLoader) extends URLClassLoader(urls, parent) {
+
+    override def addURL(url: URL): Unit = {
+      super.addURL(url)
+    }
+  }
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/DefaultSparkInterpreter.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/DefaultSparkInterpreter.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+
+import scala.tools.nsc.Settings
+import scala.tools.nsc.io.AbstractFile
+
+/**
+  * Default implementation of [[co.cask.cdap.api.spark.dynamic.SparkInterpreter]] for Scala 2.10.
+  */
+class DefaultSparkInterpreter(settings: Settings, outputDir: AbstractFile, onClose: () => Unit)
+  extends DefaultSparkCompiler(settings, outputDir, onClose) with AbstractSparkInterpreter {
+
+}

--- a/cdap-spark-core/src/test/scala/co/cask/cdap/app/runtime/spark/dynamic/SparkCompilerTest.scala
+++ b/cdap-spark-core/src/test/scala/co/cask/cdap/app/runtime/spark/dynamic/SparkCompilerTest.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+import co.cask.cdap.api.spark.dynamic.{SparkCompiler, SparkInterpreter}
+
+import scala.reflect.io.{PlainFile, VirtualDirectory}
+import scala.tools.nsc.Settings
+
+/**
+  * Unit test for SparkCompiler and SparkInterpreter.
+  */
+class SparkCompilerTest extends SparkCompilerTestBase {
+
+  override protected def createCompiler(): SparkCompiler = {
+    val settings = AbstractSparkCompiler.setClassPath(new Settings(), getClass.getClassLoader)
+    new DefaultSparkCompiler(settings, new VirtualDirectory("in-memory", None), () => { });
+  }
+
+  override protected def createInterpreter(): SparkInterpreter = {
+    val settings = AbstractSparkCompiler.setClassPath(new Settings(), getClass.getClassLoader)
+    return new DefaultSparkInterpreter(settings,
+                                       new PlainFile(SparkCompilerTestBase.TEMP_FOLDER.newFolder()), () => { });
+  }
+}

--- a/cdap-spark-core2_2.11/pom.xml
+++ b/cdap-spark-core2_2.11/pom.xml
@@ -89,6 +89,10 @@
       <artifactId>spark-mllib_2.11</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_2.11</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>

--- a/cdap-spark-core2_2.11/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core2_2.11/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -18,19 +18,29 @@ package co.cask.cdap.app.runtime.spark
 import java.io.File
 import java.util
 
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter
+import co.cask.cdap.app.runtime.spark.dynamic.DefaultSparkInterpreter
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
+import scala.tools.nsc.Settings
+
 /**
   * Spark2 SparkExecutionContext
   */
-class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext, localizeResources: util.Map[String, File])
-  extends AbstractSparkExecutionContext(runtimeContext, localizeResources) {
+class DefaultSparkExecutionContext(sparkClassLoader: SparkClassLoader, localizeResources: util.Map[String, File])
+  extends AbstractSparkExecutionContext(sparkClassLoader, localizeResources) {
 
   override protected def saveAsNewAPIHadoopDataset[K: ClassManifest, V: ClassManifest](sc: SparkContext,
                                                                                        conf: Configuration,
                                                                                        rdd: RDD[(K, V)]): Unit = {
     rdd.saveAsNewAPIHadoopDataset(conf)
+  }
+
+  override protected def createInterpreter(settings: Settings,
+                                           classDir: File, onClose: () => Unit): SparkInterpreter = {
+    settings.Yreploutdir.value = classDir.getAbsolutePath
+    new DefaultSparkInterpreter(settings, onClose)
   }
 }

--- a/cdap-spark-core2_2.11/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/DefaultSparkCompiler.scala
+++ b/cdap-spark-core2_2.11/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/DefaultSparkCompiler.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+
+import java.net.URL
+
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interpreter.{IMain, ReplReporter}
+import scala.tools.nsc.io.AbstractFile
+
+/**
+  * A default implementation of [[co.cask.cdap.api.spark.dynamic.SparkCompiler]] for Scala 2.11 that uses Scala
+  * [[scala.tools.nsc.interpreter.IMain]] for the compilation.
+  */
+
+class DefaultSparkCompiler(settings: Settings, onClose: () => Unit) extends AbstractSparkCompiler(settings, onClose) {
+
+  override protected def createIMain(settings: Settings, errorReporter: ErrorReporter): IMain with URLAdder = {
+    // Overrides the error reporting so that we can collect the errors instead of just getting printed to console
+    new IMain(settings) with URLAdder {
+
+      override lazy val reporter: ReplReporter = {
+        new ReplReporter(this) {
+          override def printMessage(msg: String): Unit = {
+            errorReporter.report(msg)
+          }
+
+          override def reset(): Unit = {
+            super.reset()
+            errorReporter.clear()
+          }
+
+          override def toString: String = {
+            errorReporter.toString
+          }
+        }
+      }
+
+      override def addURLs(urls: URL*): Unit = {
+        ensureClassLoader()
+        addUrlsToClassPath(urls: _*)
+        resetClassLoader()
+      }
+    }
+  }
+
+  override protected def getOutputDir(): AbstractFile = {
+    getIMain().replOutput.dir
+  }
+}

--- a/cdap-spark-core2_2.11/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/DefaultSparkInterpreter.scala
+++ b/cdap-spark-core2_2.11/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/DefaultSparkInterpreter.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+
+import scala.tools.nsc.Settings
+
+/**
+  * Default implementation of [[co.cask.cdap.api.spark.dynamic.SparkInterpreter]] for Scala 2.11.
+  */
+class DefaultSparkInterpreter(settings: Settings, onClose: () => Unit)
+  extends DefaultSparkCompiler(settings, onClose) with AbstractSparkInterpreter {
+
+}

--- a/cdap-spark-core2_2.11/src/test/scala/co/cask/cdap/app/runtime/spark/dynamic/SparkCompilerTest.scala
+++ b/cdap-spark-core2_2.11/src/test/scala/co/cask/cdap/app/runtime/spark/dynamic/SparkCompilerTest.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.dynamic
+
+import co.cask.cdap.api.spark.dynamic.{SparkCompiler, SparkInterpreter}
+
+import scala.tools.nsc.Settings
+
+/**
+  * Unit test for SparkCompiler and SparkInterpreter.
+  */
+class SparkCompilerTest extends SparkCompilerTestBase {
+
+  override protected def createCompiler(): SparkCompiler = {
+    val settings = AbstractSparkCompiler.setClassPath(new Settings(), getClass.getClassLoader)
+    new DefaultSparkCompiler(settings, () => { });
+  }
+
+  override protected def createInterpreter(): SparkInterpreter = {
+    val settings = AbstractSparkCompiler.setClassPath(new Settings(), getClass.getClassLoader)
+    settings.Yreploutdir.value = SparkCompilerTestBase.TEMP_FOLDER.newFolder.getAbsolutePath
+    new DefaultSparkInterpreter(settings, () => { });
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
@@ -44,6 +44,7 @@ import co.cask.cdap.spark.app.Person;
 import co.cask.cdap.spark.app.ScalaCharCountProgram;
 import co.cask.cdap.spark.app.ScalaClassicSparkProgram;
 import co.cask.cdap.spark.app.ScalaCrossNSProgram;
+import co.cask.cdap.spark.app.ScalaDynamicSpark;
 import co.cask.cdap.spark.app.ScalaSparkLogParser;
 import co.cask.cdap.spark.app.ScalaStreamFormatSpecSpark;
 import co.cask.cdap.spark.app.SparkAppUsingGetDataset;
@@ -167,6 +168,31 @@ public class SparkTestRun extends TestFrameworkTestBase {
     KeyValueTable resultTable = this.<KeyValueTable>getDataset("ResultTable").get();
     Assert.assertEquals(1L, Bytes.toLong(resultTable.read(ClassicSparkProgram.class.getName())));
     Assert.assertEquals(1L, Bytes.toLong(resultTable.read(ScalaClassicSparkProgram.class.getName())));
+  }
+
+  @Test
+  public void testDynamicSpark() throws Exception {
+    ApplicationManager appManager = deploy(TestSparkApp.class);
+
+    // Populate data into the stream
+    StreamManager streamManager = getStreamManager("SparkStream");
+    for (int i = 0; i < 10; i++) {
+      streamManager.send("Line " + (i + 1));
+    }
+
+    SparkManager sparkManager = appManager.getSparkManager(ScalaDynamicSpark.class.getSimpleName());
+    sparkManager.start(ImmutableMap.of("input", "SparkStream", "output", "ResultTable"));
+
+    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    // Validate the result written to dataset
+    KeyValueTable resultTable = this.<KeyValueTable>getDataset("ResultTable").get();
+    // There should be ten "Line"
+    Assert.assertEquals(10, Bytes.toInt(resultTable.read("Line")));
+    // Each number should appear once
+    for (int i = 0; i < 10; i++) {
+      Assert.assertEquals(1, Bytes.toInt(resultTable.read(Integer.toString(i + 1))));
+    }
   }
 
   @Test

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaDynamicSpark.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaDynamicSpark.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spark.app
+
+import co.cask.cdap.api.spark.{AbstractSpark, SparkExecutionContext, SparkMain}
+
+/**
+  *
+  */
+class ScalaDynamicSpark extends AbstractSpark with SparkMain {
+
+  override protected def configure(): Unit = {
+    setMainClass(classOf[ScalaDynamicSpark])
+  }
+
+  override def run(implicit sec: SparkExecutionContext): Unit = {
+
+  }
+}

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/TestSparkApp.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/TestSparkApp.scala
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.spark.app
 
-import co.cask.cdap.api.ProgramStatus
 import co.cask.cdap.api.annotation.{Property, UseDataSet}
 import co.cask.cdap.api.app.AbstractApplication
 import co.cask.cdap.api.common.Bytes
@@ -25,6 +24,7 @@ import co.cask.cdap.api.data.stream.Stream
 import co.cask.cdap.api.dataset.lib._
 import co.cask.cdap.api.spark.AbstractSpark
 import co.cask.cdap.api.workflow.AbstractWorkflow
+import co.cask.cdap.api.{Config, ProgramStatus}
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat
 
 import scala.collection.JavaConversions._
@@ -32,7 +32,7 @@ import scala.collection.JavaConversions._
 /**
   * An application for SparkTestRun.
   */
-class TestSparkApp extends AbstractApplication {
+class TestSparkApp extends AbstractApplication[Config] {
 
   override def configure() = {
     addStream(new Stream("SparkStream"))
@@ -58,6 +58,8 @@ class TestSparkApp extends AbstractApplication {
     addSpark(new ScalaStreamFormatSpecSpark)
 
     addSpark(new KafkaSparkStreaming)
+
+    addSpark(new ScalaDynamicSpark)
 
     addSpark(new ForkSpark("ForkSpark1"))
     addSpark(new ForkSpark("ForkSpark2"))

--- a/pom.xml
+++ b/pom.xml
@@ -1484,6 +1484,16 @@
         <version>${spark2.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-repl_2.10</artifactId>
+        <version>${spark1.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-repl_2.11</artifactId>
+        <version>${spark2.version}</version>
+      </dependency>
+      <dependency>
         <groupId>co.cask.cdap</groupId>
         <artifactId>cdap-authentication-client</artifactId>
         <version>${cdap.client.version}</version>


### PR DESCRIPTION
The PR has changes grouped by commits already. The easiest way to review is to go through them one by one. Here is a short summary for each of the commit.

1. Just adding spark-repl dependencies to cdap-api-spark* and cdap-spark-core*
2. This is the main change. It adds two new interfaces `SparkCompiler` and `SparkInterpreter`. This commit contains most of the new code that works across different Spark version.
3. A small change to make all implicit conversions public in SparkMain.
4. A simple refactoring to turn `SparkTransactionService` into two classes `SparkDriverHttpService`, which is a generic http server and `SparkTransactionHandler`, where most of the old logic goes.
5. Changing the runtime system to exposes `SparkInterpreter` through `SparkExecutionContext`. It adjusts the runtime classloader to make on-demand compiled code ship and work in the executor.
6. Fixed CDAP-11577 Spark streaming thread leakage so that unit-test can pass
