### PR TITLE
[CDAP-9532] Adds Encode and Decode point and click directives to dataprep

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/ColumnActionsDropdown.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/ColumnActionsDropdown.scss
@@ -19,8 +19,10 @@ $dropdown-expanded-caret-bg-color: #999999;
 $action-item-bg-color: white;
 $action-item-hover-color: #eeeeee;
 $action-item-active-color: #dddddd;
+$action-item-font-color: #373a3c;
 $action-item-action-font-color: #333333;
 $action-item-font-family: Helvetica, Arial, sans-serif;
+$action-item-disabled-color: lighten($action-item-font-color, 50%);
 
 .column-actions-dropdown-container {
   > .fa.fa-caret-down {
@@ -42,8 +44,12 @@ $action-item-font-family: Helvetica, Arial, sans-serif;
     box-shadow: 1px 1px 5px $border-shadow-color;
 
     .disabled {
-      pointer-events: none;
-      opacity: 0.5;
+      /* using color here instead of just opacity, because this class might be applied multiple times */
+      color: $action-item-disabled-color;
+
+      .action-item {
+        cursor: not-allowed;
+      }
     }
 
     .column-action-divider {
@@ -67,6 +73,10 @@ $action-item-font-family: Helvetica, Arial, sans-serif;
 
     &.active {
       background-color: $action-item-active-color;
+    }
+
+    &.disabled {
+      cursor: not-allowed;
     }
 
     .second-level-popover {

--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -39,6 +39,10 @@ import ExtractFields from 'components/DataPrep/Directives/ExtractFields';
 import Format from 'components/DataPrep/Directives/Format';
 import Explode from 'components/DataPrep/Directives/Explode';
 import MaskData from 'components/DataPrep/Directives/MaskData';
+import EncodeDecode from 'components/DataPrep/Directives/EncodeDecode';
+import Decode from 'components/DataPrep/Directives/Decode';
+import SetCharacterEncoding from 'components/DataPrep/Directives/SetCharacterEncoding';
+
 import ee from 'event-emitter';
 
 require('./ColumnActionsDropdown.scss');
@@ -138,7 +142,24 @@ export default class ColumnActionsDropdown extends Component {
       },
       {
         id: shortid.generate(),
-        tag: MaskData,
+        tag: MaskData
+      },
+      {
+        tag: 'divider'
+      },
+      {
+        id: shortid.generate(),
+        tag: EncodeDecode,
+        requiredColCount: 1
+      },
+      {
+        id: shortid.generate(),
+        tag: Decode,
+        requiredColCount: 1
+      },
+      {
+        id: shortid.generate(),
+        tag: SetCharacterEncoding,
         requiredColCount: 1
       }
     ];
@@ -258,23 +279,23 @@ export default class ColumnActionsDropdown extends Component {
                   } else if (directive.requiredColCount === 2) {
                     disabled = true;
                   }
-
-                  return (
-                    <div
-                      key={directive.id}
-                      onClick={this.directiveClick.bind(this, directive.id)}
-                      className={classnames({'disabled': disabled})}
-                    >
-                      <Tag
-                        column={column}
-                        onComplete={this.toggleDropdown.bind(this, false)}
-                        isOpen={this.state.open === directive.id}
-                        close={this.directiveClick.bind(this, null)}
-                      />
-                    </div>
-                  );
-                })
-              }
+                return (
+                  <div
+                    key={directive.id}
+                    onClick={!disabled && this.directiveClick.bind(this, directive.id)}
+                    className={classnames({'disabled': disabled})}
+                  >
+                    <Tag
+                      column={column}
+                      onComplete={this.toggleDropdown.bind(this, false)}
+                      isOpen={this.state.open === directive.id}
+                      isDisabled={disabled}
+                      close={this.directiveClick.bind(this, null)}
+                    />
+                  </div>
+                );
+              })
+            }
           </ScrollableList>
         </PopoverContent>
       </Popover>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Decode/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Decode/index.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {PropTypes} from 'react';
+import EncodeDecode from 'components/DataPrep/Directives/EncodeDecode';
+import T from 'i18n-react';
+
+const PREFIX = 'features.DataPrep.Directives.Decode';
+
+const DECODEOPTIONS = [
+  {
+    label: T.translate(`${PREFIX}.base64`),
+    getDirective: (column) => `decode base64 ${column}`
+  },
+  {
+    label: T.translate(`${PREFIX}.base32`),
+    getDirective: (column) => `decode base32 ${column}`
+  },
+  {
+    label: T.translate(`${PREFIX}.hex`),
+    getDirective: (column) => `decode hex ${column}`
+  },
+  {
+    label: T.translate(`${PREFIX}.urldecode`),
+    getDirective: (column) => `url-decode ${column}`
+  }
+];
+export default function Decode({onComplete, column, isOpen}) {
+  return (
+    <EncodeDecode
+      options={DECODEOPTIONS}
+      directive="decode"
+      onComplete={onComplete}
+      column={column}
+      isOpen={isOpen}
+      mainMenuLabel={T.translate(`${PREFIX}.title`)}
+    />
+  );
+}
+
+Decode.propTypes = {
+  onComplete: PropTypes.func,
+  column: PropTypes.string,
+  isOpen: PropTypes.bool
+};

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/EncodeDecode/EncodeDecode.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/EncodeDecode/EncodeDecode.scss
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+$option-hover-bg-color: #dddddd;
+
+.dataprep-columns-action-dropdown {
+  .encode-decode-directive {
+    &.action-item {
+      .encode-decode-options {
+        padding: 0;
+
+        .option {
+          padding: 10px;
+          cursor: pointer;
+          line-height: 1.5;
+          font-size: 13px;
+
+          &:hover {
+            background-color: $option-hover-bg-color;
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, { Component, PropTypes } from 'react';
+import T from 'i18n-react';
+import classnames from 'classnames';
+import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
+import DataPrepStore from 'components/DataPrep/store';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import {UncontrolledTooltip} from 'components/UncontrolledComponents';
+import debounce from 'lodash/debounce';
+import {setPopoverOffset} from 'components/DataPrep/helper';
+import {preventPropagation} from 'services/helpers';
+
+require('./EncodeDecode.scss');
+const PREFIX = 'features.DataPrep.Directives.Encode';
+const ENCODEOPTIONS = [
+  {
+    label: T.translate(`${PREFIX}.base64`),
+    getDirective: (column) => `encode base64 ${column}`
+  },
+  {
+    label: T.translate(`${PREFIX}.base32`),
+    getDirective: (column) => `encode base32 ${column}`
+  },
+  {
+    label: T.translate(`${PREFIX}.hex`),
+    getDirective: (column) => `encode hex ${column}`
+  },
+  {
+    label: T.translate(`${PREFIX}.url`),
+    getDirective: (column) => `url-encode ${column}`
+  }
+];
+export default class EncodeDecode extends Component {
+  constructor(props) {
+    super(props);
+    this.preventPropagation = preventPropagation;
+  }
+  componentDidUpdate() {
+    if (this.props.isOpen && !this.props.isDisabled && this.calculateOffset) {
+      this.calculateOffset();
+    }
+  }
+
+  componentDidMount() {
+    this.calculateOffset = setPopoverOffset.bind(this, document.getElementById(`${this.props.directive}-directive`));
+    this.offsetCalcDebounce = debounce(this.calculateOffset, 1000);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.offsetCalcDebounce);
+  }
+
+  applyDirective({getDirective = () => {}}) {
+    let directive = getDirective(this.props.column);
+    if (!directive) {
+      return;
+    }
+    execute([directive])
+      .subscribe(
+        () => {
+          this.props.onComplete();
+        },
+        (err) => {
+          console.log('error', err);
+
+          DataPrepStore.dispatch({
+            type: DataPrepActions.setError,
+            payload: {
+              message: err.message || err.response.message
+            }
+          });
+        }
+      );
+  }
+  renderDetail() {
+    if (!this.props.isOpen || this.props.isDisabled) {
+      return;
+    }
+    return (
+      <div
+        className="encode-decode-options second-level-popover"
+        onClick={this.preventPropagation}
+      >
+        {
+          this.props.options.map((option, i) => {
+            return (
+              <div
+                className="option"
+                key={i}
+                onClick={this.applyDirective.bind(this, option)}
+              >
+                {option.label}
+              </div>
+            );
+          })
+        }
+      </div>
+    );
+  }
+  render() {
+    let id = `${this.props.directive}-directive`;
+    return (
+      <div>
+        <div
+          id={id}
+          className={classnames('encode-decode-directive clearfix action-item', {
+            'active': this.props.isOpen && !this.props.isDisabled,
+            'disabled': this.props.isDisabled
+          })}
+        >
+          <span>{this.props.mainMenuLabel}</span>
+
+          <span className="float-xs-right">
+            <span className="fa fa-caret-right" />
+          </span>
+
+          {this.renderDetail()}
+        </div>
+        {
+          this.props.isDisabled && this.props.disabledTooltip ? (
+            <UncontrolledTooltip
+              target={id}
+              delay={{show: 250, hide: 0}}
+            >
+              {this.props.disabledTooltip}
+            </UncontrolledTooltip>
+          ) : null
+        }
+      </div>
+    );
+  }
+}
+
+EncodeDecode.defaultProps = {
+  options: ENCODEOPTIONS,
+  directive: 'encode',
+  mainMenuLabel: T.translate(`${PREFIX}.title`)
+};
+
+EncodeDecode.propTypes = {
+  column: PropTypes.string,
+  isOpen: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  disabledTooltip: PropTypes.string,
+  onComplete: PropTypes.func,
+  options: PropTypes.arrayOf(PropTypes.object),
+  directive: PropTypes.string,
+  mainMenuLabel: PropTypes.string
+};

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/SetCharacterEncoding/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/SetCharacterEncoding/index.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {PropTypes} from 'react';
+import EncodeDecode from 'components/DataPrep/Directives/EncodeDecode';
+import DataPrepStore from 'components/DataPrep/store';
+import T from 'i18n-react';
+
+const PREFIX = 'features.DataPrep.Directives.SetCharEncoding';
+
+const CHARENCODINGOPTIONS = [
+  {
+    label: T.translate(`${PREFIX}.utf8`),
+    getDirective: (column) => `set-charset ${column} utf-8`
+  },
+  {
+    label: T.translate(`${PREFIX}.utf16`),
+    getDirective: (column) => `set-charset ${column} utf-16`
+  },
+  {
+    label: T.translate(`${PREFIX}.usascii`),
+    getDirective: (column) => `set-charset ${column} us-ascii`
+  },
+  {
+    label: T.translate(`${PREFIX}.iso88591`),
+    getDirective: (column) => `set-charset ${column} iso-8859-1`
+  },
+  {
+    label: T.translate(`${PREFIX}.utf16be`),
+    getDirective: (column) => `set-charset ${column} utf-16be`
+  },
+  {
+    label: T.translate(`${PREFIX}.utf16le`),
+    getDirective: (column) => `set-charset ${column} utf-16le`
+  }
+];
+
+export default function Decode({onComplete, column, isOpen}) {
+  let {types} = DataPrepStore.getState().dataprep;
+  let disabled = types[column] !== 'byte[]';
+  let disabledTooltip = T.translate(`${PREFIX}.disabledTooltip`);
+
+  return (
+    <EncodeDecode
+      options={CHARENCODINGOPTIONS}
+      directive="set-char-encoding"
+      onComplete={onComplete}
+      column={column}
+      isOpen={isOpen}
+      isDisabled={disabled}
+      disabledTooltip={disabledTooltip}
+      mainMenuLabel={T.translate(`${PREFIX}.title`)}
+    />
+  );
+}
+
+Decode.propTypes = {
+  onComplete: PropTypes.func,
+  column: PropTypes.string,
+  isOpen: PropTypes.bool
+};

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
@@ -49,7 +49,7 @@ export default class SwapColumnsDirective extends Component {
     return (
       <div
         className="swap-column-directive clearfix action-item"
-        onClick={this.applyDirective}
+        onClick={!this.props.isDisabled && this.applyDirective}
       >
         <span>
           {T.translate('features.DataPrep.Directives.Swap.title')}
@@ -61,5 +61,6 @@ export default class SwapColumnsDirective extends Component {
 
 SwapColumnsDirective.propTypes = {
   column: PropTypes.array,
-  onComplete: PropTypes.func
+  onComplete: PropTypes.func,
+  isDisabled: PropTypes.bool
 };

--- a/cdap-ui/app/cdap/components/DataPrep/helper.js
+++ b/cdap-ui/app/cdap/components/DataPrep/helper.js
@@ -45,23 +45,26 @@ export function isCustomOption(selectedOption) {
   return selectedOption.substr(0, 6) === 'CUSTOM';
 }
 
-export function setPopoverOffset(element, header_height = 50, footer_height = 54) {
+export function setPopoverOffset(element, footer_height = 54) {
   let elem = element;
   let elemBounding = elem.getBoundingClientRect();
-
   const FOOTER_HEIGHT = footer_height;
 
   let popover = document.getElementsByClassName('second-level-popover');
   let popoverHeight = popover[0].getBoundingClientRect().height;
   let tableContainerScroll = document.getElementById('dataprep-table-id').scrollTop;
   let popoverMenuItemTop = elemBounding.top;
-  let bodyBottom = document.body.getBoundingClientRect().bottom + FOOTER_HEIGHT; // Since we have footer absolutely positioned.
+  let bodyBottom = document.body.getBoundingClientRect().bottom - FOOTER_HEIGHT;
 
   let diff = bodyBottom - (popoverMenuItemTop + popoverHeight) - tableContainerScroll;
 
   if (diff < 0) {
-    diff = diff - 5; // Give that extra margin at the bottom just so that the menu doesn't stick to the bottom of the browser.
     popover[0].style.top = `${diff}px`;
+    // This is to align the bottom of second level popover menu with that of the main menu
+    if (elemBounding.bottom > popover[0].getBoundingClientRect().bottom) {
+      popover[0].style.bottom = `-1px`;
+      popover[0].style.top = 'inherit';
+    }
   } else {
     popover[0].style.top = 0;
   }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -410,10 +410,22 @@ features:
         popoverTitle: Extract Using Position
       CutMenuItem:
         menuLabel: Using Positions
+      Decode:
+        base32: Base32
+        base64: Base64
+        hex: Hex
+        title: Decode
+        urldecode: URL
       Drop:
         title:
           plural: Delete Selected Columns
           singular: Delete Column
+      Encode:
+        base32: Base32
+        base64: Base64
+        hex: Hex
+        title: Encode
+        url: URL
       Explode:
         title: Explode
         filtersSubmenuTitle: Delimited Text
@@ -611,6 +623,15 @@ features:
             label: XML to JSON
             placeholder: Enter depth
         title: Parse
+      SetCharEncoding:
+        disabledTooltip: Character encoding can only be set on columns of type byte array
+        iso88591: ISO-8859-1
+        title: Set Character Encoding
+        usascii: US-ASCII
+        utf16: UTF-16
+        utf16be: UTF-16BE
+        utf16le: UTF-16LE
+        utf8: UTF-8
       Swap:
         title: Swap Two Column Names
     pageTitle: CDAP | Data Preparation


### PR DESCRIPTION
- Adds EncodeDecode component to handle both encoding and decoding data in dataprep 
- Disables certain decode options that require the column to be of type `byte[]`.

JIRA: https://issues.cask.co/browse/CDAP-9532