### PR TITLE
[CDAP-12121] Fixes pipeline metrics to fetch only user metrics

### DIFF
--- a/cdap-ui/app/hydrator/services/detail/actions/pipeline-detail-metrics-actions.js
+++ b/cdap-ui/app/hydrator/services/detail/actions/pipeline-detail-metrics-actions.js
@@ -55,7 +55,9 @@ angular.module(PKG.name + '.feature.hydrator')
 
           if (res.length > 0) {
             angular.forEach(stagesArray, function (node) {
-              metricQuery = metricQuery.concat(filter(res, node));
+              // Prefixing it with user. as we to filter out only user metrics and not system metrics
+              // This was a problem if a node name is a substring of a system metric. Ref: CDAP-12121
+              metricQuery = metricQuery.concat(filter(res, 'user.' + node));
             });
 
             if (metricQuery.length === 0) {


### PR DESCRIPTION
- Today we fetch all metrics for a pipeline and filter by node name and get the values for metrics with the node name.
- Unfortunately we could have system metrics that can have node name as a substring (eg: `system.driver.DataStreamsSparkStreaming.StreamingMetrics.streaming.lastCompletedBatch_processingDelay` and the node name is `Stream`).
- This causes js error. 
- Fixed by filtering out metrics by `user.<node-name>` and fetching only those metrics.

JIRA: https://issues.cask.co/browse/CDAP-12121