### PR TITLE
Adding salting to metrics table while writing metrics

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -580,6 +580,12 @@ public final class Constants {
     // NOTE: "v2" to avoid conflict with data of older metrics system
     public static final String DEFAULT_ENTITY_TABLE_NAME = "metrics.v2.entity";
     public static final String DEFAULT_METRIC_TABLE_PREFIX = "metrics.v2.table";
+
+    // NOTE: "v3" to avoid conflict with data of older metrics system
+    public static final String DEFAULT_METRIC_V3_TABLE_PREFIX = "metrics.v3.table";
+    public static final String DEFAULT_METRIC_HBASE_TABLE_SPLITS = "metrics.hbase.table.splits";
+    public static final String METRICS_HBASE_MAX_SCAN_THREADS = "metrics.hbase.max.scan.threads";
+
     public static final int DEFAULT_TIME_SERIES_TABLE_ROLL_TIME = 3600;
     public static final long DEFAULT_RETENTION_HOURS = 2;
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2041,6 +2041,14 @@
     </description>
   </property>
 
+  <property>
+    <name>metrics.hbase.max.scan.threads</name>
+    <value>96</value>
+    <description>
+      Maximum number of threads used for scanning HBase tables
+    </description>
+  </property>
+
 
   <!-- Monitor Handler Configuration -->
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -154,4 +154,5 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
     return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId,
                                            MetricsTable.class.getName(), props, null);
   }
+
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
@@ -22,6 +22,9 @@ import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.TableProperties;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.logging.LogSamplers;
+import co.cask.cdap.common.logging.Loggers;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
@@ -30,6 +33,9 @@ import co.cask.cdap.data2.util.hbase.DeleteBuilder;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.PutBuilder;
 import co.cask.cdap.data2.util.hbase.ScanBuilder;
+import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
+import co.cask.cdap.hbase.wd.DistributedScanner;
+import co.cask.cdap.hbase.wd.RowKeyDistributorByHashPrefix;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -41,12 +47,20 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.util.Pair;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.SortedMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -54,28 +68,83 @@ import javax.annotation.Nullable;
  */
 public class HBaseMetricsTable implements MetricsTable {
 
+  private static final Logger LOG = LoggerFactory.getLogger(HBaseMetricsTable.class);
+  // Exponentially log less on executor rejected execution due to limit threads
+  private static final Logger REJECTION_LOG = Loggers.sampling(LOG, LogSamplers.exponentialLimit(1, 1024, 2.0d));
+
   private final HBaseTableUtil tableUtil;
   private final TableId tableId;
   private final HTable hTable;
   private final byte[] columnFamily;
+  private final boolean isV3Table;
+  private final AbstractRowKeyDistributor rowKeyDistributor;
+  private final ExecutorService scanExecutor;
 
   public HBaseMetricsTable(DatasetContext datasetContext, DatasetSpecification spec,
                            Configuration hConf, HBaseTableUtil tableUtil) throws IOException {
     this.tableUtil = tableUtil;
     this.tableId = tableUtil.createHTableId(new NamespaceId(datasetContext.getNamespaceId()), spec.getName());
+    this.isV3Table = Boolean.parseBoolean(spec.getProperty(Constants.Metrics.DEFAULT_METRIC_V3_TABLE_PREFIX, "false"));
     HTable hTable = tableUtil.createHTable(hConf, tableId);
     // todo: make configurable
     hTable.setWriteBufferSize(HBaseTableUtil.DEFAULT_WRITE_BUFFER_SIZE);
     hTable.setAutoFlushTo(false);
     this.hTable = hTable;
     this.columnFamily = TableProperties.getColumnFamilyBytes(spec.getProperties());
+
+    RejectedExecutionHandler callerRunsPolicy = new RejectedExecutionHandler() {
+
+      @Override
+      public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+        REJECTION_LOG.info(
+          "No more threads in the HBase scan thread pool. Consider increase {}. Scan from caller thread {}",
+          Constants.MessagingSystem.HBASE_MAX_SCAN_THREADS, Thread.currentThread().getName()
+        );
+        // Runs it from the caller thread
+        if (!executor.isShutdown()) {
+          r.run();
+        }
+      }
+    };
+
+    // Creates a executor that will shrink to 0 threads if left idle
+    // Uses daemon thread, hence no need to worry about shutdown
+    // When all threads are busy, use the caller thread to execute
+    this.scanExecutor = new ThreadPoolExecutor(0, spec.getIntProperty(Constants.Metrics.METRICS_HBASE_MAX_SCAN_THREADS,
+                                                                      96),
+                                               60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
+                                               Threads.createDaemonThreadFactory("metrics-hbase-scanner-%d"),
+                                               callerRunsPolicy);
+
+    rowKeyDistributor = getRowKeyDistributor(spec);
+  }
+
+  private AbstractRowKeyDistributor getRowKeyDistributor(DatasetSpecification spec) throws IOException {
+    if (isV3Table) {
+      try {
+        String splits = spec.getProperty(Constants.Metrics.DEFAULT_METRIC_HBASE_TABLE_SPLITS);
+        if (splits == null) {
+          // Cannot be null
+          throw new IOException("Missing table property " + Constants.Metrics.DEFAULT_METRIC_HBASE_TABLE_SPLITS +
+                                  " on HBase table " + tableId);
+        }
+        int numOfsplits = Integer.parseInt(splits);
+        return new RowKeyDistributorByHashPrefix(new RowKeyDistributorByHashPrefix.OneByteSimpleHash(numOfsplits));
+      } catch (NumberFormatException e) {
+        throw new IOException("Invalid value for property " + Constants.Metrics.DEFAULT_METRIC_HBASE_TABLE_SPLITS
+                                + " on HBase table " + tableId, e);
+      }
+    }
+
+    return null;
   }
 
   @Override
   @Nullable
   public byte[] get(byte[] row, byte[] column) {
     try {
-      Get get = tableUtil.buildGet(row)
+      byte[] distributedKey = getRowKey(row);
+      Get get = tableUtil.buildGet(distributedKey)
         .addColumn(columnFamily, column)
         .setMaxVersions(1)
         .build();
@@ -93,7 +162,8 @@ public class HBaseMetricsTable implements MetricsTable {
   public void put(SortedMap<byte[], ? extends SortedMap<byte[], Long>> updates) {
     List<Put> puts = Lists.newArrayList();
     for (Map.Entry<byte[], ? extends SortedMap<byte[], Long>> row : updates.entrySet()) {
-      PutBuilder put = tableUtil.buildPut(row.getKey());
+      byte[] distributedKey = getRowKey(row.getKey());
+      PutBuilder put = tableUtil.buildPut(distributedKey);
       for (Map.Entry<byte[], Long> column : row.getValue().entrySet()) {
         put.add(columnFamily, column.getKey(), Bytes.toBytes(column.getValue()));
       }
@@ -111,7 +181,8 @@ public class HBaseMetricsTable implements MetricsTable {
   public void putBytes(SortedMap<byte[], ? extends SortedMap<byte[], byte[]>> updates) {
     List<Put> puts = Lists.newArrayList();
     for (Map.Entry<byte[], ? extends SortedMap<byte[], byte[]>> row : updates.entrySet()) {
-      PutBuilder put = tableUtil.buildPut(row.getKey());
+      byte[] distributedKey = getRowKey(row.getKey());
+      PutBuilder put = tableUtil.buildPut(distributedKey);
       for (Map.Entry<byte[], byte[]> column : row.getValue().entrySet()) {
         put.add(columnFamily, column.getKey(), column.getValue());
       }
@@ -128,17 +199,18 @@ public class HBaseMetricsTable implements MetricsTable {
   @Override
   public boolean swap(byte[] row, byte[] column, byte[] oldValue, byte[] newValue) {
     try {
+      byte[] distributedKey = getRowKey(row);
       if (newValue == null) {
         // HBase API weirdness: we must use deleteColumns() because deleteColumn() deletes only the last version.
-        Delete delete = tableUtil.buildDelete(row)
+        Delete delete = tableUtil.buildDelete(distributedKey)
           .deleteColumns(columnFamily, column)
           .build();
-        return hTable.checkAndDelete(row, columnFamily, column, oldValue, delete);
+        return hTable.checkAndDelete(distributedKey, columnFamily, column, oldValue, delete);
       } else {
-        Put put = tableUtil.buildPut(row)
+        Put put = tableUtil.buildPut(distributedKey)
           .add(columnFamily, column, newValue)
           .build();
-        return hTable.checkAndPut(row, columnFamily, column, oldValue, put);
+        return hTable.checkAndPut(distributedKey, columnFamily, column, oldValue, put);
       }
     } catch (IOException e) {
       throw new DataSetException("Swap failed on table " + tableId, e);
@@ -147,7 +219,8 @@ public class HBaseMetricsTable implements MetricsTable {
 
   @Override
   public void increment(byte[] row, Map<byte[], Long> increments) {
-    Put increment = getIncrementalPut(row, increments);
+    byte[] distributedKey = getRowKey(row);
+    Put increment = getIncrementalPut(distributedKey, increments);
     try {
       hTable.put(increment);
       hTable.flushCommits();
@@ -156,10 +229,14 @@ public class HBaseMetricsTable implements MetricsTable {
       // currently there is not other way to extract that from the HBase exception than string match
       if (e.getMessage() != null && e.getMessage().contains("isn't 64 bits wide")) {
         throw new NumberFormatException("Attempted to increment a value that is not convertible to long," +
-                                          " row: " + Bytes.toStringBinary(row));
+                                          " row: " + Bytes.toStringBinary(distributedKey));
       }
       throw new DataSetException("Increment failed on table " + tableId, e);
     }
+  }
+
+  private byte[] getRowKey(byte[] row) {
+    return isV3Table ? rowKeyDistributor.getDistributedKey(row) : row;
   }
 
   private Put getIncrementalPut(byte[] row, Map<byte[], Long> increments) {
@@ -182,8 +259,9 @@ public class HBaseMetricsTable implements MetricsTable {
   @Override
   public void increment(NavigableMap<byte[], NavigableMap<byte[], Long>> updates) {
     List<Put> puts = Lists.newArrayList();
-    for (Map.Entry<byte[], NavigableMap<byte[], Long>> update : updates.entrySet()) {
-      Put increment = getIncrementalPut(update.getKey(), update.getValue());
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> row : updates.entrySet()) {
+      byte[] distributedKey = getRowKey(row.getKey());
+      Put increment = getIncrementalPut(distributedKey, row.getValue());
       puts.add(increment);
     }
 
@@ -202,7 +280,8 @@ public class HBaseMetricsTable implements MetricsTable {
 
   @Override
   public long incrementAndGet(byte[] row, byte[] column, long delta) {
-    Increment increment = new Increment(row);
+    byte[] distributedKey = getRowKey(row);
+    Increment increment = new Increment(distributedKey);
     increment.addColumn(columnFamily, column, delta);
     try {
       Result result = hTable.increment(increment);
@@ -212,7 +291,7 @@ public class HBaseMetricsTable implements MetricsTable {
       // currently there is not other way to extract that from the HBase exception than string match
       if (e.getMessage() != null && e.getMessage().contains("isn't 64 bits wide")) {
         throw new NumberFormatException("Attempted to increment a value that is not convertible to long," +
-                                          " row: " + Bytes.toStringBinary(row) +
+                                          " row: " + Bytes.toStringBinary(distributedKey) +
                                           " column: " + Bytes.toStringBinary(column));
       }
       throw new DataSetException("IncrementAndGet failed on table " + tableId, e);
@@ -221,7 +300,8 @@ public class HBaseMetricsTable implements MetricsTable {
 
   @Override
   public void delete(byte[] row, byte[][] columns) {
-    DeleteBuilder delete = tableUtil.buildDelete(row);
+    byte[] distributedKey = getRowKey(row);
+    DeleteBuilder delete = tableUtil.buildDelete(distributedKey);
     for (byte[] column : columns) {
       delete.deleteColumns(columnFamily, column);
     }
@@ -238,7 +318,14 @@ public class HBaseMetricsTable implements MetricsTable {
     ScanBuilder scanBuilder = tableUtil.buildScan();
     configureRangeScan(scanBuilder, startRow, stopRow, filter);
     try {
-      ResultScanner resultScanner = hTable.getScanner(scanBuilder.build());
+      ResultScanner resultScanner;
+      if (isV3Table) {
+        resultScanner = DistributedScanner.create(hTable, scanBuilder.build(), rowKeyDistributor,
+                                                    scanExecutor);
+      } else {
+        resultScanner = hTable.getScanner(scanBuilder.build());
+      }
+
       return new HBaseScanner(resultScanner, columnFamily);
     } catch (IOException e) {
       throw new DataSetException("Scan failed on table " + tableId, e);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.AbstractTableDefinition;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.filesystem.LocationFactory;
@@ -49,7 +50,7 @@ public class HBaseMetricsTableDefinition extends AbstractTableDefinition<Metrics
     super(name);
   }
 
-  // for unit-test purposes only
+  @VisibleForTesting
   HBaseMetricsTableDefinition(String name, Configuration hConf, HBaseTableUtil hBaseTableUtil,
                               LocationFactory locationFactory, CConfiguration cConf) {
     super(name);

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
@@ -50,6 +50,7 @@ public class PurchaseApp extends AbstractApplication {
     createDataset("userProfiles", KeyValueTable.class,
                   DatasetProperties.builder().setDescription("Store user profiles").build());
 
+
     // Process events in realtime using a Flow
     addFlow(new PurchaseFlow());
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -74,7 +74,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
   @Override
   public FactTable getOrCreateFactTable(int resolution) {
     String tableName = cConf.get(Constants.Metrics.METRICS_TABLE_PREFIX,
-                                 Constants.Metrics.DEFAULT_METRIC_TABLE_PREFIX) + ".ts." + resolution;
+                                 Constants.Metrics.DEFAULT_METRIC_V3_TABLE_PREFIX) + ".ts." + resolution;
     int ttl = cConf.getInt(Constants.Metrics.RETENTION_SECONDS + "." + resolution + ".seconds", -1);
 
     TableProperties.Builder props = TableProperties.builder();
@@ -87,6 +87,11 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
     // configuring pre-splits
     props.add(HBaseTableAdmin.PROPERTY_SPLITS,
               GSON.toJson(FactTable.getSplits(DefaultMetricStore.AGGREGATIONS.size())));
+    // Property to specify whether to do salting while accessing metrics table
+    props.add(Constants.Metrics.DEFAULT_METRIC_V3_TABLE_PREFIX, "true");
+    props.add(Constants.Metrics.DEFAULT_METRIC_HBASE_TABLE_SPLITS, DefaultMetricStore.AGGREGATIONS.size());
+    props.add(Constants.Metrics.METRICS_HBASE_MAX_SCAN_THREADS,
+              cConf.get(Constants.Metrics.METRICS_HBASE_MAX_SCAN_THREADS));
 
     MetricsTable table = getOrCreateMetricsTable(tableName, props.build());
     return new FactTable(table, entityTable.get(), resolution, getRollTime(resolution));


### PR DESCRIPTION
Changes:

- Applies only in distributed mode
- Adding salting to metrics tables by creating new tables with v3 version: cdap_system:metrics.v3.table.ts.1                                                                                                                           
cdap_system:metrics.v3.table.ts.2147483647                                                                                                                  
cdap_system:metrics.v3.table.ts.3600                                                                                                                        
cdap_system:metrics.v3.table.ts.60

Remaining: 
- Reader/scanner to read row keys along with migration

Build: https://builds.cask.co/browse/CDAP-DUT5937-5