### PR TITLE
CDAP-12317 Add security.authorization.extension.extra.classpath support

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramClassLoader.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime;
 
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.dataset.DatasetClassRewriter;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.lang.DirectoryClassLoader;
@@ -58,7 +59,7 @@ public class ProgramClassLoader extends DirectoryClassLoader {
    * </pre>
    */
   public ProgramClassLoader(CConfiguration cConf, File dir, ClassLoader parent) {
-    super(cConf, dir, parent, "lib");
+    super(dir, cConf.get(Constants.AppFabric.PROGRAM_EXTRA_CLASSPATH), parent, "lib");
     this.dir = dir;
     this.classResourceLookup = ClassLoaders.createClassResourceLookup(this);
     this.datasetClassCache = new HashMap<>();

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -931,6 +931,8 @@ public final class Constants {
       public static final String ENABLED = "security.authorization.enabled";
       /** Extension jar path */
       public static final String EXTENSION_JAR_PATH = "security.authorization.extension.jar.path";
+      /** Extra classpath for security extension **/
+      public static final String EXTENSION_EXTRA_CLASSPATH = "security.authorization.extension.extra.classpath";
       /** Prefix for extension properties */
       public static final String EXTENSION_CONFIG_PREFIX =
         "security.authorization.extension.config.";

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/DirectoryClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/DirectoryClassLoader.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.common.lang;
 
-import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.DirUtils;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
@@ -61,15 +59,11 @@ public class DirectoryClassLoader extends InterceptableClassLoader {
     this(dir, "", parent, ImmutableSet.copyOf(libDirs));
   }
 
-  public DirectoryClassLoader(CConfiguration cConf, File dir, ClassLoader parent, String...libDirs) {
-    this(cConf, dir, parent, Arrays.asList(libDirs));
+  public DirectoryClassLoader(File dir, @Nullable String extraClassPath, ClassLoader parent, String...libDirs) {
+    this(dir, extraClassPath, parent, Arrays.asList(libDirs));
   }
 
-  public DirectoryClassLoader(CConfiguration cConf, File dir, ClassLoader parent, Iterable<String> libDirs) {
-    this(dir, cConf.get(Constants.AppFabric.PROGRAM_EXTRA_CLASSPATH), parent, libDirs);
-  }
-
-  public DirectoryClassLoader(File dir, String extraClassPath, ClassLoader parent, Iterable<String> libDirs) {
+  public DirectoryClassLoader(File dir, @Nullable String extraClassPath, ClassLoader parent, Iterable<String> libDirs) {
     super(getClassPathURLs(dir, extraClassPath, ImmutableSet.copyOf(libDirs)), parent);
 
     // Try to load the Manifest from the unpacked directory
@@ -110,7 +104,7 @@ public class DirectoryClassLoader extends InterceptableClassLoader {
     throw new UnsupportedOperationException("Class rewriting of class '" + className + "' is not supported");
   }
 
-  private static URL[] getClassPathURLs(File dir, String extraClassPath, Set<String> libDirs) {
+  private static URL[] getClassPathURLs(File dir, @Nullable String extraClassPath, Set<String> libDirs) {
     try {
       List<URL> urls = Lists.newArrayList(dir.toURI().toURL());
       addJarURLs(dir, urls);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
@@ -151,7 +151,7 @@ public class DatasetTypeManager {
             // NOTE: if jarLocation is null, we assume that this is a system module, ie. always present in classpath
             if (jarLocation != null) {
               BundleJarUtil.unJar(jarLocation, unpackedLocation);
-              cl = new DirectoryClassLoader(cConf, unpackedLocation,
+              cl = new DirectoryClassLoader(unpackedLocation, cConf.get(Constants.AppFabric.PROGRAM_EXTRA_CLASSPATH),
                                             FilterClassLoader.create(getClass().getClassLoader()), "lib");
             }
             reg = new DependencyTrackingRegistry(datasetModuleId, datasetTypeMDS, cl, force);

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * {@link DirectoryClassLoader} for {@link Authorizer} extensions.
@@ -71,7 +72,7 @@ public class AuthorizerClassLoader extends DirectoryClassLoader {
     }
   }
 
-  AuthorizerClassLoader(File unpackedJarDir) {
-    super(unpackedJarDir, createParent(), "lib");
+  AuthorizerClassLoader(File unpackedJarDir, @Nullable String authorizerExtraClasspath) {
+    super(unpackedJarDir, authorizerExtraClasspath, createParent(), "lib");
   }
 }


### PR DESCRIPTION
- Added a new configuration security.authorization.extension.extra.classpath which allow user to specify extra classpath for security extensions

Build: https://builds.cask.co/browse/CDAP-RUT1252