### PR TITLE
CDAP-12036 spark splitter transform

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -2016,6 +2016,7 @@ public class DataPipelineTest extends HydratorTestBase {
   @Test
   public void testSplitterToConnector() throws Exception {
     testSplitterToConnector(Engine.MAPREDUCE);
+    testSplitterToConnector(Engine.SPARK);
   }
 
   private void testSplitterToConnector(Engine engine) throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.JavaSparkMain;
 import co.cask.cdap.etl.api.ErrorTransform;
+import co.cask.cdap.etl.api.SplitterTransform;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
@@ -61,7 +62,7 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
   private static final Set<String> SUPPORTED_PLUGIN_TYPES = ImmutableSet.of(
     StreamingSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE,
     BatchAggregator.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, Windower.PLUGIN_TYPE,
-    ErrorTransform.PLUGIN_TYPE);
+    ErrorTransform.PLUGIN_TYPE, SplitterTransform.PLUGIN_TYPE);
 
   @Override
   public void run(final JavaSparkExecutionContext sec) throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/RecordInfo.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/RecordInfo.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.common;
 
+import java.io.Serializable;
 import javax.annotation.Nullable;
 
 /**
@@ -24,7 +25,8 @@ import javax.annotation.Nullable;
  *
  * @param <T> the type of value
  */
-public class RecordInfo<T> {
+public class RecordInfo<T> implements Serializable {
+  private static final long serialVersionUID = 2507536440619795611L;
   private final T value;
   private final String fromStage;
   private final String fromPort;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.spark;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.Windower;
+import co.cask.cdap.etl.common.RecordInfo;
 import co.cask.cdap.etl.spec.StageSpec;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
@@ -44,11 +45,13 @@ public interface SparkCollection<T> {
 
   SparkCollection<T> union(SparkCollection<T> other);
 
-  SparkCollection<Tuple2<Boolean, Object>> transform(StageSpec stageSpec);
+  SparkCollection<RecordInfo<Object>> transform(StageSpec stageSpec);
+
+  SparkCollection<RecordInfo<Object>> multiOutputTransform(StageSpec stageSpec);
 
   <U> SparkCollection<U> flatMap(StageSpec stageSpec, FlatMapFunction<T, U> function);
 
-  SparkCollection<Tuple2<Boolean, Object>> aggregate(StageSpec stageSpec, @Nullable Integer partitions);
+  SparkCollection<RecordInfo<Object>> aggregate(StageSpec stageSpec, @Nullable Integer partitions);
 
   <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function);
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.api.JoinElement;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.batch.BatchPhaseSpec;
 import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.RecordInfo;
 import co.cask.cdap.etl.common.SetMultimapCodec;
 import co.cask.cdap.etl.common.plugin.PipelinePluginContext;
 import co.cask.cdap.etl.spark.Compat;
@@ -74,7 +75,7 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
   private transient int numOfRecordsPreview;
 
   @Override
-  protected SparkCollection<Tuple2<Boolean, Object>> getSource(StageSpec stageSpec) {
+  protected SparkCollection<RecordInfo<Object>> getSource(StageSpec stageSpec) {
     PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageSpec, sec);
     return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory,
                                sourceFactory.createRDD(sec, jsc, stageSpec.getName(), Object.class, Object.class)

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
@@ -20,6 +20,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.Transformation;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.RecordInfo;
 import co.cask.cdap.etl.common.TrackedTransform;
 import co.cask.cdap.etl.spark.CombinedEmitter;
 import scala.Tuple2;
@@ -33,7 +34,7 @@ import scala.Tuple2;
  * @param <OUT> type of aggregate output
  */
 public class AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT>
-  implements FlatMapFunc<Tuple2<GROUP_KEY, Iterable<GROUP_VAL>>, Tuple2<Boolean, Object>> {
+  implements FlatMapFunc<Tuple2<GROUP_KEY, Iterable<GROUP_VAL>>, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
   private transient TrackedTransform<Tuple2<GROUP_KEY, Iterable<GROUP_VAL>>, OUT> aggregateTransform;
   private transient CombinedEmitter<OUT> emitter;
@@ -43,7 +44,7 @@ public class AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT>
   }
 
   @Override
-  public Iterable<Tuple2<Boolean, Object>> call(Tuple2<GROUP_KEY, Iterable<GROUP_VAL>> input) throws Exception {
+  public Iterable<RecordInfo<Object>> call(Tuple2<GROUP_KEY, Iterable<GROUP_VAL>> input) throws Exception {
     if (aggregateTransform == null) {
       BatchAggregator<GROUP_KEY, GROUP_VAL, OUT> aggregator = pluginFunctionContext.createPlugin();
       aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/BatchSourceFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/BatchSourceFunction.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.spark.function;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Transformation;
 import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.common.RecordInfo;
 import co.cask.cdap.etl.common.TrackedTransform;
 import co.cask.cdap.etl.common.preview.LimitingTransform;
 import co.cask.cdap.etl.spark.CombinedEmitter;
@@ -28,7 +29,7 @@ import scala.Tuple2;
  * Function that uses a BatchSource to transform a pair of objects into a single object.
  * Non-serializable fields are lazily created since this is used in a Spark closure.
  */
-public class BatchSourceFunction implements FlatMapFunc<Tuple2<Object, Object>, Tuple2<Boolean, Object>> {
+public class BatchSourceFunction implements FlatMapFunc<Tuple2<Object, Object>, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
   private final int numOfRecordsPreview;
   private transient Transformation<KeyValue<Object, Object>, Object> transform;
@@ -40,7 +41,7 @@ public class BatchSourceFunction implements FlatMapFunc<Tuple2<Object, Object>, 
   }
 
   @Override
-  public Iterable<Tuple2<Boolean, Object>> call(Tuple2<Object, Object> input) throws Exception {
+  public Iterable<RecordInfo<Object>> call(Tuple2<Object, Object> input) throws Exception {
     if (transform == null) {
       BatchSource<Object, Object, Object> batchSource = pluginFunctionContext.createPlugin();
       batchSource.initialize(pluginFunctionContext.createBatchRuntimeContext());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/ErrorPassFilter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/ErrorPassFilter.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.etl.spark.function;
 
 import co.cask.cdap.etl.api.ErrorRecord;
-import scala.Tuple2;
+import co.cask.cdap.etl.common.RecordInfo;
 
 import java.util.Collections;
 
@@ -26,12 +26,12 @@ import java.util.Collections;
  *
  * @param <T> type of error record
  */
-public class OutputFilter<T> implements FlatMapFunc<Tuple2<Boolean, Object>, ErrorRecord<T>> {
+public class ErrorPassFilter<T> implements FlatMapFunc<RecordInfo<Object>, ErrorRecord<T>> {
 
   @Override
-  public Iterable<ErrorRecord<T>> call(Tuple2<Boolean, Object> input) throws Exception {
+  public Iterable<ErrorRecord<T>> call(RecordInfo<Object> input) throws Exception {
     //noinspection unchecked
-    return input._1() ?
-      Collections.singletonList((ErrorRecord<T>) input._2()) : Collections.<ErrorRecord<T>>emptyList();
+    return input.isError() ?
+      Collections.singletonList((ErrorRecord<T>) input.getValue()) : Collections.<ErrorRecord<T>>emptyList();
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/ErrorTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/ErrorTransformFunction.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.spark.function;
 
 import co.cask.cdap.etl.api.ErrorRecord;
 import co.cask.cdap.etl.api.ErrorTransform;
+import co.cask.cdap.etl.common.RecordInfo;
 import co.cask.cdap.etl.common.TrackedTransform;
 import co.cask.cdap.etl.spark.CombinedEmitter;
 import scala.Tuple2;
@@ -29,7 +30,7 @@ import scala.Tuple2;
  * @param <T> type of input object
  * @param <U> type of output object
  */
-public class ErrorTransformFunction<T, U> implements FlatMapFunc<ErrorRecord<T>, Tuple2<Boolean, Object>> {
+public class ErrorTransformFunction<T, U> implements FlatMapFunc<ErrorRecord<T>, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
   private transient TrackedTransform<ErrorRecord<T>, U> transform;
   private transient CombinedEmitter<U> emitter;
@@ -39,7 +40,7 @@ public class ErrorTransformFunction<T, U> implements FlatMapFunc<ErrorRecord<T>,
   }
 
   @Override
-  public Iterable<Tuple2<Boolean, Object>> call(ErrorRecord<T> inputError) throws Exception {
+  public Iterable<RecordInfo<Object>> call(ErrorRecord<T> inputError) throws Exception {
     if (transform == null) {
       ErrorTransform<T, U> plugin = pluginFunctionContext.createPlugin();
       plugin.initialize(pluginFunctionContext.createBatchRuntimeContext());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -24,6 +24,7 @@ import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.Windower;
+import co.cask.cdap.etl.common.RecordInfo;
 import co.cask.cdap.etl.spark.Compat;
 import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPairCollection;
@@ -80,8 +81,13 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   @Override
-  public SparkCollection<Tuple2<Boolean, Object>> transform(StageSpec stageSpec) {
-    return wrap(stream.transform(new DynamicTransform<T, Object>(new DynamicDriverContext(stageSpec, sec))));
+  public SparkCollection<RecordInfo<Object>> transform(StageSpec stageSpec) {
+    return wrap(stream.transform(new DynamicTransform<T>(new DynamicDriverContext(stageSpec, sec), false)));
+  }
+
+  @Override
+  public SparkCollection<RecordInfo<Object>> multiOutputTransform(StageSpec stageSpec) {
+    return wrap(stream.transform(new DynamicTransform<T>(new DynamicDriverContext(stageSpec, sec), true)));
   }
 
   @Override
@@ -95,7 +101,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   @Override
-  public SparkCollection<Tuple2<Boolean, Object>> aggregate(StageSpec stageSpec, @Nullable Integer partitions) {
+  public SparkCollection<RecordInfo<Object>> aggregate(StageSpec stageSpec, @Nullable Integer partitions) {
     DynamicDriverContext dynamicDriverContext = new DynamicDriverContext(stageSpec, sec);
     JavaPairDStream<Object, T> keyedCollection =
       stream.transformToPair(new DynamicAggregatorGroupBy<Object, T>(dynamicDriverContext));

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicAggregatorAggregate.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicAggregatorAggregate.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.spark.streaming.function;
 
+import co.cask.cdap.etl.common.RecordInfo;
 import co.cask.cdap.etl.spark.Compat;
 import co.cask.cdap.etl.spark.function.AggregatorAggregateFunction;
 import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
@@ -35,16 +36,16 @@ import scala.Tuple2;
  * @param <OUT> type of output object
  */
 public class DynamicAggregatorAggregate<GROUP_KEY, GROUP_VAL, OUT>
-  implements Function2<JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>>, Time, JavaRDD<Tuple2<Boolean, Object>>> {
+  implements Function2<JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>>, Time, JavaRDD<RecordInfo<Object>>> {
   private final DynamicDriverContext dynamicDriverContext;
-  private transient FlatMapFunction<Tuple2<GROUP_KEY, Iterable<GROUP_VAL>>, Tuple2<Boolean, Object>> function;
+  private transient FlatMapFunction<Tuple2<GROUP_KEY, Iterable<GROUP_VAL>>, RecordInfo<Object>> function;
 
   public DynamicAggregatorAggregate(DynamicDriverContext dynamicDriverContext) {
     this.dynamicDriverContext = dynamicDriverContext;
   }
 
   @Override
-  public JavaRDD<Tuple2<Boolean, Object>> call(JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>> input,
+  public JavaRDD<RecordInfo<Object>> call(JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>> input,
                                                Time batchTime) throws Exception {
     if (function == null) {
       function = Compat.convert(

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/function/WrapOutputTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/function/WrapOutputTransformFunction.java
@@ -16,18 +16,23 @@
 
 package co.cask.cdap.etl.spark.streaming.function;
 
+import co.cask.cdap.etl.common.RecordInfo;
 import org.apache.spark.api.java.function.Function;
-import scala.Tuple2;
 
 /**
- * Simply wraps all elements into a Tuple2 whose first element is false, indicating everything is output and nothing
- * is an error.
+ * Simply wraps all elements into a non-error, non-port RecordInfo.
  *
  * @param <T> the type of output object
  */
-public class WrapOutputTransformFunction<T> implements Function<T, Tuple2<Boolean, T>> {
+public class WrapOutputTransformFunction<T> implements Function<T, RecordInfo<T>> {
+  private final String stageName;
+
+  public WrapOutputTransformFunction(String stageName) {
+    this.stageName = stageName;
+  }
+
   @Override
-  public Tuple2<Boolean, T> call(T inputRecord) throws Exception {
-    return new Tuple2<>(false, inputRecord);
+  public RecordInfo<T> call(T inputRecord) throws Exception {
+    return RecordInfo.builder(inputRecord, stageName).build();
   }
 }


### PR DESCRIPTION
Implementing SplitterTransform in Spark pipelines. Involves
refactoring the Spark collections to output RecordInfo instead
of KeyValue, then filtering that output based on the port.