### PR TITLE
(CDAP-4871) Refactoring Spark runtime. Preparing for PySpark.

### DIFF
--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkClassLoader.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkClassLoader.java
@@ -46,8 +46,8 @@ public class SparkClassLoader extends CombineClassLoader {
    */
   public static SparkClassLoader findFromContext() {
     ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-    SparkClassLoader sparkClassLoader = ClassLoaders.find(contextClassLoader,
-                                                          SparkClassLoader.class);
+    SparkClassLoader sparkClassLoader = ClassLoaders.find(contextClassLoader, SparkClassLoader.class);
+
     // Should find the Spark ClassLoader
     Preconditions.checkState(sparkClassLoader != null, "Cannot find SparkClassLoader from context ClassLoader %s",
                              contextClassLoader);

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -151,35 +151,35 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
   /**
    * Returns the {@link TransactionSystemClient} for this execution.
    */
-  TransactionSystemClient getTransactionSystemClient() {
+  public TransactionSystemClient getTransactionSystemClient() {
     return txClient;
   }
 
   /**
    * Returns the CDAP {@link CConfiguration} used for the execution.
    */
-  CConfiguration getCConfiguration() {
+  public CConfiguration getCConfiguration() {
     return cConf;
   }
 
   /**
    * Returns the {@link Configuration} used for the execution.
    */
-  Configuration getConfiguration() {
+  public Configuration getConfiguration() {
     return hConf;
   }
 
   /**
    * Returns the {@link LoggingContext} representing the program.
    */
-  LoggingContext getLoggingContext() {
+  public LoggingContext getLoggingContext() {
     return loggingContext;
   }
 
   /**
    * Returns the {@link StreamAdmin} used for this execution.
    */
-  StreamAdmin getStreamAdmin() {
+  public StreamAdmin getStreamAdmin() {
     return streamAdmin;
   }
 

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkDriverService.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkDriverService.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.distributed;
+
+import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.app.runtime.spark.SparkCredentialsUpdater;
+import co.cask.cdap.app.runtime.spark.SparkRuntimeContext;
+import co.cask.cdap.app.runtime.spark.SparkRuntimeEnv;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
+import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.spark.SparkConf;
+import org.apache.twill.filesystem.FileContextLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * A service that runs in the Spark Driver process in distributed mode. It is responsible for
+ * maintaining heartbeat with the client, and optionally transmitting the {@link WorkflowToken}.
+ * If runs in secure mode, the service is also responsible for updating the delegation tokens for itself
+ * as well as all executors.
+ */
+public class SparkDriverService extends AbstractExecutionThreadService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkDriverService.class);
+  private static final long HEARTBEAT_INTERVAL_MILLIS = 1000L;
+  private static final int MAX_HEARTBEAT_FAILURES = 60;
+
+  private final SparkExecutionClient client;
+  @Nullable
+  private final SparkCredentialsUpdater credentialsUpdater;
+  @Nullable
+  private final BasicWorkflowToken workflowToken;
+
+  private Thread runThread;
+
+  public SparkDriverService(URI baseURI, SparkRuntimeContext runtimeContext) {
+    this.client = new SparkExecutionClient(baseURI, runtimeContext.getProgramRunId());
+    this.credentialsUpdater = createCredentialsUpdater(runtimeContext.getConfiguration(), client);
+    WorkflowProgramInfo workflowInfo = runtimeContext.getWorkflowInfo();
+    this.workflowToken = workflowInfo == null ? null : workflowInfo.getWorkflowToken();
+
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    runThread = Thread.currentThread();
+
+    // Make the first heartbeat, fail the startup if failed to make the heartbeat
+    heartbeat(client, workflowToken);
+
+    // Schedule the credentials update if necessary
+    if (credentialsUpdater != null) {
+      credentialsUpdater.startAndWait();
+    }
+
+    LOG.info("SparkDriverService started.");
+  }
+
+  @Override
+  protected void run() throws Exception {
+    // Performs heartbeat once per heartbeat interval.
+    int failureCount = 0;
+    while (isRunning()) {
+      try {
+        long nextHeartbeatTime = System.currentTimeMillis() + HEARTBEAT_INTERVAL_MILLIS;
+        heartbeat(client, workflowToken);
+        failureCount = 0;
+
+        long sleepTime = nextHeartbeatTime - System.currentTimeMillis();
+        if (isRunning() && sleepTime > 0) {
+          TimeUnit.MILLISECONDS.sleep(sleepTime);
+        }
+      } catch (InterruptedException e) {
+        // It's issue on stop. So just continue and let the while loop to handle the condition
+        continue;
+      } catch (BadRequestException e) {
+        LOG.error("Invalid spark program heartbeat. Terminating the execution.", e);
+        throw e;
+      } catch (Throwable t) {
+        if (failureCount++ < MAX_HEARTBEAT_FAILURES) {
+          LOG.warn("Failed to make heartbeat for {} times", failureCount, t);
+        } else {
+          LOG.error("Failed to make heartbeat for {} times. Terminating the execution", failureCount, t);
+          throw t;
+        }
+      }
+    }
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    // Clear the interrupt flag.
+    Thread.interrupted();
+    try {
+      if (credentialsUpdater != null) {
+        credentialsUpdater.stopAndWait();
+      }
+    } finally {
+      client.completed(workflowToken);
+    }
+    LOG.info("SparkDriverService stopped.");
+  }
+
+  @Override
+  protected void triggerShutdown() {
+    if (runThread != null && runThread != Thread.currentThread()) {
+      runThread.interrupt();
+    }
+  }
+
+  @Override
+  protected Executor executor() {
+    return new Executor() {
+      @Override
+      public void execute(Runnable command) {
+        Thread thread = new Thread(command, "SparkDriverService");
+        thread.setDaemon(true);
+        thread.start();
+      }
+    };
+  }
+
+  /**
+   * Creates a {@link SparkCredentialsUpdater} for {@link Credentials} in secure environment. If security is disable,
+   * or failure to create one due to {@link IOException} from {@link LocationFactory}, {@code null} will be returned.
+   */
+  @Nullable
+  private SparkCredentialsUpdater createCredentialsUpdater(Configuration hConf, SparkExecutionClient client) {
+    try {
+      SparkConf sparkConf = new SparkConf();
+      long updateIntervalMs = sparkConf.getLong("spark.yarn.token.renewal.interval", -1L);
+      if (updateIntervalMs <= 0) {
+        return null;
+      }
+
+      // This env variable is set by Spark for all known Spark versions
+      // If it is missing, exception will be thrown
+      URI stagingURI = URI.create(System.getenv("SPARK_YARN_STAGING_DIR"));
+      LocationFactory lf = new FileContextLocationFactory(hConf);
+      Location credentialsDir = stagingURI.isAbsolute()
+        ? lf.create(stagingURI.getPath())
+        : lf.getHomeLocation().append(stagingURI.getPath());
+
+      LOG.info("Credentials DIR: {}", credentialsDir);
+
+      int daysToKeepFiles = sparkConf.getInt("spark.yarn.credentials.file.retention.days", 5);
+      int numFilesToKeep = sparkConf.getInt("spark.yarn.credentials.file.retention.count", 5);
+      Location credentialsFile = credentialsDir.append("credentials-" + UUID.randomUUID());
+
+      // Update this property so that the executor will pick it up. It can't get set from the client side,
+      // otherwise the AM process will try to look for keytab file
+      SparkRuntimeEnv.setProperty("spark.yarn.credentials.file", credentialsFile.toURI().toString());
+      return new SparkCredentialsUpdater(createCredentialsSupplier(client, credentialsDir), credentialsDir,
+                                         credentialsFile.getName(), updateIntervalMs,
+                                         TimeUnit.DAYS.toMillis(daysToKeepFiles), numFilesToKeep);
+    } catch (IOException e) {
+      LOG.warn("Failed to create credentials updater. Credentials update disabled", e);
+      return null;
+    }
+  }
+
+  /**
+   * Creates a {@link Supplier} to supply {@link Credentials} for update. It talks to the {@link SparkExecutionClient}
+   * to request for an updated {@link Credentials}.
+   */
+  private Supplier<Credentials> createCredentialsSupplier(final SparkExecutionClient client,
+                                                          final Location credentialsDir) {
+    return new Supplier<Credentials>() {
+      @Override
+      public Credentials get() {
+        // Request for the credentials to be written to a temp location
+        try {
+          Location tmpLocation = credentialsDir.append("fetch-credentials-" + UUID.randomUUID() + ".tmp");
+          try {
+            client.writeCredentials(tmpLocation);
+
+            // Decode the credentials, update the credentials of the current user and return it
+            Credentials credentials = new Credentials();
+            try (DataInputStream input = new DataInputStream(tmpLocation.getInputStream())) {
+              credentials.readTokenStorageStream(input);
+              UserGroupInformation.getCurrentUser().addCredentials(credentials);
+              LOG.debug("Credentials updated: {}", credentials.getAllTokens());
+              return credentials;
+            }
+          } finally {
+            if (!tmpLocation.delete()) {
+              LOG.warn("Failed to delete temporary location {}", tmpLocation);
+            }
+          }
+        } catch (Exception e) {
+          // Just throw it out. The SparkCredentialsUpdater will handle it
+          throw Throwables.propagate(e);
+        }
+      }
+    };
+  }
+
+  /**
+   * Calls the heartbeat endpoint and handle the {@link SparkCommand}.
+   * returned from the call.
+   */
+  private void heartbeat(SparkExecutionClient client, @Nullable BasicWorkflowToken workflowToken) throws Exception {
+    LOG.trace("Sending heartbeat with workflow token {}",
+              workflowToken == null ? null : workflowToken.getAllFromCurrentNode());
+    SparkCommand command = client.heartbeat(workflowToken);
+    if (command == null) {
+      return;
+    }
+    if (SparkCommand.STOP.equals(command)) {
+      LOG.info("Stop command received from client. Stopping spark program.");
+      stop();
+    } else {
+      LOG.warn("Ignoring unsupported command {}", command);
+    }
+  }
+}

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
@@ -16,10 +16,10 @@
 
 package co.cask.cdap.app.runtime.spark.submit;
 
-import co.cask.cdap.app.runtime.spark.SparkMainWrapper;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeContext;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeContextConfig;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeEnv;
+import co.cask.cdap.app.runtime.spark.SparkRuntimeUtils;
 import co.cask.cdap.app.runtime.spark.distributed.SparkExecutionService;
 import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
@@ -90,8 +90,9 @@ public class DistributedSparkSubmitter extends AbstractSparkSubmitter {
     }
 
     sparkExecutionService.startAndWait();
-    return Collections.singletonList("--" + SparkMainWrapper.ARG_EXECUTION_SERVICE_URI()
-                                       + "=" + sparkExecutionService.getBaseURI());
+    SparkRuntimeEnv.setProperty("spark.yarn.appMasterEnv." + SparkRuntimeUtils.CDAP_SPARK_EXECUTION_SERVICE_URI,
+                                sparkExecutionService.getBaseURI().toString());
+    return Collections.emptyList();
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/LocalSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/LocalSparkSubmitter.java
@@ -18,6 +18,7 @@ package co.cask.cdap.app.runtime.spark.submit;
 
 import co.cask.cdap.app.runtime.spark.SparkMainWrapper;
 import com.google.common.collect.ImmutableList;
+import org.apache.twill.common.Cancellable;
 
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -50,6 +51,6 @@ public class LocalSparkSubmitter extends AbstractSparkSubmitter {
   protected void triggerShutdown() {
     // We just stop the SparkMainWrapper directly. Through the SparkClassLoader, we make sure that Spark
     // sees the same SparkMainWrapper class as this one
-    SparkMainWrapper.triggerShutdown();
+    SparkMainWrapper.cancellable().cancel();
   }
 }

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SparkMainWrapper.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SparkMainWrapper.scala
@@ -16,28 +16,12 @@
 
 package co.cask.cdap.app.runtime.spark
 
-import java.io.DataInputStream
 import java.lang.reflect.{Method, Modifier}
-import java.net.URI
-import java.util.UUID
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.{Executors, TimeUnit}
 
 import co.cask.cdap.api.common.RuntimeArguments
 import co.cask.cdap.api.spark.{JavaSparkMain, SparkMain}
-import co.cask.cdap.app.runtime.spark.distributed.{SparkCommand, SparkExecutionClient}
-import co.cask.cdap.common.BadRequestException
-import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken
-import com.google.common.base.Supplier
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.security.{Credentials, UserGroupInformation}
-import org.apache.spark.SparkConf
-import org.apache.twill.common.{Cancellable, Threads}
-import org.apache.twill.filesystem.{FileContextLocationFactory, Location}
+import org.apache.twill.common.Cancellable
 import org.slf4j.LoggerFactory
-
-import scala.collection.JavaConversions._
-import scala.util.{Failure, Success, Try}
 
 /**
   * The main class that get submitted to Spark for execution of Spark program in CDAP.
@@ -45,89 +29,73 @@ import scala.util.{Failure, Success, Try}
   */
 object SparkMainWrapper {
 
-  val ARG_USER_CLASS = "userClass"
-  val ARG_EXECUTION_SERVICE_URI = "executionServiceURI"
-
-  private val HEARTBEAT_INTERVAL_SECONDS = 1L
   private val LOG = LoggerFactory.getLogger(SparkMainWrapper.getClass)
 
   @volatile
   private var stopped = false
-  @volatile
-  private var mainThread: Option[Thread] = None
 
-  /**
-    * Triggers the shutdown of the main execution thread.
-    */
-  def triggerShutdown(): Unit = {
-    stopped = true
-    SparkRuntimeEnv.stop(mainThread)
+  @volatile
+  var cancellable = new Cancellable {
+    override def cancel(): Unit = {
+      stopped = true
+    }
   }
 
   def main(args: Array[String]): Unit = {
-    mainThread = Some(Thread.currentThread)
     if (stopped) {
       return
     }
 
-    val arguments: Map[String, String] = RuntimeArguments.fromPosixArray(args).toMap
-    require(arguments.contains(ARG_USER_CLASS), "Missing Spark program class name")
+    // Initialize the Spark runtime and update the Cancellable.
+    cancellable = new Cancellable() {
+      val delegate = SparkRuntimeUtils.initSparkMain()
 
-    // Find the SparkRuntimeContext from the classloader. Create a new one if not found (for Spark 1.2)
-    val sparkClassLoader = Try(SparkClassLoader.findFromContext()) match {
-      case Success(classLoader) => classLoader
-      case Failure(exception) =>
-        val classLoader = SparkClassLoader.create()
-        // For Spark 1.2 driver. No need to reset the classloader at the end since this is the driver process.
-        SparkRuntimeUtils.setContextClassLoader(classLoader)
-        classLoader
+      override def cancel(): Unit = {
+        stopped = true
+        delegate.cancel()
+      }
     }
 
-    val cancellable = SparkRuntimeUtils.setContextClassLoader(sparkClassLoader)
     try {
+      val sparkClassLoader = SparkClassLoader.findFromContext()
       val runtimeContext = sparkClassLoader.getRuntimeContext
+      val executionContext = sparkClassLoader.getSparkExecutionContext(false)
+      val serializableExecutionContext = new SerializableSparkExecutionContext(executionContext)
+
+      // Check one more time before calling user main
+      if (stopped) {
+        return
+      }
 
       // Load the user Spark class
-      val userSparkClass = sparkClassLoader.getProgramClassLoader.loadClass(arguments(ARG_USER_CLASS))
-      val executionContext = sparkClassLoader.getSparkExecutionContext(true)
-      val serializableExecutionContext = new SerializableSparkExecutionContext(executionContext)
-      try {
-        val cancelHeartbeat = startHeartbeat(arguments, runtimeContext, () => triggerShutdown)
-        try {
-          userSparkClass match {
-            // SparkMain
-            case cls if classOf[SparkMain].isAssignableFrom(cls) =>
-              cls.asSubclass(classOf[SparkMain]).newInstance().run(serializableExecutionContext)
+      val userSparkClass = sparkClassLoader.getProgramClassLoader.loadClass(
+        runtimeContext.getSparkSpecification.getMainClassName)
+      userSparkClass match {
+        // SparkMain
+        case cls if classOf[SparkMain].isAssignableFrom(cls) =>
+          cls.asSubclass(classOf[SparkMain]).newInstance().run(serializableExecutionContext)
 
-            // JavaSparkMain
-            case cls if classOf[JavaSparkMain].isAssignableFrom(cls) =>
-              cls.asSubclass(classOf[JavaSparkMain]).newInstance().run(
-                sparkClassLoader.createJavaExecutionContext(serializableExecutionContext))
+        // JavaSparkMain
+        case cls if classOf[JavaSparkMain].isAssignableFrom(cls) =>
+          cls.asSubclass(classOf[JavaSparkMain]).newInstance().run(
+            sparkClassLoader.createJavaExecutionContext(serializableExecutionContext))
 
-            // main() method
-            case cls =>
-              getMainMethod(cls).invoke(null, RuntimeArguments.toPosixArray(runtimeContext.getRuntimeArguments))
-          }
-          stopped = true
-        } finally {
-          // If stop is request or the program returns normally, cancel the heartbeat
-          if (stopped) cancelHeartbeat.cancel
-        }
-      } catch {
-        // If there is InterruptedException after stop is being request, we don't treat it as failure
-        case interrupted: InterruptedException => if (!stopped) throw interrupted
-        case t: Throwable => throw t
-      } finally {
-        executionContext match {
-          case c: AutoCloseable => c.close
-          case _ => // no-op
-        }
+        // main() method
+        case cls =>
+          getMainMethod(cls).invoke(null, RuntimeArguments.toPosixArray(runtimeContext.getRuntimeArguments))
       }
+    } catch {
+      // If it is stopped, ok to ignore the InterruptedException, as system issues interrupt to the main thread
+      // to unblock the main method.
+      case e: InterruptedException => if (!SparkRuntimeEnv.isStopped) throw e
     } finally {
       cancellable.cancel
     }
   }
 
+  /**
+    * Gets the static main method from the givne class.
+    */
   private def getMainMethod(obj: Class[_]): Method = {
     try {
       val mainMethod = obj.getDeclaredMethod("main", classOf[Array[String]])
@@ -140,177 +108,6 @@ object SparkMainWrapper {
         + " is not a supported Spark program. It should either implement "
         + classOf[SparkMain].getName + " or " + classOf[JavaSparkMain].getName
         + " or define a main method")
-    }
-  }
-
-  /**
-    * Starts the heartbeating thread if there is a [[co.cask.cdap.app.runtime.spark.distributed.SparkExecutionService]]
-    * running.
-    *
-    * @param arguments the arguments to the main method
-    * @param runtimeContext the [[co.cask.cdap.app.runtime.spark.SparkRuntimeContext]] for this execution
-    * @return a [[org.apache.twill.common.Cancellable]] to stop the heartbeating thread and signal the completion
-    *         of the execution.
-    */
-  private def startHeartbeat(arguments: Map[String, String],
-                             runtimeContext: SparkRuntimeContext, stopFunc: () => Unit): Cancellable = {
-    arguments.get(ARG_EXECUTION_SERVICE_URI).fold(new Cancellable {
-      override def cancel() = {
-        // no-op
-      }
-    })(baseURI => {
-      val programRunId = runtimeContext.getProgram.getId.run(runtimeContext.getRunId.getId)
-      val client = new SparkExecutionClient(URI.create(baseURI), programRunId)
-      val workflowToken = Option(runtimeContext.getWorkflowInfo).map(_.getWorkflowToken).orNull
-      val executor = Executors.newSingleThreadScheduledExecutor(
-        Threads.createDaemonThreadFactory("heartbeat-" + programRunId.getRun))
-      val credentialsUpdater = createCredentialsUpdater(runtimeContext.getConfiguration, client)
-
-      // Make the first heartbeat. If it fails, we will not start the spark execution.
-      heartbeat(client, stopFunc)
-
-      if (!SparkRuntimeEnv.isStopped) {
-        // Schedule the credentials update if necessary
-        credentialsUpdater.foreach(_.startAndWait())
-
-        // Schedule the next heartbeat
-        executor.schedule(new Runnable() {
-          val failureCount = new AtomicInteger
-
-          override def run() = {
-            try {
-              heartbeat(client, stopFunc, workflowToken)
-              failureCount.set(0)
-              if (!SparkRuntimeEnv.isStopped) {
-                executor.schedule(this, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS)
-              }
-            } catch {
-              case badRequest: BadRequestException =>
-                LOG.error("Invalid spark program heartbeat. Terminating the execution.", badRequest)
-                stopFunc()
-              case t: Throwable =>
-                if (failureCount.getAndIncrement() < 10) {
-                  LOG.warn("Failed to make heartbeat for {} times", failureCount.get, t)
-                } else {
-                  LOG.error("Failed to make heartbeat for {} times. Terminating the execution", failureCount.get)
-                  stopFunc()
-                }
-            }
-          }
-        }, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS)
-      }
-
-      new Cancellable {
-        override def cancel() = {
-          credentialsUpdater.foreach(updater => {
-            if (updater.isRunning) {
-              updater.stopAndWait()
-            }
-          })
-
-          executor.shutdownNow
-          // Wait for the last heartbeat to complete
-          executor.awaitTermination(5L, TimeUnit.SECONDS)
-          // Send the complete call
-          client.completed(workflowToken)
-          LOG.info("Spark program '{}' completed. Program RunID: [{}]",
-            programRunId.getProgram, programRunId.getRun : Any)
-        }
-      }
-    })
-  }
-
-  /**
-    * Calls the heartbeat endpoint and handle the [[co.cask.cdap.app.runtime.spark.distributed.SparkCommand]]
-    * returned from the call.
-    */
-  private def heartbeat(client: SparkExecutionClient, stopFunc: () => Unit,
-                        workflowToken: BasicWorkflowToken = null) = {
-    Option(client.heartbeat(workflowToken)).foreach {
-      case stop if SparkCommand.STOP == stop =>
-        LOG.info("Stopping Spark program upon receiving stop command")
-        stopFunc()
-      case notSupported => LOG.warn("Ignoring unsupported command {}", notSupported)
-    }
-  }
-
-  /**
-    * Creates a [[co.cask.cdap.app.runtime.spark.SparkCredentialsUpdater]] for user Credentials updates.
-    */
-  private def createCredentialsUpdater(hConf: Configuration,
-                                       client: SparkExecutionClient): Option[SparkCredentialsUpdater] = {
-    try {
-      // This env variable is set by Spark for all known Spark versions
-      // If it is missing, exception will be thrown
-      val stagingURI = URI.create(sys.env("SPARK_YARN_STAGING_DIR"))
-      val lf = new FileContextLocationFactory(hConf)
-      val credentialsDir =
-        if (stagingURI.isAbsolute) {
-          lf.create(stagingURI.getPath)
-        } else {
-          lf.getHomeLocation.append(stagingURI.getPath)
-        }
-
-      LOG.info("Credentials DIR: {}", credentialsDir)
-
-      val sparkConf = new SparkConf
-      val updateIntervalMs = sparkConf.getLong("spark.yarn.token.renewal.interval", -1L)
-      if (updateIntervalMs <= 0) {
-        return None
-      }
-
-      val daysToKeepFiles = sparkConf.getInt("spark.yarn.credentials.file.retention.days", 5)
-      val numFilesToKeep = sparkConf.getInt("spark.yarn.credentials.file.retention.count", 5)
-      val credentialsFile = credentialsDir.append("credentials-" + UUID.randomUUID().toString)
-
-      // Update this property so that the executor will pick it up. It can't get set from the client side,
-      // otherwise the AM process will try to look for keytab file
-      SparkRuntimeEnv.setProperty("spark.yarn.credentials.file", credentialsFile.toURI.toString)
-      Some(new SparkCredentialsUpdater(createCredentialsSupplier(client, credentialsDir), credentialsDir,
-                                       credentialsFile.getName, updateIntervalMs,
-                                       TimeUnit.DAYS.toMillis(daysToKeepFiles), numFilesToKeep))
-    } catch {
-      case t: Throwable => {
-        LOG.warn("Failed to create credentials updater. Credentials update disabled", t)
-        None
-      }
-    }
-  }
-
-  /**
-    * Creates a [[com.google.common.base.Supplier]] to supply [[org.apache.hadoop.security.Credentials]] for update.
-    */
-  private def createCredentialsSupplier(client: SparkExecutionClient,
-                                        credentialsDir: Location): Supplier[Credentials] = {
-    new Supplier[Credentials] {
-      override def get() = {
-        // Request for the credentials to be written to a temp location
-        val tmpLocation = credentialsDir.append("fetch-credentials-" + UUID.randomUUID().toString + ".tmp")
-        try {
-          client.writeCredentials(tmpLocation)
-
-          // Decode the credentials, update the credentials of the current user and return it
-          val credentials = new Credentials()
-          val input = new DataInputStream(tmpLocation.getInputStream)
-          try {
-            credentials.readTokenStorageStream(input)
-            UserGroupInformation.getCurrentUser.addCredentials(credentials)
-            LOG.debug("Credentials updated: {}", credentials.getAllTokens)
-            credentials
-          } finally {
-            input.close()
-          }
-        } finally {
-          try {
-            if (!tmpLocation.delete()) {
-              LOG.warn("Failed to delete temporary location {}", tmpLocation)
-            }
-          } catch {
-            case t: Throwable => LOG.warn("Exception raised when deleting temporary location {}",
-                                          tmpLocation.asInstanceOf[Any], t.asInstanceOf[Any])
-          }
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
- Refactoring the heartbeat and credentials updater out of SparkMainWrapper
  - Move those code in Java, making it easier to maintain and also will be reused in PySpark case.