### PR TITLE
[CDAP-11889] Adds visualization to pipeline summary

### DIFF
--- a/cdap-ui/app/cdap/api/pipeline.js
+++ b/cdap-ui/app/cdap/api/pipeline.js
@@ -19,7 +19,9 @@ import {apiCreator} from 'services/resource-helper';
 
 let dataSrc = DataSourceConfigurer.getInstance();
 let basepath = '/namespaces/:namespace/apps/:appId';
+let statsPath = `${basepath}/workflows/:workflowId/statistics`;
 
 export const MyPipelineApi = {
-  publish: apiCreator(dataSrc, 'PUT', 'REQUEST', basepath)
+  publish: apiCreator(dataSrc, 'PUT', 'REQUEST', basepath),
+  pollStatistics: apiCreator(dataSrc, 'GET', 'REQUEST', statsPath),
 };

--- a/cdap-ui/app/cdap/components/PipelineSummary/EmptyRunsContainer.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/EmptyRunsContainer.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -12,7 +12,26 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
-[pipeline-summary] {
+*/
+
+$container_border_color: #e1e1e1;
+$font_size: 40px;
+
+@mixin empty_runs_container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100% - 50px);
+  margin: 0;
   width: 100%;
+  border: 1px solid $container_border_color;
+  h1 {
+    margin: 0;
+    line-height: 1;
+    font-size: $font_size;
+    opacity: 0.5;
+  }
+  .icon-spinner.fa-spin {
+    font-size: $font_size;
+  }
 }

--- a/cdap-ui/app/cdap/components/PipelineSummary/HintStyles.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/HintStyles.scss
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+$hint_body_font_color: black;
+$hint_bg_color: white;
+
+@mixin chart_hints() {
+  .rv-xy-plot__inner {
+    .rv-xy-plot__series--bar {
+      rect {
+        cursor: pointer;
+      }
+    }
+  }
+  .rv-hint {
+    background: $hint_bg_color;
+    padding: 10px;
+    box-shadow: 0px 10px 15px -5px rgba(0, 0, 0, 0.4);
+    color: $hint_body_font_color;
+    pointer-events: auto;
+
+    h4 {
+      margin: 0;
+      font-weight: bold;
+      color: $hint_body_font_color;
+    }
+    .log-stats {
+      margin: 5px 0;
+      > div {
+        > span {
+          &:first-child {
+            width: 40%;
+            display: inline-block;
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/LogsMetricsGraph.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/LogsMetricsGraph.scss
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import '../StickyTableHeader.scss';
+@import '../HintStyles.scss';
+@import '../EmptyRunsContainer.scss';
+
+$legend_font_color: black;
+$container_border_color: lightgray;
+
+.logs-metrics-graph {
+  padding: 20px;
+  margin: 10px;
+  height: auto;
+  border: 1px solid $container_border_color;
+
+  .graph-plot-container {
+    width: calc(100% - 30px);
+    margin: 15px;
+  }
+
+  .rv-discrete-color-legend.horizontal {
+    .rv-discrete-color-legend-item {
+      display: inline-block;
+      margin: 0 20px;
+      .rv-discrete-color-legend-item__color {
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        vertical-align: middle;
+        margin: 0 5px;
+      }
+      .rv-discrete-color-legend-item__title {
+        color: $legend_font_color;
+      }
+    }
+  }
+  .x-axis-title {
+    position: absolute;
+    bottom: -20px;
+    right: 0;
+  }
+  .y-axis-title {
+    position: absolute;
+    left: -95px;
+    transform: rotate(-90deg);
+    top: 40%;
+  }
+  .logs-metrics-fp-plot {
+    @include chart_hints;
+  }
+
+  .empty-runs-container {
+    @include empty_runs_container;
+  }
+
+  .title-container {
+    display: flex;
+    justify-content: space-between;
+    margin: 10px;
+
+    .title {
+      font-size: 18px;
+      font-weight: 600;
+    }
+    .viz-switcher {
+      span {
+        cursor: pointer;
+        &:first-child {
+          border-right: 1px solid;
+          margin-right: 5px;
+          padding-right: 8px;
+        }
+        &.active {
+          font-weight: bold;
+        }
+      }
+    }
+  }
+
+  @include stickyheader(20%, 15%, 15%, 20%, 30%);
+
+}
+

--- a/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/index.js
@@ -1,0 +1,324 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component, PropTypes} from 'react';
+import {objectQuery} from 'services/helpers';
+import {XYPlot, makeWidthFlexible, XAxis, YAxis, HorizontalGridLines, Hint, DiscreteColorLegend, VerticalBarSeries as BarSeries} from 'react-vis';
+import moment from 'moment';
+import isEqual from 'lodash/isEqual';
+import {convertProgramToApi} from 'services/program-api-converter';
+import classnames from 'classnames';
+import T from 'i18n-react';
+import IconSVG from 'components/IconSVG';
+import {getTicksTotal, xTickFormat, getXDomain, getGraphHeight} from 'components/PipelineSummary/RunsGraphHelpers';
+
+const WARNINGBARCOLOR = '#FDA639';
+const ERRORBARCOLOR = '#A40403';
+const PREFIX = `features.PipelineSummary.logsMetricsGraph`;
+const GRAPHPREFIX = `features.PipelineSummary.graphs`;
+const COLOR_LEGEND = [
+  {
+    title: T.translate(`${PREFIX}.legend1`),
+    color: WARNINGBARCOLOR
+  },
+  {
+    title: T.translate(`${PREFIX}.legend2`),
+    color: ERRORBARCOLOR
+  }
+];
+require('./LogsMetricsGraph.scss');
+/*
+   - Better name
+   - Name says LogsMetricsGraph but we are passing in runs. Its logs metrics (warning, error, info etc.,) per run. but ugh..
+*/
+export default class LogsMetricsGraph extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentHoveredElement: null,
+      viewState: 'chart',
+      runsLimit: props.runsLimit
+    };
+  }
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      currentHoveredElement: null,
+      runsLimit: nextProps.runsLimit
+    });
+  }
+  getDataClusters() {
+    let warnings = [];
+    let errors = [];
+    // Clustering by runs. Stack warnings and errors by clusters.
+    [].concat(this.props.runs).reverse().forEach((run, i) => {
+      let {totalRunsCount, runsLimit, xDomainType} = this.props;
+      let x;
+      if (xDomainType === 'limit') {
+        x = totalRunsCount > runsLimit ? totalRunsCount - runsLimit : 0;
+        x = x + (i + 1);
+      }
+      if (xDomainType === 'time') {
+        x = run.start;
+      }
+      warnings.push({
+        x,
+        y: objectQuery(run, 'logsMetrics', 'system.app.log.warn') || '',
+        runid: run.runid
+      });
+      errors.push({
+        x,
+        y: objectQuery(run, 'logsMetrics', 'system.app.log.error') || '',
+        runid: run.runid
+      });
+    });
+    if (errors.length === 1 || warnings.length === 1) {
+      // FIXME: This is a hack. Something is not right with VerticalBarSeries
+      // if it has only one data point. The width of rect element is not scaled correctly
+      let maxXValue = errors.length === 1 ? errors[0].x : warnings[0].x;
+      errors.push({
+        x: maxXValue + 1,
+        y: ''
+      });
+      warnings.push({
+        x: maxXValue + 1,
+        y: ''
+      });
+    }
+    return {errors, warnings};
+  }
+  renderEmptyMessage() {
+    return (
+      <div className="empty-runs-container">
+        <h1>
+          {
+            T.translate(`${GRAPHPREFIX}.emptyMessage`, {
+              filter: this.props.xDomainType === 'time' ? `in ${this.props.activeFilterLabel}` : ''
+            })
+          }
+        </h1>
+      </div>
+    );
+  }
+  renderChart() {
+    let FPlot = makeWidthFlexible(XYPlot);
+    let {errors, warnings} = this.getDataClusters();
+    let height = getGraphHeight(this.containerRef);
+    let xDomain = [];
+    if (errors.length > 0 || warnings.length > 0) {
+      xDomain = getXDomain(this.props);
+    }
+    let popOverData, logUrl;
+    if (this.state.currentHoveredElement) {
+      popOverData = this.props.runs.find(run => this.state.currentHoveredElement.runid === run.runid);
+      let {namespaceId, appId, programType, programId} = this.props.runContext;
+      logUrl = `/logviewer/view?namespace=${namespaceId}&appId=${appId}&programType=${convertProgramToApi(programType)}&programId=${programId}&runId=${popOverData.runid}`;
+    }
+    if (this.props.isLoading) {
+      return (
+        <div className="empty-runs-container">
+          <IconSVG
+            name="icon-spinner"
+            className="fa-spin"
+          />
+        </div>
+      );
+    }
+    if (!this.props.runs.length) {
+      return this.renderEmptyMessage();
+    }
+    return (
+      <div className="graph-plot-container">
+        <FPlot
+          className="logs-metrics-fp-plot"
+          xType="linear"
+          xDomain={xDomain}
+          stackBy="y"
+          height={height}>
+          <DiscreteColorLegend
+            style={{position: 'absolute', left: '40px', top: '0px'}}
+            orientation="horizontal"
+            items={COLOR_LEGEND}
+          />
+          <HorizontalGridLines />
+          <XAxis
+            tickTotal={getTicksTotal(this.props)}
+            tickFormat={xTickFormat(this.props)}
+          />
+          <YAxis tickFormat={(v) => Math.floor(v) !== v ? '' : v} />
+          {
+            warnings.length > 0 ?
+              <BarSeries
+                cluster="runs"
+                color={WARNINGBARCOLOR}
+                onValueClick={(d) => {
+                  this.setState({
+                    currentHoveredElement: isEqual(this.state.currentHoveredElement || {}, d) ? null : d
+                  });
+                }}
+                data={warnings}/>
+              :
+                null
+          }
+          {
+            errors.length > 0 ?
+              <BarSeries
+                cluster="runs"
+                color={ERRORBARCOLOR}
+                onValueClick={(d) => {
+                  this.setState({
+                    currentHoveredElement: isEqual(this.state.currentHoveredElement || {}, d) ? null : d
+                  });
+                }}
+                data={errors}/>
+              :
+                null
+          }
+          {
+            this.state.currentHoveredElement && popOverData ?
+              (
+                <Hint value={this.state.currentHoveredElement}>
+                  <h4>{T.translate(`${PREFIX}.hint.title`)} </h4>
+                  <div className="log-stats">
+                    <div>
+                      <span>{T.translate(`${PREFIX}.hint.errors`)}</span>
+                      <span className="text-danger">{popOverData.logsMetrics['system.app.log.error']}</span>
+                    </div>
+                    <div>
+                      <span>{T.translate(`${PREFIX}.hint.warnings`)}</span>
+                      <span className="text-warning">{popOverData.logsMetrics['system.app.log.warn']}</span>
+                    </div>
+                    <a href={logUrl} target="_blank">{T.translate(`${PREFIX}.hint.viewLogs`)}</a>
+                  </div>
+                  {
+                    this.props.xDomainType === 'limit' ?
+                      <div>
+                        <strong>{T.translate(`${PREFIX}.hint.runNumber`)}: </strong>
+                        <span>{this.state.currentHoveredElement.x}</span>
+                      </div>
+                    :
+                      null
+                  }
+                  <div>
+                    <strong>{T.translate(`${PREFIX}.hint.startTime`)}: </strong>
+                    <span>{ moment(popOverData.start * 1000).format('llll')}</span>
+                  </div>
+                </Hint>
+              )
+            :
+              null
+          }
+          {
+              this.props.xDomainType === 'limit' ?
+                <div className="x-axis-title"> {T.translate(`${PREFIX}.xAxisTitle`)} </div>
+              :
+                null
+          }
+          <div className="y-axis-title">{T.translate(`${PREFIX}.yAxisTitle`)}</div>
+        </FPlot>
+      </div>
+    );
+  }
+  renderTable() {
+    if (!this.props.runs.length) {
+      return this.renderEmptyMessage();
+    }
+    let {namespaceId, appId, programType, programId} = this.props.runContext;
+    return (
+      <div className="table-container">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>{T.translate(`${PREFIX}.table.header.runCount`)}</th>
+              <th>{T.translate(`${PREFIX}.table.header.errors`)}</th>
+              <th>{T.translate(`${PREFIX}.table.header.warnings`)}</th>
+              <th></th>
+              <th>{T.translate(`${PREFIX}.table.header.startTime`)}</th>
+            </tr>
+          </thead>
+        </table>
+        <div className="table-scroll">
+          <table className="table">
+            <tbody>
+              {
+                this.props.runs.map((run, i) => {
+                  let logUrl = `/logviewer/view?namespace=${namespaceId}&appId=${appId}&programType=${convertProgramToApi(programType)}&programId=${programId}&runId=${run.runid}`;
+                  return (
+                    <tr>
+                      <td>{i+1} </td>
+                      <td>
+                        <span className="text-danger">{objectQuery(run, 'logsMetrics', 'system.app.log.error')}</span>
+                      </td>
+                      <td>
+                        <span className="text-warning">{objectQuery(run, 'logsMetrics', 'system.app.log.warn')}</span>
+                      </td>
+                      <td>
+                        <a href={logUrl} target="_blank">{T.translate(`${PREFIX}.table.body.viewLog`)} </a>
+                      </td>
+                      <td> {moment(run.start).format('llll')}</td>
+                    </tr>
+                  );
+                })
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+  render() {
+    return (
+      <div
+        className="logs-metrics-graph"
+        ref={ref => this.containerRef = ref}
+      >
+        <div className="title-container">
+          <div className="title">{T.translate(`${PREFIX}.title`)} </div>
+          <div className="viz-switcher">
+            <span
+              className={classnames({"active": this.state.viewState === 'chart'})}
+              onClick={() => this.setState({viewState: 'chart'})}
+            >
+              {T.translate(`${GRAPHPREFIX}.vizSwitcher.chart`)}
+            </span>
+            <span
+              className={classnames({"active": this.state.viewState === 'table'})}
+              onClick={() => this.setState({viewState: 'table'})}
+            >
+              {T.translate(`${GRAPHPREFIX}.vizSwitcher.table`)}
+            </span>
+          </div>
+        </div>
+        {
+          this.state.viewState === 'chart' ?
+            this.renderChart()
+          :
+            this.renderTable()
+        }
+      </div>
+    );
+  }
+}
+LogsMetricsGraph.propTypes = {
+  runs: PropTypes.arrayOf(PropTypes.object),
+  totalRunsCount: PropTypes.number,
+  runsLimit: PropTypes.number,
+  xDomainType: PropTypes.oneOf(['limit', 'time']),
+  runContext: PropTypes.object,
+  isLoading: PropTypes.bool,
+  start: PropTypes.number,
+  end: PropTypes.number,
+  activeFilterLabel: PropTypes.string
+};

--- a/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+$pipeline-summary-bg: white;
+$summary_titlebar_bg: #f5f5f5;
+$summary_border_color: #e1e1e1;
+$option-hover-bg-color: #eeeeee;
+$run_menu_bg_color: gray;
+$graph_containers_border_color: lightgray;
+
+.pipeline-summary {
+  .graphs-container {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    background: $pipeline-summary-bg;
+    overflow: auto;
+    height: calc(100vh - 240px); // Header + Top panel = 95 + Footer = 51 + summary title bar = 49 + border 1px
+
+    > div {
+      width: calc(50% - 20px);
+      padding: 10px;
+      border-radius: 4px;
+      height: 50%;
+      min-height: 400px;
+    }
+  }
+  .top-title-bar {
+    padding: 15px 10px;
+    background: $summary_titlebar_bg;
+    display: flex;
+    border: 1px solid $summary_border_color;
+    > div {
+      &:nth-child(1) {
+        flex: 0.2;
+        font-size: 16px;
+        font-weight: 500;
+      }
+      &:nth-child(2) {
+        flex: 1;
+      }
+    }
+    .stats-container {
+      > span {
+        margin: 0 10px;
+        vertical-align: middle;
+        &.run-times {
+          > span {
+            margin: 0 10px;
+          }
+          .run-time-label {
+            margin-right: 15px;
+          }
+        }
+      }
+      .icon-close {
+        cursor: pointer;
+        margin-left: 20px;
+      }
+    }
+  }
+  .filter-container {
+    padding: 5px 10px 5px 10px;
+    background: white;
+    .runs-dropdown {
+      display: inline-block;
+      margin-left: 10px;
+      .btn.btn-secondary {
+        border: 0;
+        border-bottom: 1px solid lightgray;
+        border-radius: 0;
+        background: transparent;
+        padding-left: 5px;
+        padding-right: 5px;
+        &:focus,
+        &:active,
+        &.active,
+        &:hover {
+          background: transparent;
+          outline: none;
+          box-shadow: none;
+        }
+        span {
+          &:first-child {
+            margin-right: 5px;
+          }
+        }
+        .icon-chevron-down {
+          font-size: 12px;
+          margin-left: 5px;
+        }
+      }
+      .dropdown-menu {
+        padding: 0;
+        .dropdown-item {
+          padding: 10px;
+          cursor: pointer;
+          &:focus,
+          &:active,
+          &.active,
+          &:hover {
+            background: transparent;
+            outline: none;
+          }
+          &:hover {
+            background-color: $option-hover-bg-color;
+          }
+        }
+        .dropdown-divider {
+          height: 1px;
+          background: $run_menu_bg_color;
+          margin: 1px 0;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummaryActions.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummaryActions.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {MyProgramApi} from 'api/program';
+import PipelineSummaryStore, {PIPELINESSUMMARYACTIONS} from 'components/PipelineSummary/PipelineSummaryStore';
+import {MyMetricApi} from 'api/metric';
+import {convertProgramToMetricParams} from 'services/program-api-converter';
+import {objectQuery} from 'services/helpers';
+import isNil from 'lodash/isNil';
+
+function setRuns(runs) {
+  PipelineSummaryStore.dispatch({
+    type: PIPELINESSUMMARYACTIONS.SETRUNS,
+    payload: {
+      runs: runs.map(run => ({
+        runid: run.runid,
+        start: run.start,
+        end: run.end,
+        duration: isNil(run.end) ? -1 : (run.end - run.start),
+        status: run.status
+      }))
+    }
+  });
+}
+
+function fetchMetrics({namespaceId, appId, programType, programId}, metrics) {
+  let {runs} = PipelineSummaryStore.getState().pipelinerunssummary;
+  let postBody = {};
+  runs.forEach((run) => {
+    postBody[`qid_${run.runid}`] = {
+      tags: {
+        namespace: namespaceId,
+        app: appId,
+        [convertProgramToMetricParams(programType)]: programId,
+        run: run.runid
+      },
+      metrics,
+      timeRange: {
+        aggregate: 'true'
+      }
+    };
+  });
+  return MyMetricApi.query(null, postBody);
+}
+
+function updateMetrics(metrics, mapKey = 'metrics') {
+  let modMetrics = {};
+  Object
+    .keys(metrics)
+    .forEach(key => {
+      let runId = key.replace('qid_', '');
+      modMetrics[runId] = {[mapKey]: {}};
+      metrics[key]
+        .series
+        .forEach(metricObj => {
+          modMetrics[runId][mapKey][metricObj.metricName] = objectQuery(metricObj, 'data', 0, 'value');
+        });
+    });
+  let {runs} = PipelineSummaryStore.getState().pipelinerunssummary;
+  runs = runs.map(run => {
+    let runid = run.runid;
+    return Object.assign({}, run, modMetrics[runid]);
+  });
+  PipelineSummaryStore.dispatch({
+    type: PIPELINESSUMMARYACTIONS.SETRUNS,
+    payload: {
+      runs
+    }
+  });
+}
+
+function fetchSummary({namespaceId, appId, programType, programId, pipelineConfig, limit = -1, start = -1, end = -1}) {
+  let params = {
+    namespace: namespaceId,
+    appId,
+    programType,
+    programId
+  };
+  PipelineSummaryStore.dispatch({
+    type: PIPELINESSUMMARYACTIONS.SETLOADING,
+    payload: {
+      loading: true
+    }
+  });
+  const addProperty = (propertyValue, propertyName) => {
+    if (propertyValue === -1) {
+      return {};
+    }
+    return {[propertyName]: propertyValue};
+  };
+  params = Object.assign({}, params, addProperty(limit, 'limit'), addProperty(start, 'start'), addProperty(end, 'end'));
+  MyProgramApi
+    .runs(params)
+    .subscribe((runs) => {
+      setRuns(runs);
+      let logMetrics = [
+        'system.app.log.error',
+        'system.app.log.warn',
+        'system.app.log.info',
+        'system.app.log.debug',
+        'system.app.log.trace'
+      ];
+      let nodeMetrics = [];
+      pipelineConfig.config.stages.forEach(node => {
+        nodeMetrics = nodeMetrics.concat([`user.${node.name}.records.in`, `user.${node.name}.records.out`]);
+      });
+      fetchMetrics(params, logMetrics)
+        .subscribe(logsMetrics => updateMetrics(logsMetrics, 'logsMetrics'));
+      fetchMetrics(params, nodeMetrics)
+        .subscribe(nodesMetrics => updateMetrics(nodesMetrics, 'nodesMetrics'));
+    });
+}
+
+export {fetchSummary};

--- a/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummaryStore.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummaryStore.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {createStore, combineReducers} from 'redux';
+import {defaultAction} from 'services/helpers';
+const PIPELINESSUMMARYACTIONS = {
+  SETRUNS: 'SETRUNS',
+  SETMETRICS: 'SETMETRICS',
+  SETLOADING: 'SETLOADING'
+};
+const defaultRunsSummary = {
+  runs: [],
+  loading: false
+};
+
+const pipelinerunssummary = (state = defaultRunsSummary, action = defaultAction) => {
+  switch (action.type) {
+    case PIPELINESSUMMARYACTIONS.SETRUNS:
+      return Object.assign({}, state, {
+        runs: action.payload.runs || [],
+        loading: false
+      });
+    case PIPELINESSUMMARYACTIONS.SETLOADING:
+      return Object.assign({}, state, {
+        loading: action.payload.loading
+      });
+    default:
+      return state;
+  }
+};
+
+const PipelineSummaryStore = createStore(
+  combineReducers({
+    pipelinerunssummary
+  }),
+  {
+    pipelinerunssummary: defaultRunsSummary
+  }
+);
+
+export {PIPELINESSUMMARYACTIONS};
+export default PipelineSummaryStore;

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsGraphHelpers.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsGraphHelpers.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import isNil from 'lodash/isNil';
+import moment from 'moment';
+
+export const ONE_MIN_SECONDS = 60;
+export const ONE_HOUR_SECONDS = ONE_MIN_SECONDS * 60;
+export const ONE_DAY_SECONDS = ONE_HOUR_SECONDS * 24;
+const DEFAULT_GRAPH_HEIGHT = 300;
+const DEFAULT_TICKS_TOTAL = 10;
+const WEEKS_TICKS_TOTAL = 7;
+const SECONDS_RESOLUTION = 'sec';
+const MINS_RESOLUTION = 'minutes';
+const HOURS_RESOLUTION = 'hours';
+const DAYS_RESOLUTION = 'days';
+
+
+export function getTicksTotal({start, end}) {
+  if (isNil(start) || isNil(end)) {
+    return DEFAULT_TICKS_TOTAL;
+  }
+  let timeWindow = end - start;
+  if (timeWindow < ONE_DAY_SECONDS || timeWindow === ONE_DAY_SECONDS * 7) {
+    return WEEKS_TICKS_TOTAL;
+  }
+  return DEFAULT_TICKS_TOTAL;
+}
+
+export function getXDomain({xDomainType, runsLimit, totalRunsCount, start, end}) {
+  let startDomain, endDomain;
+  if (xDomainType === 'limit') {
+    startDomain = totalRunsCount > runsLimit ? (totalRunsCount - runsLimit) + 1 : 1;
+    endDomain = totalRunsCount > runsLimit ? totalRunsCount : runsLimit;
+  }
+  if (xDomainType === 'time') {
+    startDomain = start;
+    endDomain = end;
+  }
+  return [startDomain, endDomain];
+}
+
+export function xTickFormat({xDomainType, start, end}) {
+  let lastDisplayedDate;
+  return (v) => {
+    if (xDomainType === 'time') {
+      let timeWindow = end - start;
+      let date = moment(v).format('ddd M/D/YY');
+      if (timeWindow < ONE_DAY_SECONDS) {
+        date = v % 2 === 0 ? moment(v * 1000).format('HH:mm a') : null;
+      }
+      if (timeWindow === ONE_DAY_SECONDS) {
+        date = v % 2 === 0 ? moment(v * 1000).format('HH:mm a') : null;
+      }
+      if (timeWindow === ONE_DAY_SECONDS * 7) {
+        date = v % 2 === 0 ? moment(v * 1000).format('Do MMM') : null;
+      }
+      if (timeWindow >= ONE_DAY_SECONDS * 30) {
+        date = v % 2 === 0 ? moment(v * 1000).format('M/D/YY') : null;
+      }
+      if (!isNil(date) && lastDisplayedDate !== date) {
+        lastDisplayedDate = date;
+        return date;
+      }
+      return;
+    }
+    return v;
+  };
+}
+
+export function getGraphHeight(containerRef) {
+  if (containerRef) {
+    let clientRect = containerRef.getBoundingClientRect();
+    return clientRect.height - 100;
+  }
+  return DEFAULT_GRAPH_HEIGHT;
+}
+
+export function getTimeResolution(maxYDomain) {
+  let yAxisResolution = SECONDS_RESOLUTION;
+  if (maxYDomain > ONE_MIN_SECONDS) {
+    yAxisResolution = MINS_RESOLUTION;
+  }
+  if (maxYDomain > ONE_HOUR_SECONDS) {
+    yAxisResolution = HOURS_RESOLUTION;
+  }
+  if (maxYDomain > ONE_DAY_SECONDS) {
+    yAxisResolution = DAYS_RESOLUTION;
+  }
+  return yAxisResolution;
+}
+
+export function tickFormatBasedOnTimeResolution(timeResolution) {
+  return (v) => {
+    if (timeResolution === MINS_RESOLUTION) {
+      return (v / ONE_MIN_SECONDS).toFixed(2);
+    }
+    if (timeResolution === HOURS_RESOLUTION) {
+      return (v / (ONE_HOUR_SECONDS)).toFixed(2);
+    }
+    if (timeResolution === DAYS_RESOLUTION) {
+      return (v / ONE_DAY_SECONDS).toFixed(2);
+    }
+    return v;
+  };
+}
+
+export function getDuration(time) {
+  if (typeof time !== 'number') {
+    return '-';
+  }
+  if (time < ONE_MIN_SECONDS) {
+    return `${time} seconds`;
+  }
+  return moment.duration(time, 'seconds').humanize();
+}

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/RunsHistoryGraph.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/RunsHistoryGraph.scss
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import '../StickyTableHeader.scss';
+@import '../HintStyles.scss';
+@import '../EmptyRunsContainer.scss';
+
+$legend_font_color: black;
+$container_border_color: lightgray;
+
+.runs-history-graph {
+  padding: 20px;
+  margin: 10px;
+  height: auto;
+  border: 1px solid $container_border_color;
+
+  .graph-plot-container {
+    width: calc(100% - 30px);
+    margin: 15px;
+  }
+  .rv-discrete-color-legend.horizontal {
+    .rv-discrete-color-legend-item {
+      display: inline-block;
+      margin: 0 20px;
+      .rv-discrete-color-legend-item__color {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        margin: 0 5px;
+        border-radius: 50%;
+      }
+      .rv-discrete-color-legend-item__title {
+        color: $legend_font_color;
+      }
+    }
+  }
+  .run-history-fp-plot {
+    @include chart_hints;
+  }
+  .x-axis-title {
+    position: absolute;
+    bottom: -20px;
+    right: 0;
+  }
+  .y-axis-title {
+    position: absolute;
+    left: -60px;
+    transform: rotate(-90deg);
+    top: 40%;
+  }
+
+  .empty-runs-container {
+    @include empty_runs_container;
+  }
+
+  .title-container {
+    display: flex;
+    justify-content: space-between;
+    margin: 10px;
+
+    .title {
+      font-size: 18px;
+      font-weight: 600;
+    }
+    .viz-switcher {
+      span {
+        cursor: pointer;
+        &:first-child {
+          border-right: 1px solid;
+          margin-right: 5px;
+          padding-right: 8px;
+        }
+        &.active {
+          font-weight: bold;
+        }
+      }
+    }
+  }
+
+  @include stickyheader;
+
+}

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
@@ -1,0 +1,337 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component, PropTypes} from 'react';
+import {XYPlot, makeWidthFlexible, XAxis, YAxis, HorizontalGridLines, LineSeries, MarkSeries, DiscreteColorLegend, Hint} from 'react-vis';
+import moment from 'moment';
+import classnames from 'classnames';
+import isEqual from 'lodash/isEqual';
+import IconSVG from 'components/IconSVG';
+import T from 'i18n-react';
+import {
+  getTicksTotal,
+  xTickFormat,
+  getXDomain,
+  ONE_MIN_SECONDS,
+  tickFormatBasedOnTimeResolution,
+  getGraphHeight,
+  getTimeResolution
+} from 'components/PipelineSummary/RunsGraphHelpers';
+
+require('./RunsHistoryGraph.scss');
+require('react-vis/dist/styles/plot.scss');
+
+const MARKSERIESSTROKECOLOR = '#999999';
+const FAILEDRUNCOLOR = '#A40403';
+const SUCCESSRUNCOLOR = '#3cc801';
+const LINECOLOR = '#DBDBDB';
+const PREFIX = `features.PipelineSummary.runsHistoryGraph`;
+const GRAPHPREFIX = `features.PipelineSummary.graphs`;
+const COLORLEGENDS = [
+  {
+    title: T.translate(`${PREFIX}.legend1`),
+    color: FAILEDRUNCOLOR
+  },
+  {
+    title: T.translate(`${PREFIX}.legend2`),
+    color: SUCCESSRUNCOLOR
+  }
+];
+
+export default class RunsHistoryGraph extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: this.constructData(),
+      totalRunsCount: props.totalRunsCount,
+      viewState: 'chart',
+      currentHoveredElement: null,
+      runsLimit: props.runsLimit
+    };
+    this.renderChart = this.renderChart.bind(this);
+    this.renderTable = this.renderTable.bind(this);
+  }
+  componentDidMount() {
+    this.setState({
+      data: this.constructData()
+    });
+  }
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      data: this.constructData(nextProps),
+      totalRunsCount: nextProps.totalRunsCount,
+      currentHoveredElement: null,
+      runsLimit: nextProps.runsLimit
+    });
+  }
+  constructData(props = this.props) {
+    let data = [].concat(props.runs).reverse().map((run, id) => {
+      let {totalRunsCount, runsLimit, xDomainType} = this.props;
+      let x;
+      if (xDomainType === 'limit') {
+        x = totalRunsCount > runsLimit ? totalRunsCount - runsLimit : 0;
+        x = x + (id + 1);
+      }
+      if (xDomainType === 'time') {
+        x = run.start;
+      }
+      return {
+        x,
+        y: run.duration,
+        color: run.status === 'FAILED' ? FAILEDRUNCOLOR : SUCCESSRUNCOLOR,
+        runid: run.runid
+      };
+    });
+    return data;
+  }
+  renderEmptyMessage() {
+    return (
+      <div className="empty-runs-container">
+        <h1>
+          {
+            T.translate(`${GRAPHPREFIX}.emptyMessage`, {
+              filter: this.props.xDomainType === 'time' ? `in ${this.props.activeFilterLabel}` : ''
+            })
+          }
+        </h1>
+      </div>
+    );
+  }
+  renderChart() {
+    let FPlot = makeWidthFlexible(XYPlot);
+    let height = getGraphHeight(this.containerRef);
+    let maxYDomain = Number.MAX_SAFE_INTEGER, minYDomain = {y: 0};
+    if (this.state.data.length > 1) {
+      maxYDomain = this.state.data.reduce((prev, curr) => {
+        return (prev.y > curr.y) ? prev : curr;
+      });
+      minYDomain = this.state.data.reduce((prev, curr) => {
+        return (prev.y < curr.y) ? prev : curr;
+      });
+    }
+    if (this.state.data.length == 1) {
+      maxYDomain = this.state.data[0];
+    }
+    let yAxisResolution = getTimeResolution(maxYDomain.y);
+    let xDomain = [];
+    if (this.state.data.length > 0) {
+      xDomain = getXDomain(this.props);
+    }
+    let popOverData;
+    if (this.state.currentHoveredElement) {
+      popOverData = this.props.runs.find(run => this.state.currentHoveredElement.runid === run.runid);
+    }
+    if (this.props.isLoading) {
+      return (
+        <div className="empty-runs-container">
+          <IconSVG
+            name="icon-spinner"
+            className="fa-spin"
+          />
+        </div>
+      );
+    }
+    if (!this.props.runs.length) {
+      return this.renderEmptyMessage();
+    }
+    return (
+      <div className="graph-plot-container">
+        <FPlot
+          xType="linear"
+          xDomain={xDomain}
+          height={height}
+          className="run-history-fp-plot"
+        >
+          <DiscreteColorLegend
+            style={{position: 'absolute', left: '40px', top: '0px'}}
+            orientation="horizontal"
+            items={COLORLEGENDS}
+          />
+          <XAxis
+            tickTotal={getTicksTotal(this.props)}
+            tickFormat={xTickFormat(this.props)}
+          />
+          <YAxis
+            tickTotal={10}
+            yDomain={[minYDomain.y, maxYDomain.y]}
+            tickFormat={tickFormatBasedOnTimeResolution(yAxisResolution)}
+          />
+          <HorizontalGridLines />
+          <LineSeries
+            color={LINECOLOR}
+            data={this.state.data}
+          />
+          <MarkSeries
+            data={this.state.data}
+            colorType={'literal'}
+            stroke={MARKSERIESSTROKECOLOR}
+            onValueClick={(d) => {
+              if (isEqual(this.state.currentHoveredElement || {}, d)) {
+                this.setState({
+                  currentHoveredElement: null
+                });
+              } else {
+                this.setState({
+                  currentHoveredElement: d
+                });
+              }
+            }}
+          />
+
+          {
+            this.state.currentHoveredElement && popOverData ?
+              (
+                <Hint value={this.state.currentHoveredElement}>
+                  <h4>{T.translate(`${PREFIX}.hint.title`)}</h4>
+                  <div className="log-stats">
+                    <div>
+                      <span>{T.translate(`${PREFIX}.hint.duration`)}</span>
+                      <span>
+                        {
+                          popOverData.duration < ONE_MIN_SECONDS ?
+                            `${popOverData.duration} seconds`
+                          :
+                            moment.duration(popOverData.duration, yAxisResolution)
+                        }
+                      </span>
+                    </div>
+                    <div>
+                      <span>{T.translate(`${PREFIX}.hint.status`)}</span>
+                      <span className={classnames({
+                        'text-danger': ['FAILED', 'KILLED', 'RUN_FAILED'].indexOf(popOverData.status) !== -1,
+                        'text-success': ['FAILED', 'KILLED', 'RUN_FAILED'].indexOf(popOverData.status) === -1
+                      })}>{popOverData.status}</span>
+                    </div>
+                  </div>
+                  {
+                    this.props.xDomainType === 'limit' ?
+                      <div>
+                        <strong>{T.translate(`${PREFIX}.hint.runNumber`)}: </strong>
+                        <span>{this.state.currentHoveredElement.x}</span>
+                      </div>
+                    :
+                      null
+                  }
+                  <div>
+                    <strong>{T.translate(`${PREFIX}.hint.startTime`)}: </strong>
+                    <span>{moment(popOverData.start * 1000).format('llll')}</span>
+                  </div>
+                </Hint>
+              )
+            :
+              null
+          }
+          {
+            this.props.xDomainType === 'limit' ?
+              <div className="x-axis-title"> {T.translate(`${PREFIX}.xAxisTitle`)} </div>
+            :
+              null
+          }
+          <div className="y-axis-title">{T.translate(`${PREFIX}.yAxisTitle`, {
+            resolution: yAxisResolution
+          })}</div>
+        </FPlot>
+      </div>
+    );
+  }
+  renderTable() {
+    if (!this.props.runs.length) {
+      return this.renderEmptyMessage();
+    }
+    return (
+      <div className="table-container">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>{T.translate(`${PREFIX}.table.headers.runCount`)}</th>
+              <th>{T.translate(`${PREFIX}.table.headers.status`)}</th>
+              <th>{T.translate(`${PREFIX}.table.headers.startTime`)}</th>
+              <th>{T.translate(`${PREFIX}.table.headers.duration`)}</th>
+            </tr>
+          </thead>
+        </table>
+        <div className="table-scroll">
+          <table className="table">
+            <tbody>
+              {
+                this.props.runs.map((run, i) => {
+                  return (
+                    <tr>
+                      <td> {i+1} </td>
+                      <td>
+                        <span className={classnames({
+                          'text-danger': ['FAILED', 'KILLED', 'RUN_FAILED'].indexOf(run.status) !== -1,
+                          'text-success': ['FAILED', 'KILLED', 'RUN_FAILED'].indexOf(run.status) === -1
+                        })}>
+                          {run.status}
+                        </span>
+                      </td>
+                      <td> {moment(run.start).format('llll')}</td>
+                      <td> {run.duration}</td>
+                    </tr>
+                  );
+                })
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+  render() {
+    return (
+      <div
+        className="runs-history-graph"
+        ref={ref => this.containerRef = ref}
+      >
+        <div className="title-container">
+          <div className="title">{T.translate(`${PREFIX}.title`)} </div>
+          <div className="viz-switcher">
+            <span
+              className={classnames({"active": this.state.viewState === 'chart'})}
+              onClick={() => this.setState({viewState: 'chart'})}
+            >
+              {T.translate(`${GRAPHPREFIX}.vizSwitcher.chart`)}
+            </span>
+            <span
+              className={classnames({"active": this.state.viewState === 'table'})}
+              onClick={() => this.setState({viewState: 'table'})}
+            >
+              {T.translate(`${GRAPHPREFIX}.vizSwitcher.table`)}
+            </span>
+          </div>
+        </div>
+        {
+          this.state.viewState === 'chart' ?
+            this.renderChart()
+          :
+            this.renderTable()
+        }
+      </div>
+    );
+  }
+}
+RunsHistoryGraph.propTypes = {
+  runs: PropTypes.arrayOf(PropTypes.object),
+  totalRunsCount: PropTypes.number,
+  runsLimit: PropTypes.number,
+  xDomainType: PropTypes.oneOf(['limit', 'time']),
+  runContext: PropTypes.object,
+  isLoading: PropTypes.bool,
+  start: PropTypes.number,
+  end: PropTypes.number,
+  activeFilterLabel: PropTypes.string
+};

--- a/cdap-ui/app/cdap/components/PipelineSummary/StickyTableHeader.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/StickyTableHeader.scss
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@mixin stickyheader($col1Width: 20%, $col2Width: 20%, $col3Width: 30%, $col4Width: 20%, $col5Width: 10%, $bgColor: white ) {
+  .table-container {
+    height: calc(100% - 50px);
+    .table {
+      margin: 0;
+      background: $bgColor;
+      thead,
+      tbody {
+        th,
+        tr td {
+          &:nth-child(1) {
+            width: $col1Width;
+          }
+          &:nth-child(2) {
+            width: $col2Width;
+          }
+          &:nth-child(3) {
+            width: $col3Width;
+          }
+          &:nth-child(4) {
+            width: $col4Width;
+          }
+          &:nth-child(5) {
+            width: $col5Width;
+          }
+        }
+      }
+      tbody {
+        tr {
+          td {
+            a {
+              &:hover {
+                border-bottom: 1px solid;
+              }
+            }
+          }
+        }
+      }
+      thead {
+        background: $bgColor;
+        tr {
+          th {
+            &:not(:first-child) {
+              padding-left: 0;
+            }
+          }
+        }
+      }
+    }
+    .table-scroll {
+      overflow-y: auto;
+      height: calc(100% - 55px);
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineSummary/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/index.js
@@ -1,0 +1,318 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component, PropTypes} from 'react';
+import {fetchSummary} from 'components/PipelineSummary/PipelineSummaryActions';
+import PipelineSummaryStore from 'components/PipelineSummary/PipelineSummaryStore';
+import {convertProgramToApi} from 'services/program-api-converter';
+import RunsHistoryGraph from 'components/PipelineSummary/RunsHistoryGraph';
+import LogsMetricsGraph from 'components/PipelineSummary/LogsMetricsGraph';
+import { DropdownToggle, DropdownItem } from 'reactstrap';
+import CustomDropdownMenu from 'components/CustomDropdownMenu';
+import {UncontrolledDropdown} from 'components/UncontrolledComponents';
+import IconSVG from 'components/IconSVG';
+import T from 'i18n-react';
+import {MyPipelineApi} from 'api/pipeline';
+import {getDuration} from 'components/PipelineSummary/RunsGraphHelpers';
+import isNil from 'lodash/isNil';
+
+const PREFIX = 'features.PipelineSummary';
+
+require('./PipelineSummary.scss');
+const ONE_DAY_SECONDS = 86400;
+
+export default class PipelineSummary extends Component {
+  constructor(props) {
+    super(props);
+    const RUNSFILTERPREFIX = `${PREFIX}.runsFilter`;
+    let {namespaceId, appId, programType, programId, pipelineConfig} = props;
+    this.state = {
+      runs: [],
+      logsMetrics: [],
+      nodesMetrics: [],
+      totalRunsCount: props.totalRunsCount,
+      runsLimit: 10,
+      filterType: 'limit',
+      activeRunsFilter: T.translate(`${RUNSFILTERPREFIX}.last10Runs`),
+      loading: true,
+      start: null,
+      end: null,
+      avgRunTime: '-'
+    };
+    this.fetchRunsByLimit = this.fetchRunsByLimit.bind(this);
+    this.fetchRunsByTime = this.fetchRunsByTime.bind(this);
+    this.runsDropdown = [
+      {
+        label: T.translate(`${RUNSFILTERPREFIX}.last10Runs`),
+        onClick: this.fetchRunsByLimit.bind(this, 10)
+      },
+      {
+        label: T.translate(`${RUNSFILTERPREFIX}.last50Runs`),
+        onClick: this.fetchRunsByLimit.bind(this, 50)
+      },
+      {
+        label: T.translate(`${RUNSFILTERPREFIX}.last100Runs`),
+        onClick: this.fetchRunsByLimit.bind(this, 100)
+      },
+      {
+        label: 'divider'
+      },
+      {
+        label: T.translate(`${RUNSFILTERPREFIX}.last1Day`),
+        onClick: this.fetchRunsByTime.bind(this, ONE_DAY_SECONDS)
+      },
+      {
+        label: T.translate(`${RUNSFILTERPREFIX}.last7Days`),
+        onClick: this.fetchRunsByTime.bind(this, ONE_DAY_SECONDS * 7)
+      },
+      {
+        label: T.translate(`${RUNSFILTERPREFIX}.last30Days`),
+        onClick: this.fetchRunsByTime.bind(this, ONE_DAY_SECONDS * 30)
+      },
+      {
+        label: T.translate(`${RUNSFILTERPREFIX}.sinceInception`),
+        onClick: () => {
+          this.setState({
+            activeRunsFilter: T.translate(`${RUNSFILTERPREFIX}.sinceInception`),
+            filterType: 'time'
+          });
+          fetchSummary({
+            namespaceId,
+            appId,
+            programType: convertProgramToApi(programType),
+            programId,
+            pipelineConfig
+          });
+        }
+      }
+    ];
+    fetchSummary({
+      namespaceId,
+      appId,
+      programType: convertProgramToApi(programType),
+      programId,
+      pipelineConfig,
+      limit: this.state.runsLimit
+    });
+  }
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.totalRunsCount !== this.state.totalRunsCount) {
+      this.setState({
+        totalRunsCount: nextProps.totalRunsCount
+      });
+    }
+  }
+  componentDidMount() {
+    let {namespaceId: namespace, appId, programId: workflowId} = this.props;
+    MyPipelineApi.pollStatistics({
+      namespace,
+      appId,
+      workflowId
+    })
+      .subscribe(
+        res => {
+          if (typeof res !== 'object') {
+            return;
+          }
+          this.setState({
+            avgRunTime: res.avgRunTime
+          });
+        }
+      );
+    this.storeSubscription = PipelineSummaryStore.subscribe(() => {
+      let {runs, loading} = PipelineSummaryStore.getState().pipelinerunssummary;
+      let logsMetrics = runs.map(run => ({
+        runid: run.runid,
+        logsMetrics: run.logsMetrics,
+        start: run.start,
+        end: run.end
+      }));
+      let nodesMetrics = runs.map(run => ({
+        runid: run.runid,
+        nodesMetrics: run.nodesMetrics,
+        start: run.start,
+        end: run.end
+      }));
+      runs = runs.map(run => ({
+        runid: run.runid,
+        duration: run.duration,
+        start: run.start,
+        end: run.end,
+        status: run.status
+      }));
+      let state = {
+        runs,
+        logsMetrics,
+        nodesMetrics,
+        loading
+      };
+      if (this.state.filterType === 'time') {
+        const getStartAndEnd = () => {
+          let start, end;
+          // Will happen if chosen 'Since Inception' as UI doesn't know a start and end beforehand.
+          if (isNil(this.state.start) || isNil(this.state.end)) {
+            end = runs[0].start;
+            start = runs[runs.length - 1].start;
+          }
+          return !isNil(start) && !isNil(end) ? {start, end}: {};
+        };
+        state = Object.assign({}, state, getStartAndEnd() , {
+          limit: runs.length
+        });
+      }
+      this.setState(state);
+    });
+  }
+  fetchRunsByLimit(limit, filterLabel) {
+    this.setState({
+      runsLimit: limit,
+      activeRunsFilter: filterLabel,
+      filterType: 'limit',
+      start: null,
+      end: null
+    });
+    let {namespaceId, appId, programType, programId, pipelineConfig} = this.props;
+    fetchSummary({
+      namespaceId,
+      appId,
+      programType: convertProgramToApi(programType),
+      programId,
+      pipelineConfig,
+      limit
+    });
+  }
+  fetchRunsByTime(time, filterLabel) {
+    let end = Math.floor(Date.now() / 1000);
+    let start = end - time;
+    this.setState({
+      activeRunsFilter: filterLabel,
+      filterType: 'time',
+      runsLimit: null,
+      start,
+      end
+    });
+    let {namespaceId, appId, programType, programId, pipelineConfig} = this.props;
+    fetchSummary({
+      namespaceId,
+      appId,
+      programType: convertProgramToApi(programType),
+      programId,
+      pipelineConfig,
+      start,
+      end
+    });
+  }
+  renderTitleBar() {
+    return (
+      <div className="top-title-bar">
+        <div> {T.translate(`${PREFIX}.title`)}</div>
+        <div className="stats-container text-xs-right">
+          <span>
+            <strong>{T.translate(`${PREFIX}.statsContainer.runTime`)}: </strong>
+          </span>
+          <span>
+            <strong>{T.translate(`${PREFIX}.statsContainer.avgRunTime`)}: </strong>
+            {getDuration(this.state.avgRunTime)}
+          </span>
+          <span>
+            <strong>{T.translate(`${PREFIX}.statsContainer.totalRuns`)}: </strong>
+            {this.state.totalRunsCount}
+          </span>
+          <IconSVG
+            name="icon-close"
+            onClick={this.props.onClose}
+          />
+        </div>
+      </div>
+    );
+  }
+  render() {
+    return (
+      <div className="pipeline-summary">
+        {
+          this.renderTitleBar()
+        }
+        <div className="filter-container">
+          <span> {T.translate(`${PREFIX}.filterContainer.view`)} </span>
+          <UncontrolledDropdown className="runs-dropdown">
+            <DropdownToggle caret>
+              <span>{this.state.activeRunsFilter}</span>
+              <IconSVG name="icon-chevron-down" />
+            </DropdownToggle>
+            <CustomDropdownMenu>
+              {
+                this.runsDropdown.map(dropdown => {
+                  if (dropdown.label === 'divider') {
+                    return (
+                      <DropdownItem
+                        tag="li"
+                        divider
+                      />
+                    );
+                  }
+                  return (
+                    <DropdownItem
+                      tag="li"
+                      onClick={dropdown.onClick.bind(this, dropdown.label)}
+                    >
+                      {
+                        dropdown.label
+                      }
+                    </DropdownItem>
+                  );
+                })
+              }
+            </CustomDropdownMenu>
+          </UncontrolledDropdown>
+        </div>
+        <div className="graphs-container">
+          <RunsHistoryGraph
+            activeFilterLabel={this.state.activeRunsFilter}
+            totalRunsCount={this.state.totalRunsCount}
+            runs={this.state.runs}
+            runsLimit={this.state.runsLimit}
+            start={this.state.start}
+            end={this.state.end}
+            xDomainType={this.state.filterType}
+            runContext={this.props}
+            isLoading={this.state.loading}
+          />
+          <LogsMetricsGraph
+            activeFilterLabel={this.state.activeRunsFilter}
+            totalRunsCount={this.state.totalRunsCount}
+            runs={this.state.logsMetrics}
+            runsLimit={this.state.runsLimit}
+            start={this.state.start}
+            end={this.state.end}
+            xDomainType={this.state.filterType}
+            runContext={this.props}
+            isLoading={this.state.loading}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+PipelineSummary.propTypes = {
+  namespaceId: PropTypes.string.isRequired,
+  appId: PropTypes.string.isRequired,
+  programType: PropTypes.string.isRequired,
+  programId: PropTypes.string.isRequired,
+  pipelineConfig: PropTypes.object.isRequired,
+  totalRunsCount: PropTypes.number,
+  onClose: PropTypes.func
+};

--- a/cdap-ui/app/cdap/services/program-api-converter/index.js
+++ b/cdap-ui/app/cdap/services/program-api-converter/index.js
@@ -27,6 +27,15 @@ const apiProgramTypeConvert = {
   workflows: 'workflows'
 };
 
+const metricApiProgramTypeConvert = Object.assign({}, apiProgramTypeConvert, {
+  workflows: 'workflow',
+  workflow: 'workflow'
+});
 export function convertProgramToApi(program) {
   return apiProgramTypeConvert[program.toLowerCase()];
 }
+
+export function convertProgramToMetricParams(program) {
+  return metricApiProgramTypeConvert[program.toLowerCase()];
+}
+

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1011,6 +1011,70 @@ features:
     subtitleMessage2: View all your entities in the
   Pagination:
     dropdown-label: Page
+  PipelineSummary:
+    filterContainer:
+      view: View
+    graphs:
+      emptyMessage: No Runs {filter}
+      vizSwitcher:
+        chart: Chart
+        table: Table
+    logsMetricsGraph:
+      hint:
+        errors: Errors
+        runNumber: Run Number
+        startTime: Start Time
+        title: Log Errors & Warnings
+        viewLogs: View Logs
+        warnings: Warnings
+      legend1: Warnings
+      legend2: Errors
+      table:
+        body:
+          viewLog: View Log
+        header:
+          errors: Errors
+          runCount: Run#
+          startTime: Start Time
+          warnings: Warnings
+      title: Log Errors and Warnings
+      xAxisTitle: Pipeline Run #
+      yAxisTitle: Number of Errors and Warnings
+    runsHistoryGraph:
+      hint:
+        duration: Duration
+        runNumber: Run Number
+        status: Status
+        startTime: Start Time
+        title: Run History
+      legend1: Failed
+      legend2: Successful
+      table:
+        headers:
+          duration: Duration
+          runCount: Run#
+          status: Status
+          startTime: Start Time
+      title: Run History
+      xAxisTitle: Pipeline Run #
+      yAxisTitle: Run Duration ({resolution})
+    runsFilter:
+      last10Runs: Last 10 runs
+      last50Runs: Last 50 runs
+      last100Runs: Last 100 runs
+      last1Day: Last 24 hours
+      last7Days: Last 7 days
+      last30Days: Last 30 days
+      sinceInception: Since Inception
+    statsContainer:
+      avg: Average
+      avgRunTime: Average
+      currentSchedule: Current Schedule
+      min: Min
+      max: Max
+      runTime: Run Time
+      totalRuns: TotalRuns
+    title: 'Summary'
   PropertiesEditor:
     AddProperty:
       button: Add Property

--- a/cdap-ui/app/common/cask-header.js
+++ b/cdap-ui/app/common/cask-header.js
@@ -30,6 +30,7 @@
  var KeyValuePairs = require('../cdap/components/KeyValuePairs').default;
  var KeyValueStore = require('../cdap/components/KeyValuePairs/KeyValueStore').default;
  var KeyValueStoreActions = require('../cdap/components/KeyValuePairs/KeyValueStoreActions').default;
+ var PipelineSummary = require('../cdap/components/PipelineSummary').default;
  var Mousetrap = require('mousetrap');
 
  export {
@@ -47,5 +48,6 @@
   KeyValuePairs,
   KeyValueStore,
   KeyValueStoreActions,
-  Mousetrap
+  Mousetrap,
+  PipelineSummary
 };

--- a/cdap-ui/app/directives/my-pipeline-summary/my-pipeline-summary-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-summary/my-pipeline-summary-ctrl.js
@@ -15,7 +15,8 @@
  */
 
 class MyPipelineSummaryCtrl {
-  constructor($scope, moment, $interval, GLOBALS) {
+  constructor($scope, moment, $interval, GLOBALS, $stateParams) {
+    this.$stateParams = $stateParams;
     this.runs = [];
     this.programId = '';
     this.programType = '';
@@ -51,7 +52,7 @@ class MyPipelineSummaryCtrl {
       if (nextRunTimeInterval) {
         $interval.cancel(nextRunTimeInterval);
       }
-      if(statisticsInterval) {
+      if (statisticsInterval) {
         $interval.cancel(statisticsInterval);
       }
     });
@@ -63,6 +64,7 @@ class MyPipelineSummaryCtrl {
     this.programType = params.programType.toUpperCase();
     this.programId = params.programName;
     this.appId = params.app;
+    this.namespaceId = this.$stateParams.namespace;
 
     var averageRunTime = this.store.getStatistics().avgRunTime;
     // We get time as seconds from backend. So multiplying it by 1000 to give moment.js in milliseconds.
@@ -81,7 +83,7 @@ class MyPipelineSummaryCtrl {
 
   }
 }
-MyPipelineSummaryCtrl.$inject = ['$scope', 'moment', '$interval', 'GLOBALS'];
+MyPipelineSummaryCtrl.$inject = ['$scope', 'moment', '$interval', 'GLOBALS', '$stateParams'];
 
  angular.module(PKG.name + '.commons')
   .controller('MyPipelineSummaryCtrl', MyPipelineSummaryCtrl);

--- a/cdap-ui/app/directives/my-pipeline-summary/my-pipeline-summary.html
+++ b/cdap-ui/app/directives/my-pipeline-summary/my-pipeline-summary.html
@@ -13,39 +13,12 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<my-card data-title="History" class="history">
-  <my-program-history
-    data-runs="MyPipelineSummaryCtrl.runs"
-    data-type="{{ MyPipelineSummaryCtrl.programType }}"
-    data-app-id="MyPipelineSummaryCtrl.appId"
-    data-program-id="MyPipelineSummaryCtrl.programId"
-    class="history-table"></my-program-history>
-</my-card>
-<my-card data-title="Summary" class="summary">
-  <table class="table borderless">
-    <thead>
-      <tr>
-        <th>Total Runs</th>
-        <th>Average Duration</th>
-        <th>Next Run</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>{{MyPipelineSummaryCtrl.totalRunsCount}}</td>
-        <td>
-            {{ MyPipelineSummaryCtrl.avgRunTime !== 'N/A' ? MyPipelineSummaryCtrl.avgRunTime : '—' }}
-        </td>
-        <td>
-          <span ng-if="MyPipelineSummaryCtrl.nextRunTime !== 'N/A'">
-            {{ MyPipelineSummaryCtrl.nextRunTime | amDateFormat:'h:mm:ss A'}}
-            <small> {{ MyPipelineSummaryCtrl.nextRunTime | amDateFormat:'MM/DD/YYYY' }}</small>
-          </span>
-          <span ng-if="MyPipelineSummaryCtrl.nextRunTime === 'N/A'">
-            —
-          </span>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</my-card>
+<pipeline-summary
+  namespace-id="MyPipelineSummaryCtrl.namespaceId"
+  app-id="MyPipelineSummaryCtrl.appId"
+  program-type="MyPipelineSummaryCtrl.programType"
+  program-id="MyPipelineSummaryCtrl.programId"
+  pipeline-config="MyPipelineSummaryCtrl.pipelineConfig"
+  total-runs-count="MyPipelineSummaryCtrl.totalRunsCount"
+  on-close="MyPipelineSummaryCtrl.onClose"
+> </pipeline-summary>

--- a/cdap-ui/app/directives/my-pipeline-summary/my-pipeline-summary.js
+++ b/cdap-ui/app/directives/my-pipeline-summary/my-pipeline-summary.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,13 +15,18 @@
  */
 
 angular.module(PKG.name + '.commons')
+  .directive('pipelineSummary', function(reactDirective) {
+    return reactDirective(window.CaskCommon.PipelineSummary);
+  })
   .directive('myPipelineSummary', function() {
     return {
       restrict: 'A',
       scope: {
         store: '=',
+        pipelineConfig: '=',
         actionCreator: '=',
-        pipelineType: '@'
+        pipelineType: '@',
+        onClose: '&'
       },
       replace: false,
       templateUrl: 'my-pipeline-summary/my-pipeline-summary.html',

--- a/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
@@ -494,6 +494,9 @@ class HydratorDetailTopPanelController {
         }
       );
   }
+  hidePipelineSummary() {
+    this.viewSummary = false;
+  }
   suspendPipeline() {
     this.scheduleLoading = true;
     this.HydratorPlusPlusDetailActions.suspendSchedule(

--- a/cdap-ui/app/hydrator/templates/detail/top-panel.html
+++ b/cdap-ui/app/hydrator/templates/detail/top-panel.html
@@ -293,12 +293,14 @@
       is-pipeline="true">
     </my-log-viewer>
   </div>
-  <div class="pipeline-settings">
+  <div class="pipeline-settings pipeline-summary">
     <div
       store="TopPanelCtrl.HydratorPlusPlusDetailRunsStore"
+      pipeline-config="TopPanelCtrl.cloneConfig"
       action-creator="TopPanelCtrl.HydratorPlusPlusDetailActions"
       pipeline-type="{{TopPanelCtrl.pipelineType}}"
       ng-if="TopPanelCtrl.viewSummary"
+      on-close="TopPanelCtrl.hidePipelineSummary()"
       my-pipeline-summary>
     </div>
   </div>

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -671,6 +671,11 @@ body.theme-cdap {
       }
       .pipeline-settings {
         width: 100%;
+        &.pipeline-summary {
+          > div {
+            padding: 0;
+          }
+        }
         > div {
           width: 100%;
           padding: 10px;


### PR DESCRIPTION
#### Things done:
- Removed old summary view
- Adds graph visualization for Run history and Errors, Warning logs
- Adds `react-viz` to draw graphs

#### Things to be done:
~- The Run time stats in the title bar is dummy. Need to add actual values.~
- Have to add Node level metrics graphs.
- The Table view still needs more work.
  - Sorting,
  - ID in Runs History graph,
  - Highlight on hover
- Add `react-viz` to package.json and build dlls. Have not added the commit as it increases the number of changes significantly. Have removed it for now to make this PR reviewable. (https://github.com/caskdata/cdap/pull/9188)


#### To test locally:
- Install react-vis locally before running dev build (`npm i react-vis -S`)

JIRAs:
https://issues.cask.co/browse/CDAP-11889
https://issues.cask.co/browse/CDAP-11893
https://issues.cask.co/browse/CDAP-11894
Bamboo build: 
https://builds.cask.co/browse/CDAP-DRC6869/latest