### PR TITLE
fix ugi cache for explore

### DIFF
--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/AbstractCachedUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/AbstractCachedUGIProvider.java
@@ -60,11 +60,9 @@ public abstract class AbstractCachedUGIProvider implements UGIProvider {
 
   @Override
   public final UGIWithPrincipal getConfiguredUGI(ImpersonationRequest impersonationRequest) throws IOException {
-    if (impersonationRequest.getImpersonatedOpType().equals(ImpersonatedOpType.EXPLORE)) {
-      return createUGI(impersonationRequest);
-    }
     try {
-      UGIWithPrincipal ugi = impersonationRequest.getPrincipal() == null ?
+      UGIWithPrincipal ugi = impersonationRequest.getImpersonatedOpType().equals(ImpersonatedOpType.EXPLORE) ||
+        impersonationRequest.getPrincipal() == null ?
         null : ugiCache.getIfPresent(new UGICacheKey(impersonationRequest));
       if (ugi != null) {
         return ugi;


### PR DESCRIPTION
in #9191 we change the implementation of the ugi cache. Using this implementation, we can now cache for explore type since we do the check before we get the cache. Note that the regression will only happen on 4.2 and develop. 4.1 will not get affected since we still cache the explore impersonation request.