### PR TITLE
Log a heapdump file on OOM by default, for YARN containers.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -356,9 +356,9 @@
 
   <property>
     <name>app.program.jvm.opts</name>
-    <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts}</value>
+    <value>-XX:MaxPermSize=128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=&lt;LOG_DIR&gt; ${twill.jvm.gc.opts}</value>
     <description>
-      Java options for all program containers
+      Java options for all Apache Twill containers
     </description>
   </property>
 


### PR DESCRIPTION
The result:
![image](https://user-images.githubusercontent.com/2440977/27166461-a5d0f41a-514f-11e7-9d0b-8b8ccb264e7e.png)
