### PR TITLE
more user-friendly message

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -237,7 +237,7 @@ cdap_check_pidfile() {
   cdap_status_pidfile ${__pidfile} ${__label} > /dev/null
   __ret=$?
   case ${__ret} in
-    0) echo "$(date) Please stop ${__label} running at $(<${__pidfile}), first, or use the restart function" ;;
+    0) echo "$(date) Please stop CDAP ${__label} running as process $(<${__pidfile}) first, or use the restart function" ;;
     *) return 0 ;;
   esac
   return 1


### PR DESCRIPTION
less confusing error message:

before:
```
# service cdap-ui start
Wed Jun 28 01:34:20 UTC 2017 Please stop UI running at 29176, first, or use the restart function
```


after:
```
# service cdap-ui start
Wed Jun 28 01:38:08 UTC 2017 Please stop CDAP UI running as process 29176 first, or use the restart function
```