### PR TITLE
[CDAP-9107] Adds undo & redo functionality to Studio

### DIFF
--- a/cdap-ui/app/common/cask-header.js
+++ b/cdap-ui/app/common/cask-header.js
@@ -30,6 +30,7 @@
  var KeyValuePairs = require('../cdap/components/KeyValuePairs').default;
  var KeyValueStore = require('../cdap/components/KeyValuePairs/KeyValueStore').default;
  var KeyValueStoreActions = require('../cdap/components/KeyValuePairs/KeyValueStoreActions').default;
+ var Mousetrap = require('mousetrap');
 
  export {
   Store,
@@ -45,5 +46,6 @@
   ResourceCenterButton,
   KeyValuePairs,
   KeyValueStore,
-  KeyValueStoreActions
+  KeyValueStoreActions,
+  Mousetrap
 };

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2015-2017 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -66,6 +66,30 @@
           tooltip-placement="left"
           tooltip-popup-delay="500">
     <i class="fa fa-commenting"></i>
+  </button>
+
+  <!-- Undo Nodes Action -->
+  <button class="btn btn-default"
+          ng-click="DAGPlusPlusCtrl.undoActions()"
+          ng-if="!DAGPlusPlusCtrl.isDisabled"
+          ng-disabled="DAGPlusPlusCtrl.undoStates.length === 0"
+          uib-tooltip="Undo (Ctrl/Cmd + Z)"
+          tooltip-append-to-body="true"
+          tooltip-placement="left"
+          tooltip-popup-delay="500">
+    <i class="fa fa-undo"></i>
+  </button>
+
+  <!-- Redo Nodes Action -->
+  <button class="btn btn-default"
+          ng-click="DAGPlusPlusCtrl.redoActions()"
+          ng-if="!DAGPlusPlusCtrl.isDisabled"
+          ng-disabled="DAGPlusPlusCtrl.redoStates.length === 0"
+          uib-tooltip="Redo (Ctrl/Cmd + Shift + Z)"
+          tooltip-append-to-body="true"
+          tooltip-placement="left"
+          tooltip-popup-delay="500">
+    <i class="fa fa-repeat"></i>
   </button>
 </div>
 

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -133,6 +133,17 @@ my-dag-plus {
   .zoom-control {
     z-index: 998;
     right: 15px;
+
+    button.btn.btn-default {
+      &[disabled] {
+        opacity: 1;
+        background-color: white;
+
+        i.fa {
+          opacity: 0.5;
+        }
+      }
+    }
   }
 
   .my-js-dag.preview-mode {

--- a/cdap-ui/app/directives/dag-plus/services/actions/nodes-actions.js
+++ b/cdap-ui/app/directives/dag-plus/services/actions/nodes-actions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -50,7 +50,6 @@ class DAGPlusPlusNodesActionsFactory {
           top: (sourcePosition.top + sourceOffset) + 'px',
           left: (sourcePosition.left + sourceOffset) + 'px'
         };
-        this.nodesDispatcher.dispatch('onAddSourceCount');
         break;
       case 'sink':
         let sinkOffset = this.DAGPlusPlusNodesStore.getSinkCount() * offset;
@@ -58,7 +57,6 @@ class DAGPlusPlusNodesActionsFactory {
           top: (sinkPosition.top + sinkOffset) + 'px',
           left: (sinkPosition.left + sinkOffset) + 'px'
         };
-        this.nodesDispatcher.dispatch('onAddSinkCount');
         break;
       default:
         let transformOffset = this.DAGPlusPlusNodesStore.getTransformCount() * offset;
@@ -66,7 +64,6 @@ class DAGPlusPlusNodesActionsFactory {
           top: (transformPosition.top + transformOffset) + 'px',
           left: (transformPosition.left + transformOffset) + 'px'
         };
-        this.nodesDispatcher.dispatch('onAddTransformCount');
         break;
     }
 
@@ -129,6 +126,19 @@ class DAGPlusPlusNodesActionsFactory {
   }
   updateComment(commentId, config) {
     this.nodesDispatcher.dispatch('onUpdateComment', commentId, config);
+  }
+
+  undoActions() {
+    this.nodesDispatcher.dispatch('onUndoActions');
+  }
+  redoActions() {
+    this.nodesDispatcher.dispatch('onRedoActions');
+  }
+  removePreviousState() {
+    this.nodesDispatcher.dispatch('onRemovePreviousState');
+  }
+  resetFutureStates() {
+    this.nodesDispatcher.dispatch('onResetFutureStates');
   }
 
 }

--- a/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
@@ -77,6 +77,9 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
     vm.error = '';
     if (typeof vm.schemaObj !== 'string') {
       vm.model = JSON.stringify(vm.schemaObj);
+      if (vm.updateOutputSchema) {
+        vm.updateOutputSchema({outputSchema: vm.model});
+      }
     } else {
       vm.model = vm.schemaObj;
     }
@@ -217,7 +220,8 @@ angular.module(PKG.name + '.commons')
         isDisabled: '=',
         pluginProperties: '=?',
         config: '=?',
-        pluginName: '='
+        pluginName: '=',
+        updateOutputSchema: '&'
       },
       controller: ComplexSchemaEditorController,
       controllerAs: 'SchemaEditor'

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorPlusPlusNodeConfigCtrl {
-  constructor($scope, $timeout, $state, HydratorPlusPlusPluginConfigFactory, EventPipe, GLOBALS, HydratorPlusPlusConfigActions, myHelpers, NonStorePipelineErrorFactory, $uibModal, HydratorPlusPlusConfigStore, rPlugin, rDisabled, HydratorPlusPlusHydratorService, myPipelineApi, HydratorPlusPlusPreviewStore, rIsStudioMode, HydratorPlusPlusOrderingFactory, avsc, LogViewerStore) {
+  constructor($scope, $timeout, $state, HydratorPlusPlusPluginConfigFactory, EventPipe, GLOBALS, HydratorPlusPlusConfigActions, myHelpers, NonStorePipelineErrorFactory, $uibModal, HydratorPlusPlusConfigStore, rPlugin, rDisabled, HydratorPlusPlusHydratorService, myPipelineApi, HydratorPlusPlusPreviewStore, rIsStudioMode, HydratorPlusPlusOrderingFactory, avsc, LogViewerStore, DAGPlusPlusNodesActionsFactory) {
     'ngInject';
     this.$scope = $scope;
     this.$timeout = $timeout;
@@ -35,6 +35,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.myPipelineApi = myPipelineApi;
     this.previewStore = HydratorPlusPlusPreviewStore;
     this.HydratorPlusPlusOrderingFactory = HydratorPlusPlusOrderingFactory;
+    this.DAGPlusPlusNodesActionsFactory = DAGPlusPlusNodesActionsFactory;
     this.avsc = avsc;
     this.LogViewerStore = LogViewerStore;
     this.setDefaults(rPlugin);
@@ -66,6 +67,10 @@ class HydratorPlusPlusNodeConfigCtrl {
     }
 
     this.activeTab = this.isPreviewMode && !rPlugin.isAction ? 2 : 1;
+
+    this.$scope.$on('modal.closing', () => {
+      this.updateNodeStateIfDirty();
+    });
 
     // Timeouts
     this.setStateTimeout = null;
@@ -128,6 +133,8 @@ class HydratorPlusPlusNodeConfigCtrl {
       schemaAdvance: false
     };
 
+    this.defaultState = angular.copy(this.state);
+
     if (this.state.node.outputSchema && this.state.node.outputSchema.length > 0) {
       try {
         this.avsc.parse(this.state.node.outputSchema);
@@ -161,6 +168,7 @@ class HydratorPlusPlusNodeConfigCtrl {
       propertiesFromBackend.forEach( (property) => {
         this.state.node.plugin.properties[property] = this.state.node.plugin.properties[property] || '';
       });
+      this.defaultState = angular.copy(this.state);
       this.state.watchers.push(
         this.$scope.$watch(
           'HydratorPlusPlusNodeConfigCtrl.state.node',
@@ -292,6 +300,7 @@ class HydratorPlusPlusNodeConfigCtrl {
             this.state.configfetched = true;
             this.state.config = res;
             this.state.noconfig = false;
+            this.defaultState = angular.copy(this.state);
           },
           noJsonErrorHandler
         );
@@ -352,6 +361,29 @@ class HydratorPlusPlusNodeConfigCtrl {
 
     if (fields.length !== unique.length) {
       error.push('There are two or more fields with the same name.');
+    }
+  }
+  updateNodeStateIfDirty() {
+    let stateIsDirty = this.stateIsDirty();
+    // because we are adding state to history before we open a node config, so if the config wasn't changed at all,
+    // then we should remove that state from history
+    if (!stateIsDirty) {
+      this.DAGPlusPlusNodesActionsFactory.removePreviousState();
+    // if it was changed, then reset future states so user can't redo
+    } else {
+      this.DAGPlusPlusNodesActionsFactory.resetFutureStates();
+    }
+  }
+  stateIsDirty() {
+    let defaults = this.defaultState.node;
+    let state = this.state.node;
+    return !angular.equals(defaults, state);
+  }
+  updateDefaultOutputSchema(outputSchema) {
+    let configOutputSchema = this.state.groupsConfig.outputSchema;
+    if (!configOutputSchema.implicitSchema && configOutputSchema.isOutputSchemaExists) {
+      this.defaultState.node.outputSchema = outputSchema;
+      this.defaultState.node.plugin.properties[configOutputSchema.outputSchemaProperty[0]] = this.defaultState.node.outputSchema;
     }
   }
 

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
@@ -94,7 +94,8 @@
         is-disabled="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.implicitSchema"
         plugin-properties="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties"
         config="::HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.schemaProperties"
-        plugin-name="::HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name">
+        plugin-name="::HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name"
+        update-output-schema="HydratorPlusPlusNodeConfigCtrl.updateDefaultOutputSchema(outputSchema)">
       </my-complex-schema-editor>
 
       <div ng-if="HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance">


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-9107

Added two control buttons in Studio to allow undoing/redoing of:
- Nodes configuring/moving/addition/deletion
- Connections addition/deletion
- Comments addition/deletion

Users can also press `command+z` or `ctrl+z` to undo, or `command+shift+z` or `ctrl+shift+z` to redo.

~Currently there seems to be a js error when the user deletes a node. This doesn't break anything, but will investigate and fix.~ Fixed