### PR TITLE
CDAP-6329 CDAP services should have GC logging.

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -656,7 +656,6 @@ cdap_service() {
   local readonly __pidfile=${PID_DIR}/${__service}-${IDENT_STRING}.pid
   local readonly __log_prefix=${LOG_DIR}/${__service}-${IDENT_STRING}-${HOSTNAME}
   local readonly __logfile=${__log_prefix}.log
-  local readonly __gc_file=${__log_prefix}.gc
   local readonly __svc=${__service/-server/}
   local readonly __ret
 
@@ -758,6 +757,8 @@ cdap_start_java() {
   # Split JVM_OPTS array
   eval split_jvm_opts ${!JAVA_OPTS_VAR} ${OPTS} ${JAVA_OPTS}
   local __defines="-Dcdap.service=${CDAP_SERVICE} ${JAVA_HEAPMAX} -Duser.dir=${LOCAL_DIR} -Djava.io.tmpdir=${TEMP_DIR}"
+  # Enable GC logging
+  __defines+=" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${__log_prefix}-heap.hprof -verbose:gc -Xloggc:${__log_prefix}-gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M"
   logecho "$(date) Starting CDAP ${__name} service on ${HOSTNAME}"
   echo
   if [[ ${CDAP_SERVICE} == master ]]; then

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -188,7 +188,7 @@
 
   <property>
     <name>twill.jvm.gc.opts</name>
-    <value>-verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
+    <value>-verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
     <description>
       Java garbage collection options for all Apache Twill containers;
       "&lt;LOG_DIR&gt;" is the location of the log directory in the
@@ -358,7 +358,7 @@
     <name>app.program.jvm.opts</name>
     <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts}</value>
     <description>
-      Java options for all program containers
+      Java options for all Apache Twill containers
     </description>
   </property>
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-6329
Enable gc logging for cdap-master, cdap-kafka-server, cdap-auth-server, and cdap-router to the log dir.

![image](https://user-images.githubusercontent.com/2440977/27409465-80294144-5696-11e7-8392-7fb44a72050b.png)


Also updated gc logging in YARN containers to print datestamps instead of timetamps.

![image](https://user-images.githubusercontent.com/2440977/27752931-3abf52fc-5d98-11e7-8141-343e2a56697a.png)
