### PR TITLE
Fixes average run time for pipelines in summary

### DIFF
--- a/cdap-ui/app/cdap/api/pipeline.js
+++ b/cdap-ui/app/cdap/api/pipeline.js
@@ -19,7 +19,7 @@ import {apiCreator} from 'services/resource-helper';
 
 let dataSrc = DataSourceConfigurer.getInstance();
 let basepath = '/namespaces/:namespace/apps/:appId';
-let statsPath = `${basepath}/workflows/:workflowId/statistics`;
+let statsPath = `${basepath}/workflows/:workflowId/statistics?start=0`;
 
 export const MyPipelineApi = {
   publish: apiCreator(dataSrc, 'PUT', 'REQUEST', basepath),

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities.js
@@ -23,6 +23,7 @@ import T from 'i18n-react';
 import Rx from 'rx';
 
 const PREFIX = 'features.DataPrep.Upgrade';
+const MIN_DATAPREP_VERSION = '2.1.0';
 
 export default function enableDataPreparationService(shouldStopService) {
   function enableService(observer) {
@@ -55,11 +56,14 @@ export default function enableDataPreparationService(shouldStopService) {
 
         let highestVersion = findHighestVersion(versionsArray, true);
 
-        let minimumVersion = new Version('2.1.0-SNAPSHOT');
+        let minimumVersion = new Version(MIN_DATAPREP_VERSION);
 
         if (minimumVersion.compareTo(new Version(highestVersion)) > 0) {
           observer.onError({
-            error: T.translate(`${PREFIX}.minimumVersionError`, { highestVersion })
+            error: T.translate(`${PREFIX}.minimumVersionError`, {
+              highestVersion,
+              minimumVersion: MIN_DATAPREP_VERSION
+            })
           });
           return;
         }

--- a/cdap-ui/app/cdap/components/PipelineSummary/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/index.js
@@ -26,7 +26,7 @@ import {UncontrolledDropdown} from 'components/UncontrolledComponents';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import {MyPipelineApi} from 'api/pipeline';
-import {getDuration} from 'components/PipelineSummary/RunsGraphHelpers';
+import {humanReadableDuration} from 'services/helpers';
 import isNil from 'lodash/isNil';
 
 const PREFIX = 'features.PipelineSummary';
@@ -50,7 +50,7 @@ export default class PipelineSummary extends Component {
       loading: true,
       start: null,
       end: null,
-      avgRunTime: '-'
+      avgRunTime: '--'
     };
     this.fetchRunsByLimit = this.fetchRunsByLimit.bind(this);
     this.fetchRunsByTime = this.fetchRunsByTime.bind(this);
@@ -224,11 +224,10 @@ export default class PipelineSummary extends Component {
         <div> {T.translate(`${PREFIX}.title`)}</div>
         <div className="stats-container text-xs-right">
           <span>
-            <strong>{T.translate(`${PREFIX}.statsContainer.runTime`)}: </strong>
-          </span>
-          <span>
             <strong>{T.translate(`${PREFIX}.statsContainer.avgRunTime`)}: </strong>
-            {getDuration(this.state.avgRunTime)}
+            {
+              humanReadableDuration(this.state.avgRunTime)
+            }
           </span>
           <span>
             <strong>{T.translate(`${PREFIX}.statsContainer.totalRuns`)}: </strong>

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -93,20 +93,40 @@ function humanReadableDate(date, isMilliseconds) {
 }
 
 function humanReadableDuration(timeInSeconds) {
+  if (typeof timeInSeconds !== 'number') {
+    return timeInSeconds;
+  }
   const ONE_MIN_SECONDS = 60;
   const ONE_HOUR_SECONDS = ONE_MIN_SECONDS * 60;
   const ONE_DAY_SECONDS = ONE_HOUR_SECONDS * 24;
+  const ONE_WEEK_SECONDS = ONE_DAY_SECONDS * 7;
+  const ONE_MONTH_SECONDS = ONE_DAY_SECONDS * 30;
+  const ONE_YEAR_SECONDS = ONE_MONTH_SECONDS * 12;
+  const pluralize = (number, label) => number > 1 ? `${label}s` : label;
   if (timeInSeconds < 60) {
-    return `${timeInSeconds} seconds`;
+    return `${Math.floor(timeInSeconds)} ${pluralize(timeInSeconds, 'sec')}`;
   }
   if (timeInSeconds < ONE_HOUR_SECONDS) {
     let mins = Math.floor(timeInSeconds / ONE_MIN_SECONDS);
-    let secs = timeInSeconds % ONE_MIN_SECONDS;
-    return `${mins} mins ${secs} secs`;
+    let secs = Math.floor(timeInSeconds % ONE_MIN_SECONDS);
+    return `${mins} ${pluralize(mins, 'min')} ${secs} secs`;
   }
   if (timeInSeconds < ONE_DAY_SECONDS) {
     let hours = Math.floor(timeInSeconds / ONE_HOUR_SECONDS);
-    return `${hours} hours ${humanReadableDuration(timeInSeconds - (ONE_HOUR_SECONDS * hours))}`;
+    return `${hours} ${pluralize(hours, 'hour')} ${humanReadableDuration(timeInSeconds - (ONE_HOUR_SECONDS * hours))}`;
+  }
+  if (timeInSeconds < ONE_WEEK_SECONDS) {
+    let days = Math.floor(timeInSeconds / ONE_DAY_SECONDS);
+    return `${days} ${pluralize(days, 'day')} ${humanReadableDuration(timeInSeconds - (ONE_DAY_SECONDS * days))}`;
+  }
+  // Hopefully we don't reach beyond this point.
+  if (timeInSeconds < ONE_MONTH_SECONDS) {
+    let weeks = Math.floor(timeInSeconds / ONE_WEEK_SECONDS);
+    return `${weeks} ${pluralize(weeks, 'week')} ${humanReadableDuration(timeInSeconds - (ONE_WEEK_SECONDS * weeks))}`;
+  }
+  if (timeInSeconds < ONE_YEAR_SECONDS) {
+    let months = Math.floor(timeInSeconds / ONE_MONTH_SECONDS);
+    return `${months} ${pluralize(months, 'month')} ${humanReadableDuration(timeInSeconds - (ONE_MONTH_SECONDS * months))}`;
   }
 }
 function contructUrl ({path}) {

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -737,7 +737,7 @@ features:
         uploadSubTitle: Select the file to be uploaded to the workspace
         uploadBtnLabel: Upload
     Upgrade:
-      minimumVersionError: "Data Preparation requires wrangler-service artifact version 2.0.0 or above. Version {highestVersion} found. Please install the latest wrangler-service from Cask Market."
+      minimumVersionError: "Data Preparation requires wrangler-service artifact version {minimumVersion} or above. Version {highestVersion} found. Please install the latest wrangler-service from Cask Market."
     WorkspaceTabs:
       DeleteModal:
         cancelButton: No, keep tab open
@@ -1114,7 +1114,7 @@ features:
       sinceInception: Since Inception
     statsContainer:
       avg: Average
-      avgRunTime: Average
+      avgRunTime: Average Run Time
       currentSchedule: Current Schedule
       min: Min
       max: Max


### PR DESCRIPTION
- Fixes i18n error message for min version of dataprep while trying to start dataprep service. We updated the min version to be `2.1.0` but missed the version in i18n error message.
- Fixes duration utility method to account for days
- Fixes duration to use the custom utility method instead of using `moment.duration().humanize()`
