### PR TITLE
Introduce a setMetadata API, and reinstate the old behavior of addMetadata API

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -68,8 +68,9 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
 
   /**
    * Adds a new metadata entry for a particular partition.
-   * If the metadata key already exists, it will be overwritten.
+   * Note that existing entries cannot be updated.
    *
+   * @throws DataSetException when an attempt is made to update an existing entry
    * @throws PartitionNotFoundException when a partition for the given key is not found
    * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
@@ -77,12 +78,22 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
 
   /**
    * Adds a set of new metadata entries for a particular partition.
-   * If the metadata key already exists, it will be overwritten.
+   * Note that existing entries cannot be updated.
    *
+   * @throws DataSetException when an attempt is made to update existing entries
    * @throws PartitionNotFoundException when a partition for the given key is not found
    * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
+
+  /**
+   * Sets metadata entries for a particular partition. If the metadata entry key does not already exist, it will be
+   * created; otherwise, it will be overwritten. Other existing keys remain unchanged.
+   *
+   * @throws PartitionNotFoundException when a partition for the given key is not found
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
+   */
+  void setMetadata(PartitionKey key, Map<String, String> metadata);
 
   /**
    * Removes a metadata entry for a particular partition.

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.PartitionNotFoundException;
 
 import java.util.Map;
@@ -64,21 +65,32 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
 
   /**
    * Adds a new metadata entry for a particular partition.
-   * If the metadata key already exists, it will be overwritten.
+   * Note that existing entries can not be updated.
    *
    * @param time the partition time in milliseconds since the Epoch
-   * @throws PartitionNotFoundException when a partition for the given time is not found
+   *
+   * @throws DataSetException in case an attempt is made to update existing entries.
    */
   void addMetadata(long time, String metadataKey, String metadataValue);
 
   /**
    * Adds a set of new metadata entries for a particular partition
-   * If the metadata key already exists, it will be overwritten.
+   * Note that existing entries can not be updated.
    *
    * @param time the partition time in milliseconds since the Epoch
-   * @throws PartitionNotFoundException when a partition for the given time is not found
+   *
+   * @throws DataSetException in case an attempt is made to update existing entries.
    */
   void addMetadata(long time, Map<String, String> metadata);
+
+  /**
+   * Sets metadata entries for a particular partition. If the metadata entry key does not already exist, it will be
+   * created; otherwise, it will be overwritten. Other existing keys remain unchanged.
+   *
+   * @throws PartitionNotFoundException when a partition for the given key is not found
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
+   */
+  void setMetadata(long time, Map<String, String> metadata);
 
   /**
    * Removes a metadata entry for a particular time.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -102,6 +102,11 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
   }
 
   @Override
+  public void setMetadata(long time, Map<String, String> metadata) {
+    setMetadata(partitionKeyForTime(time), metadata);
+  }
+
+  @Override
   public void removeMetadata(long time, String metadataKey) {
     removeMetadata(partitionKeyForTime(time), metadataKey);
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -579,13 +579,20 @@ public class PartitionedFileSetTest {
         combinedEntries.putAll(updatedMetadata);
         Assert.assertEquals(combinedEntries, partitionDetail.getMetadata().asMap());
 
-        // adding an entry, for a key that already exists will overwrite the previous value
-        dataset.addMetadata(PARTITION_KEY, "key3", "value4");
+        // using the setMetadata API, adding an entry, for a key that already exists will overwrite the previous value
+        dataset.setMetadata(PARTITION_KEY, Collections.singletonMap("key3", "value4"));
 
         partitionDetail = dataset.getPartition(PARTITION_KEY);
         Assert.assertNotNull(partitionDetail);
         Assert.assertEquals(ImmutableMap.of("key1", "value1", "key2", "value2", "key3", "value4"),
                             partitionDetail.getMetadata().asMap());
+
+        // adding an entry, for a key that already exists will throw an Exception
+        try {
+          dataset.addMetadata(PARTITION_KEY, "key2", "value3");
+          Assert.fail("Expected not to be able to update an existing metadata entry");
+        } catch (DataSetException expected) {
+        }
 
         // possible to remove multiple metadata entries; if a key doesn't exist, no error is thrown
         dataset.removeMetadata(PARTITION_KEY, ImmutableSet.of("key2", "key3", "key4"));

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -106,14 +106,21 @@ public class TimePartitionedFileSetTest {
         tpfs.addMetadata(time, "key3", "value4");
         allMetadata.put("key3", "value4");
 
-        // adding an entry, for a key that already exists will overwrite the previous value
-        tpfs.addMetadata(time, "key3", "value5");
+        // using the setMetadata API, adding an entry, for a key that already exists will overwrite the previous value
+        tpfs.setMetadata(time, Collections.singletonMap("key3", "value5"));
         allMetadata.put("key3", "value5");
 
         Map<String, String> newMetadata = ImmutableMap.of("key4", "value4",
                                                           "key5", "value5");
         tpfs.addMetadata(time, newMetadata);
         allMetadata.putAll(newMetadata);
+
+        try {
+          // attempting to update an existing key throws a DatasetException
+          tpfs.addMetadata(time, "key3", "value5");
+          Assert.fail("Expected not to be able to update an existing metadata entry");
+        } catch (DataSetException expected) {
+        }
 
         partitionByTime = tpfs.getPartitionByTime(time);
         Assert.assertNotNull(partitionByTime);


### PR DESCRIPTION
In https://github.com/caskdata/cdap/pull/9344, I updated the semantics of `PartitionedFileSet.addMetadata` to allow updating existing metadata entries.
This PR introduces a setMetadata API, and reinstates the previous behavior of addMetadata API to disallow modifying existing keys.

https://builds.cask.co/browse/CDAP-RUT1254-1