### PR TITLE
[CDAP-12200] Fixes preview not sending additional runtime args

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -532,7 +532,7 @@ class HydratorPlusPlusTopPanelCtrl {
     let previewConfig = {
       startStages: [],
       endStages: [],
-      runtimeArgs: Object.assign({}, macrosWithNonEmptyValues, this.userRuntimeArguments)
+      runtimeArgs: Object.assign({}, macrosWithNonEmptyValues, this.userRuntimeArgumentsMap)
     };
 
     if (this.state.artifact.name === this.GLOBALS.etlDataPipeline) {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12200

Currently in preview, values for macros are sent, but additional runtime args created by the user are not. This is because of a refactoring that changed `this.userRuntimeArguments` to `this.userRuntimeArgumentsMap`, but there was one place where I missed this.