### PR TITLE
CDAP-12170 Avoid unnecessary file rollback

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionAlreadyExistsException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2017 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,21 +14,16 @@
  * the License.
  */
 
-package co.cask.cdap.api.dataset;
+package co.cask.cdap.api.dataset.lib;
+
+import co.cask.cdap.api.dataset.DataSetException;
 
 /**
- * Thrown when a data operation fails.
+ * Thrown when a Partition already exists.
  */
-public class DataSetException extends RuntimeException {
-  public DataSetException(String message) {
-    super(message);
-  }
-
-  public DataSetException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public DataSetException(Throwable cause) {
-    super(cause);
+public class PartitionAlreadyExistsException extends DataSetException {
+  public PartitionAlreadyExistsException(String datasetName, PartitionKey partitionKey) {
+    super(String.format("Dataset '%s' already has a partition with the same key: %s",
+                        datasetName, partitionKey.toString()));
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -51,7 +51,7 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
   /**
    * Add a partition for a given partition key, stored at a given path (relative to the file set's base path).
    *
-   * @throws DataSetException if a partition for the same key already exists
+   * @throws PartitionAlreadyExistsException if a partition for the same key already exists
    * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void addPartition(PartitionKey key, String path);
@@ -60,7 +60,7 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Add a partition for a given partition key, stored at a given path (relative to the file set's base path),
    * with the given metadata.
    *
-   * @throws DataSetException if a partition for the same key already exists
+   * @throws PartitionAlreadyExistsException if a partition for the same key already exists
    * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void addPartition(PartitionKey key, String path, Map<String, String> metadata);
@@ -139,6 +139,7 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Obtain the location to write from the PartitionOutput, then call the {@link PartitionOutput#addPartition}
    * to add the partition to this dataset.
    *
+   * @throws PartitionAlreadyExistsException if the partition already exists
    * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   PartitionOutput getPartitionOutput(PartitionKey key);

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -18,6 +18,7 @@ package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.DataSetException;
+import co.cask.cdap.api.dataset.PartitionNotFoundException;
 
 import java.util.Map;
 import java.util.Set;
@@ -49,6 +50,7 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
    * Add a partition for a given time, stored at a given path (relative to the file set's base path).
    *
    * @param time the partition time in milliseconds since the Epoch
+   * @throws PartitionAlreadyExistsException if the partition for the given time already exists
    */
   void addPartition(long time, String path);
 
@@ -57,6 +59,7 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
    * with given metadata.
    *
    * @param time the partition time in milliseconds since the Epoch
+   * @throws PartitionAlreadyExistsException if the partition for the given time already exists
    */
   void addPartition(long time, String path, Map<String, String> metadata);
 
@@ -67,6 +70,7 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
    * @param time the partition time in milliseconds since the Epoch
    *
    * @throws DataSetException in case an attempt is made to update existing entries.
+   * @throws PartitionNotFoundException when a partition for the given time is not found
    */
   void addMetadata(long time, String metadataKey, String metadataValue);
 
@@ -77,6 +81,7 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
    * @param time the partition time in milliseconds since the Epoch
    *
    * @throws DataSetException in case an attempt is made to update existing entries.
+   * @throws PartitionNotFoundException when a partition for the given time is not found
    */
   void addMetadata(long time, Map<String, String> metadata);
 
@@ -111,6 +116,7 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
    * to add the partition to this dataset.
    *
    * @param time the partition time in milliseconds since the Epoch
+   * @throws PartitionAlreadyExistsException if the partition for the given time already exists
    */
   TimePartitionOutput getPartitionOutput(long time);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -149,6 +149,7 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
         "Output is not supported for external time-partitioned file set '" + spec.getName() + "'");
     }
     PartitionKey key = partitionKeyForTime(time);
+    assertNotExists(key, true);
     return new BasicTimePartitionOutput(this, getOutputPath(key), key);
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.PartitionNotFoundException;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
 import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionAlreadyExistsException;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
@@ -605,15 +606,7 @@ public class PartitionedFileSetTest {
 
     txContext.start();
 
-    PartitionOutput output = pfs.getPartitionOutput(PARTITION_KEY);
-    Location outputLocation = output.getLocation().append("file");
-    Assert.assertFalse(outputLocation.exists());
-
-    // this will create the file
-    outputLocation.getOutputStream().close();
-    Assert.assertTrue(outputLocation.exists());
-
-    output.addPartition();
+    Location outputLocation = createPartition(pfs, PARTITION_KEY, "file");;
     Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
     Assert.assertTrue(pfs.getPartition(PARTITION_KEY).getLocation().exists());
 
@@ -632,43 +625,21 @@ public class PartitionedFileSetTest {
     TransactionContext txContext = new TransactionContext(txClient, (TransactionAware) pfs);
 
     txContext.start();
-
-    PartitionOutput output = pfs.getPartitionOutput(PARTITION_KEY);
-    Location outputLocation = output.getLocation().append("file");
-    Assert.assertFalse(outputLocation.exists());
-
-    try (OutputStream outputStream = outputLocation.getOutputStream()) {
-      // write 1 to the first file
-      outputStream.write(1);
-    }
-    Assert.assertTrue(outputLocation.exists());
-
-    output.addPartition();
+    // write 1 to the first file
+    Location outputLocation = createPartition(pfs, PARTITION_KEY, "file", 1);
     Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
     Assert.assertTrue(pfs.getPartition(PARTITION_KEY).getLocation().exists());
-
     txContext.finish();
 
-    // because the previous transaction aborted, the partition as well as the file will not exist
     txContext.start();
     pfs.dropPartition(PARTITION_KEY);
-
     Assert.assertNull(pfs.getPartition(PARTITION_KEY));
     Assert.assertFalse(outputLocation.exists());
 
-    // create a new partition with the same partition key (same relative path for the partition
-    PartitionOutput partitionOutput2 = pfs.getPartitionOutput(PARTITION_KEY);
-    Location outputLocation2 = partitionOutput2.getLocation().append("file");
-    Assert.assertFalse(outputLocation2.exists());
-    // create the file
-    try (OutputStream outputStream = outputLocation2.getOutputStream()) {
-      // write 2 to the second file
-      outputStream.write(2);
-    }
+    // create a new partition with the same partition key (same relative path for the partition)
+    // write 2 to the second file
+    Location outputLocation2 = createPartition(pfs, PARTITION_KEY, "file", 2);
     Assert.assertTrue(outputLocation2.exists());
-
-    partitionOutput2.addPartition();
-
     txContext.abort();
 
     // since the previous transaction aborted, the partition and its files should still exist
@@ -681,7 +652,6 @@ public class PartitionedFileSetTest {
       // should be nothing else in the file
       Assert.assertEquals(0, inputStream.available());
     }
-
     txContext.finish();
   }
 
@@ -690,32 +660,74 @@ public class PartitionedFileSetTest {
     PartitionedFileSet pfs = dsFrameworkUtil.getInstance(pfsInstance);
     TransactionContext txContext = new TransactionContext(txClient, (TransactionAware) pfs);
 
-    // because the previous transaction aborted, the partition as well as the file will not exist
     txContext.start();
-
     Assert.assertNull(pfs.getPartition(PARTITION_KEY));
-
-    PartitionOutput partitionOutput = pfs.getPartitionOutput(PARTITION_KEY);
-    Location outputLocation = partitionOutput.getLocation().append("file");
-
-    Assert.assertFalse(outputLocation.exists());
-
-    try (OutputStream outputStream = outputLocation.getOutputStream()) {
-      // create and write 1 to the file
-      outputStream.write(1);
-    }
-
-    Assert.assertTrue(outputLocation.exists());
-
-    partitionOutput.addPartition();
+    Location outputLocation = createPartition(pfs, PARTITION_KEY, "file");
     Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
-
     pfs.dropPartition(PARTITION_KEY);
-
     txContext.abort();
 
     // the file shouldn't exist because the transaction was aborted (AND because it was dropped at the end of the tx)
     Assert.assertFalse(outputLocation.exists());
+  }
+
+  @Test
+  public void testRollbackOfPartitionCreateWhereItAlreadyExisted() throws Exception {
+    PartitionedFileSet pfs = dsFrameworkUtil.getInstance(pfsInstance);
+    TransactionContext txContext = new TransactionContext(txClient, (TransactionAware) pfs);
+
+    txContext.start();
+    Assert.assertNull(pfs.getPartition(PARTITION_KEY));
+    Location file1Location = createPartition(pfs, PARTITION_KEY, "file1");
+    Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
+    txContext.finish();
+
+    // the file should exist because the transaction completed successfully
+    Assert.assertTrue(file1Location.exists());
+
+    // if you attempt to add a partition X, and it already existed, the transaction rollback should not remove
+    // the files of the original, existing partition X.
+    txContext.start();
+    Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
+
+    try {
+      // PartitionedFileSet#getPartitionOutput should fail
+      createPartition(pfs, PARTITION_KEY, "file2");
+      Assert.fail("Expected PartitionAlreadyExistsException");
+    } catch (PartitionAlreadyExistsException expected) {
+    }
+    // because of the above failure, we want to abort and rollback the transaction
+    txContext.abort();
+
+    // the file should still exist because the aborted transaction should've failed before even needing to rollback
+    // the partition's files
+    Assert.assertTrue(file1Location.exists());
+
+    // file2 shouldn't exist
+    txContext.start();
+    Assert.assertFalse(pfs.getPartition(PARTITION_KEY).getLocation().append("file2").exists());
+    txContext.finish();
+  }
+
+  private Location createPartition(PartitionedFileSet pfs, PartitionKey key, String fileName) throws IOException {
+    return createPartition(pfs, key, fileName, 1);
+  }
+
+  // creates a file under the partition path for the given key and adds it to the PartitionedFileSet
+  // writes the given int into the file and asserts that it exists
+  private Location createPartition(PartitionedFileSet pfs, PartitionKey key, String fileName,
+                                   int intToWrite) throws IOException {
+    PartitionOutput partitionOutput = pfs.getPartitionOutput(key);
+    Location outputLocation = partitionOutput.getLocation().append(fileName);
+    Assert.assertFalse(outputLocation.exists());
+
+    try (OutputStream outputStream = outputLocation.getOutputStream()) {
+      outputStream.write(intToWrite);
+    }
+    Assert.assertTrue(outputLocation.exists());
+
+    partitionOutput.addPartition();
+    return outputLocation;
   }
 
   @Test
@@ -820,12 +832,8 @@ public class PartitionedFileSetTest {
     dsFrameworkUtil.newTransactionExecutor((TransactionAware) pfs).execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        PartitionOutput output = pfs.getPartitionOutput(PARTITION_KEY);
-        Location outputLocation = output.getLocation().append("file");
+        Location outputLocation = createPartition(pfs, PARTITION_KEY, "file");
         outputLocationRef.set(outputLocation);
-        OutputStream out = outputLocation.getOutputStream();
-        out.close();
-        output.addPartition();
         Assert.assertTrue(outputLocation.exists());
         Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
         Assert.assertTrue(pfs.getPartition(PARTITION_KEY).getLocation().exists());
@@ -1027,7 +1035,7 @@ public class PartitionedFileSetTest {
     return true;
   }
 
-  public static List<PartitionFilter> generateFilters() {
+  private static List<PartitionFilter> generateFilters() {
     List<PartitionFilter> filters = Lists.newArrayList();
     addSingleConditionFilters(filters, "s", S_CONDITIONS);
     addSingleConditionFilters(filters, "i", I_CONDITIONS);

--- a/cdap-docs/developer-manual/build.sh
+++ b/cdap-docs/developer-manual/build.sh
@@ -87,7 +87,7 @@ function download_includes() {
 
   test_an_include f9acd1e2ed73ba5e83b9a0cd6c75f988 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
-  test_an_include fb8055d43cb481c1d5b404d0d1278f51 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
+  test_an_include 26486a370532d820bde854d42990a868 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
 
   test_an_include ce88887b4e60273e60deeb6d233be7ae ../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
   test_an_include 52f6fc93e4e96c0c1d208a335827e110 ../../cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ClusteringUtils.scala

--- a/cdap-docs/developer-manual/source/building-blocks/transaction-system.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/transaction-system.rst
@@ -210,7 +210,7 @@ performed outside the transaction:
 
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
    :language: java
-   :lines: 74-103
+   :lines: 75-104
    :dedent: 4
 
 Be aware that you cannot nest transactions. For example, either:

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -163,7 +163,7 @@ function download_includes() {
   test_an_include f9acd1e2ed73ba5e83b9a0cd6c75f988 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
   test_an_include 61aac2c868c7966847aec6520dcf7529 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
-  test_an_include fb8055d43cb481c1d5b404d0d1278f51 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
+  test_an_include 26486a370532d820bde854d42990a868 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
   test_an_include 6e0ed4027acafd163e8b891a1045717f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
 
   test_an_include d37a5de57003b17df4ee0f4ac8cbddb2 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java

--- a/cdap-docs/examples-manual/source/examples/sport-results.rst
+++ b/cdap-docs/examples-manual/source/examples/sport-results.rst
@@ -66,7 +66,7 @@ dataset as a file. It declares its use of the dataset using a ``@UseDataSet`` an
 
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
     :language: java
-    :lines: 71-72
+    :lines: 72-73
     :dedent: 4
 
 Let's take a closer look at the upload method:
@@ -87,7 +87,7 @@ Let's take a closer look at the upload method:
 
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
     :language: java
-    :lines: 105-171
+    :lines: 106-171
     :dedent: 4
 
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkFileSetTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkFileSetTestRun.java
@@ -101,7 +101,7 @@ public class SparkFileSetTestRun extends TestFrameworkTestBase {
 
   private void testSparkWithFileSet(ApplicationManager applicationManager, String sparkProgram) throws Exception {
     DataSetManager<FileSet> filesetManager = getDataset("fs");
-    final FileSet fileset = filesetManager.get();
+    FileSet fileset = filesetManager.get();
 
     Location location = fileset.getLocation("nn");
     prepareFileInput(location);
@@ -128,10 +128,10 @@ public class SparkFileSetTestRun extends TestFrameworkTestBase {
 
   private void testSparkWithCustomFileSet(ApplicationManager applicationManager,
                                           String sparkProgram) throws Exception {
-    final DataSetManager<SparkAppUsingFileSet.MyFileSet> myFileSetManager = getDataset("myfs");
+    DataSetManager<SparkAppUsingFileSet.MyFileSet> myFileSetManager = getDataset("myfs");
     SparkAppUsingFileSet.MyFileSet myfileset = myFileSetManager.get();
 
-    final FileSet fileset = myfileset.getEmbeddedFileSet();
+    FileSet fileset = myfileset.getEmbeddedFileSet();
 
     Location location = fileset.getLocation("nn");
     prepareFileInput(location);
@@ -214,11 +214,6 @@ public class SparkFileSetTestRun extends TestFrameworkTestBase {
     validateFileOutput(customPartition.getLocation());
 
     // Cleanup after running the test
-    tpfs.getPartitionOutput(inputTime).getLocation().delete(true);
-    tpfs.getPartitionOutput(customInputPartitionKey).getLocation().delete(true);
-    partition.getLocation().delete(true);
-    customPartition.getLocation().delete(true);
-
     tpfs.dropPartition(inputTime);
     tpfs.dropPartition(customInputPartitionKey);
     tpfs.dropPartition(partition.getPartitionKey());
@@ -241,7 +236,7 @@ public class SparkFileSetTestRun extends TestFrameworkTestBase {
     PartitionedFileSetArguments.setInputPartitionFilter(
       inputArgs, PartitionFilter.builder().addRangeCondition("x", "na", "nx").build());
     Map<String, String> outputArgs = new HashMap<>();
-    final PartitionKey outputKey = PartitionKey.builder().addStringField("x", "xx").build();
+    PartitionKey outputKey = PartitionKey.builder().addStringField("x", "xx").build();
     PartitionedFileSetArguments.setOutputPartitionKey(outputArgs, outputKey);
     Map<String, String> args = new HashMap<>();
     args.putAll(RuntimeArguments.addScope(Scope.DATASET, "pfs", inputArgs));
@@ -258,8 +253,6 @@ public class SparkFileSetTestRun extends TestFrameworkTestBase {
     validateFileOutput(partition.getLocation());
 
     // Cleanup after test completed
-    location.delete(true);
-    partition.getLocation().delete(true);
     pfs.dropPartition(partitionOutput.getPartitionKey());
     pfs.dropPartition(partition.getPartitionKey());
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12170
Check that partition doesn't already exist, before returning a PartitionOutput, from PartitionedFileSet#getPartitionOutput(PartitionKey key).

Otherwise, if you attempt to add a partition that already exists, the dataset rollback will remove the files of the original partition.

The only downside to this is that now PartitionedFileSet#getPartitionOutput must be run in a transaction, whereas this was previously not a requirement. Edit: it is not strictly a requirement currently. I updated the code to LOG.warn and fallback to performing a check for the partition's files, if the operation is not executed within a transaction.

https://builds.cask.co/browse/CDAP-RUT1199-4