### PR TITLE
[CDAP-11618][CDAP-11621] DataPrep Kafka Connection

### DIFF
--- a/cdap-ui/app/cdap/api/dataprep.js
+++ b/cdap-ui/app/cdap/api/dataprep.js
@@ -60,6 +60,12 @@ const MyDataPrepApi = {
   jdbcTestConnection: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/methods/connections/jdbc/test`),
   getDatabaseList: apiCreator(dataSrc, 'POST', 'REQUEST', `${connectionsPath}/databases`),
 
+  // Kafka
+  kafkaTestConnection: apiCreator(dataSrc, 'POST', 'REQUEST', `${connectionsPath}/kafka/test`),
+  listTopics: apiCreator(dataSrc, 'POST', 'REQUEST', `${connectionsPath}/kafka`),
+  readTopic: apiCreator(dataSrc, 'GET', 'REQUEST', `${connectionsPath}/:connectionId/kafka/:topic/read`),
+  getKafkaSpecification: apiCreator(dataSrc, 'GET', 'REQUEST', `${connectionsPath}/:connectionId/kafka/:topic/specification`),
+
   // Connections
   listConnections: apiCreator(dataSrc, 'GET', 'REQUEST', `${connectionsPath}`),
   createConnection: apiCreator(dataSrc, 'POST', 'REQUEST', `${connectionsPath}/create`),

--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -81,6 +81,14 @@ export default class ColumnActionsDropdown extends Component {
       },
       {
         id: shortid.generate(),
+        tag: SetCharacterEncoding,
+        requiredColCount: 1
+      },
+      {
+        tag: 'divider'
+      },
+      {
+        id: shortid.generate(),
         tag: Format,
         requiredColCount: 1
       },
@@ -155,11 +163,6 @@ export default class ColumnActionsDropdown extends Component {
       {
         id: shortid.generate(),
         tag: Decode,
-        requiredColCount: 1
-      },
-      {
-        id: shortid.generate(),
-        tag: SetCharacterEncoding,
         requiredColCount: 1
       }
     ];

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
@@ -21,13 +21,25 @@ const Actions = {
   SET_DATABASE_PROPERTIES: 'SET_DATABASE_PROPERTIES',
   SET_DATABASE_LOADING: 'SET_DATABASE_LOADING',
   SET_ACTIVEBROWSER: 'SET_ACTIVE_BROWSER',
-  SET_DATABASE_ERROR: 'SET_DATABASE_ERROR'
+  SET_DATABASE_ERROR: 'SET_DATABASE_ERROR',
+  SET_KAFKA_PROPERTIES: 'SET_KAFKA_PROPERTIES',
+  SET_KAFKA_LOADING: 'SET_KAFKA_LOADING',
+  SET_KAFKA_ERROR: 'SET_KAFKA_ERROR'
 };
 
 export {Actions} ;
 
 const defaultDatabaseValue = {
-  properties: {},
+  info: {},
+  tables: [],
+  loading: false,
+  error: null,
+  connectionId: ''
+};
+
+const defaultKafkaValue = {
+  info: {},
+  topics: [],
   loading: false,
   error: null,
   connectionId: ''
@@ -41,8 +53,9 @@ const database = (state = defaultDatabaseValue, action = defaultAction) => {
   switch (action.type) {
     case Actions.SET_DATABASE_PROPERTIES:
       return Object.assign({}, state, {
-        properties: objectQuery(action, 'payload', 'properties') || state.properties,
+        info: objectQuery(action, 'payload', 'info') || state.info,
         connectionId: objectQuery(action, 'payload', 'connectionId'),
+        tables: objectQuery(action, 'payload', 'tables'),
         error: null
       });
     case Actions.SET_DATABASE_LOADING:
@@ -52,7 +65,34 @@ const database = (state = defaultDatabaseValue, action = defaultAction) => {
       });
     case Actions.SET_DATABASE_ERROR:
       return Object.assign({}, state, {
-        error: action.payload.error
+        error: action.payload.error,
+        info: objectQuery(action, 'payload', 'info') || state.info,
+        loading: false
+      });
+    default:
+      return state;
+  }
+};
+
+const kafka = (state = defaultKafkaValue, action = defaultAction) => {
+  switch (action.type) {
+    case Actions.SET_KAFKA_PROPERTIES:
+      return Object.assign({}, state, {
+        info: objectQuery(action, 'payload', 'info') || state.info,
+        connectionId: objectQuery(action, 'payload', 'connectionId'),
+        topics: objectQuery(action, 'payload', 'topics'),
+        error: null
+      });
+    case Actions.SET_KAFKA_LOADING:
+      return Object.assign({}, state, {
+        loading: action.payload.loading,
+        error: null
+      });
+    case Actions.SET_KAFKA_ERROR:
+      return Object.assign({}, state, {
+        error: action.payload.error,
+        info: objectQuery(action, 'payload', 'info') || state.info,
+        loading: false
       });
     default:
       return state;
@@ -73,10 +113,12 @@ const activeBrowser = (state = defaultActiveBrowser, action = defaultAction) => 
 const DataPrepBrowserStore = createStore(
   combineReducers({
     database,
+    kafka,
     activeBrowser
   }),
   {
     database: defaultDatabaseValue,
+    kafka: defaultKafkaValue,
     activeBrowser: defaultActiveBrowser
   },
   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/KafkaBrowser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/KafkaBrowser.scss
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import '../../../../styles/variables.scss';
+
+$header-border: #cccccc;
+$header-bg: #eeeeee;
+$content-font-color: #333333;
+$hr_color: #999999;
+
+.kafka-browser {
+  height: calc(100vh - 50px - 54px);
+
+  .kafka-browser-header,
+  .kafka-browser-content {
+    padding-left: 15px;
+    padding-right: 15px;
+  }
+
+  .kafka-browser-content { height: calc(100% - 56px - 46px); }
+
+  .kafka-content-table {
+    padding: 0;
+    height: 100%;
+
+    .row {
+      margin: 0;
+    }
+    .kafka-content-header {
+      border-bottom: 1px solid $header-border;
+      border-top: 1px solid $header-border;
+      background-color: $header-bg;
+      line-height: 36px;
+      font-weight: 600;
+    }
+    .kafka-content-body {
+      height: calc(100% - 38px);
+      overflow-y: auto;
+      .content-row {
+        border-bottom: 1px solid $header-border;
+        line-height: 36px;
+        color: $content-font-color;
+        cursor: pointer;
+        &:hover {
+          background: $header-border;
+        }
+      }
+    }
+  }
+  .tables-count {
+    color: gray;
+    font-size: 12px;
+  }
+  .kafka-browser-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 46px;
+
+    .kafka-metadata { padding-left: 5px; }
+  }
+  .empty-search-container {
+    display: flex;
+    flex-wrap: wrap;
+    flex: 1;
+    width: 100%;
+
+    .empty-search {
+      font-size: 18px;
+      font-weight: 500;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 25vh;
+      max-width: 80%;
+      word-wrap: break-word;
+
+      hr {
+        color: $hr_color;
+        background-color: $hr_color;
+      }
+      span {
+        font-size: 14px;
+      }
+      ul {
+        padding: 0;
+        list-style: none;
+        font-size: 14px;
+        .link-text {
+          cursor: pointer;
+          color: $cdap-orange;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
@@ -18,10 +18,12 @@ import React, {Component, PropTypes} from 'react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import DatabaseBrowser from 'components/DataPrep/DataPrepBrowser/DatabaseBrowser';
 import FileBrowser from 'components/FileBrowser';
+import KafkaBrowser from 'components/DataPrep/DataPrepBrowser/KafkaBrowser';
 
 const browserMap = {
   database: DatabaseBrowser,
-  file: FileBrowser
+  file: FileBrowser,
+  kafka: KafkaBrowser
 };
 
 export default class DataPrepBrowser extends Component {

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
@@ -192,6 +192,54 @@ export default class AddToHydratorModal extends Component {
     };
   }
 
+  constructKafkaSource(artifactsList, kafkaInfo) {
+    if (!kafkaInfo) { return null; }
+
+    let plugin = objectQuery(kafkaInfo, 'values', '0');
+    let pluginName = Object.keys(plugin)[0];
+
+    // This is a hack.. should not do this
+    // We are still shipping kafka-plugins with hydrator-plugins 1.7 but
+    // it doesn't contain the streamingsource or batchsource plugins
+    let pluginArtifact = artifactsList.filter((artifact) => artifact.name === 'kafka-plugins');
+    pluginArtifact = pluginArtifact[pluginArtifact.length - 1];
+
+    plugin = plugin[pluginName];
+
+    plugin.properties.schema = "{\"name\":\"kafkaAvroSchema\",\"type\":\"record\",\"fields\":[{\"name\":\"body\",\"type\":\"string\"}]}";
+    let batchPluginInfo = {
+      name: plugin.name,
+      label: plugin.name,
+      type: 'batchsource',
+      artifact: pluginArtifact,
+      properties: plugin.properties
+    };
+
+    let realtimePluginInfo = Object.assign({}, batchPluginInfo, {
+      type: 'streamingsource',
+      artifact: pluginArtifact
+    });
+
+    let batchStage = {
+      name: plugin.name,
+      plugin: batchPluginInfo
+    };
+
+    let realtimeStage = {
+      name: plugin.name,
+      plugin: realtimePluginInfo
+    };
+
+    return {
+      batchSource: batchStage,
+      realtimeSource: realtimeStage,
+      connections: [{
+        from: plugin.name,
+        to: 'Wrangler'
+      }]
+    };
+  }
+
   constructProperties(pluginVersion) {
     let namespace = NamespaceStore.getState().selectedNamespace;
     let state = DataPrepStore.getState().dataprep;
@@ -225,6 +273,14 @@ export default class AddToHydratorModal extends Component {
       };
 
       rxArray.push(MyDataPrepApi.getDatabaseSpecification(specParams));
+    } else if (state.workspaceInfo.properties.connection === 'kafka') {
+      let specParams = {
+        namespace,
+        connectionId: state.workspaceInfo.properties.connectionid,
+        topic: state.workspaceInfo.properties.topic
+      };
+
+      rxArray.push(MyDataPrepApi.getKafkaSpecification(specParams));
     }
 
     MyArtifactApi.list({ namespace })
@@ -283,6 +339,8 @@ export default class AddToHydratorModal extends Component {
           sourceConfigs = this.constructFileSource(res[0], res[2]);
         } else if (state.workspaceInfo.properties.connection === 'database') {
           sourceConfigs = this.constructDatabaseSource(res[0], res[2]);
+        } else if (state.workspaceInfo.properties.connection === 'kafka') {
+          sourceConfigs = this.constructKafkaSource(res[0], res[2]);
         }
 
         if (sourceConfigs) {

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/PipelineConfigHelper.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/PipelineConfigHelper.js
@@ -155,6 +155,64 @@ function constructDatabaseSource(artifactsList, dbInfo) {
   }
 }
 
+function constructKafkaSource(artifactsList, kafkaInfo) {
+  if (!kafkaInfo) { return null; }
+
+  let plugin = objectQuery(kafkaInfo, 'values', '0');
+  let pluginName = Object.keys(plugin)[0];
+
+  // This is a hack.. should not do this
+  // We are still shipping kafka-plugins with hydrator-plugins 1.7 but
+  // it doesn't contain the streamingsource or batchsource plugins
+  let pluginArtifact = artifactsList.filter((artifact) => artifact.name === 'kafka-plugins');
+  pluginArtifact = pluginArtifact[pluginArtifact.length - 1];
+
+  plugin = plugin[pluginName];
+
+  plugin.properties.schema = {
+    name: 'kafkaAvroSchema',
+    type: 'record',
+    fields: [
+      {
+        name: 'message',
+        type: ['bytes', 'null']
+      }
+    ]
+  };
+
+  let batchPluginInfo = {
+    name: plugin.name,
+    label: plugin.name,
+    type: 'batchsource',
+    artifact: pluginArtifact,
+    properties: plugin.properties
+  };
+
+  let realtimePluginInfo = Object.assign({}, batchPluginInfo, {
+    type: 'streamingsource',
+    artifact: pluginArtifact
+  });
+
+  let batchStage = {
+    name: plugin.name,
+    plugin: batchPluginInfo
+  };
+
+  let realtimeStage = {
+    name: plugin.name,
+    plugin: realtimePluginInfo
+  };
+
+  return {
+    batchSource: batchStage,
+    realtimeSource: realtimeStage,
+    connections: [{
+      from: plugin.name,
+      to: 'Wrangler'
+    }]
+  };
+}
+
 function constructProperties(workspaceInfo, pluginVersion) {
   let  observable = new Rx.Subject();
   let namespace = NamespaceStore.getState().selectedNamespace;
@@ -190,6 +248,14 @@ function constructProperties(workspaceInfo, pluginVersion) {
     rxArray.push(MyDataPrepApi.getDatabaseSpecification(specParams));
     let requestBody = directiveRequestBodyCreator([]);
     rxArray.push(MyDataPrepApi.getSchema(requestObj, requestBody));
+  } else if (state.workspaceInfo.properties.connection === 'kafka') {
+    let specParams = {
+      namespace,
+      connectionId: state.workspaceInfo.properties.connectionid,
+      topic: state.workspaceInfo.properties.topic
+    };
+
+    rxArray.push(MyDataPrepApi.getKafkaSpecification(specParams));
   }
 
   try {
@@ -252,6 +318,8 @@ function constructProperties(workspaceInfo, pluginVersion) {
           type: 'record',
           fields: res[3]
         });
+      } else if (state.workspaceInfo.properties.connection === 'kafka') {
+        sourceConfigs = constructKafkaSource(res[0], res[2]);
       }
 
       if (sourceConfigs) {

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -152,6 +152,7 @@ export default class DataPrepTopPanel extends Component {
 
   renderTopPanelDisplay() {
     let info = this.state.workspaceInfo;
+
     if (info) {
       if (info.properties.connection === 'file') {
         return (
@@ -182,6 +183,17 @@ export default class DataPrepTopPanel extends Component {
             <div className="connection-type">
               {T.translate('features.DataPrep.TopPanel.upload')}
               <span className="connection-name">{info.properties.connectionid}</span>
+            </div>
+            <div className="title">
+              {info.properties.name}
+            </div>
+          </div>
+        );
+      } else if (info.properties.connection === 'kafka') {
+        return (
+          <div className={classnames("data-prep-name", {"upgrade": this.state.higherVersion})}>
+            <div className="connection-type">
+              {T.translate('features.DataPrep.TopPanel.kafka')}
             </div>
             <div className="title">
               {info.properties.name}

--- a/cdap-ui/app/cdap/components/DataPrepConnections/AddConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/AddConnection/index.js
@@ -18,6 +18,7 @@ import React, { Component, PropTypes } from 'react';
 import IconSVG from 'components/IconSVG';
 import { Popover, PopoverTitle, PopoverContent } from 'reactstrap';
 import DatabaseConnection from 'components/DataPrepConnections/DatabaseConnection';
+import KafkaConnection from 'components/DataPrepConnections/KafkaConnection';
 import T from 'i18n-react';
 
 require('./AddConnection.scss');
@@ -46,10 +47,11 @@ export default class AddConnection extends Component {
       //   type: 'S3',
       //   icon: 'icon-s3'
       // },
-      // {
-      //   type: 'Kafka',
-      //   icon: 'icon-kafka'
-      // }
+      {
+        type: 'Kafka',
+        icon: 'icon-kafka',
+        component: KafkaConnection
+      }
     ];
   }
 

--- a/cdap-ui/app/cdap/components/DataPrepConnections/ConnectionPopover/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/ConnectionPopover/index.js
@@ -21,12 +21,18 @@ import NamespaceStore from 'services/NamespaceStore';
 import {Modal, ModalHeader, ModalBody} from 'reactstrap';
 import LoadingSVG from 'components/LoadingSVG';
 import DatabaseConnection from 'components/DataPrepConnections/DatabaseConnection';
+import KafkaConnection from 'components/DataPrepConnections/KafkaConnection';
 import T from 'i18n-react';
 import {objectQuery} from 'services/helpers';
 
 require('./ConnectionPopover.scss');
 
 const PREFIX = 'features.DataPrepConnections.ConnectionManagement';
+
+const COMPONENT_MAP = {
+  'DATABASE': DatabaseConnection,
+  'KAFKA': KafkaConnection
+};
 
 export default class ConnectionPopover extends Component {
   constructor(props) {
@@ -156,8 +162,10 @@ export default class ConnectionPopover extends Component {
   renderEdit() {
     if (!this.state.edit) { return null; }
 
+    let Tag = COMPONENT_MAP[this.props.connectionInfo.type];
+
     return (
-      <DatabaseConnection
+      <Tag
         close={this.toggleEdit}
         mode="EDIT"
         connectionId={this.props.connectionInfo.id}
@@ -169,8 +177,10 @@ export default class ConnectionPopover extends Component {
   renderDuplicate() {
     if (!this.state.duplicate) { return null; }
 
+    let Tag = COMPONENT_MAP[this.props.connectionInfo.type];
+
     return (
-      <DatabaseConnection
+      <Tag
         close={this.toggleDuplicate}
         mode="DUPLICATE"
         connectionId={this.props.connectionInfo.id}

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortActions.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortActions.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+const HostPortActions = {
+  setHost: 'SET-KEY',
+  setPort: 'SET-VALUE',
+  addRow: 'ADD-ROW',
+  deletePair: 'DELETE-PAIR',
+  onReset: 'ON-RESET',
+  onUpdate: 'ON-UPDATE'
+};
+
+export default HostPortActions;

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortEditor.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortEditor.scss
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+.host-port-editor-container {
+  .host-port-row-container {
+    margin-bottom: 10px;
+
+    .port-input-container,
+    .host-input-container,
+    .port-label,
+    .action-buttons-container {
+      display: inline-block;
+    }
+
+    .port-label {
+      width: 40px;
+      margin-left: 10px;
+    }
+
+    .action-buttons-container {
+      width: 80px;
+
+      .add-row-btn { color: inherit; }
+    }
+
+    .port-input-container {
+      width: 100px;
+    }
+
+    .host-input-container {
+      // 100% - port - port label - buttons
+      width: calc(100% - 100px - 50px - 80px);
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortRow.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortRow.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+
+export default class HostPortRow extends Component {
+  constructor(props) {
+    super(props);
+
+    this.keyDown = this.keyDown.bind(this);
+  }
+
+  keyDown(e) {
+    if (e.keyCode === 13) {
+      this.props.addRow();
+    }
+  }
+
+  render() {
+    return (
+      <div className="host-port-row-container">
+        <div className="host-input-container">
+          <input
+            type="text"
+            value={this.props.host}
+            autoFocus
+            onKeyDown={this.keyDown}
+            onChange={this.props.onChange.bind(null, 'host')}
+            className="form-control"
+          />
+        </div>
+
+        <span className="port-label">
+          Port:
+        </span>
+        <div className="port-input-container">
+          <input
+            type="number"
+            value={this.props.port}
+            onKeyDown={this.keyDown}
+            onChange={this.props.onChange.bind(null, 'port')}
+            className="form-control"
+          />
+        </div>
+
+        <div className="action-buttons-container text-xs-right">
+          <button
+            className="btn add-row-btn btn-link"
+            onClick={this.props.addRow}
+          >
+            <i className="fa fa-plus" />
+          </button>
+          <button
+            className="btn remove-row-btn btn-link"
+            onClick={this.props.removeRow}
+          >
+            <i className="fa fa-trash text-danger" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+HostPortRow.propTypes = {
+  className: PropTypes.string,
+  host: PropTypes.string,
+  port: PropTypes.string,
+  index: PropTypes.number,
+  onChange: PropTypes.func,
+  addRow: PropTypes.func,
+  removeRow: PropTypes.func,
+};

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortStore.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortStore.js
@@ -1,0 +1,86 @@
+/*
+* Copyright © 2016-2017 Cask Data, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+
+import {combineReducers, createStore} from 'redux';
+import HostPortActions from 'components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortActions';
+import shortid from 'shortid';
+
+const defaultAction = {
+  type: '',
+  payload: {}
+};
+
+const initialState = {
+  rows: []
+};
+
+const hostport = (state = initialState, action = defaultAction) => {
+  let stateCopy;
+  switch (action.type) {
+    case HostPortActions.setHost:
+      stateCopy = Object.assign({}, state);
+      if (action.payload.host === null || typeof action.payload.host === 'undefined') {
+        return stateCopy;
+      }
+      stateCopy.rows[action.payload.index].host = action.payload.host;
+      return stateCopy;
+    case HostPortActions.setPort:
+      stateCopy = Object.assign({}, state);
+      if (action.payload.port === null || typeof action.payload.port === 'undefined') {
+        return stateCopy;
+      }
+      stateCopy.rows[action.payload.index].port = action.payload.port;
+      return stateCopy;
+
+    case HostPortActions.addRow:
+      stateCopy = Object.assign({}, state);
+      stateCopy.rows.splice(action.payload.index + 1, 0, {
+        host: '',
+        port: '',
+        uniqueId: shortid.generate()
+      });
+      return stateCopy;
+    case HostPortActions.deletePair:
+      stateCopy = Object.assign({}, state);
+      stateCopy.rows.splice(action.payload.index, 1);
+      if (!stateCopy.rows.length) {
+        stateCopy.rows.push({
+          host: '',
+          port: '',
+          uniqueId: shortid.generate()
+        });
+      }
+      return stateCopy;
+    case HostPortActions.onReset:
+      return initialState;
+    case HostPortActions.onUpdate:
+      stateCopy = Object.assign({}, state);
+      stateCopy.rows = action.payload.rows;
+      return stateCopy;
+    default:
+      return state;
+  }
+};
+
+const HostPortStore = createStore(
+  combineReducers({
+    hostport
+  }),
+  initialState,
+  window.devToolsExtension ? window.devToolsExtension() : f => f
+);
+
+export default HostPortStore;

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/index.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import {connect , Provider} from 'react-redux';
+import HostPortActions from 'components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortActions';
+import HostPortStore from 'components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortStore';
+import HostPortRow from 'components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortRow';
+
+require('./HostPortEditor.scss');
+
+const mapStateToFieldNameProps = (state, ownProps) => {
+  return {
+    host: state.hostport.rows[ownProps.index].host,
+    port: state.hostport.rows[ownProps.index].port
+  };
+};
+
+const fieldToActionMap = {
+  host: HostPortActions.setHost,
+  port: HostPortActions.setPort
+};
+
+const mapDispatchToFieldNameProps = (dispatch, ownProps) => {
+  return {
+    removeRow: () => {
+      dispatch({
+        type: HostPortActions.deletePair,
+        payload: {index: ownProps.index}
+      });
+    },
+    addRow: () => {
+      dispatch({
+        type: HostPortActions.addRow,
+        payload: {index: ownProps.index}
+      });
+    },
+    onChange: (fieldProp, e) => {
+      dispatch({
+        type: fieldToActionMap[fieldProp],
+        payload: {
+          index: ownProps.index,
+          [fieldProp]: e.target.value
+        }
+      });
+    }
+  };
+};
+
+let HostPortRowWrapper = connect(
+  mapStateToFieldNameProps,
+  mapDispatchToFieldNameProps
+)(HostPortRow);
+
+export default class HostPortEditor extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      rows: this.props.values
+    };
+
+    this.sub = HostPortStore.subscribe(() => {
+      let rows = HostPortStore.getState().hostport.rows;
+
+      this.setState({
+        rows
+      });
+
+      this.props.onChange(rows);
+    });
+
+    HostPortStore.dispatch({
+      type: HostPortActions.onUpdate,
+      payload: {
+        rows: this.props.values
+      }
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      rows: [...nextProps.values]
+    });
+  }
+
+  shouldComponentUpdate(nextProps) {
+    let check = this.state.rows.length !== nextProps.values.length;
+
+    return check;
+  }
+
+  componentWillUnmount() {
+    if (this.sub) {
+      this.sub();
+    }
+    HostPortStore.dispatch({
+      type: HostPortActions.onReset
+    });
+  }
+
+  render() {
+    return (
+      <div className="host-port-editor-container">
+        {
+          this.state.rows.map( (row, index) => {
+            return (
+              <div key={row.uniqueId}>
+                <Provider store={HostPortStore}>
+                  <HostPortRowWrapper index={index} />
+                </Provider>
+              </div>
+            );
+          })
+        }
+      </div>
+    );
+  }
+}
+
+HostPortEditor.propTypes = {
+  values: PropTypes.array,
+  onChange: PropTypes.func
+};

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/KafkaConnection.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/KafkaConnection.scss
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+$asterisk-color: #d50000;
+$success-color: #00c853;
+$modal-header-bg-color: #efefef;
+$close-button-color: #333333;
+
+.kafka-connection-modal.modal-dialog {
+  .modal-content { border-radius: 0; }
+
+  .modal-header {
+    border-bottom: none;
+    background-color: $modal-header-bg-color;
+
+    .modal-title { font-size: 16px; }
+
+    .close {
+      color: $close-button-color;
+      font-size: 23px;
+      opacity: 1;
+    }
+  }
+
+  .modal-footer {
+    padding: 0;
+    text-align: left;
+    border-top: 0;
+  }
+
+  .kafka-detail {
+    .col-form-label {
+      font-weight: 500;
+      font-size: 14px;
+      padding-top: 4px;
+
+      .asterisk {
+        position: relative;
+        top: -3px;
+        left: 2px;
+      }
+    }
+
+    .input-name {
+      width: calc(100% - 100px - 50px - 80px);
+    }
+
+    .connection-check { margin-left: 5px; }
+
+    .asterisk {
+      color: $asterisk-color;
+    }
+
+    .action-buttons-container {
+      .btn.btn-link {
+        padding: 7px 5px;
+      }
+
+      .add-row-btn i { vertical-align: middle; }
+    }
+  }
+
+  .test-connection-button {
+    margin-left: 5px;
+  }
+
+  .loading-indicator {
+    vertical-align: middle;
+    margin-left: 5px;
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/index.js
@@ -1,0 +1,407 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import {objectQuery} from 'services/helpers';
+import NamespaceStore from 'services/NamespaceStore';
+import MyDataPrepApi from 'api/dataprep';
+import T from 'i18n-react';
+import LoadingSVG from 'components/LoadingSVG';
+import HostPortEditor from 'components/DataPrepConnections/KafkaConnection/HostPortEditor';
+import shortid from 'shortid';
+import ee from 'event-emitter';
+import CardActionFeedback from 'components/CardActionFeedback';
+
+const PREFIX = 'features.DataPrepConnections.AddConnections.Kafka';
+
+const LABEL_COL_CLASS = 'col-xs-3 col-form-label text-xs-right';
+const INPUT_COL_CLASS = 'col-xs-8';
+
+require('./KafkaConnection.scss');
+
+export default class KafkaConnection extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      name: '',
+      brokersList: [{
+        host: 'localhost',
+        port: '9092',
+        uniqueId: shortid.generate()
+      }],
+      connectionResult: null,
+      testConnectionLoading: false,
+      error: null,
+      loading: false
+    };
+
+    this.eventEmitter = ee(ee);
+    this.preventDefault = this.preventDefault.bind(this);
+    this.addConnection = this.addConnection.bind(this);
+    this.editConnection = this.editConnection.bind(this);
+    this.testConnection = this.testConnection.bind(this);
+    this.handleBrokersChange = this.handleBrokersChange.bind(this);
+  }
+
+  componentWillMount() {
+    if (this.props.mode === 'ADD') { return; }
+
+    this.setState({ loading: true });
+
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let params = {
+      namespace,
+      connectionId: this.props.connectionId
+    };
+
+    MyDataPrepApi.getConnection(params)
+      .subscribe((res) => {
+        let info = objectQuery(res, 'values', 0),
+            brokers = objectQuery(info, 'properties', 'brokers');
+
+        let name = this.props.mode === 'EDIT' ? info.name : '';
+        let brokersList = this.parseBrokers(brokers);
+
+        this.setState({
+          name,
+          brokersList,
+          loading: false
+        });
+      }, (err) => {
+        console.log('failed to fetch connection detail', err);
+
+        this.setState({
+          loading: false
+        });
+      });
+  }
+
+  parseBrokers(brokers) {
+    let brokersList = [];
+
+    brokers.split(',').forEach((broker) => {
+      let split = broker.trim().split(':');
+
+      let obj = {
+        host: split[0] || '',
+        port: split[1] || '',
+        uniqueId: shortid.generate()
+      };
+
+      brokersList.push(obj);
+    });
+
+    return brokersList;
+  }
+
+  preventDefault(e) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  handleBrokersChange(rows) {
+    this.setState({
+      brokersList: rows
+    });
+  }
+
+  convertBrokersList() {
+    return this.state.brokersList.map((broker) => {
+      return `${broker.host}:${broker.port}`;
+    }).join(',');
+  }
+
+  addConnection() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let requestBody = {
+      name: this.state.name,
+      type: 'KAFKA',
+      properties: {
+        brokers: this.convertBrokersList()
+      }
+    };
+
+    MyDataPrepApi.createConnection({namespace}, requestBody)
+      .subscribe(() => {
+        this.setState({error: null});
+        this.props.onAdd();
+        this.props.close();
+      }, (err) => {
+        console.log('err', err);
+
+        let error = objectQuery(err, 'response', 'message') || objectQuery(err, 'response');
+        this.setState({ error });
+      });
+  }
+
+  editConnection() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let params = {
+      namespace,
+      connectionId: this.props.connectionId
+    };
+
+    let requestBody = {
+      name: this.state.name,
+      id: this.props.connectionId,
+      type: 'KAFKA',
+      properties: {
+        brokers: this.convertBrokersList()
+      }
+    };
+
+    MyDataPrepApi.updateConnection(params, requestBody)
+      .subscribe(() => {
+        this.setState({error: null});
+        this.eventEmitter.emit('DATAPREP_CONNECTION_EDIT_KAFKA', this.props.connectionId);
+        this.props.onAdd();
+        this.props.close();
+      }, (err) => {
+        console.log('err', err);
+
+        let error = objectQuery(err, 'response', 'message') || objectQuery(err, 'response');
+        this.setState({ error });
+      });
+  }
+
+  testConnection() {
+    this.setState({
+      testConnectionLoading: true,
+      connectionResult: null,
+      error: null
+    });
+
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let requestBody = {
+      name: this.state.name,
+      type: 'KAFKA',
+      properties: {
+        brokers: this.convertBrokersList()
+      }
+    };
+
+    MyDataPrepApi.kafkaTestConnection({namespace}, requestBody)
+      .subscribe((res) => {
+        this.setState({
+          connectionResult: {
+            type: 'success',
+            message: res.message
+          },
+          testConnectionLoading: false
+        });
+      }, (err) => {
+        console.log('Error testing kafka connection', err);
+
+        let errorMessage = objectQuery(err, 'response', 'message') || objectQuery(err, 'response') || T.translate(`${PREFIX}.defaultTestErrorMessage`);
+
+        this.setState({
+          connectionResult: {
+            type: 'danger',
+            message: errorMessage
+          },
+          testConnectionLoading: false
+        });
+      });
+  }
+
+  handleChange(key, e) {
+    this.setState({
+      [key]: e.target.value
+    });
+  }
+
+  renderKafka() {
+    return (
+      <div className="form-group row">
+        <label className={LABEL_COL_CLASS}>
+          {T.translate(`${PREFIX}.brokersList`)}
+          <span className="asterisk">*</span>
+        </label>
+        <div className={INPUT_COL_CLASS}>
+          <HostPortEditor
+            values={this.state.brokersList}
+            onChange={this.handleBrokersChange}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  renderAddConnectionButton() {
+    let disabled = !this.state.name;
+    disabled = disabled || this.state.brokersList.length === 0 || (this.state.brokersList.length === 1 && (!this.state.brokersList[0].host || !this.state.brokersList[0].port));
+
+    let onClickFn = this.addConnection;
+
+    if (this.props.mode === 'EDIT') {
+      onClickFn = this.editConnection;
+    }
+
+    return (
+      <div className="row">
+        <div className="col-xs-9 offset-xs-3 col-xs-offset-3">
+          <button
+            className="btn btn-primary"
+            onClick={onClickFn}
+            disabled={disabled}
+          >
+            {T.translate(`${PREFIX}.Buttons.${this.props.mode}`)}
+          </button>
+
+          {this.renderTestButton()}
+        </div>
+      </div>
+    );
+  }
+
+  renderTestButton() {
+    let disabled = this.state.testConnectionLoading || !this.state.name;
+    disabled = disabled || this.state.brokersList.length === 0 || (this.state.brokersList.length === 1 && (!this.state.brokersList[0].host || !this.state.brokersList[0].port));
+
+    return (
+      <span className="test-connection-button">
+        <button
+          className="btn btn-secondary"
+          onClick={this.testConnection}
+          disabled={disabled}
+        >
+          {T.translate(`${PREFIX}.testConnection`)}
+        </button>
+        {
+          this.state.testConnectionLoading ?
+            (
+              <span className="fa loading-indicator">
+                <LoadingSVG />
+              </span>
+            )
+          :
+            null
+        }
+        {
+          this.state.connectionResult ?
+            (
+              <span
+                className={`connection-check text-${this.state.connectionResult.type}`}
+              >
+                {this.state.connectionResult.message}
+              </span>
+            )
+          :
+            null
+        }
+      </span>
+    );
+  }
+
+  renderError() {
+    if (!this.state.error) { return null; }
+
+    return (
+      <ModalFooter>
+        <CardActionFeedback
+          type="DANGER"
+          message={T.translate(`${PREFIX}.ErrorMessages.${this.props.mode}`)}
+          extendedMessage={this.state.error}
+        />
+      </ModalFooter>
+    );
+  }
+
+  renderContent() {
+    if (this.state.loading) {
+      return (
+        <div className="kafka-detail text-xs-center">
+          <br />
+          <LoadingSVG />
+        </div>
+      );
+    }
+
+    return (
+      <div className="kafka-detail">
+        <div className="row">
+          <div className={`${INPUT_COL_CLASS} offset-xs-3 col-xs-offset-3`}>
+            <span className="asterisk">*</span>
+            <em>{T.translate(`${PREFIX}.required`)}</em>
+          </div>
+        </div>
+
+        <div className="form">
+          <div className="form-group row">
+            <label className={LABEL_COL_CLASS}>
+              {T.translate(`${PREFIX}.name`)}
+              <span className="asterisk">*</span>
+            </label>
+            <div className={INPUT_COL_CLASS}>
+              <div className="input-name">
+                <input
+                  type="text"
+                  className="form-control"
+                  value={this.state.name}
+                  onChange={this.handleChange.bind(this, 'name')}
+                  disabled={this.props.mode === 'EDIT'}
+                />
+              </div>
+            </div>
+          </div>
+
+          {this.renderKafka()}
+
+          {this.renderAddConnectionButton()}
+
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <Modal
+          isOpen={true}
+          toggle={this.props.close}
+          size="lg"
+          className="kafka-connection-modal"
+          backdrop="static"
+          zIndex="1061"
+        >
+          <ModalHeader toggle={this.props.close}>
+            {T.translate(`${PREFIX}.ModalHeader.${this.props.mode}`, {connection: this.props.connectionId})}
+          </ModalHeader>
+
+          <ModalBody>
+            {this.renderContent()}
+          </ModalBody>
+
+          {this.renderError()}
+        </Modal>
+      </div>
+    );
+  }
+}
+
+KafkaConnection.propTypes = {
+  close: PropTypes.func,
+  onAdd: PropTypes.func,
+  mode: PropTypes.oneOf(['ADD', 'EDIT', 'DUPLICATE']).isRequired,
+  connectionId: PropTypes.string
+};

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -18,7 +18,11 @@ import React, { Component, PropTypes } from 'react';
 import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';
 import DataPrepBrowser from 'components/DataPrep/DataPrepBrowser';
-import {setActiveBrowser, setDatabaseAsActiveBrowser} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
+import {
+  setActiveBrowser,
+  setDatabaseAsActiveBrowser,
+  setKafkaAsActiveBrowser
+} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import {Route, NavLink, Redirect, Switch} from 'react-router-dom';
 import NamespaceStore from 'services/NamespaceStore';
 import {preventPropagation} from 'services/helpers';
@@ -80,7 +84,8 @@ export default class DataPrepConnections extends Component {
       sidePanelExpanded: this.props.enableRouting ? true : false,
       backendChecking: true,
       backendDown: false,
-      connectionsList: [],
+      databaseList: [],
+      kafkaList: [],
       activeConnectionid: objectQuery(workspaceInfo, 'properties', 'connectionid'),
       activeConnectionType: objectQuery(workspaceInfo, 'properties', 'connection'),
       showUpload: false // FIXME: This is used only when showing with no routing. We can do better.
@@ -169,6 +174,10 @@ export default class DataPrepConnections extends Component {
       setDatabaseAsActiveBrowser({name: 'database', id: browserName.id});
       activeConnectionType = 'database';
       activeConnectionid = browserName.id;
+    } else if (typeof browserName === 'object' && browserName.type === 'KAFKA') {
+      setKafkaAsActiveBrowser({name: 'kafka', id: browserName.id});
+      activeConnectionType = 'kafka';
+      activeConnectionid = browserName.id;
     }
 
     this.setState({
@@ -187,16 +196,30 @@ export default class DataPrepConnections extends Component {
 
     MyDataPrepApi.listConnections({
       namespace,
-      type: 'database' // currently only going to fetch database connection
+      type: '*' // currently only going to fetch database connection
     }).subscribe((res) => {
       // need to group by connection type
+
+      let databaseList = [],
+          kafkaList = [];
+
       let state = {};
       if (action === 'delete' && this.state.activeConnectionid === targetId) {
         state.activeConnectionid = null;
         state.activeConnectionType = 'file';
         setActiveBrowser({name: 'file'});
       }
-      state.connectionsList = res.values;
+
+      res.values.forEach((connection) => {
+        if (connection.type === 'DATABASE') {
+          databaseList.push(connection);
+        } else if (connection.type === 'KAFKA') {
+          kafkaList.push(connection);
+        }
+      });
+
+      state.databaseList = databaseList;
+      state.kafkaList = kafkaList;
       this.setState(state);
     });
   }
@@ -222,7 +245,7 @@ export default class DataPrepConnections extends Component {
 
     return (
       <div>
-        {this.state.connectionsList.map((database) => {
+        {this.state.databaseList.map((database) => {
           return (
             <div
               key={database.id}
@@ -241,6 +264,40 @@ export default class DataPrepConnections extends Component {
 
               <ConnectionPopover
                 connectionInfo={database}
+                onAction={this.fetchConnectionsList}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  renderKafkaDetail() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+    const baseLinkPath = `/ns/${namespace}/connections`;
+
+    return (
+      <div>
+        {this.state.kafkaList.map((kafka) => {
+          return (
+            <div
+              key={kafka.id}
+              title={kafka.name}
+              className="clearfix"
+            >
+              <NavLinkWrapper
+                to={`${baseLinkPath}/kafka/${kafka.id}`}
+                activeClassName="active"
+                className="menu-item-expanded-list"
+                onClick={this.handlePropagation.bind(this, kafka)}
+                singleWorkspaceMode={this.props.singleWorkspaceMode}
+              >
+                {kafka.name}
+              </NavLinkWrapper>
+
+              <ConnectionPopover
+                connectionInfo={kafka}
                 onAction={this.fetchConnectionsList}
               />
             </div>
@@ -314,10 +371,22 @@ export default class DataPrepConnections extends Component {
                 <IconSVG name="icon-database" />
               </span>
               <span>
-              {T.translate(`${PREFIX}.database`, {count: this.state.connectionsList.length})}
+              {T.translate(`${PREFIX}.database`, {count: this.state.databaseList.length})}
               </span>
             </div>
             {this.renderDatabaseDetail()}
+          </ExpandableMenu>
+
+          <ExpandableMenu>
+            <div>
+              <span className="fa fa-fw">
+                <IconSVG name="icon-kafka" />
+              </span>
+              <span>
+              {T.translate(`${PREFIX}.kafka`, {count: this.state.kafkaList.length})}
+              </span>
+            </div>
+            {this.renderKafkaDetail()}
           </ExpandableMenu>
         </div>
 
@@ -372,6 +441,21 @@ export default class DataPrepConnections extends Component {
             );
           }}
         />
+        <Route
+          path={`${BASEPATH}/kafka/:kafkaId`}
+          render={(match) => {
+            let id  = match.match.params.kafkaId;
+            setKafkaAsActiveBrowser({name: 'kafka', id});
+            return (
+              <DataPrepBrowser
+                match={match}
+                location={location}
+                toggle={this.toggleSidePanel}
+                onWorkspaceCreate={this.onUploadSuccess}
+              />
+            );
+          }}
+        />
         <Route component={RouteToHDFS} />
       </Switch>
     );
@@ -389,6 +473,8 @@ export default class DataPrepConnections extends Component {
     enableRouting = this.props.singleWorkspaceMode ? false : this.props.enableRouting;
     if (this.state.activeConnectionType === 'database') {
       setDatabaseAsActiveBrowser({name: 'database', id: this.state.activeConnectionid});
+    } else if (this.state.activeConnectionType === 'kafka') {
+      setKafkaAsActiveBrowser({name: 'kafka', id: this.state.activeConnectionid});
     } else if (this.state.activeConnectionType === 'file') {
       setActiveBrowser({name: 'file'});
     }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -392,6 +392,21 @@ features:
           1: '{context} Table'
           _: "{context} Tables"
         title: Select Table
+      KafkaBrowser:
+        EmptyMessage:
+          clearLabel: Clear
+          emptyKafka: 'No topics in connection _{connectionName}_'
+          suggestionTitle: "You can try to:"
+          suggestion1: your search
+          title: 'No match found for "{searchText}"'
+        searchPlaceholder: Search topic
+        table:
+          topics: Topics
+        topicCount:
+          0: No Topics
+          1: '{count} Topic'
+          _: "{count} Topics"
+        title: Select Topic
     Directives:
       apply: Apply
       cancel: Cancel
@@ -672,6 +687,7 @@ features:
       invalidFieldNameRemedies2: "You can try to "
       cleanseLinkLabel: "cleanse "
       invalidFieldNameRemedies3: column names.
+      kafka: Kafka
       SchemaModal:
         defaultErrorMessage: Error generating schema.
       PipelineModal:
@@ -761,6 +777,30 @@ features:
           ADD: "Add Connection: Database"
           DUPLICATE: "Duplicate Connection: {connection}"
           EDIT: "Edit Connection: {connection}"
+      Kafka:
+        brokersList: Broker Host
+        Buttons:
+          ADD: Add Connection
+          DUPLICATE: Duplicate Connection
+          EDIT: Save Changes
+        connectionType: Connection Type
+        defaultTestErrorMessage: Cannot connect to Kafka
+        ErrorMessages:
+          ADD: Failed to add connection
+          DUPLICATE: Failed to duplicate connection
+          EDIT: Failed to edit connection
+        kafka: Kafka
+        ModalHeader:
+          ADD: "Add Connection: Kafka"
+          DUPLICATE: "Duplicate Connection: {connection}"
+          EDIT: "Edit Connection: {connection}"
+        name: Name
+        port: Port
+        required: Required
+        testConnection: Test Connection
+        zkQuorum: Zookeeper Host
+        zookeeper: Zookeeper
+
       label: Add Connection
       Popover:
         title: Select a source to connect
@@ -777,6 +817,7 @@ features:
       edit: Edit
     database: Database ({count})
     hdfs: File System
+    kafka: Kafka ({count})
     title: "Connections in \"{namespace}\""
     upload: Upload
     UploadComponent:


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-11621
- https://issues.cask.co/browse/CDAP-11618


### There are still a few things not working:
~1. Currently the connectionId is being hardcoded as `testkafka` for when you add to pipeline. This is because the backend app is not returning the `connectionid` as part of the workspace properties.~
2. I have not added the ability for one time copy yet. There are properties missing for batch pipeline that is not macro enabled.
3. Existence of Kafka Plugins is still an open question....



#### Side note:
We should be able to refactor the browser to be a generic browser, especially when it only has 1 column. All the functionality is the same except the API to prep the content before going to workspace