### PR TITLE
Fixes node level metrics for all stages

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineSummary/NodesMetricsGraph/NodesMetricsGraph.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/NodesMetricsGraph/NodesMetricsGraph.scss
@@ -18,6 +18,7 @@ $dropdown_border_color: lightgray;
 $option-hover-bg-color: #eeeeee;
 $menu_bg_color: gray;
 
+@import '../PipelineSummary.scss';
 @import '../StickyTableHeader.scss';
 
 .nods-metrics-graph {
@@ -51,6 +52,9 @@ $menu_bg_color: gray;
     }
     .dropdown-menu {
       padding: 0;
+      max-height: calc(#{$min_height_of_graph} - 65px);
+      overflow-y: auto;
+
       .dropdown-item {
         padding: 10px;
         cursor: pointer;

--- a/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
@@ -22,6 +22,7 @@ $run_menu_bg_color: gray;
 $graph_containers_border_color: lightgray;
 $hint_body_font_color: black;
 $hint_bg_color: white;
+$min_height_of_graph: 340px;
 
 .pipeline-summary {
   .graphs-container {
@@ -36,7 +37,7 @@ $hint_bg_color: white;
       width: calc(50% - 20px);
       border-radius: 4px;
       height: calc(50% - 20px);
-      min-height: 340px;
+      min-height: $min_height_of_graph;
       padding: 10px;
       margin: 5px 10px;
       border: 1px solid lightgray;
@@ -74,6 +75,9 @@ $hint_bg_color: white;
           rect {
             cursor: pointer;
           }
+        }
+        .rv-xy-plot__axis__tick__text {
+          font-size: 8.5px;
         }
       }
       .rv-hint {

--- a/cdap-ui/app/cdap/components/PipelineSummary/Store/PipelineSummaryActions.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/Store/PipelineSummaryActions.js
@@ -20,6 +20,7 @@ import {MyMetricApi} from 'api/metric';
 import {convertProgramToMetricParams} from 'services/program-api-converter';
 import {objectQuery} from 'services/helpers';
 import isNil from 'lodash/isNil';
+import cloneDeep from 'lodash/cloneDeep';
 
 function setRuns(runs) {
   PipelineSummaryStore.dispatch({
@@ -84,20 +85,23 @@ function updateMetrics(metrics, mapKey = 'metrics') {
 
 function updateNodeMetrics(pipelineConfig) {
   let {runs} = PipelineSummaryStore.getState().pipelinerunssummary;
+  let nodesMap = {
+    recordsin: {},
+    recordsout: {}
+  };
   const sourcePluginTypes = ['batchsource', 'realtimesource', 'streamingsource'];
   const sinkPluginTypes = ['batchsink', 'realtimesink', 'sparksink'];
-
-  let nodesMap = {
-    sources: {},
-    sinks: {}
-  };
+  let sourcePlugins = [];
+  let sinkPlugins = [];
   pipelineConfig.config.stages.forEach(stage => {
-    if (sourcePluginTypes.indexOf(stage.plugin.type) !== -1) {
-      nodesMap.sources[stage.name] = [];
-    }
-    if (sinkPluginTypes.indexOf(stage.plugin.type) !== -1) {
-      nodesMap.sinks[stage.name] = [];
-    }
+      nodesMap.recordsin[stage.name] = [];
+      nodesMap.recordsout[stage.name] = [];
+      if (sourcePluginTypes.indexOf(stage.plugin.type) !== -1) {
+        sourcePlugins.push(stage.name);
+      }
+      if (sinkPluginTypes.indexOf(stage.plugin.type) !== -1) {
+        sinkPlugins.push(stage.name);
+      }
   });
   /*
     Sample node metrics:
@@ -109,15 +113,17 @@ function updateNodeMetrics(pipelineConfig) {
       }
     Sample nodesMap:
       {
-        sources: {
-          TPFSAvro: {}
+        recordsin: {
+          TPFSAvro: [run records],
+          File: [run records]
         },
-        sinks: {
-          File: {}
+        recordsout: {
+          TPFSAvro: [run records],
+          File: [run records]
         }
       }
   */
-  const getRecords = (run, nodesMap, type = '.records.in') => {
+  const getNodesMetricsMapRecords = (run, nodesMap, type = '.records.in') => {
     let cleanUpRegex = /\user.|\.records\.out|\.records\.in/gi;
     let getNodeLabel = (node) => node.replace(cleanUpRegex, () => '');
     let nodesCount = Object.keys(nodesMap);
@@ -143,11 +149,28 @@ function updateNodeMetrics(pipelineConfig) {
     map[nodeLabel].push(runRecord);
   };
   runs.forEach(run => {
-    getRecords(run, nodesMap.sources)
-      .forEach(node => addRunRecordTo(nodesMap.sources, node, run));
-    getRecords(run, nodesMap.sinks, '.records.out')
-      .forEach(node => addRunRecordTo(nodesMap.sinks, node, run));
+    getNodesMetricsMapRecords(run, nodesMap.recordsin, '.records.in')
+      .forEach(nodeMetricMap => addRunRecordTo(nodesMap.recordsin, nodeMetricMap, cloneDeep(run)));
+    getNodesMetricsMapRecords(run, nodesMap.recordsout, '.records.out')
+      .forEach(nodeMetricMap => addRunRecordTo(nodesMap.recordsout, nodeMetricMap, cloneDeep(run)));
   });
+  let recordsInNonSourcePluginsMap = {};
+  let recordsOutNoneSinkPluginsMap = {};
+  Object.keys(nodesMap.recordsin)
+    .filter(node => sourcePlugins.indexOf(node) === -1)
+    .forEach(node => {
+      recordsInNonSourcePluginsMap[node] = nodesMap.recordsin[node];
+    });
+  Object.keys(nodesMap.recordsout)
+    .filter(node => sinkPlugins.indexOf(node) === -1)
+    .forEach(node => {
+      recordsOutNoneSinkPluginsMap[node] = nodesMap.recordsin[node];
+    });
+  nodesMap = {
+    recordsin: recordsInNonSourcePluginsMap,
+    recordsout: recordsOutNoneSinkPluginsMap
+  };
+
   PipelineSummaryStore.dispatch({
     type: PIPELINESSUMMARYACTIONS.SETNODESMETRICSMAP,
     payload: {

--- a/cdap-ui/app/cdap/components/PipelineSummary/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/index.js
@@ -323,8 +323,8 @@ export default class PipelineSummary extends Component {
             xDomainType={this.state.filterType}
             runContext={this.props}
             isLoading={this.state.nodeMetricsLoading}
-            recordType="recordsin"
-            nodesMap={this.state.nodesMap['sources']}
+            recordType="recordsout"
+            nodesMap={this.state.nodesMap.recordsout}
           />
           <NodesMetricsGraph
             activeFilterLabel={this.state.activeRunsFilter}
@@ -336,8 +336,8 @@ export default class PipelineSummary extends Component {
             xDomainType={this.state.filterType}
             runContext={this.props}
             isLoading={this.state.nodeMetricsLoading}
-            recordType="recordsout"
-            nodesMap={this.state.nodesMap['sinks']}
+            recordType="recordsin"
+            nodesMap={this.state.nodesMap.recordsin}
           />
         </div>
       </div>


### PR DESCRIPTION
Fixes visualization for sources and sinks to be `records.out` and `records.in` respectively.