### PR TITLE
Handles parsing CDCHBase and CDCSQLServer plugins

### DIFF
--- a/cdap-ui/app/filters/remove-camel-case.js
+++ b/cdap-ui/app/filters/remove-camel-case.js
@@ -25,6 +25,17 @@ angular.module(PKG.name+'.filters').filter('myRemoveCamelcase', function() {
       return input;
     }
 
+    // FIXME: Hardcoded for now since we don't want to modify algorithm for these 2 cases.
+    // Also we don't know where exactly to split either
+    // Ideally this should come from the backend
+    if (input.match(/^CDCHBase?/)) {
+      return 'CDC HBase';
+    }
+
+    if (input.match(/^CDCSQLServer?/)) {
+      return 'CDC SQLServer';
+    }
+
     return input.replace(/([a-z])([A-Z])/g, '$1 $2')
     .replace(/([A-Z])([a-z])/g, ' $1$2')
     .replace(/\ +/g, ' ').trim();


### PR DESCRIPTION
This is to correctly show the label for these two plugins when they're available. Hardcoded for now since each plugin requires a different split.

Without these changes the current algo would display `CDCHBase` as `CDCH Base`, and `CDCSQLServer` as `CDCSQL Server`.