### PR TITLE
pin eclipse m2e to release version

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -149,7 +149,7 @@
           "release_code": "3",
           "plugins": [
             { "http://download.eclipse.org/releases/neon": "org.eclipse.egit.feature.group" },
-            { "http://download.eclipse.org/technology/m2e/releases": "org.eclipse.m2e.feature.feature.group" }
+            { "http://download.eclipse.org/technology/m2e/releases/1.7": "org.eclipse.m2e.feature.feature.group" }
           ],
           "url": "file:///tmp/eclipse.tar.gz"
         },


### PR DESCRIPTION
when building the VM, pin the eclipse m2e plugin to the latest release version (per https://www.eclipse.org/m2e/m2e-downloads.html).  Otherwise, it pulls in a milestone build and fails due to missing dependency.

Will need to be backported to all active branches