### PR TITLE
change attribute name for plugin display name

### DIFF
--- a/cdap-ui/app/directives/group-side-panel/group-side-panel-ctrl.js
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel-ctrl.js
@@ -72,7 +72,7 @@ angular.module(PKG.name + '.commons')
 
       let key = generatePluginMapKey(plugin);
 
-      let displayName = myHelpers.objectQuery(this.pluginsMap, key, 'widgets', 'displayName');
+      let displayName = myHelpers.objectQuery(this.pluginsMap, key, 'widgets', 'display-name');
 
       displayName = displayName || myRemoveCamelCase(plugin.name);
 

--- a/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
@@ -298,7 +298,7 @@ class HydratorPlusPlusLeftPanelCtrl {
     if (!item.pluginTemplate) {
       let itemArtifact = item.artifact;
       let key = `${item.name}-${item.type}-${itemArtifact.name}-${itemArtifact.version}-${itemArtifact.scope}`;
-      let displayName = this.myHelpers.objectQuery(this.availablePluginMap, key, 'widgets', 'displayName');
+      let displayName = this.myHelpers.objectQuery(this.availablePluginMap, key, 'widgets', 'display-name');
 
       name = displayName || name;
     }


### PR DESCRIPTION
changing display name property for pipeline plugin from `displayName` to `display-name` to be consistent with the rest of the JSON config