### PR TITLE
(CDAP 11410) dynamic spark compute

### DIFF
--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/dynamic/SparkCompiler.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/dynamic/SparkCompiler.scala
@@ -29,12 +29,12 @@ import scala.tools.nsc.interpreter.IMain
 trait SparkCompiler extends AutoCloseable {
 
   /**
-    * Adds dependency to the compiler. Classes loadable from the given file are usable by the code to be compiled
+    * Adds dependencies to the compiler. Classes loadable from the given files are usable by the code to be compiled
     * by this compiler.
     *
-    * @param file a directory or a jar file.
+    * @param files a set of directories or jar files.
     */
-  def addDependency(file: File): Unit
+  def addDependencies(file: File*): Unit
 
   /**
     * Compiles the given source code. The source code must have content the same as a valid scala source file.

--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/dynamic/SparkInterpreter.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/dynamic/SparkInterpreter.scala
@@ -27,6 +27,15 @@ import scala.reflect.{ClassTag, runtime}
 trait SparkInterpreter extends SparkCompiler {
 
   /**
+    * Adds a set of imports to the context.
+    *
+    * @param imports set of imports
+    * @throws co.cask.cdap.api.spark.dynamic.InterpretFailureException if failed to add the imports
+    */
+  @throws(classOf[InterpretFailureException])
+  def addImports(imports: String*): Unit
+
+  /**
     * Binds a variable to a specific value.
     *
     * @param name name of the variable
@@ -62,7 +71,8 @@ trait SparkInterpreter extends SparkCompiler {
     * Gets the value of the given variable if it exists in the context.
     *
     * @param name name of the variable
+    * @tparam T type of the result
     * @return an [[scala.Option]] that will content [[scala.Some]] value if it exists, or [[scala.None]] otherwise.
     */
-  def getValue(name: String): Option[Any]
+  def getValue[T](name: String): Option[T]
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/SparkExecutionPluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/SparkExecutionPluginContext.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.etl.api.TransformContext;
 import org.apache.hadoop.io.ByteWritable;
@@ -32,6 +33,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -193,4 +195,12 @@ public interface SparkExecutionPluginContext extends DatasetContext, TransformCo
    * @return A {@link Serializable} {@link PluginContext}.
    */
   PluginContext getPluginContext();
+
+  /**
+   * Creates a new instance of {@link SparkInterpreter} for Scala code compilation and interpretation.
+   *
+   * @return a new instance of {@link SparkInterpreter}
+   * @throws IOException if failed to create a local directory for storing the compiled class files
+   */
+  SparkInterpreter createSparkInterpreter() throws IOException;
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/BasicSparkExecutionPluginContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/BasicSparkExecutionPluginContext.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
@@ -33,6 +34,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
+import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -125,6 +127,11 @@ public class BasicSparkExecutionPluginContext extends AbstractTransformContext i
   @Override
   public PluginContext getPluginContext() {
     return sec.getPluginContext();
+  }
+
+  @Override
+  public SparkInterpreter createSparkInterpreter() throws IOException {
+    return sec.createInterpreter();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/SparkStreamingExecutionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/SparkStreamingExecutionContext.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.spark.dynamic.SparkInterpreter;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
@@ -32,6 +33,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
+import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -124,6 +126,11 @@ public class SparkStreamingExecutionContext extends AbstractTransformContext imp
   @Override
   public PluginContext getPluginContext() {
     return sec.getPluginContext();
+  }
+
+  @Override
+  public SparkInterpreter createSparkInterpreter() throws IOException {
+    return sec.createInterpreter();
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkCompiler.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkCompiler.scala
@@ -110,8 +110,8 @@ abstract class AbstractSparkCompiler(settings: Settings, onClose: () => Unit) ex
     }
   }
 
-  override def addDependency(file: File): Unit = {
-    iMain.addURLs(file.toURI.toURL)
+  override def addDependencies(file: File*): Unit = {
+    iMain.addURLs(file.map(_.toURI.toURL): _*)
   }
 
   override def getIMain(): IMain = {

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkInterpreter.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkInterpreter.scala
@@ -27,6 +27,12 @@ import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
   */
 trait AbstractSparkInterpreter extends SparkInterpreter {
 
+  override def addImports(imports: String*): Unit = {
+    if (!imports.isEmpty) {
+      interpret("import " + imports.mkString(", "))
+    }
+  }
+
   override def bind[T: runtime.universe.TypeTag : ClassTag](name: String, value: T): Unit = {
     val valueType = implicitly[runtime.universe.TypeTag[T]].tpe
     val iMain = getIMain()
@@ -57,7 +63,7 @@ trait AbstractSparkInterpreter extends SparkInterpreter {
     }
   }
 
-  override def getValue(name: String): Option[Any] = {
-    getIMain().valueOfTerm(name)
+  override def getValue[T](name: String): Option[T] = {
+    getIMain().valueOfTerm(name).map(_.asInstanceOf[T])
   }
 }

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaDynamicSpark.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaDynamicSpark.scala
@@ -68,11 +68,12 @@ class ScalaDynamicSpark extends AbstractSpark with SparkMain {
 
     val intp = sec.createInterpreter()
     try {
-      intp.addDependency(depJar)
+      intp.addDependencies(depJar)
+      intp.addImports("test.dynamic.Compute")
       intp.bind("sc", sc)
       intp.bind("sparkMain", this)
       intp.bind("sec", sec)
-      intp.interpret("test.dynamic.Compute.run(sc, sparkMain)(sec)");
+      intp.interpret("Compute.run(sc, sparkMain)(sec)");
     } finally {
       intp.close()
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1372,9 +1372,14 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
           </exclusion>
+          <!-- excludes scala-compiler and scala-reflect to avoid conflicting with the one from spark-repl -->
           <exclusion>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.eclipse.jetty.orbit</groupId>
@@ -1419,9 +1424,14 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
           </exclusion>
+          <!-- excludes scala-compiler and scala-reflect to avoid conflicting with the one from spark-repl -->
           <exclusion>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.eclipse.jetty.orbit</groupId>


### PR DESCRIPTION
Currently the compilation won't work with Checkpointing in Spark Streaming, since it serializes the dynamically compiled classes, which it will fail to restore due to missing class.

Since the only existing unit-test that uses SparkCompute is using checkpointing, adding of unit-test for this would be in separate PR, although the core functionalities testing have already been covered in cdap-spark-core and cdap-unit.