### PR TITLE
[CDAP-12106] Adds send-to-error point and click directive

### DIFF
--- a/cdap-ui/.babelrc
+++ b/cdap-ui/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-object-rest-spread"]
+  "plugins": ["transform-object-rest-spread", "transform-class-properties"]
 }

--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -42,6 +42,7 @@ import MaskData from 'components/DataPrep/Directives/MaskData';
 import EncodeDecode from 'components/DataPrep/Directives/EncodeDecode';
 import Decode from 'components/DataPrep/Directives/Decode';
 import SetCharacterEncoding from 'components/DataPrep/Directives/SetCharacterEncoding';
+import MarkAsError from 'components/DataPrep/Directives/MarkAsError';
 
 import ee from 'event-emitter';
 
@@ -96,6 +97,10 @@ export default class ColumnActionsDropdown extends Component {
         id: shortid.generate(),
         tag: FilterDirective,
         requiredColCount: 1
+      },
+      {
+        id: shortid.generate(),
+        tag: MarkAsError
       },
       {
         id: shortid.generate(),

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/FillNullOrEmpty/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/FillNullOrEmpty/index.js
@@ -83,7 +83,7 @@ export default class FillNullOrEmptyDirective extends Component {
 
     return (
       <div
-        className="fill-null-or-empty-detail second-level-popover"
+        className="second-level-popover"
         onClick={this.preventPropagation}
       >
         <h5>Fill Null or Empty Cells</h5>
@@ -126,7 +126,7 @@ export default class FillNullOrEmptyDirective extends Component {
   render() {
     return (
       <div
-        className={classnames('fill-null-or-empty-directive clearfix action-item', {
+        className={classnames('clearfix action-item', {
           'active': this.props.isOpen
         })}
       >

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
@@ -22,6 +22,7 @@ import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import T from 'i18n-react';
 import {setPopoverOffset} from 'components/DataPrep/helper';
 import debounce from 'lodash/debounce';
+import MouseTrap from 'mousetrap';
 
 const PREFIX = `features.DataPrep.Directives.FindAndReplace`;
 
@@ -53,11 +54,13 @@ export default class FindAndReplaceDirective extends Component {
   componentDidUpdate() {
     if (this.props.isOpen && this.calculateOffset) {
       this.calculateOffset();
+      MouseTrap.bind('enter', this.applyDirective);
     }
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.offsetCalcDebounce);
+    MouseTrap.unbind('enter');
   }
 
   componentWillReceiveProps(nextProps) {
@@ -119,6 +122,7 @@ export default class FindAndReplaceDirective extends Component {
     } else {
       directive = `${directive}/g`;
     }
+    MouseTrap.unbind('enter');
     execute([directive])
       .subscribe(() => {
         this.props.close();
@@ -136,11 +140,14 @@ export default class FindAndReplaceDirective extends Component {
   }
 
   renderDetail() {
-    if (!this.state.isOpen) { return null; }
+    if (!this.state.isOpen) {
+      MouseTrap.unbind('enter');
+      return null;
+    }
 
     return (
       <div
-        className="fill-null-or-empty-detail second-level-popover"
+        className="second-level-popover"
         onClick={this.preventPropagation}
       >
         <h5>{T.translate(`${PREFIX}.find`)}</h5>
@@ -233,7 +240,7 @@ export default class FindAndReplaceDirective extends Component {
     return (
       <div
         id="find-and-replace-directive"
-        className={classnames('fill-null-or-empty-directive clearfix action-item', {
+        className={classnames('clearfix action-item', {
           'active': this.state.isOpen
         })}
       >

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/MarkAsError/MarkAsError.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/MarkAsError/MarkAsError.scss
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+#mark-as-error-directive {
+  .condition-select {
+    > div {
+      display: inline-block;
+      margin-left: 10px;
+    }
+  }
+  .second-level-popover {
+    .icon-svg {
+      margin-right: 5px;
+    }
+    .mark-as-error-tooltip {
+      line-height: 1.5;
+      margin-top: 10px;
+    }
+    .custom-condition-input {
+      max-height: 150px;
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
@@ -1,0 +1,395 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {PropTypes, Component} from 'react';
+import classnames from 'classnames';
+import T from 'i18n-react';
+import {setPopoverOffset} from 'components/DataPrep/helper';
+import debounce from 'lodash/debounce';
+import {preventPropagation} from 'services/helpers';
+import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
+import DataPrepStore from 'components/DataPrep/store';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import IconSVG from 'components/IconSVG';
+import MouseTrap from 'mousetrap';
+
+require('./MarkAsError.scss');
+
+const PREFIX = 'features.DataPrep.Directives.MarkAsError';
+const conditionsOptions = [
+  'EMPTY',
+  'TEXTEXACTLY',
+  'TEXTCONTAINS',
+  'TEXTSTARTSWITH',
+  'TEXTENDSWITH',
+  'TEXTREGEX',
+  'divider',
+  'ISNUMBER',
+  'ISNOTNUMBER',
+  'ISDOUBLE',
+  'ISNOTDOUBLE',
+  'ISINTEGER',
+  'ISNOTINTEGER',
+  'ISBOOLEAN',
+  'ISNOTBOOLEAN',
+  'divider',
+  'ISDATE',
+  'ISNOTDATE',
+  'ISTIME',
+  'ISNOTTIME',
+  'divider',
+  'CUSTOMCONDITION'
+];
+export default class MarkAsError extends Component {
+  state = {
+    selectedCondition: conditionsOptions[0],
+    conditionValue: '',
+    customCondition: `${this.props.column} == 0`,
+    ignoreCase: false
+  };
+
+  componentDidMount() {
+    this.calculateOffset = setPopoverOffset.bind(this, document.getElementById('mark-as-error-directive'));
+    this.offsetCalcDebounce = debounce(this.calculateOffset, 1000);
+  }
+
+  componentDidUpdate() {
+    if (this.props.isOpen && this.calculateOffset) {
+      this.calculateOffset();
+      MouseTrap.bind('enter', this.applyDirective);
+    }
+    if (this.state.selectedCondition.substr(0, 4) === 'TEXT' && this.state.conditionValue.length === 0 && this.conditionValueRef) {
+      this.conditionValueRef.focus();
+    } else if (this.state.selectedCondition.substr(0, 6) === 'CUSTOM' && this.state.customCondition.length === 0 && this.customConditionRef) {
+      this.customConditionRef.focus();
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.offsetCalcDebounce);
+    MouseTrap.unbind('enter');
+  }
+
+  applyDirective = () => {
+    if (this.isApplyDisabled()) {
+      return;
+    }
+    MouseTrap.unbind('enter');
+    execute([this.getDirectiveExpression()])
+      .subscribe(() => {
+        this.props.close();
+        this.props.onComplete();
+      }, (err) => {
+        console.log('error', err);
+
+        DataPrepStore.dispatch({
+          type: DataPrepActions.setError,
+          payload: {
+            message: err.message || err.response.message
+          }
+        });
+      });
+  };
+
+  handleConditionValueChange = (e) => {
+    this.setState({conditionValue: e.target.value});
+  };
+
+  handleCustomFilterChange = (e) => {
+    this.setState({customCondition: e.target.value});
+  };
+
+  toggleIgnoreCase = () => {
+    this.setState({
+      ignoreCase: !this.state.ignoreCase
+    });
+  };
+
+  getDQFunction(condition) {
+    let conditionToFnMap = {
+      'ISNUMBER' : 'isNumber',
+      'ISINTEGER' : 'isInteger',
+      'ISDOUBLE' : 'isDouble',
+      'ISBOOLEAN' : 'isBoolean',
+      'ISDATE' : 'isDate',
+      'ISTIME' : 'isTime'
+    };
+    let c = condition.replace('NOT', '');
+    return conditionToFnMap[c];
+  }
+
+  getDirectiveExpression = () => {
+    let directive = 'send-to-error';
+    let condition;
+    let column = this.props.column;
+    let textValue = this.state.conditionValue;
+    let equalityOperator = '==';
+    let finalExpression;
+
+    switch (this.state.selectedCondition) {
+      case 'EMPTY':
+        finalExpression = `${directive} empty(${column})`;
+        break;
+      case 'TEXTCONTAINS':
+        if (this.state.ignoreCase) {
+          textValue = `(?i).*${textValue}`;
+        } else {
+          textValue = `.*${textValue}`;
+        }
+        finalExpression = `${directive} ${column} =~ "${textValue}.*"`;
+        break;
+      case 'TEXTSTARTSWITH':
+        equalityOperator = '=^';
+        if (this.state.ignoreCase) {
+          textValue = `(?i)^${textValue}.*`;
+          equalityOperator = '=~';
+        }
+        finalExpression = `${directive} ${column} ${equalityOperator} "${textValue}"`;
+        break;
+      case 'TEXTENDSWITH':
+        equalityOperator = '=$';
+        if (this.state.ignoreCase) {
+          textValue = `(?i).*${textValue}$`;
+          equalityOperator = '=~';
+        }
+        finalExpression = `${directive} ${column} ${equalityOperator} "${textValue}"`;
+        break;
+      case 'TEXTEXACTLY':
+        if (this.state.ignoreCase) {
+          textValue = `(?i)${textValue}`;
+          equalityOperator = `=~`;
+        }
+        finalExpression = `${directive} ${column} ${equalityOperator} "${textValue}"`;
+        break;
+      case 'TEXTREGEX':
+        finalExpression = `${directive} ${column} =~ "${textValue}"`;
+        break;
+      case 'CUSTOMCONDITION':
+        finalExpression = `${directive} ${this.state.customCondition}`;
+        break;
+      case 'ISNUMBER':
+      case 'ISNOTNUMBER':
+      case 'ISINTEGER':
+      case 'ISNOTINTEGER':
+      case 'ISDOUBLE':
+      case 'ISNOTDOUBLE':
+      case 'ISBOOLEAN':
+      case 'ISNOTBOOLEAN':
+      case 'ISDATE':
+      case 'ISNOTDATE':
+      case 'ISTIME':
+      case 'ISNOTTIME':
+        condition = `dq:${this.getDQFunction(this.state.selectedCondition)}(${column})`;
+        if (this.state.selectedCondition.indexOf('NOT') !== -1) {
+          condition = `!${condition}`;
+        }
+        finalExpression = `${directive} ${condition}`;
+        break;
+    }
+    return finalExpression;
+  }
+
+  renderTextCondition = () => {
+    if (this.state.selectedCondition.substr(0, 4) !== 'TEXT') { return null; }
+
+    let ignoreCase;
+    if (this.state.selectedCondition !== 'TEXTREGEX') {
+      ignoreCase = (
+        <div>
+          <span
+            className="cursor-pointer"
+            onClick={this.toggleIgnoreCase}
+          >
+            <IconSVG
+              className="fa"
+              name={this.state.ignoreCase ? "icon-check-square-o" : "icon-square-o"}
+            />
+            <span>
+              {T.translate(`${PREFIX}.ignoreCase`)}
+            </span>
+          </span>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <br />
+        <div>
+          <input
+            type="text"
+            className="form-control mousetrap"
+            value={this.state.conditionValue}
+            onChange={this.handleConditionValueChange}
+            placeholder={T.translate(`${PREFIX}.Placeholders.${this.state.selectedCondition}`)}
+            ref={ref => this.conditionValueRef = ref}
+          />
+        </div>
+        {ignoreCase}
+      </div>
+    );
+  };
+
+  renderCustomFilter = () => {
+    if (this.state.selectedCondition.substr(0, 6) !== 'CUSTOM') { return null; }
+
+    return (
+      <div>
+        <br />
+        <textarea
+          className="form-control custom-condition-input"
+          value={this.state.customCondition}
+          onChange={this.handleCustomFilterChange}
+          ref={ref => this.customConditionRef = ref}
+          placeholder={T.translate(`${PREFIX}.Placeholders.CUSTOMCONDITION`, {column: this.props.column})}
+        />
+      </div>
+    );
+  };
+
+  setCondition = (e) => {
+    this.setState({
+      selectedCondition: e.target.value
+    });
+  };
+
+  renderCondition = () => {
+    let markAsConditions = conditionsOptions.map((id) => {
+      return {
+        id,
+        displayText: T.translate(`${PREFIX}.Conditions.${id}`)
+      };
+    });
+    return (
+      <div>
+        <div className="mark-as-error-condition">
+          <div className="condition-select">
+            <strong>{T.translate(`${PREFIX}.if`)}</strong>
+            <div>
+              <select
+                className="form-control mousetrap"
+                value={this.state.selectedCondition}
+                onChange={this.setCondition}
+              >
+                {
+                  markAsConditions.map(condition => {
+                    if (condition.id === 'divider') {
+                      return (
+                        <option
+                          disabled="disabled"
+                          role="separator"
+                        >
+                          &#x2500;&#x2500;&#x2500;&#x2500;
+                        </option>
+                      );
+                    }
+                    return (
+                      <option
+                        value={condition.id}
+                        key={condition.id}
+                      >
+                        {condition.displayText}
+                      </option>
+                    );
+                  })
+                }
+              </select>
+            </div>
+          </div>
+        </div>
+        {this.renderTextCondition()}
+        {this.renderCustomFilter()}
+      </div>
+    );
+  };
+
+  isApplyDisabled = () => {
+    if (this.state.selectedCondition.substr(0, 4) === 'TEXT') {
+      return this.state.conditionValue.length === 0;
+    }
+
+    if (this.state.selectedCondition.substr(0, 6) === 'CUSTOM') {
+      return this.state.customCondition.length === 0;
+    }
+  };
+
+  renderDetail = () => {
+    if (!this.props.isOpen) {
+      MouseTrap.unbind('enter');
+      return null;
+    }
+
+    return (
+      <div
+        className="filter-detail second-level-popover"
+        onClick={preventPropagation}
+      >
+        {this.renderCondition()}
+
+        <div className="mark-as-error-tooltip">
+          <span>{T.translate(`${PREFIX}.tooltip`)}</span>
+        </div>
+        <hr />
+
+        <div className="action-buttons">
+          <button
+            className="btn btn-primary float-xs-left"
+            onClick={this.applyDirective}
+            disabled={this.isApplyDisabled()}
+          >
+            {T.translate('features.DataPrep.Directives.apply')}
+          </button>
+
+          <button
+            className="btn btn-link float-xs-right"
+            onClick={this.props.close}
+          >
+            {T.translate('features.DataPrep.Directives.cancel')}
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <div
+        id="mark-as-error-directive"
+        className={classnames('clearfix action-item', {
+          'active': this.state.isOpen
+        })}
+      >
+        <span>{T.translate(`${PREFIX}.title`)}</span>
+
+        <span className="float-xs-right">
+          <IconSVG
+            name="icon-caret-right"
+            className="fa"
+          />
+        </span>
+
+        {this.renderDetail()}
+      </div>
+    );
+  }
+}
+
+MarkAsError.propTypes = {
+  column: PropTypes.string,
+  onComplete: PropTypes.func,
+  isOpen: PropTypes.bool,
+  close: PropTypes.func
+};

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -527,7 +527,7 @@ features:
         ignoreCase: Ignore Case
         KEEP: Keep rows
         Placeholders:
-          CUSTOMCONDITION: e.g. < 30
+          CUSTOMCONDITION: "E.g. < 30 || gender == \"Male\""
           TEXTCONTAINS: Enter contained value
           TEXTENDSWITH: Enter suffix
           TEXTEXACTLY: Enter value
@@ -559,6 +559,38 @@ features:
        title:
           plural: Keep Selected Columns
           singular: Keep Column
+      MarkAsError:
+        Conditions:
+          CUSTOMCONDITION: Custom condition
+          EMPTY: value is empty
+          ISNUMBER: Is Number
+          ISNOTNUMBER: Is Not Number
+          ISINTEGER: Is Integer
+          ISNOTINTEGER: Is Not Integer
+          ISDOUBLE: Is Double
+          ISNOTDOUBLE: Is Not Double
+          ISBOOLEAN: Is Boolean
+          ISNOTBOOLEAN: Is Not Boolean
+          ISDATE: Is Date
+          ISNOTDATE: Is Not Date
+          ISTIME: Is Time
+          ISNOTTIME: Is Not Time
+          TEXTCONTAINS: value contains
+          TEXTENDSWITH: value ends with
+          TEXTEXACTLY: value is
+          TEXTREGEX: value matches regex
+          TEXTSTARTSWITH: value starts with
+        ignoreCase: Ignore Case
+        if: If
+        Placeholders:
+          CUSTOMCONDITION: "E.g. {column} < 30 || gender == \"Male\""
+          TEXTCONTAINS: Enter contained value
+          TEXTENDSWITH: Enter suffix
+          TEXTEXACTLY: Enter value
+          TEXTREGEX: Enter regex
+          TEXTSTARTSWITH: Enter prefix
+        title: Send to Error
+        tooltip: When used in a pipeline, these errors can be collected by an error collector
       MaskData:
         menuLabel: Mask Data
         option1: Show last 4 characters only

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -31,6 +31,7 @@
     "babel-loader": "6.2.5",
     "babel-plugin-lodash": "3.2.8",
     "babel-plugin-transform-async-to-generator": "6.8.0",
+    "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.23.0",
     "babel-preset-es2015": "6.3.13",
     "babel-preset-react": "6.11.1",

--- a/cdap-ui/webpack.config.cdap.js
+++ b/cdap-ui/webpack.config.cdap.js
@@ -81,12 +81,7 @@ var loaders = [
     ],
     include: [
       path.join(__dirname, 'app')
-    ],
-    query: {
-      cacheDirectory: true,
-      plugins: ['lodash'],
-      presets: ['react', 'es2015']
-    }
+    ]
   },
   {
     test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,

--- a/cdap-ui/webpack.config.common.js
+++ b/cdap-ui/webpack.config.common.js
@@ -43,11 +43,7 @@ var loaders = [
   {
     test: /\.js$/,
     loader: 'babel',
-    exclude: /node_modules/,
-    query: {
-      plugins: ['lodash'],
-      presets: ['react', 'es2015']
-    }
+    exclude: /node_modules/
   },
   {
     test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,

--- a/cdap-ui/webpack.config.login.js
+++ b/cdap-ui/webpack.config.login.js
@@ -59,10 +59,7 @@ var loaders = [
   {
     test: /\.js$/,
     loader: 'babel',
-    exclude: /node_modules/,
-    query: {
-      presets: ['react', 'es2015']
-    }
+    exclude: /node_modules/
   },
   {
     test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,


### PR DESCRIPTION
- Adds `mark-as-error` point and click directive to dataprep
- Adds `transform-class-properties` babel plugin to make use of stage-2 proposal to use class properties to avoid un-necessary binding of functions in constructor
- Removes un-necessary css classes in different directives in dataprep

JIRA: https://issues.cask.co/browse/CDAP-12106

#### Note:
- The `mark-as-error` directive (all use cases) are not working yet. Trying to integrate with backend  by generating appropriate `JEXL` expression accepted by backend. Created this PR so that we can start with code review.