### PR TITLE
[CDAP-11712] Remove the ability to create etl-batch and etl-realtime pipelines

### DIFF
--- a/cdap-ui/app/cdap/components/Header/Header.scss
+++ b/cdap-ui/app/cdap/components/Header/Header.scss
@@ -16,9 +16,6 @@
 
 @import '../../styles/variables.scss';
 
-$beta-badge-font-color: white;
-$beta-badge-bg-color: $cdap-orange;
-
 .global-navbar {
   height: 50px;
   background: $navbar-bg;
@@ -40,9 +37,6 @@ $beta-badge-bg-color: $cdap-orange;
     &:active {
       color: $cdap-light-orange;
 
-      .beta-badge {
-        background-color: $cdap-light-orange;
-      }
     }
     .active {
       color: $cdap-orange;
@@ -189,14 +183,4 @@ $beta-badge-bg-color: $cdap-orange;
     }
   }
 
-  .beta-badge {
-    font-size: 10px;
-    border-radius: 5px;
-    color: $beta-badge-font-color;
-    background-color: $beta-badge-bg-color;
-    margin-left: 4px;
-    padding: 0 4px 1px 4px;
-    position: relative;
-    top: -1px;
-  }
 }

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -174,14 +174,12 @@ export default class Header extends Component {
                     isActive={!isCDAPActive}
                   >
                     {T.translate('features.Navbar.dataprepLabel')}
-                    <span className="beta-badge">BETA</span>
                   </NavLink>
                 )
               :
                 (
                   <a href={dataprepUrl}>
                     {T.translate('features.Navbar.dataprepLabel')}
-                    <span className="beta-badge">BETA</span>
                   </a>
                 )
             }

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -744,13 +744,13 @@ class HydratorPlusPlusTopPanelCtrl {
       let validArtifact = isValidArtifact(jsonData.artifact);
       if (!validArtifact.name || !validArtifact.version || !validArtifact.scope) {
         if (!validArtifact.name) {
-          invalidFields.push('Artifact name');
+          invalidFields.push('Artifact name: ' + jsonData.artifact.name);
         } else {
           if (!validArtifact.version) {
-            invalidFields.push('Artifact version');
+            invalidFields.push('Artifact version: ' + jsonData.artifact.version);
           }
           if (!validArtifact.scope) {
-            invalidFields.push('Artifact scope');
+            invalidFields.push('Artifact scope: ' + jsonData.artifact.scope);
           }
         }
         invalidFields = invalidFields.length === 1 ? invalidFields[0] : invalidFields.join(', ');

--- a/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
@@ -100,6 +100,8 @@ class HydratorDetailTopPanelController {
     this.validToStartOrSchedule = true;
     this.pipelineAction = 'Run';
 
+    this.isCloneDisabled = [GLOBALS.etlBatch, GLOBALS.etlRealtime].indexOf(HydratorPlusPlusDetailNonRunsStore.getArtifact().name) !== -1;
+
     if (Object.keys(this.macrosMap).length === 0) {
       this.fetchMacros();
     }

--- a/cdap-ui/app/hydrator/routes.js
+++ b/cdap-ui/app/hydrator/routes.js
@@ -62,7 +62,7 @@ angular.module(PKG.name + '.feature.hydrator')
             highlightTab: 'hydratorStudioPlusPlus'
           },
           resolve: {
-            rConfig: function($stateParams, mySettings, $q, myHelpers, $window, $rootScope, HydratorPlusPlusHydratorService) {
+            rConfig: function($stateParams, mySettings, $q, myHelpers, $window, $rootScope, HydratorPlusPlusHydratorService, GLOBALS) {
               var defer = $q.defer();
               if ($stateParams.draftId) {
                 mySettings.get('hydratorDrafts', true)
@@ -74,6 +74,11 @@ angular.module(PKG.name + '.feature.hydrator')
                           supportedVersion: $rootScope.cdapVersion,
                           versionRange: draft.artifact.version
                         });
+                      let isOldArtifact = draft.artifact.name;
+                      if ([GLOBALS.etlRealtime, GLOBALS.etlBatch].indexOf(isOldArtifact) !== -1) {
+                        defer.reject(false);
+                        return defer.promise;
+                      }
                       if (isVersionInRange) {
                         draft.artifact.version = $rootScope.cdapVersion;
                       } else {
@@ -100,6 +105,11 @@ angular.module(PKG.name + '.feature.hydrator')
                     supportedVersion: $rootScope.cdapVersion,
                     versionRange: $stateParams.data.artifact.version
                   });
+                let isOldArtifact = $stateParams.data.artifact.name;
+                if ([GLOBALS.etlRealtime, GLOBALS.etlBatch].indexOf(isOldArtifact) !== -1) {
+                  defer.reject(false);
+                  return defer.promise;
+                }
                 if (isVersionInRange) {
                   $stateParams.data.artifact.version = $rootScope.cdapVersion;
                 } else {
@@ -124,7 +134,7 @@ angular.module(PKG.name + '.feature.hydrator')
             },
             rSelectedArtifact: function($stateParams, $q, myPipelineApi, myAlertOnValium, $state, GLOBALS, $rootScope) {
               var defer = $q.defer();
-              let uiSupportedArtifacts = [GLOBALS.etlBatch, GLOBALS.etlRealtime, GLOBALS.etlDataPipeline, GLOBALS.etlDataStreams];
+              let uiSupportedArtifacts = [GLOBALS.etlDataPipeline, GLOBALS.etlDataStreams];
               let isArtifactValid = (backendArtifacts, artifact) => {
                 return backendArtifacts.filter( a =>
                   (a.name === artifact && a.version === $rootScope.cdapVersion)
@@ -199,7 +209,7 @@ angular.module(PKG.name + '.feature.hydrator')
                 if (!res.length) {
                   return;
                 } else {
-                  let uiSupportedArtifacts = [GLOBALS.etlBatch, GLOBALS.etlRealtime, GLOBALS.etlDataPipeline, GLOBALS.etlDataStreams];
+                  let uiSupportedArtifacts = [GLOBALS.etlDataPipeline, GLOBALS.etlDataStreams];
                   let filteredRes = res
                     .filter( artifact => artifact.version === $rootScope.cdapVersion)
                     .filter( r => uiSupportedArtifacts.indexOf(r.name) !== -1 );

--- a/cdap-ui/app/hydrator/templates/detail/top-panel.html
+++ b/cdap-ui/app/hydrator/templates/detail/top-panel.html
@@ -217,7 +217,14 @@
       </div>
     </div>
     <div class="btn margin-left"
-         ui-sref="hydrator.create({data: TopPanelCtrl.cloneConfig, type: TopPanelCtrl.app.type, isClone: true})">
+         ui-sref="hydrator.create({data: TopPanelCtrl.cloneConfig, type: TopPanelCtrl.app.type, isClone: true})"
+         ng-disabled="TopPanelCtrl.isCloneDisabled"
+         uib-tooltip="etl-batch and etl-realtime pipelines are no longer supported"
+         tooltip-enable="TopPanelCtrl.isCloneDisabled"
+         tooltip-placement="bottom-right"
+         tooltip-append-to-body="true"
+         tooltip-class="toppanel-tooltip"
+         ng-class="{'disabled': TopPanelCtrl.isCloneDisabled}">
       <div class="btn-container">
         <span class="icon-clone"></span>
         <div class="button-label">Clone</div>

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -669,6 +669,9 @@ body.theme-cdap {
           color: rgba(0, 0, 0, 0.4);
           font-weight: 600;
         }
+        .btn.disabled {
+          color: #cccccc;
+        }
       }
       .pipeline-settings {
         width: 100%;


### PR DESCRIPTION
- Removes the options from the dropdown in pipeline studio
- Disables the clone button for old batch and realtime pipelines
- Import throws an invalid artifact error in pipeline studio.
- Removes "Beta" tag from Data Preparation in Header.

JIRAs: 
https://issues.cask.co/browse/CDAP-11745
https://issues.cask.co/browse/CDAP-11712