### PR TITLE
Add run column to program runs command

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
@@ -78,12 +78,13 @@ public class GetProgramRunsCommand extends AbstractCommand {
     }
 
     Table table = Table.builder()
-      .setHeader("pid", "end status", "start", "stop")
+      .setHeader("pid", "end status", "init time", "start time", "stop time")
       .setRows(records, new RowMaker<RunRecord>() {
         @Override
         public List<?> makeRow(RunRecord object) {
-          return Lists.newArrayList(object.getPid(), object.getStatus(), object.getRunTs(),
-                                    object.getStatus().name().equals("RUNNING") ? "" : object.getStopTs());
+          return Lists.newArrayList(object.getPid(), object.getStatus(), object.getStartTs(),
+                                    object.getRunTs() == null ? "" : object.getRunTs(),
+                                    object.getStopTs() == null ? "" : object.getStopTs());
         }
       }).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);


### PR DESCRIPTION
We introduced a `runs` column to the `RunRecord` class when introducing a new `ProgramRunStatus`. This PR updates the `GetProgramRunsCommand` to show that new column, or an empty string if the data is not available.

Every run record will have a `startTs`, run records that have been running will have both a `startTs` and a `runTs`, and "finished" runs will have `startTs`, `runTs`, and `stopTs`.