### PR TITLE
For individual system services status endpoints, don't go via appfabric.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -223,6 +223,11 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.STREAMS);
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.PREVIEW_HTTP);
 
+                               // for PingHandler
+                               servicesNamesBinder.addBinding().toInstance(Constants.Service.METRICS_PROCESSOR);
+                               servicesNamesBinder.addBinding().toInstance(Constants.Service.LOGSAVER);
+                               servicesNamesBinder.addBinding().toInstance(Constants.Service.TRANSACTION_HTTP);
+
                                // TODO: Uncomment after CDAP-7688 is resolved
                                // servicesNamesBinder.addBinding().toInstance(Constants.Service.MESSAGING_SERVICE);
 
@@ -232,6 +237,11 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                handlerHookNamesBinder.addBinding().toInstance(Constants.Service.APP_FABRIC_HTTP);
                                handlerHookNamesBinder.addBinding().toInstance(Constants.Stream.STREAM_HANDLER);
                                handlerHookNamesBinder.addBinding().toInstance(Constants.Service.PREVIEW_HTTP);
+
+                               // for PingHandler
+                               handlerHookNamesBinder.addBinding().toInstance(Constants.Service.METRICS_PROCESSOR);
+                               handlerHookNamesBinder.addBinding().toInstance(Constants.Service.LOGSAVER);
+                               handlerHookNamesBinder.addBinding().toInstance(Constants.Service.TRANSACTION_HTTP);
 
                                // TODO: Uncomment after CDAP-7688 is resolved
                                // handlerHookNamesBinder.addBinding().toInstance(Constants.Service.MESSAGING_SERVICE);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
@@ -166,30 +166,6 @@ public class MonitorHandler extends AbstractAppFabricHttpHandler {
     responder.sendJson(HttpResponseStatus.OK, result);
   }
 
-  @Path("/system/services/{service-name}/status")
-  @GET
-  public void monitor(HttpRequest request, HttpResponder responder,
-                      @PathParam("service-name") String serviceName) throws Exception {
-    if (!serviceManagementMap.containsKey(serviceName)) {
-      throw new NotFoundException(String.format("Invalid service name %s", serviceName));
-    }
-    MasterServiceManager masterServiceManager = serviceManagementMap.get(serviceName);
-    if (!masterServiceManager.isServiceEnabled()) {
-      throw new ForbiddenException(String.format("Service %s is not enabled", serviceName));
-    }
-    if (masterServiceManager.canCheckStatus() && masterServiceManager.isServiceAvailable()) {
-      JsonObject json = new JsonObject();
-      json.addProperty("status", STATUSOK);
-      responder.sendJson(HttpResponseStatus.OK, json);
-    } else if (masterServiceManager.canCheckStatus()) {
-      JsonObject json = new JsonObject();
-      json.addProperty("status", STATUSNOTOK);
-      responder.sendJson(HttpResponseStatus.OK, json);
-    } else {
-      throw new BadRequestException("Operation not valid for this service");
-    }
-  }
-
   @Path("/system/services")
   @GET
   public void getServiceSpec(HttpRequest request, HttpResponder responder) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
@@ -43,13 +43,13 @@ import java.util.Map;
  */
 public class MonitorHandlerTest extends AppFabricTestBase {
 
-  protected HttpURLConnection openURL(String path, HttpMethod method) throws IOException, URISyntaxException {
+  private HttpURLConnection openURL(String path, HttpMethod method) throws IOException, URISyntaxException {
     HttpURLConnection urlConn = (HttpURLConnection) createURL(path).openConnection();
     urlConn.setRequestMethod(method.getName());
     return urlConn;
   }
 
-  protected URL createURL(String path) throws URISyntaxException, MalformedURLException {
+  private URL createURL(String path) throws URISyntaxException, MalformedURLException {
     return getEndPoint(String.format("/v3/%s", path)).toURL();
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PingHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PingHandlerTest.java
@@ -33,8 +33,7 @@ public class PingHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testStatus() throws Exception {
-    HttpResponse response = doGet("/status");
+    HttpResponse response = doGet("/v3/system/services/appfabric/status");
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
   }
-
 }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MonitorClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MonitorClientTestRun.java
@@ -46,10 +46,12 @@ public class MonitorClientTestRun extends ClientTestBase {
     List<SystemServiceMeta> services = monitorClient.listSystemServices();
     Assert.assertTrue(services.size() > 0);
 
-    String someService = services.get(0).getName();
-    String serviceStatus = monitorClient.getSystemServiceStatus(someService);
-    Assert.assertEquals("OK", serviceStatus);
+    // check that all the system services can have their status individually retrieved
+    for (SystemServiceMeta service : services) {
+      Assert.assertEquals("OK", monitorClient.getSystemServiceStatus(service.getName()));
+    }
 
+    String someService = services.get(0).getName();
     List<Containers.ContainerInfo> containers = monitorClient.getSystemServiceLiveInfo(someService).getContainers();
     Assert.assertNotNull(containers);
     Assert.assertTrue(containers.isEmpty());

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -91,6 +91,7 @@ public final class Constants {
     public static final String ACL = "acl";
     public static final String APP_FABRIC_HTTP = "appfabric";
     public static final String TRANSACTION = "transaction";
+    public static final String TRANSACTION_HTTP = "transaction.http";
     public static final String METRICS = "metrics";
     public static final String LOGSAVER = "log.saver";
     public static final String GATEWAY = "gateway";

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -85,9 +85,9 @@ public class ExploreRuntimeModule extends RuntimeModule {
 
     @Override
     protected void configure() {
-      Named exploreSeriveName = Names.named(Constants.Service.EXPLORE_HTTP_USER_SERVICE);
+      Named exploreServiceName = Names.named(Constants.Service.EXPLORE_HTTP_USER_SERVICE);
       Multibinder<HttpHandler> handlerBinder =
-          Multibinder.newSetBinder(binder(), HttpHandler.class, exploreSeriveName);
+          Multibinder.newSetBinder(binder(), HttpHandler.class, exploreServiceName);
       handlerBinder.addBinding().to(NamespacedExploreQueryExecutorHttpHandler.class);
       handlerBinder.addBinding().to(ExploreQueryExecutorHttpHandler.class);
       handlerBinder.addBinding().to(NamespacedExploreMetadataHttpHandler.class);

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -40,6 +40,11 @@ public final class RouterPathLookup extends AbstractHttpHandler {
     Constants.Service.EXPLORE_HTTP_USER_SERVICE);
   public static final RouteDestination STREAMS_SERVICE = new RouteDestination(Constants.Service.STREAMS);
   public static final RouteDestination PREVIEW_HTTP = new RouteDestination(Constants.Service.PREVIEW_HTTP);
+  public static final RouteDestination TRANSACTION = new RouteDestination(Constants.Service.TRANSACTION_HTTP);
+  public static final RouteDestination LOG_SAVER = new RouteDestination(Constants.Service.LOGSAVER);
+  public static final RouteDestination METRICS_PROCESSOR = new RouteDestination(Constants.Service.METRICS_PROCESSOR);
+  public static final RouteDestination DATASET_EXECUTOR = new RouteDestination(Constants.Service.DATASET_EXECUTOR);
+  public static final RouteDestination MESSAGING = new RouteDestination(Constants.Service.MESSAGING_SERVICE);
   public static final RouteDestination DONT_ROUTE = new RouteDestination(Constants.Router.DONT_ROUTE_SERVICE);
 
   /**
@@ -155,6 +160,21 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       return EXPLORE_HTTP_USER_SERVICE;
     } else if ((uriParts.length == 3) && uriParts[1].equals("explore") && uriParts[2].equals("status")) {
       return EXPLORE_HTTP_USER_SERVICE;
+    } else if (matches(uriParts, "v3", "system", "services", null, "status")) {
+      switch (uriParts[3]) {
+        case Constants.Service.LOGSAVER: return LOG_SAVER;
+        case Constants.Service.TRANSACTION: return TRANSACTION;
+        case Constants.Service.METRICS_PROCESSOR: return METRICS_PROCESSOR;
+        case Constants.Service.METRICS: return METRICS;
+        case Constants.Service.APP_FABRIC_HTTP: return APP_FABRIC_HTTP;
+        case Constants.Service.STREAMS: return STREAMS_SERVICE;
+        case Constants.Service.DATASET_EXECUTOR: return DATASET_EXECUTOR;
+        case Constants.Service.REMOTE_SYSTEM_OPERATION: return DATASET_EXECUTOR;
+        case Constants.Service.METADATA_SERVICE: return METADATA_SERVICE;
+        case Constants.Service.EXPLORE_HTTP_USER_SERVICE: return EXPLORE_HTTP_USER_SERVICE;
+        case Constants.Service.MESSAGING_SERVICE: return MESSAGING;
+        default: return null;
+      }
     } else if (uriParts.length == 7 && uriParts[3].equals("data") && uriParts[4].equals("datasets") &&
       (uriParts[6].equals("flows") || uriParts[6].equals("workers") || uriParts[6].equals("mapreduce"))) {
       // namespaced app fabric data operations:

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/transaction/TransactionHttpService.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/transaction/TransactionHttpService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.runtime.main.transaction;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.ResolvingDiscoverable;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
+import co.cask.cdap.common.metrics.MetricsReporterHook;
+import co.cask.http.HttpHandler;
+import co.cask.http.NettyHttpService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * Transaction Http service implemented using the common http netty framework.
+ * Currently only used for PingHandler.
+ */
+public class TransactionHttpService extends AbstractIdleService {
+  private static final Logger LOG = LoggerFactory.getLogger(TransactionHttpService.class);
+
+  private final NettyHttpService httpService;
+  private final DiscoveryService discoveryService;
+  private Cancellable cancelDiscovery;
+
+  @Inject
+  public TransactionHttpService(CConfiguration cConf,
+                                @Named(Constants.Service.TRANSACTION_HTTP) Set<HttpHandler> handlers,
+                                DiscoveryService discoveryService,
+                                MetricsCollectionService metricsCollectionService) {
+    // netty http server config
+    String address = cConf.get(Constants.Transaction.Container.ADDRESS);
+
+    NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.TRANSACTION_HTTP);
+    builder.setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
+                                                                     Constants.Service.TRANSACTION_HTTP)));
+    builder.addHttpHandlers(handlers);
+
+    builder.setHost(address);
+
+    this.httpService = builder.build();
+    this.discoveryService = discoveryService;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting Transaction HTTP Service...");
+    httpService.startAndWait();
+    // Register the service
+    cancelDiscovery = discoveryService.register(
+      ResolvingDiscoverable.of(new Discoverable(Constants.Service.TRANSACTION_HTTP, httpService.getBindAddress())));
+    LOG.info("Transaction HTTP started successfully on {}", httpService.getBindAddress());
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping Transaction HTTP...");
+
+    // Unregister the service
+    cancelDiscovery.cancel();
+    httpService.stopAndWait();
+  }
+}


### PR DESCRIPTION
For individual system services status endpoints, don't go via appfabric.
This involves starting a http service in Transaction twill runnable, which wasn't previously there.

https://issues.cask.co/browse/CDAP-12298
https://builds.cask.co/browse/CDAP-DUT6046-5 (GREEN)

Tested on cluster:
```
$ cat status.sh 
curl `hostname -f`:11015/v3/system/services/dataset.executor/status && echo
curl `hostname -f`:11015/v3/system/services/remote.system.operation/status && echo
curl `hostname -f`:11015/v3/system/services/metrics/status && echo
curl `hostname -f`:11015/v3/system/services/transaction/status && echo
curl `hostname -f`:11015/v3/system/services/appfabric/status && echo
curl `hostname -f`:11015/v3/system/services/messaging.service/status && echo
curl `hostname -f`:11015/v3/system/services/metadata.service/status && echo
curl `hostname -f`:11015/v3/system/services/streams/status && echo
curl `hostname -f`:11015/v3/system/services/explore.service/status && echo
curl `hostname -f`:11015/v3/system/services/log.saver/status && echo
curl `hostname -f`:11015/v3/system/services/metrics.processor/status && echo
$ bash status.sh 
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
{"status":"OK"}
$ 
```