### PR TITLE
CDAP-12135 Add visibility check method to authorization enforcer interface

### DIFF
--- a/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
@@ -88,6 +88,11 @@ public class AuthorizationClient extends AbstractAuthorizer {
   }
 
   @Override
+  public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception {
+    throw new UnsupportedOperationException("Visibility check is not supported via Java Client.");
+  }
+
+  @Override
   public Predicate<EntityId> createFilter(Principal principal) throws Exception {
     throw new UnsupportedOperationException("Filtering is not supported via Java Client.");
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetClassRewriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetClassRewriterTest.java
@@ -404,6 +404,11 @@ public class DatasetClassRewriterTest {
     }
 
     @Override
+    public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception {
+      throw new UnsupportedOperationException("This method needs to be implemented!");
+    }
+
+    @Override
     public Predicate<EntityId> createFilter(Principal principal) throws Exception {
       return new Predicate<EntityId>() {
         @Override
@@ -433,6 +438,11 @@ public class DatasetClassRewriterTest {
       for (Action action : actions) {
         privileges.add(new Privilege(entity, action));
       }
+    }
+
+    @Override
+    public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception {
+      throw new UnsupportedOperationException("This method needs to be implemented!");
     }
 
     @Override

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationEnforcer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationEnforcer.java
@@ -55,11 +55,25 @@ public interface AuthorizationEnforcer {
   void enforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception;
 
   /**
+   * Checks whether the set of {@link EntityId}s are visible to the specified {@link Principal}.
+   * An entity is visible to a principal if the principal has any privileges on the entity, or any of its descendants.
+   *
+   * @param entityIds the entities on which the visibility check is to be performed
+   * @param principal the principal to check the visibility for
+   * @return a set of entities that are visible to the principal
+   * @throws Exception if any errors occured while performing the check
+   */
+  Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception;
+
+  /**
    * Returns a {@link Predicate} that can be used to filter a set of entities to only return the entities that the
    * specified {@link Principal} has access (READ/WRITE/ADMIN/ALL) to.
+   *
+   * @deprecated this method has been deprecated since 4.3, please use {@link #isVisible(Set, Principal)} instead.
    *
    * @param principal the {@link Principal} for which to filter
    * @return a set of {@link EntityId entities} that the specified user has access to
    */
+  @Deprecated
   Predicate<EntityId> createFilter(Principal principal) throws Exception;
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
@@ -37,6 +37,11 @@ public class NoOpAuthorizer extends AbstractAuthorizer {
   }
 
   @Override
+  public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception {
+    return entityIds;
+  }
+
+  @Override
   public Predicate<EntityId> createFilter(Principal principal) throws Exception {
     return ALLOW_ALL;
   }

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcer.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcer.java
@@ -82,6 +82,12 @@ public class DefaultAuthorizationEnforcer extends AbstractAuthorizationEnforcer 
     doEnforce(entity, principal, Collections.singleton(action));
   }
 
+  @Override
+  public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception {
+    LOG.debug("Checking visibility of {} for principal {}.", entityIds, principal);
+    return authorizerInstantiator.get().isVisible(entityIds, principal);
+  }
+
   private void doEnforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
     // bypass the check when the principal is the master user and the entity is in the system namespace
     if (entity instanceof NamespacedEntityId &&

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemoteAuthorizationEnforcer.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemoteAuthorizationEnforcer.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -97,6 +98,12 @@ public class RemoteAuthorizationEnforcer extends AbstractAuthorizationEnforcer {
     if (!allowed) {
       throw new UnauthorizedException(principal, action, entity);
     }
+  }
+
+  @Override
+  public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception {
+    // TODO: needs to be implemented
+    throw new UnsupportedOperationException("This method needs to be implemented!");
   }
 
   private boolean doEnforce(AuthorizationPrivilege authorizationPrivilege) throws IOException {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/ExceptionAuthorizationEnforcer.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/ExceptionAuthorizationEnforcer.java
@@ -42,6 +42,11 @@ public class ExceptionAuthorizationEnforcer implements AuthorizationEnforcer {
   }
 
   @Override
+  public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception {
+    throw new UnsupportedOperationException("This method needs to be implemented!");
+  }
+
+  @Override
   public Predicate<EntityId> createFilter(Principal principal) throws Exception {
     return null;
   }

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/InMemoryAuthorizer.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/InMemoryAuthorizer.java
@@ -85,6 +85,12 @@ public class InMemoryAuthorizer extends AbstractAuthorizer {
   }
 
   @Override
+  public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception {
+    // TODO: needs to be implemented
+    throw new UnsupportedOperationException("This method needs to be implemented!");
+  }
+
+  @Override
   public Predicate<EntityId> createFilter(Principal principal) throws Exception {
     // super users do not have any enforcement
     if (superUsers.contains(principal) || superUsers.contains(allSuperUsers)) {


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-12135
Build - https://builds.cask.co/browse/CDAP-DUT6020-1

Note: the `isVisible()` method of RemoteAuthorizationEnforcer will be implemented later