### PR TITLE
Removes duplication in UI pipeline config code

### DIFF
--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
@@ -49,7 +49,7 @@ class MyBatchPipelineConfigCtrl {
       'pairs': HydratorPlusPlusHydratorService.convertMapToKeyValuePairs(this.store.getCustomConfigForDisplay())
     };
 
-    if (this.customEngineConfig.pairs.length === 0 && !this.isDisabled) {
+    if (this.customEngineConfig.pairs.length === 0 && !this.isDeployed) {
       this.customEngineConfig.pairs.push({
         key: '',
         value: '',
@@ -60,7 +60,7 @@ class MyBatchPipelineConfigCtrl {
     this.activeTab = 'runtimeArgs';
 
     // studio config, but not in preview mode
-    if (!this.isDisabled && !this.showPreviewConfig) {
+    if (!this.isDeployed && !this.showPreviewConfig) {
       this.activeTab = 'pipelineConfig';
     }
 
@@ -121,7 +121,7 @@ class MyBatchPipelineConfigCtrl {
 
   applyConfig() {
     this.applyRuntimeArguments();
-    if (!this.isDisabled) {
+    if (!this.isDeployed) {
       this.store.setEngine(this.engine);
       this.store.setCustomConfig(this.HydratorPlusPlusHydratorService.convertKeyValuePairsToMap(this.customEngineConfig));
       this.store.setInstrumentation(this.instrumentation);
@@ -168,7 +168,7 @@ class MyBatchPipelineConfigCtrl {
     let runtimeArgsMissingValues = false;
     let customConfigMissingValues = false;
 
-    if (this.isDisabled || this.showPreviewConfig) {
+    if (this.isDeployed || this.showPreviewConfig) {
       runtimeArgsMissingValues = this.HydratorPlusPlusHydratorService.keyValuePairsHaveMissingValues(this.runtimeArguments);
     }
     customConfigMissingValues = this.HydratorPlusPlusHydratorService.keyValuePairsHaveMissingValues(this.customEngineConfig);

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
@@ -14,317 +14,7 @@
   the License.
 -->
 
-<div ng-if="BatchPipelineConfigCtrl.isDisabled">
-  <div class="pipeline-configurations-content">
-    <div class="pipeline-configurations-header">
-      <h3 class="modeless-title">
-        Configure
-        <span ng-if="BatchPipelineConfigCtrl.pipelineName.length > 0">
-          "{{BatchPipelineConfigCtrl.pipelineName}}"
-        </span>
-      </h3>
-      <div class="btn-group">
-        <a class="btn" ng-click="BatchPipelineConfigCtrl.onClose()">
-          <span class="fa fa-remove"></span>
-        </a>
-      </div>
-    </div>
-    <div class="pipeline-configurations-body">
-      <div class="configurations-side-panel">
-        <div class="configurations-headers">
-          <div class="configuration-header"
-                ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'runtimeArgs'}"
-                ng-click="BatchPipelineConfigCtrl.activeTab = 'runtimeArgs'"
-                ng-if="BatchPipelineConfigCtrl.isDisabled || BatchPipelineConfigCtrl.showPreviewConfig">
-            Runtime Arguments
-          </div>
-          <div class="configuration-header"
-                ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'previewConfig'}"
-                ng-click="BatchPipelineConfigCtrl.activeTab = 'previewConfig'"
-                ng-if="!BatchPipelineConfigCtrl.isDisabled && BatchPipelineConfigCtrl.showPreviewConfig">
-            Preview Config
-          </div>
-          <div class="configuration-header toggle-advanced-options"
-                ng-click="BatchPipelineConfigCtrl.showAdvanced = !BatchPipelineConfigCtrl.showAdvanced"
-                ng-if="BatchPipelineConfigCtrl.isDisabled || BatchPipelineConfigCtrl.showPreviewConfig">
-            <span class="fa"
-                  ng-class="{'fa-caret-down': BatchPipelineConfigCtrl.showAdvanced, 'fa-caret-right': !BatchPipelineConfigCtrl.showAdvanced}">
-            </span>
-            Advanced options
-          </div>
-          <div class="advanced-options"
-                ng-show="BatchPipelineConfigCtrl.showAdvanced || !BatchPipelineConfigCtrl.isDisabled && !BatchPipelineConfigCtrl.showPreviewConfig">
-            <div class="configuration-header"
-                  ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'pipelineConfig'}"
-                  ng-click="BatchPipelineConfigCtrl.activeTab = 'pipelineConfig'">
-              Pipeline Config
-            </div>
-            <div class="configuration-header"
-                  ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'engineConfig'}"
-                  ng-click="BatchPipelineConfigCtrl.activeTab = 'engineConfig'">
-              Engine Config
-            </div>
-            <div class="configuration-header"
-                  ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'resources', 'disabled': BatchPipelineConfigCtrl.showPreviewConfig}"
-                  ng-click="BatchPipelineConfigCtrl.activeTab = 'resources'">
-              Resources
-            </div>
-            <div class="configuration-header"
-                  ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'alerts', 'disabled': BatchPipelineConfigCtrl.showPreviewConfig}"
-                  ng-click="BatchPipelineConfigCtrl.activeTab = 'alerts'">
-              Alerts
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="configuration-content">
-
-        <div class="configuration-step-content configuration-content-container runtime-arguments"
-              ng-if="BatchPipelineConfigCtrl.activeTab === 'runtimeArgs'">
-          <div class="step-content-heading">
-            Specify Runtime Arguments or Update the Ones Derived from Preferences
-            <div class="step-content-subtitle">
-              By default, values for all runtime arguments must be provided before running the pipeline. If a stage in your pipeline provides the value of an argument, you can skip that argument by marking it as Provided.
-            </div>
-          </div>
-          <div class="runtime-arguments-labels key-value-pair-labels">
-            <span class="key-label">Name</span>
-            <span class="value-label">Value</span>
-            <span class="provided-label"
-                  ng-if="BatchPipelineConfigCtrl.containsMacros">
-              Provided
-            </span>
-          </div>
-          <div class="runtime-arguments-values key-value-pair-values">
-            <key-value-pairs
-              key-values="BatchPipelineConfigCtrl.runtimeArguments"
-              on-key-value-change="BatchPipelineConfigCtrl.onRuntimeArgumentsChange"
-              get-resetted-key-value="BatchPipelineConfigCtrl.getResettedRuntimeArgument"
-            ></key-value-pairs>
-          </div>
-        </div>
-
-        <div class="configuration-step-content pipeline-config"
-              ng-if="BatchPipelineConfigCtrl.activeTab === 'pipelineConfig'">
-          <div class="step-content-heading">
-            Set configurations for this pipeline
-          </div>
-          <div class="label-with-toggle instrumentation row">
-            <span class="toggle-label col-xs-4">Instrumentation</span>
-            <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
-                is-on="BatchPipelineConfigCtrl.instrumentation"
-                on-toggle="BatchPipelineConfigCtrl.onToggleInstrumentationChange()"
-              ></my-toggle-switch-widget>
-              <i class="fa fa-info-circle"
-                  uib-tooltip="Emits timing metrics such as total time, mean, standard deviation for pipeline stages."
-                  tooltip-placement="right">
-              </i>
-            </div>
-          </div>
-          <div class="label-with-toggle stageLogging row">
-            <span class="toggle-label col-xs-4">Stage Level Logging</span>
-            <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
-                is-on="BatchPipelineConfigCtrl.stageLogging"
-                on-toggle="BatchPipelineConfigCtrl.onStageLoggingChange()"
-              ></my-toggle-switch-widget>
-              <i class="fa fa-info-circle"
-                  uib-tooltip="Allows logs from each stage in the pipeline to be queried individually."
-                  tooltip-placement="right">
-              </i>
-            </div>
-          </div>
-        </div>
-        <div class="configuration-step-content resources"
-              ng-if="BatchPipelineConfigCtrl.activeTab === 'resources'">
-          <div class="step-content-heading">
-            Specify the resources for the following processes of the {{ BatchPipelineConfigCtrl.engineForDisplay }} program
-          </div>
-          <div class="col-xs-6 driver">
-            <span class="resource-title">
-              Driver
-            </span>
-            <i class="fa fa-info-circle"
-                uib-tooltip="Resources for the driver process which initializes the pipeline"
-                tooltip-placement="right">
-            </i>
-            <div class="resource-holder">
-              <div
-                action-creator="BatchPipelineConfigCtrl.actionCreator"
-                store="BatchPipelineConfigCtrl.store"
-                resource-type="driverResource"
-                is-disabled="BatchPipelineConfigCtrl.isDisabled"
-                on-memory-change="BatchPipelineConfigCtrl.onDriverMemoryChange"
-                on-core-change="BatchPipelineConfigCtrl.onDriverCoreChange"
-                virtual-cores-value="BatchPipelineConfigCtrl.driverResources.virtualCores"
-                memory-mb-value="BatchPipelineConfigCtrl.driverResources.memoryMB"
-                my-pipeline-resource-factory
-              ></div>
-            </div>
-          </div>
-          <div class="col-xs-6 executor">
-            <span ng-if="BatchPipelineConfigCtrl.engine === 'mapreduce'"
-                  class="resource-title">
-              Mapper/Reducer
-            </span>
-            <span ng-if="BatchPipelineConfigCtrl.engine === 'spark'"
-                  class="resource-title">
-              Executor
-            </span>
-            <i class="fa fa-info-circle"
-                ng-if="BatchPipelineConfigCtrl.engine === 'mapreduce'"
-                uib-tooltip="Resources for Map and Reduce Tasks of the MapReduce program"
-                tooltip-placement="right">
-            </i>
-            <i class="fa fa-info-circle"
-                ng-if="BatchPipelineConfigCtrl.engine === 'spark'"
-                uib-tooltip="Resources for executor processes which run tasks in an Apache Spark pipeline"
-                tooltip-placement="right">
-            </i>
-            <div class="resource-holder">
-              <div
-                action-creator="BatchPipelineConfigCtrl.actionCreator"
-                store="BatchPipelineConfigCtrl.store"
-                resource-type="executorResource"
-                is-disabled="BatchPipelineConfigCtrl.isDisabled"
-                on-memory-change="BatchPipelineConfigCtrl.onExecutorMemoryChange"
-                on-core-change="BatchPipelineConfigCtrl.onExecutorCoreChange"
-                virtual-cores-value="BatchPipelineConfigCtrl.executorResources.virtualCores"
-                memory-mb-value="BatchPipelineConfigCtrl.executorResources.memoryMB"
-                my-pipeline-resource-factory
-              ></div>
-            </div>
-          </div>
-        </div>
-        <div class="configuration-step-content alerts"
-              ng-if="BatchPipelineConfigCtrl.activeTab === 'alerts'">
-          <div class="step-content-heading">
-            Set an alert for your batch pipeline
-          </div>
-          <my-post-run-actions
-            is-disabled="BatchPipelineConfigCtrl.isDisabled"
-            action-creator="BatchPipelineConfigCtrl.actionCreator"
-            store="BatchPipelineConfigCtrl.store">
-          </my-post-run-actions>
-        </div>
-        <fieldset class="configuration-content-container"
-                  ng-if="BatchPipelineConfigCtrl.activeTab === 'engineConfig'"
-                  ng-disabled="BatchPipelineConfigCtrl.isDisabled">
-
-
-          <div class="configuration-step-content engine-config"
-                ng-if="BatchPipelineConfigCtrl.activeTab === 'engineConfig'">
-            <div class="step-content-heading">
-              Select the type of engine running your batch pipeline
-            </div>
-            <div class="engine-config-radio">
-              <label class="radio-inline radio-spark">
-                <input type="radio"
-                        ng-model="BatchPipelineConfigCtrl.engine"
-                        ng-change="BatchPipelineConfigCtrl.onEngineChange()"
-                        value="spark">
-                Spark
-              </label>
-              <label class="radio-inline radio-mapReduce">
-                <input type="radio"
-                        ng-model="BatchPipelineConfigCtrl.engine"
-                        ng-change="BatchPipelineConfigCtrl.onEngineChange()"
-                        value="mapreduce">
-                MapReduce
-              </label>
-            </div>
-            <div class="add-custom-config">
-              <span ng-if="BatchPipelineConfigCtrl.customEngineConfig.pairs.length === 0"
-                    ng-hide="BatchPipelineConfigCtrl.isDisabled">
-                <a class="add-custom-config-label"
-                    ng-click="BatchPipelineConfigCtrl.addCustomConfig()">
-                    Add Custom Config
-                </a>
-                <i class="fa fa-info-circle"
-                  uib-tooltip="Enter key-value pairs of configuration parameters that will be passed to the underlying {{ BatchPipelineConfigCtrl.engineForDisplay }} program."
-                  tooltip-placement="right">
-                </i>
-              </span>
-              <span ng-if="BatchPipelineConfigCtrl.customEngineConfig.pairs.length > 0">
-                <hr />
-                <label>Custom Config</label>
-                <i class="fa fa-info-circle"
-                  uib-tooltip="Enter key-value pairs of configuration parameters that will be passed to the underlying {{ BatchPipelineConfigCtrl.engineForDisplay }} program."
-                  tooltip-placement="right">
-                </i>
-                <div class="custom-config-labels key-value-pair-labels">
-                  <span class="key-label">Name</span>
-                  <span class="value-label">Value</span>
-                </div>
-                <div class="custom-config-values key-value-pair-values">
-                  <key-value-pairs
-                    key-values="BatchPipelineConfigCtrl.customEngineConfig"
-                    on-key-value-change="BatchPipelineConfigCtrl.onCustomEngineConfigChange"
-                  ></key-value-pairs>
-                </div>
-              </span>
-            </div>
-          </div>
-
-        </fieldset>
-
-        <div class="configuration-step-navigation">
-          <div ng-if="BatchPipelineConfigCtrl.isDisabled || BatchPipelineConfigCtrl.showPreviewConfig">
-            <div class="apply-run-container">
-              <button
-                class="btn btn-primary apply-run"
-                ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled() || BatchPipelineConfigCtrl.startingPipeline || BatchPipelineConfigCtrl.updatingPipeline"
-                ng-click="BatchPipelineConfigCtrl.applyAndRunPipeline()">
-                <span>Save &amp; {{ BatchPipelineConfigCtrl.pipelineAction }}</span>
-                <span ng-if="BatchPipelineConfigCtrl.startingPipeline" class="fa fa-spinner fa-spin"></span>
-              </button>
-              <button
-                class="btn btn-secondary"
-                ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled()"
-                ng-if="BatchPipelineConfigCtrl.activeTab === 'runtimeArgs'"
-                ng-click="BatchPipelineConfigCtrl.applyAndClose()">
-                Save
-              </button>
-              <button
-                class="btn btn-secondary"
-                ng-if="BatchPipelineConfigCtrl.activeTab !== 'runtimeArgs' && BatchPipelineConfigCtrl.activeTab !== engineConfig"
-                ng-click="BatchPipelineConfigCtrl.updatePipeline()"
-                ng-disabled="!BatchPipelineConfigCtrl.enablePipelineUpdate || BatchPipelineConfigCtrl.updatingPipeline || BatchPipelineConfigCtrl.startingPipeline"
-              >
-               <span ng-if="!BatchPipelineConfigCtrl.updatingPipeline">Save</span>
-               <span ng-if="BatchPipelineConfigCtrl.updatingPipeline">Saving</span>
-               <span ng-if="BatchPipelineConfigCtrl.updatingPipeline">
-                 <span class="fa fa-spinner fa-spin"></span>
-               </span>
-              </button>
-              <span class="num-runtime-args"
-                    ng-if="BatchPipelineConfigCtrl.activeTab === 'runtimeArgs'">
-                  {{ BatchPipelineConfigCtrl.runtimeArguments.pairs.length }}
-                <ng-pluralize
-                  count="BatchPipelineConfigCtrl.runtimeArguments.pairs.length"
-                  when="{'one': 'runtime argument',
-                        'other': 'runtime arguments'}">
-                </ng-pluralize>
-              </span>
-            </div>
-          </div>
-          <div ng-if="!BatchPipelineConfigCtrl.isDisabled && !BatchPipelineConfigCtrl.showPreviewConfig">
-            <button
-              class="btn btn-primary apply-close"
-              ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled()"
-              ng-click="BatchPipelineConfigCtrl.applyAndClose()">
-              Save
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-</div>
-
-<div class="pipeline-configurations-content" ng-if="!BatchPipelineConfigCtrl.isDisabled">
+<div class="pipeline-configurations-content">
   <div class="pipeline-configurations-header">
     <h3 class="modeless-title">
       Configure
@@ -344,25 +34,25 @@
         <div class="configuration-header"
               ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'runtimeArgs'}"
               ng-click="BatchPipelineConfigCtrl.activeTab = 'runtimeArgs'"
-              ng-if="BatchPipelineConfigCtrl.isDisabled || BatchPipelineConfigCtrl.showPreviewConfig">
+              ng-if="BatchPipelineConfigCtrl.isDeployed || BatchPipelineConfigCtrl.showPreviewConfig">
           Runtime Arguments
         </div>
         <div class="configuration-header"
               ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'previewConfig'}"
               ng-click="BatchPipelineConfigCtrl.activeTab = 'previewConfig'"
-              ng-if="!BatchPipelineConfigCtrl.isDisabled && BatchPipelineConfigCtrl.showPreviewConfig">
+              ng-if="!BatchPipelineConfigCtrl.isDeployed && BatchPipelineConfigCtrl.showPreviewConfig">
           Preview Config
         </div>
         <div class="configuration-header toggle-advanced-options"
               ng-click="BatchPipelineConfigCtrl.showAdvanced = !BatchPipelineConfigCtrl.showAdvanced"
-              ng-if="BatchPipelineConfigCtrl.isDisabled || BatchPipelineConfigCtrl.showPreviewConfig">
+              ng-if="BatchPipelineConfigCtrl.isDeployed || BatchPipelineConfigCtrl.showPreviewConfig">
           <span class="fa"
                 ng-class="{'fa-caret-down': BatchPipelineConfigCtrl.showAdvanced, 'fa-caret-right': !BatchPipelineConfigCtrl.showAdvanced}">
-           </span>
+          </span>
           Advanced options
         </div>
         <div class="advanced-options"
-              ng-show="BatchPipelineConfigCtrl.showAdvanced || !BatchPipelineConfigCtrl.isDisabled && !BatchPipelineConfigCtrl.showPreviewConfig">
+              ng-show="BatchPipelineConfigCtrl.showAdvanced || !BatchPipelineConfigCtrl.isDeployed && !BatchPipelineConfigCtrl.showPreviewConfig">
           <div class="configuration-header"
                 ng-class="{'active': BatchPipelineConfigCtrl.activeTab === 'pipelineConfig'}"
                 ng-click="BatchPipelineConfigCtrl.activeTab = 'pipelineConfig'">
@@ -386,8 +76,8 @@
         </div>
       </div>
     </div>
-    <div class="configuration-content">
 
+    <div class="configuration-content">
       <div class="configuration-step-content configuration-content-container runtime-arguments"
             ng-if="BatchPipelineConfigCtrl.activeTab === 'runtimeArgs'">
         <div class="step-content-heading">
@@ -400,7 +90,7 @@
           <span class="key-label">Name</span>
           <span class="value-label">Value</span>
           <span class="provided-label"
-                  ng-if="BatchPipelineConfigCtrl.containsMacros">
+                ng-if="BatchPipelineConfigCtrl.containsMacros">
             Provided
           </span>
         </div>
@@ -430,45 +120,112 @@
         </div>
       </div>
 
-      <fieldset class="configuration-content-container"
-                ng-if="BatchPipelineConfigCtrl.activeTab !== 'runtimeArgs' && BatchPipelineConfigCtrl.activeTab !== 'previewConfig'"
-                ng-disabled="BatchPipelineConfigCtrl.isDisabled">
-
-        <div class="configuration-step-content pipeline-config"
-              ng-if="BatchPipelineConfigCtrl.activeTab === 'pipelineConfig'">
-          <div class="step-content-heading">
-            Set configurations for this pipeline
-          </div>
-          <div class="label-with-toggle instrumentation row">
-            <span class="toggle-label col-xs-4">Instrumentation</span>
-            <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
-                is-on="BatchPipelineConfigCtrl.instrumentation"
-                is-disabled="BatchPipelineConfigCtrl.isDisabled"
-                on-toggle="BatchPipelineConfigCtrl.instrumentation = !BatchPipelineConfigCtrl.instrumentation"
-              ></my-toggle-switch-widget>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="Emits timing metrics such as total time, mean, standard deviation for pipeline stages. It is recommended to always have this setting on, unless the environment is short on resources."
-                 tooltip-placement="right">
-              </i>
-            </div>
-          </div>
-          <div class="label-with-toggle stageLogging row">
-            <span class="toggle-label col-xs-4">Stage Level Logging</span>
-            <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
-                is-on="BatchPipelineConfigCtrl.stageLogging"
-                is-disabled="BatchPipelineConfigCtrl.isDisabled"
-                on-toggle="BatchPipelineConfigCtrl.stageLogging = !BatchPipelineConfigCtrl.stageLogging"
-              ></my-toggle-switch-widget>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="Allows logs from each stage in the pipeline to be queried individually. It is recommended to always have this setting on, unless the environment is short on resources."
-                 tooltip-placement="right">
-              </i>
-            </div>
+      <div class="configuration-step-content pipeline-config"
+            ng-if="BatchPipelineConfigCtrl.activeTab === 'pipelineConfig'">
+        <div class="step-content-heading">
+          Set configurations for this pipeline
+        </div>
+        <div class="label-with-toggle instrumentation row">
+          <span class="toggle-label col-xs-4">Instrumentation</span>
+          <div class="col-xs-7 toggle-container">
+            <my-toggle-switch-widget
+              is-on="BatchPipelineConfigCtrl.instrumentation"
+              on-toggle="BatchPipelineConfigCtrl.onToggleInstrumentationChange()"
+            ></my-toggle-switch-widget>
+            <i class="fa fa-info-circle"
+                uib-tooltip="Emits timing metrics such as total time, mean, standard deviation for pipeline stages. It is recommended to always have this setting on, unless the environment is short on resources."
+                tooltip-placement="right">
+            </i>
           </div>
         </div>
+        <div class="label-with-toggle stageLogging row">
+          <span class="toggle-label col-xs-4">Stage Level Logging</span>
+          <div class="col-xs-7 toggle-container">
+            <my-toggle-switch-widget
+              is-on="BatchPipelineConfigCtrl.stageLogging"
+              on-toggle="BatchPipelineConfigCtrl.onStageLoggingChange()"
+            ></my-toggle-switch-widget>
+            <i class="fa fa-info-circle"
+                uib-tooltip="Allows logs from each stage in the pipeline to be queried individually. It is recommended to always have this setting on, unless the environment is short on resources."
+                tooltip-placement="right">
+            </i>
+          </div>
+        </div>
+      </div>
+      <div class="configuration-step-content resources"
+            ng-if="BatchPipelineConfigCtrl.activeTab === 'resources'">
+        <div class="step-content-heading">
+          Specify the resources for the following processes of the {{ BatchPipelineConfigCtrl.engineForDisplay }} program
+        </div>
+        <div class="col-xs-6 driver">
+          <span class="resource-title">
+            Driver
+          </span>
+          <i class="fa fa-info-circle"
+              uib-tooltip="Resources for the driver process which initializes the pipeline"
+              tooltip-placement="right">
+          </i>
+          <div class="resource-holder">
+            <div
+              action-creator="BatchPipelineConfigCtrl.actionCreator"
+              store="BatchPipelineConfigCtrl.store"
+              resource-type="driverResource"
+              on-memory-change="BatchPipelineConfigCtrl.onDriverMemoryChange"
+              on-core-change="BatchPipelineConfigCtrl.onDriverCoreChange"
+              virtual-cores-value="BatchPipelineConfigCtrl.driverResources.virtualCores"
+              memory-mb-value="BatchPipelineConfigCtrl.driverResources.memoryMB"
+              my-pipeline-resource-factory
+            ></div>
+          </div>
+        </div>
+        <div class="col-xs-6 executor">
+          <span ng-if="BatchPipelineConfigCtrl.engine === 'mapreduce'"
+                class="resource-title">
+            Mapper/Reducer
+          </span>
+          <span ng-if="BatchPipelineConfigCtrl.engine === 'spark'"
+                class="resource-title">
+            Executor
+          </span>
+          <i class="fa fa-info-circle"
+              ng-if="BatchPipelineConfigCtrl.engine === 'mapreduce'"
+              uib-tooltip="Resources for Map and Reduce Tasks of the MapReduce program"
+              tooltip-placement="right">
+          </i>
+          <i class="fa fa-info-circle"
+              ng-if="BatchPipelineConfigCtrl.engine === 'spark'"
+              uib-tooltip="Resources for executor processes which run tasks in an Apache Spark pipeline"
+              tooltip-placement="right">
+          </i>
+          <div class="resource-holder">
+            <div
+              action-creator="BatchPipelineConfigCtrl.actionCreator"
+              store="BatchPipelineConfigCtrl.store"
+              resource-type="executorResource"
+              on-memory-change="BatchPipelineConfigCtrl.onExecutorMemoryChange"
+              on-core-change="BatchPipelineConfigCtrl.onExecutorCoreChange"
+              virtual-cores-value="BatchPipelineConfigCtrl.executorResources.virtualCores"
+              memory-mb-value="BatchPipelineConfigCtrl.executorResources.memoryMB"
+              my-pipeline-resource-factory
+            ></div>
+          </div>
+        </div>
+      </div>
+      <div class="configuration-step-content alerts"
+            ng-if="BatchPipelineConfigCtrl.activeTab === 'alerts'">
+        <div class="step-content-heading">
+          Set alerts for your batch pipeline
+        </div>
+        <my-post-run-actions
+          is-disabled="BatchPipelineConfigCtrl.isDeployed"
+          action-creator="BatchPipelineConfigCtrl.actionCreator"
+          store="BatchPipelineConfigCtrl.store">
+        </my-post-run-actions>
+      </div>
 
+      <fieldset class="configuration-content-container"
+                ng-if="BatchPipelineConfigCtrl.activeTab === 'engineConfig'"
+                ng-disabled="BatchPipelineConfigCtrl.isDeployed">
         <div class="configuration-step-content engine-config"
               ng-if="BatchPipelineConfigCtrl.activeTab === 'engineConfig'">
           <div class="step-content-heading">
@@ -491,13 +248,13 @@
             </label>
           </div>
           <div class="add-custom-config">
-            <span ng-if="!BatchPipelineConfigCtrl.isDisabled">
+            <span ng-if="!BatchPipelineConfigCtrl.isDeployed">
               <a class="add-custom-config-label"
                   ng-click="BatchPipelineConfigCtrl.showCustomConfig = !BatchPipelineConfigCtrl.showCustomConfig">
                   <span class="fa"
                         ng-class="{'fa-caret-down': BatchPipelineConfigCtrl.showCustomConfig, 'fa-caret-right': !BatchPipelineConfigCtrl.showCustomConfig}">
                    </span>
-                  Add Custom Config
+                  Show Custom Config
               </a>
               <i class="fa fa-info-circle"
                  uib-tooltip="Enter key-value pairs of configuration parameters that will be passed to the underlying {{ BatchPipelineConfigCtrl.engineForDisplay }} program."
@@ -506,18 +263,17 @@
               <span class="float-xs-right num-rows"
                     ng-if="BatchPipelineConfigCtrl.showCustomConfig">
                   {{ BatchPipelineConfigCtrl.customEngineConfig.pairs.length }}
-                <span ng-if="BatchPipelineConfigCtrl.customEngineConfig.pairs.length === 1">
-                  custom config
-                </span>
-                <span ng-if="BatchPipelineConfigCtrl.customEngineConfig.pairs.length > 1">
-                  custom configs
-                </span>
+                <ng-pluralize
+                  count="BatchPipelineConfigCtrl.customEngineConfig.pairs.length"
+                  when="{'one': 'custom config',
+                        'other': 'custom configs'}">
+                </ng-pluralize>
               </span>
             </span>
-            <span ng-if="(BatchPipelineConfigCtrl.isDisabled && BatchPipelineConfigCtrl.customEngineConfig.pairs.length > 0) || (!BatchPipelineConfigCtrl.isDisabled && BatchPipelineConfigCtrl.showCustomConfig)">
+            <span ng-if="(BatchPipelineConfigCtrl.isDeployed && BatchPipelineConfigCtrl.customEngineConfig.pairs.length > 0) || (!BatchPipelineConfigCtrl.isDeployed && BatchPipelineConfigCtrl.showCustomConfig)">
               <hr />
-              <span ng-if="BatchPipelineConfigCtrl.isDisabled && BatchPipelineConfigCtrl.customEngineConfig.pairs.length > 0">
-                <label> Custom Config</label>
+              <span ng-if="BatchPipelineConfigCtrl.isDeployed && BatchPipelineConfigCtrl.customEngineConfig.pairs.length > 0">
+                <label>Custom Config</label>
                 <i class="fa fa-info-circle"
                    uib-tooltip="Enter key-value pairs of configuration parameters that will be passed to the underlying {{ BatchPipelineConfigCtrl.engineForDisplay }} program."
                    tooltip-placement="right">
@@ -544,95 +300,49 @@
             </span>
           </div>
         </div>
-
-        <div class="configuration-step-content resources"
-              ng-if="BatchPipelineConfigCtrl.activeTab === 'resources'">
-          <div class="step-content-heading">
-            Specify the resources for the following processes of the {{ BatchPipelineConfigCtrl.engineForDisplay }} program
-          </div>
-          <div class="col-xs-6 driver">
-            <span class="resource-title">
-              Driver
-            </span>
-            <i class="fa fa-info-circle"
-                uib-tooltip="Resources for the driver process which initializes the pipeline"
-                tooltip-placement="right">
-            </i>
-            <div class="resource-holder">
-              <div
-                action-creator="BatchPipelineConfigCtrl.actionCreator"
-                store="BatchPipelineConfigCtrl.store"
-                resource-type="driverResource"
-                is-disabled="BatchPipelineConfigCtrl.isDisabled"
-                on-memory-change="BatchPipelineConfigCtrl.onDriverMemoryChange"
-                on-core-change="BatchPipelineConfigCtrl.onDriverCoreChange"
-                virtual-cores-value="BatchPipelineConfigCtrl.driverResources.virtualCores"
-                memory-mb-value="BatchPipelineConfigCtrl.driverResources.memoryMB"
-                my-pipeline-resource-factory
-              ></div>
-            </div>
-          </div>
-          <div class="col-xs-6 executor">
-            <span ng-if="BatchPipelineConfigCtrl.engine === 'mapreduce'"
-                  class="resource-title">
-              Mapper/Reducer
-            </span>
-            <span ng-if="BatchPipelineConfigCtrl.engine === 'spark'"
-                  class="resource-title">
-              Executor
-            </span>
-            <i class="fa fa-info-circle"
-                ng-if="BatchPipelineConfigCtrl.engine === 'mapreduce'"
-                uib-tooltip="Resources for Map and Reduce Tasks of the MapReduce program"
-                tooltip-placement="right">
-            </i>
-            <i class="fa fa-info-circle"
-                ng-if="BatchPipelineConfigCtrl.engine === 'spark'"
-                uib-tooltip="Resources for executor processes which run tasks in an Apache Spark pipeline"
-                tooltip-placement="right">
-            </i>
-            <div class="resource-holder">
-              <div
-                action-creator="BatchPipelineConfigCtrl.actionCreator"
-                store="BatchPipelineConfigCtrl.store"
-                resource-type="executorResource"
-                is-disabled="BatchPipelineConfigCtrl.isDisabled"
-                on-memory-change="BatchPipelineConfigCtrl.onExecutorMemoryChange"
-                on-core-change="BatchPipelineConfigCtrl.onExecutorCoreChange"
-                virtual-cores-value="BatchPipelineConfigCtrl.executorResources.virtualCores"
-                memory-mb-value="BatchPipelineConfigCtrl.executorResources.memoryMB"
-                my-pipeline-resource-factory
-              ></div>
-            </div>
-          </div>
-        </div>
       </fieldset>
-
-      <div class="configuration-step-content alerts"
-            ng-if="BatchPipelineConfigCtrl.activeTab === 'alerts'">
-        <div class="step-content-heading">
-          Set alerts for your batch pipeline
-        </div>
-        <my-post-run-actions
-          is-disabled="BatchPipelineConfigCtrl.isDisabled"
-          action-creator="BatchPipelineConfigCtrl.actionCreator"
-          store="BatchPipelineConfigCtrl.store">
-        </my-post-run-actions>
-      </div>
 
       <div class="configuration-step-navigation">
         <div class="apply-run-container"
-              ng-if="BatchPipelineConfigCtrl.isDisabled || BatchPipelineConfigCtrl.showPreviewConfig">
+          ng-if="BatchPipelineConfigCtrl.isDeployed || BatchPipelineConfigCtrl.showPreviewConfig">
           <button
             class="btn btn-primary apply-run"
+            ng-if="BatchPipelineConfigCtrl.isDeployed"
+            ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled() || BatchPipelineConfigCtrl.startingPipeline || BatchPipelineConfigCtrl.updatingPipeline"
+            ng-click="BatchPipelineConfigCtrl.applyAndRunPipeline()">
+            <span>Save &amp; {{ BatchPipelineConfigCtrl.pipelineAction }}</span>
+            <span ng-if="BatchPipelineConfigCtrl.startingPipeline" class="fa fa-spinner fa-spin"></span>
+          </button>
+          <button
+            class="btn btn-primary apply-run"
+            ng-if="BatchPipelineConfigCtrl.showPreviewConfig"
             ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled()"
             ng-click="BatchPipelineConfigCtrl.applyAndRunPipeline()">
-            Save &amp; Run
+            <span>Save &amp; Run</span>
           </button>
           <button
             class="btn btn-secondary"
+            ng-if="BatchPipelineConfigCtrl.isDeployed && BatchPipelineConfigCtrl.activeTab === 'runtimeArgs'"
             ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled()"
-            ng-click="BatchPipelineConfigCtrl.applyConfig()">
+            ng-click="BatchPipelineConfigCtrl.applyAndClose()">
+            Save
+          </button>
+          <button
+            class="btn btn-secondary"
+            ng-if="BatchPipelineConfigCtrl.isDeployed && BatchPipelineConfigCtrl.activeTab !== 'runtimeArgs' && BatchPipelineConfigCtrl.activeTab !== engineConfig"
+            ng-disabled="!BatchPipelineConfigCtrl.enablePipelineUpdate || BatchPipelineConfigCtrl.updatingPipeline || BatchPipelineConfigCtrl.startingPipeline"
+            ng-click="BatchPipelineConfigCtrl.updatePipeline()">
+            <span ng-if="!BatchPipelineConfigCtrl.updatingPipeline">Save</span>
+            <span ng-if="BatchPipelineConfigCtrl.updatingPipeline">Saving</span>
+            <span ng-if="BatchPipelineConfigCtrl.updatingPipeline">
+              <span class="fa fa-spinner fa-spin"></span>
+           </span>
+          </button>
+          <button
+            class="btn btn-secondary"
+            ng-if="BatchPipelineConfigCtrl.showPreviewConfig"
+            ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled()"
+            ng-click="BatchPipelineConfigCtrl.applyAndClose()">
             Save
           </button>
           <span class="num-runtime-args"
@@ -645,7 +355,7 @@
             </ng-pluralize>
           </span>
         </div>
-        <div ng-if="!BatchPipelineConfigCtrl.isDisabled && !BatchPipelineConfigCtrl.showPreviewConfig">
+        <div ng-if="!BatchPipelineConfigCtrl.isDeployed && !BatchPipelineConfigCtrl.showPreviewConfig">
           <button
             class="btn btn-primary apply-close"
             ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled()"

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.js
@@ -29,7 +29,7 @@ angular.module(PKG.name + '.commons')
         namespace: '@',
         store: '=',
         actionCreator: '=',
-        isDisabled: '=',
+        isDeployed: '=',
         showPreviewConfig: '='
       },
       bindToController: true,

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations-factory.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations-factory.js
@@ -27,7 +27,7 @@ angular.module(PKG.name + '.commons')
       'namespace': 'namespace',
       'store': 'store',
       'action-creator': 'actionCreator',
-      'is-disabled': 'isDisabled',
+      'is-deployed': 'isDeployed',
       'show-preview-config': 'showPreviewConfig'
     };
     let batchPipelineConfig = {

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-pipeline-configurations.js
@@ -30,7 +30,7 @@ angular.module(PKG.name + '.commons')
         store: '=',
         actionCreator: '=',
         templateType: '@',
-        isDisabled: '=',
+        isDeployed: '=',
         showPreviewConfig: '='
       },
       replace: false,

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config-ctrl.js
@@ -64,7 +64,7 @@ class MyRealtimePipelineConfigCtrl {
       'pairs': HydratorPlusPlusHydratorService.convertMapToKeyValuePairs(this.store.getCustomConfigForDisplay())
     };
 
-    if (this.customEngineConfig.pairs.length === 0 && !this.isDisabled) {
+    if (this.customEngineConfig.pairs.length === 0 && !this.isDeployed) {
       this.customEngineConfig.pairs.push({
         key: '',
         value: '',
@@ -74,7 +74,7 @@ class MyRealtimePipelineConfigCtrl {
 
     this.activeTab = 'runtimeArgs';
     // studio config, but not in preview mode
-    if (!this.isDisabled && !this.showPreviewConfig) {
+    if (!this.isDeployed && !this.showPreviewConfig) {
       this.activeTab = 'pipelineConfig';
     }
 
@@ -145,7 +145,7 @@ class MyRealtimePipelineConfigCtrl {
 
   applyConfig() {
     this.applyRuntimeArguments();
-    if (!this.isDisabled) {
+    if (!this.isDeployed) {
       this.store.setBackpressure(this.backpressure);
       this.store.setNumExecutors(this.numExecutors);
       this.store.setCustomConfig(this.HydratorPlusPlusHydratorService.convertKeyValuePairsToMap(this.customEngineConfig));
@@ -199,7 +199,7 @@ class MyRealtimePipelineConfigCtrl {
     let runtimeArgsMissingValues = false;
     let customConfigMissingValues = false;
 
-    if (this.isDisabled || this.showPreviewConfig) {
+    if (this.isDeployed || this.showPreviewConfig) {
       runtimeArgsMissingValues = this.HydratorPlusPlusHydratorService.keyValuePairsHaveMissingValues(this.runtimeArguments);
     }
     customConfigMissingValues = this.HydratorPlusPlusHydratorService.keyValuePairsHaveMissingValues(this.customEngineConfig);

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config.html
@@ -14,7 +14,7 @@
   the License.
 -->
 
-<div class="pipeline-configurations-content" ng-if="RealtimePipelineConfigCtrl.isDisabled">
+<div class="pipeline-configurations-content"">
   <div class="pipeline-configurations-header">
     <h3 class="modeless-title">
       Configure
@@ -34,25 +34,25 @@
         <div class="configuration-header"
               ng-class="{'active': RealtimePipelineConfigCtrl.activeTab === 'runtimeArgs'}"
               ng-click="RealtimePipelineConfigCtrl.activeTab = 'runtimeArgs'"
-              ng-if="RealtimePipelineConfigCtrl.isDisabled || RealtimePipelineConfigCtrl.showPreviewConfig">
+              ng-if="RealtimePipelineConfigCtrl.isDeployed || RealtimePipelineConfigCtrl.showPreviewConfig">
           Runtime Arguments
         </div>
         <div class="configuration-header"
               ng-class="{'active': RealtimePipelineConfigCtrl.activeTab === 'previewConfig'}"
               ng-click="RealtimePipelineConfigCtrl.activeTab = 'previewConfig'"
-              ng-if="!RealtimePipelineConfigCtrl.isDisabled && RealtimePipelineConfigCtrl.showPreviewConfig">
+              ng-if="!RealtimePipelineConfigCtrl.isDeployed && RealtimePipelineConfigCtrl.showPreviewConfig">
           Preview Config
         </div>
         <div class="configuration-header toggle-advanced-options"
               ng-click="RealtimePipelineConfigCtrl.showAdvanced = !RealtimePipelineConfigCtrl.showAdvanced"
-              ng-if="RealtimePipelineConfigCtrl.isDisabled || RealtimePipelineConfigCtrl.showPreviewConfig">
+              ng-if="RealtimePipelineConfigCtrl.isDeployed || RealtimePipelineConfigCtrl.showPreviewConfig">
           <span class="fa"
                 ng-class="{'fa-caret-down': RealtimePipelineConfigCtrl.showAdvanced, 'fa-caret-right': !RealtimePipelineConfigCtrl.showAdvanced}">
            </span>
           Advanced options
         </div>
         <div class="advanced-options"
-              ng-show="RealtimePipelineConfigCtrl.showAdvanced || !RealtimePipelineConfigCtrl.isDisabled && !RealtimePipelineConfigCtrl.showPreviewConfig">
+              ng-show="RealtimePipelineConfigCtrl.showAdvanced || !RealtimePipelineConfigCtrl.isDeployed && !RealtimePipelineConfigCtrl.showPreviewConfig">
           <div class="configuration-header"
                 ng-class="{'active': RealtimePipelineConfigCtrl.activeTab === 'pipelineConfig'}"
                 ng-click="RealtimePipelineConfigCtrl.activeTab = 'pipelineConfig'">
@@ -71,8 +71,8 @@
         </div>
       </div>
     </div>
-    <div class="configuration-content">
 
+    <div class="configuration-content">
       <div class="configuration-step-content configuration-content-container runtime-arguments"
             ng-if="RealtimePipelineConfigCtrl.activeTab === 'runtimeArgs'">
         <div class="step-content-heading">
@@ -157,7 +157,7 @@
               on-toggle="RealtimePipelineConfigCtrl.onInstrumentationChange()"
             ></my-toggle-switch-widget>
             <i class="fa fa-info-circle"
-                uib-tooltip="Emits timing metrics such as total time, mean and standard deviation for pipeline stages."
+                uib-tooltip="Emits timing metrics such as total time, mean, and and standard deviation for pipeline stages. It is recommended to always have this setting on, unless the environment is short on resources."
                 tooltip-placement="right">
             </i>
           </div>
@@ -170,7 +170,7 @@
               on-toggle="RealtimePipelineConfigCtrl.onStageLoggingChange()"
             ></my-toggle-switch-widget>
             <i class="fa fa-info-circle"
-                uib-tooltip="Allows logs from each stage in the pipeline to be queried individually."
+                uib-tooltip="Allows logs from each stage in the pipeline to be queried individually. It is recommended to always have this setting on, unless the environment is short on resources."
                 tooltip-placement="right">
             </i>
           </div>
@@ -186,7 +186,7 @@
             Client
           </span>
           <i class="fa fa-info-circle"
-              uib-tooltip="Resources for the client process"
+              uib-tooltip="Resources for the client process which launches the Apache Spark Streaming pipeline"
               tooltip-placement="right">
           </i>
           <div class="resource-holder">
@@ -194,7 +194,6 @@
               action-creator="RealtimePipelineConfigCtrl.actionCreator"
               store="RealtimePipelineConfigCtrl.store"
               resource-type="clientResource"
-              is-disabled="RealtimePipelineConfigCtrl.isDisabled"
               on-memory-change="RealtimePipelineConfigCtrl.onClientMemoryChange"
               on-core-change="RealtimePipelineConfigCtrl.onClientCoreChange"
               virtual-cores-value="RealtimePipelineConfigCtrl.clientResources.virtualCores"
@@ -208,7 +207,7 @@
             Driver
           </span>
           <i class="fa fa-info-circle"
-              uib-tooltip="Resources for the driver process which initializes the pipeline"
+              uib-tooltip="Resources for the Apache Spark driver process which initializes the pipeline"
               tooltip-placement="right">
           </i>
           <div class="resource-holder">
@@ -216,7 +215,6 @@
               action-creator="RealtimePipelineConfigCtrl.actionCreator"
               store="RealtimePipelineConfigCtrl.store"
               resource-type="driverResource"
-              is-disabled="RealtimePipelineConfigCtrl.isDisabled"
               on-memory-change="RealtimePipelineConfigCtrl.onDriverMemoryChange"
               on-core-change="RealtimePipelineConfigCtrl.onDriverCoreChange"
               virtual-cores-value="RealtimePipelineConfigCtrl.driverResources.virtualCores"
@@ -238,7 +236,6 @@
               action-creator="RealtimePipelineConfigCtrl.actionCreator"
               store="RealtimePipelineConfigCtrl.store"
               resource-type="executorResource"
-              is-disabled="RealtimePipelineConfigCtrl.isDisabled"
               on-memory-change="RealtimePipelineConfigCtrl.onExecutorMemoryChange"
               on-core-change="RealtimePipelineConfigCtrl.onExecutorCoreChange"
               virtual-cores-value="RealtimePipelineConfigCtrl.executorResources.virtualCores"
@@ -248,13 +245,11 @@
           </div>
         </div>
       </div>
+
       <fieldset class="configuration-content-container"
                 ng-if="RealtimePipelineConfigCtrl.activeTab === 'engineConfig'"
-                ng-disabled="RealtimePipelineConfigCtrl.isDisabled">
-
-
-        <div class="configuration-step-content engine-config"
-              ng-if="RealtimePipelineConfigCtrl.activeTab === 'engineConfig'">
+                ng-disabled="RealtimePipelineConfigCtrl.isDeployed">
+        <div class="configuration-step-content engine-config">
           <div class="step-content-heading">
             Select the type of engine running your realtime pipeline
           </div>
@@ -263,7 +258,7 @@
             <div class="col-xs-7 toggle-container">
               <my-toggle-switch-widget
                 is-on="RealtimePipelineConfigCtrl.backpressure"
-                is-disabled="RealtimePipelineConfigCtrl.isDisabled"
+                is-disabled="RealtimePipelineConfigCtrl.isDeployed"
                 on-toggle="RealtimePipelineConfigCtrl.backpressure = !RealtimePipelineConfigCtrl.backpressure"
               ></my-toggle-switch-widget>
               <i class="fa fa-info-circle"
@@ -286,300 +281,13 @@
             </div>
           </div>
           <div class="add-custom-config">
-            <span ng-if="RealtimePipelineConfigCtrl.customEngineConfig.pairs.length === 0"
-                  ng-hide="RealtimePipelineConfigCtrl.isDisabled">
-              <a class="add-custom-config-label"
-                  ng-click="RealtimePipelineConfigCtrl.addCustomConfig()"
-                  ng-hide="RealtimePipelineConfigCtrl.isDisabled">>
-                  Add Custom Config
-              </a>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="Enter key-value pairs of configuration parameters that will be passed to the underlying Apache Spark program."
-                 tooltip-placement="right">
-              </i>
-            </span>
-            <span ng-if="RealtimePipelineConfigCtrl.customEngineConfig.pairs.length > 0">
-              <hr />
-              <label>Custom Config</label>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="Enter key-value pairs of configuration parameters that will be passed to the underlying Apache Spark program."
-                 tooltip-placement="right">
-              </i>
-              <div class="custom-config-labels key-value-pair-labels">
-                <span class="key-label">Name</span>
-                <span class="value-label">Value</span>
-              </div>
-              <div class="custom-config-values key-value-pair-values">
-                <key-value-pairs
-                  key-values="RealtimePipelineConfigCtrl.customEngineConfig"
-                  on-key-value-change="RealtimePipelineConfigCtrl.onCustomEngineConfigChange"
-                ></key-value-pairs>
-              </div>
-            </span>
-          </div>
-        </div>
-
-      </fieldset>
-
-      <div class="configuration-step-navigation">
-        <div class="apply-run-container"
-              ng-if="RealtimePipelineConfigCtrl.isDisabled || RealtimePipelineConfigCtrl.showPreviewConfig">
-          <button
-            class="btn btn-primary apply-run"
-            ng-disabled="RealtimePipelineConfigCtrl.buttonsAreDisabled() || RealtimePipelineConfigCtrl.startingPipeline || RealtimePipelineConfigCtrl.updatingPipeline "
-            ng-click="RealtimePipelineConfigCtrl.applyAndRunPipeline()">
-            <span>Save &amp; Run</span>
-            <span ng-if="RealtimePipelineConfigCtrl.startingPipeline" class="fa fa-spinner fa-spin"></span>
-          </button>
-          <button
-            class="btn btn-secondary"
-            ng-disabled="RealtimePipelineConfigCtrl.buttonsAreDisabled()"
-            ng-if="RealtimePipelineConfigCtrl.activeTab === 'runtimeArgs'"
-            ng-click="RealtimePipelineConfigCtrl.applyAndClose()">
-            Save
-          </button>
-          <button
-            class="btn btn-secondary"
-            ng-if="RealtimePipelineConfigCtrl.activeTab !== 'runtimeArgs' && RealtimePipelineConfigCtrl.activeTab !== engineConfig"
-            ng-disabled="!RealtimePipelineConfigCtrl.enablePipelineUpdate || RealtimePipelineConfigCtrl.startingPipeline || RealtimePipelineConfigCtrl.updatingPipeline "
-            ng-click="RealtimePipelineConfigCtrl.updatePipeline()">
-            <span ng-if="!RealtimePipelineConfigCtrl.updatingPipeline">Save</span>
-            <span ng-if="RealtimePipelineConfigCtrl.updatingPipeline">Saving</span>
-             <span ng-if="RealtimePipelineConfigCtrl.updatingPipeline">
-               <span class="fa fa-spinner fa-spin"></span>
-             </span>
-          </button>
-          <span class="num-runtime-args"
-                ng-if="RealtimePipelineConfigCtrl.activeTab === 'runtimeArgs'">
-              {{ RealtimePipelineConfigCtrl.runtimeArguments.pairs.length }}
-            <ng-pluralize
-              count="RealtimePipelineConfigCtrl.runtimeArguments.pairs.length"
-              when="{'one': 'runtime argument',
-                    'other': 'runtime arguments'}">
-            </ng-pluralize>
-          </span>
-        </div>
-        <div ng-if="!RealtimePipelineConfigCtrl.isDisabled && !RealtimePipelineConfigCtrl.showPreviewConfig">
-          <button
-            class="btn btn-primary apply-close"
-            ng-disabled="RealtimePipelineConfigCtrl.buttonsAreDisabled()"
-            ng-click="RealtimePipelineConfigCtrl.applyAndClose()">
-            Save
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="pipeline-configurations-content" ng-if="!RealtimePipelineConfigCtrl.isDisabled">
-  <div class="pipeline-configurations-header">
-    <h3 class="modeless-title">
-      Configure
-      <span ng-if="RealtimePipelineConfigCtrl.pipelineName.length > 0">
-        "{{RealtimePipelineConfigCtrl.pipelineName}}"
-      </span>
-    </h3>
-    <div class="btn-group">
-      <a class="btn" ng-click="RealtimePipelineConfigCtrl.onClose()">
-        <span class="fa fa-remove"></span>
-      </a>
-    </div>
-  </div>
-  <div class="pipeline-configurations-body">
-    <div class="configurations-side-panel">
-      <div class="configurations-headers">
-        <div class="configuration-header"
-              ng-class="{'active': RealtimePipelineConfigCtrl.activeTab === 'runtimeArgs'}"
-              ng-click="RealtimePipelineConfigCtrl.activeTab = 'runtimeArgs'"
-              ng-if="RealtimePipelineConfigCtrl.isDisabled || RealtimePipelineConfigCtrl.showPreviewConfig">
-          Runtime Arguments
-        </div>
-        <div class="configuration-header"
-              ng-class="{'active': RealtimePipelineConfigCtrl.activeTab === 'previewConfig'}"
-              ng-click="RealtimePipelineConfigCtrl.activeTab = 'previewConfig'"
-              ng-if="!RealtimePipelineConfigCtrl.isDisabled && RealtimePipelineConfigCtrl.showPreviewConfig">
-          Preview Config
-        </div>
-        <div class="configuration-header toggle-advanced-options"
-              ng-click="RealtimePipelineConfigCtrl.showAdvanced = !RealtimePipelineConfigCtrl.showAdvanced"
-              ng-if="RealtimePipelineConfigCtrl.isDisabled || RealtimePipelineConfigCtrl.showPreviewConfig">
-          <span class="fa"
-                ng-class="{'fa-caret-down': RealtimePipelineConfigCtrl.showAdvanced, 'fa-caret-right': !RealtimePipelineConfigCtrl.showAdvanced}">
-           </span>
-          Advanced options
-        </div>
-        <div class="advanced-options"
-              ng-show="RealtimePipelineConfigCtrl.showAdvanced || !RealtimePipelineConfigCtrl.isDisabled && !RealtimePipelineConfigCtrl.showPreviewConfig">
-          <div class="configuration-header"
-                ng-class="{'active': RealtimePipelineConfigCtrl.activeTab === 'pipelineConfig'}"
-                ng-click="RealtimePipelineConfigCtrl.activeTab = 'pipelineConfig'">
-            Pipeline Config
-          </div>
-          <div class="configuration-header"
-                ng-class="{'active': RealtimePipelineConfigCtrl.activeTab === 'engineConfig'}"
-                ng-click="RealtimePipelineConfigCtrl.activeTab = 'engineConfig'">
-            Engine Config
-          </div>
-          <div class="configuration-header"
-                ng-class="{'active': RealtimePipelineConfigCtrl.activeTab === 'resources', 'disabled': RealtimePipelineConfigCtrl.showPreviewConfig}"
-                ng-click="RealtimePipelineConfigCtrl.activeTab = 'resources'">
-            Resources
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="configuration-content">
-
-      <div class="configuration-step-content configuration-content-container runtime-arguments"
-            ng-if="RealtimePipelineConfigCtrl.activeTab === 'runtimeArgs'">
-        <div class="step-content-heading">
-          Specify Runtime Arguments or Update the Ones Derived from Preferences
-          <div class="step-content-subtitle">
-            By default, values for all runtime arguments must be provided before running the pipeline. If a stage in your pipeline provides the value of an argument, you can skip that argument by marking it as Provided.
-          </div>
-        </div>
-        <div class="runtime-arguments-labels key-value-pair-labels">
-          <span class="key-label">Name</span>
-          <span class="value-label">Value</span>
-          <span class="provided-label"
-                ng-if="RealtimePipelineConfigCtrl.containsMacros">
-            Provided
-          </span>
-        </div>
-        <div class="runtime-arguments-values key-value-pair-values">
-          <key-value-pairs
-            key-values="RealtimePipelineConfigCtrl.runtimeArguments"
-            on-key-value-change="RealtimePipelineConfigCtrl.onRuntimeArgumentsChange"
-            get-resetted-key-value="RealtimePipelineConfigCtrl.getResettedRuntimeArgument"
-          ></key-value-pairs>
-        </div>
-      </div>
-
-      <div class="configuration-step-content configuration-content-container preview-config"
-            ng-if="RealtimePipelineConfigCtrl.activeTab === 'previewConfig'">
-        <div class="step-content-heading">
-          Set how long you want to run your preview
-        </div>
-        <div class="label-with-toggle timeout-in-minutes row">
-          <span class="toggle-label col-xs-4">Time to run preview</span>
-          <my-number-widget
-            ng-model="RealtimePipelineConfigCtrl.timeoutInMinutes"
-            config="RealtimePipelineConfigCtrl.numberConfig"
-          ></my-number-widget>
-          <span class="control-label min">min</span>
-          <i class="fa fa-info-circle"
-             uib-tooltip="Number of minutes to run Realtime pipeline preview. It can be run for a maximum of 15 mins."
-             tooltip-placement="right">
-        </div>
-      </div>
-
-      <fieldset class="configuration-content-container"
-                ng-if="RealtimePipelineConfigCtrl.activeTab !== 'runtimeArgs' && RealtimePipelineConfigCtrl.activeTab !== 'previewConfig'"
-                ng-disabled="RealtimePipelineConfigCtrl.isDisabled">
-
-        <div class="configuration-step-content pipeline-config"
-              ng-if="RealtimePipelineConfigCtrl.activeTab === 'pipelineConfig'">
-          <div class="step-content-heading">
-            Set configurations for this pipeline
-          </div>
-          <div class="label-with-toggle batch-interval form-group row">
-            <span class="toggle-label col-xs-4">Batch Interval</span>
-            <div class="col-xs-7">
-              <select class="form-control small-dropdown"
-                      ng-model="RealtimePipelineConfigCtrl.batchIntervalTime"
-                      ng-options="option as option for option in RealtimePipelineConfigCtrl.batchIntervalTimeOptions">
-              </select>
-              <select class="form-control small-dropdown batch-interval-unit"
-                      ng-model="RealtimePipelineConfigCtrl.batchIntervalUnit"
-                      ng-options="optionKey as optionVal for (optionKey,optionVal) in RealtimePipelineConfigCtrl.batchIntervalUnits">
-              </select>
-            </div>
-          </div>
-          <div class="label-with-toggle checkpointing row">
-            <span class="toggle-label col-xs-4">Checkpointing</span>
-            <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
-                is-on="!RealtimePipelineConfigCtrl.checkpointing"
-                is-disabled="RealtimePipelineConfigCtrl.isDisabled"
-                on-toggle="RealtimePipelineConfigCtrl.checkpointing = !RealtimePipelineConfigCtrl.checkpointing"
-              ></my-toggle-switch-widget>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="Allows Apache Spark Streaming to checkpoint data (RDDs) to persistent storage so that the pipeline can recover from failures."
-                 tooltip-placement="right">
-              </i>
-            </div>
-          </div>
-          <div class="label-with-toggle instrumentation row">
-            <span class="toggle-label col-xs-4">Instrumentation</span>
-            <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
-                is-on="RealtimePipelineConfigCtrl.instrumentation"
-                is-disabled="RealtimePipelineConfigCtrl.isDisabled"
-                on-toggle="RealtimePipelineConfigCtrl.instrumentation = !RealtimePipelineConfigCtrl.instrumentation"
-              ></my-toggle-switch-widget>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="Emits timing metrics such as total time, mean, standard deviation for pipeline stages. It is recommended to always have this setting on, unless the environment is short on resources."
-                 tooltip-placement="right">
-              </i>
-            </div>
-          </div>
-          <div class="label-with-toggle stage-logging row">
-            <span class="toggle-label col-xs-4">Stage Level Logging</span>
-            <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
-                is-on="RealtimePipelineConfigCtrl.stageLogging"
-                is-disabled="RealtimePipelineConfigCtrl.isDisabled"
-                on-toggle="RealtimePipelineConfigCtrl.stageLogging = !RealtimePipelineConfigCtrl.stageLogging"
-              ></my-toggle-switch-widget>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="Allows logs from each stage in the pipeline to be queried individually. It is recommended to always have this setting on, unless the environment is short on resources."
-                 tooltip-placement="right">
-              </i>
-            </div>
-          </div>
-        </div>
-
-        <div class="configuration-step-content engine-config"
-              ng-if="RealtimePipelineConfigCtrl.activeTab === 'engineConfig'">
-          <div class="step-content-heading">
-            Select the type of engine running your realtime pipeline
-          </div>
-          <div class="label-with-toggle backpressure row">
-            <span class="toggle-label col-xs-4">Backpressure</span>
-            <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
-                is-on="RealtimePipelineConfigCtrl.backpressure"
-                is-disabled="RealtimePipelineConfigCtrl.isDisabled"
-                on-toggle="RealtimePipelineConfigCtrl.backpressure = !RealtimePipelineConfigCtrl.backpressure"
-              ></my-toggle-switch-widget>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="Allows the Apache Spark Streaming engine to control the receiving rate based on the current batch scheduling delays and processing times so that the system receives only as fast as the system can process."
-                 tooltip-placement="right">
-              </i>
-            </div>
-          </div>
-          <div class="label-with-toggle numExecutors form-group row">
-            <span class="toggle-label col-xs-4">Number of Executors</span>
-            <div class="col-xs-7">
-              <select class="form-control small-dropdown"
-                  ng-model="RealtimePipelineConfigCtrl.numExecutors"
-                  ng-options="option as option for option in RealtimePipelineConfigCtrl.numExecutorsOptions">
-              </select>
-              <i class="fa fa-info-circle"
-                 uib-tooltip="The number of executors to allocate for this pipeline on Apache Yarn."
-                 tooltip-placement="right">
-              </i>
-            </div>
-          </div>
-          <div class="add-custom-config">
-            <span ng-hide="RealtimePipelineConfigCtrl.isDisabled">
+            <span ng-hide="RealtimePipelineConfigCtrl.isDeployed">
               <a class="add-custom-config-label"
                   ng-click="RealtimePipelineConfigCtrl.showCustomConfig = !RealtimePipelineConfigCtrl.showCustomConfig">
                   <span class="fa"
                         ng-class="{'fa-caret-down': RealtimePipelineConfigCtrl.showCustomConfig, 'fa-caret-right': !RealtimePipelineConfigCtrl.showCustomConfig}">
                    </span>
-                  Add Custom Config
+                  Show Custom Config
               </a>
               <i class="fa fa-info-circle"
                  uib-tooltip="Enter key-value pairs of configuration parameters that will be passed to the underlying Apache Spark Streaming program."
@@ -588,17 +296,16 @@
               <span class="float-xs-right num-rows"
                     ng-if="RealtimePipelineConfigCtrl.showCustomConfig">
                   {{ RealtimePipelineConfigCtrl.customEngineConfig.pairs.length }}
-                <span ng-if="RealtimePipelineConfigCtrl.customEngineConfig.pairs.length === 1">
-                  custom config
-                </span>
-                <span ng-if="RealtimePipelineConfigCtrl.customEngineConfig.pairs.length > 1">
-                  custom configs
-                </span>
+                <ng-pluralize
+                  count="RealtimePipelineConfigCtrl.customEngineConfig.pairs.length"
+                  when="{'one': 'custom config',
+                        'other': 'custom configs'}">
+                </ng-pluralize>
               </span>
             </span>
-            <span ng-if="(RealtimePipelineConfigCtrl.isDisabled && RealtimePipelineConfigCtrl.customEngineConfig.pairs.length > 0) || (!RealtimePipelineConfigCtrl.isDisabled && RealtimePipelineConfigCtrl.showCustomConfig)">
+            <span ng-if="(RealtimePipelineConfigCtrl.isDeployed && RealtimePipelineConfigCtrl.customEngineConfig.pairs.length > 0) || (!RealtimePipelineConfigCtrl.isDeployed && RealtimePipelineConfigCtrl.showCustomConfig)">
               <hr />
-              <span ng-if="RealtimePipelineConfigCtrl.isDisabled && RealtimePipelineConfigCtrl.customEngineConfig.pairs.length > 0">
+              <span ng-if="RealtimePipelineConfigCtrl.isDeployed && RealtimePipelineConfigCtrl.customEngineConfig.pairs.length > 0">
                 <label>Custom Config</label>
                 <i class="fa fa-info-circle"
                    uib-tooltip="Enter key-value pairs of configuration parameters that will be passed to the underlying Apache Spark Streaming program."
@@ -626,94 +333,49 @@
             </span>
           </div>
         </div>
-
-        <div class="configuration-step-content resources"
-              ng-if="RealtimePipelineConfigCtrl.activeTab === 'resources'">
-          <div class="step-content-heading">
-            Specify the resources for the following processes of the Spark program
-          </div>
-          <div class="col-xs-4 client">
-            <span class="resource-title">
-              Client
-            </span>
-            <i class="fa fa-info-circle"
-                uib-tooltip="Resources for the client process which launches the Apache Spark Streaming pipeline"
-                tooltip-placement="right">
-            </i>
-            <div class="resource-holder">
-              <div
-                action-creator="RealtimePipelineConfigCtrl.actionCreator"
-                store="RealtimePipelineConfigCtrl.store"
-                resource-type="clientResource"
-                is-disabled="RealtimePipelineConfigCtrl.isDisabled"
-                on-memory-change="RealtimePipelineConfigCtrl.onClientMemoryChange"
-                on-core-change="RealtimePipelineConfigCtrl.onClientCoreChange"
-                virtual-cores-value="RealtimePipelineConfigCtrl.clientResources.virtualCores"
-                memory-mb-value="RealtimePipelineConfigCtrl.clientResources.memoryMB"
-                my-pipeline-resource-factory
-              ></div>
-            </div>
-          </div>
-          <div class="col-xs-4 driver">
-            <span class="resource-title">
-              Driver
-            </span>
-            <i class="fa fa-info-circle"
-                uib-tooltip="Resources for the Apache Spark driver process which initializes the pipeline"
-                tooltip-placement="right">
-            </i>
-            <div class="resource-holder">
-              <div
-                action-creator="RealtimePipelineConfigCtrl.actionCreator"
-                store="RealtimePipelineConfigCtrl.store"
-                resource-type="driverResource"
-                is-disabled="RealtimePipelineConfigCtrl.isDisabled"
-                on-memory-change="RealtimePipelineConfigCtrl.onDriverMemoryChange"
-                on-core-change="RealtimePipelineConfigCtrl.onDriverCoreChange"
-                virtual-cores-value="RealtimePipelineConfigCtrl.driverResources.virtualCores"
-                memory-mb-value="RealtimePipelineConfigCtrl.driverResources.memoryMB"
-                my-pipeline-resource-factory
-              ></div>
-            </div>
-          </div>
-          <div class="col-xs-4 executor">
-            <span class="resource-title">
-              Executor
-            </span>
-            <i class="fa fa-info-circle"
-                uib-tooltip="Resources for executor processes which run tasks in an Apache Spark pipeline"
-                tooltip-placement="right">
-            </i>
-            <div class="resource-holder">
-              <div
-                action-creator="RealtimePipelineConfigCtrl.actionCreator"
-                store="RealtimePipelineConfigCtrl.store"
-                resource-type="executorResource"
-                is-disabled="RealtimePipelineConfigCtrl.isDisabled"
-                on-memory-change="RealtimePipelineConfigCtrl.onExecutorMemoryChange"
-                on-core-change="RealtimePipelineConfigCtrl.onExecutorCoreChange"
-                virtual-cores-value="RealtimePipelineConfigCtrl.executorResources.virtualCores"
-                memory-mb-value="RealtimePipelineConfigCtrl.executorResources.memoryMB"
-                my-pipeline-resource-factory
-              ></div>
-            </div>
-          </div>
-        </div>
       </fieldset>
 
       <div class="configuration-step-navigation">
         <div class="apply-run-container"
-            ng-if="RealtimePipelineConfigCtrl.isDisabled || RealtimePipelineConfigCtrl.showPreviewConfig">
+              ng-if="RealtimePipelineConfigCtrl.isDeployed || RealtimePipelineConfigCtrl.showPreviewConfig">
           <button
             class="btn btn-primary apply-run"
+            ng-if="RealtimePipelineConfigCtrl.isDeployed"
+            ng-disabled="RealtimePipelineConfigCtrl.buttonsAreDisabled() || RealtimePipelineConfigCtrl.startingPipeline || RealtimePipelineConfigCtrl.updatingPipeline"
+            ng-click="RealtimePipelineConfigCtrl.applyAndRunPipeline()">
+            <span>Save &amp; Run</span>
+            <span ng-if="RealtimePipelineConfigCtrl.startingPipeline" class="fa fa-spinner fa-spin"></span>
+          </button>
+          <button
+            class="btn btn-primary apply-run"
+            ng-if="RealtimePipelineConfigCtrl.showPreviewConfig"
             ng-disabled="RealtimePipelineConfigCtrl.buttonsAreDisabled()"
             ng-click="RealtimePipelineConfigCtrl.applyAndRunPipeline()">
-            Save &amp; Run
+            <span>Save &amp; Run</span>
           </button>
           <button
             class="btn btn-secondary"
+            ng-if="RealtimePipelineConfigCtrl.isDeployed && RealtimePipelineConfigCtrl.activeTab === 'runtimeArgs'"
             ng-disabled="RealtimePipelineConfigCtrl.buttonsAreDisabled()"
-            ng-click="RealtimePipelineConfigCtrl.applyConfig()">
+            ng-click="RealtimePipelineConfigCtrl.applyAndClose()">
+            Save
+          </button>
+          <button
+            class="btn btn-secondary"
+            ng-if="RealtimePipelineConfigCtrl.isDeployed && RealtimePipelineConfigCtrl.activeTab !== 'runtimeArgs' && RealtimePipelineConfigCtrl.activeTab !== engineConfig"
+            ng-disabled="!RealtimePipelineConfigCtrl.enablePipelineUpdate || RealtimePipelineConfigCtrl.startingPipeline || RealtimePipelineConfigCtrl.updatingPipeline "
+            ng-click="RealtimePipelineConfigCtrl.updatePipeline()">
+            <span ng-if="!RealtimePipelineConfigCtrl.updatingPipeline">Save</span>
+            <span ng-if="RealtimePipelineConfigCtrl.updatingPipeline">Saving</span>
+            <span ng-if="RealtimePipelineConfigCtrl.updatingPipeline">
+              <span class="fa fa-spinner fa-spin"></span>
+            </span>
+          </button>
+          <button
+            class="btn btn-secondary"
+            ng-if="RealtimePipelineConfigCtrl.showPreviewConfig"
+            ng-disabled="RealtimePipelineConfigCtrl.buttonsAreDisabled()"
+            ng-click="RealtimePipelineConfigCtrl.applyAndClose()">
             Save
           </button>
           <span class="num-runtime-args"
@@ -726,7 +388,7 @@
             </ng-pluralize>
           </span>
         </div>
-        <div ng-if="!RealtimePipelineConfigCtrl.isDisabled && !RealtimePipelineConfigCtrl.showPreviewConfig">
+        <div ng-if="!RealtimePipelineConfigCtrl.isDeployed && !RealtimePipelineConfigCtrl.showPreviewConfig">
           <button
             class="btn btn-primary apply-close"
             ng-disabled="RealtimePipelineConfigCtrl.buttonsAreDisabled()"

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config.js
@@ -28,7 +28,7 @@ angular.module(PKG.name + '.commons')
         namespace: '@',
         store: '=',
         actionCreator: '=',
-        isDisabled: '=',
+        isDeployed: '=',
         showPreviewConfig: '='
       },
       bindToController: true,

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -240,12 +240,13 @@
     resolved-macros="HydratorPlusPlusTopPanelCtrl.resolvedMacros"
     run-pipeline="HydratorPlusPlusTopPanelCtrl.startOrStopPreview()"
     pipeline-name="{{HydratorPlusPlusTopPanelCtrl.state.metadata['name']}}"
+    pipeline-action="Run"
     on-close="HydratorPlusPlusTopPanelCtrl.viewConfig = false"
     namespace-id="{{HydratorPlusPlusTopPanelCtrl.$state.params.namespace}}"
     store="HydratorPlusPlusTopPanelCtrl.HydratorPlusPlusConfigStore"
     action-creator="HydratorPlusPlusTopPanelCtrl.HydratorPlusPlusConfigActions"
     template-type="{{HydratorPlusPlusTopPanelCtrl.state.artifact.name}}"
-    is-disabled="false"
+    is-deployed="false"
     show-preview-config="HydratorPlusPlusTopPanelCtrl.previewMode"
     my-pipeline-config>
   </div>

--- a/cdap-ui/app/hydrator/templates/detail/top-panel.html
+++ b/cdap-ui/app/hydrator/templates/detail/top-panel.html
@@ -279,7 +279,7 @@
       store="TopPanelCtrl.HydratorPlusPlusDetailNonRunsStore"
       action-creator="TopPanelCtrl.HydratorPlusPlusDetailActions"
       template-type="{{TopPanelCtrl.config.artifact.name}}"
-      is-disabled="true"
+      is-deployed="true"
       my-pipeline-config>
     </div>
   </div>


### PR DESCRIPTION
In both `my-batch-pipeline-config.html` and `my-realtime-pipeline-config.html`, we had two near-identical sections of code, one for draft pipelines and the other for published pipelines. This PR removes the duplicate code in each file.