### PR TITLE
[CDAP-11860] Adds SimpleDateParsing options to data prep

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SimpleDateModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SimpleDateModal.js
@@ -26,13 +26,15 @@ const OPTIONS_MAP = {
   'OPTION2': 'dd/MM/yyyy',
   'OPTION3': 'MM-dd-yyyy',
   'OPTION4': 'MM-dd-yy',
-  'OPTION5': 'MM-dd-yyyy G \'at\' HH:mm:ss z',
-  'OPTION6': 'dd/MM/yy HH:mm:ss',
-  'OPTION7': 'yyyy,MM.dd\'T\'HH:mm:ss.SSSZ',
-  'OPTION8': 'EEE, d MMM yyyy HH:mm:ss Z',
-  'OPTION9': 'EEE, MMM d, \'\'yy',
-  'OPTION10': 'h:mm a',
-  'OPTION11': 'H:mm a, z',
+  'OPTION5': 'yyyy-MM-dd',
+  'OPTION6': "yyyy-MM-dd HH:mm:ss",
+  'OPTION7': 'MM-dd-yyyy G \'at\' HH:mm:ss z',
+  'OPTION8': 'dd/MM/yy HH:mm:ss',
+  'OPTION9': 'yyyy,MM.dd\'T\'HH:mm:ss.SSSZ',
+  'OPTION10': 'EEE, d MMM yyyy HH:mm:ss Z',
+  'OPTION11': 'EEE, MMM d, \'\'yy',
+  'OPTION12': 'h:mm a',
+  'OPTION13': 'H:mm a, z',
   'CUSTOM': 'CUSTOM'
 };
 

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -578,13 +578,15 @@ features:
               OPTION2: "dd/MM/yyyy"
               OPTION3: "MM-dd-yyyy"
               OPTION4: "MM-dd-yy"
-              OPTION5: "MM-dd-yyyy 'at' HH:mm:ss"
-              OPTION6: "dd/MM/yy HH:mm:ss"
-              OPTION7: "MM.dd.yyyy HH:mm:ss.SSS"
-              OPTION8: "EEE, d MMM yyyy HH:mm:ss"
-              OPTION9: "EEE, MMM d, 'yy"
-              OPTION10: "h:mm AM/PM"
-              OPTION11: "H:mm with timezone"
+              OPTION5: "yyyy-MM-dd"
+              OPTION6: "yyyy-MM-dd HH:mm:ss"
+              OPTION7: "MM-dd-yyyy 'at' HH:mm:ss"
+              OPTION8: "dd/MM/yy HH:mm:ss"
+              OPTION9: "MM.dd.yyyy HH:mm:ss.SSS"
+              OPTION10: "EEE, d MMM yyyy HH:mm:ss"
+              OPTION11: "EEE, MMM d, 'yy"
+              OPTION12: "h:mm AM/PM"
+              OPTION13: "H:mm with timezone"
           XML:
             label: XML
           XMLTOJSON:


### PR DESCRIPTION
This allows users to parse simple dates in common MySQL, PostgeSQL, and SQL Server formats without needing to use the custom format.