### PR TITLE
lib folder addition to artifact classloader 

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/DefaultArtifactManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/DefaultArtifactManager.java
@@ -181,8 +181,10 @@ public class DefaultArtifactManager {
       File unpackedDir = DirUtils.createTempDir(tmpDir);
       BundleJarUtil.unJar(location, unpackedDir);
       DirectoryClassLoader directoryClassLoader =
-        new DirectoryClassLoader(unpackedDir, parentClassLoader == null ? bootstrapClassLoader : parentClassLoader);
-      return new CloseableClassLoader(directoryClassLoader, new ClassLoaderCleanup(directoryClassLoader, unpackedDir));
+        new DirectoryClassLoader(unpackedDir,
+                                 parentClassLoader == null ? bootstrapClassLoader : parentClassLoader, "lib");
+      return new CloseableClassLoader(directoryClassLoader,
+                                      new ClassLoaderCleanup(directoryClassLoader, unpackedDir));
     } else {
       throw new IOException(String.format("Exception while getting artifacts list %s",
                                           httpResponse.getResponseBodyAsString()));


### PR DESCRIPTION
When we create artifact classloader (created from service, given an artifact) we weren't including the lib folder. 
fix to add lib folder.
JIRA : https://issues.cask.co/browse/CDAP-12280
