### PR TITLE
CDAP-5067 Do not retry Workflow driver upon failure.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillApplication.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * An abstract base class for all program {@link TwillApplication}.
@@ -149,10 +150,16 @@ public abstract class AbstractProgramTwillApplication implements TwillApplicatio
   protected static final class RunnableResource {
     private final TwillRunnable runnable;
     private final ResourceSpecification resources;
+    private final Integer maxRetries;
 
     public RunnableResource(TwillRunnable runnable, ResourceSpecification resources) {
+      this(runnable, resources, null);
+    }
+
+    public RunnableResource(TwillRunnable runnable, ResourceSpecification resources, @Nullable Integer maxRetries) {
       this.runnable = runnable;
       this.resources = resources;
+      this.maxRetries = maxRetries;
     }
 
     public TwillRunnable getRunnable() {
@@ -161,6 +168,11 @@ public abstract class AbstractProgramTwillApplication implements TwillApplicatio
 
     public ResourceSpecification getResources() {
       return resources;
+    }
+
+    @Nullable
+    public Integer getMaxRetries() {
+      return maxRetries;
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillApplication.java
@@ -53,7 +53,7 @@ public class WorkflowTwillApplication extends AbstractProgramTwillApplication {
   protected void addRunnables(Map<String, RunnableResource> runnables) {
     runnables.put(spec.getName(), new RunnableResource(
       new WorkflowTwillRunnable(spec.getName()),
-      createResourceSpec(resources, 1)
+      createResourceSpec(resources, 1), 0
     ));
   }
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-5067
https://builds.cask.co/browse/CDAP-RUT1156

Applying a fix very similar to https://github.com/caskdata/cdap/pull/8975, for release/4.1 (4.1.2).
The patch differs in the *DistributedProgramRunner.java class, because the LaunchConfig class is not available in release/4.1, due to refactorings in: https://github.com/caskdata/cdap/commit/d302c80f7774dd936049a49692b7bf894d537eea and https://github.com/caskdata/cdap/commit/e0e93e4e791a0ede6d4bea0d8dd25b61445203b9.