### PR TITLE
In studio, uses stage info from the config instead of from __ui__ attribute

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
@@ -48,7 +48,7 @@ export default class DatabaseDetail extends Component {
     this.state = {
       connType: this.props.db.name === 'oraclethin' ? CONN_TYPE.advanced : CONN_TYPE.basic,
       name: '',
-      hostname: '',
+      hostname: 'localhost',
       port: this.props.mode === 'ADD' ? defaultPort : '',
       username: '',
       password: '',

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -282,7 +282,7 @@ class HydratorPlusPlusTopPanelCtrl {
 
   fetchMacros() {
     let newMacrosMap = {};
-    let nodes = this.HydratorPlusPlusConfigStore.getNodes();
+    let nodes = this.HydratorPlusPlusConfigStore.getStages();
 
     for (let i = 0; i < nodes.length; i++) {
       let properties = this.myHelpers.objectQuery(nodes[i], 'plugin', 'properties');

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -703,6 +703,9 @@ class HydratorPlusPlusConfigStore {
   getNodes() {
     return this.getState().__ui__.nodes;
   }
+  getStages() {
+    return this.getState().config.stages;
+  }
   getSourceNodes(nodeId) {
     let nodesMap = {};
     this.state.__ui__.nodes.forEach( node => nodesMap[node.name] = node );


### PR DESCRIPTION
Currently in studio, we are fetching the nodes from the __ui__ property, instead of from the config. This would be a problem when we create a pipeline from Market.