### PR TITLE
Make v2 table scan optional

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -584,6 +584,7 @@ public final class Constants {
     // NOTE: "v3" to avoid conflict with data of older metrics system
     public static final String DEFAULT_METRIC_V3_TABLE_PREFIX = "metrics.v3.table";
     public static final String METRICS_HBASE_MAX_SCAN_THREADS = "metrics.hbase.max.scan.threads";
+    public static final String METRICS_V2_TABLE_SCAN_ENABLED = "metrics.v2.table.scan.enabled";
     // Hardcode this value because we do not want user to control it
     public static final int METRICS_HBASE_SPLITS = 16;
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2087,6 +2087,14 @@
     </description>
   </property>
 
+  <property>
+    <name>metrics.v2.table.scan.enabled</name>
+    <value>false</value>
+    <description>
+      Enable or disable scanning v2 metrics tables. By default set to false.
+    </description>
+  </property>
+
   <!-- Monitor Handler Configuration -->
 
   <property>

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -121,9 +121,13 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
   public MetricsTable getOrCreateResolutionMetricsTable(String v2TableName, String v3TableName,
                                                          TableProperties.Builder props) {
     try {
-      // metrics tables are in the system namespace
-      DatasetId v2TableId = NamespaceId.SYSTEM.dataset(v2TableName);
-      MetricsTable v2Table = dsFramework.getDataset(v2TableId, null, null);
+      MetricsTable v2Table = null;
+      // TODO: By default do not allow reading from v2 tables. Remove this check once CDAP-12306 is fixed
+      if (cConf.getBoolean(Constants.Metrics.METRICS_V2_TABLE_SCAN_ENABLED)) {
+        // metrics tables are in the system namespace
+        DatasetId v2TableId = NamespaceId.SYSTEM.dataset(v2TableName);
+        v2Table = dsFramework.getDataset(v2TableId, null, null);
+      }
 
       props.add(HBaseTableAdmin.PROPERTY_SPLITS,
                 GSON.toJson(getV3MetricsTableSplits(Constants.Metrics.METRICS_HBASE_SPLITS)));


### PR DESCRIPTION
Making v2 Table scan optional. We need this because when cluster is upgraded, we do not see metrics for runs/apps after upgrade. We are still investing the issue: https://issues.cask.co/browse/CDAP-12306.

As a workaround, we are adding this option. Once above jira is fixed, we will revert this change. 

Tested on cluster which had both v2 and v3 tables by deploying a new application and querying the metrics for that application.