### PR TITLE
prevent downgrading to jdk7

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -199,7 +199,7 @@
         },
         "java": {
           "install_flavor": "openjdk",
-          "jdk_version": 7
+          "jdk_version": 8
         },
         "nodejs": {
           "install_method": "binary",


### PR DESCRIPTION
fixes [CDAP-9126](https://issues.cask.co/browse/CDAP-9126).

During the build process jdk8 was initially getting installed but then downgraded to 7 in a subsequent step.