### PR TITLE
[CDAP-12344] fix macro schema not appearing in detail pipeline view

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -161,9 +161,12 @@ class HydratorPlusPlusNodeConfigCtrl {
 
     this.defaultState = angular.copy(this.state);
 
-    if (this.state.node.outputSchema && this.state.node.outputSchema.length > 0) {
+    let propertiesSchema = this.myHelpers.objectQuery(this.state.node, 'plugin', 'properties', 'schema');
+    let schema = propertiesSchema || this.state.node.outputSchema;
+
+    if (schema && schema.length > 0) {
       try {
-        this.avsc.parse(this.state.node.outputSchema);
+        this.avsc.parse(schema);
       } catch (e) {
         this.state.schemaAdvance = true;
       }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12344

#### Root Cause:
The UI is parsing schema from the property `outputSchema` which is not guaranteed to be there. Instead it should check the stage properties first for the schema before going into outputSchema