### PR TITLE
CDAP-12122 fix control dag flatten bug

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ControlDagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ControlDagTest.java
@@ -69,6 +69,23 @@ public class ControlDagTest {
         new Connection("n3", "n5"),
         new Connection("n4", "n5")));
     Assert.assertEquals(0, cdag.trim());
+
+    /*
+              |--> n2 --|
+              |         |--> n5
+         n1 --|--> n3 --|
+              |
+              |--> n4 --> n6
+     */
+    cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n1", "n4"),
+        new Connection("n2", "n5"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n6")));
+    Assert.assertEquals(0, cdag.trim());
   }
 
   @Test
@@ -313,6 +330,42 @@ public class ControlDagTest {
         new Connection("n4", "n6"),
         new Connection("n3", "n3.n6"),
         new Connection("n6", "n3.n6")));
+    Assert.assertEquals(expected, cdag);
+
+    /*
+              |--> n2 --|
+              |         |--> n5
+         n1 --|--> n3 --|
+              |
+              |--> n4 --> n6
+     */
+    cdag = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n1", "n4"),
+        new Connection("n2", "n5"),
+        new Connection("n3", "n5"),
+        new Connection("n4", "n6")));
+    cdag.flatten();
+
+    /*
+              |--> n2 ---------|
+              |                |
+         n1 --|--> n3 ---------|--> n2.n3.n6 --> n5
+              |                |
+              |--> n4 --> n6 --|
+     */
+    expected = new ControlDag(
+      ImmutableSet.of(
+        new Connection("n1", "n2"),
+        new Connection("n1", "n3"),
+        new Connection("n1", "n4"),
+        new Connection("n4", "n6"),
+        new Connection("n2", "n2.n3.n6"),
+        new Connection("n3", "n2.n3.n6"),
+        new Connection("n6", "n2.n3.n6"),
+        new Connection("n2.n3.n6", "n5")));
     Assert.assertEquals(expected, cdag);
   }
 }


### PR DESCRIPTION
Fixed a bug in the flatten logic of the control dag that could
create a flattened dag without a join node, which breaks the logic
in SmartWorkflow. The bug happens when there is a branch and
some of the branches join to a single node, but other branches
end in a sink. In those situations, a join node was not being
inserted, causing issues.