### PR TITLE
[CDAP-118866] Enables dataprep popover menu to be scrollable.

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -23,6 +23,7 @@ import classnames from 'classnames';
 import Mousetrap from 'mousetrap';
 import isEqual from 'lodash/isEqual';
 import DataPrepStore from 'components/DataPrep/store';
+import ScrollableList from 'components/ScrollableList';
 
 // Directives List
 import ParseDirective from 'components/DataPrep/Directives/Parse';
@@ -227,47 +228,47 @@ export default class ColumnActionsDropdown extends Component {
         tether={tetherOption}
       >
         <PopoverContent>
-          <div>
-            {
-              this.directives.map((directive) => {
-                if (directive.tag === 'divider') {
-                  return (
-                    <div className="column-action-divider">
-                      <hr />
-                    </div>
-                  );
-                }
-                let Tag = directive.tag;
-                let disabled = false;
-                let column = this.props.column;
+          <ScrollableList target={`dataprep-action-${this.dropdownId}`}>
+              {
+                this.directives.map((directive) => {
+                  if (directive.tag === 'divider') {
+                    return (
+                      <div className="column-action-divider">
+                        <hr />
+                      </div>
+                    );
+                  }
+                  let Tag = directive.tag;
+                  let disabled = false;
+                  let column = this.props.column;
 
-                if (this.state.selectedHeaders.indexOf(this.props.column) !== -1) {
-                  column = this.state.selectedHeaders;
+                  if (this.state.selectedHeaders.indexOf(this.props.column) !== -1) {
+                    column = this.state.selectedHeaders;
 
-                  if (this.state.selectedHeaders.length !== directive.requiredColCount && directive.requiredColCount !== 0) {
+                    if (this.state.selectedHeaders.length !== directive.requiredColCount && directive.requiredColCount !== 0) {
+                      disabled = true;
+                    }
+                  } else if (directive.requiredColCount === 2) {
                     disabled = true;
                   }
-                } else if (directive.requiredColCount === 2) {
-                  disabled = true;
-                }
 
-                return (
-                  <div
-                    key={directive.id}
-                    onClick={this.directiveClick.bind(this, directive.id)}
-                    className={classnames({'disabled': disabled})}
-                  >
-                    <Tag
-                      column={column}
-                      onComplete={this.toggleDropdown.bind(this, false)}
-                      isOpen={this.state.open === directive.id}
-                      close={this.directiveClick.bind(this, null)}
-                    />
-                  </div>
-                );
-              })
-            }
-          </div>
+                  return (
+                    <div
+                      key={directive.id}
+                      onClick={this.directiveClick.bind(this, directive.id)}
+                      className={classnames({'disabled': disabled})}
+                    >
+                      <Tag
+                        column={column}
+                        onComplete={this.toggleDropdown.bind(this, false)}
+                        isOpen={this.state.open === directive.id}
+                        close={this.directiveClick.bind(this, null)}
+                      />
+                    </div>
+                  );
+                })
+              }
+          </ScrollableList>
         </PopoverContent>
       </Popover>
     );

--- a/cdap-ui/app/cdap/components/ScrollableList/ScrollableList.scss
+++ b/cdap-ui/app/cdap/components/ScrollableList/ScrollableList.scss
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+$scroll-container-bg: #cccccc;
+
+.scrollable-list {
+  .scroll-down-container,
+  .scroll-up-container {
+    cursor: pointer;
+    background: $scroll-container-bg;
+  }
+  .icon-caret-down,
+  .icon-caret-up {
+    height: 20px;
+  }
+}

--- a/cdap-ui/app/cdap/components/ScrollableList/index.js
+++ b/cdap-ui/app/cdap/components/ScrollableList/index.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, { Component, PropTypes } from 'react';
+import IconSVG from 'components/IconSVG';
+import {difference} from 'services/helpers';
+import findIndex from 'lodash/findIndex';
+import classnames from 'classnames';
+
+require('./ScrollableList.scss');
+
+export default class ScrollableList extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      children: this.props.children,
+      numberOfElemsInList: null,
+      startingIndex: 0
+    };
+    this.computeHeight = this.computeHeight.bind(this);
+    this.scrollUp = this.scrollUp.bind(this);
+    this.scrollDown = this.scrollDown.bind(this);
+    this.onMouseEnter = this.onMouseEnter.bind(this);
+    this.onMouseOut = this.onMouseOut.bind(this);
+    this.shouldScrollDown = this.shouldScrollDown.bind(this);
+    this.shouldScrollUp = this.shouldScrollUp.bind(this);
+  }
+  componentDidMount() {
+    this.computeHeight();
+  }
+  componentWillReceiveProps(nextProps) {
+    let {children: newChildren} = this.getItemsInWindow(this.state.startingIndex, nextProps.children);
+    this.setState({
+      children: newChildren
+    });
+  }
+  computeHeight() {
+    let targetDimensions = document.getElementById(this.props.target).getBoundingClientRect();
+    let bodyBottom = document.body.getBoundingClientRect().bottom;
+    let targetBottom = targetDimensions.bottom;
+    let heightOfList = bodyBottom - targetBottom;
+    let numberOfElemsInList = Math.floor(heightOfList / 39);
+    let children = this.props.children.slice(0, numberOfElemsInList);
+    let numberOfActualElements = children.filter(child => child.props.className.indexOf('column-action-divider') === -1);
+    if (children.length > numberOfActualElements.length) {
+      children = this.props.children.slice(0, numberOfElemsInList + difference(children.length, numberOfActualElements.length));
+    }
+    this.setState({
+      children,
+      numberOfElemsInList,
+      startingIndex: 0
+    });
+  }
+
+  // This is to exclude considering line divider as a child.
+  getItemsInWindow(startIndex, children = this.props.children) {
+    let nonDividerChildren = children
+      .filter(child => child.props.className.indexOf('column-action-divider') === -1);
+    nonDividerChildren = nonDividerChildren.slice(startIndex, startIndex + this.state.numberOfElemsInList);
+    let actualStartIndex = findIndex(children, nonDividerChildren[0]);
+    let actualLastIndex = findIndex(children, nonDividerChildren[nonDividerChildren.length - 1]);
+    return {
+      children: children.slice(actualStartIndex, actualLastIndex + 1)
+    };
+  }
+  scrollDown() {
+    if (!this.shouldScrollDown()) {
+      return null;
+    }
+    let startIndex = this.state.startingIndex + 1;
+    let {children: newChildren} = this.getItemsInWindow(startIndex);
+    this.setState({
+      children: newChildren,
+      startingIndex: startIndex
+    });
+  }
+  scrollUp() {
+    if (!this.shouldScrollUp()) {
+      return null;
+    }
+    let startIndex = this.state.startingIndex - 1;
+    let {children: newChildren} = this.getItemsInWindow(startIndex);
+    this.setState({
+      children: newChildren,
+      startingIndex: startIndex
+    });
+  }
+  onMouseEnter(listener) {
+    this.interval = setInterval(listener, 500);
+  }
+  onMouseOut() {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
+  shouldScrollDown() {
+    if (this.props.children.length === this.state.startingIndex + this.state.children.length) {
+      return false;
+    }
+    let lastChildInWindow = this.state.children[this.state.children.length - 1].key;
+    let lastChild = this.props.children[this.props.children.length - 1].key;
+    if (lastChild === lastChildInWindow) {
+      return  false;
+    }
+    return true;
+  }
+  shouldScrollUp() {
+    return this.state.startingIndex !== 0;
+  }
+  renderScrollDownContainer() {
+    return (
+      <div
+        className={classnames("scroll-down-container text-xs-center", {
+          'disabled': !this.shouldScrollDown()
+        })}
+        onClick={this.scrollDown}
+        onMouseEnter={this.onMouseEnter.bind(this, this.scrollDown)}
+        onMouseOut={this.onMouseOut}
+      >
+        <IconSVG name="icon-caret-down" />
+      </div>
+    );
+  }
+  renderScrollUpContainer() {
+    return (
+      <div
+        className={classnames("scroll-down-container text-xs-center", {
+          'disabled': !this.shouldScrollUp()
+        })}
+        onClick={this.scrollUp}
+        onMouseEnter={this.onMouseEnter.bind(this, this.scrollUp)}
+        onMouseOut={this.onMouseOut}
+      >
+        <IconSVG name="icon-caret-up" />
+      </div>
+    );
+  }
+  render() {
+    return (
+      <div className="scrollable-list">
+        {this.renderScrollUpContainer()}
+        {this.state.children}
+        {this.renderScrollDownContainer()}
+      </div>
+    );
+  }
+}
+ScrollableList.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.node).isRequired,
+  target: PropTypes.string.isRequired
+};

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -183,6 +183,7 @@ const defaultEventObject = {
   },
   preventDefault: () => {}
 };
+
 function preventPropagation(e = defaultEventObject) {
   e.stopPropagation();
   e.nativeEvent.stopImmediatePropagation();
@@ -192,6 +193,10 @@ function preventPropagation(e = defaultEventObject) {
 const defaultAction = {
   action : '',
   payload : {}
+};
+
+const difference = (first, second) => {
+  return first > second ? first - second : second - first;
 };
 
 export {
@@ -206,5 +211,6 @@ export {
   contructUrl,
   getIcon,
   preventPropagation,
-  defaultAction
+  defaultAction,
+  difference
 };

--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
@@ -194,6 +194,11 @@ body.state-hydrator-create.state-hydrator {
     hr {
       margin: 10px -10px;
     }
+    .column-action-divider {
+      hr {
+        margin: 0;
+      }
+    }
     h5 {
       font-size: 13px;
       margin-top: 0;


### PR DESCRIPTION
- Adds a wrapper `ScrollableList` that will take an array of children and render only those that fit the window.

JIRA: https://issues.cask.co/browse/CDAP-11886