### PR TITLE
increase expect timeout

### DIFF
--- a/cdap-distributions/bin/rpmsign.expect
+++ b/cdap-distributions/bin/rpmsign.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/expect -f
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 # rpmsign.expect : expect powered rpm signing command
 #
 
+set timeout -1
 proc usage {} {
         send_user "Usage: rpmsign.expect gpgname passphrase rpmfile\n\n"
         exit


### PR DESCRIPTION
The size of the ``cdap-master`` package has increased enough that it is taking longer than expect's default 10s timeout to sign the rpm.  This removes the timeout altogether (let bamboo's HBK take care of any hangs).