### PR TITLE
Ability for DynamicPartitioner to append to an existing PFS partition

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/DynamicPartitioner.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/DynamicPartitioner.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.dataset.lib;
 
+import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 
 /**
@@ -27,6 +28,27 @@ import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
  */
 public abstract class DynamicPartitioner<K, V> {
 
+  /**
+   * Defines options for when writing to a partition.
+   */
+  public enum PartitionWriteOption {
+    /**
+     * Will only allow writing to a new partition. If an attempt is made to write to a previously-existing partition,
+     * a {@link DataSetException} will be thrown.
+     */
+    CREATE,
+    /**
+     * Allows appending to an existing partition. If the partition does not already exist, it will be created.
+     * Existing partition's metadata is merged with the appending partition's metadata, with the appending partition's
+     * metadata taking precedence if keys conflict.
+     */
+    CREATE_OR_APPEND,
+    /**
+     * Overwrites the existing partition being written to. It's contents as well as any related metadata will be
+     * overwritten. If the partition does not already exist, it will be created.
+     */
+    CREATE_OR_OVERWRITE
+  }
 
   /**
    *  Initializes a DynamicPartitioner.

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -27,11 +28,13 @@ import javax.annotation.Nullable;
  */
 public class PartitionMetadata implements Iterable<Map.Entry<String, String>> {
   private final Map<String, String> metadata;
-  private final Long creationTime;
+  private final long creationTime;
+  private final long lastModificationTime;
 
-  public PartitionMetadata(Map<String, String> metadata, long creationTime) {
+  public PartitionMetadata(Map<String, String> metadata, long creationTime, long lastModificationTime) {
     this.metadata = Collections.unmodifiableMap(new HashMap<>(metadata));
     this.creationTime = creationTime;
+    this.lastModificationTime = lastModificationTime;
   }
 
   /**
@@ -59,6 +62,13 @@ public class PartitionMetadata implements Iterable<Map.Entry<String, String>> {
     return creationTime;
   }
 
+  /**
+   * @return the last modification time of the partition, in milliseconds
+   */
+  public long lastModificationTime() {
+    return lastModificationTime;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -68,14 +78,15 @@ public class PartitionMetadata implements Iterable<Map.Entry<String, String>> {
       return false;
     }
 
-    PartitionMetadata that = (PartitionMetadata) o;
-
-    return this.metadata.equals(that.metadata) && this.creationTime.equals(that.creationTime);
+    PartitionMetadata other = (PartitionMetadata) o;
+    return creationTime == other.creationTime
+      && lastModificationTime == other.lastModificationTime
+      && metadata.equals(other.metadata);
   }
 
   @Override
   public int hashCode() {
-    return metadata.hashCode() + 31 * creationTime.hashCode();
+    return Objects.hash(metadata, creationTime, lastModificationTime);
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -68,9 +68,8 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
 
   /**
    * Adds a new metadata entry for a particular partition.
-   * Note that existing entries cannot be updated.
-   * 
-   * @throws DataSetException when an attempt is made to update an existing entry
+   * If the metadata key already exists, it will be overwritten.
+   *
    * @throws PartitionNotFoundException when a partition for the given key is not found
    * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
@@ -78,13 +77,30 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
 
   /**
    * Adds a set of new metadata entries for a particular partition.
-   * Note that existing entries cannot be updated.
+   * If the metadata key already exists, it will be overwritten.
    *
-   * @throws DataSetException when an attempt is made to update existing entries
    * @throws PartitionNotFoundException when a partition for the given key is not found
    * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
+
+  /**
+   * Removes a metadata entry for a particular partition.
+   * If the metadata key does not exist, no error is thrown.
+   *
+   * @throws PartitionNotFoundException when a partition for the given key is not found
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
+   */
+  void removeMetadata(PartitionKey key, String metadataKey);
+
+  /**
+   * Removes a set of metadata entries for a particular partition.
+   * If any metadata key does not exist, no error is thrown.
+   *
+   * @throws PartitionNotFoundException when a partition for the given key is not found
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
+   */
+  void removeMetadata(PartitionKey key, Set<String> metadataKeys);
 
   /**
    * Remove a partition for a given partition key, silently ignoring if the key is not found.

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -18,6 +18,7 @@ package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.DataSetException;
+import co.cask.cdap.api.dataset.PartitionNotFoundException;
 
 import java.util.Map;
 import java.util.Set;
@@ -62,23 +63,37 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
 
   /**
    * Adds a new metadata entry for a particular partition.
-   * Note that existing entries can not be updated.
+   * If the metadata key already exists, it will be overwritten.
    *
    * @param time the partition time in milliseconds since the Epoch
-   *
-   * @throws DataSetException in case an attempt is made to update existing entries.
+   * @throws PartitionNotFoundException when a partition for the given time is not found
    */
   void addMetadata(long time, String metadataKey, String metadataValue);
 
   /**
    * Adds a set of new metadata entries for a particular partition
-   * Note that existing entries can not be updated.
+   * If the metadata key already exists, it will be overwritten.
    *
    * @param time the partition time in milliseconds since the Epoch
-   *
-   * @throws DataSetException in case an attempt is made to update existing entries.
+   * @throws PartitionNotFoundException when a partition for the given time is not found
    */
   void addMetadata(long time, Map<String, String> metadata);
+
+  /**
+   * Removes a metadata entry for a particular time.
+   * If the metadata key does not exist, no error is thrown.
+   *
+   * @throws PartitionNotFoundException when a partition for the given time is not found
+   */
+  void removeMetadata(long time, String metadataKey);
+
+  /**
+   * Removes a set of metadata entries for a particular time.
+   * If any metadata key does not exist, no error is thrown.
+   *
+   * @throws PartitionNotFoundException when a partition for the given time is not found
+   */
+  void removeMetadata(long time, Set<String> metadataKeys);
 
   /**
    * Remove a partition for a given time.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/WrapperUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/WrapperUtil.java
@@ -40,7 +40,7 @@ public final class WrapperUtil {
   static <T> T createDelegate(Configuration conf, String attrClass) {
     String delegateClassName = conf.get(attrClass);
     Class<?> delegateClass = conf.getClassByNameOrNull(delegateClassName);
-    Preconditions.checkNotNull(delegateClass, "Class could not be found: ", delegateClassName);
+    Preconditions.checkNotNull(delegateClass, "Class could not be found: %s", delegateClassName);
     T delegate = (T) ReflectionUtils.newInstance(delegateClass, conf);
 
     if (!(delegate instanceof ProgramLifecycle)) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultiInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultiInputFormat.java
@@ -59,7 +59,8 @@ public class MultiInputFormat<K, V> extends InputFormat<K, V> {
       ConfigurationUtil.setAll(mapperInput.getInputFormatConfiguration(), confCopy);
 
       Class<?> inputFormatClass = confCopy.getClassByNameOrNull(mapperInput.getInputFormatClassName());
-      Preconditions.checkNotNull(inputFormatClass, "Class could not be found: ", mapperInput.getInputFormatClassName());
+      Preconditions.checkNotNull(inputFormatClass,
+                                 "Class could not be found: %s", mapperInput.getInputFormatClassName());
 
       InputFormat<K, V> inputFormat = (InputFormat) ReflectionUtils.newInstance(inputFormatClass, confCopy);
       //some input format need a jobId to getSplits

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -102,6 +102,16 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
   }
 
   @Override
+  public void removeMetadata(long time, String metadataKey) {
+    removeMetadata(partitionKeyForTime(time), metadataKey);
+  }
+
+  @Override
+  public void removeMetadata(long time, Set<String> metadataKeys) {
+    removeMetadata(partitionKeyForTime(time), metadataKeys);
+  }
+
+  @Override
   public void dropPartition(long time) {
     dropPartition(partitionKeyForTime(time));
   }


### PR DESCRIPTION
If using DynamicPartitioner APIs, user can append to or overwrite partitions of a PartitionedFileSet.
Note that failure scenarios are not yet handled.

https://issues.cask.co/browse/CDAP-12084
https://builds.cask.co/browse/CDAP-DUT5988