### PR TITLE
[UI-Bugfix] Fixes editing draft in pipelines + Typo fix in pipeline summary

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineSummary/Store/PipelineSummaryActions.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/Store/PipelineSummaryActions.js
@@ -130,7 +130,7 @@ function updateNodeMetrics(pipelineConfig) {
     let metricsCount = Object.keys(run.nodesMetrics);
     let defaultMetrics = {};
     Object.keys(nodesMap).map(n => defaultMetrics[`user.${n}${type}`] = 0);
-    let nodesWithMetrics = run.nodeMetrics;
+    let nodesWithMetrics = run.nodesMetrics;
     if (!nodesCount.length || nodesCount.length!== metricsCount.length) {
       nodesWithMetrics = Object.assign({}, defaultMetrics, run.nodesMetrics);
     }

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -270,6 +270,7 @@ angular.module(PKG.name + '.commons')
       // FIXME: This directive should not be dependent on specific external component to render itself.
       // The left panel should default to expanded view and cleaning up the graph and fit to screen should happen in parallel.
       fitToScreenTimeout = $timeout(() => {
+        vm.cleanUpGraph();
         vm.fitToScreen();
       }, 500);
     }

--- a/cdap-ui/app/directives/dag-plus/services/stores/nodes-store.js
+++ b/cdap-ui/app/directives/dag-plus/services/stores/nodes-store.js
@@ -188,6 +188,9 @@ class DAGPlusPlusNodesStore {
       if (!node.name) {
         node.name = node.label + '-' + this.uuid.v4();
       }
+      if (!node.type) {
+        node.type = node.plugin.type;
+      }
     });
     this.state.nodes = nodes;
     this.emitChange();

--- a/cdap-ui/app/hydrator/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/canvas-ctrl.js
@@ -96,17 +96,18 @@ class HydratorPlusPlusCreateCanvasCtrl {
               let artifactVersion = HydratorPlusPlusConfigStore.getArtifact().version;
               return HydratorPlusPlusNodeService
                 .getPluginInfo(pluginNode, appType, sourceConn, artifactVersion)
-                .then((nodeWithInfo) => (
-                  {
+                .then((nodeWithInfo) => {
+                  let pluginType = nodeWithInfo.type || nodeWithInfo.plugin.type;
+                  return {
                     node: nodeWithInfo,
                     isValidPlugin: true,
                     type: appType,
-                    isSource: GLOBALS.pluginConvert[nodeWithInfo.type] === 'source',
-                    isSink: GLOBALS.pluginConvert[nodeWithInfo.type] === 'sink',
-                    isTransform: GLOBALS.pluginConvert[nodeWithInfo.type] === 'transform',
-                    isAction: GLOBALS.pluginConvert[nodeWithInfo.type] === 'action'
-                  }
-                ));
+                    isSource: GLOBALS.pluginConvert[pluginType] === 'source',
+                    isSink: GLOBALS.pluginConvert[pluginType] === 'sink',
+                    isTransform: GLOBALS.pluginConvert[pluginType] === 'transform',
+                    isAction: GLOBALS.pluginConvert[pluginType] === 'action'
+                  };
+                });
             }]
           }
         })

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -202,7 +202,7 @@ class HydratorPlusPlusNodeConfigCtrl {
         artifactName,
         artifactVersion,
         artifactScope,
-        `widgets.${this.state.node.plugin.name}-${this.state.node.type}`
+        `widgets.${this.state.node.plugin.name}-${this.state.node.type || this.state.node.plugin.type}`
       )
         .then(
           (res) => {

--- a/cdap-ui/app/hydrator/controllers/create/partials/reference-tab-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/reference-tab-ctrl.js
@@ -26,7 +26,7 @@ class HydratorPlusPlusReferenceTabCtrl {
     if (!node.plugin) {
       this.state.docReference = this.GLOBALS.en.hydrator.studio.info['DEFAULT-REFERENCE'];
     } else {
-      let key = `doc.${node.plugin.name}-${node.type}`;
+      let key = `doc.${node.plugin.name}-${node.type || node.plugin.type}`;
       this.HydratorPlusPlusPluginConfigFactory.fetchDocJson(
         this.myHelpers.objectQuery(node, 'plugin', 'artifact', 'name'),
         this.myHelpers.objectQuery(node, 'plugin', 'artifact', 'version'),

--- a/cdap-ui/app/hydrator/routes.js
+++ b/cdap-ui/app/hydrator/routes.js
@@ -64,6 +64,21 @@ angular.module(PKG.name + '.feature.hydrator')
           resolve: {
             rConfig: function($stateParams, mySettings, $q, myHelpers, $window, $rootScope, HydratorPlusPlusHydratorService) {
               var defer = $q.defer();
+              if ($stateParams.data) {
+                // This is being used while cloning a published a pipeline.
+                let isVersionInRange = HydratorPlusPlusHydratorService
+                  .isVersionInRange({
+                    supportedVersion: $rootScope.cdapVersion,
+                    versionRange: $stateParams.data.artifact.version
+                  });
+                if (isVersionInRange) {
+                  $stateParams.data.artifact.version = $rootScope.cdapVersion;
+                } else {
+                  defer.resolve(false);
+                }
+                defer.resolve($stateParams.data);
+                return defer.promise;
+              }
               if ($stateParams.draftId) {
                 mySettings.get('hydratorDrafts', true)
                   .then(function(res) {
@@ -94,19 +109,6 @@ angular.module(PKG.name + '.feature.hydrator')
                 } catch (e) {
                   defer.resolve(false);
                 }
-              } else if ($stateParams.data) {
-                // This is being used while cloning a published a pipeline.
-                let isVersionInRange = HydratorPlusPlusHydratorService
-                  .isVersionInRange({
-                    supportedVersion: $rootScope.cdapVersion,
-                    versionRange: $stateParams.data.artifact.version
-                  });
-                if (isVersionInRange) {
-                  $stateParams.data.artifact.version = $rootScope.cdapVersion;
-                } else {
-                  defer.resolve(false);
-                }
-                defer.resolve($stateParams.data);
               } else if ($stateParams.workspaceId) {
                 // This is being used by dataprep to pipelines transition
                 try {

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorPlusPlusConfigStore {
-  constructor(HydratorPlusPlusConfigDispatcher, HydratorPlusPlusCanvasFactory, GLOBALS, mySettings, HydratorPlusPlusConsoleActions, $stateParams, NonStorePipelineErrorFactory, HydratorPlusPlusHydratorService, $q, HydratorPlusPlusPluginConfigFactory, uuid, $state, HYDRATOR_DEFAULT_VALUES, myHelpers, avsc, MY_CONFIG){
+  constructor(HydratorPlusPlusConfigDispatcher, HydratorPlusPlusCanvasFactory, GLOBALS, mySettings, HydratorPlusPlusConsoleActions, $stateParams, NonStorePipelineErrorFactory, HydratorPlusPlusHydratorService, $q, HydratorPlusPlusPluginConfigFactory, uuid, $state, HYDRATOR_DEFAULT_VALUES, myHelpers, avsc, MY_CONFIG) {
     this.state = {};
     this.mySettings = mySettings;
     this.myHelpers = myHelpers;
@@ -173,7 +173,7 @@ class HydratorPlusPlusConfigStore {
             outputSchema.fields = outputSchema.fields.filter( field => !field.readonly);
           }
           node.plugin.properties[node.outputSchemaProperty] = JSON.stringify(outputSchema);
-        } catch(e) {}
+        } catch (e) {}
       }
       node.plugin.properties = stripFormatSchemas(node.watchProperty, node.outputSchemaProperty, angular.copy(node.plugin.properties));
 
@@ -384,7 +384,7 @@ class HydratorPlusPlusConfigStore {
     this.emitChange();
   }
   setConfig(config, type) {
-    switch(type) {
+    switch (type) {
       case 'source':
         this.state.config.source = config;
         break;
@@ -595,7 +595,7 @@ class HydratorPlusPlusConfigStore {
       this.$q.all(listOfPromises)
         .then(
           () => {
-            if(!this.validateState()) {
+            if (!this.validateState()) {
               this.emitChange();
             }
             // Once the backend properties are fetched for all nodes, fetch their config jsons.
@@ -986,22 +986,15 @@ class HydratorPlusPlusConfigStore {
       }]);
       return;
     }
-    if(!this.getDraftId()) {
+    if (!this.getDraftId()) {
       this.setDraftId(this.uuid.v4());
       this.$stateParams.draftId = this.getDraftId();
       this.$state.go('hydrator.create', this.$stateParams, {notify: false});
     }
-    let config = this.getState();
-    if (config.__ui__.nodes.length === 0) {
-      config.__ui__.nodes = angular.copy(this.getStages());
-    }
-    // This is not to fall in the scenario where when the user saves a draft with a node selected.
-    // Next time they come to the draft and we still have the node selected but the bottom panel not updated.
-    config.__ui__.nodes = config.__ui__.nodes.map( node => {
-      delete node.selected;
-      delete node.error;
-      return node;
-    });
+    let config = this.getDisplayConfig();
+    config.__ui__ = {
+      draftId: this.getDraftId()
+    };
     let checkForDuplicateDrafts = (config, draftsMap = {}) => {
       return Object.keys(draftsMap).filter(
         draft => {
@@ -1011,13 +1004,13 @@ class HydratorPlusPlusConfigStore {
       ).length > 0;
     };
     let saveDraft = (config, draftsMap = {}) => {
-      draftsMap[config.__ui__.draftId] = config;
+      draftsMap[this.getDraftId()] = config;
       return draftsMap;
     };
     this.mySettings.get('hydratorDrafts', true)
       .then( (res = {isMigrated: true}) => {
         let draftsMap = res[this.$stateParams.namespace];
-        if(!checkForDuplicateDrafts(config, draftsMap)) {
+        if (!checkForDuplicateDrafts(config, draftsMap)) {
           res[this.$stateParams.namespace] = saveDraft(config, draftsMap);
         } else {
           throw 'A Draft with the same name already exist. Plesae rename your draft';

--- a/cdap-ui/app/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-service.js
@@ -131,7 +131,7 @@ class HydratorPlusPlusHydratorService {
       namespace: this.$state.params.namespace,
       pipelineType: appType,
       version: artifactVersion || this.$rootScope.cdapVersion,
-      extensionType: node.type,
+      extensionType: node.type || node.plugin.type,
       pluginName: node.plugin.name,
       artifactVersion: node.plugin.artifact.version,
       artifactName: node.plugin.artifact.name,


### PR DESCRIPTION
#### Issues:
- We modified the way we set nodes in `config-store`. It worked initially when we import, however when we edit a draft the config being passed is different. The draft had `__ui__.nodes` however the config stages were not updated. This can be reproduced by following steps,
  1. Go to Dataprep and create a pipeline out of a workspace
  2. Once in pipeline studio add a sink and connect it to the wrangler transform
  3. Save the draft with a name 
  4. Go to pipelines list view and edit the draft created in step 3
  5. The draft should open without the newly added node and connection.
- When in draft, if the user imports a pipeline the draft remains in the studio rather than rendering the imported pipeline. The issue is, during `hydrator.create` route resolve step the draft id takes precedence over the imported data. This was causing the import to silently fail while in draft.
- Typo while showing node metrics in pipeline summary. 

#### Fixes:
- Make sure the way we store draft and render them back operates on the same pipeline config
- Fix the precedence when navigating to pipeline studio with imported data being highest priority.