### PR TITLE
[CDAP-9253] Add tooltip to custom condition option in filter directive

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/ColumnActionsDropdown.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/ColumnActionsDropdown.scss
@@ -155,30 +155,32 @@ $column-type-label-color: #b6babc;
   }
 }
 
-.popover.bs-tether-element {
-  padding: 0;
-  border-radius: 0;
-  z-index: 999; // z-index of service down modal is 1000
+.popover {
+  &.column_actions_dropdown-element {
+    padding: 0;
+    border-radius: 0;
+    z-index: 999; // z-index of service down modal is 1000
 
-  &.bs-tether-element-attached-top {
-    margin-top: 8px;
-  }
+    &.column_actions_dropdown-element-attached-top {
+      margin-top: 8px;
+    }
 
-  &.bs-tether-element-attached-right {
-    margin-left: 18px;
-  }
+    &.column_actions_dropdown-element-attached-right {
+      margin-left: 18px;
+    }
 
-  &.bs-tether-element-attached-left {
-    margin-left: -18px;
-  }
+    &.column_actions_dropdown-element-attached-left {
+      margin-left: -18px;
+    }
 
-  &.bs-tether-out-of-bounds-right,
-  &.bs-tether-out-of-bounds-top {
-    display: none;
-  }
+    &.column_actions_dropdown-out-of-bounds-right,
+    &.column_actions_dropdown-out-of-bounds-top {
+      display: none;
+    }
 
-  &:before,
-  &:after {
-    display: none;
+    &:before,
+    &:after {
+      display: none;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -261,6 +261,7 @@ export default class ColumnActionsDropdown extends Component {
     const tetherOption = {
       attachment: 'top right',
       targetAttachment: 'bottom left',
+      classPrefix: 'column_actions_dropdown',
       constraints: [
         {
           to: tableContainer,

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/FilterDirective.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/FilterDirective.scss
@@ -14,6 +14,11 @@
  * the License.
  */
 
+@import '../../../../styles/variables.scss';
+
+$tooltip_arrow_color: rgba(0, 0, 0, 0.2);
+$tooltip_arrow_after_color: #eeeeee;
+
 .filter-directive {
   .filter-detail {
     .row-filter-container { margin-bottom: 10px; }
@@ -33,6 +38,13 @@
         div { width: calc(100% - 15px); }
       }
 
+      .custom-condition-container {
+        margin-top: 10px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
       textarea.form-control {
         min-width: 100%;
         max-width: 100%;
@@ -45,6 +57,30 @@
         font-weight: 600;
         text-decoration: underline;
       }
+    }
+    #customConditionTooltip {
+      color: $brand-primary;
+      cursor: pointer;
+    }
+  }
+}
+
+.popover {
+  margin-left: 10px;
+  &.filter-popover-element {
+    &:before {
+      left: -11px;
+      margin-top: -11px;
+      border-right-color: $tooltip_arrow_color;
+      top: 50%;
+      border-left-width: 0;
+    }
+    &:after {
+      top: 50%;
+      border-left-width: 0;
+      left: -10px;
+      margin-top: -10px;
+      border-right-color: $tooltip_arrow_after_color;
     }
   }
 }

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/index.js
@@ -21,6 +21,8 @@ import T from 'i18n-react';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import MouseTrap from 'mousetrap';
+import { Popover, PopoverTitle, PopoverContent } from 'reactstrap';
+import IconSVG from 'components/IconSVG';
 
 require('./FilterDirective.scss');
 
@@ -56,7 +58,8 @@ export default class FilterDirective extends Component {
       textFilter: '',
       rowFilter: 'KEEP',
       customFilter: '',
-      ignoreCase: false
+      ignoreCase: false,
+      customConditionTooltip: false
     };
 
     this.handleConditionSelect = this.handleConditionSelect.bind(this);
@@ -203,12 +206,45 @@ export default class FilterDirective extends Component {
       });
   }
 
+  toggleCustomTooltip() {
+    this.setState({
+      customConditionTooltip: !this.state.customConditionTooltip
+    });
+  }
+
   renderCustomFilter() {
     if (this.state.selectedCondition.substr(0, 6) !== 'CUSTOM') { return null; }
 
     return (
       <div>
-        <br />
+        <div className="custom-condition-container">
+          <strong>{T.translate(`${PREFIX}.customconditionlabel`)}</strong>
+          <div id="customConditionTooltip">
+            <IconSVG
+              name="icon-info-circle"
+              onClick={this.toggleCustomTooltip.bind(this)}
+            />
+          </div>
+          <Popover
+            placement="right"
+            tether={{classPrefix: 'filter-popover'}}
+            isOpen={this.state.customConditionTooltip}
+            target="customConditionTooltip"
+            toggle={this.toggleCustomTooltip.bind(this)}
+          >
+            <PopoverTitle>{T.translate(`${PREFIX}.customconditiontooltiptitle`)}</PopoverTitle>
+            <PopoverContent>
+              <span>{T.translate(`${PREFIX}.customconditiontooltip`)}</span>
+              <a
+                href="http://commons.apache.org/proper/commons-jexl/"
+                target="_blank"
+              >
+                {T.translate(`${PREFIX}.customconditiontooltiplink`)}
+              </a>
+            </PopoverContent>
+          </Popover>
+        </div>
+
         <textarea
           className="form-control"
           value={this.state.customFilter}

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -563,6 +563,10 @@ features:
           TEXTEXACTLY: value is
           TEXTREGEX: value matches regex
           TEXTSTARTSWITH: value starts with
+        customconditionlabel: 'equals to: '
+        customconditiontooltiptitle: JEXL expressions
+        customconditiontooltip: "A custom condition can be defined using JEXL expressions. For more details regarding JEXL, please refer to  "
+        customconditiontooltiplink: JEXL Expressions
         if: If
         ignoreCase: Ignore Case
         KEEP: Keep rows


### PR DESCRIPTION
- Fixes styling for `ColumnActionsDropdown` to be namespaced to avoid affecting popovers added under it
- Adds tooltip to custom condition option in filter directive

JIRA: https://issues.cask.co/browse/CDAP-9253

#### Note:
The tooltip doesn't appear on hover as it gets tricky to go inside the tooltip when its open. Tooltip is shown on click instead of hover.