### PR TITLE
CDAP-11873 CDAP–11880 Fix for not impersonate dataset created at runtime

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -78,6 +78,7 @@ import co.cask.cdap.proto.Notification;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.KerberosPrincipalId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.ProgramId;
@@ -188,9 +189,15 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.pluginInstantiator = pluginInstantiator;
     this.pluginContext = new DefaultPluginContext(pluginInstantiator, program.getId(),
                                                   program.getApplicationSpecification().getPlugins());
+    String appPrincipalExists = programOptions.getArguments().getOption(ProgramOptionConstants.APP_PRINCIPAL_EXISTS);
+    KerberosPrincipalId principalId = null;
+    if (appPrincipalExists != null && Boolean.parseBoolean(appPrincipalExists)) {
+      String principal = programOptions.getArguments().getOption(ProgramOptionConstants.PRINCIPAL);
+      principalId = principal == null ? null : new KerberosPrincipalId(principal);
+    }
     this.admin = new DefaultAdmin(dsFramework, program.getId().getNamespaceId(), secureStoreManager,
                                   new BasicMessagingAdmin(messagingService, program.getId().getNamespaceId()),
-                                  retryStrategy);
+                                  retryStrategy, principalId);
     this.secureStore = secureStore;
     this.defaultTxTimeout = determineTransactionTimeout(cConf);
     this.transactional = Transactions.createTransactional(getDatasetCache(), defaultTxTimeout);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -192,8 +192,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     String appPrincipalExists = programOptions.getArguments().getOption(ProgramOptionConstants.APP_PRINCIPAL_EXISTS);
     KerberosPrincipalId principalId = null;
     if (appPrincipalExists != null && Boolean.parseBoolean(appPrincipalExists)) {
-      String principal = programOptions.getArguments().getOption(ProgramOptionConstants.PRINCIPAL);
-      principalId = principal == null ? null : new KerberosPrincipalId(principal);
+      principalId = new KerberosPrincipalId(programOptions.getArguments().getOption(ProgramOptionConstants.PRINCIPAL));
     }
     this.admin = new DefaultAdmin(dsFramework, program.getId().getNamespaceId(), secureStoreManager,
                                   new BasicMessagingAdmin(messagingService, program.getId().getNamespaceId()),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
@@ -26,6 +26,7 @@ import co.cask.cdap.common.service.RetryStrategies;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.datafabric.dataset.DefaultDatasetManager;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.proto.id.KerberosPrincipalId;
 import co.cask.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
@@ -45,7 +46,7 @@ public class DefaultAdmin extends DefaultDatasetManager implements Admin {
    * Creates an instance without messaging admin support.
    */
   public DefaultAdmin(DatasetFramework dsFramework, NamespaceId namespace, SecureStoreManager secureStoreManager) {
-    this(dsFramework, namespace, secureStoreManager, null, RetryStrategies.noRetry());
+    this(dsFramework, namespace, secureStoreManager, null, RetryStrategies.noRetry(), null);
   }
 
   /**
@@ -53,8 +54,8 @@ public class DefaultAdmin extends DefaultDatasetManager implements Admin {
    */
   public DefaultAdmin(DatasetFramework dsFramework, NamespaceId namespace,
                       SecureStoreManager secureStoreManager, @Nullable MessagingAdmin messagingAdmin,
-                      RetryStrategy retryStrategy) {
-    super(dsFramework, namespace, retryStrategy);
+                      RetryStrategy retryStrategy, KerberosPrincipalId principalId) {
+    super(dsFramework, namespace, retryStrategy, principalId);
     this.secureStoreManager = secureStoreManager;
     this.messagingAdmin = messagingAdmin;
     this.retryStrategy = retryStrategy;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -76,7 +76,11 @@ public final class ProgramOptionConstants {
   /**
    * Options for impersonation
    */
+  // This is the principal that the program will be run as. Currently, it will be either the app principal if that
+  // exists or it will be the namespace principal.
   public static final String PRINCIPAL = "principal";
+
+  public static final String APP_PRINCIPAL_EXISTS = "appPrincipalExists";
 
   public static final String KEYTAB_URI = "keytabURI";
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -515,8 +515,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     String appPrincipalExists = programOptions.getArguments().getOption(ProgramOptionConstants.APP_PRINCIPAL_EXISTS);
     KerberosPrincipalId principalId = null;
     if (appPrincipalExists != null && Boolean.parseBoolean(appPrincipalExists)) {
-      String principal = programOptions.getArguments().getOption(ProgramOptionConstants.PRINCIPAL);
-      principalId = principal == null ? null : new KerberosPrincipalId(principal);
+      principalId = new KerberosPrincipalId(programOptions.getArguments().getOption(ProgramOptionConstants.PRINCIPAL));
     }
 
     final KerberosPrincipalId finalPrincipalId = principalId;
@@ -531,8 +530,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
           @Override
           public Void call() throws Exception {
             DatasetProperties properties = addLocalDatasetProperty(instanceSpec.getProperties());
-            // we have to do this check since sometimes addInstance method can only be used when app impersonation is
-            // enabled
+            // we have to do this check since addInstance method can only be used when app impersonation is enabled
             if (finalPrincipalId != null) {
               datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId, properties, finalPrincipalId);
             } else {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
@@ -66,6 +66,8 @@ public class PropertiesResolver {
     if (SecurityUtil.isKerberosEnabled(cConf)) {
       ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, id.toEntityId());
       systemArgs.put(ProgramOptionConstants.PRINCIPAL, impersonationInfo.getPrincipal());
+      systemArgs.put(ProgramOptionConstants.APP_PRINCIPAL_EXISTS,
+                     String.valueOf(ownerAdmin.exists(id.toEntityId().getParent())));
     }
     return systemArgs;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetManager.java
@@ -105,8 +105,7 @@ public class DefaultDatasetManager implements DatasetManager {
       @Override
       public Void call() throws DatasetManagementException {
         try {
-          // we have to do this check since sometimes addInstance method can only be used when app impersonation is
-          // enabled
+          // we have to do this check since addInstance method can only be used when app impersonation is enabled
           if (principalId != null) {
             datasetFramework.addInstance(type, createInstanceId(name), properties, principalId);
           } else {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DefaultDatasetManager.java
@@ -26,9 +26,11 @@ import co.cask.cdap.common.service.Retries;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.KerberosPrincipalId;
 import co.cask.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
+import javax.annotation.Nullable;
 
 /**
  * Default implementation of {@link DatasetManager} that performs operation via {@link DatasetFramework}.
@@ -38,20 +40,24 @@ public class DefaultDatasetManager implements DatasetManager {
   private final DatasetFramework datasetFramework;
   private final NamespaceId namespaceId;
   private final RetryStrategy retryStrategy;
+  @Nullable
+  private final KerberosPrincipalId principalId;
 
   /**
    * Constructor.
-   *
    * @param datasetFramework the {@link DatasetFramework} to use for performing the actual operation
    * @param namespaceId the {@link NamespaceId} for all dataset managed through this class
    * @param retryStrategy the {@link RetryStrategy} to use for {@link RetryableException}.
+   * @param principalId the {@link KerberosPrincipalId} for all datasets created.
    */
   public DefaultDatasetManager(DatasetFramework datasetFramework,
                                NamespaceId namespaceId,
-                               RetryStrategy retryStrategy) {
+                               RetryStrategy retryStrategy,
+                               @Nullable KerberosPrincipalId principalId) {
     this.datasetFramework = datasetFramework;
     this.namespaceId = namespaceId;
     this.retryStrategy = retryStrategy;
+    this.principalId = principalId;
   }
 
   @Override
@@ -99,7 +105,13 @@ public class DefaultDatasetManager implements DatasetManager {
       @Override
       public Void call() throws DatasetManagementException {
         try {
-          datasetFramework.addInstance(type, createInstanceId(name), properties);
+          // we have to do this check since sometimes addInstance method can only be used when app impersonation is
+          // enabled
+          if (principalId != null) {
+            datasetFramework.addInstance(type, createInstanceId(name), properties, principalId);
+          } else {
+            datasetFramework.addInstance(type, createInstanceId(name), properties);
+          }
         } catch (IOException ioe) {
           // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
           throw new DatasetManagementException(String.format("Failed to add instance %s, details: %s",

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -145,6 +145,9 @@ public interface DatasetFramework {
    * method to build {@link DatasetSpecification} which describes dataset instance
    * and later used to initialize {@link DatasetAdmin} and {@link Dataset} for the dataset instance.
    *
+   * Note this method can only be used when app impersonation is enabled, since it will assume the keytab url is in the
+   * default keytab path.
+   *
    * @param datasetTypeName dataset instance type name
    * @param datasetInstanceId dataset instance name
    * @param props dataset instance properties

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/AbstractAppenderContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/AbstractAppenderContext.java
@@ -54,7 +54,7 @@ public abstract class AbstractAppenderContext extends AppenderContext {
     // No need to have retry for dataset admin operations
     // The log framework itself will perform retries and state management
     this.datasetManager = new DefaultDatasetManager(datasetFramework, NamespaceId.SYSTEM,
-                                                    co.cask.cdap.common.service.RetryStrategies.noRetry());
+                                                    co.cask.cdap.common.service.RetryStrategies.noRetry(), null);
     this.transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(datasetFramework), txClient,

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/system/LogFileManagerTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/system/LogFileManagerTest.java
@@ -119,7 +119,8 @@ public class LogFileManagerTest {
     long maxFileSizeInBytes = 104857600;
     DatasetManager datasetManager = new DefaultDatasetManager(injector.getInstance(DatasetFramework.class),
                                                               NamespaceId.SYSTEM,
-                                                              co.cask.cdap.common.service.RetryStrategies.noRetry());
+                                                              co.cask.cdap.common.service.RetryStrategies.noRetry(),
+                                                              null);
     Transactional transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(injector.getInstance(DatasetFramework.class)),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/clean/FileMetadataCleanerTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/clean/FileMetadataCleanerTest.java
@@ -139,7 +139,8 @@ public class FileMetadataCleanerTest {
     // scan for old files and make sure we only get the old meta data entries.
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     DatasetManager datasetManager = new DefaultDatasetManager(datasetFramework, NamespaceId.SYSTEM,
-                                                              co.cask.cdap.common.service.RetryStrategies.noRetry());
+                                                              co.cask.cdap.common.service.RetryStrategies.noRetry(),
+                                                              null);
     Transactional transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(datasetFramework), injector.getInstance(TransactionSystemClient.class),
@@ -254,7 +255,8 @@ public class FileMetadataCleanerTest {
     // scan for old files and make sure we only get the old meta data entries.
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     DatasetManager datasetManager = new DefaultDatasetManager(datasetFramework, NamespaceId.SYSTEM,
-                                                              co.cask.cdap.common.service.RetryStrategies.noRetry());
+                                                              co.cask.cdap.common.service.RetryStrategies.noRetry(),
+                                                              null);
     Transactional transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(datasetFramework), injector.getInstance(TransactionSystemClient.class),
@@ -376,7 +378,8 @@ public class FileMetadataCleanerTest {
   public void testFileMetadataWithCommonContextPrefix() throws Exception {
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     DatasetManager datasetManager = new DefaultDatasetManager(datasetFramework, NamespaceId.SYSTEM,
-                                                              co.cask.cdap.common.service.RetryStrategies.noRetry());
+                                                              co.cask.cdap.common.service.RetryStrategies.noRetry(),
+                                                              null);
     Transactional transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(datasetFramework), injector.getInstance(TransactionSystemClient.class),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/clean/LogCleanerTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/clean/LogCleanerTest.java
@@ -118,7 +118,8 @@ public class LogCleanerTest {
     // scan for old files and make sure we only get the old meta data entries.
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     DatasetManager datasetManager = new DefaultDatasetManager(datasetFramework, NamespaceId.SYSTEM,
-                                                              co.cask.cdap.common.service.RetryStrategies.noRetry());
+                                                              co.cask.cdap.common.service.RetryStrategies.noRetry(),
+                                                              null);
     Transactional transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(datasetFramework), injector.getInstance(TransactionSystemClient.class),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/read/FileMetadataTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/read/FileMetadataTest.java
@@ -121,7 +121,8 @@ public class FileMetadataTest {
   public void testFileMetadataReadWrite() throws Exception {
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     DatasetManager datasetManager = new DefaultDatasetManager(datasetFramework, NamespaceId.SYSTEM,
-                                                              co.cask.cdap.common.service.RetryStrategies.noRetry());
+                                                              co.cask.cdap.common.service.RetryStrategies.noRetry(),
+                                                              null);
     Transactional transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(datasetFramework), injector.getInstance(TransactionSystemClient.class),
@@ -169,7 +170,8 @@ public class FileMetadataTest {
   public void testFileMetadataReadWriteAcrossFormats() throws Exception {
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     DatasetManager datasetManager = new DefaultDatasetManager(datasetFramework, NamespaceId.SYSTEM,
-                                                              co.cask.cdap.common.service.RetryStrategies.noRetry());
+                                                              co.cask.cdap.common.service.RetryStrategies.noRetry(),
+                                                              null);
     Transactional transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
         new SystemDatasetInstantiator(datasetFramework), injector.getInstance(TransactionSystemClient.class),


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-11880
https://issues.cask.co/browse/CDAP-11873

Build: https://builds.cask.co/browse/CDAP-DUT5858-2

We need to know the principal is coming from the app or the namespace, since datasetFramework.addInstance(..., ..., principalId) can only be used for app impersonation, since we will assume keytab url of this principal to be present in the default keytab path, which is not true for namespace impersonation.