### PR TITLE
CDAP-12109 Validation of the condition plugins.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
@@ -31,6 +31,7 @@ import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkSink;
+import co.cask.cdap.etl.api.condition.Condition;
 import co.cask.cdap.etl.batch.BatchPipelineSpec;
 import co.cask.cdap.etl.batch.BatchPipelineSpecGenerator;
 import co.cask.cdap.etl.common.Constants;
@@ -51,7 +52,8 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
   private static final Set<String> supportedPluginTypes = ImmutableSet.of(
     BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE,
     Constants.CONNECTOR_TYPE, BatchAggregator.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE,
-    Action.PLUGIN_TYPE, ErrorTransform.PLUGIN_TYPE, Constants.SPARK_PROGRAM_PLUGIN_TYPE, SplitterTransform.PLUGIN_TYPE);
+    Action.PLUGIN_TYPE, ErrorTransform.PLUGIN_TYPE, Constants.SPARK_PROGRAM_PLUGIN_TYPE, SplitterTransform.PLUGIN_TYPE,
+    Condition.PLUGIN_TYPE);
 
   @Override
   public void configure() {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
@@ -34,6 +34,7 @@ import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.PostAction;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkSink;
+import co.cask.cdap.etl.api.condition.Condition;
 import co.cask.cdap.etl.batch.ActionSpec;
 import co.cask.cdap.etl.batch.BatchPhaseSpec;
 import co.cask.cdap.etl.batch.BatchPipelineSpec;
@@ -139,7 +140,8 @@ public class SmartWorkflow extends AbstractWorkflow {
     } else {
       planner = new PipelinePlanner(supportedPluginTypes,
                                     ImmutableSet.of(BatchAggregator.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE),
-                                    ImmutableSet.of(SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE),
+                                    ImmutableSet.of(SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE,
+                                                    Condition.PLUGIN_TYPE),
                                     actionTypes);
     }
     plan = planner.plan(spec);

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/condition/PipelineCondition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/condition/PipelineCondition.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.condition;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.workflow.WorkflowContext;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents conditions in the data pipelines.
+ */
+public class PipelineCondition implements Predicate<WorkflowContext> {
+  @Override
+  public boolean apply(@Nullable WorkflowContext input) {
+    return false;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -32,6 +32,7 @@ import co.cask.cdap.etl.api.action.Action;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.condition.Condition;
 import co.cask.cdap.etl.common.ArtifactSelectorProvider;
 import co.cask.cdap.etl.common.Constants;
 import co.cask.cdap.etl.common.DefaultPipelineConfigurer;
@@ -357,6 +358,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
     }
 
     Set<String> actionStages = new HashSet<>();
+    Set<String> conditionStages = new HashSet<>();
     Map<String, String> stageTypes = new HashMap<>();
     // check stage name uniqueness
     Set<String> stageNames = new HashSet<>();
@@ -370,10 +372,18 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       if (isAction(stage.getPlugin().getType())) {
         actionStages.add(stage.getName());
       }
+      // if the stage is condition add it to the Condition stage set
+      if (stage.getPlugin().getType().equals(Condition.PLUGIN_TYPE)) {
+        conditionStages.add(stage.getName());
+      }
+
       stageTypes.put(stage.getName(), stage.getPlugin().getType());
     }
 
     // check that the from and to are names of actual stages
+    // also check that conditions have at most 2 outgoing connections each label with true or
+    // false but not both
+    Map<String, Boolean> conditionBranch = new HashMap<>();
     for (Connection connection : config.getConnections()) {
       if (!stageNames.contains(connection.getFrom())) {
         throw new IllegalArgumentException(
@@ -382,6 +392,23 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       if (!stageNames.contains(connection.getTo())) {
         throw new IllegalArgumentException(
           String.format("Invalid connection %s. %s is not a stage.", connection, connection.getTo()));
+      }
+
+      if (conditionStages.contains(connection.getFrom())) {
+        if (connection.getCondition() == null) {
+          String msg = String.format("For condition stage %s, the connection %s is not marked with either " +
+                                       "'true' or 'false'.", connection.getFrom(), connection);
+          throw new IllegalArgumentException(msg);
+        }
+
+        // check if connection from the condition node is marked as true or false multiple times
+        if (conditionBranch.containsKey(connection.getFrom())
+          && connection.getCondition().equals(conditionBranch.get(connection.getFrom()))) {
+          String msg = String.format("For condition stage '%s', more than one outgoing connections are marked as %s.",
+                                     connection.getFrom(), connection.getCondition());
+          throw new IllegalArgumentException(msg);
+        }
+        conditionBranch.put(connection.getFrom(), connection.getCondition());
       }
     }
 
@@ -451,6 +478,8 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       stages.put(stageName, stage);
     }
 
+    validateConditionBranches(conditionStages, dag);
+
     for (String stageName : dag.getTopologicalOrder()) {
       traversalOrder.add(stages.get(stageName));
     }
@@ -484,4 +513,63 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
     }
   }
 
+  /**
+   * Make sure that the stages on the condition branches do not have more than one incoming connections
+   * @param conditionStages the set of condition stages in the pipeline
+   * @param dag the dag of connections
+   * @throws IllegalArgumentException if there is an error in the configurations, for example condition stage
+   * is not configured correctly to have 'true' and 'false' branches or there are multiple incoming connections
+   * on the stages which are on condition branches
+   */
+  private void validateConditionBranches(Set<String> conditionStages, Dag dag) {
+    for (String conditionStage : conditionStages) {
+      // Get the output connection stages for this condition. Should be max 2
+      Set<String> outputs = dag.getNodeOutputs(conditionStage);
+      if (outputs == null || outputs.size() > 2) {
+        String msg = String.format("Condition stage in the pipeline '%s' should have at least 1 and at max 2 " +
+                                     "outgoing connections corresponding to 'true' and 'false' branches " +
+                                     "but found '%s'.", conditionStage, outputs == null ? 0 : outputs.size());
+        throw new IllegalArgumentException(msg);
+      }
+      for (String output : outputs) {
+        // Check that each stage in this branch starting from output has only one incoming connection
+        validateSingleInput(conditionStage, output, dag);
+      }
+    }
+  }
+
+  /**
+   * Current stage can only have either one incoming connection if its one of the stage on the condition branch or
+   * two incoming connections if it is condition stopper stage. We do not allow cross connections from sources.
+   */
+  private void validateSingleInput(String currentCondition, String currentStage, Dag dag) {
+    if (dag.getNodeInputs(currentStage).size() > 1) {
+      Set<String> stopNodes = new HashSet<>(dag.getSources());
+      stopNodes.add(currentCondition);
+      Set<String> parents = dag.parentsOf(currentStage, stopNodes);
+      parents.retainAll(dag.getSources());
+      if (parents.size() > 0) {
+        String paths = "";
+        for (String parent : parents) {
+          if (!paths.isEmpty()) {
+            paths = paths + ", ";
+          }
+          paths += parent + "->" + currentStage;
+        }
+        String msg = String.format("Stage in the pipeline '%s' is on the branch of condition '%s'. However it also " +
+                                     "has following incoming paths: '%s', which is not supported.", currentStage,
+                                   currentCondition, paths);
+        throw new IllegalArgumentException(msg);
+      }
+    }
+
+    Set<String> outputStages = dag.getNodeOutputs(currentStage);
+    if (outputStages.size() == 0) {
+      // We reached sink. simply return
+      return;
+    }
+    for (String output : outputStages) {
+      validateSingleInput(currentCondition, output, dag);
+    }
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/Connection.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/Connection.java
@@ -28,15 +28,25 @@ public class Connection {
   private final String from;
   private final String to;
   private final String port;
+  private final Boolean condition;
 
   public Connection(String from, String to) {
-    this(from, to, null);
+    this(from, to, null, null);
   }
 
   public Connection(String from, String to, @Nullable String port) {
+    this(from, to, port, null);
+  }
+
+  public Connection(String from, String to, Boolean condition) {
+    this(from, to, null, condition);
+  }
+
+  private Connection(String from, String to, @Nullable String port, @Nullable Boolean condition) {
     this.from = from;
     this.to = to;
     this.port = port;
+    this.condition = condition;
   }
 
   public String getFrom() {
@@ -52,6 +62,11 @@ public class Connection {
     return port;
   }
 
+  @Nullable
+  public Boolean getCondition() {
+    return condition;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -63,12 +78,13 @@ public class Connection {
 
     Connection that = (Connection) o;
 
-    return Objects.equals(from, that.from) && Objects.equals(to, that.to) && Objects.equals(port, that.port);
+    return Objects.equals(from, that.from) && Objects.equals(to, that.to) && Objects.equals(port, that.port)
+      && Objects.equals(condition, that.condition);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(from, to, port);
+    return Objects.hash(from, to, port, condition);
   }
 
   @Override
@@ -77,6 +93,7 @@ public class Connection {
       "from='" + from + '\'' +
       ", to='" + to + '\'' +
       ", port='" + port + '\'' +
+      ", condition='" + condition + '\'' +
       '}';
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/ETLConfig.java
@@ -258,6 +258,11 @@ public class ETLConfig extends Config implements UpgradeableConfig {
       return (T) this;
     }
 
+    public T addConnection(String from, String to, Boolean condition) {
+      this.connections.add(new Connection(from, to, condition));
+      return (T) this;
+    }
+
     public T addConnection(Connection connection) {
       this.connections.add(connection);
       return (T) this;


### PR DESCRIPTION
First part of the planner changes. This PR includes changes for validating the pipeline when condition stages are added in the pipeline.

Following validations are added:
1. Make sure that outgoing connections for conditions have at least 1 and at max 2 connections.
2. These connections are marked appropriately.
3. Stages on the condition branches are not allowed to have any incoming connection from sources which are not passing through current condition.