### PR TITLE
Update BUILD.rst MD5 Hash

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -120,6 +120,7 @@ function build_docs_check() {
   USE_SPHINX_BUILD="${FALSE}"
   export USE_SPHINX_BUILD
   build_docs_only
+  check_build_rst
 }
 
 function build_docs_set() {

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -23,7 +23,7 @@ MANUALS="${CDAP_MANUALS} ${EXTENSION_MANUALS}"
 # Used to monitor any changes in scripts or commands for the building of Javadocs
 BUILD_RST="BUILD.rst"
 BUILD_RST_HASH_LOCATION="cdap-docs/vars"
-BUILD_RST_HASH="5db96f8c4866f62b2f28b4ca3c99448c"
+BUILD_RST_HASH="7fa2dfa8ae24e7d6f8d871eb53affb29"
 
 #
 # All "GIT_" variables are loaded by the Sphinx build and need to be static as they are not sourced


### PR DESCRIPTION
Updated the MD5 Hash for the Build.rst after reviewing changes.
Add "check_build_rst" to the build script's "check" option.

Passed a local docs build. Fixes current broken build.