### PR TITLE
Making metrics splits configurable from cConf at creation time

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -590,9 +590,7 @@ public final class Constants {
     // NOTE: "v3" to avoid conflict with data of older metrics system
     public static final String DEFAULT_METRIC_V3_TABLE_PREFIX = "metrics.v3.table";
     public static final String METRICS_HBASE_MAX_SCAN_THREADS = "metrics.hbase.max.scan.threads";
-    public static final String METRICS_V2_TABLE_SCAN_ENABLED = "metrics.v2.table.scan.enabled";
-    // Hardcode this value because we do not want user to control it
-    public static final int METRICS_HBASE_SPLITS = 16;
+    public static final String METRICS_HBASE_TABLE_SPLITS = "metrics.table.splits";
 
     public static final int DEFAULT_TIME_SERIES_TABLE_ROLL_TIME = 3600;
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2097,10 +2097,11 @@
   </property>
 
   <property>
-    <name>metrics.v2.table.scan.enabled</name>
-    <value>false</value>
+    <name>metrics.table.splits</name>
+    <value>16</value>
     <description>
-      Enable or disable scanning v2 metrics tables. By default set to false.
+      Number of splits for all metrics tables. This property can only be changed before CDAP starts up for the first
+      time and creates the metrics tables. Once all metrics tables are created, this property will not take any effect.
     </description>
   </property>
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.TableProperties;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LogSamplers;
 import co.cask.cdap.common.logging.Loggers;
@@ -81,11 +82,11 @@ public class HBaseMetricsTable implements MetricsTable {
   private ExecutorService scanExecutor;
 
   public HBaseMetricsTable(DatasetContext datasetContext, DatasetSpecification spec,
-                           Configuration hConf, HBaseTableUtil tableUtil) throws IOException {
+                           Configuration hConf, HBaseTableUtil tableUtil, CConfiguration cConf) throws IOException {
     this.tableUtil = tableUtil;
     this.tableId = tableUtil.createHTableId(new NamespaceId(datasetContext.getNamespaceId()), spec.getName());
 
-    initializeV3Vars(spec);
+    initializeV3Vars(cConf, spec);
 
     HTable hTable = tableUtil.createHTable(hConf, tableId);
     // todo: make configurable
@@ -95,7 +96,7 @@ public class HBaseMetricsTable implements MetricsTable {
     this.columnFamily = TableProperties.getColumnFamilyBytes(spec.getProperties());
   }
 
-  private void initializeV3Vars(DatasetSpecification spec) {
+  private void initializeV3Vars(CConfiguration cConf, DatasetSpecification spec) {
     boolean isV3Table = spec.getName().contains("v3");
     this.scanExecutor = null;
     this.rowKeyDistributor = null;
@@ -115,7 +116,7 @@ public class HBaseMetricsTable implements MetricsTable {
         }
       };
 
-      int maxScanThread = spec.getIntProperty(Constants.Metrics.METRICS_HBASE_MAX_SCAN_THREADS, 96);
+      int maxScanThread = cConf.getInt(Constants.Metrics.METRICS_HBASE_MAX_SCAN_THREADS);
       // Creates a executor that will shrink to 0 threads if left idle
       // Uses daemon thread, hence no need to worry about shutdown
       // When all threads are busy, use the caller thread to execute
@@ -125,7 +126,8 @@ public class HBaseMetricsTable implements MetricsTable {
                                                  callerRunsPolicy);
 
       this.rowKeyDistributor = new RowKeyDistributorByHashPrefix(
-        new RowKeyDistributorByHashPrefix.OneByteSimpleHash(Constants.Metrics.METRICS_HBASE_SPLITS));
+        new RowKeyDistributorByHashPrefix.
+          OneByteSimpleHash(spec.getIntProperty(Constants.Metrics.METRICS_HBASE_TABLE_SPLITS, 16)));
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.IncompatibleUpdateException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.AbstractTableDefinition;
@@ -71,12 +72,18 @@ public class HBaseMetricsTableDefinition extends AbstractTableDefinition<Metrics
   @Override
   public MetricsTable getDataset(DatasetContext datasetContext, DatasetSpecification spec,
                                  Map<String, String> arguments, ClassLoader classLoader) throws IOException {
-    return new HBaseMetricsTable(datasetContext, spec, hConf, hBaseTableUtil);
+    return new HBaseMetricsTable(datasetContext, spec, hConf, hBaseTableUtil, cConf);
   }
 
   @Override
   public DatasetAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
                                ClassLoader classLoader) throws IOException {
     return new HBaseTableAdmin(datasetContext, spec, hConf, hBaseTableUtil, cConf, locationFactory);
+  }
+
+  @Override
+  public DatasetSpecification reconfigure(String instanceName, DatasetProperties properties,
+                                          DatasetSpecification currentSpec) throws IncompatibleUpdateException {
+    throw new IncompatibleUpdateException("System Metrics Table properties can not be changed after creation.");
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -119,21 +119,17 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
   protected MetricsTable getOrCreateResolutionMetricsTable(String v3TableName, TableProperties.Builder props,
                                                            int resolution) {
     try {
-      MetricsTable v2Table = null;
+      String v2TableName = cConf.get(Constants.Metrics.METRICS_TABLE_PREFIX,
+                                     Constants.Metrics.DEFAULT_METRIC_TABLE_PREFIX + ".ts." + resolution);
 
-      // TODO: By default do not allow reading from v2 tables. Remove this check once CDAP-12306 is fixed
-      if (cConf.getBoolean(Constants.Metrics.METRICS_V2_TABLE_SCAN_ENABLED)) {
-        String v2TableName = cConf.get(Constants.Metrics.METRICS_TABLE_PREFIX,
-                                       Constants.Metrics.DEFAULT_METRIC_TABLE_PREFIX + ".ts." + resolution);
-        // metrics tables are in the system namespace
-        DatasetId v2TableId = NamespaceId.SYSTEM.dataset(v2TableName);
-        v2Table = dsFramework.getDataset(v2TableId, ImmutableMap.<String, String>of(), null);
-      }
+      // metrics tables are in the system namespace
+      DatasetId v2TableId = NamespaceId.SYSTEM.dataset(v2TableName);
+      MetricsTable v2Table = dsFramework.getDataset(v2TableId, ImmutableMap.<String, String>of(), null);
 
       props.add(HBaseTableAdmin.PROPERTY_SPLITS,
-                GSON.toJson(getV3MetricsTableSplits(Constants.Metrics.METRICS_HBASE_SPLITS)));
-      props.add(Constants.Metrics.METRICS_HBASE_MAX_SCAN_THREADS,
-                cConf.get(Constants.Metrics.METRICS_HBASE_MAX_SCAN_THREADS));
+                GSON.toJson(getV3MetricsTableSplits(cConf.getInt(Constants.Metrics.METRICS_HBASE_TABLE_SPLITS))));
+      props.add(Constants.Metrics.METRICS_HBASE_TABLE_SPLITS,
+                cConf.getInt(Constants.Metrics.METRICS_HBASE_TABLE_SPLITS));
 
       DatasetId v3TableId = NamespaceId.SYSTEM.dataset(v3TableName);
       MetricsTable v3Table = DatasetsUtil.getOrCreateDataset(dsFramework, v3TableId, MetricsTable.class.getName(),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorServiceTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.api.metrics.TagValue;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.io.DatumReaderFactory;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.metrics.store.MetricDatasetFactory;
@@ -86,7 +87,8 @@ public class MessagingMetricsProcessorServiceTest extends MetricsProcessorServic
         new MessagingMetricsProcessorService(injector.getInstance(MetricDatasetFactory.class), TOPIC_PREFIX,
                                              messagingService, injector.getInstance(SchemaGenerator.class),
                                              injector.getInstance(DatumReaderFactory.class), metricStore,
-                                             1000L, 5, partitions, new NoopMetricsContext(), 50, 0);
+                                             1000L, 5, partitions, new NoopMetricsContext(), 50, 0,
+                                             injector.getInstance(DatasetFramework.class), cConf);
       messagingMetricsProcessorService.startAndWait();
 
       // Wait for the 1 aggregated counter metric (with value 50) and 50 gauge metrics to be stored in the metricStore

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/process/MetricsProcessorServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/process/MetricsProcessorServiceTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.api.metrics.NoopMetricsContext;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.io.DatumReaderFactory;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.metrics.store.MetricDatasetFactory;
@@ -129,7 +130,8 @@ public class MetricsProcessorServiceTest extends MetricsProcessorServiceTestBase
       new MessagingMetricsProcessorService(injector.getInstance(MetricDatasetFactory.class), TOPIC_PREFIX,
                                            messagingService, injector.getInstance(SchemaGenerator.class),
                                            injector.getInstance(DatumReaderFactory.class),
-                                           metricStore, 1000L, 5, partitions, new NoopMetricsContext(), 50, 0);
+                                           metricStore, 1000L, 5, partitions, new NoopMetricsContext(), 50, 0,
+                                           injector.getInstance(DatasetFramework.class), cConf);
     messagingMetricsProcessorService.startAndWait();
 
     long startTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
@@ -147,7 +149,8 @@ public class MetricsProcessorServiceTest extends MetricsProcessorServiceTestBase
       new MessagingMetricsProcessorService(injector.getInstance(MetricDatasetFactory.class), TOPIC_PREFIX,
                                            messagingService, injector.getInstance(SchemaGenerator.class),
                                            injector.getInstance(DatumReaderFactory.class),
-                                           metricStore, 500L, 100, partitions, new NoopMetricsContext(), 50, 0);
+                                           metricStore, 500L, 100, partitions, new NoopMetricsContext(), 50, 0,
+                                           injector.getInstance(DatasetFramework.class), cConf);
     messagingMetricsProcessorService.startAndWait();
 
     // Publish metrics after MessagingMetricsProcessorService restarts and record expected metrics


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-12297
Build: https://builds.cask.co/browse/CDAP-RUT1244

Tested on cluster by updating the dataset properties of metrics table.