### PR TITLE
configure cloud-init to manage /etc/hosts in aws, to ensure cdap-sand…

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -245,6 +245,12 @@
     {
       "type": "shell",
       "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
+      "scripts": "scripts/sdk-ami-common.sh",
+      "only": ["cdap-cloud-sandbox-aws", "cdap-cloud-sandbox-aws-community"]
+    },
+    {
+      "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
       "scripts": "scripts/sdk-ami-security.sh",
       "only": ["cdap-cloud-sandbox-aws"]
     },

--- a/cdap-distributions/src/packer/scripts/sdk-ami-common.sh
+++ b/cdap-distributions/src/packer/scripts/sdk-ami-common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright © 2017 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+#
+# Configure cloud-init to manage /etc/hosts, to ensure hostname is resolvable. See CDAP-11896
+#
+
+echo "manage_etc_hosts: true" >> /etc/cloud/cloud.cfg.d/99_manage_etc_hosts.cfg
+
+exit 0


### PR DESCRIPTION
…box still works in VPCs with no internal DNS

This "fixes" [CDAP-11896](https://issues.cask.co/browse/CDAP-11896) by updating the packer build to enable `manage_etc_hosts` in cloud-init.  This causes cloud-init to insert a record into `/etc/hosts` at boot time, ensuring the hostname is resolvable locally.  See [here](https://issues.cask.co/browse/CDAP-11896?focusedCommentId=30288&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-30288) for more details.