### PR TITLE
CDAP-8345 TMS hdfs directory for coprocessors under /cdap is not required

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1256,9 +1256,6 @@ public final class Constants {
     public static final String CONTAINER_INSTANCES = "messaging.container.instances";
     public static final String MAX_INSTANCES = "messaging.max.instances";
 
-    // directory to store the messaging system coprocessor jars
-    public static final String COPROCESSOR_DIR = "messaging.coprocessor.dir";
-
     // The following configuration keys are set by messaging service TwillRunnable only,
     // not available in cdap-default.xml
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1563,15 +1563,6 @@
   </property>
 
   <property>
-    <name>messaging.coprocessor.dir</name>
-    <value>tms</value>
-    <description>
-      Directory to store messaging service table coprocessors. This path is
-      relative to ${hdfs.namespace}.
-    </description>
-  </property>
-
-  <property>
     <name>messaging.coprocessor.metadata.cache.expiration.seconds</name>
     <value>120</value>
     <description>

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -257,7 +257,6 @@ public class MasterServiceMain extends DaemonMain {
     logAppenderInitializer.initialize();
     resetShutdownTime();
     createDirectory("twill");
-    createDirectory(cConf.get(Constants.MessagingSystem.COPROCESSOR_DIR));
     createSystemHBaseNamespace();
     updateConfigurationTable();
     Services.startAndWait(zkClient, cConf.getLong(Constants.Zookeeper.CLIENT_STARTUP_TIMEOUT_MILLIS),


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-8345
Build : https://builds.cask.co/browse/CDAP-DUT5877