### PR TITLE
[CDAP-11730] Toggle between \n and '' as a delimiter for JSON files

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/UploadFile/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/UploadFile/index.js
@@ -47,6 +47,7 @@ export default class ConnectionsUpload extends Component {
   fileHandler(e) {
     this.setState({
       file: e[0],
+      recordDelimiter: (e[0].type === "application/json") ? '' : '\\n',
       error: e[0].size > FILE_SIZE_LIMIT
     });
   }


### PR DESCRIPTION
Removes `\n` for record delimiter for JSON files so that they are parsed correctly when uploading.