### PR TITLE
Update DataCleansingMapReduce to be able to run without being provided runtime args

### DIFF
--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -139,7 +139,7 @@ function download_includes() {
   test_an_include 9f963a17090976d2c15a4d092bd9e8de ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
 
   test_an_include 5a0df16e31ae9187160a84b5bb5ad013 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
-  test_an_include cc6989fe673cd88545d73cdaffad1bb1 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+  test_an_include 56b92f6e32879b55363fbde823d5e0ea ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include ce5a99853f6e2d2298888fdf15d3cfb7 ../../cdap-examples/DecisionTreeRegression/src/main/java/co/cask/cdap/examples/dtree/DecisionTreeRegressionApp.java
 

--- a/cdap-docs/examples-manual/source/examples/data-cleansing.rst
+++ b/cdap-docs/examples-manual/source/examples/data-cleansing.rst
@@ -128,7 +128,7 @@ Otherwise, this is the default schema that is matched against the records:
 
 .. literalinclude:: /../../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
     :language: java
-    :lines: 131-135
+    :lines: 134-138
     :dedent: 4
 
 Querying the Results

--- a/cdap-docs/examples-manual/source/examples/data-cleansing.rst
+++ b/cdap-docs/examples-manual/source/examples/data-cleansing.rst
@@ -105,22 +105,21 @@ Begin by uploading a file containing some newline-separated JSON records into th
 
 Starting the MapReduce
 ----------------------
-The MapReduce must be started with a runtime argument ``output.partition.key`` that
-specifies the output partition of the *cleanRecords* dataset to write to. In this
-example, we'll simply use ``1`` as the value.
+The MapReduce can be started with a runtime argument ``output.partition.key`` that
+specifies the output partition of the *cleanRecords* dataset to write to. By default,
+it uses the logical start time of the MapReduce for this value.
 
 - Using the CDAP UI, go to the |application-overview|,
-  click |example-mapreduce-italic| to get to the MapReduce detail page, set the runtime
-  arguments using ``output.partition.key`` as the key and ``1`` as the value, then click
+  click |example-mapreduce-italic| to get to the MapReduce detail page, click
   the *Start* button; or
 - From the CDAP Sandbox home directory, use the Command Line Interface:
 
   .. tabbed-parsed-literal::
 
-      $ cdap cli start mapreduce |example|.\ |example-mapreduce| output.partition.key=1
+      $ cdap cli start mapreduce |example|.\ |example-mapreduce|
 
       Successfully started mapreduce '|example-mapreduce|' of application '|example|'
-      with provided runtime arguments 'output.partition.key=1'
+      with stored runtime arguments '{}'
 
 Optionally, to specify a custom schema to match records against, the JSON of the schema can be
 specified as an additional runtime argument to the MapReduce with the key ``'schema.key'``.
@@ -139,7 +138,7 @@ To sample the *cleanRecords* ``PartitionedFileSet``, execute an explore query us
 
 .. tabbed-parsed-literal::
 
-  $ cdap cli execute "\"SELECT record FROM dataset_cleanRecords where TIME = 1 LIMIT 5\""
+  $ cdap cli execute "\"SELECT record FROM dataset_cleanRecords LIMIT 5\""
 
 - Alternatively, go to the *rawRecords*
   :cdap-ui-datasets-explore:`dataset overview page, explore tab <rawRecords>`

--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
@@ -69,7 +69,8 @@ public class DataCleansingMapReduce extends AbstractMapReduce {
                                    new KVTableStatePersistor(DataCleansing.CONSUMING_STATE, "state.key"));
 
     // Each run writes its output to a partition for the league
-    Long timeKey = Long.valueOf(context.getRuntimeArguments().get(OUTPUT_PARTITION_KEY));
+    String outputPartitionKey = context.getRuntimeArguments().get(OUTPUT_PARTITION_KEY);
+    Long timeKey = outputPartitionKey != null ? Long.valueOf(outputPartitionKey) : context.getLogicalStartTime();
     PartitionKey outputKey = PartitionKey.builder().addLongField("time", timeKey).build();
 
     Map<String, String> metadataToAssign = ImmutableMap.of("source.program", "DataCleansingMapReduce");
@@ -112,7 +113,9 @@ public class DataCleansingMapReduce extends AbstractMapReduce {
 
     @Override
     public void initialize(MapReduceTaskContext<NullWritable, Text> mapReduceTaskContext) {
-      this.time = Long.valueOf(mapReduceTaskContext.getRuntimeArguments().get(OUTPUT_PARTITION_KEY));
+      String outputPartitionKey = mapReduceTaskContext.getRuntimeArguments().get(OUTPUT_PARTITION_KEY);
+      this.time =
+        outputPartitionKey != null ? Long.valueOf(outputPartitionKey) : mapReduceTaskContext.getLogicalStartTime();
       this.jsonParser = new JsonParser();
     }
 


### PR DESCRIPTION
Update DataCleansingMapReduce to be able to run without being provided any runtime arguments.

In case `output.partition.key` is not given in runtime arguments, we will now fallback to using the logical start time for the output partition key.
This allows the containing Workflow to be scheduled without any schedule properties.

https://builds.cask.co/browse/CDAP-RUT1133-1
https://builds.cask.co/browse/CDAP-DQB367-1