### PR TITLE
Fixes lint error in pipelines

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -122,7 +122,6 @@ my-dag-plus {
     .box {
       position: absolute;
       cursor: move;
-      left: 100px;
       top: 150px;
       padding: 0;
       height: @node-box-height;
@@ -133,7 +132,6 @@ my-dag-plus {
       // Setting default node color
       color: @transform-plugins-color;
       left: 30vw;
-      .border-color-hover();
 
       .node {
         position: relative;
@@ -341,13 +339,11 @@ my-dag-plus {
       &.batchsource {
         color: @source-plugins-color;
         left: 10vw;
-        .border-color-hover();
       }
 
       &.errortransform {
         color: @error-transform;
         left: 30vw;
-        .border-color-hover();
       }
 
       &.realtimesink,


### PR DESCRIPTION
There was a CSS lint error after https://github.com/caskdata/cdap/pull/9303 was merged, since that change made it so that the `border-color-hover` function requires a param. I have just removed those calls in this PR, since we only need to call it once on the `.box` selector, not individually on each separate node type.

Also, removed the `left: 100px`, since by default we already have `left: 30vw`.