### PR TITLE
[CDAP-11795] Fix BasicThrowable and its Codec when the message is null

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/BasicThrowable.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/BasicThrowable.java
@@ -19,6 +19,7 @@ package co.cask.cdap.proto;
 import co.cask.cdap.proto.codec.BasicThrowableCodec;
 
 import java.util.Arrays;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -38,7 +39,9 @@ public final class BasicThrowable {
    * @param stackTraces stack traces associated with the Throwable
    * @param cause cause associated with the Throwable
    */
-  public BasicThrowable(String className, String message, StackTraceElement[] stackTraces,
+  public BasicThrowable(String className,
+                        @Nullable String message,
+                        StackTraceElement[] stackTraces,
                         @Nullable BasicThrowable cause) {
     this.className = className;
     this.message = message;
@@ -72,6 +75,7 @@ public final class BasicThrowable {
   /**
    * Return the detail message associated with the Throwable.
    */
+  @Nullable
   public String getMessage() {
     return message;
   }
@@ -102,25 +106,14 @@ public final class BasicThrowable {
 
     BasicThrowable that = (BasicThrowable) o;
 
-    if (!className.equals(that.className)) {
-      return false;
-    }
-    if (!message.equals(that.message)) {
-      return false;
-    }
-
-    if (!Arrays.equals(stackTraces, that.stackTraces)) {
-      return false;
-    }
-    return cause != null ? cause.equals(that.cause) : that.cause == null;
+    return className.equals(that.className)
+      && Objects.equals(message, that.message)
+      && Arrays.equals(stackTraces, that.stackTraces)
+      && Objects.equals(cause, that.cause);
   }
 
   @Override
   public int hashCode() {
-    int result = className.hashCode();
-    result = 31 * result + message.hashCode();
-    result = 31 * result + Arrays.hashCode(stackTraces);
-    result = 31 * result + (cause != null ? cause.hashCode() : 0);
-    return result;
+    return Objects.hash(className, message, Arrays.hashCode(stackTraces), cause);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/BasicThrowableCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/BasicThrowableCodec.java
@@ -46,7 +46,7 @@ public final class BasicThrowableCodec extends AbstractSpecificationCodec<BasicT
     throws JsonParseException {
     JsonObject jsonObj = json.getAsJsonObject();
     String className = jsonObj.get("className").getAsString();
-    String message = jsonObj.get("message").getAsString();
+    String message = jsonObj.get("message") == null ? null : jsonObj.get("message").getAsString();
     JsonArray stackTraces = jsonObj.get("stackTraces").getAsJsonArray();
     StackTraceElement[] stackTraceElements = context.deserialize(stackTraces, StackTraceElement[].class);
     JsonElement cause = jsonObj.get("cause");

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/codec/BasicThrowableCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/codec/BasicThrowableCodecTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.api.dataset.InstanceNotFoundException;
+import co.cask.cdap.proto.BasicThrowable;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for BasicThrowableCodec.
+ */
+public class BasicThrowableCodecTest {
+
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec()).create();
+
+  @Test
+  public void testCodec() {
+    testCodec(new InstanceNotFoundException("myInstance"));
+    testCodec(new IllegalArgumentException());
+    testCodec(new NullPointerException());
+    testCodec(new Exception(new RuntimeException("some error")));
+  }
+
+  private void testCodec(Throwable t) {
+    BasicThrowable bt = new BasicThrowable(t);
+    String json = GSON.toJson(bt);
+    BasicThrowable bt1 = GSON.fromJson(json, BasicThrowable.class);
+    Assert.assertEquals(bt, bt1);
+  }
+}


### PR DESCRIPTION
Cherry-picks the commit from https://github.com/caskdata/cdap/pull/9024, back porting it to 4.1