### PR TITLE
(CDAP-387) Refactor Spark Dataset to prepare for DS -> DF support

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SimpleSplit.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SimpleSplit.java
@@ -16,6 +16,9 @@
 
 package co.cask.cdap.api.data.batch;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,7 +26,8 @@ import java.util.Map;
  * Handy implementation of the {@link Split}. Acts as a map of attributes.
  */
 public final class SimpleSplit extends Split {
-  private Map<String, String> attributes = new HashMap<>();
+
+  private final Map<String, String> attributes = new HashMap<>();
 
   /**
    * Sets an attribute.
@@ -52,5 +56,22 @@ public final class SimpleSplit extends Split {
   public String get(String name, String defaultValue) {
     String value = attributes.get(name);
     return value == null ? defaultValue : value;
+  }
+
+  @Override
+  public void writeExternal(DataOutput out) throws IOException {
+    out.writeInt(attributes.size());
+    for (Map.Entry<String, String> entry : attributes.entrySet()) {
+      out.writeUTF(entry.getKey());
+      out.writeUTF(entry.getValue());
+    }
+  }
+
+  @Override
+  public void readExternal(DataInput in) throws IOException {
+    int len = in.readInt();
+    for (int i = 0; i < len; i++) {
+      attributes.put(in.readUTF(), in.readUTF());
+    }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Split.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Split.java
@@ -16,11 +16,19 @@
 
 package co.cask.cdap.api.data.batch;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
 /**
  * Defines split of the dataset.
  * <b>
  *   Typically a dataset is spit into multiple chunks that are fed into a batch job.
  * </b>
+ *
+ * Sub-class can implements the {@link #writeExternal(DataOutput)} and the {@link #readExternal(DataInput)}
+ * and have a public default constructor (constructor without arguments)
+ * to provide a more efficient serialization mechanism.
  */
 public abstract class Split {
   /**
@@ -30,5 +38,25 @@ public abstract class Split {
    */
   public long getLength() {
     return 0;
+  }
+
+  /**
+   * Serializing this split.
+   *
+   * @param out the {@link DataOutput} for writing out this split information
+   * @throws IOException if failed to serialize
+   */
+  public void writeExternal(DataOutput out) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Deserialize this split.
+   *
+   * @param in the {@link DataInput} to read back the split information.
+   * @throws IOException if failed to deserialize
+   */
+  public void readExternal(DataInput in) throws IOException {
+    throw new UnsupportedOperationException();
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Splits.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Splits.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.data.batch;
+
+import co.cask.cdap.api.common.Bytes;
+import com.google.gson.Gson;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+/**
+ * Utility class to serialize and deserialize {@link Split}.
+ */
+public final class Splits {
+
+  /**
+   * Serialize a list of {@link Splits}s to a {@link String}.
+   *
+   * @param splits the list of splits to serialize
+   * @return a {@link String} representation of the splits.
+   * @throws IOException if failed to serialize
+   */
+  public static String encode(Iterable<? extends Split> splits) throws IOException {
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(os)) {
+      for (Split split : splits) {
+        serialize(split, out);
+      }
+    }
+    return Bytes.toStringBinary(os.toByteArray());
+  }
+
+  /**
+   * Deserialize a list of {@link Split}s encoded by the {@link #encode(Iterable)} method
+   *
+   * @param encoded the encoded string produced by the {@link #encode(Iterable)} method
+   * @param splits a {@link Collection} for storing the decoded splits
+   * @param classLoader the {@link ClassLoader} for loading the {@link Split} class
+   * @param <T> type of the {@link Collection}
+   * @return the same {@link Collection} passed in the arguments
+   * @throws IOException if failed to deserialize
+   * @throws ClassNotFoundException if failed to load the {@link Split} class.
+   */
+  public static <T extends Collection<? super Split>> T decode(String encoded, T splits, ClassLoader classLoader)
+    throws IOException, ClassNotFoundException {
+
+    InputStream is = new ByteArrayInputStream(Bytes.toBytesBinary(encoded));
+    try (DataInputStream in = new DataInputStream(is)) {
+      while (in.available() > 0) {
+        splits.add(deserialize(in, classLoader));
+      }
+    }
+    return splits;
+  }
+
+  /**
+   * Serialize a {@link Split} instance.
+   *
+   * @param split the {@link Split} to serialize
+   * @param out the {@link DataOutput} that the serialized data is writing to
+   * @throws IOException if failed to serialize
+   */
+  public static void serialize(Split split, DataOutput out) throws IOException {
+    try {
+      // Write out the class name
+      out.writeUTF(split.getClass().getName());
+      // Write out the split. For custom split that doesn't override the writeExternal method,
+      // an UnsupportedOperationException will be thrown.
+      // Also if the Split doesn't have a public default constructor, use Gson as well
+      if ((split.getClass().getConstructor().getModifiers() & Modifier.PUBLIC) == Modifier.PUBLIC) {
+        split.writeExternal(out);
+        return;
+      }
+    } catch (UnsupportedOperationException | NoSuchMethodException e) {
+      // Use gson
+    }
+
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    try (Writer writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)) {
+      new Gson().toJson(split, writer);
+    }
+    byte[] bytes = os.toByteArray();
+    out.writeInt(bytes.length);
+    out.write(bytes);
+  }
+
+  /**
+   * Deserialize a {@link Split} that was written by the {@link #serialize(Split, DataOutput)} method
+   * using a provided {@link ClassLoader} to load the {@link Split} class.
+   *
+   * @param in the {@link DataInput} for reading the serialized data
+   * @param classLoader the {@link ClassLoader} for loading the actual {@link Split} class
+   * @return a {@link Split} instance
+   * @throws IOException if failed to deserialize
+   * @throws ClassNotFoundException if failed to load the split class as indicated by the encoded string
+   */
+  public static Split deserialize(DataInput in, ClassLoader classLoader) throws IOException, ClassNotFoundException {
+    String className = in.readUTF();
+    try {
+      Split split = (Split) classLoader.loadClass(className).getConstructor().newInstance();
+      split.readExternal(in);
+      return split;
+    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException |
+             InvocationTargetException | UnsupportedOperationException e) {
+      // If failed to instantiate the class using default constructor or the readExternal
+      // throws UnsupportedOperationException, deserialize with Gson
+    }
+
+    // Use Gson if failed to do readExternal.
+    byte[] bytes = new byte[in.readInt()];
+    in.readFully(bytes);
+    return (Split) new Gson().fromJson(new InputStreamReader(new ByteArrayInputStream(bytes),
+                                                             StandardCharsets.UTF_8), classLoader.loadClass(className));
+  }
+
+  private Splits() {
+    // no-op
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
@@ -27,10 +27,15 @@ import co.cask.cdap.api.data.batch.SplitReader;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 /**
  * Defines a Dataset implementation for managing time series data. This class offers simple ways to process read
@@ -217,17 +222,92 @@ public class TimeseriesTable extends TimeseriesDataset
   /**
    * A method for using a Dataset as input for a MapReduce job.
    */
-  private static final class InputSplit extends Split {
+  public static final class InputSplit extends Split {
     private byte[] key;
     private long startTime;
     private long endTime;
     private byte[][] tags;
+
+    /**
+     * Constructor for serialization only. Don't call directly.
+     */
+    public InputSplit() {
+      // no-op
+    }
 
     private InputSplit(byte[] key, long startTime, long endTime, byte[][] tags) {
       this.key = key;
       this.startTime = startTime;
       this.endTime = endTime;
       this.tags = tags;
+    }
+
+    @Override
+    public void writeExternal(DataOutput out) throws IOException {
+      if (key == null) {
+        out.writeInt(-1);
+      } else {
+        out.writeInt(key.length);
+        out.write(key);
+      }
+
+      out.writeLong(startTime);
+      out.writeLong(endTime);
+
+      out.writeInt(tags.length);
+      for (byte[] tag : tags) {
+        if (tag == null) {
+          out.writeInt(-1);
+        } else {
+          out.writeInt(tag.length);
+          out.write(tag);
+        }
+      }
+    }
+
+    @Override
+    public void readExternal(DataInput in) throws IOException {
+      int len = in.readInt();
+      if (len < 0) {
+        key = null;
+      } else {
+        key = new byte[len];
+        in.readFully(key);
+      }
+
+      startTime = in.readLong();
+      endTime = in.readLong();
+
+      tags = new byte[in.readInt()][];
+      for (int i = 0; i < tags.length; i++) {
+        len = in.readInt();
+        if (len < 0) {
+          tags[i] = null;
+        } else {
+          tags[i] = new byte[len];
+          in.readFully(tags[i]);
+        }
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      InputSplit that = (InputSplit) o;
+      return startTime == that.startTime &&
+        endTime == that.endTime &&
+        Arrays.equals(key, that.key) &&
+        Arrays.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(key, startTime, endTime, tags);
     }
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/TableSplit.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/TableSplit.java
@@ -19,11 +19,25 @@ package co.cask.cdap.api.dataset.table;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.Split;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * Table splits are simply a start and stop key.
  */
 public class TableSplit extends Split {
-  private final byte[] start, stop;
+
+  private byte[] start, stop;
+
+  /**
+   * Constructor for serialization only. Don't call directly.
+   */
+  public TableSplit() {
+    // No-op
+  }
 
   public TableSplit(byte[] start, byte[] stop) {
     this.start = start;
@@ -44,5 +58,57 @@ public class TableSplit extends Split {
       "start=" + Bytes.toStringBinary(start) +
       ", stop=" + Bytes.toStringBinary(stop) +
       '}';
+  }
+
+  @Override
+  public void writeExternal(DataOutput out) throws IOException {
+    if (start == null) {
+      out.writeInt(-1);
+    } else {
+      out.writeInt(start.length);
+      out.write(start);
+    }
+    if (stop == null) {
+      out.writeInt(-1);
+    } else {
+      out.writeInt(stop.length);
+      out.write(stop);
+    }
+  }
+
+  @Override
+  public void readExternal(DataInput in) throws IOException {
+    int len = in.readInt();
+    if (len < 0) {
+      start = null;
+    } else {
+      start = new byte[len];
+      in.readFully(start);
+    }
+
+    len = in.readInt();
+    if (len < 0) {
+      stop = null;
+    } else {
+      stop = new byte[len];
+      in.readFully(stop);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TableSplit that = (TableSplit) o;
+    return Arrays.equals(start, that.start) && Arrays.equals(stop, that.stop);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(start, stop);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputSplit.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputSplit.java
@@ -17,10 +17,9 @@
 package co.cask.cdap.internal.app.runtime.batch.dataset;
 
 import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.data.batch.Splits;
 import co.cask.cdap.api.dataset.Dataset;
 import com.google.common.base.Throwables;
-import com.google.gson.Gson;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.InputSplit;
 
@@ -60,9 +59,7 @@ public class DataSetInputSplit extends InputSplit implements Writable {
 
   @Override
   public void write(final DataOutput out) throws IOException {
-    Text.writeString(out, split.getClass().getName());
-    String ser = new Gson().toJson(split);
-    Text.writeString(out, ser);
+    Splits.serialize(split, out);
   }
 
   @SuppressWarnings("unchecked")
@@ -73,8 +70,7 @@ public class DataSetInputSplit extends InputSplit implements Writable {
       if (classLoader == null) {
         classLoader = getClass().getClassLoader();
       }
-      Class<? extends Split> splitClass = (Class<Split>) classLoader.loadClass(Text.readString(in));
-      split = new Gson().fromJson(Text.readString(in), splitClass);
+      split = Splits.deserialize(in, classLoader);
     } catch (ClassNotFoundException e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-common/src/test/java/co/cask/cdap/api/data/batch/SplitsTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/api/data/batch/SplitsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.data.batch;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.table.TableSplit;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Unit test for the {@link Splits} class in API.
+ */
+public class SplitsTest {
+
+  @Test
+  public void testSerde() throws IOException, ClassNotFoundException {
+    List<TableSplit> splits = Arrays.asList(
+      new TableSplit(Bytes.toBytes("0"), Bytes.toBytes("1")),
+      new TableSplit(Bytes.toBytes("1"), Bytes.toBytes("2"))
+    );
+
+    List<Split> decoded = Splits.decode(Splits.encode(splits), new ArrayList<Split>(), getClass().getClassLoader());
+    Assert.assertEquals(splits, decoded);
+  }
+
+  @Test
+  public void testOldSplit() throws IOException, ClassNotFoundException {
+    // Test splits that doesn't override the
+    List<OldSplit> splits = Arrays.asList(new OldSplit("1"), new OldSplit("2"));
+    List<Split> decoded = Splits.decode(Splits.encode(splits), new ArrayList<Split>(), getClass().getClassLoader());
+    Assert.assertEquals(splits, decoded);
+  }
+
+  @Test
+  public void testNoDefaultCons() throws IOException, ClassNotFoundException {
+    // Test splits that doesn't override the
+    List<NewSplitNoDefaultCons> splits = Arrays.asList(new NewSplitNoDefaultCons("1"), new NewSplitNoDefaultCons("2"));
+    List<Split> decoded = Splits.decode(Splits.encode(splits), new ArrayList<Split>(), getClass().getClassLoader());
+    Assert.assertEquals(splits, decoded);
+  }
+
+  /**
+   * A {@link Split} to simulate old split implementation.
+   */
+  public static final class OldSplit extends Split {
+    private String start;
+
+    public OldSplit() {
+      this("0");
+    }
+
+    public OldSplit(String start) {
+      this.start = start;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      OldSplit that = (OldSplit) o;
+      return Objects.equals(start, that.start);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(start);
+    }
+  }
+
+  /**
+   * A {@link Split} that implements the serialization methods, but don't have a default constructor
+   */
+  public static final class NewSplitNoDefaultCons extends Split {
+    private String start;
+
+    public NewSplitNoDefaultCons(String start) {
+      this.start = start;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      NewSplitNoDefaultCons that = (NewSplitNoDefaultCons) o;
+      return Objects.equals(start, that.start);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(start);
+    }
+
+    @Override
+    public void writeExternal(DataOutput out) throws IOException {
+      out.writeUTF(start);
+    }
+
+    @Override
+    public void readExternal(DataInput in) throws IOException {
+      start = in.readUTF();
+    }
+  }
+}

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/data/DatumScannerBasedRDD.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/data/DatumScannerBasedRDD.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.data
+
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+import co.cask.cdap.api.data.batch.Split
+import co.cask.cdap.api.dataset.Dataset
+import co.cask.cdap.app.runtime.spark.{SparkRuntimeContextProvider, SparkTransactionClient}
+import co.cask.cdap.data2.metadata.lineage.AccessType
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+import org.apache.tephra.TransactionAware
+
+import scala.annotation.meta.param
+import scala.collection.JavaConversions._
+import scala.reflect.ClassTag
+
+/**
+  * A base implementation of [[org.apache.spark.rdd.RDD]] that iterates based
+  * on [[co.cask.cdap.app.runtime.spark.data.DatumScanner]].
+  */
+abstract class DatumScannerBasedRDD[R: ClassTag](@(transient @param) sc: SparkContext,
+                                                 namespace: String,
+                                                 datasetName: String,
+                                                 arguments: Map[String, String],
+                                                 @(transient @param) splits: Iterable[_ <: Split],
+                                                 txServiceBaseURI: Broadcast[URI]) extends RDD[R](sc, Nil) {
+
+  final override protected def getPartitions: Array[Partition] = {
+    splits.zipWithIndex.map(t => new SplitPartition(id, t._2, t._1)).toArray
+  }
+
+  final override def compute(partition: Partition, context: TaskContext): Iterator[R] = {
+    val split = partition.asInstanceOf[SplitPartition].split
+    val sparkTxClient = new SparkTransactionClient(txServiceBaseURI.value)
+
+    val datasetCache = SparkRuntimeContextProvider.get().getDatasetCache
+    val dataset: Dataset = datasetCache.getDataset(namespace, datasetName, arguments, true, AccessType.READ)
+
+    try {
+      // Get the Transaction of the dataset if it is TransactionAware
+      dataset match {
+        case txAware: TransactionAware => {
+          // Try to get the transaction for this stage. Hardcoded the timeout to 10 seconds for now
+          txAware.startTx(sparkTxClient.getTransaction(context.stageId(), 10, TimeUnit.SECONDS))
+        }
+        case _ => // Nothing happen
+      }
+
+      // Create an iterator from the split
+      val iterator = new DatumScannerIterator[R](context, createDatumScanner(dataset, split))
+      context.addTaskCompletionListener(context => {
+        try {
+          iterator.close
+        } finally {
+          dataset.close
+        }
+      })
+      iterator
+    } catch {
+      case t: Throwable =>
+        dataset.close()
+        throw t
+    }
+  }
+
+  /**
+    * Creates a [[co.cask.cdap.app.runtime.spark.data.DatumScanner]] from the given [[co.cask.cdap.api.dataset.Dataset]]
+    * and [[co.cask.cdap.api.data.batch.Split]]. This is called from the `compute` method in the executor node.
+    */
+  protected def createDatumScanner(dataset: Dataset, split: Split): DatumScanner[R]
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/data/DatumScannerIterator.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/data/DatumScannerIterator.scala
@@ -16,13 +16,20 @@
 
 package co.cask.cdap.app.runtime.spark.data
 
-import co.cask.cdap.api.data.batch.SplitReader
 import org.apache.spark.TaskContext
+import org.apache.spark.executor.InputMetrics
 
 /**
-  * Spark2 SplitReaderIterator, which does not have access to Spark's metrics.
+  * Spark 1 implementation of [[co.cask.cdap.app.runtime.spark.data.AbstractDatumScannerIterator]] that supports
+  * emitting metrics.
   */
-class SplitReaderIterator[K, V](context: TaskContext, splitReader: SplitReader[K, V])
-  extends AbstractDatumScannerIterator(context, splitReader) {
+class DatumScannerIterator[T](context: TaskContext,
+                              scanner: DatumScanner[T]) extends AbstractDatumScannerIterator[T](context, scanner) {
 
+  val inputMetrics: Option[InputMetrics] = context.taskMetrics.inputMetrics
+
+  override def incrementMetrics(): Unit = {
+    // TODO: Add metrics for size being read. It requires dataset to expose it.
+    inputMetrics.foreach(_.incRecordsRead(1L))
+  }
 }

--- a/cdap-spark-core2_2.11/src/main/scala/co/cask/cdap/app/runtime/spark/data/DatumScannerIterator.scala
+++ b/cdap-spark-core2_2.11/src/main/scala/co/cask/cdap/app/runtime/spark/data/DatumScannerIterator.scala
@@ -16,20 +16,12 @@
 
 package co.cask.cdap.app.runtime.spark.data
 
-import co.cask.cdap.api.data.batch.SplitReader
 import org.apache.spark.TaskContext
-import org.apache.spark.executor.InputMetrics
 
 /**
-  * Spark1 SplitReaderIterator, which has access to Spark's metrics.
+  * Spark 2 implementation of [[co.cask.cdap.app.runtime.spark.data.AbstractDatumScannerIterator]] that doesn't emit
+  * metrics.
   */
-class SplitReaderIterator[K, V](context: TaskContext, splitReader: SplitReader[K, V])
-  extends AbstractDatumScannerIterator[(K, V)](context, splitReader) {
-
-  val inputMetrics: Option[InputMetrics] = context.taskMetrics.inputMetrics
-
-  override def incrementMetrics(): Unit = {
-    // TODO: Add metrics for size being read. It requires dataset to expose it.
-    inputMetrics.foreach(_.incRecordsRead(1L))
-  }
+class DatumScannerIterator[T](context: TaskContext,
+                              scanner: DatumScanner[T]) extends AbstractDatumScannerIterator[T](context, scanner) {
 }


### PR DESCRIPTION
- Rename BatchReadablePartition to SplitPartition
- Enhance Split class to support custom serialization
- Use the new Splits serialization in DataSetInputSplit
- Make Spark SplitPartition use the Split serialization
- Refactor DatasetRDD and BatchReadableRDD