### PR TITLE
Asynchronously start scheduler and improve schedule migration

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
@@ -24,6 +24,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.StreamSizeTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import co.cask.cdap.internal.schedule.StreamSizeSchedule;
@@ -140,15 +141,6 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
   }
 
   @Override
-  public void schedule(ProgramId programId, SchedulableProgramType programType, Schedule schedule,
-                       Map<String, String> properties) throws SchedulerException {
-    Scheduler scheduler;
-    scheduler = getScheduler(schedule);
-
-    scheduler.schedule(programId, programType, schedule, properties);
-  }
-
-  @Override
   public List<ScheduledRuntime> previousScheduledRuntime(ProgramId program, SchedulableProgramType programType)
     throws SchedulerException {
     return timeScheduler.previousScheduledRuntime(program, programType);
@@ -193,7 +185,25 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
                                              String scheduleName)
     throws SchedulerException, NotFoundException {
     Scheduler scheduler = getSchedulerForSchedule(program, scheduleName);
-    return scheduler.scheduleState(program, programType, scheduleName);
+    ProgramScheduleStatus status;
+    try {
+      status = scheduler.scheduleState(program, programType, scheduleName);
+    } catch (NotFoundException e) {
+      // Directly throw the NotFoundException if scheduler has already been started
+      if (scheduler instanceof TimeScheduler) {
+        if (((TimeScheduler) scheduler).isStarted()) {
+          throw e;
+        }
+      } else {
+        if (((StreamSizeScheduler) scheduler).isStarted()) {
+          throw e;
+        }
+      }
+      // Schedules may not be all read into memory before scheduler fully starts,
+      // throw ServiceUnavailableException to retry next time
+      throw new ServiceUnavailableException(this.getClass().getSimpleName());
+    }
+    return status;
   }
 
   public static String scheduleIdFor(ProgramId program, SchedulableProgramType programType, String scheduleName) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/NoOpScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/NoOpScheduler.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.internal.app.runtime.schedule;
 
 import co.cask.cdap.api.schedule.SchedulableProgramType;
-import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.ScheduledRuntime;
@@ -25,7 +24,6 @@ import co.cask.cdap.proto.id.ProgramId;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Noop scheduler.
@@ -48,12 +46,6 @@ public class NoOpScheduler implements Scheduler {
 
   @Override
   public void resumeProgramSchedule(ProgramSchedule schedule) throws NotFoundException, SchedulerException {
-
-  }
-
-  @Override
-  public void schedule(ProgramId program, SchedulableProgramType programType, Schedule schedule,
-                       Map<String, String> properties) throws SchedulerException {
 
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/Scheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/Scheduler.java
@@ -74,18 +74,6 @@ public interface Scheduler {
   void resumeProgramSchedule(ProgramSchedule schedule) throws NotFoundException, SchedulerException;
 
   /**
-   * Schedule a program to be run in a defined schedule.
-   *
-   * @param program Program that needs to be run.
-   * @param programType type of program.
-   * @param schedule Schedule with which the program runs.
-   * @param properties system properties to be passed to the schedule
-   * @throws SchedulerException on unforeseen error.
-   */
-  void schedule(ProgramId program, SchedulableProgramType programType, Schedule schedule,
-                Map<String, String> properties) throws SchedulerException;
-
-  /**
    * Get the previous run time for the program. A program may contain one or more schedules
    * the method returns the previous runtimes for all the schedules. This method only takes
    + into account {@link Schedule}s based on time. For schedules based on data, an empty list will

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.metrics.MetricDataQuery;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
-import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -233,14 +232,6 @@ public class StreamSizeScheduler implements Scheduler {
   public void resumeProgramSchedule(ProgramSchedule schedule) throws NotFoundException, SchedulerException {
     resumeSchedule(schedule.getProgramId(), schedule.getProgramId().getType().getSchedulableType(),
                    schedule.getName());
-  }
-
-  @Override
-  public void schedule(ProgramId program, SchedulableProgramType programType, Schedule schedule,
-                       Map<String, String> properties) throws SchedulerException {
-    Preconditions.checkArgument(schedule instanceof StreamSizeSchedule,
-                                "Schedule should be of type StreamSizeSchedule");
-    scheduleStreamSizeSchedule(program, programType, properties, (StreamSizeSchedule) schedule);
   }
 
   private void scheduleStreamSizeSchedule(ProgramId program, SchedulableProgramType programType,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -150,8 +150,6 @@ public class AppFabricServer extends AbstractIdleService {
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.APP_FABRIC_HTTP));
-    // TODO: [CDAP-11862] Start CoreSchedulerService synchronously once schedule migration is removed
-    coreSchedulerService.start();
     Futures.allAsList(
       ImmutableList.of(
         notificationService.start(),
@@ -160,7 +158,8 @@ public class AppFabricServer extends AbstractIdleService {
         programRuntimeService.start(),
         streamCoordinatorClient.start(),
         programLifecycleService.start(),
-        pluginService.start()
+        pluginService.start(),
+        coreSchedulerService.start()
       )
     ).get();
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.internal.guice;
 
 import co.cask.cdap.api.schedule.SchedulableProgramType;
-import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
@@ -67,7 +66,6 @@ import org.apache.hadoop.conf.Configuration;
 
 import java.io.File;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -153,11 +151,6 @@ public final class AppFabricTestModule extends AbstractModule {
 
       @Override
       public void resumeProgramSchedule(ProgramSchedule schedule) throws NotFoundException, SchedulerException {
-      }
-
-      @Override
-      public void schedule(ProgramId program, SchedulableProgramType programType, Schedule schedule,
-                           Map<String, String> properties) {
       }
 
       @Override


### PR DESCRIPTION
https://builds.cask.co/browse/CDAP-DUT5853-JOB1-3
Tested on clusters with two cases:
1. Always throw `ServiceUnavailableException` from `CoreSchedulerService#migrateSchedules`, but was able to stop cdap-master successfully when `CoreSchedulerService` keeps retrying starting up.
2. On a CM cluster, deployed apps with schedules in 4.1 and upgraded to 4.2. All schedules were migrated successfully in all namespaces. `ServiceUnavailableException` was thrown when `TimeScheduler` or `StreamSizeScheduler` were not fully started yet, and `CoreSchedulerService` keeps retrying to migrate the same namespace.