### PR TITLE
Feature release/rename sdk sandbox

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -83,7 +83,7 @@ case ${1} in
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   version) shift; cdap_version_command ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
-  sdk) shift; echo "[WARN] sdk commands are deprecated, please use sandbox commands instead."; cdap_sdk ${@}; __ret=${?} ;;
+  sdk) shift; echo "[WARN] sdk commands are deprecated, please use sandbox commands instead.">&2; cdap_sdk ${@}; __ret=${?} ;;
   sandbox) shift; cdap_sdk ${@}; __ret=${?} ;;
   setup) shift; cdap_setup ${@}; __ret=${?} ;;
   debug) shift; cdap_debug ${@}; __ret=${?} ;;

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -83,7 +83,8 @@ case ${1} in
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   version) shift; cdap_version_command ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
-  sdk) shift; cdap_sdk ${@}; __ret=${?} ;;
+  sdk) shift; echo "[WARN] sdk commands are deprecated, please use sandbox commands instead."; cdap_sdk ${@}; __ret=${?} ;;
+  sandbox) shift; cdap_sdk ${@}; __ret=${?} ;;
   setup) shift; cdap_setup ${@}; __ret=${?} ;;
   debug) shift; cdap_debug ${@}; __ret=${?} ;;
   *)
@@ -107,8 +108,7 @@ case ${1} in
     echo "    setup        - Setup the specified component (coprocessors) required by CDAP at runtime"
     echo
     else
-    echo "    sdk          - Sends the arguments (start/stop/etc.) to the Standalone CDAP service on this host"
-    echo
+    echo "    sandbox      - Sends the arguments (start/stop/etc.) to the CDAP Sandbox on this host"
     fi
     echo "    apply-pack   - Installs a CDAP Pack specified as an argument"
     echo "    cli          - Starts an interactive CDAP CLI session"

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -905,7 +905,7 @@ cdap_version_command() {
   local readonly __context=$(cdap_context)
   local __component __name
   if [[ ${__context} == sdk ]]; then
-    echo "CDAP SDK version $(cdap_version)"
+    echo "CDAP Sandbox version $(cdap_version)"
     echo
   else # Distributed, possibly CLI-only
     if [[ -r ${CDAP_HOME}/VERSION ]]; then
@@ -933,11 +933,11 @@ cdap_version_command() {
 #
 cdap_sdk_usage() {
   echo
-  echo "Usage: ${0} sdk {start|stop|restart|status|usage}"
+  echo "Usage: ${0} sandbox {start|stop|restart|status|usage}"
   echo
   echo "Additional options with start, restart:"
-  echo "--enable-debug [ <port> ] to connect to a debug port for Standalone CDAP (default port is 5005)"
-  echo "--foreground to run the SDK in the foreground, showing logs on STDOUT"
+  echo "--enable-debug [ <port> ] to connect to a debug port for CDAP Sandbox (default port is 5005)"
+  echo "--foreground to run the Sandbox in the foreground, showing logs on STDOUT"
   echo
   return 0
 }
@@ -958,13 +958,13 @@ cdap_sdk_restart() { cdap_sdk_stop ; cdap_sdk_start ${@}; };
 #
 # cdap_sdk_stop
 #
-cdap_sdk_stop() { cdap_stop_pidfile ${__pidfile} "CDAP Standalone (SDK)"; };
+cdap_sdk_stop() { cdap_stop_pidfile ${__pidfile} "CDAP Sandbox"; };
 
 #
 # cdap_sdk_check_before_start
 #
 cdap_sdk_check_before_start() {
-  cdap_check_pidfile ${__pidfile} Standalone || return ${?}
+  cdap_check_pidfile ${__pidfile} Sandbox || return ${?}
   cdap_check_node_version ${CDAP_NODE_VERSION_MINIMUM:-v4.5.0} || return ${?}
   local __node_pid=$(ps | grep ${CDAP_UI_PATH:-ui/server.js} | grep -v grep | awk '{ print $1 }')
   if [[ -z ${__node_pid} ]]; then
@@ -1023,7 +1023,7 @@ cdap_sdk_start() {
   cd "${CDAP_HOME}"
 
   # Start SDK processes
-  echo -n "$(date) Starting CDAP Standalone (SDK) ..."
+  echo -n "$(date) Starting CDAP Sandbox ..."
   if ${__foreground}; then
     echo
     nice -1 "${JAVA}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
@@ -1391,7 +1391,7 @@ cdap_sdk() {
       ${__command} ${__foreground} ${__debug} ${__port} ${__arg}
       __ret=${?}
       ;;
-    status) cdap_status_pidfile ${__pidfile} "CDAP Standalone (SDK)"; __ret=${?} ;;
+    status) cdap_status_pidfile ${__pidfile} "CDAP Sandbox"; __ret=${?} ;;
     stop) cdap_sdk_stop; __ret=${?} ;;
     usage) cdap_sdk_usage; __ret=${?} ;;
     cleanup) cdap_sdk_cleanup; __ret=${?} ;;

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -54,7 +54,10 @@ cd "%CDAP_HOME%"
 
 REM Process command line
 IF "%1" == "cli" GOTO CLI
-IF "%1" == "sdk" GOTO SDK
+IF "%1" == "sdk" ( 
+ECHO [WARN] sdk commands are deprecated, please use sandbox commands instead. 
+GOTO SDK )
+IF "%1" == "sandbox" GOTO SDK 
 IF "%1" == "tx-debugger" GOTO TX_DEBUGGER
 IF "%1" == "apply-pack" GOTO APPLY_PACK
 IF "%1" == "version" GOTO VERSION
@@ -70,9 +73,9 @@ GOTO USAGE
 :SDK_DEPRECATED
 REM Process deprecated SDK arguments
 ECHO:
-ECHO [WARN] %0 is deprecated and will be removed in CDAP 5.0. Please use 'cdap sdk' for the CDAP command line.
+ECHO [WARN] %0 is deprecated and will be removed in CDAP 5.0. Please use 'cdap sandbox' for the CDAP command line.
 ECHO:
-ECHO   cdap sdk %*
+ECHO   cdap sandbox %*
 ECHO:
 ECHO:
 IF "%1" == "start" GOTO SDK_START
@@ -133,7 +136,7 @@ GOTO :EOF
 REM Check if Node.js is installed
 set nodejs_minimum=v4.5.0
 for %%x in (node.exe) do if [%%~$PATH:x]==[] (
-  echo Standalone CDAP requires Node.js but it is either not installed or not in the path.
+  echo CDAP Sandbox requires Node.js but it is either not installed or not in the path.
   echo We recommend any version of Node.js starting with %nodejs_minimum%.
   GOTO FINALLY
 )
@@ -268,7 +271,7 @@ echo   Commands:
 echo:
 echo     apply-pack  - Installs a CDAP Pack specified as an argument
 echo     cli         - Starts a CDAP CLI session
-echo     sdk         - Sends the arguments to the SDK service
+echo     sandbox     - Sends the arguments to the CDAP Sandbox
 echo     tx-debugger - Sends the arguments to the CDAP transaction debugger
 echo     version     - Displays version of the CDAP SDK
 echo:
@@ -280,11 +283,11 @@ GOTO FINALLY
 
 :SDK_USAGE
 echo:
-echo Usage: %APP% sdk [ start ^| stop ^| restart ^| status ^| reset ]
+echo Usage: %APP% sandbox [ start ^| stop ^| restart ^| status ^| reset ]
 echo:
 echo Additional options with start or restart:
 echo:
-echo   --enable-debug [ ^<port^> ] to connect to a debug port for Standalone CDAP (default port is %DEFAULT_DEBUG_PORT%)
+echo   --enable-debug [ ^<port^> ] to connect to a debug port for CDAP Sandbox (default port is %DEFAULT_DEBUG_PORT%)
 echo:
 GOTO FINALLY
 
@@ -295,18 +298,18 @@ IF %ERRORLEVEL% == 0 (
   CHOICE /C yn /N /M "This deletes all apps, data, and logs. Are you certain you want to proceed? (y/n) "
   IF ERRORLEVEL 2 GOTO FINALLY
   REM Delete logs and data directories
-  echo Resetting Standalone CDAP...
+  echo Resetting CDAP Sandbox...
   rmdir /S /Q "%CDAP_HOME%\logs" "%CDAP_HOME%\data" > NUL 2>&1
-  echo CDAP reset successfully.
+  echo CDAP Sandbox reset successfully.
 ) else (
-  echo Stop it first using the 'cdap sdk stop' command.
+  echo Stop it first using the 'cdap sandbox stop' command.
 )
 GOTO FINALLY
 
 :SDK_START
 CALL :CHECK_PID
 IF %ERRORLEVEL% NEQ 0 (
-  echo Stop it first using either the 'cdap sdk stop' or 'cdap sdk restart' commands.
+  echo Stop it first using either the 'cdap sandbox stop' or 'cdap sandbox restart' commands.
   GOTO FINALLY
 )
 REM See TX_DEBUGGER for notes on setting CLASSPATH
@@ -356,7 +359,7 @@ set class=co.cask.cdap.StandaloneMain
 REM Note use of an empty title "" in the start command; without it, Windows will
 REM mis-interpret the JAVACMD incorrectly if it has spaces in it
 start "" /B "%JAVACMD%" %DEFAULT_JVM_OPTS% %HADOOP_HOME_OPTS% %HIVE_SCRATCH_DIR_OPTS% %HIVE_LOCAL_SCRATCH_DIR_OPTS% !DEBUG_OPTIONS! %SECURITY_OPTS% -classpath "%CLASSPATH%" %class% >> "%CDAP_HOME%\logs\cdap-process.log" 2>&1 < NUL
-echo Starting Standalone CDAP...
+echo Starting CDAP Sandbox...
 
 for /F "TOKENS=1,2,*" %%a in ('tasklist /FI "IMAGENAME eq java.exe"') DO SET MyPID=%%b
 echo %MyPID% > %~dsp0MyProg.pid
@@ -384,7 +387,7 @@ GOTO FINALLY
 
 :ServerSuccess
 echo:
-echo Standalone CDAP started.
+echo CDAP Sandbox started.
 
 IF NOT "!DEBUG_OPTIONS!" == "" (
   echo Remote debugger agent started on port !port!.
@@ -398,7 +401,7 @@ PING 127.0.0.1 -n 6 > NUL 2>&1
 for /F "TOKENS=1,2,*" %%a in ('tasklist /FI "IMAGENAME eq node.exe"') DO SET MyNodePID=%%b
 echo %MyNodePID% > %~dsp0MyProgNode.pid
 attrib +h %~dsp0MyProgNode.pid >NUL
-echo Standalone CDAP started successfully.
+echo CDAP Sandbox started successfully.
 GOTO FINALLY
 
 :SDK_STOP
@@ -409,7 +412,7 @@ GOTO FINALLY
 REM Pass a flag as a parameter to show or hide error messages
 SET show_error_messages=%1%
 SET error_code=0
-echo Stopping Standalone CDAP...
+echo Stopping CDAP Sandbox...
 attrib -h %~dsp0MyProg.pid >NUL
 IF exist %~dsp0MyProg.pid (
   for /F %%i in (%~dsp0MyProg.pid) do (
@@ -444,10 +447,10 @@ IF exist %~dsp0MyProgNode.pid (
 )
 IF %error_code% EQU 1 (
   IF %show_error_messages% EQU 1 (
-    echo Is CDAP running? Use 'cdap sdk status'.
+    echo Is CDAP running? Use 'cdap sandbox status'.
   )
 ) else (
-  echo Finished stopping Standalone CDAP.
+  echo Finished stopping CDAP Sandbox.
 )
 GOTO :EOF
 

--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -16,11 +16,11 @@
 # the License.
 #
 
-# This script is a wrapper for "cdap sdk" and will be removed in 5.0
+# This script is a wrapper for "cdap sandbox" and will be removed in 5.0
 echo
-echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap sdk' to manage Standalone CDAP."
+echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap sandbox' to manage CDAP Sandbox."
 echo
-echo "  cdap sdk ${@}"
+echo "  cdap sandbox ${@}"
 echo
 echo
 
@@ -38,4 +38,4 @@ __readlink() {
 }
 __target=$(__readlink ${__script})
 __app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
-${__app_home}/bin/cdap sdk ${@}
+${__app_home}/bin/cdap sandbox ${@}

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -279,7 +279,7 @@ public class StandaloneMain {
     int dashboardPort = sslEnabled ?
       cConf.getInt(Constants.Dashboard.SSL_BIND_PORT) :
       cConf.getInt(Constants.Dashboard.BIND_PORT);
-    System.out.println("Standalone CDAP started successfully.");
+    System.out.println("CDAP Sandbox started successfully.");
     System.out.printf("Connect to the CDAP UI at %s://%s:%d\n", protocol, "localhost", dashboardPort);
   }
 

--- a/cdap-ui/BUILD.rst
+++ b/cdap-ui/BUILD.rst
@@ -65,22 +65,22 @@ This will build the pre-built library dlls that we use in CDAP
 
 Building a Running Backend
 ==========================
-UI work generally requires having a running Standalone CDAP instance. To build an instance::
+UI work generally requires having a running CDAP Sandbox instance. To build an instance::
 
     $ git clone git@github.com:caskdata/cdap.git
     $ cd cdap
     $ mvn package -pl cdap-standalone -am -DskipTests -P dist,release
     $ cd cdap-standalone/target
-    $ unzip cdap-sdk-{version}.zip
-    $ cd <cdap-sdk-folder>
-    $ bin/cdap sdk start
+    $ unzip cdap-local-sandbox-{version}.zip
+    $ cd <cdap-local-sandbox-folder>
+    $ bin/cdap sandbox start
 
-Once you have started the Standalone CDAP, it starts the UI node server as part of its init script.
+Once you have started the CDAP Sandbox, it starts the UI node server as part of its init script.
 
 To work on UI Code
 ------------------
-If you want to develop and test the UI against the Standalone CDAP that was just built as above,
-you need to first kill the node server started by the Standalone CDAP and follow this process:
+If you want to develop and test the UI against the CDAP Sandbox that was just built as above,
+you need to first kill the node server started by the CDAP Sandbox and follow this process:
 
 Start these processes, each in their own terminal tab or browser window:
 


### PR DESCRIPTION
Add sandbox commands to startup scripts, deprecate sdk
https://issues.cask.co/browse/CDAP-11491

This is effectively the intended changes from https://github.com/caskdata/cdap/pull/8999.