### PR TITLE
CDAP-6329 CDAP services should enable GC logging by default.

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -567,7 +567,6 @@ cdap_service() {
   local readonly __pidfile=${PID_DIR}/${__service}-${IDENT_STRING}.pid
   local readonly __log_prefix=${LOG_DIR}/${__service}-${IDENT_STRING}-${HOSTNAME}
   local readonly __logfile=${__log_prefix}.log
-  local readonly __gc_file=${__log_prefix}.gc
   local readonly __svc=${__service/-server/}
   local readonly __ret
 
@@ -667,6 +666,8 @@ cdap_start_java() {
   JAVA_HEAPMAX=${JAVA_HEAPMAX:-${!JAVA_HEAP_VAR}}
   export JAVA_HEAPMAX
   local __defines="-Dcdap.service=${CDAP_SERVICE} ${JAVA_HEAPMAX} -Duser.dir=${LOCAL_DIR} -Djava.io.tmpdir=${TEMP_DIR}"
+  # Enable GC logging
+  __defines+=" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${__log_prefix}-heap.hprof -verbose:gc -Xloggc:${__log_prefix}-gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M"
   if [[ ${CDAP_SERVICE} == master ]]; then
     # Determine SPARK_HOME
     cdap_set_spark || logecho "Could not determine SPARK_HOME! Spark support unavailable!"

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -198,7 +198,7 @@
 
   <property>
     <name>twill.jvm.gc.opts</name>
-    <value>-verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
+    <value>-verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
     <description>
       Java garbage collection options for all Apache Twill containers;
       "&lt;LOG_DIR&gt;" is the location of the log directory in the
@@ -358,7 +358,7 @@
     <name>app.program.jvm.opts</name>
     <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts}</value>
     <description>
-      Java options for all program containers
+      Java options for all Apache Twill containers
     </description>
   </property>
 


### PR DESCRIPTION
Cherry-pick https://github.com/caskdata/cdap/pull/9135 to release/4.1.