### PR TITLE
version bump for packer builds

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -187,8 +187,8 @@
       "skip_install": true,
       "json": {
         "cdap": {
-          "comment": "DO NOT PUT SNAPHOT IN THE VERSION BELOW, THIS CONTROLS CDAP COOKBOOK CODE",
-          "version": "4.2.0-1",
+          "comment": "DO NOT PUT SNAPSHOT IN THE VERSION BELOW (UPDATE TO NEXT RELEASE), THIS CONTROLS CDAP COOKBOOK CODE",
+          "version": "4.2.1-1",
           "sdk": {
             "comment": "COPY SDK ZIP TO files/cdap-sdk.zip BEFORE RUNNING ME",
             "url": "file:///tmp/cdap-sdk.zip",

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -1,6 +1,6 @@
 {
   "cdap": {
-    "version": "4.2.0-1"
+    "version": "4.2.1-1"
   },
   "nodejs": {
     "install_method": "binary",


### PR DESCRIPTION
Version bumps for packer builds.  without this, the cdap cookbook will enforce md5 checksums, which will fail in bamboo