### PR TITLE
[CDAP-8419] Modifies resource center modal to assume the height of children 

### DIFF
--- a/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.scss
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.scss
@@ -20,8 +20,11 @@
   overflow-x: hidden;
   position: relative;
 
-  &.modal-dialog {
+  &.cask-market {
     height: 75vh;
+  }
+
+  &.modal-dialog {
     width: 70vw;
     max-width: 1200px;
     margin-top: 120px;
@@ -42,6 +45,40 @@
           display: inline-block;
           height: 100%;
           width: 100%;
+        }
+
+        /*
+          width of each card = 100% (of remaining width after parent's padding) - (combined margin of all cards in the row)
+          margin for each card is 5px (as mentioned above).
+          So the combined margin for all cards in say ,
+            3 column layout : 5px + (5px + 5px) + (5px + 5px) + 5px = (3 * 10px)
+            4 column layout : 5px + (5px + 5px) + (5px + 5px) + (5px + 5px) + 5px = (4 * 10px)
+            5 column layout : 5px + (5px + 5px) + (5px + 5px) + (5px + 5px) + (5px + 5px) + 5px = (5 * 10px)
+            n column layout : (n-1 * 10px);
+        */
+
+        @media (min-width: 1601px) {
+          .resourcecenter-entity-card {
+            width: calc((100% - (4 * 10px)) / 4);
+          }
+        }
+
+        @media (min-width: 1201px) and (max-width: 1600px) {
+          .resourcecenter-entity-card {
+            width: calc((100% - (3 * 10px)) / 3);
+          }
+        }
+
+        @media (min-width: 992px) and (max-width: 1200px) {
+          .resourcecenter-entity-card {
+            width: calc((100% - (2 * 10px)) / 2);
+          }
+        }
+
+        @media(max-width: 991px) {
+          .resourcecenter-entity-card {
+            width: calc((100% - 10px));
+          }
         }
       }
       .modal-header {

--- a/cdap-ui/app/cdap/components/PlusButtonModal/index.js
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/index.js
@@ -20,6 +20,7 @@ import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import Market from 'components/Market';
 import ResourceCenter from 'components/ResourceCenter';
 import IconSVG from 'components/IconSVG';
+import classnames from 'classnames';
 
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import T from 'i18n-react';
@@ -68,7 +69,9 @@ export default class PlusButtonModal extends Component {
       <Modal
         isOpen={this.props.isOpen}
         toggle={this.closeHandler.bind(this)}
-        className="plus-button-modal"
+        className={classnames("plus-button-modal", {
+          "cask-market": this.state.viewMode === 'marketplace'
+        })}
         size="lg"
         backdrop='static'
       >

--- a/cdap-ui/app/cdap/components/ResourceCenter/ResourceCenter.scss
+++ b/cdap-ui/app/cdap/components/ResourceCenter/ResourceCenter.scss
@@ -17,5 +17,6 @@
 .cask-resource-center {
   height: 100%;
   padding: 10px;
-  overflow: auto;
+  overflow-y: auto;
+  max-height: 75vh;
 }


### PR DESCRIPTION
- Existing UI had a fixed height for resource center modal 
- Removed `75vh` height for resource center modal + makes entities in resource center modal responsive.

JIRA: https://issues.cask.co/browse/CDAP-8419