### PR TITLE
Implement prepareRun method for Transform

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -725,6 +725,15 @@ public class DataPipelineTest extends HydratorTestBase {
     validateMetric(3, appId, "sleep.records.out");
     validateMetric(3, appId, "sink.records.in");
     Assert.assertTrue(getMetric(appId, "sleep." + co.cask.cdap.etl.common.Constants.Metrics.TOTAL_TIME) > 0L);
+
+    try (CloseableIterator<Message> messages =
+      getMessagingContext().getMessageFetcher().fetch(appId.getNamespace(), "sleepTopic", 10, null)) {
+      Assert.assertTrue(messages.hasNext());
+      Assert.assertEquals("2", messages.next().getPayloadAsString());
+      Assert.assertFalse(messages.hasNext());
+    }
+
+    getMessagingAdmin(appId.getNamespace()).deleteTopic("sleepTopic");
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageSubmitterContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageSubmitterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,12 +16,12 @@
 
 package co.cask.cdap.etl.api;
 
-import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.messaging.MessagingAdmin;
+import co.cask.cdap.api.messaging.MessagingContext;
 
 /**
- * Context passed to ETL Transform stages.
+ * Similar to {@link TransformContext}, but also exposing functionality of {@link MessagingContext}.
  */
-@Beta
-public interface TransformContext extends StageContext, LookupProvider {
+public interface StageSubmitterContext extends MessagingContext, MessagingAdmin, TransformContext {
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/SubmitterLifecycle.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/SubmitterLifecycle.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api;
+
+import co.cask.cdap.api.annotation.Beta;
+
+/**
+ * Interface for stage that supports initialize call for resource setup.
+ *
+ * @param <T> execution context
+ */
+@Beta
+public interface SubmitterLifecycle<T> {
+
+  /**
+   * Prepare the run. Used to configure the job before starting the run.
+   *
+   * @param context submitter context
+   * @throws Exception if there's an error during this method invocation
+   */
+  void prepareRun(T context) throws Exception;
+
+  /**
+   * Invoked after the run finishes. Used to perform any end of the run logic.
+   *
+   * @param succeeded defines the result of batch execution: true if run succeeded, false otherwise
+   * @param context submitter context
+   */
+  void onRunFinish(boolean succeeded, T context);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/Transform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/Transform.java
@@ -26,7 +26,7 @@ import co.cask.cdap.api.annotation.Beta;
  */
 @Beta
 public abstract class Transform<IN, OUT> implements StageLifecycle<TransformContext>,
-  Transformation<IN, OUT>, PipelineConfigurable {
+  SubmitterLifecycle<StageSubmitterContext>, Transformation<IN, OUT>, PipelineConfigurable {
   public static final String PLUGIN_TYPE = "transform";
 
   private TransformContext context;
@@ -61,7 +61,19 @@ public abstract class Transform<IN, OUT> implements StageLifecycle<TransformCont
     //no-op
   }
 
+  @Override
+  public void prepareRun(StageSubmitterContext context) throws Exception {
+    //no-op
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, StageSubmitterContext context) {
+    //no-op
+  }
+
+  // not available in configurePipeline, prepareRun, onRunFinish.
   protected TransformContext getContext() {
     return context;
   }
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchSource.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.StageLifecycle;
+import co.cask.cdap.etl.api.SubmitterLifecycle;
 import co.cask.cdap.etl.api.Transformation;
 
 /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -30,6 +30,7 @@ import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.etl.api.AlertPublisher;
+import co.cask.cdap.etl.api.StageSubmitterContext;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchConfigurable;
@@ -203,15 +204,15 @@ public class ETLMapReduce extends AbstractMapReduce {
     PipelinePluginInstantiator pluginInstantiator = new PipelinePluginInstantiator(context, mrMetrics, phaseSpec);
 
     Map<String, String> inputAliasToStage = new HashMap<>();
-    for (String sourceName : phaseSpec.getPhase().getSources()) {
+    for (String sourceName : phase.getSources()) {
       try {
         BatchConfigurable<BatchSourceContext> batchSource = pluginInstantiator.newPluginInstance(sourceName, evaluator);
         StageSpec stageSpec = phaseSpec.getPhase().getStage(sourceName);
         MapReduceBatchContext sourceContext = new MapReduceBatchContext(context, pipelineRuntime, stageSpec,
                                                                         connectorDatasets);
         batchSource.prepareRun(sourceContext);
-        for (String inputAlias : sourceContext.getInputNames()) {
-          inputAliasToStage.put(inputAlias, sourceName);
+        for (Object inputAlias : sourceContext.getInputNames()) {
+          inputAliasToStage.put((String) inputAlias, sourceName);
         }
         finishers.add(batchSource, sourceContext);
       } catch (Exception e) {
@@ -223,6 +224,14 @@ public class ETLMapReduce extends AbstractMapReduce {
       }
     }
     hConf.set(INPUT_ALIAS_KEY, GSON.toJson(inputAliasToStage));
+
+    for (StageSpec transformInfo : phase.getStagesOfType(Transform.PLUGIN_TYPE)) {
+      Transform transform = pluginInstantiator.newPluginInstance(transformInfo.getName(), evaluator);
+      StageSubmitterContext transformContext =
+        new MapReduceBatchContext(context, pipelineRuntime, transformInfo, connectorDatasets);
+      transform.prepareRun(transformContext);
+      finishers.add(transform, transformContext);
+    }
 
     Map<String, SinkOutput> sinkOutputs = new HashMap<>();
     for (StageSpec stageInfo :

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/CompositeFinisher.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/CompositeFinisher.java
@@ -16,6 +16,9 @@
 
 package co.cask.cdap.etl.common;
 
+import co.cask.cdap.etl.api.StageSubmitterContext;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.TransformContext;
 import co.cask.cdap.etl.api.batch.BatchConfigurable;
 import co.cask.cdap.etl.api.batch.BatchContext;
 import co.cask.cdap.etl.api.batch.MultiInputBatchConfigurable;
@@ -71,6 +74,20 @@ public class CompositeFinisher implements Finisher {
         public void onFinish(boolean succeeded) {
           try {
             configurable.onRunFinish(succeeded, context);
+          } catch (Throwable t) {
+            LOG.warn("Error calling onRunFinish on stage {}.", context.getStageName(), t);
+          }
+        }
+      });
+      return this;
+    }
+
+    public <T extends StageSubmitterContext> Builder add(final Transform transform, final T context) {
+      finishers.add(new Finisher() {
+        @Override
+        public void onFinish(boolean succeeded) {
+          try {
+            transform.onRunFinish(succeeded, context);
           } catch (Throwable t) {
             LOG.warn("Error calling onRunFinish on stage {}.", context.getStageName(), t);
           }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedTransform.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.common.plugin;
 
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageSubmitterContext;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;
 
@@ -45,6 +46,28 @@ public class WrappedTransform<IN, OUT> extends Transform<IN, OUT> {
       @Override
       public Void call() {
         transform.configurePipeline(pipelineConfigurer);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void prepareRun(final StageSubmitterContext context) throws Exception {
+    caller.call(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        transform.prepareRun(context);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void onRunFinish(final boolean succeeded, final StageSubmitterContext context) {
+    caller.callUnchecked(new Callable<Void>() {
+      @Override
+      public Void call() {
+        transform.onRunFinish(succeeded, context);
         return null;
       }
     });

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
@@ -26,6 +26,8 @@ import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.spark.AbstractSpark;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.etl.api.StageSubmitterContext;
+import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchConfigurable;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
@@ -142,6 +144,12 @@ public class ETLSpark extends AbstractSpark {
                                                                        pipelineRuntime, stageSpec);
         batchSource.prepareRun(sourceContext);
         finishers.add(batchSource, sourceContext);
+      } else if (Transform.PLUGIN_TYPE.equals(pluginType)) {
+        Transform transform = pluginContext.newPluginInstance(stageName, evaluator);
+        StageSubmitterContext transformContext =
+          new SparkBatchSourceContext(sourceFactory, context, pipelineRuntime, stageSpec);
+        transform.prepareRun(transformContext);
+        finishers.add(transform, transformContext);
       } else if (BatchSink.PLUGIN_TYPE.equals(pluginType)) {
         BatchConfigurable<BatchSinkContext> batchSink = pluginContext.newPluginInstance(stageName, evaluator);
         BatchSinkContext sinkContext = new SparkBatchSinkContext(sinkFactory, context, pipelineRuntime, stageSpec);

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/SleepTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/SleepTransform.java
@@ -19,13 +19,16 @@ package co.cask.cdap.etl.mock.transform;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
+import co.cask.cdap.etl.api.StageSubmitterContext;
 import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.TransformContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.HashMap;
@@ -53,6 +56,16 @@ public class SleepTransform extends Transform<StructuredRecord, StructuredRecord
     }
     StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
+  }
+
+  @Override
+  public void prepareRun(StageSubmitterContext context) throws Exception {
+    try {
+      context.createTopic("sleepTopic");
+    } catch (TopicAlreadyExistsException e) {
+      // ok
+    }
+    context.getMessagePublisher().publish(context.getNamespace(), "sleepTopic", Long.toString(config.millis));
   }
 
   @Override


### PR DESCRIPTION
Motivation: Transform should be able to write to TMS once (at the beginning of a batch job).

Implement prepareRun and onRunFinish methods for Transform. The prepareRun will get called once at the beginning of the batch job and the onRunFinish will get called at the end of the batch job.
Currently, they expose a context which is the same as TransformContext, but additionally exposes access to the current namespace as well as implementing methods of `MessagingContext`.

Related: https://issues.cask.co/browse/CDAP-10974

https://builds.cask.co/browse/CDAP-RUT1234-1