### PR TITLE
CDAP-11815 Fix DatasetUpgrader#upgrade and HBaseQueueAdmin#upgrade.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -249,7 +249,9 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
     final ExecutorService executor =
       Executors.newFixedThreadPool(numThreads,
                                    new ThreadFactoryBuilder()
-                                     .setNameFormat("hbase-cmd-executor-%d")
+                                     // all the threads should be created as 'cdap'
+                                     .setThreadFactory(Executors.privilegedThreadFactory())
+                                     .setNameFormat("hbase-queue-upgrader-%d")
                                      .setDaemon(true)
                                      .build());
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -101,7 +101,9 @@ public class DatasetUpgrader extends AbstractUpgrader {
     ExecutorService executor =
       Executors.newFixedThreadPool(numThreads,
                                    new ThreadFactoryBuilder()
-                                     .setNameFormat("hbase-cmd-executor-%d")
+                                     // all the threads should be created as 'cdap'
+                                     .setThreadFactory(Executors.privilegedThreadFactory())
+                                     .setNameFormat("dataset-upgrader-%d")
                                      .setDaemon(true)
                                      .build());
     try {

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/ImpersonationUtils.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/ImpersonationUtils.java
@@ -73,12 +73,7 @@ public final class ImpersonationUtils {
     return new Callable<T>() {
       @Override
       public T call() throws Exception {
-        return impersonator.doAs(namespaceMeta.getNamespaceId(), new Callable<T>() {
-          @Override
-          public T call() throws Exception {
-            return callable.call();
-          }
-        });
+        return impersonator.doAs(namespaceMeta.getNamespaceId(), callable);
       }
     };
   }


### PR DESCRIPTION
[CDAP-11815](https://issues.cask.co/browse/CDAP-11815) Fix DatasetUpgrader#upgrade and HBaseQueueAdmin#upgrade.

If the thread in the threadpool is created while impersonating 'alice', then when it is reused for other tables, it will attempt to do impersonation as the table owner, but it will unable to be do so, due to the logic here:
https://github.com/caskdata/cdap/blob/v4.1.1/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultImpersonator.java#L87-L93

This change makes it so that all threads are created as the cdap system user (kerberos principal).