### PR TITLE
Bugfix to not popup alert when user opens a sink in Details view

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-dataset-selector/widget-dataset-selector.js
+++ b/cdap-ui/app/directives/widget-container/widget-dataset-selector/widget-dataset-selector.js
@@ -149,7 +149,7 @@ angular.module(PKG.name + '.commons')
               } else if ($scope.datasetType === 'dataset') {
                   schema = res.spec.properties.schema;
 
-                  if (initialized && !isCurrentlyExistingDataset) {
+                  if (initialized && !isCurrentlyExistingDataset && newDataset !== oldDataset) {
                     if (!modalOpen) {
                       debouncedPopup(schema, oldDataset);
                     }


### PR DESCRIPTION
Currently in Studio, when user changes the dataset of a sink to an existing dataset, there will be an popup asking if they want to do this, since it will overwrite the existing schema (relevant JIRA: https://issues.cask.co/browse/CDAP-9090). 

However currently there's a bug where this popup will also show when the user clicks on a sink in Details mode, even though they can't edit anything.