### PR TITLE
[CDAP-11913] Refactor Schedule Creation and Add ProgramStatusTrigger

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/app/AbstractApplication.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/app/AbstractApplication.java
@@ -29,7 +29,7 @@ import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.internal.api.AbstractPluginConfigurable;
-import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
+import co.cask.cdap.internal.schedule.ScheduleCreationBuilder;
 
 import java.util.Collections;
 import java.util.Map;
@@ -193,10 +193,10 @@ public abstract class AbstractApplication<T extends Config> extends AbstractPlug
   /**
    * Schedules a program, using the given scheduleCreationSpec.
    *
-   * @param scheduleCreationSpec defines the schedule. Can be built using the builder obtained
-   *                             from {@link #buildSchedule(String, ProgramType, String)}
+   * @param scheduleCreationBuilder defines the schedule. Can be built using the builder obtained
+   *                                from {@link #buildSchedule(String, ProgramType, String)}
    */
-  protected void schedule(ScheduleCreationSpec scheduleCreationSpec) {
-    configurer.schedule(scheduleCreationSpec);
+  protected void schedule(ScheduleCreationBuilder scheduleCreationBuilder) {
+    configurer.schedule(scheduleCreationBuilder);
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/app/ApplicationConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/app/ApplicationConfigurer.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.api.app;
 
-import co.cask.cdap.api.customaction.CustomAction;
 import co.cask.cdap.api.flow.Flow;
 import co.cask.cdap.api.mapreduce.MapReduce;
 import co.cask.cdap.api.plugin.PluginConfigurer;
@@ -26,9 +25,8 @@ import co.cask.cdap.api.schedule.ScheduleBuilder;
 import co.cask.cdap.api.service.Service;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.worker.Worker;
-import co.cask.cdap.api.workflow.AbstractWorkflow;
 import co.cask.cdap.api.workflow.Workflow;
-import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
+import co.cask.cdap.internal.schedule.ScheduleCreationBuilder;
 
 import java.util.Map;
 
@@ -119,10 +117,10 @@ public interface ApplicationConfigurer extends PluginConfigurer {
                                 String programName);
 
   /**
-   * Schedules a program, using the given scheduleCreationSpec.
+   * Schedules a program, using the given scheduleCreationBuilder.
    *
-   * @param scheduleCreationSpec defines the schedule. Can be built using the builder obtained
-   *                             from {@link #buildSchedule(String, ProgramType, String)}
+   * @param scheduleCreationBuilder defines the builder for a schedule. The ScheduleCreationBuilder is built into a
+   *                                ScheduleCreationSpec when the application specification is created.
    */
-  void schedule(ScheduleCreationSpec scheduleCreationSpec);
+  void schedule(ScheduleCreationBuilder scheduleCreationBuilder);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/schedule/ScheduleBuilder.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/schedule/ScheduleBuilder.java
@@ -16,7 +16,9 @@
 
 package co.cask.cdap.api.schedule;
 
-import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
+import co.cask.cdap.api.ProgramStatus;
+import co.cask.cdap.api.app.ProgramType;
+import co.cask.cdap.internal.schedule.ScheduleCreationBuilder;
 
 import java.util.Map;
 import java.util.TimeZone;
@@ -118,15 +120,67 @@ public interface ScheduleBuilder {
    * @param cronExpression the cron expression to specify the time to trigger the schedule
    * @return this {@link ScheduleBuilder}
    */
-  ScheduleCreationSpec triggerByTime(String cronExpression);
+  ScheduleCreationBuilder triggerByTime(String cronExpression);
 
   /**
    * Create a schedule which is triggered whenever at least a certain number of new partitions
-   * are added to a certain dataset.
+   * are added to a certain dataset in the same namespace as the app.
    *
    * @param datasetName the name of the dataset in the same namespace of the app
    * @param numPartitions the minimum number of new partitions added to the dataset to trigger the schedule
    * @return this {@link ScheduleBuilder}
    */
-  ScheduleCreationSpec triggerOnPartitions(String datasetName, int numPartitions);
+  ScheduleCreationBuilder triggerOnPartitions(String datasetName, int numPartitions);
+
+  /**
+   * Create a schedule which is triggered whenever at least a certain number of new partitions
+   * are added to a certain dataset in the specified namespace.
+   *
+   * @param datasetNamespace the namespace where the dataset is defined
+   * @param datasetName the name of the dataset in the specified namespace of the app
+   * @param numPartitions the minimum number of new partitions added to the dataset to trigger the schedule
+   * @return this {@link ScheduleBuilder}
+   */
+  ScheduleCreationBuilder triggerOnPartitions(String datasetNamespace, String datasetName, int numPartitions);
+
+  /**
+   * Create a schedule which is triggered when the given program in the given namespace, application, and
+   * application version transitions to any one of the given program statuses.
+   *
+   * @param programNamespace the namespace where this program is defined
+   * @param application the name of the application where this program is defined
+   * @param appVersion the version of the application
+   * @param programType the type of the program, as supported by the system
+   * @param program the name of the program
+   * @param programStatuses the set of statuses to trigger the schedule. The schedule will be triggered if the status of
+   *                        the specific program transitioned to one of these statuses.
+   * @return this {@link ScheduleBuilder}
+   */
+  ScheduleCreationBuilder triggerOnProgramStatus(String programNamespace, String application, String appVersion,
+                                                 ProgramType programType, String program,
+                                                 ProgramStatus... programStatuses);
+
+  /**
+   * Creates a schedule which is triggered in the same application version.
+   *
+   * @see ScheduleBuilder#triggerOnProgramStatus(String, String, ProgramType, String, ProgramStatus...)
+   */
+  ScheduleCreationBuilder triggerOnProgramStatus(String programNamespace, String application, ProgramType programType,
+                                                 String program, ProgramStatus... programStatuses);
+
+  /**
+   * Creates a schedule which is triggered in the same application and application version.
+   *
+   * @see ScheduleBuilder#triggerOnProgramStatus(String, String, ProgramType, String, ProgramStatus...)
+   */
+  ScheduleCreationBuilder triggerOnProgramStatus(String programNamespace, ProgramType programType, String program,
+                                                 ProgramStatus... programStatuses);
+
+  /**
+   * Creates a schedule which is triggered in the same namespace, application, and application version.
+   *
+   * @see ScheduleBuilder#triggerOnProgramStatus(String, String, ProgramType, String, ProgramStatus...)
+   */
+  ScheduleCreationBuilder triggerOnProgramStatus(ProgramType programType, String program,
+                                                 ProgramStatus... programStatuses);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/schedule/ScheduleCreationBuilder.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/schedule/ScheduleCreationBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.schedule;
+
+import co.cask.cdap.internal.schedule.constraint.Constraint;
+import co.cask.cdap.internal.schedule.trigger.TriggerBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builder for creating a ScheduleCreationSpec.
+ */
+public class ScheduleCreationBuilder {
+
+  protected final String name;
+  protected final String description;
+  protected final String programName;
+  protected final Map<String, String> properties;
+  protected final List<? extends Constraint> constraints;
+  protected final long timeoutMillis;
+  protected final TriggerBuilder triggerBuilder;
+
+  public ScheduleCreationBuilder(String name, String description, String programName, Map<String, String> properties,
+                                 List<? extends Constraint> constraints, long timeoutMillis,
+                                 TriggerBuilder triggerBuilder) {
+    this.name = name;
+    this.description = description;
+    this.programName = programName;
+    this.properties = properties;
+    this.constraints = constraints;
+    this.timeoutMillis = timeoutMillis;
+    this.triggerBuilder = triggerBuilder;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ScheduleCreationSpec build(String namespace, String applicationName, String applicationVersion) {
+    return new ScheduleCreationSpec(name, description, programName, properties,
+                                    triggerBuilder.build(namespace, applicationName, applicationVersion),
+                                    constraints, timeoutMillis);
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/schedule/trigger/TriggerBuilder.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/schedule/trigger/TriggerBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.schedule.trigger;
+
+/**
+ * A builder to create a Trigger object.
+ */
+public interface TriggerBuilder {
+
+  /**
+   * Builds a Trigger given the deployed namespace, application, and application version.
+   *
+   * @param namespace the namespace
+   * @param applicationName the deployed application name
+   * @param applicationVersion the deployed application version
+   * @return a Trigger
+   */
+  Trigger build(String namespace, String applicationName, String applicationVersion);
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DefaultScheduleBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DefaultScheduleBuilder.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.internal.app.runtime.schedule;
 
+import co.cask.cdap.api.ProgramStatus;
+import co.cask.cdap.api.app.ProgramType;
 import co.cask.cdap.api.schedule.ConstraintProgramScheduleBuilder;
 import co.cask.cdap.api.schedule.ScheduleBuilder;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.ConcurrencyConstraint;
@@ -23,10 +25,13 @@ import co.cask.cdap.internal.app.runtime.schedule.constraint.DelayConstraint;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.LastRunConstraint;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.TimeRangeConstraint;
 import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
-import co.cask.cdap.internal.app.runtime.schedule.trigger.PartitionTrigger;
-import co.cask.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
-import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.PartitionTriggerBuilder;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTriggerBuilder;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.TimeTriggerBuilder;
+import co.cask.cdap.internal.schedule.ScheduleCreationBuilder;
+import co.cask.cdap.internal.schedule.trigger.TriggerBuilder;
 import co.cask.cdap.proto.ProtoConstraint;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableMap;
 
@@ -108,16 +113,60 @@ public class DefaultScheduleBuilder implements ConstraintProgramScheduleBuilder 
   }
 
   @Override
-  public ScheduleCreationSpec triggerByTime(String cronExpression) {
-    return new ScheduleCreationSpec(name, description, programName, properties,
-                                    new TimeTrigger(cronExpression), constraints, timeoutMillis);
+  public ScheduleCreationBuilder triggerByTime(String cronExpression) {
+    return new ScheduleCreationBuilder(name, description, programName, properties, constraints, timeoutMillis,
+                                       new TimeTriggerBuilder(cronExpression));
   }
 
   @Override
-  public ScheduleCreationSpec triggerOnPartitions(String datasetName, int numPartitions) {
-    return new ScheduleCreationSpec(name, description, programName, properties,
-                                    new PartitionTrigger(namespace.dataset(datasetName), numPartitions),
-                                    constraints, timeoutMillis);
+  public ScheduleCreationBuilder triggerOnPartitions(String datasetName, int numPartitions) {
+    return new ScheduleCreationBuilder(name, description, programName, properties, constraints, timeoutMillis,
+                                       new PartitionTriggerBuilder(namespace.dataset(datasetName), numPartitions));
+  }
+
+  @Override
+  public ScheduleCreationBuilder triggerOnPartitions(String datasetNamespace, String datasetName, int numPartitions) {
+    return new ScheduleCreationBuilder(name, description, programName, properties, constraints, timeoutMillis,
+                                       new PartitionTriggerBuilder(new DatasetId(datasetNamespace, datasetName),
+                                                                   numPartitions));
+  }
+
+  @Override
+  public ScheduleCreationBuilder triggerOnProgramStatus(String programNamespace, String application, String appVersion,
+                                                        ProgramType programType, String program,
+                                                        ProgramStatus... programStatuses) {
+    return new ScheduleCreationBuilder(name, description, programName, properties, constraints, timeoutMillis,
+                                       new ProgramStatusTriggerBuilder(programNamespace, application, appVersion,
+                                                                       programType.toString(), program,
+                                                                       programStatuses));
+  }
+
+  @Override
+  public ScheduleCreationBuilder triggerOnProgramStatus(String programNamespace, String application,
+                                                        ProgramType programType, String program,
+                                                        ProgramStatus... programStatuses) {
+    return new ScheduleCreationBuilder(name, description, programName, properties, constraints, timeoutMillis,
+                                       new ProgramStatusTriggerBuilder(programNamespace, application, null,
+                                                                       programType.toString(), program,
+                                                                       programStatuses));
+  }
+
+  @Override
+  public ScheduleCreationBuilder triggerOnProgramStatus(String programNamespace, ProgramType programType,
+                                                        String program, ProgramStatus... programStatuses) {
+    return new ScheduleCreationBuilder(name, description, programName, properties, constraints, timeoutMillis,
+                                       new ProgramStatusTriggerBuilder(programNamespace, null, null,
+                                                                       programType.toString(), program,
+                                                                       programStatuses));
+  }
+
+  @Override
+  public ScheduleCreationBuilder triggerOnProgramStatus(ProgramType programType, String program,
+                                                        ProgramStatus... programStatuses) {
+    return new ScheduleCreationBuilder(name, description, programName, properties, constraints, timeoutMillis,
+                                       new ProgramStatusTriggerBuilder(null, null, null,
+                                                                       programType.toString(), program,
+                                                                       programStatuses));
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/PartitionTriggerBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/PartitionTriggerBuilder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.cdap.internal.app.runtime.schedule.trigger;
+
+import co.cask.cdap.internal.schedule.trigger.TriggerBuilder;
+import co.cask.cdap.proto.id.DatasetId;
+
+/**
+ * A Trigger builder that builds a PartitionTrigger.
+ */
+public class PartitionTriggerBuilder implements TriggerBuilder {
+  private final DatasetId dataset;
+  private final int numPartitions;
+
+  public PartitionTriggerBuilder(DatasetId dataset, int numPartitions) {
+    this.dataset = dataset;
+    this.numPartitions = numPartitions;
+  }
+
+  @Override
+  public PartitionTrigger build(String namespace, String applicationName, String applicationVersion) {
+    return new PartitionTrigger(dataset, numPartitions);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTrigger.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTrigger.java
@@ -16,27 +16,27 @@
 
 package co.cask.cdap.internal.app.runtime.schedule.trigger;
 
+
+import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.internal.schedule.trigger.Trigger;
 import co.cask.cdap.proto.ProtoTrigger;
-import co.cask.cdap.proto.ProtoTriggerCodec;
-import com.google.common.collect.ImmutableMap;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.annotations.VisibleForTesting;
 
-import java.util.Map;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
- * Serialization and deserialization of Triggers as Json.
+ * A Trigger that schedules a ProgramSchedule, when a certain status of a program has been achieved.
  */
-public class TriggerCodec extends ProtoTriggerCodec {
+public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger implements Trigger {
+  public ProgramStatusTrigger(ProgramId programId, Set<ProgramStatus> programStatuses) {
+    super(programId, programStatuses);
+  }
 
-  private static final Map<ProtoTrigger.Type, Class<? extends Trigger>> TYPE_TO_INTERNAL_TRIGGER =
-    ImmutableMap.<ProtoTrigger.Type, Class<? extends Trigger>>builder()
-      .put(ProtoTrigger.Type.TIME, TimeTrigger.class)
-      .put(ProtoTrigger.Type.PARTITION, PartitionTrigger.class)
-      .put(ProtoTrigger.Type.STREAM_SIZE, StreamSizeTrigger.class)
-      .put(ProtoTrigger.Type.PROGRAM_STATUS, ProgramStatusTrigger.class)
-      .build();
-
-  public TriggerCodec() {
-    super(TYPE_TO_INTERNAL_TRIGGER);
+  @VisibleForTesting
+  public ProgramStatusTrigger(ProgramId programId, ProgramStatus... programStatuses) {
+    super(programId, new HashSet<>(Arrays.asList(programStatuses)));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTriggerBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTriggerBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.cdap.internal.app.runtime.schedule.trigger;
+
+import co.cask.cdap.api.ProgramStatus;
+import co.cask.cdap.internal.schedule.trigger.TriggerBuilder;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.base.Objects;
+
+import java.util.EnumSet;
+import javax.annotation.Nullable;
+
+/**
+ * A Trigger builder that builds a ProgramStatusTrigger.
+ */
+public class ProgramStatusTriggerBuilder implements TriggerBuilder {
+  private final String programNamespace;
+  private final String programApplication;
+  private final String programApplicationVersion;
+  private final ProgramType programType;
+  private final String programName;
+  private final EnumSet<ProgramStatus> programStatuses;
+
+  public ProgramStatusTriggerBuilder(@Nullable String programNamespace, @Nullable String programApplication,
+                                     @Nullable String programApplicationVersion, String programType,
+                                     String programName, ProgramStatus... programStatuses) {
+    this.programNamespace = programNamespace;
+    this.programApplication = programApplication;
+    this.programApplicationVersion = programApplicationVersion;
+    this.programType = ProgramType.valueOf(programType);
+    this.programName = programName;
+
+    // User can not specify any program statuses, or specify null, which is an array of length 1 containing null
+    if (programStatuses.length == 0 || (programStatuses.length == 1 && programStatuses[0] == null)) {
+      throw new IllegalArgumentException("Must set a program state for the triggering program");
+    }
+    this.programStatuses = EnumSet.of(programStatuses[0], programStatuses);
+  }
+
+  @Override
+  public ProgramStatusTrigger build(String namespace, String applicationName, String applicationVersion) {
+    // Inherit environment attributes from the deployed application
+    ProgramId programId = new ApplicationId(
+                            Objects.firstNonNull(programNamespace, namespace),
+                            Objects.firstNonNull(programApplication, applicationName),
+                            Objects.firstNonNull(programApplicationVersion, applicationVersion)).program(programType,
+                                                                                                         programName);
+    return new ProgramStatusTrigger(programId, programStatuses);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/StreamSizeTriggerBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/StreamSizeTriggerBuilder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.cdap.internal.app.runtime.schedule.trigger;
+
+import co.cask.cdap.internal.schedule.trigger.TriggerBuilder;
+import co.cask.cdap.proto.id.StreamId;
+
+/**
+ * A Trigger builder that builds a StreamSizeTrigger.
+ */
+public class StreamSizeTriggerBuilder implements TriggerBuilder {
+  private final StreamId streamId;
+  private final int triggerMB;
+
+  public StreamSizeTriggerBuilder(StreamId streamId, int triggerMB) {
+    this.streamId = streamId;
+    this.triggerMB = triggerMB;
+  }
+
+  @Override
+  public StreamSizeTrigger build(String namespace, String applicationName, String applicationVersion) {
+    return new StreamSizeTrigger(streamId, triggerMB);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/TimeTriggerBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/TimeTriggerBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.schedule.trigger;
+
+import co.cask.cdap.internal.schedule.trigger.TriggerBuilder;
+
+/**
+ * A Trigger builder that builds a TimeTrigger.
+ */
+public class TimeTriggerBuilder implements TriggerBuilder {
+  private final String cronExpression;
+
+  public TimeTriggerBuilder(String cronExpression) {
+    this.cronExpression = cronExpression;
+  }
+
+  @Override
+  public TimeTrigger build(String namespace, String applicationName, String applicationVersion) {
+    return new TimeTrigger(cronExpression);
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/MockAppConfigurer.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/MockAppConfigurer.java
@@ -35,7 +35,7 @@ import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.internal.app.runtime.schedule.DefaultScheduleBuilder;
-import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
+import co.cask.cdap.internal.schedule.ScheduleCreationBuilder;
 import co.cask.cdap.proto.id.NamespaceId;
 
 import java.util.Map;
@@ -108,7 +108,7 @@ public final class MockAppConfigurer implements ApplicationConfigurer {
   }
 
   @Override
-  public void schedule(ScheduleCreationSpec programSchedule) {
+  public void schedule(ScheduleCreationBuilder programSchedule) {
 
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProtoTriggerCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProtoTriggerCodec.java
@@ -44,6 +44,7 @@ public class ProtoTriggerCodec implements JsonSerializer<Trigger>, JsonDeseriali
     map.put(ProtoTrigger.Type.TIME, ProtoTrigger.TimeTrigger.class);
     map.put(ProtoTrigger.Type.PARTITION, ProtoTrigger.PartitionTrigger.class);
     map.put(ProtoTrigger.Type.STREAM_SIZE, ProtoTrigger.StreamSizeTrigger.class);
+    map.put(ProtoTrigger.Type.PROGRAM_STATUS, ProtoTrigger.ProgramStatusTrigger.class);
     return map;
   }
 

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/ProtoTriggerCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/ProtoTriggerCodecTest.java
@@ -21,9 +21,11 @@ import co.cask.cdap.api.workflow.ScheduleProgramInfo;
 import co.cask.cdap.internal.schedule.constraint.Constraint;
 import co.cask.cdap.internal.schedule.trigger.Trigger;
 import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.Assert;
@@ -37,26 +39,20 @@ public class ProtoTriggerCodecTest {
 
   @Test
   public void testTriggerCodec() {
+    testTriggerCodec(new ProtoTrigger.PartitionTrigger(new DatasetId("test", "myds"), 4));
 
-    Trigger trigger = new ProtoTrigger.PartitionTrigger(new DatasetId("test", "myds"), 4);
+    testTriggerCodec(new ProtoTrigger.TimeTrigger("* * * * *"));
+
+    testTriggerCodec(new ProtoTrigger.StreamSizeTrigger(new StreamId("x", "y"), 17));
+
+    testTriggerCodec(new ProtoTrigger.ProgramStatusTrigger(new ProgramId("test", "myapp",
+                                                    ProgramType.FLOW, "myprog"),
+                                                    ImmutableSet.of(co.cask.cdap.api.ProgramStatus.FAILED)));
+  }
+
+  private void testTriggerCodec(ProtoTrigger trigger) {
     String json = GSON.toJson(trigger);
     Trigger trigger1 = GSON.fromJson(json, Trigger.class);
-    Assert.assertEquals(trigger, trigger1);
-    json = GSON.toJson(trigger, Trigger.class);
-    trigger1 = GSON.fromJson(json, Trigger.class);
-    Assert.assertEquals(trigger, trigger1);
-
-    trigger = new ProtoTrigger.TimeTrigger("* * * * *");
-    json = GSON.toJson(trigger);
-    trigger1 = GSON.fromJson(json, Trigger.class);
-    Assert.assertEquals(trigger, trigger1);
-    json = GSON.toJson(trigger, Trigger.class);
-    trigger1 = GSON.fromJson(json, Trigger.class);
-    Assert.assertEquals(trigger, trigger1);
-
-    trigger = new ProtoTrigger.StreamSizeTrigger(new StreamId("x", "y"), 17);
-    json = GSON.toJson(trigger);
-    trigger1 = GSON.fromJson(json, Trigger.class);
     Assert.assertEquals(trigger, trigger1);
     json = GSON.toJson(trigger, Trigger.class);
     trigger1 = GSON.fromJson(json, Trigger.class);


### PR DESCRIPTION
- Adds Java APIs to create a `ProgramStatusTrigger`

After this PR, we need to:
- Send `ProgramStatusNotification` whenever a program's status changes
- Schedule a job based on `ProgramStatusNotification`

Design doc here for more context: https://wiki.cask.co/display/CE/Program+Status+Based+Scheduling

JIRA: https://issues.cask.co/browse/CDAP-11913

Build: https://builds.cask.co/browse/CDAP-DUT5863
Checkstyle: https://builds.cask.co/browse/CDAP-DRC6822