### PR TITLE
CDAP-11659 reduce startup time

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
@@ -41,6 +41,7 @@ import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.io.Files;
 import com.google.inject.Injector;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.junit.AfterClass;
@@ -83,6 +84,8 @@ public class SystemArtifactsAuthorizationTest {
     cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
     cConf.setBoolean(Constants.Security.Authorization.ENABLED, true);
     cConf.setInt(Constants.Security.Authorization.CACHE_MAX_ENTRIES, 0);
+    // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+    cConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName());
     Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
                                                               InMemoryAuthorizer.class);
     cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, deploymentJar.toURI().getPath());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
@@ -126,6 +127,8 @@ public class DefaultSecureStoreServiceTest {
     // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
     cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
     cConf.setInt(Constants.Security.Authorization.CACHE_MAX_ENTRIES, 0);
+    // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+    cConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName());
 
     LocationFactory locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceAuthorizationTest.java
@@ -32,6 +32,7 @@ import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import com.google.inject.Injector;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -104,6 +105,8 @@ public class ProgramLifecycleServiceAuthorizationTest {
     LocationFactory locationFactory = new LocalLocationFactory(new File(TEMPORARY_FOLDER.newFolder().toURI()));
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
     cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, authorizerJar.toURI().getPath());
+    // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+    cConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName());
     return cConf;
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesTest.java
@@ -37,6 +37,7 @@ import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.cdap.security.spi.authorization.PrivilegesManager;
 import com.google.common.base.Preconditions;
 import com.google.inject.Injector;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
@@ -86,6 +87,8 @@ public class RemotePrivilegesTest {
     cConf.setBoolean(Constants.Security.Authorization.ENABLED, true);
     cConf.setInt(Constants.Security.Authorization.CACHE_MAX_ENTRIES, 10000);
     cConf.setInt(Constants.Security.Authorization.CACHE_TTL_SECS, CACHE_TIMEOUT);
+    // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+    cConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName());
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, InMemoryAuthorizer.class.getName());
     LocationFactory locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -34,6 +34,7 @@ import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import com.google.inject.Injector;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -105,6 +106,8 @@ public class MetadataAdminAuthorizationTest {
     LocationFactory locationFactory = new LocalLocationFactory(new File(TEMPORARY_FOLDER.newFolder().toURI()));
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
     cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, authorizerJar.toURI().getPath());
+    // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+    cConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName());
     return cConf;
   }
 }

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -29,6 +29,7 @@ import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.server.BasicAuthenticationHandler;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.common.cli.CLI;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -97,7 +98,9 @@ public class AuthorizationCLITest extends CLITestBase {
         Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "superusers", "*",
         // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
         Constants.Security.KERBEROS_ENABLED, "false",
-        Constants.Explore.EXPLORE_ENABLED, "false"
+        Constants.Explore.EXPLORE_ENABLED, "false",
+        // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+        Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName()
       };
     }
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
@@ -55,6 +55,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -103,6 +104,8 @@ public abstract class StreamAdminTest {
     cConf.setBoolean(Constants.Security.ENABLED, true);
     cConf.setBoolean(Constants.Security.Authorization.ENABLED, true);
     cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
+    // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+    cConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName());
     cConf.setInt(Constants.Security.Authorization.CACHE_MAX_ENTRIES, 0);
     LocationFactory locationFactory = new LocalLocationFactory(rootLocationFactoryPath);
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
@@ -453,7 +453,6 @@ public class DatasetTypeService extends AbstractIdleService {
   }
 
   private void deleteSystemModules() throws Exception {
-    final List<DatasetModuleMeta> toRevoke = new ArrayList<>();
     Transactions.createTransactional(datasetCache).execute(60, new TxRunnable() {
       @Override
       public void run(DatasetContext context) throws Exception {
@@ -464,24 +463,13 @@ public class DatasetTypeService extends AbstractIdleService {
             LOG.debug("Deleting system dataset module: {}", ds.toString());
             DatasetModuleId moduleId = NamespaceId.SYSTEM.datasetModule(ds.getName());
             datasetTypeMDS.deleteModule(moduleId);
-            toRevoke.add(ds);
           }
         }
       }
     });
-    long startTime = System.currentTimeMillis();
-    LOG.trace("Revoking all privileges for {} system dataset modules. ", toRevoke.size());
-    for (DatasetModuleMeta ds : toRevoke) {
-      revokeAllPrivilegesOnModule(NamespaceId.SYSTEM.datasetModule(ds.getName()), ds);
-    }
-    long doneTime = System.currentTimeMillis();
-    float elapsedSeconds = doneTime == startTime ? 0.0F : ((float) doneTime - startTime) / 1000;
-    LOG.debug("Revoking all privileges for {} system dataset modules took {} seconds.",
-              toRevoke.size(), elapsedSeconds);
   }
 
   private void deployDefaultModules() throws Exception {
-    List<DatasetModuleId> toGrant = new ArrayList<>();
     // adding default modules to be available in dataset manager service
     for (Map.Entry<String, DatasetModule> module : defaultModules.entrySet()) {
       try {
@@ -489,7 +477,6 @@ public class DatasetTypeService extends AbstractIdleService {
         // NOTE: we add default modules in the system namespace
         DatasetModuleId defaultModule = NamespaceId.SYSTEM.datasetModule(module.getKey());
         typeManager.addModule(defaultModule, module.getValue().getClass().getName(), null, false);
-        toGrant.add(defaultModule);
       } catch (DatasetModuleConflictException e) {
         // perfectly fine: we need to add default modules only the very first time service is started
         LOG.debug("Not adding {} module: it already exists", module.getKey());
@@ -498,15 +485,6 @@ public class DatasetTypeService extends AbstractIdleService {
         throw Throwables.propagate(th);
       }
     }
-    long startTime = System.currentTimeMillis();
-    LOG.trace("Granting all privileges for {} default dataset modules. ", toGrant.size());
-    for (DatasetModuleId defaultModule : toGrant) {
-      grantAllPrivilegesOnModule(defaultModule, authenticationContext.getPrincipal());
-    }
-    long doneTime = System.currentTimeMillis();
-    float elapsedSeconds = doneTime == startTime ? 0.0F : ((float) doneTime - startTime) / 1000;
-    LOG.debug("Granting all privileges for {} default dataset modules took {} seconds.",
-              toGrant.size(), elapsedSeconds);
   }
 
   private Map<String, DatasetModule> getExtensionModules(CConfiguration cConf) {
@@ -535,7 +513,6 @@ public class DatasetTypeService extends AbstractIdleService {
         // NOTE: we add extension modules in the system namespace
         DatasetModuleId theModule = NamespaceId.SYSTEM.datasetModule(module.getKey());
         typeManager.addModule(theModule, module.getValue().getClass().getName(), null, false);
-        grantAllPrivilegesOnModule(theModule, authenticationContext.getPrincipal());
       } catch (DatasetModuleConflictException e) {
         // perfectly fine: we need to add the modules only the very first time service is started
         LOG.debug("Not adding {} extension module: it already exists", module.getKey());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
@@ -44,6 +44,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.junit.After;
@@ -81,6 +82,8 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
     cConf.setInt(Constants.Security.Authorization.CACHE_MAX_ENTRIES, 0);
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
     cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, authorizerJar.toURI().getPath());
+    // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+    cConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName());
     return cConf;
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -93,6 +93,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.tephra.TxConstants;
@@ -188,6 +189,9 @@ public class BaseHiveExploreServiceTest {
       cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath());
       cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
       cConf.setInt(Constants.Security.Authorization.CACHE_MAX_ENTRIES, 0);
+      // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+      cConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL,
+                UserGroupInformation.getLoginUser().getShortUserName());
     }
     List<Module> modules = useStandalone ? createStandaloneModules(cConf, hConf, tmpFolder)
       : createInMemoryModules(cConf, hConf, tmpFolder);

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AbstractAuthorizationEnforcer.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AbstractAuthorizationEnforcer.java
@@ -94,7 +94,7 @@ public abstract class AbstractAuthorizationEnforcer implements AuthorizationEnfo
     };
   }
 
-  boolean isSecurityAuthorizationEnabled() {
+  protected boolean isSecurityAuthorizationEnabled() {
     return securityEnabled && authorizationEnabled;
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcer.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcer.java
@@ -19,18 +19,24 @@ package co.cask.cdap.security.authorization;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.ParentedId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.impersonation.SecurityUtil;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * An implementation of {@link AuthorizationEnforcer} that runs on the master. It calls the authorizer directly to
@@ -43,12 +49,29 @@ public class DefaultAuthorizationEnforcer extends AbstractAuthorizationEnforcer 
 
   private final AuthorizerInstantiator authorizerInstantiator;
   private final boolean propagatePrivileges;
+  @Nullable
+  private final Principal masterUser;
 
   @Inject
   DefaultAuthorizationEnforcer(CConfiguration cConf, AuthorizerInstantiator authorizerInstantiator) {
     super(cConf);
     this.propagatePrivileges = cConf.getBoolean(Constants.Security.Authorization.PROPAGATE_PRIVILEGES);
     this.authorizerInstantiator = authorizerInstantiator;
+    if (isSecurityAuthorizationEnabled()) {
+      String masterPrincipal = SecurityUtil.getMasterPrincipal(cConf);
+      if (masterPrincipal == null) {
+        throw new RuntimeException("Kerberos master principal is null. Authorization can only be used when kerberos" +
+                                     " is used");
+      }
+      try {
+        this.masterUser = new Principal(new KerberosName(masterPrincipal).getShortName(), Principal.PrincipalType.USER);
+      } catch (IOException e) {
+        throw new RuntimeException(String.format("Failed to translate the principal name %s to an operating system " +
+                                                   "user name.", masterPrincipal), e);
+      }
+    } else {
+      masterUser = null;
+    }
   }
 
   @Override
@@ -60,6 +83,12 @@ public class DefaultAuthorizationEnforcer extends AbstractAuthorizationEnforcer 
   }
 
   private void doEnforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
+    // bypass the check when the principal is the master user and the entity is in the system namespace
+    if (entity instanceof NamespacedEntityId &&
+      ((NamespacedEntityId) entity).getNamespaceId().equals(NamespaceId.SYSTEM) &&
+      principal.equals(masterUser)) {
+      return;
+    }
     LOG.debug("Enforcing actions {} on {} for principal {}.", actions, entity, principal);
     try {
       authorizerInstantiator.get().enforce(entity, principal, actions);

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizationTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizationTestBase.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.security.auth.context.AuthenticationTestContext;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.BeforeClass;
@@ -44,6 +45,8 @@ public class AuthorizationTestBase {
     CCONF.set(Constants.CFG_LOCAL_DATA_DIR, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
     CCONF.setBoolean(Constants.Security.ENABLED, true);
     CCONF.setBoolean(Constants.Security.Authorization.ENABLED, true);
+    // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+    CCONF.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName());
     locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -80,6 +80,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -159,6 +160,8 @@ public class AuthorizationTest extends TestBase {
         Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
         // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
         Constants.Security.KERBEROS_ENABLED, "false",
+        // this is needed since now DefaultAuthorizationEnforcer expects this non-null
+        Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, UserGroupInformation.getLoginUser().getShortUserName()
       };
     }
   }


### PR DESCRIPTION
jira: https://issues.cask.co/browse/CDAP-11659
build: https://builds.cask.co/browse/CDAP-DUT5935-2

Currently have the following tests:
Having a cluster with 10 namespaces, and 50 streams in each namespace:
without this fix, startup took 16mins 15s
with this fix, startup took 3 mins 54s
with authorization turned off, startup took 3 min 20s
turned authorization back, startup took 3 min 59s

Update: after doubling the entity number to around 1000, the startup took 3 min 27s, so startup is not affected by the entity number now