### PR TITLE
CDAP-1952 Refactor MapReduce to make DatasetOutputCommitter execute in the MapReduce job

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Output.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Output.java
@@ -104,6 +104,8 @@ public abstract class Output {
    * Returns an Output defined by an OutputFormatProvider.
    *
    * @param outputName the name of the output
+   * @param outputFormatProvider an instance of an OutputFormatProvider. It can not be an instance of
+   *                             a {@link DatasetOutputCommitter}.
    */
   public static Output of(String outputName, OutputFormatProvider outputFormatProvider) {
     return new OutputFormatProviderOutput(outputName, outputFormatProvider);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicOutputFormatProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicOutputFormatProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+
+import java.util.Map;
+
+/**
+ * Simple implementation of {@link OutputFormatProvider}.
+ */
+public class BasicOutputFormatProvider implements OutputFormatProvider {
+
+  private final String outputFormatClassName;
+  private final Map<String, String> outputFormatConfiguration;
+
+  public BasicOutputFormatProvider(String outputFormatClassName, Map<String, String> outputFormatConfiguration) {
+    this.outputFormatClassName = outputFormatClassName;
+    this.outputFormatConfiguration = outputFormatConfiguration;
+  }
+
+  @Override
+  public String getOutputFormatClassName() {
+    return outputFormatClassName;
+  }
+
+  @Override
+  public Map<String, String> getOutputFormatConfiguration() {
+    return outputFormatConfiguration;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MainOutputCommitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MainOutputCommitter.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.batch.DatasetOutputCommitter;
+import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.service.RetryStrategy;
+import co.cask.cdap.data2.transaction.RetryingLongTransactionSystemClient;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
+import co.cask.cdap.internal.app.runtime.SystemArguments;
+import co.cask.cdap.internal.app.runtime.batch.dataset.output.MultipleOutputsCommitter;
+import co.cask.cdap.internal.app.runtime.batch.dataset.output.Outputs;
+import co.cask.cdap.internal.app.runtime.batch.dataset.output.ProvidedOutput;
+import co.cask.cdap.messaging.client.StoreRequestBuilder;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.base.Throwables;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.v2.util.MRApps;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionCodec;
+import org.apache.tephra.TransactionFailureException;
+import org.apache.tephra.TransactionSystemClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * An {@link OutputCommitter} used to start/finish the long transaction used by the MapReduce job.
+ * Also responsible for executing {@link DatasetOutputCommitter} methods for any such outputs.
+ */
+public class MainOutputCommitter extends MultipleOutputsCommitter {
+  private static final Logger LOG = LoggerFactory.getLogger(MainOutputCommitter.class);
+
+  private final TaskAttemptContext taskAttemptContext;
+
+  private CConfiguration cConf;
+  private TransactionSystemClient txClient;
+  private Transaction transaction;
+  private BasicMapReduceTaskContext taskContext;
+  private List<ProvidedOutput> outputs;
+  private boolean completedCallingOnFailure;
+
+  public MainOutputCommitter(OutputCommitter rootOutputCommitter, Map<String, OutputCommitter> committers,
+                             TaskAttemptContext taskAttemptContext) {
+    super(rootOutputCommitter, committers);
+    this.taskAttemptContext = taskAttemptContext;
+  }
+
+  @Override
+  public void setupJob(JobContext jobContext) throws IOException {
+    Configuration configuration = jobContext.getConfiguration();
+    MapReduceClassLoader classLoader = MapReduceClassLoader.getFromConfiguration(configuration);
+    MapReduceTaskContextProvider taskContextProvider = classLoader.getTaskContextProvider();
+    Injector injector = taskContextProvider.getInjector();
+
+    cConf = injector.getInstance(CConfiguration.class);
+    MapReduceContextConfig contextConfig = new MapReduceContextConfig(jobContext.getConfiguration());
+
+    ProgramId programId = contextConfig.getProgramId();
+    LOG.info("Setting up for MapReduce job: namespaceId={}, applicationId={}, program={}, runid={}",
+             programId.getNamespace(), programId.getApplication(), programId.getProgram(),
+             ProgramRunners.getRunId(contextConfig.getProgramOptions()));
+
+    RetryStrategy retryStrategy =
+      SystemArguments.getRetryStrategy(contextConfig.getProgramOptions().getUserArguments().asMap(),
+                                       contextConfig.getProgramId().getType(), cConf);
+    this.txClient = new RetryingLongTransactionSystemClient(injector.getInstance(TransactionSystemClient.class),
+                                                            retryStrategy);
+
+    // We start long-running tx to be used by mapreduce job tasks.
+    this.transaction = txClient.startLong();
+
+    // Write the tx somewhere, so that we can re-use it in mapreduce tasks
+    Path txFile = getTxFile(configuration, jobContext.getJobID());
+    FileSystem fs = txFile.getFileSystem(configuration);
+    try (FSDataOutputStream fsDataOutputStream = fs.create(txFile, false)) {
+      fsDataOutputStream.write(new TransactionCodec().encode(transaction));
+    }
+
+    // we can instantiate the TaskContext after we set the tx above. It's used by the operations below
+    taskContext = taskContextProvider.get(taskAttemptContext);
+    this.outputs = Outputs.transform(contextConfig.getOutputs(), taskContext);
+
+    super.setupJob(jobContext);
+  }
+
+  // returns a Path to a file in the staging directory of the MapReduce
+  static Path getTxFile(Configuration configuration, @Nullable JobID jobID) throws IOException {
+    Path stagingDir = MRApps.getStagingAreaDir(configuration, UserGroupInformation.getCurrentUser().getShortUserName());
+    int appAttemptId = configuration.getInt(MRJobConfig.APPLICATION_ATTEMPT_ID, 0);
+    // following the pattern of other files in the staging dir
+    String jobId = jobID != null ? jobID.toString() : configuration.get(MRJobConfig.ID);
+    return new Path(stagingDir, jobId + "/"  + jobId + "_" + appAttemptId + "_tx-file");
+  }
+
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException {
+    super.commitJob(jobContext);
+
+    onFinish(jobContext, true);
+    commitTx();
+  }
+
+  private void commitTx() throws IOException {
+    try {
+      LOG.debug("Committing MapReduce Job transaction: {}", transaction.getWritePointer());
+
+      // "Commit" the data event topic by publishing an empty message.
+      // Need to do it with the raw MessagingService.
+      taskContext.getMessagingService().publish(
+        StoreRequestBuilder
+          .of(NamespaceId.SYSTEM.topic(cConf.get(Constants.Dataset.DATA_EVENT_TOPIC)))
+          .setTransaction(transaction.getWritePointer())
+          .build());
+
+      // flush dataset operations (such as from any DatasetOutputCommitters)
+      taskContext.flushOperations();
+      // no need to rollback changes if commit fails, as these changes where performed by mapreduce tasks
+      // NOTE: can't call afterCommit on datasets in this case: the changes were made by external processes.
+      if (!txClient.commit(transaction)) {
+        LOG.warn("MapReduce Job transaction failed to commit");
+        throw new TransactionFailureException("Failed to commit transaction " + transaction.getWritePointer());
+      }
+      taskContext.postTxCommit();
+    } catch (Exception e) {
+      Throwables.propagateIfInstanceOf(e, IOException.class);
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void abortJob(JobContext jobContext, JobStatus.State state) throws IOException {
+    try {
+      super.abortJob(jobContext, state);
+    } finally {
+      try {
+        onFinish(jobContext, false);
+      } finally {
+        if (transaction != null) {
+          // invalids long running tx. All writes done by MR cannot be undone at this point.
+          LOG.info("Invalidating transaction {}", transaction.getWritePointer());
+          txClient.invalidate(transaction.getWritePointer());
+          transaction = null;
+        } else {
+          LOG.warn("Did not invalidate transaction; job setup did not complete or invalidate already happened.");
+        }
+      }
+    }
+  }
+
+  private void onFinish(JobContext jobContext, boolean success) throws IOException {
+    try {
+      if (taskContext == null || outputs == null) {
+        // taskContext or outputs can only be null if #setupJob fails
+        LOG.warn("Did not commit datasets, since job setup did not complete.");
+        return;
+      }
+      finishDatasets(jobContext, success);
+    } catch (Exception e) {
+      Throwables.propagateIfInstanceOf(e, IOException.class);
+      Throwables.propagate(e);
+    }
+  }
+
+  // returns alias-->DatasetOutputCommitter mapping, given the ProvidedOutputs
+  private Map<String, DatasetOutputCommitter> getDatasetOutputCommitters(List<ProvidedOutput> providedOutputs) {
+    Map<String, DatasetOutputCommitter> datasetOutputCommitterOutputs = new HashMap<>();
+    for (ProvidedOutput providedOutput : providedOutputs) {
+      if (providedOutput.getOutputFormatProvider() instanceof DatasetOutputCommitter) {
+        datasetOutputCommitterOutputs.put(providedOutput.getOutput().getAlias(),
+                                         (DatasetOutputCommitter) providedOutput.getOutputFormatProvider());
+      }
+    }
+    return datasetOutputCommitterOutputs;
+  }
+
+  /**
+   * Either calls onSuccess or onFailure on all of the DatasetOutputCommitters.
+   */
+  private void finishDatasets(final JobContext jobContext, final boolean success) throws Exception {
+    ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(jobContext.getConfiguration().getClassLoader());
+    Map<String, DatasetOutputCommitter> datasetOutputCommitters = getDatasetOutputCommitters(outputs);
+    try {
+      if (success) {
+        commitOutputs(datasetOutputCommitters);
+      } else {
+        // but this output committer failed: call onFailure() for all committers
+        failOutputs(datasetOutputCommitters);
+      }
+    } finally {
+      ClassLoaders.setContextClassLoader(oldClassLoader);
+    }
+  }
+
+  /**
+   * Calls onSuccess on the DatasetOutputCommitters. If any throws an exception, the exception is propagated
+   * immediately. #abortJob will then be called, which is responsible for calling onFinish on each of them.
+   */
+  private void commitOutputs(Map<String, DatasetOutputCommitter> datasetOutputCommiters) {
+    for (Map.Entry<String, DatasetOutputCommitter> datasetOutputCommitter : datasetOutputCommiters.entrySet()) {
+      try {
+        datasetOutputCommitter.getValue().onSuccess();
+      } catch (Exception e) {
+        LOG.error(String.format("Error from onSuccess method of output dataset %s.",
+                                datasetOutputCommitter.getKey()), e);
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Calls onFailure for all of the DatasetOutputCommitters. If any operation throws an exception, it is suppressed
+   * until onFailure is called on all of the DatasetOutputCommitters.
+   */
+  private void failOutputs(Map<String, DatasetOutputCommitter> datasetOutputCommiters) throws Exception {
+    if (completedCallingOnFailure) {
+      // guard against multiple calls to OutputCommitter#abortJob
+      LOG.info("Not calling onFailure on outputs, as it has they have already been executed.");
+      return;
+    }
+    Exception e = null;
+    for (Map.Entry<String, DatasetOutputCommitter> datasetOutputCommitter : datasetOutputCommiters.entrySet()) {
+      try {
+        datasetOutputCommitter.getValue().onFailure();
+      } catch (Exception suppressedException) {
+        LOG.error(String.format("Error from onFailure method of output dataset %s.",
+                                datasetOutputCommitter.getKey()), suppressedException);
+        if (e != null) {
+          e.addSuppressed(suppressedException);
+        } else {
+          e = suppressedException;
+        }
+      }
+    }
+    completedCallingOnFailure = true;
+    if (e != null) {
+      throw e;
+    }
+  }
+
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -188,7 +188,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
 
       Service mapReduceRuntimeService = new MapReduceRuntimeService(injector, cConf, hConf, mapReduce, spec,
                                                                     context, program.getJarLocation(), locationFactory,
-                                                                    streamAdmin, txSystemClient, authorizationEnforcer,
+                                                                    streamAdmin, authorizationEnforcer,
                                                                     authenticationContext);
       mapReduceRuntimeService.addListener(createRuntimeServiceListener(closeables), Threads.SAME_THREAD_EXECUTOR);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DatasetOutputFormatProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DatasetOutputFormatProvider.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.common.conf.ConfigurationUtil;
+import co.cask.cdap.internal.app.runtime.batch.MapReduceBatchWritableOutputFormat;
 import org.apache.hadoop.conf.Configuration;
 
 import java.util.Map;
@@ -36,13 +37,12 @@ public class DatasetOutputFormatProvider implements OutputFormatProvider, Datase
   private final Dataset dataset;
 
   public DatasetOutputFormatProvider(String namespace, String datasetName,
-                                     Map<String, String> datasetArgs, Dataset dataset,
-                                     Class<? extends AbstractBatchWritableOutputFormat> batchWritableOutputFormat) {
+                                     Map<String, String> datasetArgs, Dataset dataset) {
     if (dataset instanceof OutputFormatProvider) {
       this.outputFormatClassName = ((OutputFormatProvider) dataset).getOutputFormatClassName();
       this.configuration = ((OutputFormatProvider) dataset).getOutputFormatConfiguration();
     } else if (dataset instanceof BatchWritable) {
-      this.outputFormatClassName = batchWritableOutputFormat.getName();
+      this.outputFormatClassName = MapReduceBatchWritableOutputFormat.class.getName();
       this.configuration = createDatasetConfiguration(namespace, datasetName, datasetArgs);
     } else {
       throw new IllegalArgumentException("Dataset '" + dataset +

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/UnsupportedOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/UnsupportedOutputFormat.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
  * OutputFormat that allows instantiation of the RecordWriter, but throws {@link UnsupportedOperationException}
  * upon any attempts to write to it.
  *
- * All other operations are no-ops.
+ * All other operations, such as its OutputCommitter's operations, are no-ops.
  *
  * @param <K> Type of key
  * @param <V> Type of value

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/Outputs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/Outputs.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.output;
+
+import co.cask.cdap.api.data.batch.DatasetOutputCommitter;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.internal.app.runtime.AbstractContext;
+import co.cask.cdap.internal.app.runtime.batch.dataset.DatasetOutputFormatProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class to help deal with Outputs.
+ */
+public final class Outputs {
+  private Outputs() { }
+
+  /**
+   * Transforms a list of {@link Output}s to {@link ProvidedOutput}.
+   */
+  public static List<ProvidedOutput> transform(List<Output.DatasetOutput> outputs,
+                                               final AbstractContext abstractContext) {
+    // we don't want to use Lists.transform, to catch any errors with transform earlier on
+    List<ProvidedOutput> providedOutputs = new ArrayList<>(outputs.size());
+    for (Output.DatasetOutput output : outputs) {
+      providedOutputs.add(transform(output, abstractContext));
+    }
+    return providedOutputs;
+  }
+
+  public static ProvidedOutput transform(Output.DatasetOutput datasetOutput,
+                                         AbstractContext abstractContext) {
+    String datasetNamespace = datasetOutput.getNamespace();
+    if (datasetNamespace == null) {
+      datasetNamespace = abstractContext.getNamespace();
+    }
+    String datasetName = datasetOutput.getName();
+    Map<String, String> args = datasetOutput.getArguments();
+    Dataset dataset = abstractContext.getDataset(datasetNamespace, datasetName, args, AccessType.WRITE);
+    DatasetOutputFormatProvider datasetOutputFormatProvider =
+      new DatasetOutputFormatProvider(datasetNamespace, datasetName, args, dataset);
+    return new ProvidedOutput(datasetOutput, datasetOutputFormatProvider);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ProvidedOutput.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ProvidedOutput.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.batch.dataset.output;
 
+import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 
 import java.util.Map;
@@ -24,36 +25,41 @@ import java.util.Map;
  * Internal helper class to represent an output format provider and its configuration.
  */
 public class ProvidedOutput {
-  private final String alias;
+  private final Output output;
   private final OutputFormatProvider outputFormatProvider;
   private final String outputFormatClassName;
   private final Map<String, String> outputFormatConfiguration;
 
-  public ProvidedOutput(String alias, OutputFormatProvider outputFormatProvider) {
-    this.alias = alias;
+  public ProvidedOutput(Output originalOutput, OutputFormatProvider outputFormatProvider) {
+    this.output = originalOutput;
     this.outputFormatProvider = outputFormatProvider;
     this.outputFormatClassName = outputFormatProvider.getOutputFormatClassName();
     this.outputFormatConfiguration = outputFormatProvider.getOutputFormatConfiguration();
     if (outputFormatClassName == null) {
-      throw new IllegalArgumentException("Output '" + alias + "' provided null as the output format");
+      throw new IllegalArgumentException(String.format("Output '%s' provided null as the output format",
+                                                       output.getAlias()));
     }
     if (outputFormatConfiguration == null) {
-      throw new IllegalArgumentException("Output '" + alias + "' provided null as the output format configuration");
+      throw new IllegalArgumentException(String.format("Output '%s' provided null as the output format configuration",
+                                                       output.getAlias()));
     }
   }
 
-  public ProvidedOutput(String alias,
+  public ProvidedOutput(Output output,
                         OutputFormatProvider outputFormatProvider,
                         String outputFormatClassName,
                         Map<String, String> outputFormatConfiguration) {
-    this.alias = alias;
+    this.output = output;
     this.outputFormatProvider = outputFormatProvider;
     this.outputFormatClassName = outputFormatClassName;
     this.outputFormatConfiguration = outputFormatConfiguration;
   }
 
-  public String getAlias() {
-    return alias;
+  /**
+   * Returns the original Output used to create this ProvidedOutput.
+   */
+  public Output getOutput() {
+    return output;
   }
 
   public OutputFormatProvider getOutputFormatProvider() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
@@ -157,14 +157,6 @@ public class DynamicPartitioningOutputCommitter extends FileOutputCommitter {
       outputDataset.addPartition(entry.getValue(), entry.getKey(), metadata, true, allowAppend);
     }
 
-    // close the TaskContext, which flushes dataset operations
-    try {
-      taskContext.flushOperations();
-    } catch (Exception e) {
-      Throwables.propagateIfPossible(e, IOException.class);
-      throw new IOException(e);
-    }
-
     // delete the job-specific _temporary folder
     cleanupJob(context);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -620,8 +620,8 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
     testFailureInInit("false", app, AppWithMapReduce.ExplicitFaiiingMR.class, ImmutableMap.of("failOutput", "true"));
   }
 
-  public void testFailureInInit(final String expected, ApplicationWithPrograms app,
-                                Class<?> programClass, Map<String, String> args) throws Exception {
+  private void testFailureInInit(final String expected, ApplicationWithPrograms app,
+                                 Class<?> programClass, Map<String, String> args) throws Exception {
     // We want to verify that when a mapreduce fails during initialize(), especially
     // if an input or output format provider fails to produce its configuration, the
     // writes by that initialize() method are rolled back. (Background: prior to

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
@@ -83,10 +83,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Category(XSlowTests.class)
 /**
  * Base class for test cases that need to run MapReduce programs.
  */
+@Category(XSlowTests.class)
 public class MapReduceRunnerTestBase {
 
   private static final Gson GSON = new Gson();

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockExternalSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockExternalSink.java
@@ -29,6 +29,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.internal.app.runtime.batch.BasicOutputFormatProvider;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
@@ -74,17 +75,9 @@ public class MockExternalSink extends BatchSink<StructuredRecord, NullWritable, 
 
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {
-    OutputFormatProvider outputFormatProvider = new OutputFormatProvider() {
-      @Override
-      public String getOutputFormatClassName() {
-        return TextOutputFormat.class.getCanonicalName();
-      }
-
-      @Override
-      public Map<String, String> getOutputFormatConfiguration() {
-        return ImmutableMap.of(TextOutputFormat.OUTDIR, config.dirName);
-      }
-    };
+    OutputFormatProvider outputFormatProvider =
+      new BasicOutputFormatProvider(TextOutputFormat.class.getCanonicalName(),
+                                    ImmutableMap.of(TextOutputFormat.OUTDIR, config.dirName));
 
     if (config.name != null) {
       Output output = Output.of(config.name, outputFormatProvider);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleThreadDatasetCache.java
@@ -35,6 +35,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
@@ -95,7 +96,8 @@ public class SingleThreadDatasetCache extends DynamicDatasetCache {
       @ParametersAreNonnullByDefault
       public Dataset load(DatasetCacheKey key) throws Exception {
         Dataset dataset = instantiator.getDataset(new DatasetId(key.getNamespace(), key.getName()),
-                                                  key.getArguments(), key.getAccessType());
+                                                  // avoid DatasetDefinition or Dataset from modifying the cache key
+                                                  ImmutableMap.copyOf(key.getArguments()), key.getAccessType());
         if (dataset instanceof MeteredDataset && metricsContext != null) {
           ((MeteredDataset) dataset).setMetricsCollector(
             metricsContext.childContext(Constants.Metrics.Tag.DATASET, key.getName()));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -230,6 +230,12 @@ public class PartitionedFileSetDataset extends AbstractDataset
 
   @Override
   public boolean rollbackTx() throws Exception {
+    rollbackPartitionOperations();
+    this.tx = null;
+    return super.rollbackTx();
+  }
+
+  private void rollbackPartitionOperations() throws Exception {
     // rollback all the partition add and drop operations, in reverse order
     // if any throw exception, suppress it temporarily while attempting to roll back the remainder operations
     Exception caughtExn = null;
@@ -245,12 +251,10 @@ public class PartitionedFileSetDataset extends AbstractDataset
         }
       }
     }
+    operationsInThisTx.clear();
     if (caughtExn != null) {
       throw caughtExn;
     }
-
-    this.tx = null;
-    return super.rollbackTx();
   }
 
   private void rollbackOperation(PartitionOperation operation) throws Exception {
@@ -975,7 +979,8 @@ public class PartitionedFileSetDataset extends AbstractDataset
   @Override
   public void onFailure() throws DataSetException {
     try {
-      // depend on FileSetDataset's implementation of #onFailure to rollback
+      rollbackPartitionOperations();
+
       ((FileSetDataset) files).onFailure();
     } catch (Throwable caught) {
       Throwables.propagateIfPossible(caught, DataSetException.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -161,8 +162,9 @@ public class PartitionedFileSetDefinition
                                                                Partitioning partitioning) {
     if (FileSetArguments.getOutputPath(arguments) == null) {
       PartitionKey key = PartitionedFileSetArguments.getOutputPartitionKey(arguments, partitioning);
+      // we need to copy the map, to avoid modifying the passed-in map
+      arguments = Maps.newHashMap(arguments);
       if (key != null) {
-        arguments = Maps.newHashMap(arguments);
         FileSetArguments.setOutputPath(arguments, PartitionedFileSetDataset.getOutputPath(key, partitioning));
       } else if (PartitionedFileSetArguments.getDynamicPartitioner(arguments) != null) {
         // when using DynamicPartitioner, use the baseLocation of the fileSet as the output location

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithPartitionConsumers.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithPartitionConsumers.java
@@ -227,10 +227,7 @@ public class AppWithPartitionConsumers extends AbstractApplication {
       PartitionKey partitionKey = PartitionKey.builder().addLongField("time", context.getLogicalStartTime()).build();
       PartitionedFileSetArguments.setOutputPartitionKey(outputArgs, partitionKey);
 
-      // We know that PartitionedFileSet is an OutputFormatProvider, so we set an instance of it as an output to the
-      // MapReduce job to test MapReduceContext#addOutput(Output#OutputFormatProviderOutput)
-      final PartitionedFileSet outputLines = context.getDataset("outputLines", outputArgs);
-      context.addOutput(Output.of("outputLines", outputLines));
+      context.addOutput(Output.ofDataset("outputLines", outputArgs));
       context.addOutput(Output.ofDataset("counts"));
 
       Job job = context.getHadoopJob();


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-1952

The changes in this PR move the starting of the MapReduce's long transaction into the MapReduce's OutputCommiter#setupJob and completion of the transaction into the commitJob/abortJob methods.
The execution of any DatasetOutputCommitters is also moved into the MapReduce's commitJob/abortJob methods.

Transaction is communicated from the OutputCommitter#setupJob to the tasks that are starting up via the MapReduce job's staging directory (the last file in the following listing):
![image](https://user-images.githubusercontent.com/2440977/29480414-0550f6a0-842d-11e7-995b-4d36fa31336f.png)