### PR TITLE
Fix/security exceptions

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/HttpExceptionHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/HttpExceptionHandler.java
@@ -40,6 +40,7 @@ public class HttpExceptionHandler extends ExceptionHandler {
     for (Throwable cause : Throwables.getCausalChain(t)) {
       // Check if the exception is caused by Service being unavailable: this will happen during master startup
       if (cause instanceof ServiceUnavailableException) {
+        logWithTrace(request, cause);
         responder.sendString(HttpResponseStatus.SERVICE_UNAVAILABLE, cause.getMessage());
         return;
       }
@@ -52,15 +53,15 @@ public class HttpExceptionHandler extends ExceptionHandler {
       }
 
       // For some known exception naming convention, response with 4xx
-      if (t.getClass().getName().endsWith("NotFoundException")) {
-        logWithTrace(request, t);
-        responder.sendString(HttpResponseStatus.NOT_FOUND, t.getMessage());
+      if (cause.getClass().getName().endsWith("NotFoundException")) {
+        logWithTrace(request, cause);
+        responder.sendString(HttpResponseStatus.NOT_FOUND, cause.getMessage());
         return;
       }
 
-      if (t.getClass().getName().endsWith("AlreadyExistsException")) {
-        logWithTrace(request, t);
-        responder.sendString(HttpResponseStatus.CONFLICT, t.getMessage());
+      if (cause.getClass().getName().endsWith("AlreadyExistsException")) {
+        logWithTrace(request, cause);
+        responder.sendString(HttpResponseStatus.CONFLICT, cause.getMessage());
         return;
       }
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/HttpExceptionHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/HttpExceptionHandler.java
@@ -36,32 +36,33 @@ public class HttpExceptionHandler extends ExceptionHandler {
 
   @Override
   public void handle(Throwable t, HttpRequest request, HttpResponder responder) {
-    // Check if the exception is caused by Service being unavailable: this will happen during master startup
+    // this is done as sometimes exceptions are not propagated properly and they are wrapped with other exceptions.
     for (Throwable cause : Throwables.getCausalChain(t)) {
+      // Check if the exception is caused by Service being unavailable: this will happen during master startup
       if (cause instanceof ServiceUnavailableException) {
         responder.sendString(HttpResponseStatus.SERVICE_UNAVAILABLE, cause.getMessage());
         return;
       }
-    }
 
-    // If the exception provides http status, response with it
-    if (t instanceof HttpErrorStatusProvider) {
-      logWithTrace(request, t);
-      responder.sendString(HttpResponseStatus.valueOf(((HttpErrorStatusProvider) t).getStatusCode()),
-                           t.getMessage());
-      return;
-    }
+      if (cause instanceof HttpErrorStatusProvider) {
+        logWithTrace(request, cause);
+        responder.sendString(HttpResponseStatus.valueOf(((HttpErrorStatusProvider) cause).getStatusCode()),
+                             cause.getMessage());
+        return;
+      }
 
-    // For some known exception naming convention, response with 4xx
-    if (t.getClass().getName().endsWith("NotFoundException")) {
-      logWithTrace(request, t);
-      responder.sendString(HttpResponseStatus.NOT_FOUND, t.getMessage());
-      return;
-    }
-    if (t.getClass().getName().endsWith("AlreadyExistsException")) {
-      logWithTrace(request, t);
-      responder.sendString(HttpResponseStatus.CONFLICT, t.getMessage());
-      return;
+      // For some known exception naming convention, response with 4xx
+      if (t.getClass().getName().endsWith("NotFoundException")) {
+        logWithTrace(request, t);
+        responder.sendString(HttpResponseStatus.NOT_FOUND, t.getMessage());
+        return;
+      }
+
+      if (t.getClass().getName().endsWith("AlreadyExistsException")) {
+        logWithTrace(request, t);
+        responder.sendString(HttpResponseStatus.CONFLICT, t.getMessage());
+        return;
+      }
     }
 
     // If it is not some known exception type, response with 500.

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AlreadyExistsException.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,16 +22,19 @@ import co.cask.cdap.proto.security.Role;
 import java.net.HttpURLConnection;
 
 /**
- * Exception thrown when a {@link Role} is not found, This is deprecated, please use {@link NotFoundException}
+ * Exception thrown when a {@link Role} or an entity already exists
  */
-@Deprecated
-public class RoleNotFoundException extends Exception implements HttpErrorStatusProvider {
-  public RoleNotFoundException(Role role) {
-    super(String.format("%s not found.", role));
+public class AlreadyExistsException extends Exception implements HttpErrorStatusProvider {
+  public AlreadyExistsException(Role role) {
+    super(String.format("%s already exists.", role));
+  }
+
+  public AlreadyExistsException(String message) {
+    super(message);
   }
 
   @Override
   public int getStatusCode() {
-    return HttpURLConnection.HTTP_NOT_FOUND;
+    return HttpURLConnection.HTTP_CONFLICT;
   }
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/BadRequestException.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/BadRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,16 +22,19 @@ import co.cask.cdap.proto.security.Role;
 import java.net.HttpURLConnection;
 
 /**
- * Exception thrown when a {@link Role} is not found, This is deprecated, please use {@link NotFoundException}
+ * Exception thrown on invalid input
  */
-@Deprecated
-public class RoleNotFoundException extends Exception implements HttpErrorStatusProvider {
-  public RoleNotFoundException(Role role) {
+public class BadRequestException extends Exception implements HttpErrorStatusProvider {
+  public BadRequestException(Role role) {
     super(String.format("%s not found.", role));
+  }
+
+  public BadRequestException(String message) {
+    super(message);
   }
 
   @Override
   public int getStatusCode() {
-    return HttpURLConnection.HTTP_NOT_FOUND;
+    return HttpURLConnection.HTTP_BAD_REQUEST;
   }
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NotFoundException.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,12 +22,15 @@ import co.cask.cdap.proto.security.Role;
 import java.net.HttpURLConnection;
 
 /**
- * Exception thrown when a {@link Role} is not found, This is deprecated, please use {@link NotFoundException}
+ * Exception thrown for handling unknown entities
  */
-@Deprecated
-public class RoleNotFoundException extends Exception implements HttpErrorStatusProvider {
-  public RoleNotFoundException(Role role) {
+public class NotFoundException extends Exception implements HttpErrorStatusProvider {
+  public NotFoundException(Role role) {
     super(String.format("%s not found.", role));
+  }
+
+  public NotFoundException(String message) {
+    super(message);
   }
 
   @Override

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/RoleAlreadyExistsException.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/RoleAlreadyExistsException.java
@@ -22,8 +22,9 @@ import co.cask.cdap.proto.security.Role;
 import java.net.HttpURLConnection;
 
 /**
- * Exception thrown when an {@link Role} already exists
+ * Exception thrown when an {@link Role} already exists, this is deprecated please use {@link AlreadyExistsException}
  */
+@Deprecated
 public class RoleAlreadyExistsException extends Exception implements HttpErrorStatusProvider {
   public RoleAlreadyExistsException(Role role) {
     super(String.format("%s already exists.", role));


### PR DESCRIPTION
JIRA https://issues.cask.co/browse/CDAP-8571

1st commit - handle cases where security and other recognized (http error code implemented class) is wrapped by other exceptions
2nd commit - add new exceptions to cdap-security-spi, this is useful for mapping sentry exceptions to cdap-security exceptions, so appropriate error codes are propagated to the user. 