### PR TITLE
add case sensitive paths webpack plugin

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -39,6 +39,7 @@
     "bower": "1.7.2",
     "browser-sync": "2.18.8",
     "browser-sync-webpack-plugin": "1.1.4",
+    "case-sensitive-paths-webpack-plugin": "2.1.1",
     "concurrently": "3.1.0",
     "copy-webpack-plugin": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-3.0.1.tgz",
     "css-loader": "0.23.1",

--- a/cdap-ui/webpack.config.cdap.js
+++ b/cdap-ui/webpack.config.cdap.js
@@ -22,8 +22,10 @@ var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 var autoprefixer = require('autoprefixer');
 var StyleLintPlugin = require('stylelint-webpack-plugin');
 var BrowserSyncPlugin = require('browser-sync-webpack-plugin');
+var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 var plugins = [
+  new CaseSensitivePathsPlugin(),
   new webpack.DllReferencePlugin({
     context: path.resolve(__dirname, 'dll'),
     manifest: require(path.join(__dirname, 'dll', 'shared-vendor-manifest.json'))

--- a/cdap-ui/webpack.config.common.js
+++ b/cdap-ui/webpack.config.common.js
@@ -15,8 +15,10 @@
  */
 var webpack = require('webpack');
 var mode = process.env.NODE_ENV;
+var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 var plugins = [
+  new CaseSensitivePathsPlugin(),
   new webpack.optimize.DedupePlugin(),
   new webpack.optimize.CommonsChunkPlugin("common-lib", "common-lib.js", Infinity),
   // by default minify it.

--- a/cdap-ui/webpack.config.login.js
+++ b/cdap-ui/webpack.config.login.js
@@ -17,7 +17,10 @@ var webpack = require('webpack');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var StyleLintPlugin = require('stylelint-webpack-plugin');
 var path = require('path');
+var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
+
 var plugins = [
+  new CaseSensitivePathsPlugin(),
   new webpack.DllReferencePlugin({
     context: path.resolve(__dirname, 'dll'),
     manifest: require(path.join(__dirname, 'dll', '/shared-vendor-manifest.json'))


### PR DESCRIPTION
Issue: OSX paths are not case sensitive, therefore there are times when the build will pass on local machine, however when the build is run from Linux box, it will fail because the path is case sensitive.