### PR TITLE
[CDAP-12022] Fix HBase version matching for HBase 1.2.0-cdh5.12.0

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -72,6 +72,7 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_10_CDH56, "1.0.0-cdh5.6.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.2.0-IBM-7");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN, "1.3.0");
 
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1-SNAPSHOT");
@@ -79,6 +80,10 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.9.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.10.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.11.0");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.12.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.2.0-cdh5.13.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.11.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.12.0");
   }
 
   private void assertCompatModuleMapping(HBaseVersion.Version expectedCompatModule,

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -45,6 +45,7 @@ public class HBaseVersion {
   private static final String CDH59_CLASSIFIER = "cdh5.9.";
   private static final String CDH510_CLASSIFIER = "cdh5.10.";
   private static final String CDH511_CLASSIFIER = "cdh5.11.";
+  private static final String CDH512_CLASSIFIER = "cdh5.12.";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -235,43 +236,57 @@ public class HBaseVersion {
   static Version determineVersionFromVersionString(String versionString) throws ParseException {
     if (versionString.startsWith(HBASE_94_VERSION)) {
       return Version.HBASE_94;
-    } else if (versionString.startsWith(HBASE_96_VERSION)) {
+    }
+    if (versionString.startsWith(HBASE_96_VERSION)) {
       return Version.HBASE_96;
-    } else if (versionString.startsWith(HBASE_98_VERSION)) {
+    }
+    if (versionString.startsWith(HBASE_98_VERSION)) {
       return Version.HBASE_98;
-    } else if (versionString.startsWith(HBASE_10_VERSION)) {
-      VersionNumber ver = VersionNumber.create(versionString);
-      if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH55_CLASSIFIER)) {
-        return Version.HBASE_10_CDH55;
-      } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH56_CLASSIFIER)) {
-        return Version.HBASE_10_CDH56;
-      } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
-        return Version.HBASE_10_CDH;
-      } else {
-        return Version.HBASE_10;
-      }
-    } else if (versionString.startsWith(HBASE_11_VERSION)) {
+    }
+    VersionNumber ver = VersionNumber.create(versionString);
+    if (versionString.startsWith(HBASE_10_VERSION)) {
+      return getHBase10VersionFromVersion(ver);
+    }
+    if (versionString.startsWith(HBASE_11_VERSION)) {
       return Version.HBASE_11;
-    } else if (versionString.startsWith(HBASE_12_VERSION)) {
-      VersionNumber ver = VersionNumber.create(versionString);
-      if (ver.getClassifier() != null &&
-        (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
-          // CDH 5.7 compat module can be re-used with CDH 5.[8-11].x
-          ver.getClassifier().startsWith(CDH58_CLASSIFIER) ||
-          ver.getClassifier().startsWith(CDH59_CLASSIFIER) ||
-          ver.getClassifier().startsWith(CDH510_CLASSIFIER) ||
-          ver.getClassifier().startsWith(CDH511_CLASSIFIER))) {
+    }
+    if (versionString.startsWith(HBASE_12_VERSION)) {
+      return getHBase12VersionFromVersion(ver);
+    }
+    if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+      return Version.UNKNOWN_CDH;
+    }
+    return Version.UNKNOWN;
+  }
+
+  private static Version getHBase10VersionFromVersion(VersionNumber ver) {
+    if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+      if (ver.getClassifier().startsWith(CDH55_CLASSIFIER)) {
+        return Version.HBASE_10_CDH55;
+      }
+      if (ver.getClassifier().startsWith(CDH56_CLASSIFIER)) {
+        return Version.HBASE_10_CDH56;
+      }
+      return Version.HBASE_10_CDH;
+    }
+    return Version.HBASE_10;
+  }
+
+  private static Version getHBase12VersionFromVersion(VersionNumber ver) {
+    if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+      if (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
+        // CDH 5.7 compat module can be re-used with CDH 5.[8-11].x
+        ver.getClassifier().startsWith(CDH58_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH59_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH510_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH511_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH512_CLASSIFIER)) {
         return Version.HBASE_12_CDH57;
-      } else {
-        // HBase-11 compat module can be re-used for HBASE-12 as there is no change needed in compat source.
-        return Version.HBASE_11;
       }
+      return Version.UNKNOWN_CDH;
     } else {
-      VersionNumber ver = VersionNumber.create(versionString);
-      if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
-        return Version.UNKNOWN_CDH;
-      }
-      return Version.UNKNOWN;
+      // HBase-11 compat module can be re-used for HBASE-12 as there is no change needed in compat source.
+      return Version.HBASE_11;
     }
   }
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12022
https://builds.cask.co/browse/CDAP-RUT1188-1
Cherry-pick changes from #9178 , against release/4.2