### PR TITLE
Bug fix in Pipeline summary graphs

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/LogsMetricsGraph.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/LogsMetricsGraph.scss
@@ -55,7 +55,7 @@ $container_border_color: lightgray;
   }
   .y-axis-title {
     position: absolute;
-    left: -95px;
+    right: -100px;
     transform: rotate(-90deg);
     top: 40%;
   }

--- a/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/index.js
@@ -157,7 +157,12 @@ export default class LogsMetricsGraph extends Component {
             tickTotal={getTicksTotal(this.props)}
             tickFormat={xTickFormat(this.props)}
           />
-          <YAxis tickFormat={(v) => Math.floor(v) !== v ? '' : v} />
+          <YAxis tickFormat={(v) => {
+            if (v < 0) {
+              return '';
+            }
+            return Math.floor(v) !== v ? '' : v;
+          }} />
           {
             warnings.length > 0 ?
               <BarSeries

--- a/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummaryActions.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummaryActions.js
@@ -29,7 +29,7 @@ function setRuns(runs) {
         runid: run.runid,
         start: run.start,
         end: run.end,
-        duration: isNil(run.end) ? -1 : (run.end - run.start),
+        duration: isNil(run.end) ? (Math.ceil(Date.now()/1000) - run.start) : (run.end - run.start),
         status: run.status
       }))
     }

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/RunsHistoryGraph.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/RunsHistoryGraph.scss
@@ -57,7 +57,7 @@ $container_border_color: lightgray;
   }
   .y-axis-title {
     position: absolute;
-    left: -60px;
+    right: -70px;
     transform: rotate(-90deg);
     top: 40%;
   }

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
@@ -120,6 +120,9 @@ export default class RunsHistoryGraph extends Component {
         return (prev.y > curr.y) ? prev : curr;
       });
       minYDomain = this.state.data.reduce((prev, curr) => {
+        if (prev.y === curr.y) {
+          return prev;
+        }
         return (prev.y < curr.y) ? prev : curr;
       });
     }
@@ -152,6 +155,7 @@ export default class RunsHistoryGraph extends Component {
       <div className="graph-plot-container">
         <FPlot
           xType="linear"
+          yType="linear"
           xDomain={xDomain}
           height={height}
           className="run-history-fp-plot"
@@ -167,7 +171,7 @@ export default class RunsHistoryGraph extends Component {
           />
           <YAxis
             tickTotal={10}
-            yDomain={[minYDomain.y, maxYDomain.y]}
+            yDomain={[minYDomain.y === maxYDomain.y ? 0 : minYDomain.y, maxYDomain.y]}
             tickFormat={tickFormatBasedOnTimeResolution(yAxisResolution)}
           />
           <HorizontalGridLines />
@@ -241,9 +245,13 @@ export default class RunsHistoryGraph extends Component {
             :
               null
           }
-          <div className="y-axis-title">{T.translate(`${PREFIX}.yAxisTitle`, {
-            resolution: yAxisResolution
-          })}</div>
+          <div className="y-axis-title">
+            {
+              T.translate(`${PREFIX}.yAxisTitle`, {
+                resolution: yAxisResolution
+              })
+            }
+            </div>
         </FPlot>
       </div>
     );

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
@@ -30,6 +30,7 @@ import {
   getGraphHeight,
   getTimeResolution
 } from 'components/PipelineSummary/RunsGraphHelpers';
+import {humanReadableDuration} from 'services/helpers';
 
 require('./RunsHistoryGraph.scss');
 require('react-vis/dist/styles/plot.scss');
@@ -204,7 +205,7 @@ export default class RunsHistoryGraph extends Component {
                           popOverData.duration < ONE_MIN_SECONDS ?
                             `${popOverData.duration} seconds`
                           :
-                            moment.duration(popOverData.duration, yAxisResolution)
+                            humanReadableDuration(popOverData.duration)
                         }
                       </span>
                     </div>

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
@@ -120,9 +120,6 @@ export default class RunsHistoryGraph extends Component {
         return (prev.y > curr.y) ? prev : curr;
       });
       minYDomain = this.state.data.reduce((prev, curr) => {
-        if (prev.y === curr.y) {
-          return prev;
-        }
         return (prev.y < curr.y) ? prev : curr;
       });
     }

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -92,6 +92,23 @@ function humanReadableDate(date, isMilliseconds) {
   return (moment(date * 1000)).format(format);
 }
 
+function humanReadableDuration(timeInSeconds) {
+  const ONE_MIN_SECONDS = 60;
+  const ONE_HOUR_SECONDS = ONE_MIN_SECONDS * 60;
+  const ONE_DAY_SECONDS = ONE_HOUR_SECONDS * 24;
+  if (timeInSeconds < 60) {
+    return `${timeInSeconds} seconds`;
+  }
+  if (timeInSeconds < ONE_HOUR_SECONDS) {
+    let mins = Math.floor(timeInSeconds / ONE_MIN_SECONDS);
+    let secs = timeInSeconds % ONE_MIN_SECONDS;
+    return `${mins} mins ${secs} secs`;
+  }
+  if (timeInSeconds < ONE_DAY_SECONDS) {
+    let hours = Math.floor(timeInSeconds / ONE_HOUR_SECONDS);
+    return `${hours} hours ${humanReadableDuration(timeInSeconds - (ONE_HOUR_SECONDS * hours))}`;
+  }
+}
 function contructUrl ({path}) {
   return [
     window.CDAP_CONFIG.sslEnabled? 'https://': 'http://',
@@ -215,6 +232,7 @@ export {
   objectQuery,
   convertBytesToHumanReadable,
   humanReadableNumber,
+  humanReadableDuration,
   isDescendant,
   getArtifactNameAndVersion,
   insertAt,


### PR DESCRIPTION
- Fixes showing tooltip on clicking on data in the graph
- Adds a generic duration method to show seconds in a human readable way.
- Fixes negative ticks in y-axis in graphs
- Moves the y-axis label to the right to prevent overlapping with the y-axis ticks. 


#### NOTE:
- Last fix still needs approval from Lea and Bhooshan. Waiting for a confirmation from them.
