### PR TITLE
Fix documentation for retrieving system service logs.

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/logging.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/logging.rst
@@ -132,7 +132,7 @@ Note that the start and stop times are **not** optional.
    :stub-columns: 1
 
    * - HTTP Method
-     - ``GET /v3/services/system/appfabric/logs?start=1428541200&stop=1428541500``
+     - ``GET /v3/system/services/appfabric/logs?start=1428541200&stop=1428541500``
    * - Description
      - Return the logs for the *AppFabric* service
        beginning ``Thu, 09 Apr 2015 01:00:00 GMT`` and


### PR DESCRIPTION
See line [112 of the same file](https://github.com/caskdata/cdap/pull/9299/files#diff-26ae3d26979cd4b9a8018f3fdc9391a2R112). The example is inconsistent from it.