### PR TITLE
CDAP-12085 Implement a PartitionedFileSet#concatenatePartition

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.PartitionNotFoundException;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 
 /**
@@ -91,6 +92,17 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void dropPartition(PartitionKey key);
+
+  /**
+   * Asynchronous operation to concatenate the partition in Hive. Note that Hive only supports certain formats.
+   * Concatenation merges the files within one partition into fewer, larger files.
+   * If this Dataset is not enabled for Explore, this operation is a no-op.
+   *
+   * @throws PartitionNotFoundException when a partition for the given key is not found
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
+   * @return a {@link Future} which returns null, but may be used to await completion of the concatenation operation.
+   */
+  Future<Void> concatenatePartition(PartitionKey key);
 
   /**
    * Return the partition for a specific partition key, or null if key is not found.

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
@@ -215,6 +215,21 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
+  public ListenableFuture<Void> concatenatePartition(final DatasetId datasetInstance,
+                                                     final DatasetSpecification spec,
+                                                     final PartitionKey key) {
+    ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
+      @Override
+      public QueryHandle getHandle() throws ExploreException, SQLException {
+        return doConcatenatePartition(datasetInstance, spec, key);
+      }
+    });
+
+    // Exceptions will be thrown in case of an error in the futureHandle
+    return Futures.transform(futureResults, Functions.<Void>constant(null));
+  }
+
+  @Override
   public ListenableFuture<ExploreExecutionResult> submit(final NamespaceId namespace, final String statement) {
     return getResultsFuture(new HandleProducer() {
       @Override

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
@@ -149,6 +149,17 @@ public interface ExploreClient extends Closeable {
                                        DatasetSpecification spec, PartitionKey key);
 
   /**
+   * Concatenates the partition in the Hive table for the given dataset.
+   *
+   * @param datasetInstance instance of the dataset
+   * @param key the partition key
+   * @return a {@code Future} object that can either successfully complete, or enters a failed state, depending on
+   *         the success of the operation
+   */
+  ListenableFuture<Void> concatenatePartition(DatasetId datasetInstance,
+                                              DatasetSpecification spec, PartitionKey key);
+
+  /**
    * Execute a Hive SQL statement asynchronously. The returned {@link ListenableFuture} can be used to get the
    * schema of the operation, and it contains an iterator on the results of the statement.
    *

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreFacade.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreFacade.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
@@ -188,6 +189,15 @@ public class ExploreFacade {
 
     ListenableFuture<Void> futureSuccess = exploreClient.dropPartition(datasetInstance, spec, key);
     handleExploreFuture(futureSuccess, "drop", "partition", datasetInstance.getDataset());
+  }
+
+  public ListenableFuture<Void> concatenatePartition(DatasetId datasetInstance, DatasetSpecification spec,
+                                                     PartitionKey key) throws ExploreException, SQLException {
+    if (!exploreEnabled) {
+      return Futures.immediateFuture(null);
+    }
+
+    return exploreClient.concatenatePartition(datasetInstance, spec, key);
   }
 
   public void createNamespace(NamespaceMeta namespace) throws ExploreException, SQLException {

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/MockExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/MockExploreClient.java
@@ -116,6 +116,12 @@ public class MockExploreClient extends AbstractIdleService implements ExploreCli
   }
 
   @Override
+  public ListenableFuture<Void> concatenatePartition(DatasetId datasetInstance, DatasetSpecification spec,
+                                                     PartitionKey key) {
+    return null;
+  }
+
+  @Override
   public ListenableFuture<ExploreExecutionResult> submit(NamespaceId namespace, final String statement) {
     SettableFuture<ExploreExecutionResult> futureDelegate = SettableFuture.create();
     futureDelegate.set(new MockExploreExecutionResult(statementsToResults.get(statement).iterator(),

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/table/AlterPartitionStatementBuilder.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/table/AlterPartitionStatementBuilder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.table;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Builds alter table partition statements for Hive.
+ */
+public class AlterPartitionStatementBuilder {
+
+  private final String databaseName;
+  private final String tableName;
+  private final PartitionKey partitionKey;
+  private final boolean shouldEscapeColumns;
+
+  public AlterPartitionStatementBuilder(@Nullable String databaseName, String tableName,
+                                        PartitionKey partitionKey, boolean shouldEscapeColumns) {
+    this.databaseName = databaseName;
+    this.tableName = tableName;
+    this.partitionKey = partitionKey;
+    this.shouldEscapeColumns = shouldEscapeColumns;
+  }
+
+  /**
+   * Builds ADD PARTITION statement. For example:
+   *   ALTER TABLE dataset_tpfs ADD PARTITION (year=2012) LOCATION '<uri>'
+   */
+  public String buildAddStatement(String fsPath) {
+    return buildCommon()
+      .append(" ADD PARTITION ")
+      .append(generateHivePartitionKey(partitionKey))
+      .append(" LOCATION '")
+      .append(fsPath)
+      .append("'")
+      .toString();
+  }
+
+  /**
+   * Builds DROP PARTITION statement. For example:
+   *   ALTER TABLE dataset_tpfs DROP PARTITION (year=2012)
+   */
+  public String buildDropStatement() {
+    return buildCommon()
+      .append(" DROP PARTITION ")
+      .append(generateHivePartitionKey(partitionKey))
+      .toString();
+  }
+
+  /**
+   * Builds PARTITION CONCATENATE statement. For example:
+   *   ALTER TABLE dataset_tpfs PARTITION (year=2012) CONCATENATE
+   */
+  public String buildConcatenateStatement() {
+    return buildCommon()
+      .append(" PARTITION ")
+      .append(generateHivePartitionKey(partitionKey))
+      .append(" CONCATENATE")
+      .toString();
+  }
+
+  private StringBuilder buildCommon() {
+    StringBuilder str = new StringBuilder("ALTER TABLE ");
+    if (databaseName != null) {
+      str.append(databaseName).append(".");
+    }
+    str.append(tableName);
+    return str;
+  }
+
+  private String generateHivePartitionKey(PartitionKey key) {
+    StringBuilder builder = new StringBuilder("(");
+    String sep = "";
+    for (Map.Entry<String, ? extends Comparable> entry : key.getFields().entrySet()) {
+      String fieldName = entry.getKey();
+      Comparable fieldValue = entry.getValue();
+      String quote = fieldValue instanceof String ? "'" : "";
+      builder.append(sep);
+      if (shouldEscapeColumns) {
+        // a literal backtick(`) is just a double backtick(``)
+        builder.append('`').append(fieldName.replace("`", "``")).append('`');
+      } else {
+        builder.append(fieldName);
+      }
+      builder.append("=").append(quote).append(fieldValue.toString()).append(quote);
+      sep = ", ";
+    }
+    builder.append(")");
+    return builder.toString();
+  }
+}

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/table/AlterPartitionStatementBuilderTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/table/AlterPartitionStatementBuilderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.table;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+/**
+ * Tests for {@link AlterPartitionStatementBuilder}.
+ */
+public class AlterPartitionStatementBuilderTest {
+
+  private final PartitionKey key = PartitionKey.builder().addIntField("year", 2012).build();
+  private final String location = "/my/path";
+
+  @Test
+  public void test() {
+    Assert.assertEquals("ALTER TABLE dbName.tblName ADD PARTITION (year=2012) LOCATION '/my/path'",
+                        createStatementBuilder("dbName").buildAddStatement(location));
+    Assert.assertEquals("ALTER TABLE dbName.tblName PARTITION (year=2012) CONCATENATE",
+                        createStatementBuilder("dbName").buildConcatenateStatement());
+    Assert.assertEquals("ALTER TABLE dbName.tblName DROP PARTITION (year=2012)",
+                        createStatementBuilder("dbName").buildDropStatement());
+  }
+
+  @Test
+  public void testWithNullDatabase() {
+    Assert.assertEquals("ALTER TABLE tblName ADD PARTITION (year=2012) LOCATION '/my/path'",
+                        createStatementBuilder(null).buildAddStatement(location));
+    Assert.assertEquals("ALTER TABLE tblName PARTITION (year=2012) CONCATENATE",
+                        createStatementBuilder(null).buildConcatenateStatement());
+    Assert.assertEquals("ALTER TABLE tblName DROP PARTITION (year=2012)",
+                        createStatementBuilder(null).buildDropStatement());
+
+  }
+
+  private AlterPartitionStatementBuilder createStatementBuilder(@Nullable String databaseName) {
+    return new AlterPartitionStatementBuilder(databaseName, "tblName", key, false);
+  }
+}

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/table/AlterStatementBuilderTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/table/AlterStatementBuilderTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  */
 public class AlterStatementBuilderTest {
 
-  LocationFactory locationFactory = new LocalLocationFactory();
+  private LocationFactory locationFactory = new LocalLocationFactory();
 
   @Test
   public void testWithLocation() throws Exception {
@@ -120,7 +120,5 @@ public class AlterStatementBuilderTest {
                         "org.apache.hadoop.hive.serde2.avro.AvroSerDe");
     Assert.assertEquals(expected, actual);
   }
-
-
 
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/concatenate/PartitionConcatenateTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/concatenate/PartitionConcatenateTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.partitioned.concatenate;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionOutput;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.base.TestFrameworkTestBase;
+import com.google.common.collect.Iterables;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.io.orc.CompressionKind;
+import org.apache.hadoop.hive.ql.io.orc.OrcFile;
+import org.apache.hadoop.hive.ql.io.orc.OrcNewOutputFormat;
+import org.apache.hadoop.hive.ql.io.orc.Writer;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests functionality to concatenate files within a partition of a PartitionedFileSet.
+ */
+public class PartitionConcatenateTest extends TestFrameworkTestBase {
+
+  /**
+   * 1. Write 100 small files (orc format) to a Partition of a PartitionedFileSet.
+   * 2. Execute a partition concatenate operation.
+   * 3. As compared to before the concatenate operation, validate that the number of files is reduced, while
+   *    the contents of the files remains the same.
+   */
+  @Test
+  public void testConcatenate() throws Exception {
+    String orcPFS = "orcPFS";
+    addDatasetInstance(PartitionedFileSet.class.getName(), orcPFS, PartitionedFileSetProperties.builder()
+      // Properties for partitioning
+      .setPartitioning(Partitioning.builder().addLongField("time").build())
+      // Properties for file set
+      .setOutputFormat(OrcNewOutputFormat.class)
+      // Properties for Explore (to create a partitioned Hive table)
+      .setEnableExploreOnCreate(true)
+      .setSerDe("org.apache.hadoop.hive.ql.io.orc.OrcSerde")
+      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat")
+      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat")
+      .setExploreSchema("record STRING")
+      .build());
+
+    // 1. create 100 small files in the input FileSet
+    DataSetManager<PartitionedFileSet> cleanRecordsManager = getDataset(orcPFS);
+    PartitionedFileSet cleanRecords = cleanRecordsManager.get();
+
+    PartitionKey outputPartition = PartitionKey.builder().addLongField("time", 5000).build();
+    PartitionOutput partitionOutput = cleanRecords.getPartitionOutput(outputPartition);
+    Location partitionLocation = partitionOutput.getLocation();
+    int numInputFiles = 100;
+    List<String> writtenData = writeSmallOrcFiles(partitionLocation, numInputFiles);
+    partitionOutput.addPartition();
+
+    Assert.assertEquals(writtenData, getExploreResults(orcPFS));
+
+    // this is a timestamp before concatenating, but after writing the files
+    long beforeConcatTime = System.currentTimeMillis();
+
+    List<Location> dataFiles = listFilteredChildren(partitionLocation);
+    // each input file will result in one output file, due to the FileInputFormat class and FileOutputFormat class
+    // being used
+    Assert.assertEquals(numInputFiles, dataFiles.size());
+    for (Location dataFile : dataFiles) {
+      // all the files should have a lastModified smaller than now
+      Assert.assertTrue(dataFile.lastModified() < beforeConcatTime);
+    }
+
+    // 2. run the concatenate operation
+    cleanRecords.concatenatePartition(outputPartition).get();
+
+    // 3. check that the data files' lastModified timestamp is updated, and there should be fewer of them
+    dataFiles = listFilteredChildren(partitionLocation);
+    Assert.assertTrue(dataFiles.size() < numInputFiles);
+    // should have a lastModified larger than now
+    Assert.assertTrue(Iterables.getOnlyElement(dataFiles).lastModified() > beforeConcatTime);
+
+    // even though the files were concatenated, the explore results should be unchanged
+    Assert.assertEquals(writtenData, getExploreResults(orcPFS));
+  }
+
+  private List<String> writeSmallOrcFiles(Location baseLocation, int numInputFiles) throws IOException {
+    TypeInfo typeInfo = TypeInfoUtils.getTypeInfoFromTypeString("struct<key:string>");
+    ObjectInspector objectInspector = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(typeInfo);
+
+    Configuration hConf = new Configuration();
+    FileSystem fileSystem = FileSystem.get(hConf);
+    long stripeSize = HiveConf.getLongVar(hConf, HiveConf.ConfVars.HIVE_ORC_DEFAULT_STRIPE_SIZE);
+    CompressionKind compressionKind =
+      CompressionKind.valueOf(HiveConf.getVar(hConf, HiveConf.ConfVars.HIVE_ORC_DEFAULT_COMPRESS));
+    int bufferSize = HiveConf.getIntVar(hConf, HiveConf.ConfVars.HIVE_ORC_DEFAULT_BUFFER_SIZE);
+    int rowIndexStride = HiveConf.getIntVar(hConf, HiveConf.ConfVars.HIVE_ORC_DEFAULT_ROW_INDEX_STRIDE);
+
+    List<String> writtenData = new ArrayList<>();
+    for (int i = 0; i < numInputFiles; i++) {
+      Location childFile = baseLocation.append("child_" + i);
+
+      Writer orcWriter = OrcFile.createWriter(fileSystem, new Path(childFile.toURI()), hConf, objectInspector,
+                                              stripeSize, compressionKind, bufferSize, rowIndexStride);
+      try {
+        String toWrite = "outputData" + i;
+        orcWriter.addRow(Collections.singletonList(toWrite));
+        writtenData.add(toWrite);
+      } finally {
+        orcWriter.close();
+      }
+    }
+    Collections.sort(writtenData);
+    return writtenData;
+  }
+
+  private List<String> getExploreResults(String datasetName) throws Exception {
+    ResultSet resultSet =
+      getQueryClient().prepareStatement("select * from dataset_" + datasetName).executeQuery();
+    List<String> strings = new ArrayList<>();
+    while (resultSet.next()) {
+      // the schema is such that the record contents are all in the first column
+      strings.add(resultSet.getString(1));
+    }
+    Collections.sort(strings);
+    return strings;
+  }
+
+  // Lists children files, and filters "_SUCCESS" files and files that begin with dot (".")
+  private List<Location> listFilteredChildren(Location location) throws IOException {
+    List<Location> children = new ArrayList<>();
+    for (Location child : location.list()) {
+      if (!child.getName().startsWith(".") && !FileOutputCommitter.SUCCEEDED_FILE_NAME.equals(child.getName())) {
+        children.add(child);
+      }
+    }
+    return children;
+  }
+}


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12085
Implement a `PartitionedFileSet#concatenatePartition(PartitionKey key)`, which allows users to concatenate the files of a PartitionedFileSet, by leveraging [Hive functionality](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-AlterTable/PartitionConcatenate). Specific Hive versions support ORC and RC file formats.

The beautiful test case that tests the `PartitionedFileSet#concatenatePartition` is PartitionConcatenateTest.java.

https://builds.cask.co/browse/CDAP-DUT5957-10

In case user tries to call `PartitionedFileSet#concatenatePartition` on a PartitionedFileSet that isn't storing its files in a supported format, user will see an error like follows. Note that the stack trace will be a bit different, now that the method has been made asynchronous. https://gist.githubusercontent.com/anwar6953/8c5666a20928980ce10e7b5d27ce87e9/raw/499eb937346638b49da5066c3758cbe70649def0/hive-concatenate-unsupported-format.txt