### PR TITLE
fix explore request on RemoteUGIProvider

### DIFF
--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultUGIProvider.java
@@ -61,8 +61,11 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
+  /**
+   * On master side, we can cache the explore request
+   */
   @Override
-  protected void checkImpersonationRequest(ImpersonationRequest impersonationRequest) throws IOException {
+  protected boolean checkExploreAndDetermineCache(ImpersonationRequest impersonationRequest) throws IOException {
     if (impersonationRequest.getEntityId().getEntityType().equals(EntityType.NAMESPACE) &&
       impersonationRequest.getImpersonatedOpType().equals(ImpersonatedOpType.EXPLORE)) {
       // CDAP-8355 If the operation being impersonated is an explore query then check if the namespace configuration
@@ -89,6 +92,7 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
         throw new IOException(e);
       }
     }
+    return true;
   }
 
   /**

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/RemoteUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/RemoteUGIProvider.java
@@ -20,8 +20,8 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.common.internal.remote.RemoteClient;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
+import co.cask.cdap.proto.element.EntityType;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
@@ -59,7 +59,7 @@ public class RemoteUGIProvider extends AbstractCachedUGIProvider {
 
   @Inject
   RemoteUGIProvider(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
-                    LocationFactory locationFactory, OwnerAdmin ownerAdmin, NamespaceQueryAdmin namespaceQueryAdmin) {
+                    LocationFactory locationFactory, OwnerAdmin ownerAdmin) {
     super(cConf, ownerAdmin);
     this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.APP_FABRIC_HTTP,
                                          new DefaultHttpRequestConfig(false), "/v1/");
@@ -89,6 +89,15 @@ public class RemoteUGIProvider extends AbstractCachedUGIProvider {
         LOG.warn("Exception raised when deleting location {}", location, e);
       }
     }
+  }
+
+  /**
+   * In remote mode, we should not cache the explore request
+   */
+  @Override
+  protected boolean checkExploreAndDetermineCache(ImpersonationRequest impersonationRequest) throws IOException {
+    return !(impersonationRequest.getEntityId().getEntityType().equals(EntityType.NAMESPACE) &&
+      impersonationRequest.getImpersonatedOpType().equals(ImpersonatedOpType.EXPLORE));
   }
 
   private HttpResponse executeRequest(ImpersonationRequest impersonationRequest) throws IOException {

--- a/cdap-security/src/test/java/co/cask/cdap/security/impersonation/UGIProviderTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/impersonation/UGIProviderTest.java
@@ -252,7 +252,7 @@ public class UGIProviderTest {
       discoveryService.register(new Discoverable(Constants.Service.APP_FABRIC_HTTP, httpService.getBindAddress()));
 
       RemoteUGIProvider ugiProvider = new RemoteUGIProvider(cConf, discoveryService, locationFactory,
-                                                            ownerAdmin, namespaceClient);
+                                                            ownerAdmin);
 
       ImpersonationRequest aliceImpRequest = new ImpersonationRequest(aliceEntity, ImpersonatedOpType.OTHER);
       UGIWithPrincipal aliceUGIWithPrincipal = ugiProvider.getConfiguredUGI(aliceImpRequest);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12142

In #9230 , we cache explore request's result on both default and remote UGIProvider.
On `DefaultUGIProvider`, we can cache the result since we have the check for explore request before we hit the cache. But in `RemoteUGIProvider`, the check actually does nothing so we should not cache the result.