### PR TITLE
[CDAP-11825] Adds icon mapping for postgresql65 tag

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseConnection.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseConnection.scss
@@ -226,7 +226,8 @@ $db-sprite-url: url('/cdap_assets/img/db-sprite.png');
   @include db-image(5);
 }
 
-.db-postgresql {
+.db-postgresql,
+.db-postgresql65 {
   @include db-image(6);
 }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-11825

The icon was not showing because we recently changed the tag for PostgreSQL v6.5 from `postgresql` to `postgresql65` (https://github.com/hydrator/wrangler/pull/115).

We had icon mapping for the former but not the latter, so this PR adds this.