### PR TITLE
[CDAP-11636] Add line numbers to dataprep table

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/DataPrepTable.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/DataPrepTable.scss
@@ -57,6 +57,9 @@ $col_type_font_color: gray;
       tbody {
         tr {
           td {
+            &:first-child {
+              background: $header-bg-color;
+            }
             white-space: nowrap;
           }
         }
@@ -68,14 +71,14 @@ $col_type_font_color: gray;
         border-bottom: 2px solid $border-and-selected-color;
         border-right: 1px solid #cccccc;
         border-top: 0;
-        position: relative;
-        padding: 0.5rem 0.75rem;
+        padding: 0;
 
         .quality-bar {
-          position: absolute;
-          top: -10px; // top padding of header
-          left: 0;
-          right: 0;
+          display: flex;
+          height: 5px;
+        }
+        .column-wrapper-container {
+          padding: 0.5rem 0.75rem;
         }
 
         .column-wrapper {
@@ -147,6 +150,11 @@ $col_type_font_color: gray;
             cursor: initial;
           }
 
+        }
+
+        &.row-count-header {
+          padding: 0;
+          width: 1px;
         }
 
         &:first-child { border-left: 0; }

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/index.js
@@ -200,12 +200,13 @@ export default class DataPrepTable extends Component {
   }
 
   renderDataprepTable() {
-    let headers = this.state.headers;
+    let headers = [...this.state.headers];
     let data = this.state.data;
     let types = DataPrepStore.getState().dataprep.types;
     return (
       <table className="table table-bordered">
         <thead className="thead-inverse">
+          <th className="row-count-header" />
           {
             headers.map((head, index) => {
               return (
@@ -218,66 +219,68 @@ export default class DataPrepTable extends Component {
                   key={head.name}
                 >
                   <DataQuality columnInfo={this.state.columns[head.name]} />
-                  <div className="col-type">{captialize(types[head.name] || 'unknown')}</div>
-                  <div
-                    className="clearfix column-wrapper"
-                  >
-                    <span className="directives-dropdown-button">
-                      <ColumnActionsDropdown
-                        column={head.name}
-                        dropdownOpened={this.columnDropdownOpened}
-                      />
-                    </span>
-                    {
-                      !head.edit ?
-                        <span
-                          className="header-text"
-                          onClick={this.switchToEditColumnName.bind(this, head)}
-                        >
-                          <span>
-                            {head.name}
+                  <div className="column-wrapper-container">
+                    <div className="col-type">{captialize(types[head.name] || 'unknown')}</div>
+                    <div
+                      className="clearfix column-wrapper"
+                    >
+                      <span className="directives-dropdown-button">
+                        <ColumnActionsDropdown
+                          column={head.name}
+                          dropdownOpened={this.columnDropdownOpened}
+                        />
+                      </span>
+                      {
+                        !head.edit ?
+                          <span
+                            className="header-text"
+                            onClick={this.switchToEditColumnName.bind(this, head)}
+                          >
+                            <span>
+                              {head.name}
+                            </span>
                           </span>
-                        </span>
-                      :
-                        <div className="warning-container-wrapper float-xs-left">
-                          <TextboxOnValium
-                            onChange={this.handleSaveEditedColumnName.bind(this, index)}
-                            value={head.name}
-                            onWarning={this.showWarningMessage.bind(this, index)}
-                            allowSpace={false}
-                          />
-                          {
-                            head.showWarning ?
-                              <WarningContainer
-                                message={T.translate('features.DataPrep.DataPrepTable.columnEditWarningMessage')}
-                              >
-                                <div className="warning-btns-container">
-                                  <div
-                                    className="btn btn-primary"
-                                    onClick={this.handleSaveEditedColumnName.bind(this, index, head.editedColumnName, false)}
-                                  >
-                                    {T.translate('features.DataPrep.Directives.apply')}
+                        :
+                          <div className="warning-container-wrapper float-xs-left">
+                            <TextboxOnValium
+                              onChange={this.handleSaveEditedColumnName.bind(this, index)}
+                              value={head.name}
+                              onWarning={this.showWarningMessage.bind(this, index)}
+                              allowSpace={false}
+                            />
+                            {
+                              head.showWarning ?
+                                <WarningContainer
+                                  message={T.translate('features.DataPrep.DataPrepTable.columnEditWarningMessage')}
+                                >
+                                  <div className="warning-btns-container">
+                                    <div
+                                      className="btn btn-primary"
+                                      onClick={this.handleSaveEditedColumnName.bind(this, index, head.editedColumnName, false)}
+                                    >
+                                      {T.translate('features.DataPrep.Directives.apply')}
+                                    </div>
+                                    <div
+                                      className="btn"
+                                      onClick={this.handleSaveEditedColumnName.bind(this, index, head.name, true)}
+                                    >
+                                      {T.translate('features.DataPrep.Directives.cancel')}
+                                    </div>
                                   </div>
-                                  <div
-                                    className="btn"
-                                    onClick={this.handleSaveEditedColumnName.bind(this, index, head.name, true)}
-                                  >
-                                    {T.translate('features.DataPrep.Directives.cancel')}
-                                  </div>
-                                </div>
-                              </WarningContainer>
-                            :
-                              null
-                          }
-                        </div>
-                    }
-                    <span
-                      onClick={this.toggleColumnSelect.bind(this, head.name)}
-                      className={classnames('float-xs-right fa column-header-checkbox', {
-                        'fa-square-o': !this.columnIsSelected(head.name),
-                        'fa-check-square': this.columnIsSelected(head.name)
-                      })}
-                    />
+                                </WarningContainer>
+                              :
+                                null
+                            }
+                          </div>
+                      }
+                      <span
+                        onClick={this.toggleColumnSelect.bind(this, head.name)}
+                        className={classnames('float-xs-right fa column-header-checkbox', {
+                          'fa-square-o': !this.columnIsSelected(head.name),
+                          'fa-check-square': this.columnIsSelected(head.name)
+                        })}
+                      />
+                    </div>
                   </div>
                 </th>
               );
@@ -286,12 +289,15 @@ export default class DataPrepTable extends Component {
         </thead>
         <tbody>
           {
-            data.map((row) => {
+            data.map((row, rowIndex) => {
               return (
                 <tr key={row.uniqueId}>
-                  {headers.map((head, i) => {
-                    return <td key={i}><div>{row[head.name]}</div></td>;
-                  })}
+                  <td>{rowIndex + 1}</td>
+                  {
+                    headers.map((head, i) => {
+                      return <td key={i}><div>{row[head.name]}</div></td>;
+                    })
+                  }
                 </tr>
               );
             })

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
@@ -289,6 +289,7 @@ export default class CutDirective extends Component {
       >
         <table className="table table-bordered">
           <colgroup>
+            <col />
             {
               headers.map(head => {
                 return (
@@ -301,6 +302,7 @@ export default class CutDirective extends Component {
           </colgroup>
           <thead className="thead-inverse">
             <tr>
+              <th />
               {
                 headers.map( head => {
                   return renderTableHeader(head);
@@ -313,6 +315,7 @@ export default class CutDirective extends Component {
                 data.map((row, i) => {
                   return (
                     <tr key={i}>
+                      <td>{i}</td>
                       {
                         headers.map((head) => {
                           return renderTableCell(row, i, head, column);

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.scss
@@ -28,6 +28,16 @@ $text-selection-color: #40c4ff;
           background-color: $highlight-color;
         }
       }
+      &.table.table-bordered {
+        .thead-inverse {
+          th {
+            padding: 0.5rem 0.75rem;
+            &:first-child {
+              width: 1px;
+            }
+          }
+        }
+      }
       td,
       th {
         &.gray-out {


### PR DESCRIPTION
- Adds line number column to the left of dataprep table 
- Fixes dataprep table header in firefox (there were issues with borders because of relative positioning of `th` element).