### PR TITLE
[CDAP-12336][CDAP-12422] [CDAP-12413] UI Bugfixes

### DIFF
--- a/cdap-ui/app/cdap/components/CaskWizards/StreamCreateWithUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/StreamCreateWithUpload/index.js
@@ -27,7 +27,7 @@ require('./StreamCreate.scss');
 import cookie from 'react-cookie';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
-
+import Rx from 'rx';
 
 export default class StreamCreateWithUploadWizard extends Component {
   constructor(props) {
@@ -71,6 +71,11 @@ export default class StreamCreateWithUploadWizard extends Component {
             let filename = state.upload.filename;
             let filetype = 'text/' + filename.split('.').pop();
             let authToken = cookie.load('CDAP_Auth_Token');
+            if (typeof fileContents !== 'object') {
+              return Rx.Observable.create((observer) => {
+                observer.onNext();
+              });
+            }
             return UploadDataActionCreator
               .uploadData({
                 url,

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
@@ -73,7 +73,7 @@ export default class DataPrepServiceControl extends Component {
         <h5 className="text-danger">
           {this.state.error}
         </h5>
-        <p className="text-dangertext-xs-center">
+        <p className="text-danger">
           {this.state.extendedMessage}
         </p>
       </div>

--- a/cdap-ui/app/cdap/components/RulesEngineHome/CreateRule/CreateRule.scss
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/CreateRule/CreateRule.scss
@@ -47,7 +47,12 @@ $dsv_input_border_color: rgba(0, 0, 0, 0.15);
       color: $brand-primary;
     }
   }
-  .dsv-editor-container .dsv-row-container input.form-control {
-    border: 1px solid $dsv_input_border_color;
+  .dsv-editor-container .dsv-row-container {
+    .btn.btn-link {
+      padding: 0.5rem 1rem;
+    }
+    input.form-control {
+      border: 1px solid $dsv_input_border_color;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/RulesEngineHome/ImportRulebookWizard/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/ImportRulebookWizard/index.js
@@ -24,6 +24,8 @@ import Rx from 'rx';
 import ImportRulebookWizardConfig from 'components/RulesEngineHome/ImportRulebookWizard/ImportRulebookWizardConfig';
 import ImportRulebookStore from 'components/RulesEngineHome/ImportRulebookWizard/ImportRulebookStore';
 import T from 'i18n-react';
+import cookie from 'react-cookie';
+import isNil from 'lodash/isNil';
 
 require('./ImportRulebookWizard.scss');
 const PREFIX = 'features.RulesEngine.ImportRulebook';
@@ -70,6 +72,12 @@ export default class ImportRulebookWizard extends Component {
     let headers = {
       'content-type': 'application/rules-engine'
     };
+    if (window.CDAP_CONFIG.securityEnabled) {
+      let token = cookie.load('CDAP_Auth_Token');
+      if (!isNil(token)) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+    }
     let data = ImportRulebookStore.getState().upload.file.contents;
     return UploadFile({
       url,

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/AddRulesEngineToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/AddRulesEngineToPipelineModal.js
@@ -28,6 +28,7 @@ import {Modal, ModalHeader, ModalBody} from 'reactstrap';
 import MyRulesEngine from 'api/rulesengine';
 import classnames from 'classnames';
 import T from 'i18n-react';
+import IconSVG from 'components/IconSVG';
 
 require('./AddRulesEngineToPipelineModal.scss');
 const PREFIX = 'features.RulesEngine.AddRulesEngineToPipelineModal';
@@ -45,7 +46,8 @@ export default class AddRulesEngineToPipelineModal extends Component {
     batchUrl: '',
     realtimeUrl: '',
     batchConfig: null,
-    realtimeConfig: null
+    realtimeConfig: null,
+    error: null
   };
 
   updateBatchAndRealtimeConfigs = () => {
@@ -66,6 +68,12 @@ export default class AddRulesEngineToPipelineModal extends Component {
           let batchArtifacts = artifacts.filter(artifact => artifact.name === 'cdap-data-pipeline');
           let realtimeArtifacts = artifacts.filter(artifact => artifact.name === 'cdap-data-streams');
           let yareArtifact = artifacts.filter(artifact => artifact.name === 'yare-plugins');
+          if (!yareArtifact.length) {
+            this.setState({
+              error: T.translate(`${PREFIX}.error`)
+            });
+            return;
+          }
           let batchHighestArtifact, realtimeHighestArtifact;
           if (batchArtifacts.length > 1) {
             let highestBatchArtifactVersion = findHighestVersion(batchArtifacts.map(artifact => artifact.version), true);
@@ -102,6 +110,7 @@ export default class AddRulesEngineToPipelineModal extends Component {
             artifact: realtimeHighestArtifact,
             config: {
               stages: [rulesEnginePlugin],
+              batchInterval: '10s',
               connections: []
             }
           };
@@ -125,7 +134,8 @@ export default class AddRulesEngineToPipelineModal extends Component {
             batchConfig,
             batchUrl,
             realtimeUrl,
-            realtimeConfig
+            realtimeConfig,
+            error: null
           });
         }
       );
@@ -152,6 +162,44 @@ export default class AddRulesEngineToPipelineModal extends Component {
     window.localStorage.setItem(this.state.rulebookid, JSON.stringify(this.state.batchConfig));
   };
 
+  renderContent = () => {
+    if (this.state.error) {
+      return (
+        <h5 className="error-message text-danger">
+          <IconSVG name="icon-exclamation-triangle" />
+          <span>{this.state.error}</span>
+        </h5>
+      );
+    }
+    return (
+      <div>
+        <div className="message">
+          {T.translate(`${PREFIX}.message`)}
+        </div>
+        <div className="action-buttons">
+          <a
+            className="btn btn-secondary"
+            href={this.state.batchUrl}
+            onClick={this.handleOnBatchUrlClick}
+          >
+            <i className="fa icon-ETLBatch" />
+            <span>{T.translate(`${PREFIX}.batchPipelineBtn`)}</span>
+          </a>
+          <a
+            href={this.state.realtimeUrl}
+            className={classnames('btn btn-secondary', {
+              'inactive': !this.state.realtimeUrl
+            })}
+            onClick={this.handleOnRealtimeUrlClick}
+          >
+            <i className="fa icon-sparkstreaming" />
+            <span>{T.translate(`${PREFIX}.realtimePipelineBtn`)}</span>
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   render() {
     return (
       <Modal
@@ -160,33 +208,11 @@ export default class AddRulesEngineToPipelineModal extends Component {
         className="rules-engine-to-pipeline-modal"
         size="lg"
       >
-        <ModalHeader>
+        <ModalHeader toggle={this.props.onClose}>
           <span>{T.translate(`${PREFIX}.modalTitle`)}</span>
         </ModalHeader>
         <ModalBody>
-          <div className="message">
-            {T.translate(`${PREFIX}.message`)}
-          </div>
-          <div className="action-buttons">
-            <a
-              className="btn btn-secondary"
-              href={this.state.batchUrl}
-              onClick={this.handleOnBatchUrlClick}
-            >
-              <i className="fa icon-ETLBatch" />
-              <span>{T.translate(`${PREFIX}.batchPipelineBtn`)}</span>
-            </a>
-            <a
-              href={this.state.realtimeUrl}
-              className={classnames('btn btn-secondary', {
-                'inactive': !this.state.realtimeUrl
-              })}
-              onClick={this.handleOnRealtimeUrlClick}
-            >
-              <i className="fa icon-sparkstreaming" />
-              <span>{T.translate(`${PREFIX}.realtimePipelineBtn`)}</span>
-            </a>
-          </div>
+          {this.renderContent()}
         </ModalBody>
       </Modal>
     );

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/AddRulesEngineToPipelineModal.scss
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/AddRulesEngineToPipelineModal.scss
@@ -37,6 +37,15 @@
           }
         }
       }
+      .error-message {
+        padding: 20px;
+        h5 > span {
+          vertical-align: bottom;
+        }
+        .icon-svg {
+          margin-right: 5px;
+        }
+      }
     }
   }
 }

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/RulesEngineServiceControl.scss
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/RulesEngineServiceControl.scss
@@ -59,4 +59,10 @@
       }
     }
   }
+  .rules-engine-service-control-error {
+    margin-top: 20px;
+    .icon-svg {
+      margin-right: 5px;
+    }
+  }
 }

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
@@ -19,6 +19,7 @@ import MyRuleEngineApi from 'api/rulesengine';
 import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
 import LoadingSVG from 'components/LoadingSVG';
 import T from 'i18n-react';
+import IconSVG from 'components/IconSVG';
 
 require('./RulesEngineServiceControl.scss');
 const PREFIX = 'features.RulesEngine.RulesEngineServiceControl';
@@ -30,7 +31,8 @@ export default class RulesEngineServiceControl extends Component {
   };
 
   state = {
-    loading: false
+    loading: false,
+    error: null
   };
 
   enableRulesEngine = () => {
@@ -44,8 +46,31 @@ export default class RulesEngineServiceControl extends Component {
       i18nPrefix: ''
     })
       .subscribe(
-        this.props.onServiceStart
+        this.props.onServiceStart,
+        (err) => {
+          this.setState({
+            error: typeof err === 'object' ? err.error : err,
+            loading: false
+          });
+        }
       );
+  }
+
+  renderError = () => {
+    if (!this.state.error) {
+      return null;
+    }
+    return (
+      <div className="rules-engine-service-control-error">
+        <h5 className="text-danger">
+          <IconSVG name="icon-exclamation-triangle" />
+          <span>{T.translate(`${PREFIX}.errorTitle`)}</span>
+        </h5>
+        <p className="text-danger">
+          {this.state.error}
+        </p>
+      </div>
+    );
   }
 
   render() {
@@ -82,6 +107,7 @@ export default class RulesEngineServiceControl extends Component {
                 null
             } <span className="btn-label">{T.translate(`${PREFIX}.enableBtnLabel`)}</span>
           </button>
+          {this.renderError()}
         </div>
       </div>
     );

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1345,6 +1345,7 @@ features:
   RulesEngine:
     AddRulesEngineToPipelineModal:
       batchPipelineBtn: Batch Pipeline
+      error: Unable to find Rules Engine Plugin. Please install Rules Engine plugin before adding to pipeline
       message: Choose the type of pipeline to create
       modalTitle: Add to Pipeline
       realtimePipelineBtn: Realtime Pipeline
@@ -1405,6 +1406,7 @@ features:
             It provides an alternative computational model for transforming your data while empowering the business
             users to specify and manage the transformations and policy enforcements.
       enableBtnLabel: Enable Rules Engine
+      errorTitle: Enabling Rules Engine Failed
       title: Welcome to Rules Engine Management
     RulesList:
       dropContainerText: Add a rule by dragging and dropping from the Rules tab


### PR DESCRIPTION
[CDAP-12336](https://issues.cask.co/browse/CDAP-12336) - Prevents UI from making uploading data to stream when user hasn't uploaded any file in stream create wizard.
[CDAP-12413](https://issues.cask.co/browse/CDAP-12413) - Fixes adding auth header while importing a rulebook
[CDAP-12422](https://issues.cask.co/browse/CDAP-12422) - Fixes passing `batchInterval` as pipeline property while adding rules engine to a realtime pipeline.
- Fixes rules engine to show appropriate error if yare-plugin is missing while adding a rulebook to a pipeline