### PR TITLE
validate rpm signature succeeded

### DIFF
--- a/cdap-distributions/bin/build_yum_repo.sh
+++ b/cdap-distributions/bin/build_yum_repo.sh
@@ -106,6 +106,12 @@ function sign_packages_in_repo_staging() {
     else
       # Sign away
       sign_rpm_package ${__rpm}
+      # Verify signature succeeded
+      verify_signature_on_package ${__rpm}
+      __ret=$?
+      if [ ${__ret} -ne 0 ]; then
+        die "Package signature failed for ${__rpm}"
+      fi
     fi
   done
 }


### PR DESCRIPTION
Adds a check to verify each rpm signature after signing.  This should prevent silent failures when the rpm signing expect script fails for whatever reason.  This will fail the build instead of attempt any retry (not trivial).