### PR TITLE
Fix scheduleSpecs overwriting bug

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -291,9 +291,10 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
         DefaultScheduleBuilder.ScheduleCreationBuilder builder =
           (DefaultScheduleBuilder.ScheduleCreationBuilder) entry.getValue();
         builtScheduleSpecs.put(entry.getKey(), builder.build(namespace, appName, appVersion));
+      } else {
+        builtScheduleSpecs.put(entry.getKey(), entry.getValue());
       }
     }
-    builtScheduleSpecs.putAll(scheduleSpecs);
 
     return new DefaultApplicationSpecification(appName, appVersion, description,
                                                configuration, artifactId, getStreams(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.test.AppJarHelper;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
@@ -165,6 +166,11 @@ public class ConfiguratorTest {
       Assert.assertTrue(specification.getStreams().containsKey(ConfigTestApp.DEFAULT_STREAM));
       Assert.assertTrue(specification.getDatasets().size() == 1);
       Assert.assertTrue(specification.getDatasets().containsKey(ConfigTestApp.DEFAULT_TABLE));
+      Assert.assertNotNull(specification.getProgramSchedules().get(ConfigTestApp.SCHEDULE_NAME));
+
+      ProgramStatusTrigger trigger = (ProgramStatusTrigger) specification.getProgramSchedules()
+                                                                         .get(ConfigTestApp.SCHEDULE_NAME).getTrigger();
+      Assert.assertEquals(trigger.getProgramId().getProgram(), ConfigTestApp.WORKFLOW_NAME);
     }
   }
 }


### PR DESCRIPTION
There was an issue where building ProgramStatusTriggers would get overridden by the line:

```
builtScheduleSpecs.putAll(scheduleSpecs);
```

This was because we were overriding the `ScheduleCreationSpecs` that were just built back into the incomplete `ScheduleCreationBuilders`. Fixed by adding `ScheduleCreationSpec` objects immediately into the map rather than at the end.