### PR TITLE
Cherry pick for latest hbase versions

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -1054,7 +1054,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     }
 
     try {
-      Class<?> hbaseTableUtilClass = HBaseTableUtilFactory.getHBaseTableUtilClass();
+      Class<?> hbaseTableUtilClass = HBaseTableUtilFactory.getHBaseTableUtilClass(cConf);
       classes.add(hbaseTableUtilClass);
     } catch (ProvisionException e) {
       LOG.warn("Not including HBaseTableUtil classes in submitted Job Jar since they are not available");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -334,7 +334,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner,
               }
 
               Iterable<Class<?>> dependencies = Iterables.concat(
-                Collections.singletonList(HBaseTableUtilFactory.getHBaseTableUtilClass()),
+                Collections.singletonList(HBaseTableUtilFactory.getHBaseTableUtilClass(cConf)),
                 getKMSSecureStore(cConf), this.dependencies);
 
               Iterable<String> yarnAppClassPath = Arrays.asList(

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -413,7 +413,20 @@ cdap_set_hbase() {
     1.2-cdh*) __compat="${CDAP_HOME}"/hbase-compat-1.2-cdh5.7.0/lib/* ;; # 5.7 and 5.8 are compatible
     1.2*) __compat="${CDAP_HOME}"/hbase-compat-1.1/lib/* ;; # 1.1 and 1.2 are compatible
     "") die "Unable to determine HBase version! Aborting." ;;
-    *) die "Unknown/Unsupported HBase version found: ${HBASE_VERSION}" ;;
+    *)
+      if [[ $(cdap_get_conf "hbase.version.resolution.strategy" "${CDAP_CONF}"/cdap-site.xml auto.strict) == 'auto.latest' ]]; then
+        local readonly __latest_hbase_compat
+        if [[ ${HBASE_VERSION} =~ -cdh ]]; then
+          __latest_hbase_compat=hbase-compat-1.2-cdh5.7.0 # must be updated if a new CDH HBase version is added
+        else
+          __latest_hbase_compat=hbase-compat-1.1 # must be updated if a new HBase version is added
+        fi
+        __compat="${CDAP_HOME}"/${__latest_hbase_compat}/lib/*
+        echo "Using ${__latest_hbase_compat} for HBase version ${HBASE_VERSION} due to 'auto.latest' resolution strategy."
+      else
+        die "Unknown or unsupported HBase version found: ${HBASE_VERSION}"
+      fi
+      ;;
   esac
   export CLASSPATH="${__compat}":${CLASSPATH}
   return 0

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -123,6 +123,15 @@ public final class Constants {
     public static final String MANAGE_COPROCESSORS = "master.manage.hbase.coprocessors";
     public static final String CLIENT_RETRIES = "hbase.client.retries.number";
     public static final String RPC_TIMEOUT = "hbase.rpc.timeout";
+    /** Determines how to behave when the HBase version is unsupported. cdap_set_hbase() method
+     * in cdap-common/bin/functions.sh must also be updated if this String is changed */
+    public static final String HBASE_VERSION_RESOLUTION_STRATEGY = "hbase.version.resolution.strategy";
+    /** Keep HBase version as it is when HBase version is unsupported. cdap_set_hbase() method
+     * in cdap-common/bin/functions.sh must also be updated if this String is changed */
+    public static final String HBASE_AUTO_STRICT_VERSION = "auto.strict";
+    /** Use latest HBase version available on the cluster when HBase version is unsupported. cdap_set_hbase() method
+     * in cdap-common/bin/functions.sh must also be updated if this String is changed */
+    public static final String HBASE_AUTO_LATEST_VERSION = "auto.latest";
   }
 
   /**
@@ -983,6 +992,11 @@ public final class Constants {
     public static final String SUBMITVIACHILD = "hive.exec.submitviachild";
     public static final String HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST_APPEND =
       "hive.security.authorization.sqlstd.confwhitelist.append";
+
+    /** Determines how to behave when the Hive version is unsupported */
+    public static final String HIVE_VERSION_RESOLUTION_STRATEGY = "hive.version.resolution.strategy";
+    public static final String HIVE_AUTO_STRICT_VERSION = "auto.strict";
+    public static final String HIVE_AUTO_LATEST_VERSION = "auto.latest";
 
     // a marker so that we know which tables are created by CDAP
     public static final String CDAP_NAME = "cdap.name";

--- a/cdap-common/src/main/java/co/cask/cdap/common/runtime/DaemonMain.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/runtime/DaemonMain.java
@@ -34,7 +34,6 @@ public abstract class DaemonMain {
    * as if the program is started by jsvc.
    */
   protected void doMain(final String[] args) throws Exception {
-    Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
     init(args);
 
     final CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -58,6 +57,9 @@ public abstract class DaemonMain {
     });
 
     start();
+    // Set uncaught exception handler after startup, this is so that if startup throws exception then we
+    // want it to be logged as error (the handler logs it as debug)
+    Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
     shutdownLatch.await();
   }
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -948,6 +948,19 @@
     </description>
   </property>
 
+  <property>
+    <name>hive.version.resolution.strategy</name>
+    <value>auto.strict</value>
+    <description>
+      Determines how to behave when the Hive version on a cluster is an unsupported value.
+      The default value of "auto.strict" will require that the Hive version matches a
+      supported value; if Explore is enabled, CDAP Master will then not start if the Hive
+      version is unsupported. Set to "auto.latest" to use the latest Hive version of CDAP
+      modules available on the cluster with an unsupported Hive version. This property is
+      ignored for supported versions of Hive or if Explore has been disabled by setting
+      ${explore.enabled} to false.
+    </description>
+  </property>
 
   <!-- Gateway Configuration -->
 
@@ -1365,6 +1378,18 @@
     <value>15000</value>
     <description>
       RPC timeout from HBase operations performed from master services
+    </description>
+  </property>
+
+  <property>
+    <name>hbase.version.resolution.strategy</name>
+    <value>auto.strict</value>
+    <description>
+      Determines how to behave when the HBase version on a cluster is an unsupported
+      value. The default value of "auto.strict" will require that the HBase version match
+      a supported value, and CDAP Master will not start if the HBase version is
+      unsupported. Set to "auto.latest" to use the latest HBase version available on the
+      cluster with an unsupported HBase version.
     </description>
   </property>
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
@@ -84,7 +84,7 @@ public class HBaseQueueClientFactory implements QueueClientFactory, ProgramConte
     this.cConf = cConf;
     this.hConf = hConf;
     this.queueAdmin = (HBaseQueueAdmin) queueAdmin;
-    this.queueUtil = new HBaseQueueUtilFactory().get();
+    this.queueUtil = new HBaseQueueUtilFactory(cConf).get();
     this.hBaseTableUtil = hBaseTableUtil;
     this.txExecutorFactory = txExecutorFactory;
     this.txMaxLifeTimeInMillis = TimeUnit.SECONDS.toMillis(cConf.getLong(TxConstants.Manager.CFG_TX_MAX_LIFETIME,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueUtilFactory.java
@@ -16,12 +16,18 @@
 
 package co.cask.cdap.data2.transaction.queue.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.util.hbase.HBaseVersionSpecificFactory;
 
 /**
  * Factory for HBase version-specific instances of {@link HBaseQueueUtil}.
  */
 public class HBaseQueueUtilFactory extends HBaseVersionSpecificFactory<HBaseQueueUtil> {
+
+  public HBaseQueueUtilFactory(CConfiguration cConf) {
+    super(cConf);
+  }
+
   @Override
   protected String getHBase96Classname() {
     return "co.cask.cdap.data2.transaction.queue.hbase.HBase96QueueUtil";

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -72,6 +72,7 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_10_CDH56, "1.0.0-cdh5.6.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.2.0-IBM-7");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN, "1.3.0");
 
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1-SNAPSHOT");
@@ -79,6 +80,10 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.9.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.10.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.11.0");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.12.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.2.0-cdh5.13.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.11.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.12.0");
   }
 
   private void assertCompatModuleMapping(HBaseVersion.Version expectedCompatModule,

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -38,6 +38,16 @@ public class HBaseVersionTest {
     Assert.assertEquals("cdh5.7.1", versionNumber.getClassifier());
     Assert.assertTrue(versionNumber.isSnapshot());
 
+    // test HDP HBase version
+    version = "1.1.2.2.5.3.0-37";
+    versionNumber = HBaseVersion.VersionNumber.create(version);
+    Assert.assertEquals(new Integer(1), versionNumber.getMajor());
+    Assert.assertEquals(new Integer(1), versionNumber.getMinor());
+    Assert.assertEquals(new Integer(2), versionNumber.getPatch());
+    Assert.assertNull(versionNumber.getLast());
+    Assert.assertNull(versionNumber.getClassifier());
+    Assert.assertFalse(versionNumber.isSnapshot());
+
     // test IBM HBase version
     version = "1.2.0-IBM-7";
     versionNumber = HBaseVersion.VersionNumber.create(version);
@@ -74,6 +84,14 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.2.0-IBM-7");
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN, "1.3.0");
 
+    // hbase versions packaged with HDP
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_96, "0.96.1.2.0.13.0-43-hadoop2"); // hdp 2.0.13.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.0.2.1.15.0-946-hadoop2"); // hdp 2.1.15.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.2.2.3.6.0-3796"); // hdp 2.3.6.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.2.2.4.3.0-227"); // hdp 2.4.3.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.2.2.5.3.0-37"); // hdp 2.5.3.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.2.2.6.1.0-129"); // hdp 2.6.1.0
+
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1-SNAPSHOT");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.8.2");
@@ -84,6 +102,9 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.2.0-cdh5.13.0");
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.11.0");
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.12.0");
+
+    // bigtop 1.1.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.12-hadoop2");
   }
 
   private void assertCompatModuleMapping(HBaseVersion.Version expectedCompatModule,

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="b9c5b067e34a14ebe66ec8c16afed0ae"
+DEFAULT_XML_MD5_HASH="0e0a885deb173c2bc6f4b1709110fcb8"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -261,9 +261,9 @@ public class ExploreRuntimeModule extends RuntimeModule {
     @Provides
     @Singleton
     @Exposed
-    public ExploreService providesExploreService(Injector injector) {
+    public ExploreService providesExploreService(Injector injector, CConfiguration cConf) {
       // Figure out which HiveExploreService class to load
-      Class<? extends ExploreService> hiveExploreServiceCl = ExploreServiceUtils.getHiveService();
+      Class<? extends ExploreService> hiveExploreServiceCl = ExploreServiceUtils.getHiveService(cConf);
       LOG.info("Using Explore service class {}", hiveExploreServiceCl.getName());
       return injector.getInstance(hiveExploreServiceCl);
     }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.service;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.service.hive.Hive12CDH5ExploreService;
 import co.cask.cdap.explore.service.hive.Hive12ExploreService;
@@ -62,6 +63,8 @@ public class ExploreServiceUtils {
     "org/apache/hadoop/hive/ql/session/SessionState.class", Collections.singleton("loadAuxJars")
   );
 
+  private static final String CDH = "cdh";
+
   /**
    * Hive support enum.
    */
@@ -75,16 +78,25 @@ public class ExploreServiceUtils {
     HIVE_CDH5_3(Pattern.compile("^.*cdh5.3\\..*$"), Hive13ExploreService.class),
     // CDH > 5.3 uses Hive >= 1.1 (which Hive14ExploreService supports)
     HIVE_CDH5(Pattern.compile("^.*cdh5\\..*$"), Hive14ExploreService.class),
+    // Current latest CDH version uses Hive >= 1.1. Need to update HIVE_CDH_LATEST when newer CDH version is added.
+    HIVE_CDH_LATEST(null, Hive14ExploreService.class),
 
     HIVE_12(null, Hive12ExploreService.class),
     HIVE_13(null, Hive13ExploreService.class),
     HIVE_14(null, Hive14ExploreService.class),
     HIVE_1_0(null, Hive14ExploreService.class),
     HIVE_1_1(null, Hive14ExploreService.class),
-    HIVE_1_2(null, Hive14ExploreService.class);
+    HIVE_1_2(null, Hive14ExploreService.class),
+    // Current latest non-CDH version is HIVE_1_2. Need to update HIVE_LATEST when newer non-CDH version is added.
+    HIVE_LATEST(HIVE_1_2);
 
     private final Pattern hadoopVersionPattern;
     private final Class<? extends ExploreService> hiveExploreServiceClass;
+
+    HiveSupport(HiveSupport hiveSupport) {
+      this.hadoopVersionPattern = hiveSupport.getHadoopVersionPattern();
+      this.hiveExploreServiceClass = hiveSupport.getHiveExploreServiceClass();
+    }
 
     HiveSupport(Pattern hadoopVersionPattern, Class<? extends ExploreService> hiveExploreServiceClass) {
       this.hadoopVersionPattern = hadoopVersionPattern;
@@ -100,14 +112,14 @@ public class ExploreServiceUtils {
     }
   }
 
-  public static Class<? extends ExploreService> getHiveService() {
-    HiveSupport hiveVersion = checkHiveSupport(null);
+  public static Class<? extends ExploreService> getHiveService(CConfiguration cConf) {
+    HiveSupport hiveVersion = checkHiveSupport(cConf, null);
     return hiveVersion.getHiveExploreServiceClass();
   }
 
-  static boolean shouldEscapeColumns(Configuration hConf) {
+  static boolean shouldEscapeColumns(CConfiguration cConf, Configuration hConf) {
     // backtick support was added in Hive13.
-    ExploreServiceUtils.HiveSupport hiveSupport = checkHiveSupport(hConf.getClassLoader());
+    ExploreServiceUtils.HiveSupport hiveSupport = checkHiveSupport(cConf, hConf.getClassLoader());
     if (hiveSupport == HiveSupport.HIVE_12
       || hiveSupport == HiveSupport.HIVE_CDH5_0
       || hiveSupport == HiveSupport.HIVE_CDH5_1) {
@@ -123,8 +135,8 @@ public class ExploreServiceUtils {
     return "column".equalsIgnoreCase(hConf.get("hive.support.quoted.identifiers", "column"));
   }
 
-  public static HiveSupport checkHiveSupport() {
-    return checkHiveSupport(ExploreUtils.getExploreClassloader());
+  public static HiveSupport checkHiveSupport(CConfiguration cConf) {
+    return checkHiveSupport(cConf, ExploreUtils.getExploreClassloader());
   }
 
   public static String getHiveVersion() {
@@ -144,7 +156,7 @@ public class ExploreServiceUtils {
   /**
    * Check that Hive is in the class path - with a right version.
    */
-  public static HiveSupport checkHiveSupport(@Nullable ClassLoader hiveClassLoader) {
+  public static HiveSupport checkHiveSupport(CConfiguration cConf, @Nullable ClassLoader hiveClassLoader) {
     // First try to figure which hive support is relevant based on Hadoop distribution name
     String hadoopVersion = VersionInfo.getVersion();
     for (HiveSupport hiveSupport : HiveSupport.values()) {
@@ -152,6 +164,25 @@ public class ExploreServiceUtils {
         hiveSupport.getHadoopVersionPattern().matcher(hadoopVersion).matches()) {
         return hiveSupport;
       }
+    }
+
+    boolean useLatestVersionForUnsupported = Constants.Explore.HIVE_AUTO_LATEST_VERSION.equals(
+      cConf.get(Constants.Explore.HIVE_VERSION_RESOLUTION_STRATEGY));
+    if (hadoopVersion.contains(CDH)) {
+      if (useLatestVersionForUnsupported) {
+        LOG.info("Hive distribution in CDH Hadoop version '{}' is not supported. " +
+                   "Continuing with latest version of Hive module available.",
+                 hadoopVersion);
+        return HiveSupport.HIVE_CDH_LATEST;
+      }
+      throw new RuntimeException(String.format("Hive distribution in Hadoop version '%s' is not supported." +
+                                                 " Set the configuration '%s' to false to start up without Explore. " +
+                                                 "Or set the configuration '%s' to '%s' to use the latest " +
+                                                 "version of Hive module available",
+                                               hadoopVersion,
+                                               Constants.Explore.EXPLORE_ENABLED,
+                                               Constants.Explore.HIVE_VERSION_RESOLUTION_STRATEGY,
+                                               Constants.Explore.HIVE_AUTO_LATEST_VERSION));
     }
 
     String hiveVersion = getHiveVersion(hiveClassLoader);
@@ -168,9 +199,20 @@ public class ExploreServiceUtils {
       return HiveSupport.HIVE_1_2;
     }
 
-    throw new RuntimeException("Hive distribution not supported. Set the configuration '" +
-                                 Constants.Explore.EXPLORE_ENABLED +
-                                 "' to false to start up without Explore.");
+    if (useLatestVersionForUnsupported) {
+      LOG.info("Hive distribution '{}' is not supported. Continuing with latest version of Hive module available.",
+               hiveVersion);
+      return HiveSupport.HIVE_LATEST;
+    }
+
+    throw new RuntimeException(String.format("Hive distribution '%s' is not supported." +
+                                               " Set the configuration '%s' to false to start up without Explore. " +
+                                               "Or set the configuration '%s' to '%s' to use the latest " +
+                                               "Hive module available",
+                                             hiveVersion,
+                                             Constants.Explore.EXPLORE_ENABLED,
+                                             Constants.Explore.HIVE_VERSION_RESOLUTION_STRATEGY,
+                                             Constants.Explore.HIVE_AUTO_LATEST_VERSION));
   }
 
   /**

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
@@ -34,6 +34,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.DatasetNotFoundException;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
@@ -98,11 +99,12 @@ public class ExploreTableManager {
   public ExploreTableManager(ExploreService exploreService,
                              SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
                              ExploreTableNaming tableNaming,
+                             CConfiguration cConf,
                              Configuration hConf) {
     this.exploreService = exploreService;
     this.datasetInstantiatorFactory = datasetInstantiatorFactory;
     this.tableNaming = tableNaming;
-    this.shouldEscapeColumns = ExploreServiceUtils.shouldEscapeColumns(hConf);
+    this.shouldEscapeColumns = ExploreServiceUtils.shouldEscapeColumns(cConf, hConf);
   }
 
   /**

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceUtilsTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceUtilsTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.service;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import com.google.common.base.Function;
 import com.google.common.io.ByteStreams;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -46,7 +47,7 @@ public class ExploreServiceUtilsTest {
   @Test
   public void testHiveVersion() throws Exception {
     // This would throw an exception if it didn't pass
-    ExploreServiceUtils.checkHiveSupport(getClass().getClassLoader());
+    ExploreServiceUtils.checkHiveSupport(CConfiguration.create(), getClass().getClassLoader());
   }
 
   @Test

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseDDLExecutorFactory.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseDDLExecutorFactory.java
@@ -34,6 +34,7 @@ public class HBaseDDLExecutorFactory extends HBaseVersionSpecificFactory<HBaseDD
   private final String extensionDir;
 
   public HBaseDDLExecutorFactory(CConfiguration cConf, Configuration hConf) {
+    super(cConf);
     this.extensionDir = cConf.get(Constants.HBaseDDLExecutor.EXTENSIONS_DIR);
     this.hBaseDDLExecutorLoader = new HBaseDDLExecutorLoader(extensionDir == null ? "" : extensionDir);
     this.context = new BasicHBaseDDLExecutorContext(cConf, hConf);

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,17 +25,16 @@ import com.google.inject.Inject;
  */
 public class HBaseTableUtilFactory extends HBaseVersionSpecificFactory<HBaseTableUtil> {
 
-  private final CConfiguration cConf;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   public HBaseTableUtilFactory(CConfiguration cConf) {
-    this.cConf = cConf;
+    super(cConf);
     this.namespaceQueryAdmin = null;
   }
 
   @Inject
   public HBaseTableUtilFactory(CConfiguration cConf, NamespaceQueryAdmin namespaceQueryAdmin) {
-    this.cConf = cConf;
+    super(cConf);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
@@ -47,10 +46,10 @@ public class HBaseTableUtilFactory extends HBaseVersionSpecificFactory<HBaseTabl
     return hBaseTableUtil;
   }
 
-  public static Class<? extends HBaseTableUtil> getHBaseTableUtilClass() {
-    // Since we only need the class name, it is fine to have a null CConfiguration and null namespaceQueryAdmin,
+  public static Class<? extends HBaseTableUtil> getHBaseTableUtilClass(CConfiguration cConf) {
+    // Since we only need the class name, it is fine to have a null namespaceQueryAdmin,
     // since we do not use the tableUtil instance
-    return new HBaseTableUtilFactory(null).get().getClass();
+    return new HBaseTableUtilFactory(cConf).get().getClass();
   }
 
   @Override

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -45,6 +45,7 @@ public class HBaseVersion {
   private static final String CDH59_CLASSIFIER = "cdh5.9.";
   private static final String CDH510_CLASSIFIER = "cdh5.10.";
   private static final String CDH511_CLASSIFIER = "cdh5.11.";
+  private static final String CDH512_CLASSIFIER = "cdh5.12.";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -235,43 +236,57 @@ public class HBaseVersion {
   static Version determineVersionFromVersionString(String versionString) throws ParseException {
     if (versionString.startsWith(HBASE_94_VERSION)) {
       return Version.HBASE_94;
-    } else if (versionString.startsWith(HBASE_96_VERSION)) {
+    }
+    if (versionString.startsWith(HBASE_96_VERSION)) {
       return Version.HBASE_96;
-    } else if (versionString.startsWith(HBASE_98_VERSION)) {
+    }
+    if (versionString.startsWith(HBASE_98_VERSION)) {
       return Version.HBASE_98;
-    } else if (versionString.startsWith(HBASE_10_VERSION)) {
-      VersionNumber ver = VersionNumber.create(versionString);
-      if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH55_CLASSIFIER)) {
-        return Version.HBASE_10_CDH55;
-      } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH56_CLASSIFIER)) {
-        return Version.HBASE_10_CDH56;
-      } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
-        return Version.HBASE_10_CDH;
-      } else {
-        return Version.HBASE_10;
-      }
-    } else if (versionString.startsWith(HBASE_11_VERSION)) {
+    }
+    VersionNumber ver = VersionNumber.create(versionString);
+    if (versionString.startsWith(HBASE_10_VERSION)) {
+      return getHBase10VersionFromVersion(ver);
+    }
+    if (versionString.startsWith(HBASE_11_VERSION)) {
       return Version.HBASE_11;
-    } else if (versionString.startsWith(HBASE_12_VERSION)) {
-      VersionNumber ver = VersionNumber.create(versionString);
-      if (ver.getClassifier() != null &&
-        (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
-          // CDH 5.7 compat module can be re-used with CDH 5.[8-11].x
-          ver.getClassifier().startsWith(CDH58_CLASSIFIER) ||
-          ver.getClassifier().startsWith(CDH59_CLASSIFIER) ||
-          ver.getClassifier().startsWith(CDH510_CLASSIFIER) ||
-          ver.getClassifier().startsWith(CDH511_CLASSIFIER))) {
+    }
+    if (versionString.startsWith(HBASE_12_VERSION)) {
+      return getHBase12VersionFromVersion(ver);
+    }
+    if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+      return Version.UNKNOWN_CDH;
+    }
+    return Version.UNKNOWN;
+  }
+
+  private static Version getHBase10VersionFromVersion(VersionNumber ver) {
+    if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+      if (ver.getClassifier().startsWith(CDH55_CLASSIFIER)) {
+        return Version.HBASE_10_CDH55;
+      }
+      if (ver.getClassifier().startsWith(CDH56_CLASSIFIER)) {
+        return Version.HBASE_10_CDH56;
+      }
+      return Version.HBASE_10_CDH;
+    }
+    return Version.HBASE_10;
+  }
+
+  private static Version getHBase12VersionFromVersion(VersionNumber ver) {
+    if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+      if (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
+        // CDH 5.7 compat module can be re-used with CDH 5.[8-11].x
+        ver.getClassifier().startsWith(CDH58_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH59_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH510_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH511_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH512_CLASSIFIER)) {
         return Version.HBASE_12_CDH57;
-      } else {
-        // HBase-11 compat module can be re-used for HBASE-12 as there is no change needed in compat source.
-        return Version.HBASE_11;
       }
+      return Version.UNKNOWN_CDH;
     } else {
-      VersionNumber ver = VersionNumber.create(versionString);
-      if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
-        return Version.UNKNOWN_CDH;
-      }
-      return Version.UNKNOWN;
+      // HBase-11 compat module can be re-used for HBASE-12 as there is no change needed in compat source.
+      return Version.HBASE_11;
     }
   }
 }

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -62,7 +62,8 @@ public class HBaseVersion {
     HBASE_10_CDH56("1.0-cdh5.6"),
     HBASE_11("1.1"),
     HBASE_12_CDH57("1.2-cdh5.7"),
-    UNKNOWN("unknown");
+    UNKNOWN("unknown"),
+    UNKNOWN_CDH("unknown-cdh");
 
     final String majorVersion;
 
@@ -266,6 +267,10 @@ public class HBaseVersion {
         return Version.HBASE_11;
       }
     } else {
+      VersionNumber ver = VersionNumber.create(versionString);
+      if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+        return Version.UNKNOWN_CDH;
+      }
       return Version.UNKNOWN;
     }
   }

--- a/cdap-hbase-compat-base/src/test/java/co/cask/cdap/data/hbase/HBaseTestFactory.java
+++ b/cdap-hbase-compat-base/src/test/java/co/cask/cdap/data/hbase/HBaseTestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.util.hbase.HBaseVersionSpecificFactory;
 import com.google.common.base.Preconditions;
 
@@ -46,6 +47,7 @@ public class HBaseTestFactory extends HBaseVersionSpecificFactory<HBaseTestBase>
   static final String PROPERTY_PREFIX = "cdap.hbase.test.";
 
   public HBaseTestFactory(Object... configs) {
+    super(CConfiguration.create());
     Preconditions.checkArgument(configs.length % 2 == 0,
                                 "Arguments must be in pair form like (k1, v1, k2, v2): %s", Arrays.toString(configs));
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -454,7 +454,7 @@ public class MasterServiceMain extends DaemonMain {
   private void checkExploreRequirements() {
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       // This check will throw an exception if Hive is not present or if it's distribution is unsupported
-      ExploreServiceUtils.checkHiveSupport();
+      ExploreServiceUtils.checkHiveSupport(cConf);
     }
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/HiveCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/HiveCheck.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.startup.Check;
+import co.cask.cdap.explore.service.ExploreServiceUtils;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks that Hive version on the cluster is supported.
+ */
+// class is picked up through classpath examination
+@SuppressWarnings("unused")
+public class HiveCheck extends Check {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveCheck.class);
+  private final CConfiguration cConf;
+
+  @Inject
+  private HiveCheck(CConfiguration cConf) {
+    this.cConf = cConf;
+  }
+
+  @Override
+  public void run() throws Exception {
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
+      ExploreServiceUtils.checkHiveSupport(cConf);
+    } else {
+      LOG.debug("Explore is disabled, skipping Hive support check.");
+    }
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -553,7 +553,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
 
     List<Class<?>> classes = new ArrayList<>();
     classes.add(SparkMainWrapper.class);
-    classes.add(HBaseTableUtilFactory.getHBaseTableUtilClass());
+    classes.add(HBaseTableUtilFactory.getHBaseTableUtilClass(cConf));
 
     // Add KMS class
     if (SecureStoreUtils.isKMSBacked(cConfCopy) && SecureStoreUtils.isKMSCapable()) {

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -182,7 +182,7 @@ public class StandaloneMain {
 
     boolean exploreEnabled = cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED);
     if (exploreEnabled) {
-      ExploreServiceUtils.checkHiveSupport(getClass().getClassLoader());
+      ExploreServiceUtils.checkHiveSupport(cConf, getClass().getClassLoader());
       exploreExecutorService = injector.getInstance(ExploreExecutorService.class);
     }
 


### PR DESCRIPTION
Cherry-pick of the following three PRs to release/4.1:
https://github.com/caskdata/cdap/pull/8643
https://github.com/caskdata/cdap/pull/9199
https://github.com/caskdata/cdap/pull/9228

This PR would enable support for CDH 5.12 on 4.1.

https://builds.cask.co/browse/CDAP-RUT1206-6