### PR TITLE
Throw an exception if a non-cdap user tries to impersonate another user.

### DIFF
--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultImpersonator.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultImpersonator.java
@@ -83,13 +83,14 @@ public class DefaultImpersonator implements Impersonator {
     }
 
     ImpersonationRequest impersonationRequest = new ImpersonationRequest(entityId, impersonatedOpType);
-    // if the current user is not same as cdap master user then it means we are already impersonating some user
-    // and hence we should not allow another impersonation. See CDAP-8641
-    if (!UserGroupInformation.getCurrentUser().getShortUserName().equals(masterShortUsername)) {
-      LOG.trace("Not impersonating for {} as the call is already impersonated as {}",
-                impersonationRequest, UserGroupInformation.getCurrentUser());
-      return UserGroupInformation.getCurrentUser();
+    UserGroupInformation configuredUGI = ugiProvider.getConfiguredUGI(impersonationRequest).getUGI();
+    // Only cdap master user is allowed to impersonate another user besides itself. See CDAP-8641
+    String currUserShortName = UserGroupInformation.getCurrentUser().getShortUserName();
+    if (currUserShortName.equals(masterShortUsername) || currUserShortName.equals(configuredUGI.getShortUserName())) {
+      return configuredUGI;
     }
-    return ugiProvider.getConfiguredUGI(impersonationRequest).getUGI();
+    throw new IllegalStateException(String.format("Invalid impersonation request made by the system. " +
+                                                    "User %s is not allowed to impersonate user %s.",
+                                                  UserGroupInformation.getCurrentUser(), configuredUGI));
   }
 }


### PR DESCRIPTION
Throw an exception if a non-cdap user tries to impersonate another user. This helps avoid issues (or find them earlier), such as CDAP-11815.

Previously, the behavior was that if a non-cdap user tries to impersonate at all, there would be a log message at level TRACE.

https://builds.cask.co/browse/CDAP-DUT5855-2