### PR TITLE
CDAP-12054 Fix PartitionedFileSet to work with CombineFileInputFormat

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/PartitionedFileSetInputContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/PartitionedFileSetInputContext.java
@@ -19,6 +19,8 @@ package co.cask.cdap.api.data.batch;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 
+import java.util.Set;
+
 /**
  * Exposes information about the {@link PartitionedFileSet} input configured for this task.
  */
@@ -26,6 +28,13 @@ public interface PartitionedFileSetInputContext extends InputContext {
 
   /**
    * Returns the {@link PartitionKey} of the input configured for this task.
+   * In case of CombineFileInputFormat, this will be the PartitionKey currently being processed by the task.
    */
   PartitionKey getInputPartitionKey();
+
+  /**
+   * Returns a Set of {@link PartitionKey}s of the input configured for this task. There can be multiple PartitionKeys
+   * for a single task if using CombineFileInputFormat.
+   */
+  Set<PartitionKey> getInputPartitionKeys();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/BasicPartitionedFileSetInputContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/BasicPartitionedFileSetInputContext.java
@@ -23,14 +23,19 @@ import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDataset;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A basic implementation of {@link PartitionedFileSetInputContext}.
@@ -42,34 +47,80 @@ class BasicPartitionedFileSetInputContext extends BasicInputContext implements P
 
   private static final Type STRING_PARTITION_KEY_MAP_TYPE = new TypeToken<Map<String, PartitionKey>>() { }.getType();
 
-  private final Path inputPath;
-  private final String mappingString;
+  private final Map<String, PartitionKey> pathToPartitionMapping;
 
-  private PartitionKey partitionKey;
+  private final boolean isCombineInputFormat;
+  private final Configuration conf;
+
+  private final Path[] inputPaths;
+  private Set<PartitionKey> partitionKeys;
+
+  // for caching in case of CombineFileInputFormat
+  private String currentInputfileName;
+  private PartitionKey currentPartitionKey;
 
   BasicPartitionedFileSetInputContext(MultiInputTaggedSplit multiInputTaggedSplit) {
     super(multiInputTaggedSplit.getName());
 
     InputSplit inputSplit = multiInputTaggedSplit.getInputSplit();
-    if (!(inputSplit instanceof FileSplit)) {
-      throw new IllegalArgumentException(String.format("Expected a '%s', but got '%s'.",
-                                                       FileSplit.class.getName(), inputSplit.getClass().getName()));
+    if (inputSplit instanceof FileSplit) {
+      isCombineInputFormat = false;
+      Path path = ((FileSplit) inputSplit).getPath();
+      inputPaths = new Path[] { path };
+    } else if (inputSplit instanceof CombineFileSplit) {
+      isCombineInputFormat = true;
+      inputPaths = ((CombineFileSplit) inputSplit).getPaths();
+    } else {
+      throw new IllegalArgumentException(String.format("Expected either a '%s' or a '%s', but got '%s'.",
+                                                       FileSplit.class.getName(), CombineFileSplit.class.getName(),
+                                                       inputSplit.getClass().getName()));
     }
-    this.inputPath = ((FileSplit) inputSplit).getPath();
-    this.mappingString = multiInputTaggedSplit.getConf().get(PartitionedFileSetDataset.PATH_TO_PARTITIONING_MAPPING);
+
+    this.conf = multiInputTaggedSplit.getConf();
+    String mappingString = conf.get(PartitionedFileSetDataset.PATH_TO_PARTITIONING_MAPPING);
+    this.pathToPartitionMapping =
+      GSON.fromJson(Objects.requireNonNull(mappingString), STRING_PARTITION_KEY_MAP_TYPE);
   }
 
   @Override
   public PartitionKey getInputPartitionKey() {
-    if (partitionKey == null) {
-      partitionKey = getPartitionKey(inputPath.toUri());
+    if (isCombineInputFormat) {
+      // org.apache.hadoop.mapreduce.lib.input.CombineFileRecordReader sets this in its initNextRecordReader method
+      String inputFileName = conf.get(MRJobConfig.MAP_INPUT_FILE);
+      if (inputFileName == null) {
+        throw new IllegalStateException(
+          String.format("The value of '%s' in the configuration must be set by the RecordReader in case of using an " +
+                          "InputFormat that returns CombineFileSplit.",
+                        MRJobConfig.MAP_INPUT_FILE));
+      }
+      if (!inputFileName.equals(currentInputfileName)) {
+        currentPartitionKey = getPartitionKey(URI.create(inputFileName));
+        currentInputfileName = inputFileName;
+      }
+      return currentPartitionKey;
     }
-    return partitionKey;
+
+    // single split per mapper task
+    Set<PartitionKey> inputPartitionKeys = getInputPartitionKeys();
+    if (inputPartitionKeys.size() != 1) {
+      throw new IllegalStateException(String.format("Expected a single PartitionKey, but found: %s",
+                                                    inputPartitionKeys));
+    }
+    return inputPartitionKeys.iterator().next();
+  }
+
+  @Override
+  public Set<PartitionKey> getInputPartitionKeys() {
+    if (partitionKeys == null) {
+      partitionKeys = new HashSet<>();
+      for (Path inputPath : inputPaths) {
+        partitionKeys.add(getPartitionKey(inputPath.toUri()));
+      }
+    }
+    return partitionKeys;
   }
 
   private PartitionKey getPartitionKey(URI inputPathURI) {
-    Map<String, PartitionKey> pathToPartitionMapping =
-      GSON.fromJson(Objects.requireNonNull(mappingString), STRING_PARTITION_KEY_MAP_TYPE);
     if (pathToPartitionMapping.containsKey(inputPathURI.toString())) {
       return pathToPartitionMapping.get(inputPathURI.toString());
     }
@@ -78,9 +129,17 @@ class BasicPartitionedFileSetInputContext extends BasicInputContext implements P
         return pathEntry.getValue();
       }
     }
-    throw new IllegalArgumentException(
-      String.format("Failed to derive PartitionKey from input path '%s' and path to key mapping '%s'.",
-                    inputPath, pathToPartitionMapping));
+    StringBuilder errorMessage = new StringBuilder(String.format("Failed to derive PartitionKey from input path '%s'.",
+                                                                 inputPathURI));
+    if (pathToPartitionMapping.size() <= 1000) {
+      errorMessage.append(String.format("Keys of path to key mapping: '%s'", pathToPartitionMapping.keySet()));
+    } else {
+      // uncommon case, but if there are too many partitions being processed by a single task, and if the partition
+      // key can not be derived from the path, omit the mapping from the logs
+      errorMessage.append(String.format("Path to key mapping had too many entries (%s) to log.",
+                                        pathToPartitionMapping.size()));
+    }
+    throw new IllegalArgumentException(errorMessage.toString());
   }
 
   // compares only the paths of the URI, ignoring the scheme, host, port, etc. of the URIs.

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithPartitionedFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithPartitionedFileSet.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.batch;
 
+import co.cask.cdap.api.Config;
 import co.cask.cdap.api.ProgramLifecycle;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
@@ -37,8 +38,10 @@ import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 
@@ -49,7 +52,7 @@ import java.util.Map;
  * App used to test whether M/R works well with time-partitioned file sets.
  * It uses M/R to read from a table and write partitions, and another M/R to read partitions and write to a table.
  */
-public class AppWithPartitionedFileSet extends AbstractApplication {
+public class AppWithPartitionedFileSet extends AbstractApplication<AppWithPartitionedFileSet.AppConfig> {
 
   public static final String INPUT = "in-table";
   public static final String PARTITIONED = "partitioned";
@@ -65,6 +68,8 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
     createDataset(INPUT, "table");
     createDataset(OUTPUT, "table");
 
+    Class<? extends InputFormat> inputFormatClass =
+      getConfig().isUseCombineFileInputFormat() ? CombineTextInputFormat.class : TextInputFormat.class;
     createDataset(PARTITIONED, "partitionedFileSet", PartitionedFileSetProperties.builder()
       .setPartitioning(Partitioning.builder()
                          .addStringField("type")
@@ -72,13 +77,25 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
                          .build())
         // properties for file set
       .setBasePath("partitioned")
-      .setInputFormat(TextInputFormat.class)
+      .setInputFormat(inputFormatClass)
       .setOutputFormat(TextOutputFormat.class)
       .setOutputProperty(TextOutputFormat.SEPERATOR, SEPARATOR)
         // don't configure properties for the Hive table - this is used in a context where explore is disabled
       .build());
     addMapReduce(new PartitionWriter());
     addMapReduce(new PartitionReader());
+  }
+
+  public static final class AppConfig extends Config {
+    private final boolean useCombineFileInputFormat;
+
+    public AppConfig(boolean useCombineFileInputFormat) {
+      this.useCombineFileInputFormat = useCombineFileInputFormat;
+    }
+
+    public boolean isUseCombineFileInputFormat() {
+      return useCombineFileInputFormat;
+    }
   }
 
   /**
@@ -108,7 +125,7 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
   }
 
   /**
-   * Map/Reduce that reads the "input" table and writes to a partition.
+   * Map/Reduce that reads the "partitioned" PFS and writes to an "output" table.
    */
   public static final class PartitionReader extends AbstractMapReduce {
 
@@ -129,14 +146,18 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
     implements ProgramLifecycle<MapReduceTaskContext<byte[], Put>> {
 
     private static byte[] rowToWrite;
+    private PartitionedFileSetInputContext pfsInputcontext;
 
     @Override
     public void initialize(MapReduceTaskContext<byte[], Put> context) throws Exception {
       InputContext inputContext = context.getInputContext();
       Preconditions.checkArgument(PARTITIONED.equals(inputContext.getInputName()));
       Preconditions.checkArgument(inputContext instanceof PartitionedFileSetInputContext);
-      PartitionedFileSetInputContext pfsInputcontext = (PartitionedFileSetInputContext) inputContext;
+      this.pfsInputcontext = (PartitionedFileSetInputContext) inputContext;
       Preconditions.checkNotNull(pfsInputcontext.getInputPartitionKey());
+      Preconditions.checkArgument(
+        pfsInputcontext.getInputPartitionKeys().contains(pfsInputcontext.getInputPartitionKey())
+      );
 
       Map<String, String> dsArguments =
         RuntimeArguments.extractScope(Scope.DATASET, PARTITIONED, context.getRuntimeArguments());
@@ -162,6 +183,8 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
       String line = text.toString();
       String[] fields = line.split(SEPARATOR);
       context.write(rowToWrite, new Put(rowToWrite, Bytes.toBytes(fields[0]), Bytes.toBytes(fields[1])));
+      context.write(rowToWrite, new Put(rowToWrite, Bytes.toBytes(fields[0] + "_key"),
+                                        Bytes.toBytes(pfsInputcontext.getInputPartitionKey().toString())));
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -199,9 +199,17 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
 
   @Test
   public void testPartitionedFileSetWithMR() throws Exception {
+    testPartitionedFileSetWithMR(false);
+  }
 
-    final ApplicationWithPrograms app = deployApp(AppWithPartitionedFileSet.class);
+  @Test
+  public void testPartitionedFileSetWithMRWithCombineFileInputFormat() throws Exception {
+    testPartitionedFileSetWithMR(true);
+  }
 
+  private void testPartitionedFileSetWithMR(boolean useCombineFileInputFormat) throws Exception {
+    ApplicationWithPrograms app = deployApp(AppWithPartitionedFileSet.class,
+                                            new AppWithPartitionedFileSet.AppConfig(useCombineFileInputFormat));
     // write a value to the input table
     final Table table = datasetCache.getDataset(AppWithPartitionedFileSet.INPUT);
     Transactions.createTransactionExecutor(txExecutorFactory, (TransactionAware) table).execute(
@@ -298,7 +306,9 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
         public void apply() {
           Row row = output.get(Bytes.toBytes("a"));
           Assert.assertEquals("1", row.getString("x"));
+          Assert.assertEquals("{type=x, time=150000}", row.getString("x_key"));
           Assert.assertEquals("2", row.getString("y"));
+          Assert.assertEquals("{type=y, time=200000}", row.getString("y_key"));
         }
       });
 
@@ -323,7 +333,9 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
         public void apply() {
           Row row = output.get(Bytes.toBytes("b"));
           Assert.assertEquals("1", row.getString("x"));
+          Assert.assertEquals("{type=x, time=150000}", row.getString("x_key"));
           Assert.assertNull(row.get("y"));
+          Assert.assertNull(row.get("y_key"));
         }
       });
 


### PR DESCRIPTION
[CDAP-12054](https://issues.cask.co/browse/CDAP-12054) Fix PartitionedFileSet to work with CombineFileInputFormat, as input to a batch job.

Previously, there was the expectation that the InputSplit for a PartitionedFileSet will be a FileSet, but CombineFileInputFormat breaks that assumption.
See JIRA for more details on why it was failing.

Tested on cluster.

https://builds.cask.co/browse/CDAP-RUT1182-8