### PR TITLE
Have the JavaSparkExecutionContext expose the underlying Scala delegate

### DIFF
--- a/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContextBase.java
+++ b/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContextBase.java
@@ -505,4 +505,9 @@ public abstract class JavaSparkExecutionContextBase implements RuntimeContext, T
    * @throws IOException if failed to create a local directory for storing the compiled class files
    */
   public abstract SparkInterpreter createInterpreter() throws IOException;
+
+  /**
+   * Returns the underlying {@link SparkExecutionContext} used by this object.
+   */
+  public abstract SparkExecutionContext getSparkExecutionContext();
 }

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -90,6 +90,8 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
 
   override def createInterpreter(): SparkInterpreter = sec.createInterpreter()
 
+  override def getSparkExecutionContext: SparkExecutionContext = sec
+
   override def fromDataset[K, V](datasetName: String, arguments: util.Map[String, String],
                                  splits: java.lang.Iterable[_ <: Split]): JavaPairRDD[K, V] = {
     // Create the implicit fake ClassTags to satisfy scala type system at compilation time.

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaDynamicSpark.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaDynamicSpark.scala
@@ -39,7 +39,9 @@ class ScalaDynamicSpark extends AbstractExtendedSpark with SparkMain {
       import org.apache.spark._
 
       object Compute {
-       def run(sc: SparkContext, sparkMain: SparkMain)(implicit sec: SparkExecutionContext) {
+       def run(sc: SparkContext)(implicit sec: SparkExecutionContext) {
+         // Creates a dummy SparkMain instance for importing implicits
+         val sparkMain = new SparkMain() { override def run(implicit sec: SparkExecutionContext): Unit = { } }
          import sparkMain._
 
          val args = sec.getRuntimeArguments()
@@ -83,9 +85,8 @@ class ScalaDynamicSpark extends AbstractExtendedSpark with SparkMain {
       intp.addDependencies(depJar)
       intp.addImports("test.dynamic.Compute")
       intp.bind("sc", sc)
-      intp.bind("sparkMain", this)
-      intp.bind("sec", sec)
-      intp.interpret("Compute.run(sc, sparkMain)(sec)");
+      intp.bind("sec", sec.getClass.getName, sec, "implicit")
+      intp.interpret("Compute.run(sc)");
     } finally {
       intp.close()
     }


### PR DESCRIPTION
- This helps hydrator plugin to use Java code to call into Scala.