### PR TITLE
CDAP-12161 fix union null check

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
@@ -243,8 +243,24 @@ public class StructuredRecord implements Serializable {
       if (field == null) {
         throw new UnexpectedFormatException("field " + fieldName + " is not in the schema.");
       }
-      if (!field.getSchema().isNullable() && val == null) {
-        throw new UnexpectedFormatException("field " + fieldName + " cannot be set to a null value.");
+      Schema fieldSchema = field.getSchema();
+      if (val == null) {
+        if (fieldSchema.getType() == Schema.Type.NULL) {
+          return field;
+        }
+        if (fieldSchema.getType() != Schema.Type.UNION) {
+          throw new UnexpectedFormatException("field " + fieldName + " cannot be set to a null value.");
+        }
+        boolean ok = false;
+        for (Schema unionSchema : fieldSchema.getUnionSchemas()) {
+          if (unionSchema.getType() == Schema.Type.NULL) {
+            ok = true;
+            break;
+          }
+        }
+        if (!ok) {
+          throw new UnexpectedFormatException("field " + fieldName + " cannot be set to a null value.");
+        }
       }
       return field;
     }

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
@@ -251,16 +251,12 @@ public class StructuredRecord implements Serializable {
         if (fieldSchema.getType() != Schema.Type.UNION) {
           throw new UnexpectedFormatException("field " + fieldName + " cannot be set to a null value.");
         }
-        boolean ok = false;
         for (Schema unionSchema : fieldSchema.getUnionSchemas()) {
           if (unionSchema.getType() == Schema.Type.NULL) {
-            ok = true;
-            break;
+            return field;
           }
         }
-        if (!ok) {
-          throw new UnexpectedFormatException("field " + fieldName + " cannot be set to a null value.");
-        }
+        throw new UnexpectedFormatException("field " + fieldName + " cannot be set to a null value.");
       }
       return field;
     }

--- a/cdap-formats/src/test/java/co/cask/cdap/format/StructuredRecordBuilderTest.java
+++ b/cdap-formats/src/test/java/co/cask/cdap/format/StructuredRecordBuilderTest.java
@@ -31,6 +31,23 @@ import java.util.TimeZone;
 public class StructuredRecordBuilderTest {
 
   @Test
+  public void testNullCheck() {
+    Schema schema = Schema.recordOf("x", Schema.Field.of("x", Schema.of(Schema.Type.NULL)));
+    Assert.assertNull(StructuredRecord.builder(schema).set("x", null).build().get("x"));
+  }
+
+  @Test
+  public void testUnionNullCheck() {
+    Schema schema = Schema.recordOf("x", Schema.Field.of("x", Schema.unionOf(
+      Schema.of(Schema.Type.NULL),
+      Schema.of(Schema.Type.INT),
+      Schema.of(Schema.Type.LONG))));
+    Assert.assertNull(StructuredRecord.builder(schema).set("x", null).build().get("x"));
+    Assert.assertEquals(5, StructuredRecord.builder(schema).set("x", 5).build().get("x"));
+    Assert.assertEquals(5L, StructuredRecord.builder(schema).set("x", 5L).build().get("x"));
+  }
+
+  @Test
   public void testDateConversion() {
     long ts = 0L;
     Date date = new Date(ts);


### PR DESCRIPTION
Fix a bug where null was not allowed for fields that are a union
of null and more than one other schema.