### PR TITLE
Allow adding configurable conditions to the Workflow.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractCondition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractCondition.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.workflow;
+
+import co.cask.cdap.api.annotation.TransactionControl;
+import co.cask.cdap.api.annotation.TransactionPolicy;
+import co.cask.cdap.api.mapreduce.MapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+
+import java.util.Map;
+
+/**
+ * The abstract class provides default implementation of the {@link Condition} methods for an easy extension
+ */
+public abstract class AbstractCondition implements Condition {
+
+  private String name;
+  private ConditionConfigurer configurer;
+  private WorkflowContext context;
+
+  protected AbstractCondition() {
+    // no-op, for instantiation only
+  }
+
+  protected AbstractCondition(String name) {
+    this.name = name;
+  }
+
+  protected void configure() {
+
+  }
+
+  @Override
+  public void configure(ConditionConfigurer configurer) {
+    this.configurer = configurer;
+    setName(name == null ? getClass().getSimpleName() : name);
+    configure();
+  }
+
+  protected void setName(String name) {
+    configurer.setName(name);
+  }
+
+  protected void setDescription(String description) {
+    configurer.setDescription(description);
+  }
+
+  protected void setProperties(Map<String, String> properties) {
+    configurer.setProperties(properties);
+  }
+
+  @Override
+  @TransactionPolicy(TransactionControl.IMPLICIT)
+  public void initialize(WorkflowContext context) throws Exception {
+    this.context = context;
+  }
+
+  /**
+   * Classes derived from {@link AbstractCondition} can override this method to destroy the {@link Condition}.
+   */
+  @Override
+  @TransactionPolicy(TransactionControl.IMPLICIT)
+  public void destroy() {
+
+  }
+
+  /**
+   * @return an instance of {@link WorkflowContext}
+   */
+  protected final WorkflowContext getContext() {
+    return context;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -147,6 +147,15 @@ public abstract class AbstractWorkflow extends AbstractPluginConfigurable<Workfl
   }
 
   /**
+   * Adds a condition to the {@link Workflow}.
+   * @param condition the {@link Condition} to be evaluated to determine which branch to take
+   * @return the {@link WorkflowConditionConfigurer} to configure the branches in the condition
+   */
+  protected final WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Condition condition) {
+    return configurer.condition(condition);
+  }
+
+  /**
    * Adds a local dataset instance to the {@link Workflow}.
    * <p>
    * Local datasets are created at the start of every {@code Workflow} run and deleted once the run

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/Condition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/Condition.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.workflow;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.ProgramLifecycle;
+
+/**
+ * Defines configurable condition in the Workflow.
+ */
+public interface Condition extends ProgramLifecycle<WorkflowContext>, Predicate<WorkflowContext> {
+  /**
+   * Configures the condition.
+   * @param configurer the {@link ConditionConfigurer} used to configure the condition.
+   */
+  void configure(ConditionConfigurer configurer);
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/ConditionConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/ConditionConfigurer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.workflow;
+
+import co.cask.cdap.api.ProgramConfigurer;
+import co.cask.cdap.api.plugin.PluginConfigurer;
+
+/**
+ * Configurer for configuring the {@link Condition} in the {@link Workflow}.
+ */
+public interface ConditionConfigurer extends ProgramConfigurer, PluginConfigurer {
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/ConditionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/ConditionSpecification.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.workflow;
+
+import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.api.dataset.Dataset;
+
+import java.util.Set;
+
+/**
+ * Specification for the condition that will be executed as a part of {@link Workflow}.
+ */
+public interface ConditionSpecification extends PropertyProvider {
+  /**
+   * @return Class name of the condition.
+   */
+  String getClassName();
+
+  /**
+   * @return Name of the condition.
+   */
+  String getName();
+
+  /**
+   * @return Description of the condition.
+   */
+  String getDescription();
+
+  /**
+   * @return an immutable set of {@link Dataset} name that are used by the {@link Condition}
+   */
+  Set<String> getDatasets();
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionConfigurer.java
@@ -67,6 +67,13 @@ public interface WorkflowConditionConfigurer<T> {
   WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(Predicate<WorkflowContext> condition);
 
   /**
+   * Adds a nested condition to the current condition.
+   * @param condition the {@link Condition} to be evaluated
+   * @return the configurer for the condition
+   */
+  WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(Condition condition);
+
+  /**
    * Adds a branch to the {@link WorkflowConditionNode} which is executed if the condition evaluates to the false.
    * @return the configurer for the condition
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionNode.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionNode.java
@@ -16,7 +16,12 @@
 
 package co.cask.cdap.api.workflow;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Represents the CONDITION node in the {@link Workflow}.
@@ -25,13 +30,26 @@ public class WorkflowConditionNode extends WorkflowNode {
   private final List<WorkflowNode> ifBranch;
   private final List<WorkflowNode> elseBranch;
   private final String predicateClassName;
+  private final ConditionSpecification conditionSpecification;
 
   public WorkflowConditionNode(String nodeId, String predicateClassName, List<WorkflowNode> ifBranch,
                                List<WorkflowNode> elseBranch) {
+    this(nodeId, ifBranch, elseBranch, predicateClassName, null);
+  }
+
+  public WorkflowConditionNode(String nodeId, ConditionSpecification conditionSpecification,
+                               List<WorkflowNode> ifBranch, List<WorkflowNode> elseBranch) {
+    this(nodeId, ifBranch, elseBranch, conditionSpecification.getClassName(), conditionSpecification);
+  }
+
+  private WorkflowConditionNode(String nodeId, List<WorkflowNode> ifBranch,
+                                List<WorkflowNode> elseBranch, String predicateClassName,
+                                @Nullable ConditionSpecification conditionSpecification) {
     super(nodeId, WorkflowNodeType.CONDITION);
     this.ifBranch = ifBranch;
     this.elseBranch = elseBranch;
     this.predicateClassName = predicateClassName;
+    this.conditionSpecification = conditionSpecification;
   }
 
   public List<WorkflowNode> getIfBranch() {
@@ -44,5 +62,55 @@ public class WorkflowConditionNode extends WorkflowNode {
 
   public String getPredicateClassName() {
     return predicateClassName;
+  }
+
+  public ConditionSpecification getConditionSpecification() {
+    return conditionSpecification == null ? createSpecifications() : conditionSpecification;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("WorkflowConditionNode{");
+    sb.append("nodeId=").append(nodeId);
+    sb.append(", predicateClassName=").append(predicateClassName);
+    sb.append(", conditionSpecification=").append(conditionSpecification);
+    sb.append(", ifBranch=").append(ifBranch);
+    sb.append(", elseBranch=").append(elseBranch);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private ConditionSpecification createSpecifications() {
+    return new ConditionSpecification() {
+      @Override
+      public String getClassName() {
+        return predicateClassName;
+      }
+
+      @Override
+      public String getName() {
+        return nodeId;
+      }
+
+      @Override
+      public String getDescription() {
+        return "";
+      }
+
+      @Override
+      public Set<String> getDatasets() {
+        return new HashSet<>();
+      }
+
+      @Override
+      public Map<String, String> getProperties() {
+        return new HashMap<>();
+      }
+
+      @Override
+      public String getProperty(String key) {
+        return null;
+      }
+    };
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
@@ -80,6 +80,13 @@ public interface WorkflowConfigurer extends ProgramConfigurer, PluginConfigurer 
   WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Predicate<WorkflowContext> condition);
 
   /**
+   * Adds a condition to the {@link Workflow}.
+   * @param condition the {@link Condition} to be evaluated
+   * @return the configurer for the condition
+   */
+  WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Condition condition);
+
+  /**
    * Adds a local dataset instance to the {@link Workflow}.
    * <p>
    * Local datasets are created at the start of every {@code Workflow} run and deleted once the run

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
@@ -65,10 +65,17 @@ public interface WorkflowForkConfigurer<T> {
 
   /**
    * Adds a condition to the current branch of the fork.
-   * @param condition the {@link Predicate} to be evaluated at the condition node
+   * @param predicate the {@link Predicate} to be evaluated at the condition node
    * @return the configurer for the condition
    */
-  WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(Predicate<WorkflowContext> condition);
+  WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(Predicate<WorkflowContext> predicate);
+
+  /**
+   * Adds a condition to the current branch of the fork.
+   * @param condition the {@link Condition} to be evaluated at the condition node
+   * @return the configurer for the condition
+   */
+  WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(Condition condition);
 
   /**
    * Adds a branch to the {@link WorkflowForkNode}

--- a/cdap-api/src/main/java/co/cask/cdap/internal/workflow/condition/DefaultConditionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/workflow/condition/DefaultConditionSpecification.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.workflow.condition;
+
+import co.cask.cdap.api.workflow.ConditionSpecification;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The default implementation for a {@link ConditionSpecification}.
+ */
+public class DefaultConditionSpecification implements ConditionSpecification {
+
+  private final String className;
+  private final String name;
+  private final String description;
+  private final Map<String, String> properties;
+  private final Set<String> datasets;
+
+  public DefaultConditionSpecification(String className, String name, String description,
+                                       Map<String, String> properties, Set<String> datasets) {
+    this.className = className;
+    this.name = name;
+    this.description = description;
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+    this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
+  }
+
+  @Override
+  public String getClassName() {
+    return className;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public Set<String> getDatasets() {
+    return datasets;
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public String getProperty(String key) {
+    return properties.get(key);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("DefaultConditionSpecification{");
+    sb.append("className='").append(className).append('\'');
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", description='").append(description).append('\'');
+    sb.append(", properties=").append(properties);
+    sb.append(", datasets=").append(datasets);
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
@@ -28,6 +28,7 @@ import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.worker.WorkerSpecification;
+import co.cask.cdap.api.workflow.ConditionSpecification;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
@@ -39,6 +40,7 @@ import co.cask.cdap.internal.schedule.constraint.Constraint;
 import co.cask.cdap.internal.schedule.trigger.Trigger;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.codec.BasicThrowableCodec;
+import co.cask.cdap.proto.codec.ConditionSpecificationCodec;
 import co.cask.cdap.proto.codec.CustomActionSpecificationCodec;
 import co.cask.cdap.proto.codec.FlowSpecificationCodec;
 import co.cask.cdap.proto.codec.FlowletSpecificationCodec;
@@ -98,6 +100,7 @@ public final class ApplicationSpecificationAdapter {
       .registerTypeAdapter(WorkflowNode.class, new WorkflowNodeCodec())
       .registerTypeAdapter(WorkflowActionSpecification.class, new WorkflowActionSpecificationCodec())
       .registerTypeAdapter(CustomActionSpecification.class, new CustomActionSpecificationCodec())
+      .registerTypeAdapter(ConditionSpecification.class, new ConditionSpecificationCodec())
       .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
       .registerTypeAdapter(ServiceSpecification.class, new ServiceSpecificationCodec())
       .registerTypeAdapter(WorkerSpecification.class, new WorkerSpecificationCodec())

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -102,6 +102,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -544,6 +545,18 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
    */
   public interface ThrowingRunnable {
     void run() throws Exception;
+  }
+
+  /**
+   * Run some code with the context class loader combined from the program class loader and the system class loader.
+   */
+  public <T> T executeChecked(final Callable<T> callable) throws Exception {
+    ClassLoader oldClassloader = setContextCombinedClassLoader();
+    try {
+      return callable.call();
+    } finally {
+      ClassLoaders.setContextClassLoader(oldClassloader);
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowServiceHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowServiceHandler.java
@@ -16,8 +16,10 @@
 package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.customaction.CustomActionSpecification;
+import co.cask.cdap.api.workflow.ConditionSpecification;
 import co.cask.cdap.api.workflow.WorkflowActionNode;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
+import co.cask.cdap.proto.codec.ConditionSpecificationCodec;
 import co.cask.cdap.proto.codec.CustomActionSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowActionSpecificationCodec;
 import co.cask.http.AbstractHttpHandler;
@@ -44,6 +46,8 @@ public final class WorkflowServiceHandler extends AbstractHttpHandler {
                                                          new WorkflowActionSpecificationCodec())
                                     .registerTypeAdapter(CustomActionSpecification.class,
                                                          new CustomActionSpecificationCodec())
+                                    .registerTypeAdapter(ConditionSpecification.class,
+                                                         new ConditionSpecificationCodec())
                                     .create();
 
   private final Supplier<List<WorkflowActionNode>> statusSupplier;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/WorkflowConditionAdder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/WorkflowConditionAdder.java
@@ -16,7 +16,10 @@
 
 package co.cask.cdap.internal.app.workflow;
 
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.workflow.Condition;
 import co.cask.cdap.api.workflow.WorkflowConditionNode;
+import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.api.workflow.WorkflowNode;
 
 import java.util.List;
@@ -27,12 +30,18 @@ import java.util.List;
 public interface WorkflowConditionAdder {
   /**
    * Adds a {@link WorkflowConditionNode} to the Workflow.
-   * @param conditionNodeName the name of the node representing the condition. We use simple name of the predicate
-   *                          class as the name of the condition node.
-   * @param predicateClassName the name of the predicate class associated with this {@link WorkflowConditionNode}
+   * @param predicate the predicate representing condition.
    * @param ifBranch the branch that is executed when the predicate evaluates to the true
    * @param elseBranch the branch that is executed when the predicate evaluates to the false
    */
-  void addWorkflowConditionNode(String conditionNodeName, String predicateClassName, List<WorkflowNode> ifBranch,
+  void addWorkflowConditionNode(Predicate<WorkflowContext> predicate, List<WorkflowNode> ifBranch,
                                 List<WorkflowNode> elseBranch);
+
+  /**
+   * Adds a {@link WorkflowConditionNode} to the Workflow.
+   * @param condition the condition in the Workflow
+   * @param ifBranch the branch that is executed when the predicate evaluates to the true
+   * @param elseBranch the branch that is executed when the predicate evaluates to the false
+   */
+  void addWorkflowConditionNode(Condition condition, List<WorkflowNode> ifBranch, List<WorkflowNode> elseBranch);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/condition/DefaultConditionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/condition/DefaultConditionConfigurer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.workflow.condition;
+
+import co.cask.cdap.api.workflow.Condition;
+import co.cask.cdap.api.workflow.ConditionConfigurer;
+import co.cask.cdap.api.workflow.ConditionSpecification;
+import co.cask.cdap.internal.app.DefaultPluginConfigurer;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.internal.lang.Reflections;
+import co.cask.cdap.internal.specification.DataSetFieldExtractor;
+import co.cask.cdap.internal.specification.PropertyFieldExtractor;
+import co.cask.cdap.internal.workflow.condition.DefaultConditionSpecification;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Default implementation of the {@link ConditionConfigurer}
+ */
+public class DefaultConditionConfigurer extends DefaultPluginConfigurer implements ConditionConfigurer {
+  private final Condition condition;
+  private String name;
+  private String description;
+  private Map<String, String> properties;
+
+  private DefaultConditionConfigurer(Condition condition, Id.Namespace deployNamespace, Id.Artifact artifactId,
+                                     ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
+    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
+    this.condition = condition;
+    this.name = condition.getClass().getSimpleName();
+    this.description = "";
+    this.properties = new HashMap<>();
+  }
+
+  @Override
+  public void setName(String name) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "Name of the Condition cannot be null or empty");
+    this.name = name;
+  }
+
+  @Override
+  public void setDescription(String description) {
+    Preconditions.checkNotNull(description, "Description of the Condition cannot be null");
+    this.description = description;
+  }
+
+  @Override
+  public void setProperties(Map<String, String> properties) {
+    Preconditions.checkNotNull(properties, "Properties of the Condition cannot be null");
+    this.properties = new HashMap<>(properties);
+  }
+
+  private DefaultConditionSpecification createSpecification() {
+    Set<String> datasets = new HashSet<>();
+    Reflections.visit(condition, condition.getClass(), new PropertyFieldExtractor(properties),
+                      new DataSetFieldExtractor(datasets));
+    return new DefaultConditionSpecification(condition.getClass().getName(), name, description, properties, datasets);
+  }
+
+  public static ConditionSpecification configureCondition(Condition condition, Id.Namespace deployNamespace,
+                                                          Id.Artifact artifactId, ArtifactRepository artifactRepository,
+                                                          PluginInstantiator pluginInstantiator) {
+    DefaultConditionConfigurer configurer = new DefaultConditionConfigurer(condition, deployNamespace, artifactId,
+                                                                           artifactRepository, pluginInstantiator);
+
+    condition.configure(configurer);
+    return configurer.createSpecification();
+  }
+}

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -18,6 +18,7 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.customaction.CustomActionSpecification;
+import co.cask.cdap.api.workflow.ConditionSpecification;
 import co.cask.cdap.api.workflow.WorkflowActionNode;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.client.config.ClientConfig;
@@ -42,6 +43,7 @@ import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.proto.codec.ConditionSpecificationCodec;
 import co.cask.cdap.proto.codec.CustomActionSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowActionSpecificationCodec;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -85,6 +87,7 @@ public class ProgramClient {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(WorkflowActionSpecification.class, new WorkflowActionSpecificationCodec())
     .registerTypeAdapter(CustomActionSpecification.class, new CustomActionSpecificationCodec())
+    .registerTypeAdapter(ConditionSpecification.class, new ConditionSpecificationCodec())
     .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
     .create();
   private static final Type BATCH_STATUS_RESPONSE_TYPE = new TypeToken<List<BatchProgramStatus>>() { }.getType();

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/ConditionSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/ConditionSpecificationCodec.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.api.workflow.ConditionSpecification;
+import co.cask.cdap.internal.workflow.condition.DefaultConditionSpecification;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Codec to serialize and deserialize {@link ConditionSpecification}.
+ */
+public class ConditionSpecificationCodec extends AbstractSpecificationCodec<ConditionSpecification> {
+  @Override
+  public ConditionSpecification deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    throws JsonParseException {
+    JsonObject jsonObj = json.getAsJsonObject();
+
+    String className = jsonObj.get("className").getAsString();
+    String name = jsonObj.get("name").getAsString();
+    String description = jsonObj.get("description").getAsString();
+    Set<String> datasets = deserializeSet(jsonObj.get("datasets"), context, String.class);
+    Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
+    return new DefaultConditionSpecification(className, name, description, properties, datasets);
+
+  }
+
+  @Override
+  public JsonElement serialize(ConditionSpecification src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject jsonObj = new JsonObject();
+
+    jsonObj.add("className", new JsonPrimitive(src.getClassName()));
+    jsonObj.add("name", new JsonPrimitive(src.getName()));
+    jsonObj.add("description", new JsonPrimitive(src.getDescription()));
+    jsonObj.add("datasets", serializeSet(src.getDatasets(), context, String.class));
+    jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
+
+    return jsonObj;
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/ConditionalWorkflowApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/ConditionalWorkflowApp.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.customaction.AbstractCustomAction;
+import co.cask.cdap.api.workflow.AbstractCondition;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.api.workflow.WorkflowContext;
+import co.cask.cdap.api.workflow.WorkflowToken;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Application to test the Conditions in the Workflow.
+ */
+public class ConditionalWorkflowApp extends AbstractApplication {
+  @Override
+  public void configure() {
+    addWorkflow(new ConditionalWorkflow());
+  }
+
+  /**
+   * Workflow with conditions
+   */
+  public static class ConditionalWorkflow extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      condition(new SimpleCondition())
+        .addAction(new MyCustomAction("action1"))
+      .otherwise()
+        .condition(new ConfigurableCondition())
+          .addAction(new MyCustomAction("action2"))
+        .otherwise()
+          .addAction(new MyCustomAction("action3"))
+        .end()
+      .end();
+    }
+  }
+
+  /**
+   * Simple condition
+   */
+  public static class SimpleCondition implements Predicate<WorkflowContext> {
+
+    @Override
+    public boolean apply(@Nullable WorkflowContext input) {
+      input.getToken().put("simple.condition.initialize", "true");
+      if (input.getRuntimeArguments().containsKey("simple.condition")) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Configurable condition
+   */
+  public static class ConfigurableCondition extends AbstractCondition {
+    @Override
+    protected void configure() {
+      super.configure();
+      setName("MyConfigurableCondition");
+      setDescription("This is configurable conditions description.");
+      Map<String, String> properties = ImmutableMap.of("prop1", "value1", "prop2", "value2", "prop3", "value3");
+      setProperties(properties);
+    }
+
+    @Override
+    public void initialize(WorkflowContext context) throws Exception {
+      super.initialize(context);
+      getContext().getToken().put("configurable.condition.initialize", "true");
+    }
+
+    @Override
+    public void destroy() {
+      super.destroy();
+      getContext().getToken().put("configurable.condition.destroy", "true");
+    }
+
+    @Override
+    public boolean apply(@Nullable WorkflowContext input) {
+      input.getToken().put("configurable.condition.apply", "true");
+      if (input.getRuntimeArguments().containsKey("configurable.condition")) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  /**
+   *
+   */
+  public static class MyCustomAction extends AbstractCustomAction {
+
+    private final String name;
+
+    public MyCustomAction(String name) {
+      this.name = name;
+    }
+
+    @Override
+    protected void configure() {
+      super.configure();
+      setName(name);
+    }
+
+    @Override
+    public void run() throws Exception {
+      WorkflowToken token = getContext().getWorkflowToken();
+      token.put("action.name", getContext().getSpecification().getName());
+    }
+  }
+}


### PR DESCRIPTION
Added new api in the Workflow to allow adding configurable conditions to it which will also have lifecycle methods, as opposed to the existing one which only has apply method.

Condition api
```java
/**
 * Defines configurable condition in the Workflow.
 */
public interface Condition extends ProgramLifecycle<WorkflowContext>, Predicate<WorkflowContext> {
  /**
   * Configures the condition.
   * @param configurer the {@link ConditionConfigurer} used to configure the condition.
   */
  void configure(ConditionConfigurer configurer);
}
```

Corresponding change in the Workflow configurer:

```java
  /**
   * Adds a condition to the {@link Workflow}.
   * @param condition the {@link Condition} to be evaluated
   * @return the configurer for the condition
   */
  WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Condition condition);
```

Example:

```java
public MyWorkflow extends AbstractWorkflow {
@Override
    protected void configure() {
      condition(new ConfigurableCondition())
          ...
      .otherwise()
         ...
      .end();
    }
}

  /**
   * Configurable condition
   */
  public class ConfigurableCondition extends AbstractCondition {
    @Override
    protected void configure() {
      setName("MyConfigurableCondition");
      setDescription("This is configurable conditions description.");
      Map<String, String> properties = ImmutableMap.of("prop1", "value1", "prop2", "value2", "prop3", "value3");
      setProperties(properties);
    }

    @Override
    protected void initialize() throws Exception {
       ...
    }

    @Override
    public void destroy() {
       ...
    }

    @Override
    public boolean apply(@Nullable WorkflowContext input) {
       ...
   }
  }

```
