### PR TITLE
update md5 hash

### DIFF
--- a/cdap-docs/developer-manual/build.sh
+++ b/cdap-docs/developer-manual/build.sh
@@ -73,7 +73,7 @@ function download_includes() {
   download_readme_file_and_test ${includes_dir} ${ingest_url} cf2d8cac45b4be267adbb0e8ecdc88a4 cdap-flume
   download_readme_file_and_test ${includes_dir} ${ingest_url} a852e493aff54ffd726368691f248d80 cdap-stream-clients/java
   download_readme_file_and_test ${includes_dir} ${ingest_url} da242d9be7051417bd5ff73b3dc5edc2 cdap-stream-clients/python
-  download_readme_file_and_test ${includes_dir} ${ingest_url} b798091f24f6ecfe05d614f1dd1f7a03 cdap-stream-clients/ruby
+  download_readme_file_and_test ${includes_dir} ${ingest_url} 4475514acbba0a5f32a61d5c13c30fdb cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"
 


### PR DESCRIPTION
This updates the md5 hash for cdap-stream-clients so that the docs build will succeed