### PR TITLE
Decrease heap memory ratio

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -182,7 +182,7 @@
 
   <property>
     <name>twill.java.heap.memory.ratio</name>
-    <value>0.7</value>
+    <value>0.6</value>
     <description>
       The minimum ratio of heap to non-heap memory for Apache Twill container
     </description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="f968419be4a1bd3cb22ff7fbf6770c39"
+DEFAULT_XML_MD5_HASH="592e5981ed61feb7f39521b850af4b38"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Decrease heap memory ratio to `0.6` so MR jobs don't exceed the 512mb limit and fail integration tests