### PR TITLE
[CDAP-12292] Fixes UI to handle starting state for a run record

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.js
@@ -431,7 +431,7 @@ export default class PipelineNodeMetricsGraph extends Component {
 
   renderRecordsCount = (type) => {
     return T.translate(`${PREFIX}.${type}`, {
-      [type]: this.state[type] || T.translate('commons.notAvailable')
+      [type]: this.state[type] || '0'
     });
   };
 

--- a/cdap-ui/app/cdap/components/PipelineSummary/Store/PipelineSummaryActions.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/Store/PipelineSummaryActions.js
@@ -23,6 +23,9 @@ import isNil from 'lodash/isNil';
 import cloneDeep from 'lodash/cloneDeep';
 
 function setRuns(runs) {
+  // This is to avoid having a run record with 'STARTING' state.
+  // Run record with just STARTING state isn't of much use in pipeline summary.
+  runs = runs.filter(run => run.start);
   PipelineSummaryStore.dispatch({
     type: PIPELINESSUMMARYACTIONS.SETRUNS,
     payload: {

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -105,7 +105,7 @@ function humanReadableDuration(timeInSeconds) {
   const ONE_YEAR_SECONDS = ONE_MONTH_SECONDS * 12;
   const pluralize = (number, label) => number > 1 ? `${label}s` : label;
   if (timeInSeconds < 60) {
-    return `${Math.floor(timeInSeconds)} ${pluralize(timeInSeconds, T.translate('commons.secondsShortLabel'))}`;
+    return `${Math.floor(timeInSeconds)} ${pluralize(timeInSeconds, T.translate('commons.secShortLabel'))}`;
   }
   if (timeInSeconds < ONE_HOUR_SECONDS) {
     let mins = Math.floor(timeInSeconds / ONE_MIN_SECONDS);

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -87,6 +87,7 @@ commons:
   please: Please
   resource-center: Add Entity
   schemaLabel: Schema
+  secShortLabel: sec
   secondsShortLabel: secs
   then: Then
   tracker: Cask Tracker

--- a/cdap-ui/app/directives/log-viewer/log-viewer-store.js
+++ b/cdap-ui/app/directives/log-viewer/log-viewer-store.js
@@ -16,9 +16,9 @@
 
 var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
   const startTime = (state = null, action = {}) => {
-    switch(action.type) {
+    switch (action.type) {
       case LOGVIEWERSTORE_ACTIONS.START_TIME:
-        if(!action.payload.startTime) {
+        if (!action.payload.startTime) {
           return state;
         }
         return action.payload.startTime;
@@ -29,11 +29,11 @@ var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
     }
   };
 
-  //Scroll Position Reducer
+  // Scroll Position Reducer
   const scrollPosition = (state = null, action = {}) => {
-    switch(action.type) {
+    switch (action.type) {
       case LOGVIEWERSTORE_ACTIONS.SCROLL_POSITION:
-        if(!action.payload.scrollPosition) {
+        if (!action.payload.scrollPosition) {
           return state;
         }
         return action.payload.scrollPosition;
@@ -44,9 +44,9 @@ var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
     }
   };
 
-  //Scroll Position Reducer
+  // Scroll Position Reducer
   const fullScreen = (state = false, action = {}) => {
-    switch(action.type) {
+    switch (action.type) {
       case LOGVIEWERSTORE_ACTIONS.FULL_SCREEN:
         return action.payload.fullScreen;
       case LOGVIEWERSTORE_ACTIONS.RESET:
@@ -57,9 +57,9 @@ var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
   };
 
   const searchResults = (state = [], action = {}) => {
-    switch(action.type) {
+    switch (action.type) {
       case LOGVIEWERSTORE_ACTIONS.SEARCH_RESULTS:
-        if(!action.payload.searchResults) {
+        if (!action.payload.searchResults) {
           return state;
         }
         return action.payload.searchResults;
@@ -71,9 +71,9 @@ var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
   };
 
   const totalLogs = (state = 0, action = {}) => {
-    switch(action.type) {
+    switch (action.type) {
       case LOGVIEWERSTORE_ACTIONS.TOTAL_LOGS:
-        if(!action.payload.totalLogs) {
+        if (!action.payload.totalLogs) {
           return state;
         }
         return action.payload.totalLogs;
@@ -85,9 +85,9 @@ var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
   };
 
   const totalErrors = (state = 0, action = {}) => {
-    switch(action.type) {
+    switch (action.type) {
       case LOGVIEWERSTORE_ACTIONS.TOTAL_ERRORS:
-        if(!action.payload.totalErrors) {
+        if (!action.payload.totalErrors) {
           return state;
         }
         return action.payload.totalErrors;
@@ -99,9 +99,9 @@ var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
   };
 
   const totalWarnings = (state = 0, action = {}) => {
-    switch(action.type) {
+    switch (action.type) {
       case LOGVIEWERSTORE_ACTIONS.TOTAL_WARNINGS:
-        if(!action.payload.totalWarnings) {
+        if (!action.payload.totalWarnings) {
           return state;
         }
         return action.payload.totalWarnings;
@@ -119,7 +119,7 @@ var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
   };
 
   const statusInfo = (state = defaultStatusState, action = {}) => {
-    switch(action.type) {
+    switch (action.type) {
       case LOGVIEWERSTORE_ACTIONS.SET_STATUS:
         return Object.assign({}, state, {
           status: action.payload.status,
@@ -133,7 +133,7 @@ var LogViewerStore = (LOGVIEWERSTORE_ACTIONS, Redux, ReduxThunk) => {
     }
   };
 
-  //Combine the reducers
+  // Combine the reducers
   let {combineReducers, applyMiddleware} = Redux;
   let combinedReducers = combineReducers({
     startTime,

--- a/cdap-ui/app/directives/log-viewer/log-viewer.js
+++ b/cdap-ui/app/directives/log-viewer/log-viewer.js
@@ -41,12 +41,13 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
   vm.setProgramMetadata = (status) => {
     vm.programStatus = status;
 
-    if(!vm.entityName) {
+    if (!vm.entityName) {
       vm.entityName = vm.programId;
     }
 
-    switch(status){
+    switch (status) {
       case 'RUNNING':
+      case 'STARTING':
       case 'STARTED':
         vm.statusType = 0;
         break;
@@ -91,13 +92,13 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
     };
     var cols = vm.configOptions;
 
-    if(cols['source']){
+    if (cols['source']) {
       columnsList.push('source');
     }
-    if(cols['level']){
+    if (cols['level']) {
       columnsList.push('level');
     }
-    if(cols['time']){
+    if (cols['time']) {
       columnsList.push('time');
     }
     // FIXME: vm should have been defaulted from LogViewerStore but since we didn't plan for having a store for logviewer
@@ -142,7 +143,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
 
     if (logViewerState.status) {
       vm.setProgramMetadata(logViewerState.status);
-      if (vm.statusType !== 0){
+      if (vm.statusType !== 0) {
         if (pollStarted) {
           // Manually request for logs one final time after the preview has stopped,
           // since we might not have reached the polling interval before we stop
@@ -152,13 +153,13 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
       }
     }
 
-    if (vm.logStartTime === logViewerState.startTime){
+    if (vm.logStartTime === logViewerState.startTime) {
       return;
     }
 
     vm.logStartTime = logViewerState.startTime;
 
-    if (!vm.logStartTime || vm.startTimeMs === vm.logStartTime){
+    if (!vm.logStartTime || vm.startTimeMs === vm.logStartTime) {
       return;
     }
 
@@ -176,7 +177,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
 
   vm.inViewScrollUpdate = (index, isInview, event) => {
 
-    if(isInview && vm.displayData && vm.displayData.length > 0) {
+    if (isInview && vm.displayData && vm.displayData.length > 0) {
 
       // tbody extends beyond the viewport when scrolling down the table
       let topOfTable = event.inViewTarget.parentElement.getBoundingClientRect().top;
@@ -194,12 +195,12 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
       let difference = adjustedVal - $scope.tableEl[0].offsetTop;
 
       // Offset the height of the bottom timeline and scrollpin row (55 + 15) if in full-screen
-      if (vm.fullScreen){
+      if (vm.fullScreen) {
         difference-=70;
       }
 
       // By taking the smallest non-negative value, we have found the top-most row
-      if (difference > 0 && (proximityVal > difference || proximityVal < 0)){
+      if (difference > 0 && (proximityVal > difference || proximityVal < 0)) {
         index++;
         newTime = vm.displayData[index].log.timestamp;
         vm.updateScrollPositionInStore(newTime);
@@ -247,7 +248,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
     // Rerender data
     vm.renderData();
     // If the search query is blank, otherwise filter
-    if (vm.searchText.length === 0){
+    if (vm.searchText.length === 0) {
       vm.updateSearchResultsInStore([]);
       return;
     }
@@ -255,7 +256,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
     let searchResults = [];
 
     vm.displayData = vm.displayData.filter( data => {
-      if (data.log.message.toLowerCase().indexOf(vm.searchText.toLowerCase()) !== -1){
+      if (data.log.message.toLowerCase().indexOf(vm.searchText.toLowerCase()) !== -1) {
         searchResults.push(data.log.timestamp);
         return true;
       }
@@ -266,17 +267,17 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
   };
 
   vm.toggleStackTrace = (index) => {
-    //If the currently clicked row is a stack trace itself, do nothing
-    if(vm.displayData[index].stackTrace){
+    // If the currently clicked row is a stack trace itself, do nothing
+    if (vm.displayData[index].stackTrace) {
       return;
     }
 
-    if( (index+1 < vm.displayData.length) && vm.displayData[index+1].stackTrace){
+    if ((index+1 < vm.displayData.length) && vm.displayData[index+1].stackTrace) {
       vm.displayData.splice(index+1, 1);
       vm.displayData[index].selected = false;
       return;
     }
-    if(vm.displayData[index].log.stackTrace){
+    if (vm.displayData[index].log.stackTrace) {
       vm.displayData[index].selected = true;
       let stackTraceObj = {
         log: {
@@ -287,25 +288,25 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
       };
       vm.displayData.splice(index+1, 0, stackTraceObj);
     } else {
-      //otherwise, it does not have stack trace but has been selected
+      // otherwise, it does not have stack trace but has been selected
       vm.displayData[index].selected = !vm.displayData[index].selected;
     }
     checkForScrollbar();
   };
 
   vm.collapseColumns = () => {
-    if(vm.isMessageExpanded){
+    if (vm.isMessageExpanded) {
       vm.isMessageExpanded = !vm.isMessageExpanded;
     }
-    if(collapseCount < columnsList.length){
+    if (collapseCount < columnsList.length) {
       vm.hiddenColumns[columnsList[collapseCount++]] = true;
-      if(collapseCount === columnsList.length){
+      if (collapseCount === columnsList.length) {
         vm.isMessageExpanded = true;
       }
     } else {
       collapseCount = 0;
-      for(var key in vm.hiddenColumns){
-        if(vm.hiddenColumns.hasOwnProperty(key)){
+      for (var key in vm.hiddenColumns) {
+        if (vm.hiddenColumns.hasOwnProperty(key)) {
           vm.hiddenColumns[key] = false;
         }
       }
@@ -355,14 +356,14 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
   function requestWithOffset() {
     if (vm.loading) { return; }
 
-    if (!validUrl()){
+    if (!validUrl()) {
        vm.loading = false;
        return;
     }
 
     vm.loading = true;
 
-    if (pollStarted){
+    if (pollStarted) {
       stopPoll();
     }
 
@@ -397,7 +398,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
 
         vm.fromOffset = res[res.length-1].offset;
         angular.forEach(res, (element, index) => {
-          //Format dates properly for rendering and computing
+          // Format dates properly for rendering and computing
           let formattedDate = new Date(res[index].log.timestamp);
           res[index].log.timestamp = formattedDate;
           res[index].log.displayTime = moment(formattedDate).format('L H:mm:ss');
@@ -406,7 +407,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
 
         vm.data = vm.data.concat(res);
         vm.renderData();
-        if(vm.displayData.length < vm.viewLimit){
+        if (vm.displayData.length < vm.viewLimit) {
           getStatus();
         }
       },
@@ -437,7 +438,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
         });
         vm.setProgramMetadata(statusRes.status);
 
-        if (vm.statusType !== 0){
+        if (vm.statusType !== 0) {
           if (pollStarted) {
             stopPoll();
           }
@@ -481,7 +482,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
         if (res.length > 0) {
           vm.fromOffset = res[res.length-1].offset;
           angular.forEach(res, (element, index) => {
-            //Format dates properly for rendering and computing
+            // Format dates properly for rendering and computing
             let formattedDate = new Date(res[index].log.timestamp);
             res[index].log.timestamp = formattedDate;
             res[index].log.displayTime = moment(formattedDate).format('L H:mm:ss');
@@ -493,7 +494,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
         }
 
 
-        if (vm.displayData.length >= vm.viewLimit){
+        if (vm.displayData.length >= vm.viewLimit) {
           stopPoll();
         } else {
           getStatus();
@@ -541,7 +542,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
   };
 
   function startTimeRequest () {
-    if(!validUrl()){
+    if (!validUrl()) {
        vm.loading = false;
        return;
     }
@@ -549,11 +550,11 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
     vm.loading = true;
     vm.data = [];
     vm.renderData();
-    if (pollStarted){
+    if (pollStarted) {
       stopPoll();
     }
 
-    //Scroll table to the top
+    // Scroll table to the top
     angular.element(document.getElementsByClassName('logs-table-body'))[0].scrollTop = 0;
     // binds window element to check whether scrollbar has appeared on resize event
     angular.element($window).bind('resize', checkForScrollbar);
@@ -577,10 +578,10 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
         vm.loading = false;
         vm.data = res;
 
-        if (res.length === 0){
-          //Update with start-time
+        if (res.length === 0) {
+          // Update with start-time
           getStatus();
-          if (vm.statusType !== 0){
+          if (vm.statusType !== 0) {
             vm.loading = false;
             vm.displayData = [];
             vm.renderData();
@@ -602,12 +603,12 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
         });
 
         vm.renderData();
-        //Update the scroll needle to be positioned at the first element in the rendered data
-        if(vm.displayData.length > 0){
+        // Update the scroll needle to be positioned at the first element in the rendered data
+        if (vm.displayData.length > 0) {
           vm.updateScrollPositionInStore(vm.displayData[0].log.timestamp);
         }
 
-        if(res.length < vm.viewLimit){
+        if (res.length < vm.viewLimit) {
           pollForNewLogs();
         }
       },
@@ -629,14 +630,14 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
     };
 
     angular.forEach(dateObj, (value, key) => {
-      if(value < 10){
+      if (value < 10) {
         dateObj[key] = '0' + value;
       } else {
         dateObj[key] = value.toString();
       }
     });
 
-    if(isDownload){
+    if (isDownload) {
       return dateObj.year + dateObj.day + dateObj.month + dateObj.hours + dateObj.minutes + dateObj.seconds;
     }
 
@@ -646,12 +647,12 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
   vm.toggleLogExpansion = function() {
     let len = vm.displayData.length;
     vm.toggleExpandAll = !vm.toggleExpandAll;
-    for(var i = 0 ; i < len ; i++) {
+    for (var i = 0; i < len; i++) {
       let entry = vm.displayData[i];
-      if(!entry.stackTrace && entry.log.stackTrace.length > 0){
+      if (!entry.stackTrace && entry.log.stackTrace.length > 0) {
         entry.isStackTraceExpanded = vm.toggleExpandAll;
 
-        if(i < vm.displayData.length && vm.toggleExpandAll && (i+1 === vm.displayData.length || !vm.displayData[i+1].stackTrace)){
+        if (i < vm.displayData.length && vm.toggleExpandAll && (i+1 === vm.displayData.length || !vm.displayData[i+1].stackTrace)) {
           vm.displayData[i].selected = true;
           let stackTraceObj = {
             log: {
@@ -662,7 +663,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
           };
           vm.displayData.splice(i+1, 0, stackTraceObj);
           len++;
-        } else if(!vm.toggleExpandAll && !entry.stackTrace && i+1 < vm.displayData.length && vm.displayData[i+1].stackTrace){
+        } else if (!vm.toggleExpandAll && !entry.stackTrace && i+1 < vm.displayData.length && vm.displayData[i+1].stackTrace) {
           vm.displayData[i].selected = false;
           vm.displayData.splice(i+1, 1);
           len--;
@@ -674,7 +675,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
     checkForScrollbar();
   };
 
-  vm.includeEvent = function(event, eventType){
+  vm.includeEvent = function(event, eventType) {
     if (eventType === vm.selectedLogLevel) {
       event.preventDefault();
       return;
@@ -724,13 +725,13 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
       now comes from backend, all the function needs to do now is set the
       displayData to the data list we get from backend
     */
-    //Clean slate
+    // Clean slate
     vm.displayData = vm.data;
     checkForScrollbar();
   };
 
   vm.highlight = (text) => {
-    if(!vm.searchText || (vm.searchText && !vm.searchText.length)){
+    if (!vm.searchText || (vm.searchText && !vm.searchText.length)) {
      return $sce.trustAsHtml(text);
     }
 
@@ -776,7 +777,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
 
   function checkForScrollbar() {
     // has to do timeout here for Firefox
-    timeout = $timeout(function(){
+    timeout = $timeout(function() {
       let tbodyEl = angular.element(document.querySelector('.logs-table-body'))[0];
       if (tbodyEl && tbodyEl.clientHeight < tbodyEl.scrollHeight) {
         let bodyRowEl = angular.element(document.querySelector('.logs-table-body tr'))[0];
@@ -818,7 +819,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
     LogViewerStore.dispatch({
       type: 'RESET'
     });
-    if (pollStarted){
+    if (pollStarted) {
       stopPoll();
     }
   });

--- a/cdap-ui/app/hydrator/controllers/detail/canvas-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail/canvas-ctrl.js
@@ -154,7 +154,8 @@ angular.module(PKG.name + '.feature.hydrator')
       let timeDifference = this.currentRun.end ? this.currentRun.end - this.currentRun.start : Math.floor(Date.now() / 1000) - this.currentRun.start;
       this.currentRun = Object.assign({}, this.currentRun, {
         duration: window.CaskCommon.CDAPHelpers.humanReadableDuration(timeDifference),
-        startTime: this.moment(this.currentRun.start * 1000).format('hh:mm:ss a'),
+        startTime: this.currentRun.start ? this.moment(this.currentRun.start * 1000).format('hh:mm:ss a') : null,
+        starting: !this.currentRun.start ? this.currentRun.starting : null,
         statusCssClass: this.MyPipelineStatusMapper.getStatusIndicatorClass(status),
         status
       });

--- a/cdap-ui/app/hydrator/services/status-mapper.js
+++ b/cdap-ui/app/hydrator/services/status-mapper.js
@@ -49,7 +49,7 @@ angular.module(PKG.name + '.feature.hydrator')
     }
 
     function getStatusIndicatorClass (displayStatus) {
-      if (displayStatus === 'Running') {
+      if (displayStatus === 'Running' || displayStatus === 'Starting') {
         return 'status-blue';
       } else if (displayStatus === 'Succeeded' || displayStatus === 'Starting' || displayStatus === 'Scheduling' || displayStatus === 'Stopping') {
         return 'status-light-green';

--- a/cdap-ui/app/hydrator/templates/detail/canvas.html
+++ b/cdap-ui/app/hydrator/templates/detail/canvas.html
@@ -18,28 +18,35 @@
   <h3 class="run-number-container">
     Run {{CanvasCtrl.currentRunIndex}} of {{CanvasCtrl.totalRuns}}
   </h3>
+
   <span>
     <span
       class="status-bubble"
       ng-class="CanvasCtrl.currentRun.statusCssClass"
-    ></span>
-  <strong>{{CanvasCtrl.currentRun.status}}</strong>
+    >
+    </span>
+    <strong ng-if="CanvasCtrl.currentRun.startTime">{{CanvasCtrl.currentRun.status}}</strong>
+    <strong ng-if="CanvasCtrl.currentRun.starting">Starting</strong>
   </span>
   <span>
     <strong> Duration </strong>
-    <span>{{CanvasCtrl.currentRun.duration}}</span>
+    <span ng-if="CanvasCtrl.currentRun.startTime">{{CanvasCtrl.currentRun.duration}}</span>
+    <span ng-if="!CanvasCtrl.currentRun.startTime">--</span>
   </span>
   <span>
     <strong> Start Time </strong>
-    <span>{{CanvasCtrl.currentRun.startTime}}</span>
+    <span ng-if="CanvasCtrl.currentRun.startTime">{{CanvasCtrl.currentRun.startTime}}</span>
+    <span ng-if="!CanvasCtrl.currentRun.startTime">--</span>
   </span>
   <span>
     <strong> Log Warnings: </strong>
-    <span>{{CanvasCtrl.logsMetrics['system.app.log.warn'] || '0'}}</span>
+    <span ng-if="CanvasCtrl.currentRun.startTime">{{CanvasCtrl.logsMetrics['system.app.log.warn'] || '0'}}</span>
+    <span ng-if="!CanvasCtrl.currentRun.startTime">--</span>
   </span>
   <span>
     <strong> Log Errors: </strong>
-    <span>{{CanvasCtrl.logsMetrics['system.app.log.error'] || '0'}}
+    <span ng-if="CanvasCtrl.currentRun.startTime">{{CanvasCtrl.logsMetrics['system.app.log.error'] || '0'}}</span>
+    <span ng-if="!CanvasCtrl.currentRun.startTime">--</span>
   </span>
 </div>
 


### PR DESCRIPTION
- Fixes pipeline detailed view when showing run level information above the dag
- Fixes pipeline summary to not include run records without start time
- Fixes log viewer to account into 'STARTING' state for a program so that the polling doesn't stop
- Fixes minor label issues in pipeline run level view + defaults `Number of Errors` to `0` in stage level metrics display.

JIRA: https://issues.cask.co/browse/CDAP-12292

Known issue: 
- Navigator - https://issues.cask.co/browse/CDAP-12424 (not necessarily in the app but with the platform).