### PR TITLE
CDAP-8629 Allow programs to have concurrent runs in integration tests.

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -146,8 +146,6 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   @Override
   public void startProgram(ProgramId programId, Map<String, String> arguments) {
     try {
-      String status = programClient.getStatus(programId);
-      Preconditions.checkState("STOPPED".equals(status), "Program %s is already running", programId);
       programClient.start(programId, false, arguments);
     } catch (Exception e) {
       throw Throwables.propagate(e);


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-8629