### PR TITLE
CDAP-12284 fix renaming of pipeline jars to happen earlier

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -551,7 +551,7 @@
               -->
               <execution>
                 <id>rename-pipeline-jars</id>
-                <phase>prepare-package</phase>
+                <phase>process-resources</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>


### PR DESCRIPTION
Fix renaming of the pipeline jars so that they happen earlier in
the build process. This fixes a bug with debian packaging, which
used to copy the jars before they got renamed.