### PR TITLE
CDAP-11704 Acquire delegation tokens for Yarn Timeline Server, if it is enabled

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1052,6 +1052,11 @@ public final class Constants {
     public static final String SUBMITVIACHILD = "hive.exec.submitviachild";
     public static final String HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST_APPEND =
       "hive.security.authorization.sqlstd.confwhitelist.append";
+    // Same as YarnConfiguration.TIMELINE_SERVICE_ENABLED, which isn't available on all hadoop versions
+    public static final String TIMELINE_SERVICE_ENABLED = "yarn.timeline-service.enabled";
+    // Same as YarnConfiguration.TIMELINE_DELEGATION_KEY_UPDATE_INTERVAL, which isn't available on all hadoop versions
+    public static final String TIMELINE_DELEGATION_KEY_UPDATE_INTERVAL =
+      "yarn.timeline-service.delegation.key.update-interval";
 
     /** Determines how to behave when the Hive version is unsupported */
     public static final String HIVE_VERSION_RESOLUTION_STRATEGY = "hive.version.resolution.strategy";

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/YarnTokenUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/YarnTokenUtils.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.common.security;
 
+import co.cask.cdap.common.conf.Constants;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import org.apache.hadoop.io.Text;
@@ -32,6 +33,7 @@ import org.apache.twill.internal.yarn.YarnUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +46,7 @@ public final class YarnTokenUtils {
 
   /**
    * Gets a Yarn delegation token and stores it in the given Credentials.
+   * Also gets Yarn App Timeline Server, if it is enabled.
    *
    * @return the same Credentials instance as the one given in parameter.
    */
@@ -58,6 +61,19 @@ public final class YarnTokenUtils {
       yarnClient.start();
 
       try {
+        if (configuration.getBoolean(Constants.Explore.TIMELINE_SERVICE_ENABLED, false)) {
+          // yarnClient.getTimelineDelegationToken() is only accessible in Hadoop 2.6.0+, and only on those versions
+          // would/should user enable Yarn ATS
+          Method method = yarnClient.getClass().getDeclaredMethod("getTimelineDelegationToken");
+          method.setAccessible(true);
+          Token<? extends TokenIdentifier> atsToken = (Token<? extends TokenIdentifier>) method.invoke(yarnClient);
+          if (atsToken != null) {
+            credentials.addToken(atsToken.getService(), atsToken);
+            LOG.info("Added Yarn Timeline Server delegation token: {}", atsToken);
+          }
+        }
+
+
         Text renewer = new Text(UserGroupInformation.getCurrentUser().getShortUserName());
         org.apache.hadoop.yarn.api.records.Token rmDelegationToken = yarnClient.getRMDelegationToken(renewer);
 


### PR DESCRIPTION
[CDAP-11704](https://issues.cask.co/browse/CDAP-11704)
Acquire delegation tokens for Yarn Timeline Server, if it is enabled.

Tested on an Ambari cluster with Yarn TS enabled, but also kicked off integration tests against a non-ambari cluster without Yarn TS enabled: https://builds.cask.co/browse/CDAP-ITM19-32

https://builds.cask.co/browse/CDAP-RUT1262