### PR TITLE
Fixing broken sdk

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
@@ -21,6 +21,9 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.metrics.collect.AggregatedMetricsCollectionService;
 import co.cask.cdap.metrics.collect.LocalMetricsCollectionService;
+import co.cask.cdap.metrics.store.DefaultMetricStore;
+import co.cask.cdap.metrics.store.LocalMetricsDatasetFactory;
+import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
@@ -40,7 +43,8 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
       protected void configure() {
         // Install the MetricsStoreModule as private bindings and expose the MetricStore.
         // Both LocalMetricsCollectionService and the AppFabricService needs it
-        install(new MetricsStoreModule());
+        bind(MetricDatasetFactory.class).to(LocalMetricsDatasetFactory.class).in(Scopes.SINGLETON);
+        bind(MetricStore.class).to(DefaultMetricStore.class);
         expose(MetricStore.class);
 
         bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
@@ -57,7 +61,8 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
       protected void configure() {
         // Install the MetricsStoreModule as private bindings and expose the MetricStore.
         // Both LocalMetricsCollectionService and the AppFabricService needs it
-        install(new MetricsStoreModule());
+        bind(MetricDatasetFactory.class).to(LocalMetricsDatasetFactory.class).in(Scopes.SINGLETON);
+        bind(MetricStore.class).to(DefaultMetricStore.class);
         expose(MetricStore.class);
 
         bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -35,7 +35,6 @@ import co.cask.cdap.metrics.store.upgrade.DataMigrationException;
 import co.cask.cdap.metrics.store.upgrade.MetricsDataMigrator;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
@@ -78,8 +77,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
   public FactTable getOrCreateFactTable(int resolution) {
     String v3TableName = cConf.get(Constants.Metrics.METRICS_TABLE_PREFIX,
                                        Constants.Metrics.DEFAULT_METRIC_V3_TABLE_PREFIX) + ".ts." + resolution;
-    String v2TableName = cConf.get(Constants.Metrics.METRICS_TABLE_PREFIX,
-                                         Constants.Metrics.DEFAULT_METRIC_TABLE_PREFIX + ".ts." + resolution);
+
     int ttl = cConf.getInt(Constants.Metrics.RETENTION_SECONDS + "." + resolution + ".seconds", -1);
 
     TableProperties.Builder props = TableProperties.builder();
@@ -93,7 +91,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
     props.add(HBaseTableAdmin.PROPERTY_SPLITS,
               GSON.toJson(FactTable.getSplits(DefaultMetricStore.AGGREGATIONS.size())));
 
-    MetricsTable table = getOrCreateResolutionMetricsTable(v2TableName, v3TableName, props);
+    MetricsTable table = getOrCreateResolutionMetricsTable(v3TableName, props, resolution);
     return new FactTable(table, entityTable.get(), resolution, getRollTime(resolution));
   }
 
@@ -104,7 +102,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
     return new MetricsConsumerMetaTable(table);
   }
 
-  private MetricsTable getOrCreateMetricsTable(String tableName, DatasetProperties props) {
+  protected MetricsTable getOrCreateMetricsTable(String tableName, DatasetProperties props) {
     // metrics tables are in the system namespace
     DatasetId metricsDatasetInstanceId = NamespaceId.SYSTEM.dataset(tableName);
     MetricsTable table = null;
@@ -117,13 +115,15 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
     return table;
   }
 
-  @VisibleForTesting
-  public MetricsTable getOrCreateResolutionMetricsTable(String v2TableName, String v3TableName,
-                                                         TableProperties.Builder props) {
+  protected MetricsTable getOrCreateResolutionMetricsTable(String v3TableName, TableProperties.Builder props,
+                                                           int resolution) {
     try {
       MetricsTable v2Table = null;
+
       // TODO: By default do not allow reading from v2 tables. Remove this check once CDAP-12306 is fixed
       if (cConf.getBoolean(Constants.Metrics.METRICS_V2_TABLE_SCAN_ENABLED)) {
+        String v2TableName = cConf.get(Constants.Metrics.METRICS_TABLE_PREFIX,
+                                       Constants.Metrics.DEFAULT_METRIC_TABLE_PREFIX + ".ts." + resolution);
         // metrics tables are in the system namespace
         DatasetId v2TableId = NamespaceId.SYSTEM.dataset(v2TableName);
         v2Table = dsFramework.getDataset(v2TableId, null, null);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/LocalMetricsDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/LocalMetricsDatasetFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metrics.store;
+
+import co.cask.cdap.api.dataset.table.TableProperties;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
+import com.google.inject.Inject;
+
+/**
+ * Standalone metrics dataset factory.
+ */
+public class LocalMetricsDatasetFactory extends DefaultMetricDatasetFactory {
+
+  @Inject
+  public LocalMetricsDatasetFactory(CConfiguration cConf, DatasetFramework dsFramework) {
+    super(cConf, dsFramework);
+  }
+
+  @Override
+  public MetricsTable getOrCreateResolutionMetricsTable(String tableName, TableProperties.Builder props,
+                                                        int resolution) {
+    return getOrCreateMetricsTable(tableName, props.build());
+  }
+}


### PR DESCRIPTION
Issue: The Metrics Salting PR: https://github.com/caskdata/cdap/pull/9371 was causing SDK to fail because we had some dependency on HBase classes in `DefaultMetricDatasetFactory` which is shared in both standalone and distributed mode.

Build: https://builds.cask.co/browse/CDAP-RUT1217-2

Fixing it by creating a separate Metrics DatasetFactory for standalone.

Tested on sdk, creating cluster to verify nothing is broken in distributed because of these changes.