### PR TITLE
CDAP-12135 Support Wildcard grant/revoke

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
@@ -31,6 +31,7 @@ import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.SecureKeyId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
@@ -202,7 +203,7 @@ public class DefaultSecureStoreServiceTest {
     Predicate<Privilege> secureKeyIdFilter = new Predicate<Privilege>() {
       @Override
       public boolean apply(Privilege input) {
-        return input.getEntity().equals(secureKeyId1);
+        return input.getAuthorizable().equals(Authorizable.fromEntityId(secureKeyId1));
       }
     };
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
@@ -20,8 +20,8 @@ import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.client.AuthorizationClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
@@ -32,7 +32,7 @@ import java.io.PrintStream;
 import java.util.Set;
 
 /**
- * Grants a user permission to perform certain actions on an entity.
+ * Grants a user permission to perform certain actions on an auhorizable.
  */
 public class GrantActionCommand extends AbstractAuthCommand {
 
@@ -46,7 +46,7 @@ public class GrantActionCommand extends AbstractAuthCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
+    Authorizable authorizable = Authorizable.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     String principalName = arguments.get("principal-name");
     Principal.PrincipalType principalType =
       Principal.PrincipalType.valueOf(arguments.get("principal-type").toUpperCase());
@@ -55,9 +55,9 @@ public class GrantActionCommand extends AbstractAuthCommand {
     // actions is not an optional argument so should never be null
     Preconditions.checkNotNull(actions, "Actions can never be null in the grant command.");
 
-    client.grant(entity, principal, actions);
+    client.grant(authorizable, principal, actions);
     output.printf("Successfully granted action(s) '%s' on entity '%s' to %s '%s'\n",
-                  Joiner.on(",").join(actions), entity.toString(), principal.getType(), principal.getName());
+                  Joiner.on(",").join(actions), authorizable.toString(), principal.getType(), principal.getName());
   }
 
   @Override
@@ -68,7 +68,7 @@ public class GrantActionCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Grants a principal privileges to perform certain actions on an entity. %s %s",
+    return String.format("Grants a principal privileges to perform certain actions on an authorizable. %s %s",
       ArgumentName.ENTITY_DESCRIPTION_ACTIONS, ArgumentName.ENTITY_DESCRIPTION_ALL_STRING);
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/ListPrivilegesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/ListPrivilegesCommand.java
@@ -49,12 +49,12 @@ public class ListPrivilegesCommand extends AbstractAuthCommand {
     String principalType = arguments.get(ArgumentName.PRINCIPAL_TYPE.toString());
     String principalName = arguments.get(ArgumentName.PRINCIPAL_NAME.toString());
     Table table = Table.builder()
-      .setHeader("Entity", "Action")
+      .setHeader("Authorizable", "Action")
       .setRows(Lists.newArrayList(client.listPrivileges(new Principal(principalName, Principal.PrincipalType.valueOf
         (principalType.toUpperCase())))), new RowMaker<Privilege>() {
         @Override
         public List<?> makeRow(Privilege privilege) {
-          return Lists.newArrayList(privilege.getEntity().toString(), privilege.getAction().name());
+          return Lists.newArrayList(privilege.getAuthorizable().toString(), privilege.getAction().name());
         }
       }).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
@@ -20,8 +20,8 @@ import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.client.AuthorizationClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
@@ -46,7 +46,7 @@ public abstract class RevokeActionCommand extends AbstractAuthCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
+    Authorizable authorizable = Authorizable.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     String principalName = arguments.getOptional("principal-name", null);
     String type = arguments.getOptional("principal-type", null);
     Principal.PrincipalType principalType =
@@ -55,10 +55,10 @@ public abstract class RevokeActionCommand extends AbstractAuthCommand {
     String actionsString = arguments.getOptional("actions", null);
     Set<Action> actions = actionsString == null ? null : ACTIONS_STRING_TO_SET.apply(actionsString);
 
-    client.revoke(entity, principal, actions);
+    client.revoke(authorizable, principal, actions);
     if (principal == null && actions == null) {
       // Revoked all actions for all principals on the entity
-      output.printf("Successfully revoked all actions on entity '%s' for all principals", entity.toString());
+      output.printf("Successfully revoked all actions on entity '%s' for all principals", authorizable.toString());
     } else {
       // currently, the CLI only supports 2 scenarios:
       // 1. both actions and principal are null - supported in the if block.
@@ -67,7 +67,7 @@ public abstract class RevokeActionCommand extends AbstractAuthCommand {
       Preconditions.checkNotNull(actions, "Actions cannot be null when principal is not null in the revoke command");
       Preconditions.checkNotNull(principal, "Principal cannot be null when actions is not null in the revoke command");
       output.printf("Successfully revoked action(s) '%s' on entity '%s' for %s '%s'\n",
-                    Joiner.on(",").join(actions), entity.toString(), principal.getType(), principal.getName());
+                    Joiner.on(",").join(actions), authorizable.toString(), principal.getType(), principal.getName());
     }
   }
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.GrantRequest;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
@@ -100,8 +101,13 @@ public class AuthorizationClient extends AbstractAuthorizer {
   @Override
   public void grant(EntityId entity, Principal principal, Set<Action> actions) throws IOException,
     UnauthenticatedException, FeatureDisabledException, UnauthorizedException, NotFoundException {
+    grant(Authorizable.fromEntityId(entity), principal, actions);
+  }
 
-    GrantRequest grantRequest = new GrantRequest(entity, principal, actions);
+  @Override
+  public void grant(Authorizable authorizable, Principal principal, Set<Action> actions) throws IOException,
+    UnauthorizedException, UnauthenticatedException, NotFoundException, FeatureDisabledException {
+    GrantRequest grantRequest = new GrantRequest(authorizable, principal, actions);
 
     URL url = config.resolveURLV3(AUTHORIZATION_BASE + "/privileges/grant");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(grantRequest)).build();
@@ -111,13 +117,24 @@ public class AuthorizationClient extends AbstractAuthorizer {
   @Override
   public void revoke(EntityId entity) throws IOException, UnauthenticatedException, FeatureDisabledException,
     UnauthorizedException, NotFoundException {
-    revoke(entity, null, null);
+    revoke(Authorizable.fromEntityId(entity), null, null);
+  }
+
+  @Override
+  public void revoke(Authorizable authorizable) throws Exception {
+    revoke(authorizable, null, null);
   }
 
   @Override
   public void revoke(EntityId entity, @Nullable Principal principal, @Nullable Set<Action> actions) throws IOException,
     UnauthenticatedException, FeatureDisabledException, UnauthorizedException, NotFoundException {
-    revoke(new RevokeRequest(entity, principal, actions));
+    revoke(Authorizable.fromEntityId(entity), principal, actions);
+  }
+
+  @Override
+  public void revoke(Authorizable authorizable, Principal principal, Set<Action> actions) throws IOException,
+    UnauthenticatedException, FeatureDisabledException, UnauthorizedException, NotFoundException {
+    revoke(new RevokeRequest(authorizable, principal, actions));
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -62,9 +62,9 @@ import javax.annotation.Nullable;
 @SuppressWarnings("unchecked")
 public abstract class EntityId implements IdCompatible {
 
-  private static final String IDSTRING_TYPE_SEPARATOR = ":";
-  private static final String IDSTRING_PART_SEPARATOR = ".";
-  private static final Pattern IDSTRING_PART_SEPARATOR_PATTERN = Pattern.compile("\\.");
+  public static final String IDSTRING_TYPE_SEPARATOR = ":";
+  public static final String IDSTRING_PART_SEPARATOR = ".";
+  public static final Pattern IDSTRING_PART_SEPARATOR_PATTERN = Pattern.compile("\\.");
 
   // Allow hyphens for other ids.
   private static final Pattern idPattern = Pattern.compile("[a-zA-Z0-9_-]+");

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Authorizable.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Authorizable.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto.security;
+
+
+import co.cask.cdap.proto.element.EntityType;
+import co.cask.cdap.proto.id.EntityId;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Class to represent entities on which privileges can be granted/revoked.
+ * This class allows wildcard privileges (* and ?).
+ */
+public class Authorizable {
+  // represents the type of entity
+  private final EntityType entityType;
+  // represent the parts of the entity
+  private final Map<EntityType, String> entityParts;
+
+
+  public Authorizable(EntityType entityType, Map<EntityType, String> entityParts) {
+    this.entityType = entityType;
+    this.entityParts = Collections.unmodifiableMap(entityParts);
+  }
+
+  /**
+   * Constructs an {@link Authorizable} from the given entityString. The entityString must be a representation of an
+   * entity similar to {@link EntityId#toString()} with the exception that the string can contain wildcards (? and *).
+   * Note:
+   * <ol>
+   * <li>
+   * The only validation that this class performs on the entityString is that it checks if the string has enough
+   * valid parts for the given {@link #entityType}. It does not check if the entity exists or not. This is
+   * required to allow pre grants.
+   * </li>
+   * <li>
+   * CDAP Authorization does not support authorization on versions of {@link co.cask.cdap.proto.id.ApplicationId}
+   * and {@link co.cask.cdap.proto.id.ArtifactId}. If a version is included while construction an Authorizable
+   * through {@link #fromString(String)} an {@link IllegalArgumentException} will be thrown.
+   * </li>
+   * </ol>
+   *
+   * @param entityString the {@link EntityId#toString()} of the entity which may or may not contains wildcards(? or *)
+   */
+  public static Authorizable fromString(String entityString) {
+    if (entityString == null || entityString.isEmpty()) {
+      throw new IllegalArgumentException("Null or empty entity string.");
+    }
+
+    String[] typeAndId = entityString.split(EntityId.IDSTRING_TYPE_SEPARATOR, 2);
+    if (typeAndId.length != 2) {
+      throw new IllegalArgumentException(
+        String.format("Cannot extract the entity type from %s", entityString));
+    }
+    String typeString = typeAndId[0];
+    EntityType type = EntityType.valueOf(typeString.toUpperCase());
+    String idString = typeAndId[1];
+    List<String> idParts;
+    if (type != EntityType.KERBEROSPRINCIPAL) {
+      // kerberos principal might contain . which is also EntityId.IDSTRING_PART_SEPARATOR_PATTERN so don't split for
+      // them and also principal doesn't have other parts so just initialize
+      idParts = Arrays.asList(EntityId.IDSTRING_PART_SEPARATOR_PATTERN.split(idString));
+    } else {
+      idParts = Collections.singletonList(idString);
+    }
+    Map<EntityType, String> entityParts = new LinkedHashMap<>();
+    checkParts(type, idParts, idParts.size() - 1, entityParts);
+    return new Authorizable(type, entityParts);
+  }
+
+  /**
+   * Creates an {@link Authorizable} which represents the given entityId.
+   * Note: CDAP Authorization does not support authorization on versions of {@link co.cask.cdap.proto.id.ApplicationId}
+   * and {@link co.cask.cdap.proto.id.ArtifactId}. If an artifactId or applicationId which has version is passed to
+   * then the version will be silently dropped to construct the authorizable.
+   *
+   * @param entityId the entity
+   * @return {@link Authorizable} representing the entity
+   */
+  public static Authorizable fromEntityId(EntityId entityId) {
+    if (entityId == null) {
+      throw new IllegalArgumentException("EntityId is required.");
+    }
+    String entity = entityId.toString();
+    // drop the version for artifact or application
+    if (entityId.getEntityType().equals(EntityType.ARTIFACT) ||
+      entityId.getEntityType().equals(EntityType.APPLICATION) || entityId.getEntityType().equals(EntityType.PROGRAM)) {
+      int versionStartIndex = entity.indexOf(EntityId.IDSTRING_PART_SEPARATOR,
+                                             entity.indexOf(EntityId.IDSTRING_PART_SEPARATOR) + 1);
+      int versionEndIndex = entity.length();
+      if (entityId.getEntityType().equals(EntityType.PROGRAM)) {
+        // for programs versions doesn't end at the end of the entity string as there is program type and name
+        // afterwards
+        versionEndIndex = entity.lastIndexOf(EntityId.IDSTRING_PART_SEPARATOR,
+                                             entity.lastIndexOf(EntityId.IDSTRING_PART_SEPARATOR) - 1);
+      }
+      // remove the version from the entity string
+      String version = entity.substring(versionStartIndex, versionEndIndex);
+      entity = entity.replace(version, "");
+    }
+    return fromString(entity);
+  }
+
+  /**
+   * @return the type of the entity which is represented by this authorizable
+   */
+  public EntityType getEntityType() {
+    return entityType;
+  }
+
+  /**
+   * @return a map which represents the parts of the entity in ordered according to CDAP entity hierarchy. For
+   * example: Stream comes after Namespace, Program comes after an Application etc. according to CDAP entity hierarchy.
+   */
+  public Map<EntityType, String> getEntityParts() {
+    return Collections.unmodifiableMap(entityParts);
+  }
+
+  /**
+   * @return a string representation of the authorizable which is compatible with {@link EntityId#toString()}.
+   */
+  @Override
+  public String toString() {
+    // the to string is done in this way to matain compatibility with EntityId.toString()
+    StringBuilder result = new StringBuilder();
+    result.append(entityType.name().toLowerCase());
+
+    String separator = EntityId.IDSTRING_TYPE_SEPARATOR;
+    for (String part : entityParts.values()) {
+      result.append(separator).append(part);
+      separator = EntityId.IDSTRING_PART_SEPARATOR;
+    }
+    return result.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Authorizable that = (Authorizable) o;
+    return entityType == that.entityType && entityParts.equals(that.entityParts);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entityType, entityParts);
+  }
+
+  private static void checkParts(EntityType entityType, List<String> parts, int index,
+                                 Map<EntityType, String> entityParts) {
+    switch (entityType) {
+      case INSTANCE:
+      case NAMESPACE:
+        entityParts.put(entityType, parts.get(index));
+        break;
+      case KERBEROSPRINCIPAL:
+        entityParts.put(entityType, parts.get(index));
+        break;
+      case ARTIFACT:
+      case APPLICATION:
+        // artifact and application have version part to it. We don't support version for authorization purpose.
+        // also throw exception only when the actual entity type in question is artifact/application not when we
+        // reached here through recursive call on program
+        if (parts.size() > 2 && index == (parts.size() - 1)) {
+          throw new UnsupportedOperationException("Privilege can only be granted at the artifact/application level. " +
+                                                    "If you are including version please remove it. Given entity: " +
+                                                    parts);
+        }
+        checkParts(EntityType.NAMESPACE, parts, index - 1, entityParts);
+        entityParts.put(entityType, parts.get(index));
+        break;
+      case DATASET:
+      case DATASET_MODULE:
+      case DATASET_TYPE:
+      case STREAM:
+      case SECUREKEY:
+        checkParts(EntityType.NAMESPACE, parts, index - 1, entityParts);
+        entityParts.put(entityType, parts.get(index));
+        break;
+      case PROGRAM:
+        // application have version part to it. We don't support version for authorization purpose.
+        // also throw exception only when the actual entity type in question is program not when we
+        // reached here through recursive call on some child of program (future security)
+        if (parts.size() > 4 && index == (parts.size() - 1)) {
+          throw new UnsupportedOperationException("Privilege can only be granted at the artifact/application level. " +
+                                                    "If you are including version please remove it. Given entity: " +
+                                                    parts);
+        }
+        checkParts(EntityType.APPLICATION, parts, index - 2, entityParts);
+        entityParts.put(entityType, parts.get(index - 1) + "." + parts.get(index));
+        break;
+      default:
+        // although it should never happen
+        throw new IllegalArgumentException(String.format("Entity type %s does not support authorization.", entityType));
+    }
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/AuthorizationRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/AuthorizationRequest.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.proto.security;
 
 import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.proto.id.EntityId;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -30,21 +29,22 @@ import javax.annotation.Nullable;
 @Beta
 public class AuthorizationRequest {
 
-  private final EntityId entity;
+  private final Authorizable authorizable;
   private final Principal principal;
   private final Set<Action> actions;
 
-  protected AuthorizationRequest(EntityId entity, @Nullable Principal principal, @Nullable Set<Action> actions) {
-    if (entity == null) {
-      throw new IllegalArgumentException("entity is required");
+  protected AuthorizationRequest(Authorizable authorizable, @Nullable Principal principal,
+                                 @Nullable Set<Action> actions) {
+    if (authorizable == null) {
+      throw new IllegalArgumentException("Authorizable is required");
     }
-    this.entity = entity;
+    this.authorizable = authorizable;
     this.principal = principal;
     this.actions = (actions != null) ? Collections.unmodifiableSet(new LinkedHashSet<>(actions)) : null;
   }
 
-  public EntityId getEntity() {
-    return entity;
+  public Authorizable getAuthorizable() {
+    return authorizable;
   }
 
   @Nullable

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/GrantRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/GrantRequest.java
@@ -27,13 +27,17 @@ import java.util.Set;
 @Beta
 public class GrantRequest extends AuthorizationRequest {
 
-  public GrantRequest(EntityId entity, Principal principal, Set<Action> actions) {
-    super(entity, principal, actions);
+  public GrantRequest(Authorizable authorizable, Principal principal, Set<Action> actions) {
+    super(authorizable, principal, actions);
     if (principal == null) {
       throw new IllegalArgumentException("principal is required");
     }
     if (actions == null) {
       throw new IllegalArgumentException("actions is required");
     }
+  }
+
+  public GrantRequest(EntityId entityId, Principal principal, Set<Action> actions) {
+    this(Authorizable.fromEntityId(entityId), principal, actions);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Privilege.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Privilege.java
@@ -27,16 +27,20 @@ import java.util.Objects;
  */
 @Beta
 public class Privilege {
-  private final EntityId entity;
+  private final Authorizable authorizable;
   private final Action action;
 
-  public Privilege(EntityId entity, Action action) {
-    this.entity = entity;
+  public Privilege(EntityId entityId, Action action) {
+    this(Authorizable.fromEntityId(entityId), action);
+  }
+
+  public Privilege(Authorizable authorizable, Action action) {
+    this.authorizable = authorizable;
     this.action = action;
   }
 
-  public EntityId getEntity() {
-    return entity;
+  public Authorizable getAuthorizable() {
+    return authorizable;
   }
 
   public Action getAction() {
@@ -53,18 +57,18 @@ public class Privilege {
     }
 
     Privilege privilege = (Privilege) o;
-    return Objects.equals(entity, privilege.entity) && Objects.equals(action, privilege.action);
+    return Objects.equals(authorizable, privilege.authorizable) && Objects.equals(action, privilege.action);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entity, action);
+    return Objects.hash(authorizable, action);
   }
 
   @Override
   public String toString() {
     return "Privilege{" +
-      "entity=" + entity +
+      "authorizable=" + authorizable +
       ", action=" + action +
       '}';
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/RevokeRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/RevokeRequest.java
@@ -28,10 +28,14 @@ import javax.annotation.Nullable;
 @Beta
 public class RevokeRequest extends AuthorizationRequest {
 
-  public RevokeRequest(EntityId entity, @Nullable Principal principal, @Nullable Set<Action> actions) {
-    super(entity, principal, actions);
+  public RevokeRequest(Authorizable authorizable, @Nullable Principal principal, @Nullable Set<Action> actions) {
+    super(authorizable, principal, actions);
     if (actions != null && principal == null) {
       throw new IllegalArgumentException("Principal is required when actions is provided");
     }
+  }
+
+  public RevokeRequest(EntityId entityId, @Nullable Principal principal, @Nullable Set<Action> actions) {
+    this(Authorizable.fromEntityId(entityId), principal, actions);
   }
 }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/security/AuthorizableTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/security/AuthorizableTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto.security;
+
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
+import co.cask.cdap.proto.id.DatasetTypeId;
+import co.cask.cdap.proto.id.KerberosPrincipalId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.SecureKeyId;
+import co.cask.cdap.proto.id.StreamId;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests {@link Authorizable}
+ */
+public class AuthorizableTest {
+
+  @Test
+  public void testArtifact() {
+    Authorizable authorizable;
+    ArtifactId artifactId = new ArtifactId("ns", "art", "1.0-SNAPSHOT");
+    authorizable = Authorizable.fromEntityId(artifactId);
+    // drop the version while asserting
+    Assert.assertEquals(artifactId.toString().replace(".1.0-SNAPSHOT", ""), authorizable.toString());
+  }
+
+  @Test
+  public void testNamespace() {
+    Authorizable authorizable;
+    NamespaceId namespaceId = new NamespaceId("ns");
+    authorizable = Authorizable.fromEntityId(namespaceId);
+    Assert.assertEquals(namespaceId.toString(), authorizable.toString());
+
+    String wildcardNs = namespaceId.toString() + "?";
+    authorizable = Authorizable.fromString(wildcardNs);
+    Assert.assertEquals(wildcardNs, authorizable.toString());
+
+    wildcardNs = namespaceId.toString() + "*" + "more";
+    authorizable = Authorizable.fromString(wildcardNs);
+    Assert.assertEquals(wildcardNs, authorizable.toString());
+  }
+
+  @Test
+  public void testProgram() {
+    ProgramId programId = new ProgramId("ns", "app", ProgramType.MAPREDUCE, "prog");
+    Authorizable authorizable = Authorizable.fromEntityId(programId);
+    // drop the version while asserting
+    Assert.assertEquals(programId.toString().replace(ApplicationId.DEFAULT_VERSION + ".", ""), authorizable.toString());
+
+    // test fromString with version should throw exception
+    String wildCardProgramId = programId.toString() + "*";
+    try {
+      Authorizable.fromString(wildCardProgramId);
+      Assert.fail();
+    } catch (UnsupportedOperationException e) {
+      // expected
+    }
+
+    ApplicationId appId = new ApplicationId("ns", "app", "1.0-SNAPSHOT");
+    programId = appId.program(ProgramType.MAPREDUCE, "prog");
+    authorizable = Authorizable.fromEntityId(programId);
+    // drop the version while asserting
+    Assert.assertEquals(programId.toString().replace(".1.0-SNAPSHOT", ""), authorizable.toString());
+  }
+
+  @Test
+  public void testApplication() {
+    ApplicationId appId = new ApplicationId("ns", "app", "1.0-SNAPSHOT");
+    Authorizable authorizable = Authorizable.fromEntityId(appId);
+    // drop the version while asserting
+    Assert.assertEquals(appId.toString().replace(".1.0-SNAPSHOT", ""), authorizable.toString());
+
+    try {
+      Authorizable.fromString(appId.toString());
+      Assert.fail();
+    } catch (UnsupportedOperationException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testPrincipal() {
+    KerberosPrincipalId kerberosPrincipalId = new KerberosPrincipalId("eve/host1.com@domain.net");
+    Authorizable authorizable = Authorizable.fromEntityId(kerberosPrincipalId);
+    Assert.assertEquals(kerberosPrincipalId.toString(), authorizable.toString());
+  }
+
+  @Test
+  public void testStream() {
+    StreamId streamId = new StreamId("ns", "stream");
+    Authorizable authorizable = Authorizable.fromEntityId(streamId);
+    Assert.assertEquals(streamId.toString(), authorizable.toString());
+  }
+
+  @Test
+  public void testDataset() {
+    DatasetId datasetId = new DatasetId("ns", "dataset");
+    Authorizable authorizable = Authorizable.fromEntityId(datasetId);
+    Assert.assertEquals(datasetId.toString(), authorizable.toString());
+  }
+
+  @Test
+  public void testSecureKey() {
+    SecureKeyId secureKeyId = new SecureKeyId("ns", "secure");
+    Authorizable authorizable = Authorizable.fromEntityId(secureKeyId);
+    Assert.assertEquals(secureKeyId.toString(), authorizable.toString());
+  }
+
+  @Test
+  public void testDatasetType() {
+    DatasetTypeId datasetTypeId = new DatasetTypeId("ns", "datasetType");
+    Authorizable authorizable = Authorizable.fromEntityId(datasetTypeId);
+    Assert.assertEquals(datasetTypeId.toString(), authorizable.toString());
+  }
+
+  @Test
+  public void testDatasetModule() {
+    DatasetModuleId datasetModuleId = new DatasetModuleId("ns", "datasetModule");
+    Authorizable authorizable = Authorizable.fromEntityId(datasetModuleId);
+    Assert.assertEquals(datasetModuleId.toString(), authorizable.toString());
+  }
+}

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/security/GrantRequestTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/security/GrantRequestTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.proto.security;
 
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.Ids;
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,14 +58,14 @@ public class GrantRequestTest {
     }
 
     try {
-      new GrantRequest(null, bob, actions);
+      new GrantRequest((EntityId) null, bob, actions);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected
     }
 
     try {
-      new GrantRequest(null, null, null);
+      new GrantRequest((EntityId) null, null, null);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/security/RevokeRequestTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/security/RevokeRequestTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.proto.security;
 
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.Ids;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,14 +46,14 @@ public class RevokeRequestTest {
     }
 
     try {
-      new RevokeRequest(null, null, actions);
+      new RevokeRequest((EntityId) null, null, actions);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected
     }
 
     try {
-      new RevokeRequest(null, null, null);
+      new RevokeRequest((EntityId) null, null, null);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // expected

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AbstractAuthorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AbstractAuthorizer.java
@@ -19,6 +19,7 @@ package co.cask.cdap.security.spi.authorization;
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,5 +68,26 @@ public abstract class AbstractAuthorizer implements Authorizer {
   @Override
   public Predicate<EntityId> createFilter(final Principal principal) throws Exception {
     throw new UnsupportedOperationException("createFilter() is deprecated, please use isVisible() instead");
+  }
+
+  @Override
+  public void grant(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
+    // grant on EntityId is deprecated 4.3 onwards. This implementation is added to remove the burden from the
+    // underlying extension to provide an implementation. This API will be removed in 4.4
+    grant(Authorizable.fromEntityId(entity), principal, actions);
+  }
+
+  @Override
+  public void revoke(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
+    // revoke on EntityId is deprecated 4.3 onwards. This implementation is added to remove the burden from the
+    // underlying extension to provide an implementation. This API will be removed in 4.4
+    revoke(Authorizable.fromEntityId(entity), principal, actions);
+  }
+
+  @Override
+  public void revoke(EntityId entity) throws Exception {
+    // revoke on EntityId is deprecated 4.3 onwards. This implementation is added to remove the burden from the
+    // underlying extension to provide an implementation. This API will be removed in 4.4
+    revoke(Authorizable.fromEntityId(entity));
   }
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
@@ -19,6 +19,7 @@ package co.cask.cdap.security.spi.authorization;
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.Role;
@@ -52,13 +53,28 @@ public class NoOpAuthorizer extends AbstractAuthorizer {
   }
 
   @Override
+  public void grant(Authorizable authorizable, Principal principal, Set<Action> actions) throws Exception {
+    // no-op
+  }
+
+  @Override
   public void revoke(EntityId entity, Principal principal, Set<Action> actions) {
     //no-op
   }
 
   @Override
+  public void revoke(Authorizable authorizable, Principal principal, Set<Action> actions) throws Exception {
+    // no-op
+  }
+
+  @Override
   public void revoke(EntityId entity) {
     //no-op
+  }
+
+  @Override
+  public void revoke(Authorizable authorizable) throws Exception {
+    // no-op
   }
 
   @Override

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/PrivilegesManager.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/PrivilegesManager.java
@@ -18,6 +18,7 @@ package co.cask.cdap.security.spi.authorization;
 
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 
@@ -33,8 +34,21 @@ public interface PrivilegesManager {
    * @param entity the {@link EntityId} to whom {@link Action actions} are to be granted
    * @param principal the {@link Principal} that performs the actions. This could be a user, or role
    * @param actions the set of {@link Action actions} to grant.
+   * @deprecated As of release 4.3.0, replaced by {@link #grant(Authorizable, Principal, Set)}
    */
+  @Deprecated
   void grant(EntityId entity, Principal principal, Set<Action> actions) throws Exception;
+
+  /**
+   * Grants a {@link Principal} authorization to perform a set of {@link Action actions} on {@link EntityId}
+   * represented by the {@link Authorizable}
+   * Note: this grant is used to support wildcard privilege management
+   *
+   * @param authorizable The {@link Authorizable} on which the {@link Action} are to be granted
+   * @param principal the {@link Principal} that performs the actions. This could be a user, or role
+   * @param actions the set of {@link Action actions} to grant.
+   */
+  void grant(Authorizable authorizable, Principal principal, Set<Action> actions) throws Exception;
 
   /**
    * Revokes a {@link Principal principal's} authorization to perform a set of {@link Action actions} on
@@ -43,16 +57,39 @@ public interface PrivilegesManager {
    * @param entity the {@link EntityId} whose {@link Action actions} are to be revoked
    * @param principal the {@link Principal} that performs the actions. This could be a user, group or role
    * @param actions the set of {@link Action actions} to revoke
+   * @deprecated As of release 4.3.0, replaced by {@link #revoke(Authorizable, Principal, Set)}
    */
+  @Deprecated
   void revoke(EntityId entity, Principal principal, Set<Action> actions) throws Exception;
+
+  /**
+   * Revokes a {@link Principal} authorization to perform a set of {@link Action actions} on {@link EntityId}
+   * represented by the {@link Authorizable}
+   * Note: this revoke is used to support wildcard privilege management.
+   *
+   * @param authorizable the {@link Authorizable} whose {@link Action actions} are to be revoked
+   * @param principal the {@link Principal} that performs the actions. This could be a user, group or role
+   * @param actions the set of {@link Action actions} to revoke
+   */
+  void revoke(Authorizable authorizable, Principal principal, Set<Action> actions) throws Exception;
 
   /**
    * Revokes all {@link Principal principals'} authorization to perform any {@link Action} on the given
    * {@link EntityId}.
    *
    * @param entity the {@link EntityId} on which all {@link Action actions} are to be revoked
+   * @deprecated As of release 4.3.0, replaced by {@link #revoke(Authorizable)}
    */
+  @Deprecated
   void revoke(EntityId entity) throws Exception;
+
+  /**
+   * Revokes all {@link Principal}s authorization to perform any set of {@link Action actions} on {@link EntityId}
+   * represented by the {@link Authorizable}
+   *
+   * @param authorizable the {@link Authorizable} on which all {@link Action actions} are to be revoked
+   */
+  void revoke(Authorizable authorizable) throws Exception;
 
   /**
    * Returns all the {@link Privilege} for the specified {@link Principal}.

--- a/cdap-security/src/main/java/co/cask/cdap/proto/security/AuthorizationPrivilege.java
+++ b/cdap-security/src/main/java/co/cask/cdap/proto/security/AuthorizationPrivilege.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.proto.security;
 
 import co.cask.cdap.proto.id.EntityId;
-import co.cask.cdap.security.authorization.RemoteAuthorizationEnforcer;
 
 import java.util.Objects;
 
@@ -25,17 +24,27 @@ import java.util.Objects;
  * Key for caching Privileges on containers. This represents a specific privilege on which authorization can be
  * enforced. The cache stores whether the enforce succeeded or failed.
  */
-public class AuthorizationPrivilege extends Privilege {
-
+public class AuthorizationPrivilege {
+  private final EntityId entityId;
+  private final Action action;
   private final Principal principal;
 
   public AuthorizationPrivilege(Principal principal, EntityId entityId, Action action) {
-    super(entityId, action);
+    this.entityId = entityId;
+    this.action = action;
     this.principal = principal;
   }
 
   public Principal getPrincipal() {
     return principal;
+  }
+
+  public EntityId getEntity() {
+    return entityId;
+  }
+
+  public Action getAction() {
+    return action;
   }
 
   @Override
@@ -47,18 +56,21 @@ public class AuthorizationPrivilege extends Privilege {
       return false;
     }
     AuthorizationPrivilege that = (AuthorizationPrivilege) o;
-    return super.equals(o) && Objects.equals(principal, that.principal);
+    return Objects.equals(entityId, that.entityId) && action == that.action &&
+      Objects.equals(principal, that.principal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), principal);
+    return Objects.hash(entityId, action, principal);
   }
 
   @Override
   public String toString() {
-    return super.toString() + "AuthorizationPrivilege{" +
-      "principal=" + principal +
+    return "AuthorizationPrivilege{" +
+      "entityId=" + entityId +
+      ", action=" + action +
+      ", principal=" + principal +
       '}';
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DelegatingPrivilegeManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DelegatingPrivilegeManager.java
@@ -18,6 +18,7 @@ package co.cask.cdap.security.authorization;
 
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.spi.authorization.Authorizer;
@@ -46,13 +47,28 @@ public class DelegatingPrivilegeManager implements PrivilegesManager {
   }
 
   @Override
+  public void grant(Authorizable authorizable, Principal principal, Set<Action> actions) throws Exception {
+    delegateAuthorizer.grant(authorizable, principal, actions);
+  }
+
+  @Override
   public void revoke(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
     delegateAuthorizer.revoke(entity, principal, actions);
   }
 
   @Override
+  public void revoke(Authorizable authorizable, Principal principal, Set<Action> actions) throws Exception {
+    delegateAuthorizer.revoke(authorizable, principal, actions);
+  }
+
+  @Override
   public void revoke(EntityId entity) throws Exception {
     delegateAuthorizer.revoke(entity);
+  }
+
+  @Override
+  public void revoke(Authorizable authorizable) throws Exception {
+    delegateAuthorizer.revoke(authorizable);
   }
 
   @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemotePrivilegesManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemotePrivilegesManager.java
@@ -22,6 +22,7 @@ import co.cask.cdap.internal.guava.reflect.TypeToken;
 import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.spi.authorization.PrivilegesManager;
@@ -55,23 +56,38 @@ public class RemotePrivilegesManager extends RemoteOpsClient implements Privileg
 
   @Override
   public void grant(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
-    LOG.trace("Making request to grant {} on {} to {}", actions, entity, principal);
-    executeRequest("grant", entity, principal, actions);
-    LOG.debug("Granted {} on {} to {} successfully", actions, entity, principal);
+    grant(Authorizable.fromEntityId(entity), principal, actions);
+  }
+
+  @Override
+  public void grant(Authorizable authorizable, Principal principal, Set<Action> actions) throws Exception {
+    LOG.trace("Making request to grant {} on {} to {}", actions, authorizable, principal);
+    executeRequest("grant", authorizable, principal, actions);
+    LOG.debug("Granted {} on {} to {} successfully", actions, authorizable, principal);
   }
 
   @Override
   public void revoke(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
-    LOG.trace("Making request to revoke {} on {} to {}", actions, entity, principal);
-    executeRequest("revoke", entity, principal, actions);
-    LOG.debug("Revoked {} on {} to {} successfully", actions, entity, principal);
+    revoke(Authorizable.fromEntityId(entity), principal, actions);
+  }
+
+  @Override
+  public void revoke(Authorizable authorizable, Principal principal, Set<Action> actions) throws Exception {
+    LOG.trace("Making request to revoke {} on {} to {}", actions, authorizable, principal);
+    executeRequest("revoke", authorizable, principal, actions);
+    LOG.debug("Revoked {} on {} to {} successfully", actions, authorizable, principal);
   }
 
   @Override
   public void revoke(EntityId entity) throws Exception {
-    LOG.trace("Making request to revoke all actions on {}", entity);
-    executeRequest("revokeAll", entity);
-    LOG.debug("Revoked all actions on {} successfully", entity);
+    revoke(Authorizable.fromEntityId(entity));
+  }
+
+  @Override
+  public void revoke(Authorizable authorizable) throws Exception {
+    LOG.trace("Making request to revoke all actions on {}", authorizable);
+    executeRequest("revokeAll", authorizable);
+    LOG.debug("Revoked all actions on {} successfully", authorizable);
   }
 
   @Override

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcerTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcerTest.java
@@ -140,11 +140,11 @@ public class DefaultAuthorizationEnforcerTest extends AuthorizationTestBase {
       Authorizer authorizer = authorizerInstantiator.get();
       NamespaceId ns1 = new NamespaceId("ns1");
       NamespaceId ns2 = new NamespaceId("ns2");
-      DatasetId ds11 = ns1.dataset("ds1");
-      DatasetId ds12 = ns1.dataset("ds2");
-      DatasetId ds21 = ns2.dataset("ds1");
-      DatasetId ds22 = ns2.dataset("ds2");
-      DatasetId ds23 = ns2.dataset("ds3");
+      DatasetId ds11 = ns1.dataset("ds11");
+      DatasetId ds12 = ns1.dataset("ds12");
+      DatasetId ds21 = ns2.dataset("ds21");
+      DatasetId ds22 = ns2.dataset("ds22");
+      DatasetId ds23 = ns2.dataset("ds33");
       Set<NamespaceId> namespaces = ImmutableSet.of(ns1, ns2);
       // Alice has access on ns1, ns2, ds11, ds21, ds23, Bob has access on ds11, ds12, ds22
       authorizer.grant(ns1, ALICE, Collections.singleton(Action.WRITE));
@@ -167,7 +167,7 @@ public class DefaultAuthorizationEnforcerTest extends AuthorizationTestBase {
                                                                                       ALICE).size());
       expectedDatasetIds = ImmutableSet.of(ds12, ds22);
       // this will be empty since now isVisible will not check the hierarchy privilege for the parent of the entity
-      Assert.assertTrue(authEnforcementService.isVisible(expectedDatasetIds, ALICE).isEmpty());
+      Assert.assertEquals(Collections.EMPTY_SET, authEnforcementService.isVisible(expectedDatasetIds, ALICE));
       expectedDatasetIds = ImmutableSet.of(ds11, ds12, ds22);
       Assert.assertEquals(expectedDatasetIds.size(), authEnforcementService.isVisible(expectedDatasetIds, BOB).size());
       expectedDatasetIds = ImmutableSet.of(ds21, ds23);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -48,6 +48,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Authorizable;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
@@ -201,7 +202,7 @@ public class AuthorizationTest extends TestBase {
       // expected
     }
     createAuthNamespace();
-    Assert.assertEquals(AUTH_NAMESPACE_META, namespaceAdmin.list().get(0));
+    Assert.assertTrue(namespaceAdmin.list().contains(AUTH_NAMESPACE_META));
     namespaceAdmin.get(AUTH_NAMESPACE);
     // revoke privileges
     revokeAndAssertSuccess(AUTH_NAMESPACE);
@@ -1529,7 +1530,7 @@ public class AuthorizationTest extends TestBase {
     Predicate<Privilege> entityFilter = new Predicate<Privilege>() {
       @Override
       public boolean apply(Privilege input) {
-        return entityId.equals(input.getEntity());
+        return Authorizable.fromEntityId(entityId).equals(input.getAuthorizable());
       }
     };
     Assert.assertTrue(Sets.filter(authorizer.listPrivileges(principal), entityFilter).isEmpty());


### PR DESCRIPTION
- Add support for wildcard for grants and revoke in CDAP authorization
- Introduces Authorizable which is an representation of EntityId but also supports wildcards.
- Removes enforcement for grant/revoke

Build: https://builds.cask.co/browse/CDAP-RUT1261-3
