### PR TITLE
CDAP-6329 Put pid in heapdump file name.

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-env.sh
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-env.sh
@@ -25,18 +25,22 @@
 # Adds Hadoop and HBase libs to the classpath on startup.
 # If the "hbase" command is on the PATH, this will be done automatically.
 # Or uncomment the line below to point to the HBase installation directly.
-# HBASE_HOME=
+# export HBASE_HOME=
 
 # Extra CLASSPATH locations to add to CDAP Java processes
-# EXTRA_CLASSPATH=""
+# export EXTRA_CLASSPATH=""
 
 # LOCAL_DIR sets the JVM -Duser.dir property of the CDAP processes, and provides a
 # local working directory for application jars during startup if needed
-LOCAL_DIR="/var/tmp/cdap"
+export LOCAL_DIR="/var/tmp/cdap"
 
 # TEMP_DIR sets the JVM -Djava.io.tmpdir property of the CDAP processes, and provides
 # temporary storage for Apache Twill
-TEMP_DIR="/tmp"
+export TEMP_DIR="/tmp"
+
+# Create heapdump upon OutOfMemoryError (true by default)
+# It will use the CDAP log directory
+# export HEAPDUMP_ON_OOM=true
 
 # Service-specific Java heap settings (overrides defaults)
 # export AUTH_JAVA_HEAPMAX="-Xmx1024m"


### PR DESCRIPTION
Followup to https://github.com/caskdata/cdap/pull/9135. The change here is to include the pid in the file name of the heapdump which is written upon OOM.
Otherwise, if the file already exists, a new heapdump will not be written.

![image](https://user-images.githubusercontent.com/2440977/27936762-5903f154-6267-11e7-8ce7-e2225875c5d2.png)


Showing how to disable the heapdump on OOM:
![image](https://user-images.githubusercontent.com/2440977/27936899-2b0d424a-6268-11e7-8837-14614f7d2d66.png)
