### PR TITLE
CDAP-12326 set up correct principal to deploy the app

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewApplicationManager.java
@@ -84,10 +84,10 @@ public class PreviewApplicationManager<I, O> implements Manager<I, O> {
     Pipeline<O> pipeline = pipelineFactory.getPipeline();
     pipeline.addLast(new LocalArtifactLoaderStage(cConf, store, artifactRepository, impersonator,
                                                   authorizationEnforcer, authenticationContext));
-    pipeline.addLast(new ApplicationVerificationStage(store, datasetFramework, ownerAdmin));
-    pipeline.addLast(new DeployDatasetModulesStage(cConf, datasetFramework,
-                                                   inMemoryDatasetFramework));
-    pipeline.addLast(new CreateDatasetInstancesStage(cConf, datasetFramework));
+    pipeline.addLast(new ApplicationVerificationStage(store, datasetFramework, ownerAdmin, authenticationContext));
+    pipeline.addLast(new DeployDatasetModulesStage(cConf, datasetFramework, inMemoryDatasetFramework,
+                                                   ownerAdmin, authenticationContext));
+    pipeline.addLast(new CreateDatasetInstancesStage(cConf, datasetFramework, ownerAdmin, authenticationContext));
     pipeline.addLast(new ProgramGenerationStage());
     pipeline.addLast(new ApplicationRegistrationStage(store, usageRegistry, ownerAdmin));
     pipeline.setFinally(new DeploymentCleanupStage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
@@ -121,10 +121,12 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
     Pipeline<O> pipeline = pipelineFactory.getPipeline();
     pipeline.addLast(new LocalArtifactLoaderStage(configuration, store, artifactRepository, impersonator,
                                                   authorizationEnforcer, authenticationContext));
-    pipeline.addLast(new ApplicationVerificationStage(store, datasetFramework, ownerAdmin));
-    pipeline.addLast(new DeployDatasetModulesStage(configuration, datasetFramework, inMemoryDatasetFramework));
-    pipeline.addLast(new CreateDatasetInstancesStage(configuration, datasetFramework));
-    pipeline.addLast(new CreateStreamsStage(streamAdmin));
+    pipeline.addLast(new ApplicationVerificationStage(store, datasetFramework, ownerAdmin, authenticationContext));
+    pipeline.addLast(new DeployDatasetModulesStage(configuration, datasetFramework, inMemoryDatasetFramework,
+                                                   ownerAdmin, authenticationContext));
+    pipeline.addLast(new CreateDatasetInstancesStage(configuration, datasetFramework, ownerAdmin,
+                                                     authenticationContext));
+    pipeline.addLast(new CreateStreamsStage(streamAdmin, ownerAdmin, authenticationContext));
     pipeline.addLast(new DeletedProgramHandlerStage(store, programTerminator, streamConsumerFactory, queueAdmin,
                                                     metricStore, metadataStore, impersonator));
     pipeline.addLast(new ProgramGenerationStage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -18,7 +18,6 @@ package co.cask.cdap.internal.app.namespace;
 
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.dataset.DatasetManagementException;
-import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NamespaceAlreadyExistsException;
@@ -33,7 +32,6 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.KerberosPrincipalId;
@@ -55,7 +53,6 @@ import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -148,11 +145,11 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
 
     // need to enforce on the principal id if impersonation is involved
     String ownerPrincipal = metadata.getConfig().getPrincipal();
+    Principal requestingUser = authenticationContext.getPrincipal();
     if (ownerPrincipal != null) {
-      authorizationEnforcer.enforce(new KerberosPrincipalId(ownerPrincipal), authenticationContext.getPrincipal(),
-                                    Action.ADMIN);
+      authorizationEnforcer.enforce(new KerberosPrincipalId(ownerPrincipal), requestingUser, Action.ADMIN);
     }
-    authorizationEnforcer.enforce(namespace, authenticationContext.getPrincipal(), Action.ADMIN);
+    authorizationEnforcer.enforce(namespace, requestingUser, Action.ADMIN);
 
     // If this namespace has custom mapping then validate the given custom mapping
     if (hasCustomMapping(metadata)) {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -25,8 +25,9 @@ import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
+import co.cask.cdap.common.namespace.SimpleNamespaceQueryAdmin;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -148,7 +149,6 @@ public class DFSStreamHeartbeatsTest {
         @Override
         protected void configure() {
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
-          install(new NamespaceClientRuntimeModule().getInMemoryModules());
           bind(StreamConsumerStateStoreFactory.class).to(LevelDBStreamConsumerStateStoreFactory.class)
             .in(Singleton.class);
           bind(StreamAdmin.class).to(FileStreamAdmin.class).in(Singleton.class);
@@ -161,6 +161,7 @@ public class DFSStreamHeartbeatsTest {
 
           bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
           bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
+          bind(NamespaceQueryAdmin.class).to(SimpleNamespaceQueryAdmin.class);
         }
       }));
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
@@ -20,8 +20,9 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
+import co.cask.cdap.common.namespace.SimpleNamespaceQueryAdmin;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -86,7 +87,6 @@ public class LevelDBStreamConsumerStateTest extends StreamConsumerStateTestBase 
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
-      new NamespaceClientRuntimeModule().getInMemoryModules(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new AuthenticationContextModules().getNoOpModule(),
@@ -98,6 +98,7 @@ public class LevelDBStreamConsumerStateTest extends StreamConsumerStateTestBase 
             bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
             bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
             bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
+            bind(NamespaceQueryAdmin.class).to(SimpleNamespaceQueryAdmin.class);
           }
         })
     );

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
@@ -19,8 +19,9 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
+import co.cask.cdap.common.namespace.SimpleNamespaceQueryAdmin;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -86,7 +87,6 @@ public class LevelDBStreamConsumerTest extends StreamConsumerTestBase {
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
-      new NamespaceClientRuntimeModule().getInMemoryModules(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new AuthenticationContextModules().getNoOpModule(),
@@ -98,6 +98,7 @@ public class LevelDBStreamConsumerTest extends StreamConsumerTestBase {
             bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
             bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
             bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
+            bind(NamespaceQueryAdmin.class).to(SimpleNamespaceQueryAdmin.class);
           }
         })
     );

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -37,6 +37,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.authorization.AuthorizationUtil;
 import co.cask.cdap.security.impersonation.SecurityUtil;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
@@ -118,6 +119,11 @@ class DatasetServiceClient {
     if (HttpResponseStatus.NOT_FOUND.getCode() == response.getResponseCode()) {
       return null;
     }
+    if (HttpResponseStatus.FORBIDDEN.getCode() == response.getResponseCode()) {
+      throw new DatasetManagementException(String.format("Failed to get dataset instance %s, details: %s",
+                                                         instanceName, response),
+                                           new UnauthorizedException(response.getResponseBodyAsString()));
+    }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Cannot retrieve dataset instance %s info, details: %s",
                                                          instanceName, response));
@@ -171,6 +177,11 @@ class DatasetServiceClient {
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new InstanceConflictException(String.format("Failed to add instance %s due to conflict, details: %s",
                                                         datasetInstanceName, response));
+    }
+    if (HttpResponseStatus.FORBIDDEN.getCode() == response.getResponseCode()) {
+      throw new DatasetManagementException(String.format("Failed to add instance %s, details: %s",
+                                                         datasetInstanceName, response),
+                                           new UnauthorizedException(response.getResponseBodyAsString()));
     }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Failed to add instance %s, details: %s",

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -427,15 +427,11 @@ public class FileStreamAdmin implements StreamAdmin {
     }
 
     // need to enforce on the principal id if impersonation is involved
-    KerberosPrincipalId principalId =
-      specifiedOwnerPrincipal == null ? null : new KerberosPrincipalId(specifiedOwnerPrincipal);
-    if (!streamId.getNamespaceId().equals(NamespaceId.SYSTEM) && principalId == null) {
-      // if stream owner is not present, get the namespace impersonation principal
-      String namespacePrincipal = ownerAdmin.getOwnerPrincipal(streamId.getNamespaceId());
-      principalId = namespacePrincipal == null ? null : new KerberosPrincipalId(namespacePrincipal);
-    }
-    if (principalId != null) {
-      authorizationEnforcer.enforce(principalId, authenticationContext.getPrincipal(), Action.ADMIN);
+    KerberosPrincipalId effectiveOwner = SecurityUtil.getEffectiveOwner(ownerAdmin, streamId.getNamespaceId(),
+                                                                        specifiedOwnerPrincipal);
+    Principal requestingUser = authenticationContext.getPrincipal();
+    if (effectiveOwner != null) {
+      authorizationEnforcer.enforce(effectiveOwner, requestingUser, Action.ADMIN);
     }
     ensureAccess(streamId, Action.ADMIN);
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/SecurityUtil.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/SecurityUtil.java
@@ -19,6 +19,7 @@ package co.cask.cdap.security.impersonation;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.id.KerberosPrincipalId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.base.Preconditions;
@@ -277,5 +278,35 @@ public final class SecurityUtil {
                                                     Constants.Security.PRINCIPAL, specifiedOwnerPrincipal,
                                                     Constants.Security.PRINCIPAL));
     }
+  }
+
+  /**
+   * Helper function to get the effective owner of an entity. It will check the owner store to get the namespace
+   * owner if the provided owner principal is null.
+   *
+   * Note that this method need not be used after the entity is created, in that case simply
+   * use {@link OwnerAdmin}.getImpersonationPrincipal()
+   *
+   * @param ownerAdmin owner admin to query the owner
+   * @param namespaceId the namespace the entity is in
+   * @param ownerPrincipal the owner principal of the entity, null if not provided
+   * @return the effective owner of the entity, null if no owner is provided for both the enity and the namespace.
+   */
+  @Nullable
+  public static KerberosPrincipalId getEffectiveOwner(OwnerAdmin ownerAdmin, NamespaceId namespaceId,
+                                                      @Nullable String ownerPrincipal) throws IOException {
+    if (ownerPrincipal != null) {
+      // if entity owner is present, return it
+      return new KerberosPrincipalId(ownerPrincipal);
+    }
+
+    if (!namespaceId.equals(NamespaceId.SYSTEM)) {
+      // if entity owner is not present, get the namespace impersonation principal
+      String namespacePrincipal = ownerAdmin.getImpersonationPrincipal(namespaceId);
+      return namespacePrincipal == null ? null : new KerberosPrincipalId(namespacePrincipal);
+    }
+
+    // No owner found
+    return null;
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyApp.java
@@ -19,6 +19,8 @@ package co.cask.cdap.test.app;
 import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.service.AbstractService;
@@ -27,6 +29,7 @@ import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import com.google.common.base.Charsets;
 
+import java.io.IOException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
@@ -41,6 +44,7 @@ public class DummyApp extends AbstractApplication {
     setDescription("DummyApp");
     addStream(new Stream("who"));
     createDataset("whom", KeyValueTable.class);
+    createDataset("customDataset", CustomDummyDataset.class);
     addService(new Greeting());
   }
 
@@ -79,6 +83,19 @@ public class DummyApp extends AbstractApplication {
         metrics.count("greetings.count.jane_doe", 1);
       }
       responder.sendString(String.format("Hello %s!", toGreet));
+    }
+  }
+
+  /**
+   * A dummy custom dataset to test the creation
+   */
+  public static final class CustomDummyDataset implements Dataset {
+
+    public CustomDummyDataset(DatasetSpecification spec) {
+    }
+
+    @Override
+    public void close() throws IOException {
     }
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12326
Build: https://builds.cask.co/browse/CDAP-RUT1242-3

Adds the Authorization.doAs() which will set the requesting user id and set back after the call.
Fixes a bug for calling wrong method in OwnerAdmin, should call `OwnerAdmin.getImpersonatinPrincipal()`
Fixes the unit test broken with this fix, since creation of stream needs to look up the ns config, while some unit tests are not creating namespace using admin, which results not found for namespace.
Also fixes a small part of http code issue, to fix the whole thing we need a separate pr to get things clear.