### PR TITLE
update checksums for the .gz distribution of nodejs, which the nodejs…

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -206,7 +206,7 @@
           "version": "4.5.0",
           "binary": {
             "checksum": {
-              "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
+              "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
             }
           }
         },

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -10,7 +10,7 @@
     "version": "4.5.0",
     "binary": {
       "checksum": {
-        "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
+        "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
       }
     }
   },

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -7,7 +7,7 @@
     "version": "4.5.0",
     "binary": {
       "checksum": {
-        "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
+        "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
       }
     }
   },


### PR DESCRIPTION
… 4.0.0 cookbook switched to

Update the checksum for nodejs 4.5.0, for the ``.tar.gz`` distribution, from the ``.xz`` distribution used previously.

The latest (4.0.0) node.js cookbook switched this, somewhat silently and is not configurable.  See https://github.com/redguide/nodejs/blob/3.0.0/recipes/nodejs_from_binary.rb#L40 vs https://github.com/redguide/nodejs/blob/v4.0.0/recipes/nodejs_from_binary.rb#L45

This should fix the docker/vm builds, and will need to be backported to all active branches:
```
build	26-Jul-2017 19:11:21	[0mChef::Exceptions::ChecksumMismatch[0m
build	26-Jul-2017 19:11:21	----------------------------------[0m
build	26-Jul-2017 19:11:21	Checksum on resource (c6ee1f) does not match checksum on content (5678ad)[0m
```