### PR TITLE
CDAP-12252 fix double counting alert publisher metrics

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
@@ -32,8 +32,6 @@ import javax.annotation.Nullable;
  * @param <OUT> Type of output object
  */
 public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destroyable {
-  public static final String RECORDS_IN = "records.in";
-  public static final String RECORDS_OUT = "records.out";
   private final Transformation<IN, OUT> transform;
   private final StageMetrics metrics;
   private final String metricInName;


### PR DESCRIPTION
Fixed a bug where records.in to an alert publisher were being
double counted in mapreduce pipelines. They were being counted
once when writing the alerts to the local dataset and once when
the actual alerts were being sent to the alert publisher.