### PR TITLE
[CDAP-12334] - Fixes popover styling to be consistent when using dataprep in pipeline studio

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
@@ -171,7 +171,7 @@ body.state-hydrator-create.state-hydrator {
       font-size: 14px;
     }
   }
-  .popover.bs-tether-element,
+  .popover.column_actions_dropdown-element,
   .highlight-popover-element {
     display: block;
     z-index: 1060;


### PR DESCRIPTION
This is caused by this regression: https://github.com/caskdata/cdap/commit/239d7d4f5101e7aae949e262f43f29b43c78477f#diff-a20dc9704a9c0f41baa5d425fa46560aL159