### PR TITLE
clear the namespace map after each test

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -127,6 +127,7 @@ public abstract class IntegrationTestBase {
       // if we didn't create the namespace, don't delete it; only clear the data/programs within it
       doClear(namespaceEntry.getKey(), deleteUponTeardown);
     }
+    registeredNamespaces.clear();
     LOG.info("Completed tearDown.");
   }
 


### PR DESCRIPTION
We need to clear this map since authorization test will clear the privileges after each test. So accessing any left over namespaces will throw an UnAuthorizedException