### PR TITLE
CDAP-12022 Fix HBaseVersion determination on HDP 2.3,2.4,2.5,2.6.

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -38,6 +38,16 @@ public class HBaseVersionTest {
     Assert.assertEquals("cdh5.7.1", versionNumber.getClassifier());
     Assert.assertTrue(versionNumber.isSnapshot());
 
+    // test HDP HBase version
+    version = "1.1.2.2.5.3.0-37";
+    versionNumber = HBaseVersion.VersionNumber.create(version);
+    Assert.assertEquals(new Integer(1), versionNumber.getMajor());
+    Assert.assertEquals(new Integer(1), versionNumber.getMinor());
+    Assert.assertEquals(new Integer(2), versionNumber.getPatch());
+    Assert.assertNull(versionNumber.getLast());
+    Assert.assertNull(versionNumber.getClassifier());
+    Assert.assertFalse(versionNumber.isSnapshot());
+
     // test IBM HBase version
     version = "1.2.0-IBM-7";
     versionNumber = HBaseVersion.VersionNumber.create(version);
@@ -74,6 +84,14 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.2.0-IBM-7");
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN, "1.3.0");
 
+    // hbase versions packaged with HDP
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_96, "0.96.1.2.0.13.0-43-hadoop2"); // hdp 2.0.13.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.0.2.1.15.0-946-hadoop2"); // hdp 2.1.15.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.2.2.3.6.0-3796"); // hdp 2.3.6.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.2.2.4.3.0-227"); // hdp 2.4.3.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.2.2.5.3.0-37"); // hdp 2.5.3.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.2.2.6.1.0-129"); // hdp 2.6.1.0
+
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1-SNAPSHOT");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.8.2");
@@ -84,6 +102,9 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.2.0-cdh5.13.0");
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.11.0");
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.12.0");
+
+    // bigtop 1.1.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.12-hadoop2");
   }
 
   private void assertCompatModuleMapping(HBaseVersion.Version expectedCompatModule,


### PR DESCRIPTION
[CDAP-12022](https://issues.cask.co/browse/CDAP-12022) Fix HBaseVersion determination on HDP 2.3,2.4,2.5,2.6, since the hbase version in those version don't match the pattern `HBaseVersion.VersionNumber.PATTERN`.

https://builds.cask.co/browse/CDAP-RUT1192-4