### PR TITLE
fix table wrap

### DIFF
--- a/cdap-docs/_common/_themes/cdap-bootstrap/static/cdap-bootstrap.css_t
+++ b/cdap-docs/_common/_themes/cdap-bootstrap/static/cdap-bootstrap.css_t
@@ -433,7 +433,7 @@ tt {
 td > code.docutils.literal {
     background-color: white;
     white-space: normal;
-    word-break: normal;
+    word-break: break-all;
 }
 
 /* -- Images -- */


### PR DESCRIPTION
This is a simple fix to the docs CSS that allows text in a table-list <td> to wrap, rather than overflow. 