### PR TITLE
CDAP-11095 add description to pipeline config

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
@@ -38,6 +38,7 @@ import co.cask.cdap.etl.batch.BatchPipelineSpecGenerator;
 import co.cask.cdap.etl.common.Constants;
 import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.spec.PipelineSpecGenerator;
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import org.apache.avro.mapreduce.AvroKeyInputFormat;
 import org.apache.avro.mapreduce.AvroKeyOutputFormat;
@@ -59,7 +60,7 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
   @Override
   public void configure() {
     ETLBatchConfig config = getConfig();
-    setDescription(DEFAULT_DESCRIPTION);
+    setDescription(Objects.firstNonNull(config.getDescription(), DEFAULT_DESCRIPTION ));
 
     PipelineSpecGenerator<ETLBatchConfig, BatchPipelineSpec> specGenerator = new BatchPipelineSpecGenerator(
       getConfigurer(),

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsApp.java
@@ -24,6 +24,7 @@ import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
 import co.cask.cdap.etl.spec.PipelineSpecGenerator;
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -35,7 +36,7 @@ public class DataStreamsApp extends AbstractApplication<DataStreamsConfig> {
   @Override
   public void configure() {
     DataStreamsConfig config = getConfig();
-    setDescription("Data Streams Application");
+    setDescription(Objects.firstNonNull(config.getDescription(), "Data Streams Application"));
 
     PipelineSpecGenerator<DataStreamsConfig, DataStreamsPipelineSpec> specGenerator =
       new DataStreamsPipelineSpecGenerator(

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/ETLConfig.java
@@ -41,6 +41,7 @@ import javax.annotation.Nullable;
 // though not marked nullable, fields can be null since these objects are created through gson deserialization
 @SuppressWarnings("ConstantConditions")
 public class ETLConfig extends Config implements UpgradeableConfig {
+  private final String description;
   private final Set<ETLStage> stages;
   private final Set<Connection> connections;
   private final Resources resources;
@@ -59,6 +60,7 @@ public class ETLConfig extends Config implements UpgradeableConfig {
                       Resources resources, Resources driverResources, Resources clientResources,
                       boolean stageLoggingEnabled, boolean processTimingEnabled,
                       int numOfRecordsPreview, Map<String, String> properties) {
+    this.description = null;
     this.stages = Collections.unmodifiableSet(stages);
     this.connections = Collections.unmodifiableSet(connections);
     this.resources = resources;
@@ -72,6 +74,11 @@ public class ETLConfig extends Config implements UpgradeableConfig {
     this.source = null;
     this.sinks = new ArrayList<>();
     this.transforms = new ArrayList<>();
+  }
+
+  @Nullable
+  public String getDescription() {
+    return description;
   }
 
   public Set<ETLStage> getStages() {
@@ -170,7 +177,8 @@ public class ETLConfig extends Config implements UpgradeableConfig {
 
     ETLConfig that = (ETLConfig) o;
 
-    return Objects.equals(stages, that.stages) &&
+    return Objects.equals(description, that.description) &&
+      Objects.equals(stages, that.stages) &&
       Objects.equals(connections, that.connections) &&
       Objects.equals(getResources(), that.getResources()) &&
       Objects.equals(getDriverResources(), that.getDriverResources()) &&
@@ -183,7 +191,7 @@ public class ETLConfig extends Config implements UpgradeableConfig {
 
   @Override
   public int hashCode() {
-    return Objects.hash(stages, connections, getResources(), getDriverResources(), getClientResources(),
+    return Objects.hash(description, stages, connections, getResources(), getDriverResources(), getClientResources(),
                         isStageLoggingEnabled(), isProcessTimingEnabled(), getNumOfRecordsPreview(), getProperties());
   }
 
@@ -200,7 +208,8 @@ public class ETLConfig extends Config implements UpgradeableConfig {
   @Override
   public String toString() {
     return "ETLConfig{" +
-      "stages=" + stages +
+      "description='" + description + '\'' +
+      ", stages=" + stages +
       ", connections=" + connections +
       ", resources=" + resources +
       ", driverResources=" + driverResources +


### PR DESCRIPTION
Adding a description field to the pipeline config, which will be
used as the application description if set.