### PR TITLE
update packer scripts to handle renamed sandbox

### DIFF
--- a/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
+++ b/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,7 @@
 
 __tmpdir=/tmp/cdap-examples.$$
 mkdir -p ${__tmpdir}
-cp -a /opt/cdap/sdk/examples ${__tmpdir}
+cp -a /opt/cdap/sandbox/examples ${__tmpdir}
 if [ -f /tmp/mavenrepo.tar.bz2 ]; then
   mkdir -p ~cdap/.m2
   cd ~cdap/.m2

--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -26,7 +26,7 @@ ln -sf /opt/idea* /opt/idea || (echo "Unable to symlink IDEA" && exit 1)
 # Copy icons
 cp -f /opt/idea/bin/idea.png /usr/share/pixmaps
 cp -f /usr/local/eclipse/icon.xpm /usr/share/pixmaps/eclipse.xpm
-cp -f /opt/cdap/sdk/ui/dist/assets/img/favicon.png /usr/share/pixmaps/cdap.png
+cp -f /opt/cdap/sandbox/ui/dist/assets/img/favicon.png /usr/share/pixmaps/cdap.png
 
 # Eclipse Menu entry
 cat > /usr/share/applications/eclipse.desktop << EOF
@@ -65,13 +65,13 @@ Icon=cdap
 Categories=GNOME;GTK;Development;
 EOF
 
-# CDAP SDK Menu Entry
-cat > /usr/share/applications/cdap-sdk.desktop << EOF
+# CDAP Sandbox Menu Entry
+cat > /usr/share/applications/cdap-sandbox.desktop << EOF
 [Desktop Entry]
 Encoding=UTF-8
-Name=CDAP SDK
-Comment=CDAP SDK directory
-Exec=xdg-open /opt/cdap/sdk
+Name=CDAP Sandbox
+Comment=CDAP Sandbox directory
+Exec=xdg-open /opt/cdap/sandbox
 Type=Application
 Icon=cdap
 Categories=GNOME;GTK;Development;
@@ -83,7 +83,7 @@ cat > /usr/share/applications/cdap-examples.desktop << EOF
 Encoding=UTF-8
 Name=CDAP Examples
 Comment=CDAP Examples directory
-Exec=xdg-open /opt/cdap/sdk/examples
+Exec=xdg-open /opt/cdap/sandbox/examples
 Type=Application
 Icon=cdap
 Categories=GNOME;GTK;Development;
@@ -92,7 +92,7 @@ EOF
 # Copy welcome.txt and some icons to the desktop
 mkdir -p ~cdap/Desktop
 cp /etc/welcome.txt ~cdap/Desktop
-for i in cdap-ui cdap-sdk cdap-examples cdap-docs eclipse idea lxterminal ; do
+for i in cdap-ui cdap-sandbox cdap-examples cdap-docs eclipse idea lxterminal ; do
   cp /usr/share/applications/${i}.desktop ~cdap/Desktop
 done
 

--- a/cdap-distributions/src/packer/scripts/motd.sh
+++ b/cdap-distributions/src/packer/scripts/motd.sh
@@ -17,25 +17,25 @@
 for i in motd welcome.txt issue issue.net ; do
 
 cat > /etc/$i << EOF
-			Welcome to the CDAP SDK VM
+			Welcome to the CDAP Sandbox VM
 
 This virtual machine uses a simple graphical interface. The menu can be accessed by
 clicking the icon at the bottom left. Included are the Eclipse and IntelliJ IDEs,
-Chromium Browser, Git, Java, Maven, Subversion, and the CDAP SDK with the Standalone CDAP.
+Chromium Browser, Git, Java, Maven, Subversion, and the CDAP Sandbox with the Standalone CDAP.
 
 The login and password to the machine is 'cdap' and the user has sudo privileges
 without a password.
 
-The SDK can be stopped/started/restarted using the /etc/init.d/cdap-sdk init
+The Sandbox can be stopped/started/restarted using the /etc/init.d/cdap-sandbox init
 script.
 
-	sudo /etc/init.d/cdap-sdk start
-	sudo /etc/init.d/cdap-sdk stop
-	sudo /etc/init.d/cdap-sdk restart
+	sudo /etc/init.d/cdap-sandbox start
+	sudo /etc/init.d/cdap-sandbox stop
+	sudo /etc/init.d/cdap-sandbox restart
 
-Logs for the SDK are found at /opt/cdap/sdk/logs, data is stored at
-/opt/cdap/sdk/data, and example applications are at
-/opt/cdap/sdk/examples.
+Logs for the Sandbox are found at /opt/cdap/sandbox/logs, data is stored at
+/opt/cdap/sandbox/data, and example applications are at
+/opt/cdap/sandbox/examples.
 
 EOF
 done

--- a/cdap-distributions/src/packer/scripts/sdk-ami-security.sh
+++ b/cdap-distributions/src/packer/scripts/sdk-ami-security.sh
@@ -15,11 +15,11 @@
 # the License.
 
 #
-# Update SDK configuration to use CDAP Basic Authentication
+# Update Sandbox configuration to use CDAP Basic Authentication
 #
 
 # Strip closing </configuration> tag
-sed -e '/<\/configuration>/d' /opt/cdap/sdk/conf/cdap-site.xml > /opt/cdap/sdk/conf/cdap-site.xml.new
+sed -e '/<\/configuration>/d' /opt/cdap/sandbox/conf/cdap-site.xml > /opt/cdap/sandbox/conf/cdap-site.xml.new
 
 # Append our security configuration
 echo "  <property>
@@ -29,7 +29,7 @@ echo "  <property>
 
   <property>
     <name>security.authentication.basic.realmfile</name>
-    <value>/opt/cdap/sdk/conf/realmfile</value>
+    <value>/opt/cdap/sandbox/conf/realmfile</value>
   </property>
 
   <property>
@@ -37,17 +37,17 @@ echo "  <property>
     <value>co.cask.cdap.security.server.BasicAuthenticationHandler</value>
   </property>
 
-</configuration>" >> /opt/cdap/sdk/conf/cdap-site.xml.new
+</configuration>" >> /opt/cdap/sandbox/conf/cdap-site.xml.new
 
 unalias mv # in case root has a "mv -i" alias
-mv -f /opt/cdap/sdk/conf/cdap-site.xml{.new,}
+mv -f /opt/cdap/sandbox/conf/cdap-site.xml{.new,}
 
 # Create init script to populate realmfile
 echo '#!/usr/bin/env bash
 
 #
 # chkconfig: 2345 95 15
-# description: Creates /opt/cdap/sdk/conf/realmfile using AWS instance ID
+# description: Creates /opt/cdap/sandbox/conf/realmfile using AWS instance ID
 #
 ### BEGIN INIT INFO
 # Provides:          cdap-realmfile
@@ -61,14 +61,14 @@ echo '#!/usr/bin/env bash
 ### END INIT INFO
 
 if [[ ${1} == start ]]; then
-  if [[ -e /opt/cdap/sdk/conf/realmfile ]]; then
-    echo "CDAP SDK Realmfile already exists... skipping generation"
+  if [[ -e /opt/cdap/sandbox/conf/realmfile ]]; then
+    echo "CDAP Sandbox Realmfile already exists... skipping generation"
   else
     __instance_id=$(curl -q http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
-    echo "Creating CDAP SDK Realmfile with Instance ID as password"
-    echo "cdap: ${__instance_id}" > /opt/cdap/sdk/conf/realmfile
-    chown cdap:cdap /opt/cdap/sdk/conf/realmfile
-    chmod 0400 /opt/cdap/sdk/conf/realmfile
+    echo "Creating CDAP Sandbox Realmfile with Instance ID as password"
+    echo "cdap: ${__instance_id}" > /opt/cdap/sandbox/conf/realmfile
+    chown cdap:cdap /opt/cdap/sandbox/conf/realmfile
+    chmod 0400 /opt/cdap/sandbox/conf/realmfile
   fi
 fi
 exit 0' > /etc/init.d/cdap-realmfile

--- a/cdap-distributions/src/packer/scripts/sdk-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/sdk-cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015-2016 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,14 +15,14 @@
 # the License.
 
 #
-# Stop SDK and remove data directory
+# Stop Sandbox and remove data directory
 #
 
-# Stop SDK
-/etc/init.d/cdap-sdk stop
+# Stop Sandbox
+/etc/init.d/cdap-sandbox stop
 
 # Remove data and logs directories
-rm -rf /opt/cdap/sdk/data /opt/cdap/sdk/logs
+rm -rf /opt/cdap/sandbox/data /opt/cdap/sandbox/logs
 
 # Make cdap own /opt/cdap
 chown -R cdap:cdap /opt/cdap


### PR DESCRIPTION
This updates the VM build to rename SDK to Sandbox.  Fixes [CDAP-11896](https://issues.cask.co/browse/CDAP-11896)

![screen shot 2017-06-15 at 12 14 17 pm](https://user-images.githubusercontent.com/1816517/27197735-3a5eee9c-51c4-11e7-99cd-b3dd02f717c9.png)

