### PR TITLE
CDAP-11848 fix deployment bug with sparkprogram and compute

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
@@ -122,14 +122,11 @@ public class SmartWorkflow extends AbstractWorkflow {
 
     stageSpecs = new HashMap<>();
     useSpark = engine == Engine.SPARK;
-    if (!useSpark) {
-      for (StageSpec stageSpec : spec.getStages()) {
-        stageSpecs.put(stageSpec.getName(), stageSpec);
-        String pluginType = stageSpec.getPlugin().getType();
-        if (SparkCompute.PLUGIN_TYPE.equals(pluginType) || SparkSink.PLUGIN_TYPE.equals(pluginType)) {
-          useSpark = true;
-          break;
-        }
+    for (StageSpec stageSpec : spec.getStages()) {
+      stageSpecs.put(stageSpec.getName(), stageSpec);
+      String pluginType = stageSpec.getPlugin().getType();
+      if (SparkCompute.PLUGIN_TYPE.equals(pluginType) || SparkSink.PLUGIN_TYPE.equals(pluginType)) {
+        useSpark = true;
       }
     }
 


### PR DESCRIPTION
Fixed a bug that could cause pipeline with a sparkprogram and
sparkcompute or sparksink to fail to deploy. The bug occurred
because a mapping from stage name to stage spec was not getting
fully populated due to a premature break in the loop.