### PR TITLE
allow dots in pipeline

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelectorProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelectorProvider.java
@@ -35,6 +35,7 @@ public class ArtifactSelectorProvider {
       .or(CharMatcher.inRange('a', 'z'))
       .or(CharMatcher.inRange('0', '9'))
       .or(CharMatcher.is('_'))
+      .or(CharMatcher.is('.'))
       .or(CharMatcher.is('-'));
 
   private final String pluginType;
@@ -67,7 +68,7 @@ public class ArtifactSelectorProvider {
     String name = config.getName();
     if (name != null && !nameMatcher.matchesAllOf(name)) {
       throw new IllegalArgumentException(String.format("'%s' is an invalid artifact name. " +
-                                                         "Must contain only alphanumeric, '-', or '_' characters.",
+                                                         "Must contain only alphanumeric, '-', '.', or '_' characters.",
                                                        name));
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/ArtifactSelectorProviderTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/ArtifactSelectorProviderTest.java
@@ -42,4 +42,11 @@ public class ArtifactSelectorProviderTest {
     ArtifactSelectorConfig config = new ArtifactSelectorConfig("usr", "abc", "1.0.0");
     PROVIDER.getPluginSelector(config);
   }
+
+  @Test
+  public void testValidArtifactNameWithDot() {
+    ArtifactSelectorConfig config = new ArtifactSelectorConfig(ArtifactScope.USER.name(),
+                                                               "cdap-artifact_2.10", "1.0.0");
+    PROVIDER.getPluginSelector(config);
+  }
 }


### PR DESCRIPTION
Changed ArtifactSelectorProvider to allow dots in artifact names for pipelines.

Issue: https://issues.cask.co/browse/CDAP-11884
Build: https://builds.cask.co/browse/CDAP-DUT5869