### PR TITLE
(CDAP-12088) Fix the Spark compiler class path construction

### DIFF
--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkCompiler.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/dynamic/AbstractSparkCompiler.scala
@@ -182,8 +182,10 @@ object AbstractSparkCompiler {
       .map(cl => new CombineClassLoader(null, List(cl, contextClassLoader)))
       .getOrElse(contextClassLoader)
     settings.embeddedDefaults(classLoader)
-    settings.classpath.value = ClassLoaders.getClassLoaderURLs(classLoader, true, new java.util.LinkedHashSet[URL])
-                                           .mkString(File.pathSeparator)
+
+    val classpath = ClassLoaders.getClassLoaderURLs(classLoader, true, new java.util.LinkedHashSet[URL]).toSet[URL]
+    settings.classpath.value = classpath.map(url => new File(url.getPath()).getAbsolutePath)
+                                        .mkString(File.pathSeparator)
     settings
   }
 


### PR DESCRIPTION
- Make it works for Windows.