### PR TITLE
CDAP-12269 fix NPE when plugin artifact version is null

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelectorProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ArtifactSelectorProvider.java
@@ -75,7 +75,7 @@ public class ArtifactSelectorProvider {
     String version = config.getVersion();
     ArtifactVersionRange range;
     try {
-      range = ArtifactVersionRange.parse(version);
+      range = version == null ? null : ArtifactVersionRange.parse(version);
     } catch (InvalidArtifactRangeException e) {
       throw new IllegalArgumentException(String.format("%s is an invalid artifact version." +
                                                          "Must be an exact version or a version range " +

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/ArtifactSelectorProviderTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/ArtifactSelectorProviderTest.java
@@ -49,4 +49,10 @@ public class ArtifactSelectorProviderTest {
                                                                "cdap-artifact_2.10", "1.0.0");
     PROVIDER.getPluginSelector(config);
   }
+
+  @Test
+  public void testNullsAllowed() {
+    ArtifactSelectorConfig config = new ArtifactSelectorConfig(null, null, null);
+    PROVIDER.getPluginSelector(config);
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/ArtifactSelectorConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/ArtifactSelectorConfig.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.proto;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Part of the etl configuration, used to choose which artifact to use for a plugin. Normally created through
@@ -34,20 +35,23 @@ public class ArtifactSelectorConfig {
   }
 
   // for unit tests
-  public ArtifactSelectorConfig(String scope, String name, String version) {
+  public ArtifactSelectorConfig(@Nullable String scope, @Nullable String name, @Nullable String version) {
     this.scope = scope;
     this.name = name;
     this.version = version;
   }
 
+  @Nullable
   public String getScope() {
     return scope;
   }
 
+  @Nullable
   public String getName() {
     return name;
   }
 
+  @Nullable
   public String getVersion() {
     return version;
   }


### PR DESCRIPTION
Fixed a bug to avoid parsing a plugin artifact version if it is
not specified. Also annotating the methods as nullable so that
this type of confusion can be more easily avoided in the future.