### PR TITLE
[CDAP-12230] Separate RunRecordCorrectorService from ProgramLifecycleService

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -81,7 +81,10 @@ import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
 import co.cask.cdap.internal.app.runtime.schedule.store.TriggerMisfireLogger;
 import co.cask.cdap.internal.app.services.AppFabricServer;
+import co.cask.cdap.internal.app.services.DistributedRunRecordCorrectorService;
+import co.cask.cdap.internal.app.services.LocalRunRecordCorrectorService;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
+import co.cask.cdap.internal.app.services.RunRecordCorrectorService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.internal.pipeline.SynchronousPipelineFactory;
@@ -158,6 +161,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new AbstractModule() {
                              @Override
                              protected void configure() {
+                               bind(RunRecordCorrectorService.class).to(LocalRunRecordCorrectorService.class)
+                                 .in(Scopes.SINGLETON);
                                bind(SchedulerService.class).to(LocalSchedulerService.class).in(Scopes.SINGLETON);
                                bind(Scheduler.class).to(SchedulerService.class);
                                bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
@@ -201,6 +206,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                              @Override
                              protected void configure() {
                                bind(AppFabricServer.class).to(StandaloneAppFabricServer.class).in(Scopes.SINGLETON);
+                               bind(RunRecordCorrectorService.class).to(LocalRunRecordCorrectorService.class)
+                                 .in(Scopes.SINGLETON);
                                bind(SchedulerService.class).to(LocalSchedulerService.class).in(Scopes.SINGLETON);
                                bind(Scheduler.class).to(SchedulerService.class);
                                bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
@@ -268,6 +275,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new AbstractModule() {
                              @Override
                              protected void configure() {
+                               bind(RunRecordCorrectorService.class).to(DistributedRunRecordCorrectorService.class)
+                                 .in(Scopes.SINGLETON);
                                bind(SchedulerService.class).to(DistributedSchedulerService.class).in(Scopes.SINGLETON);
                                bind(Scheduler.class).to(SchedulerService.class);
                                bind(MRJobInfoFetcher.class).to(DistributedMRJobInfoFetcher.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractRunRecordCorrectorService.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.app.runtime.ProgramController;
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import org.apache.twill.api.RunId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A default implementation of {@link RunRecordCorrectorService}.
+ */
+public class AbstractRunRecordCorrectorService extends AbstractIdleService implements RunRecordCorrectorService {
+  private static final Logger LOG = LoggerFactory.getLogger(ProgramLifecycleService.class);
+
+  private final Store store;
+  private final ProgramLifecycleService programLifecycleService;
+  private final ProgramRuntimeService runtimeService;
+
+  @Inject
+  AbstractRunRecordCorrectorService(Store store, ProgramLifecycleService programLifecycleService,
+                                    ProgramRuntimeService runtimeService) {
+    this.store = store;
+    this.programLifecycleService = programLifecycleService;
+    this.runtimeService = runtimeService;
+  }
+
+  void validateAndCorrectRunningRunRecords() {
+    Set<String> processedInvalidRunRecordIds = Sets.newHashSet();
+
+    // Lets update the running programs run records
+    for (ProgramType programType : ProgramType.values()) {
+      validateAndCorrectRunningRunRecords(programType, processedInvalidRunRecordIds);
+    }
+
+    if (!processedInvalidRunRecordIds.isEmpty()) {
+      LOG.info("Corrected {} of run records with RUNNING status but no actual program running.",
+               processedInvalidRunRecordIds.size());
+    }
+  }
+
+  /**
+   * Fix all the possible inconsistent states for RunRecords that shows it is in RUNNING state but actually not
+   * via check to {@link ProgramRuntimeService} for a type of CDAP program.
+   *
+   * @param programType The type of program the run records need to validate and update.
+   * @param processedInvalidRunRecordIds the {@link Set} of processed invalid run record ids.
+   */
+  private void validateAndCorrectRunningRunRecords(final ProgramType programType,
+                                                   final Set<String> processedInvalidRunRecordIds) {
+    final Map<RunId, ProgramRuntimeService.RuntimeInfo> runIdToRuntimeInfo = runtimeService.list(programType);
+
+    LOG.trace("Start getting run records not actually running ...");
+    Collection<RunRecordMeta> notActuallyRunning =
+      store.getRuns(ProgramRunStatus.RUNNING,
+                    new com.google.common.base.Predicate<RunRecordMeta>() {
+                      @Override
+                      public boolean apply(RunRecordMeta input) {
+                        String runId = input.getPid();
+                        // Check if it is not actually running.
+                        return !runIdToRuntimeInfo.containsKey(RunIds.fromString(runId));
+                      }
+                    }).values();
+    LOG.trace("End getting {} run records not actually running.", notActuallyRunning.size());
+
+    final Map<String, ProgramId> runIdToProgramId = new HashMap<>();
+
+    LOG.trace("Start getting invalid run records  ...");
+    Collection<RunRecordMeta> invalidRunRecords =
+      Collections2.filter(notActuallyRunning, new com.google.common.base.Predicate<RunRecordMeta>() {
+        @Override
+        public boolean apply(RunRecordMeta input) {
+          String runId = input.getPid();
+          // check for program Id for the run record, if null then it is invalid program type.
+          ProgramId targetProgramId = programLifecycleService.retrieveProgramIdForRunRecord(programType, runId);
+
+          // Check if run id is for the right program type
+          if (targetProgramId != null) {
+            runIdToProgramId.put(runId, targetProgramId);
+            return true;
+          } else {
+            return false;
+          }
+        }
+      });
+
+    // don't correct run records for programs running inside a workflow
+    // for instance, a MapReduce running in a Workflow will not be contained in the runtime info in this class
+    invalidRunRecords = Collections2.filter(invalidRunRecords, new com.google.common.base.Predicate<RunRecordMeta>() {
+      @Override
+      public boolean apply(RunRecordMeta invalidRunRecordMeta) {
+        boolean shouldCorrect = shouldCorrectForWorkflowChildren(invalidRunRecordMeta, processedInvalidRunRecordIds);
+        if (!shouldCorrect) {
+          LOG.trace("Will not correct invalid run record {} since it's parent workflow still running.",
+                    invalidRunRecordMeta);
+          return false;
+        }
+        return true;
+      }
+    });
+
+    LOG.trace("End getting invalid run records.");
+
+    if (!invalidRunRecords.isEmpty()) {
+      LOG.warn("Found {} RunRecords with RUNNING status and the program not actually running for program type {}",
+               invalidRunRecords.size(), programType.getPrettyName());
+    } else {
+      LOG.trace("No RunRecords found with RUNNING status and the program not actually running for program type {}",
+                programType.getPrettyName());
+    }
+
+    // Now lets correct the invalid RunRecords
+    for (RunRecordMeta invalidRunRecordMeta : invalidRunRecords) {
+      String runId = invalidRunRecordMeta.getPid();
+      ProgramId targetProgramId = runIdToProgramId.get(runId);
+
+      boolean updated = store.compareAndSetStatus(targetProgramId, runId, ProgramController.State.ALIVE.getRunStatus(),
+                                                  ProgramController.State.ERROR.getRunStatus());
+      if (updated) {
+        LOG.warn("Fixed RunRecord {} for program {} with RUNNING status because the program was not " +
+                   "actually running",
+                 runId, targetProgramId);
+
+        processedInvalidRunRecordIds.add(runId);
+      }
+    }
+  }
+
+  /**
+   * Method to check if the run record is a child program of a Workflow
+   *
+   * @param runRecordMeta The target {@link RunRecordMeta} to check
+   * @param processedInvalidRunRecordIds the {@link Set} of processed invalid run record ids.
+   * @return {@code true} if we should check and {@code false} otherwise
+   */
+  private boolean shouldCorrectForWorkflowChildren(RunRecordMeta runRecordMeta,
+                                                   Set<String> processedInvalidRunRecordIds) {
+    // check if it is part of workflow because it may not have actual runtime info
+    if (runRecordMeta.getProperties() != null && runRecordMeta.getProperties().get("workflowrunid") != null) {
+
+      // Get the parent Workflow info
+      String workflowRunId = runRecordMeta.getProperties().get("workflowrunid");
+      if (!processedInvalidRunRecordIds.contains(workflowRunId)) {
+        // If the parent workflow has not been processed, then check if it still valid
+        ProgramId workflowProgramId = programLifecycleService.retrieveProgramIdForRunRecord(ProgramType.WORKFLOW,
+                                                                                            workflowRunId);
+        if (workflowProgramId != null) {
+          // lets see if the parent workflow run records state is still running
+          RunRecordMeta wfRunRecord = store.getRun(workflowProgramId, workflowRunId);
+          ProgramRuntimeService.RuntimeInfo wfRuntimeInfo = runtimeService.lookup(workflowProgramId,
+                                                                                  RunIds.fromString(workflowRunId));
+
+          // Check of the parent workflow run record exists and it is running and runtime info said it is still there
+          // then do not update it
+          if (wfRunRecord != null && wfRunRecord.getStatus() == ProgramRunStatus.RUNNING && wfRuntimeInfo != null) {
+            return false;
+          }
+        }
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting RunRecordCorrectorService");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping RunRecordCorrectorService");
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -83,6 +83,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final Set<String> handlerHookNames;
   private final StreamCoordinatorClient streamCoordinatorClient;
   private final ProgramLifecycleService programLifecycleService;
+  private final RunRecordCorrectorService runRecordCorrectorService;
   private final SystemArtifactLoader systemArtifactLoader;
   private final PluginService pluginService;
   private final CoreSchedulerService coreSchedulerService;
@@ -109,6 +110,7 @@ public class AppFabricServer extends AbstractIdleService {
                          @Named(Constants.AppFabric.HANDLERS_BINDING) Set<HttpHandler> handlers,
                          @Nullable MetricsCollectionService metricsCollectionService,
                          ProgramRuntimeService programRuntimeService,
+                         RunRecordCorrectorService runRecordCorrectorService,
                          ApplicationLifecycleService applicationLifecycleService,
                          ProgramLifecycleService programLifecycleService,
                          StreamCoordinatorClient streamCoordinatorClient,
@@ -133,6 +135,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.applicationLifecycleService = applicationLifecycleService;
     this.streamCoordinatorClient = streamCoordinatorClient;
     this.programLifecycleService = programLifecycleService;
+    this.runRecordCorrectorService = runRecordCorrectorService;
     this.systemArtifactLoader = systemArtifactLoader;
     this.pluginService = pluginService;
     this.appVersionUpgradeService = appVersionUpgradeService;
@@ -158,6 +161,7 @@ public class AppFabricServer extends AbstractIdleService {
         programRuntimeService.start(),
         streamCoordinatorClient.start(),
         programLifecycleService.start(),
+        runRecordCorrectorService.start(),
         pluginService.start(),
         coreSchedulerService.start()
       )
@@ -276,6 +280,7 @@ public class AppFabricServer extends AbstractIdleService {
     systemArtifactLoader.stopAndWait();
     notificationService.stopAndWait();
     programLifecycleService.stopAndWait();
+    runRecordCorrectorService.stopAndWait();
     pluginService.stopAndWait();
     if (appVersionUpgradeService != null) {
       appVersionUpgradeService.stopAndWait();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DistributedRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DistributedRunRecordCorrectorService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A distributed-mode only run record corrector service that corrects run records at a scheduled, configurable rate.
+ */
+public class DistributedRunRecordCorrectorService extends AbstractRunRecordCorrectorService {
+  private static final Logger LOG = LoggerFactory.getLogger(DistributedRunRecordCorrectorService.class);
+
+  private final CConfiguration cConf;
+  private ScheduledExecutorService scheduledExecutorService;
+
+  @Inject
+  public DistributedRunRecordCorrectorService(CConfiguration cConf, Store store,
+                                              ProgramLifecycleService programLifecycleService,
+                                              ProgramRuntimeService runtimeService) {
+    super(store, programLifecycleService, runtimeService);
+    this.cConf = cConf;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    super.startUp();
+
+    scheduledExecutorService = Executors.newScheduledThreadPool(1);
+    long interval = cConf.getLong(Constants.AppFabric.PROGRAM_RUNID_CORRECTOR_INTERVAL_SECONDS);
+    if (interval <= 0) {
+      LOG.debug("Invalid run id corrector interval {}. Setting it to 180 seconds.", interval);
+      interval = 180L;
+    }
+    scheduledExecutorService.scheduleWithFixedDelay(new RunRecordsCorrectorRunnable(),
+                                                    2L, interval, TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    super.shutDown();
+
+    scheduledExecutorService.shutdown();
+    try {
+      if (!scheduledExecutorService.awaitTermination(5, TimeUnit.SECONDS)) {
+        scheduledExecutorService.shutdownNow();
+      }
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Helper class to run in separate thread to validate the invalid running run records
+   */
+  private class RunRecordsCorrectorRunnable implements Runnable {
+
+    @Override
+    public void run() {
+      try {
+        LOG.trace("Start correcting invalid run records ...");
+
+        // Lets update the running programs run records
+        validateAndCorrectRunningRunRecords();
+
+        LOG.trace("End correcting invalid run records.");
+      } catch (Throwable t) {
+        // Ignore any exception thrown since this behaves like daemon thread.
+        //noinspection ThrowableResultOfMethodCallIgnored
+        LOG.warn("Unable to complete correcting run records: {}", Throwables.getRootCause(t).getMessage());
+        LOG.debug("Exception thrown when running run id cleaner.", t);
+      }
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/LocalRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/LocalRunRecordCorrectorService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.store.Store;
+import com.google.inject.Inject;
+
+/**
+ * A local-mode only run record corrector that corrects run records once upon app fabric server startup.
+ */
+public class LocalRunRecordCorrectorService extends AbstractRunRecordCorrectorService {
+
+  @Inject
+  public LocalRunRecordCorrectorService(Store store,
+                                        ProgramLifecycleService programLifecycleService,
+                                        ProgramRuntimeService runtimeService) {
+    super(store, programLifecycleService, runtimeService);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    super.startUp();
+
+    // In local mode, correct running records just once, on startup
+    validateAndCorrectRunningRunRecords();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.cdap.internal.app.services;
+
+import com.google.common.util.concurrent.Service;
+
+/**
+ * A service interface that defines the behavior when run records are corrected
+ */
+public interface RunRecordCorrectorService extends Service {
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -60,6 +60,7 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    ProgramRuntimeService programRuntimeService,
                                    ApplicationLifecycleService applicationLifecycleService,
                                    ProgramLifecycleService programLifecycleService,
+                                   RunRecordCorrectorService runRecordCorrectorService,
                                    StreamCoordinatorClient streamCoordinatorClient,
                                    @Named("appfabric.services.names") Set<String> servicesNames,
                                    @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
@@ -70,7 +71,7 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    RouteStore routeStore,
                                    CoreSchedulerService coreSchedulerService) {
     super(cConf, sConf, discoveryService, notificationService, hostname, handlers,
-          metricsCollectionService, programRuntimeService, applicationLifecycleService,
+          metricsCollectionService, programRuntimeService, runRecordCorrectorService, applicationLifecycleService,
           programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, namespaceAdmin,
           systemArtifactLoader, pluginService, null, routeStore, coreSchedulerService);
     this.metricStore = metricStore;


### PR DESCRIPTION
Separate `RunRecordCorrector` from `ProgramLifecycleService` into its own service because the RunRecordCorrector only needs to run on startup in local mode.

JIRA: https://issues.cask.co/browse/CDAP-12230
Build: https://builds.cask.co/browse/CDAP-DUT6001