### PR TITLE
CDAP-12008 Fix sleep when there's no schedule notifications polled from TMS

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/NotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/NotificationSubscriberService.java
@@ -188,12 +188,13 @@ class NotificationSubscriberService extends AbstractIdleService {
         }, ServiceUnavailableException.class, TopicNotFoundException.class);
         failureCount = 0;
 
-        // The job queue and the last fetched message id was persisted successfully, update the local field as well.
         // Sleep for configured number of milliseconds if there's no notification, otherwise don't sleep
-        if (lastFetchedMessageId != null) {
-          messageId = lastFetchedMessageId;
+        if (lastFetchedMessageId == null) {
           return cConf.getLong(Constants.Scheduler.EVENT_POLL_DELAY_MILLIS);
         }
+
+        // The job queue and the last fetched message id was persisted successfully, update the local field as well.
+        messageId = lastFetchedMessageId;
         return 0L;
 
       } catch (ServiceUnavailableException e) {


### PR DESCRIPTION
CDAP-12008 Fix sleep when there's no schedule notifications polled from TMS.
The code was returning 0 (no sleep), when there was nothing polled from TMS, and so TMS was being hit several hundreds of times per second, even though there was no need.

Regression was brought about in https://github.com/caskdata/cdap/pull/9162.

https://builds.cask.co/browse/CDAP-RUT1174-1