### PR TITLE
Add upgrade step on pipeline import

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -301,7 +301,11 @@ gulp.task('js:app:babel', function() {
 });
 
 gulp.task('js:app', ['js:app:babel', 'js:app:hydrator', 'js:app:tracker', 'js:app:logviewer']);
-gulp.task('watch:js:app', ['watch:js:app:hydrator', 'watch:js:app:tracker', 'watch:js:app:logviewer']);
+gulp.task('watch:js:app', [
+  'watch:js:app:hydrator',
+  'watch:js:app:tracker',
+  'watch:js:app:logviewer'
+]);
 gulp.task('polyfill', function () {
   return gulp.src([
     './app/polyfill.js',

--- a/cdap-ui/app/directives/dag-plus/color-constants.less
+++ b/cdap-ui/app/directives/dag-plus/color-constants.less
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@source-plugins-color: #48c038;
+@transform-plugins-color: #4586f3;
+@action-plugins-color: #988470;
+@spark-plugins-color: #34495e;
+@sink-plugins-color: #8367df;
+@error-transform: #e74c3c;
+@configure-btn-label-color: #5c6788;
+@configure-btn-label-hover-color: #454a57;
+@configure-btn-bg-hover-color: #f5f5f5;
+@hamburger-menu-color: #b9c0d8;
+@hamburger-node-hover-color: #5c6788;
+@hamburger-hover-color: #454a57;
+@node-menu-delete-color: #cc0821;
+@node-menu-action-bg-color: #eeeeee;
+@badge-warning-color: #ffcc00;
+@badge-danger-color: #e33d3d;
+@comment-box-color: lighten(#ffff99, 10%);
+@preview-outline-color: lighten(#f1c40f, 20%);

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -113,7 +113,7 @@
             <div ng-if="node.error">
               <div class="error-node-notification"
                    ng-if="node.errorCount > 0"
-                   uib-tooltip="Please see node configuration panel"
+                   uib-tooltip="{{node.errorMessage || 'Please see node configuration panel'}}"
                    tooltip-append-to-body="true"
                    tooltip-class="tooltip-error">
                 <span class="badge badge-danger">

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -17,25 +17,7 @@
 @import "../../styles/variables.less";
 @import "../../../bower_components/bootstrap/less/mixins.less";
 @import "../../styles/themes/cdap/mixins.less";
-
-@source-plugins-color: #48c038;
-@transform-plugins-color: #4586f3;
-@action-plugins-color: #988470;
-@spark-plugins-color: #34495e;
-@sink-plugins-color: #8367df;
-@error-transform: #e74c3c;
-@configure-btn-label-color: #5c6788;
-@configure-btn-label-hover-color: #454a57;
-@configure-btn-bg-hover-color: #f5f5f5;
-@hamburger-menu-color: #b9c0d8;
-@hamburger-node-hover-color: #5c6788;
-@hamburger-hover-color: #454a57;
-@node-menu-delete-color: #cc0821;
-@node-menu-action-bg-color: #eeeeee;
-@badge-warning-color: #ffcc00;
-@badge-danger-color: #e33d3d;
-@comment-box-color: lighten(#ffff99, 10%);
-@preview-outline-color: lighten(#f1c40f, 20%);
+@import "./color-constants.less";
 
 .border-color-hover() {
   border: 1px solid currentColor;

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -17,6 +17,7 @@
 @import '../styles/variables.less';
 @import '../../bower_components/bootstrap/less/mixins.less';
 @import '../styles/themes/cdap/mixins.less';
+@import '../directives/dag-plus/color-constants.less';
 
 .modal.hydrator-modal {
   &.confirm-modal {
@@ -492,4 +493,43 @@ body.theme-cdap {
       }
     }
   }
+}
+
+.modal.upgrade-modal.hydrator-modal {
+  .modal-content .modal-body { padding-top: 0; }
+  .import-error-row {
+    padding: 10px;
+    border-bottom: 1px solid #c9ccd6;
+  }
+
+  .modal-body { overflow-x: hidden; }
+
+  h4 { font-weight: 500; }
+  .error-description { margin-bottom: 5px; }
+
+  .error-suggestion {
+    span:not(:first-child) {
+      margin-left: 20px;
+    }
+  }
+
+  .source {
+    color: @source-plugins-color;
+  }
+  .transform {
+    color: @transform-plugins-color;
+  }
+  .sink {
+    color: @sink-plugins-color;
+  }
+  .error {
+    color: @error-transform;
+  }
+  .action {
+    color: @action-plugins-color;
+  }
+  .action.sparkprogram {
+    color: @spark-plugins-color;
+  }
+
 }

--- a/cdap-ui/app/hydrator/routes.js
+++ b/cdap-ui/app/hydrator/routes.js
@@ -62,7 +62,7 @@ angular.module(PKG.name + '.feature.hydrator')
             highlightTab: 'hydratorStudioPlusPlus'
           },
           resolve: {
-            rConfig: function($stateParams, mySettings, $q, myHelpers, $window, $rootScope, HydratorPlusPlusHydratorService, GLOBALS) {
+            rConfig: function($stateParams, mySettings, $q, myHelpers, $window, $rootScope, HydratorPlusPlusHydratorService) {
               var defer = $q.defer();
               if ($stateParams.draftId) {
                 mySettings.get('hydratorDrafts', true)
@@ -74,11 +74,7 @@ angular.module(PKG.name + '.feature.hydrator')
                           supportedVersion: $rootScope.cdapVersion,
                           versionRange: draft.artifact.version
                         });
-                      let isOldArtifact = draft.artifact.name;
-                      if ([GLOBALS.etlRealtime, GLOBALS.etlBatch].indexOf(isOldArtifact) !== -1) {
-                        defer.reject(false);
-                        return defer.promise;
-                      }
+
                       if (isVersionInRange) {
                         draft.artifact.version = $rootScope.cdapVersion;
                       } else {
@@ -105,11 +101,6 @@ angular.module(PKG.name + '.feature.hydrator')
                     supportedVersion: $rootScope.cdapVersion,
                     versionRange: $stateParams.data.artifact.version
                   });
-                let isOldArtifact = $stateParams.data.artifact.name;
-                if ([GLOBALS.etlRealtime, GLOBALS.etlBatch].indexOf(isOldArtifact) !== -1) {
-                  defer.reject(false);
-                  return defer.promise;
-                }
                 if (isVersionInRange) {
                   $stateParams.data.artifact.version = $rootScope.cdapVersion;
                 } else {

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -98,6 +98,7 @@ class HydratorPlusPlusConfigStore {
       this.setGracefulStop(this.state.config.stopGracefully);
       this.setNumRecordsPreview(this.state.config.numOfRecordsPreview);
       this.setMaxConcurrentRuns(this.state.config.maxConcurrentRuns);
+      this.setNodes(this.state.config.stages || []);
     }
     this.__defaultState = angular.copy(this.state);
   }
@@ -182,7 +183,7 @@ class HydratorPlusPlusConfigStore {
           // Solely adding id and _backendProperties for validation.
           // Should be removed while saving it to backend.
           name: node.plugin.name,
-          type: node.type,
+          type: node.type || node.plugin.type,
           label: node.plugin.label,
           artifact: node.plugin.artifact,
           properties: node.plugin.properties ,

--- a/cdap-ui/app/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-service.js
@@ -331,7 +331,7 @@ class HydratorPlusPlusHydratorService {
   }
 
   isVersionInRange({supportedVersion, versionRange} = {}) {
-    let flattendVersion = versionRange;
+    let flattenedVersion = versionRange;
     let isNil = (value) => _.isUndefined(value) && _.isNull(value);
     if (isNil(supportedVersion) || isNil(versionRange)) {
       return false;
@@ -345,7 +345,12 @@ class HydratorPlusPlusHydratorService {
         return false;
       }
     }
-    return flattendVersion;
+
+    if (supportedVersion !== versionRange) {
+      return false;
+    }
+
+    return flattenedVersion;
   }
 
   convertMapToKeyValuePairs(obj) {

--- a/cdap-ui/app/hydrator/services/hydrator-upgrade-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-upgrade-service.js
@@ -1,0 +1,369 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+class HydratorUpgradeService {
+  constructor($rootScope, myPipelineApi, $state, $uibModal, HydratorPlusPlusConfigStore, HydratorPlusPlusLeftPanelStore, $q) {
+    this.$rootScope = $rootScope;
+    this.myPipelineApi = myPipelineApi;
+    this.$state = $state;
+    this.$uibModal = $uibModal;
+    this.HydratorPlusPlusConfigStore = HydratorPlusPlusConfigStore;
+    this.leftPanelStore = HydratorPlusPlusLeftPanelStore;
+    this.$q = $q;
+  }
+
+  _checkVersionIsInRange(range, version) {
+    if (!range || !version) { return false; }
+
+    if (['[', '('].indexOf(range[0]) !== -1) {
+      const supportedVersion = new window.CaskCommon.Version(version);
+      const versionRange = new window.CaskCommon.VersionRange(range);
+
+      return versionRange.versionIsInRange(supportedVersion);
+    }
+
+    // Check equality if range is just a single version
+    return range === version;
+  }
+
+  checkPipelineArtifactVersion(config) {
+    if (!config || !config.artifact) { return false; }
+
+    let cdapVersion = this.$rootScope.cdapVersion;
+
+    return this._checkVersionIsInRange(config.artifact.version, cdapVersion);
+  }
+
+  _fetchPostRunActions() {
+    let params = {
+      namespace: this.$state.params.namespace,
+      pipelineType: 'cdap-data-pipeline',
+      version: this.$rootScope.cdapVersion,
+      extensionType: 'postaction'
+    };
+
+    return this.myPipelineApi.fetchPlugins(params);
+  }
+
+  /**
+   * Create plugin artifacts map based on left panel store.
+   * The key will be '<plugin name>-<plugin type>-<artifact name>'
+   * Each map will contain an array of all the artifacts and
+   * also information about highest version.
+   * If there exist 2 artifacts with same version, it will maintain both scopes in an array.
+   **/
+  _createPluginsMap(pipelineConfig) {
+    let plugins = this.leftPanelStore.getState().plugins.pluginTypes;
+    let pluginTypes = Object.keys(plugins);
+
+    let pluginsMap = {};
+
+    pluginTypes.forEach((type) => {
+      plugins[type].forEach((plugin) => {
+        let key = `${plugin.name}-${type}-${plugin.artifact.name}`;
+
+        let allArtifacts = plugin.allArtifacts.map((artifactInfo) => {
+          return artifactInfo.artifact;
+        });
+
+        let highestVersion;
+        let artifactVersionMap = {};
+
+        allArtifacts.forEach((artifact) => {
+          if (!highestVersion) {
+            highestVersion = artifact;
+          } else if (highestVersion.version === artifact.version) {
+            highestVersion.scope = [highestVersion.scope, artifact.scope];
+          } else {
+            let prevVersion = new window.CaskCommon.Version(highestVersion.version);
+            let currVersion = new window.CaskCommon.Version(artifact.version);
+
+            if (currVersion.compareTo(prevVersion) === 1) {
+              highestVersion = artifact;
+            }
+          }
+
+          if (artifactVersionMap[artifact.version]) {
+            let existingScope = artifactVersionMap[artifact.version];
+            artifactVersionMap[artifact.version] = [existingScope, artifact.scope];
+          } else {
+            artifactVersionMap[artifact.version] = artifact.scope;
+          }
+        });
+
+        let value = {
+          allArtifacts,
+          highestVersion,
+          artifactVersionMap
+        };
+
+        pluginsMap[key] = value;
+      });
+    });
+
+    let deferred = this.$q.defer();
+
+    if (pipelineConfig.artifact.name === 'cdap-data-pipeline') {
+      this._fetchPostRunActions()
+        .$promise
+        .then((res) => {
+          let postRunActionsMap = {};
+
+          res.forEach((plugin) => {
+            let postRunKey = `${plugin.name}-${plugin.type}-${plugin.artifact.name}`;
+
+            postRunActionsMap[postRunKey] = {
+              allArtifacts: [plugin.artifact],
+              highestVersion: plugin.artifact,
+              artifactVersionMap: {}
+            };
+
+            postRunActionsMap[postRunKey].artifactVersionMap[plugin.artifact.version] = plugin.artifact.scope;
+          });
+
+          pluginsMap  = Object.assign(pluginsMap, postRunActionsMap);
+
+          deferred.resolve(pluginsMap);
+        });
+    } else {
+      deferred.resolve(pluginsMap);
+    }
+
+    return deferred.promise;
+  }
+
+  _checkErrorStages(stages, pluginsMap) {
+    let transformedStages = [];
+
+    stages.forEach((stage) => {
+      let stageKey = `${stage.plugin.name}-${stage.plugin.type}-${stage.plugin.artifact.name}`;
+
+      let stageArtifact = stage.plugin.artifact;
+
+      let data = {
+        stageInfo: stage,
+        error: null
+      };
+
+      if (!pluginsMap[stageKey]) {
+        data.error = 'NOTFOUND';
+      } else if (!this._checkVersionIsInRange(stageArtifact.version, pluginsMap[stageKey].highestVersion.version)) {
+        data.error = 'VERSION_MISMATCH';
+        data.suggestion = pluginsMap[stageKey].highestVersion;
+
+        if (typeof data.suggestion.scope !== 'string') {
+          // defaulting to USER scope when both version exists
+          data.suggestion.scope = 'USER';
+        }
+
+        // This is to check whether the version of the imported pipeline exist or not
+        let existingVersion = pluginsMap[stageKey].artifactVersionMap[stageArtifact.version];
+        if (existingVersion && existingVersion.indexOf(stageArtifact.scope) !== -1) {
+          data.error = 'CAN_UPGRADE';
+        }
+      } else if (pluginsMap[stageKey].highestVersion.scope.indexOf(stageArtifact.scope) < 0) {
+        data.error = 'SCOPE_MISMATCH';
+        data.suggestion = pluginsMap[stageKey].highestVersion;
+      }
+
+      transformedStages.push(data);
+    });
+
+    return transformedStages;
+  }
+
+  getErrorStages(pipelineConfig) {
+    let configStages = pipelineConfig.config.stages;
+    let configPostActions = pipelineConfig.config.postActions;
+
+    return this._createPluginsMap(pipelineConfig)
+      .then((pluginsMap) => {
+        let stages = this._checkErrorStages(configStages, pluginsMap);
+        let postActions = this._checkErrorStages(configPostActions, pluginsMap);
+
+        return {
+          stages,
+          postActions
+        };
+      });
+  }
+
+  upgradePipelineArtifactVersion(pipelineConfig) {
+    if (!pipelineConfig || !pipelineConfig.artifact) { return; }
+
+    let cdapVersion = this.$rootScope.cdapVersion;
+
+    let configClone = _.cloneDeep(pipelineConfig);
+
+    configClone.artifact.version = cdapVersion;
+
+    return configClone;
+  }
+
+  validateAndUpgradeConfig(pipelineConfig) {
+    this.$uibModal.open({
+      templateUrl: '/assets/features/hydrator/templates/create/pipeline-upgrade-modal.html',
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false,
+      windowTopClass: 'hydrator-modal node-config-modal upgrade-modal',
+      controllerAs: 'PipelineUpgradeController',
+      controller: function ($scope, rPipelineConfig, HydratorUpgradeService, $rootScope, HydratorPlusPlusConfigStore, $state, DAGPlusPlusFactory, GLOBALS, HydratorPlusPlusLeftPanelStore) {
+        let eventEmitter = window.CaskCommon.ee(window.CaskCommon.ee);
+        let globalEvents = window.CaskCommon.globalEvents;
+
+        this.pipelineConfig = rPipelineConfig;
+        this.cdapVersion = $rootScope.cdapVersion;
+
+        this.pipelineArtifact = HydratorUpgradeService.checkPipelineArtifactVersion(rPipelineConfig);
+
+        this.problematicStages = [];
+        this.missingArtifactStages = [];
+        this.canUpgradeStages = [];
+        let allStages = [];
+
+        let allPostActions = [];
+        this.problematicPostRunActions = [];
+        this.missingArtifactPostRunActions = [];
+        this.fixAllDisabled = true;
+
+        this.loading = true;
+
+        const checkStages = () => {
+          this.loading = true;
+
+          HydratorUpgradeService.getErrorStages(rPipelineConfig)
+            .then((transformedStages) => {
+              allStages = transformedStages.stages.map((stage) => {
+                stage.icon = DAGPlusPlusFactory.getIcon(stage.stageInfo.plugin.name.toLowerCase());
+                stage.type = GLOBALS.pluginConvert[stage.stageInfo.plugin.type];
+                return stage;
+              });
+
+              allPostActions = transformedStages.postActions.map((stage) => {
+                stage.icon = DAGPlusPlusFactory.getIcon(stage.stageInfo.plugin.name.toLowerCase());
+                stage.type = 'postaction';
+                return stage;
+              });
+
+              this.problematicStages = [];
+              this.missingArtifactStages = [];
+              this.canUpgradeStages = [];
+              this.problematicPostRunActions = [];
+              this.missingArtifactPostRunActions = [];
+
+              transformedStages.stages.forEach((artifact) => {
+                if (artifact.error === 'NOTFOUND') {
+                  this.missingArtifactStages.push(artifact);
+                } else if (artifact.error === 'CAN_UPGRADE') {
+                  artifact.upgrade = true;
+                  this.canUpgradeStages.push(artifact);
+                } else if (artifact.error) {
+                  this.problematicStages.push(artifact);
+                }
+              });
+
+              transformedStages.postActions.forEach((artifact) => {
+                if (artifact.error === 'NOTFOUND') {
+                  this.missingArtifactPostRunActions.push(artifact);
+                } else if (artifact.error) {
+                  this.problematicPostRunActions.push(artifact);
+                }
+              });
+
+              this.fixAllDisabled = this.missingArtifactStages.length > 0 || this.missingArtifactPostRunActions.length > 0;
+
+              if (
+                this.problematicStages.length === 0 &&
+                this.missingArtifactStages.length === 0 &&
+                this.pipelineArtifact &&
+                this.canUpgradeStages.length === 0 &&
+                this.missingArtifactPostRunActions.length === 0 &&
+                this.problematicPostRunActions.length === 0
+              ) {
+                HydratorPlusPlusConfigStore.setState(HydratorPlusPlusConfigStore.getDefaults());
+                $state.go('hydrator.create', { data: rPipelineConfig });
+              } else {
+                this.loading = false;
+              }
+            });
+        };
+
+        checkStages();
+
+        let sub = HydratorPlusPlusLeftPanelStore.subscribe(checkStages);
+
+        this.openMarket = () => {
+          eventEmitter.emit(globalEvents.OPENMARKET);
+        };
+
+        const fix = (stagesList) => {
+          return stagesList.map((stage) => {
+            let updatedStageInfo = stage.stageInfo;
+
+            if (stage.error && stage.error === 'NOTFOUND') {
+              updatedStageInfo.error = true;
+              updatedStageInfo.errorCount = 1;
+              updatedStageInfo.errorMessage = 'Plugin cannot be found';
+            } else if (stage.error) {
+              if (stage.error === 'CAN_UPGRADE' && stage.upgrade || stage.error !== 'CAN_UPGRADE') {
+                updatedStageInfo.plugin.artifact = stage.suggestion;
+              }
+            }
+
+            return updatedStageInfo;
+          });
+        };
+
+        this.fixAll = () => {
+          let newConfig = HydratorUpgradeService.upgradePipelineArtifactVersion(rPipelineConfig);
+
+          // Making a copy here so that the information in the modal does not change when
+          // we modify the artifact information
+          let copyAllStages = angular.copy(allStages);
+          let copyPostActions = angular.copy(allPostActions);
+
+          let stages = fix(copyAllStages);
+          let postActions = fix(copyPostActions);
+
+          newConfig.config.stages = stages;
+          newConfig.config.postActions = postActions;
+
+          if (newConfig.__ui__) {
+            delete newConfig.__ui__;
+          }
+
+          HydratorPlusPlusConfigStore.setState(HydratorPlusPlusConfigStore.getDefaults());
+          $state.go('hydrator.create', { data: newConfig });
+        };
+
+        $scope.$on('$destroy', () => {
+          sub();
+        });
+
+      },
+      resolve: {
+        rPipelineConfig: function () {
+          return pipelineConfig;
+        }
+      }
+    });
+
+  }
+}
+
+angular.module(PKG.name + '.feature.hydrator')
+  .service('HydratorUpgradeService', HydratorUpgradeService);

--- a/cdap-ui/app/hydrator/services/non-store-pipeline-error-factory.js
+++ b/cdap-ui/app/hydrator/services/non-store-pipeline-error-factory.js
@@ -96,7 +96,8 @@ let hasAtleastOneSource = (myHelpers, GLOBALS, nodes, cb) => {
     cb(false);
   }
   nodes.forEach( node => {
-    if (GLOBALS.pluginConvert[node.type] === 'source') {
+    let type = node.type || node.plugin.type;
+    if (GLOBALS.pluginConvert[type] === 'source') {
       countSource++;
     }
   });
@@ -149,7 +150,8 @@ let hasAtLeastOneSink = (myHelpers, GLOBALS, nodes, cb) => {
     cb(false);
   }
   nodes.forEach( node => {
-    if (GLOBALS.pluginConvert[node.type] === 'sink') {
+    let type = node.type || node.plugin.type;
+    if (GLOBALS.pluginConvert[type] === 'sink') {
       countSink++;
     }
   });
@@ -178,7 +180,8 @@ let allNodesConnected = (GLOBALS, nodes, connections, cb) => {
   });
 
   angular.forEach(nodes, (node) => {
-    switch (GLOBALS.pluginConvert[node.type]) {
+    let type = node.type || node.plugin.type;
+    switch (GLOBALS.pluginConvert[type]) {
       case 'source':
         if (!outputConnection[node.name]){
           cb(node);

--- a/cdap-ui/app/hydrator/templates/create/pipeline-upgrade-modal.html
+++ b/cdap-ui/app/hydrator/templates/create/pipeline-upgrade-modal.html
@@ -1,0 +1,177 @@
+<!--
+  Copyright © 2017 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="modal-header">
+  <h3 class="modal-title pull-left">Import Pipeline</h3>
+  <div class="btn-group pull-right">
+    <a class="btn" ng-click="$close()">
+      <span class="fa fa-times"></span>
+    </a>
+  </div>
+</div>
+
+<div
+  class="modal-body"
+  ng-if="PipelineUpgradeController.loading"
+>
+  <h3 class="text-xs-center">
+    <span class="fa fa-spin fa-spinner">
+  </h3>
+</div>
+
+<div
+  class="modal-body"
+  ng-if="!PipelineUpgradeController.loading"
+>
+  <h4 ng-if="PipelineUpgradeController.missingArtifactStages.length > 0 || PipelineUpgradeController.problematicStages.length > 0 || PipelineUpgradeController.problematicPostRunActions.length > 0 || PipelineUpgradeController.missingArtifactPostRunActions.length > 0">
+    Your pipeline cannot be imported because of the following issues:
+  </h4>
+
+  <div
+    class="row import-error-row"
+    ng-if="PipelineUpgradeController.missingArtifactStages.length > 0 || PipelineUpgradeController.missingArtifactPostRunActions.length > 0"
+  >
+    <div class="col-xs-12">
+      <h4>Missing Plugin Artifacts</h4>
+
+      <ul>
+        <li ng-repeat="stage in PipelineUpgradeController.missingArtifactStages.concat(PipelineUpgradeController.missingArtifactPostRunActions)">
+          {{ stage.stageInfo.plugin.name }} <em>({{ stage.stageInfo.plugin.artifact.name }} {{ stage.stageInfo.plugin.artifact.version }}) </em>
+        </li>
+      </ul>
+
+      <div>
+        <button
+          class="btn btn-primary"
+          ng-click="PipelineUpgradeController.openMarket()"
+        >
+          Find Plugin in Market
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div
+    class="row import-error-row"
+    ng-if="!PipelineUpgradeController.pipelineArtifact"
+  >
+    <div class="col-xs-12">
+      <h4>Pipeline Artifact</h4>
+
+      <span>
+        <em>{{ PipelineUpgradeController.pipelineConfig.artifact.name }}</em> artifact version {{ PipelineUpgradeController.pipelineConfig.artifact.version }} needs to be upgraded to {{ PipelineUpgradeController.cdapVersion }}
+      </span>
+    </div>
+  </div>
+
+  <div
+    class="row import-error-row"
+    ng-repeat="stage in PipelineUpgradeController.canUpgradeStages.concat(PipelineUpgradeController.problematicStages, PipelineUpgradeController.problematicPostRunActions)"
+  >
+    <div class="col-xs-12">
+      <h4 class="stage-title {{ stage.type }} {{ stage.stageInfo.plugin.type }}">
+        <span class="fa fa-fw {{ stage.icon }}"></span>
+        {{ stage.stageInfo.name }}
+      </h4>
+
+      <div ng-if="stage.error === 'VERSION_MISMATCH'">
+        <div class="error-description">
+          There is a different version available for plugin artifact <em>{{ stage.stageInfo.plugin.artifact.name }}</em>.
+        </div>
+
+        <div class="error-suggestion">
+          <span>
+            <strong>Imported Version:</strong>
+            {{ stage.stageInfo.plugin.artifact.version }}
+          </span>
+          <span>
+            <strong>Available Version:</strong>
+            {{ stage.suggestion.version }}
+          </span>
+        </div>
+      </div>
+
+      <div ng-if="stage.error === 'CAN_UPGRADE'">
+        <div class="row">
+          <div class="col-xs-8">
+            <div class="error-description">
+              A newer version of this plugin exist.
+            </div>
+
+            <div class="error-suggestion">
+              <span>
+                <strong>Imported Version:</strong>
+                {{ stage.stageInfo.plugin.artifact.version }}
+              </span>
+              <span>
+                <strong>Newer Version:</strong>
+                {{ stage.suggestion.version }}
+              </span>
+            </div>
+          </div>
+
+          <div class="col-xs-4 text-right">
+            <div class="checkbox">
+              <label>
+                <input
+                  type="checkbox"
+                  ng-model="stage.upgrade"
+                > Upgrade
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div ng-if="stage.error === 'SCOPE_MISMATCH'">
+        <div class="error-description">
+          The plugin artifact <em>{{ stage.stageInfo.plugin.artifact.name }}</em> exists in different scope.
+        </div>
+
+        <div class="error-suggestion">
+          <span>
+            <strong>Imported Scope:</strong>
+            {{ stage.stageInfo.plugin.artifact.scope }}
+          </span>
+          <span>
+            <strong>Available Scope:</strong>
+            {{ stage.suggestion.scope }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div
+  class="modal-footer"
+  ng-if="!PipelineUpgradeController.loading"
+>
+  <button
+    class="btn btn-primary"
+    ng-click="PipelineUpgradeController.fixAll()"
+  >
+    <span ng-if="!PipelineUpgradeController.fixAllDisabled">Fix All</span>
+    <span ng-if="PipelineUpgradeController.fixAllDisabled">Proceed</span>
+  </button>
+  <button
+    class="btn btn-default"
+    ng-click="$close()"
+  >
+    Cancel
+  </button>
+</div>

--- a/cdap-ui/app/services/hydrator/my-pipeline-api.js
+++ b/cdap-ui/app/services/hydrator/my-pipeline-api.js
@@ -24,6 +24,7 @@ angular.module(PKG.name + '.services')
         loadArtifactJSON = loadArtifactPath + '/versions/:version/properties',
         listPath = '/namespaces/:namespace/apps?artifactName=' + GLOBALS.etlBatch + ',' + GLOBALS.etlRealtime + ',' + GLOBALS.etlDataPipeline + ',' + GLOBALS.etlDataStreams,
         artifactsPath = '/namespaces/:namespace/artifacts?scope=SYSTEM',
+        artifactsBasePath = '/namespaces/:namespace/artifacts',
         extensionsFetchBase = '/namespaces/:namespace/artifacts/:pipelineType/versions/:version/extensions',
         pluginFetchBase = extensionsFetchBase + '/:extensionType',
         pluginsFetchPath = pluginFetchBase + '?scope=system',
@@ -45,6 +46,8 @@ angular.module(PKG.name + '.services')
         loadArtifact: myHelpers.getConfig('POST', 'REQUEST', loadArtifactPath, false, {contentType: 'application/java-archive'}),
         loadJson: myHelpers.getConfig('PUT', 'REQUEST', loadArtifactJSON, false, {contentType: 'application/json'}),
         save: myHelpers.getConfig('PUT', 'REQUEST', pipelinePath, false, {contentType: 'application/json'}),
+        getAllArtifacts:myHelpers.getConfig('GET', 'REQUEST', artifactsBasePath, true),
+
         fetchArtifacts: myHelpers.getConfig('GET', 'REQUEST', artifactsPath, true),
         fetchExtensions: myHelpers.getConfig('GET', 'REQUEST', extensionsFetchPath, true),
         fetchSources: myHelpers.getConfig('GET', 'REQUEST', pluginsFetchPath, true),
@@ -55,7 +58,6 @@ angular.module(PKG.name + '.services')
         fetchSourceProperties: myHelpers.getConfig('GET', 'REQUEST', pluginDetailFetch, true),
         fetchSinkProperties: myHelpers.getConfig('GET', 'REQUEST', pluginDetailFetch, true),
         fetchTransformProperties: myHelpers.getConfig('GET', 'REQUEST', pluginDetailFetch, true),
-
         fetchArtifactProperties: myHelpers.getConfig('GET', 'REQUEST', artifactPropertiesPath),
 
         // The above three could be replaced by this one.


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-10670 - Fixing Plugin scope between USER vs SYSTEM
- https://issues.cask.co/browse/CDAP-11051 - Missing plugin would ask the user to download from market
- https://issues.cask.co/browse/CDAP-11956 - Do a specific version comparison in addition to check version is in range for pipeline artifact
- https://issues.cask.co/browse/CDAP-11547 - Missing plugin would ask the user to download from market
- https://issues.cask.co/browse/CDAP-9224 - this error message should not happen anymore


## Approach
When you import a pipeline, there is a modal that would appear if there is some problem:
1. Pipeline artifact version/version range does not include current CDAP version
2. Newer plugin artifact version exist
3. Plugin does not exist
4. Plugin exist in different scope