### PR TITLE
removing labels since it is not being referenced

### DIFF
--- a/cdap-docs/developer-manual/source/getting-started/start-stop-cdap.rst
+++ b/cdap-docs/developer-manual/source/getting-started/start-stop-cdap.rst
@@ -25,12 +25,8 @@ CDAP Local Sandbox is installed):
     $ ./bin/cdap sandbox stop
 
 
-.. _start-stop-cdap-configure:
-
 You can configure CDAP by editing the ``cdap-site.xml`` file under your ``conf`` directory.
 CDAP must be restarted in order for changes in configuration to be picked up. 
-
-.. _start-stop-cdap-spark2:
 
 To run Spark2 programs with the CDAP Local Sandbox, edit the ``app.program.spark.compat`` setting
 in your ``cdap-site.xml`` file to be ``spark2_2.11``. When the CDAP Local Sandbox is using


### PR DESCRIPTION
Docs build fail due to the following error
```build	04-Jun-2017 00:29:51	/var/bamboo/xml-data/build-dir/CDAP-DBT22-BCD/cdap/cdap-docs/developer-manual/source/getting-started/start-stop-cdap.rst:35: WARNING: duplicate label start-stop-cdap-spark2, other instance in /var/bamboo/xml-data/build-dir/CDAP-DBT22-BCD/cdap/cdap-docs/developer-manual/source/getting-started/local-sandbox/zip.rst```

We have labels which are not being referenced. So removing it to fix.

Quick build: https://builds.cask.co/browse/CDAP-DQB364