### PR TITLE
detect /opt/cdap/sandbox path

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -46,7 +46,7 @@ __app_home=$(cd "${__app_home}"/.. >&-; pwd -P)
 __comp_home=${COMPONENT_HOME:-$(cd "${__target%/*/*}" >&- 2>/dev/null; pwd -P)}
 
 # Determine if we're in Distributed from packages or SDK/Parcel
-if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
+if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]] && [[ ${__comp_home} != /opt/cdap/sandbox* ]]; then
   # We're distributed from packages
   __app_home=${__comp_home}
   __cdap_home=${CDAP_HOME:-/opt/cdap}

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -139,7 +139,7 @@ cdap_home() {
   local readonly __dirname=$(dirname "${__script}")
   local readonly __script_bin=$(cd "${__dirname}"; pwd -P)
   local readonly __comp_home=$(cd "${__script%/*/*}" >&-; pwd -P)
-  if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
+  if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]] && [[ ${__comp_home} != /opt/cdap/sandbox* ]]; then
     __app_home=${__comp_home}
     __cdap_home=/opt/cdap
   elif [[ ${__comp_home##*/} == cli ]]; then


### PR DESCRIPTION
updates init scripts to check for ``/opt/cdap/sandbox`` installation directory when determining if this is the sdk/sandbox or not.

this will be needed if we want to change the install path in things like the vm/cloud sandbox prior to next cdap release.