### PR TITLE
CDAP-11811 fix iop spark detection

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -519,6 +519,9 @@ cdap_set_spark() {
       local __spark_shell=$(which spark-shell 2>/dev/null)
       local __spark_client_version=None
       for __dist in hdp iop; do
+        if [[ ! -d /usr/${__dist} ]]; then
+          continue
+        fi
         if [[ $(which ${__dist}-select 2>/dev/null) ]]; then
           __spark_name="spark"
           if [[ ${SPARK_MAJOR_VERSION} -ne 1 ]]; then


### PR DESCRIPTION
fix a bug that causes spark detection to fail on iop clusters
that have both hdp-select and iop-select.