### PR TITLE
Do not use deprecated 'cdap sdk' in Docker

### DIFF
--- a/cdap-distributions/src/docker-entrypoint.sh
+++ b/cdap-distributions/src/docker-entrypoint.sh
@@ -20,12 +20,12 @@ set -e
 
 export PATH=${PATH}:/opt/cdap/sdk/bin
 
-# Add cdap.sh start as command if needed
+# Add cdap sandbox start as command if needed
 if [ "${1:0:1}" = '-' ]; then
-  set -- cdap sdk start --foreground "$@"
+  set -- cdap sandbox start --foreground "$@"
 fi
 
-# Drop root privileges if we are running cdap.sh
+# Drop root privileges if we are running cdap script
 # allow the container to be started with `--user`
 if [ "${1}" = 'cdap' -a "$(id -u)" = '0' ]; then
   # Change the ownership of /opt/cdap/sdk to cdap


### PR DESCRIPTION
Prevent deprecation notices in the Docker container image. Related to #9002 changes.