### PR TITLE
CDAP-12111 allow plugins to have their own plugins

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/Plugin.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/Plugin.java
@@ -18,24 +18,58 @@ package co.cask.cdap.api.plugin;
 
 import co.cask.cdap.api.artifact.ArtifactId;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
  * A container class for holding plugin information.
  */
 public final class Plugin {
+  private final List<ArtifactId> parents;
   private final ArtifactId artifactId;
   private final PluginClass pluginClass;
   private final PluginProperties properties;
 
+  @Deprecated
   public Plugin(ArtifactId artifactId, PluginClass pluginClass, PluginProperties properties) {
+    this(new ArrayList<ArtifactId>(), artifactId, pluginClass, properties);
+  }
+
+  /**
+   * Create a Plugin
+   *
+   * @param parents iterable of parent plugins. The first parent must be the direct parent of this plugin, and each
+   *                subsequent item in the iterable must be the direct parent of the item before it
+   * @param artifactId the artifact for this plugin
+   * @param pluginClass information about the plugin class
+   * @param properties properties of the plugin
+   */
+  public Plugin(Iterable<ArtifactId> parents, ArtifactId artifactId,
+                PluginClass pluginClass, PluginProperties properties) {
+    List<ArtifactId> parentList = new ArrayList<>();
+    for (ArtifactId parent : parents) {
+      parentList.add(parent);
+    }
+    this.parents = Collections.unmodifiableList(parentList);
     this.artifactId = artifactId;
     this.pluginClass = pluginClass;
     this.properties = properties;
   }
 
   /**
-   * @return artifact id
+   * @return the artifact parent chain. Every artifact in the list is the parent of the artifact behind it.
+   *         This list does not contain the plugin's artifact, which means it will be an empty list if the plugin's
+   *         parent is a program and not another plugin.
+   */
+  public List<ArtifactId> getParents() {
+    // null check for backwards compatibility, since this field was added in 4.3.0
+    return parents == null ? Collections.<ArtifactId>emptyList() : parents;
+  }
+
+  /**
+   * @return artifact id of the plugin
    */
   public ArtifactId getArtifactId() {
     return artifactId;
@@ -65,22 +99,24 @@ public final class Plugin {
     }
 
     Plugin that = (Plugin) o;
-    return Objects.equals(artifactId, that.artifactId)
+    return Objects.equals(getParents(), that.getParents())
+      && Objects.equals(artifactId, that.artifactId)
       && Objects.equals(pluginClass, that.pluginClass)
       && Objects.equals(properties, that.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(artifactId, pluginClass, properties);
+    return Objects.hash(getParents(), artifactId, pluginClass, properties);
   }
 
   @Override
   public String toString() {
     return "Plugin{" +
-      "artifactId=" + artifactId +
-      ",pluginClass=" + pluginClass +
-      ",properties=" + properties +
+      "parents=" + getParents() +
+      ", artifactId=" + artifactId +
+      ", pluginClass=" + pluginClass +
+      ", properties=" + properties +
       '}';
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -132,7 +132,8 @@ final class ArtifactInspector {
 
         try (PluginInstantiator pluginInstantiator =
                new PluginInstantiator(cConf, parentClassLoader == null ? artifactClassLoader : parentClassLoader,
-                                      Files.createTempDirectory(stageDir, "plugins-").toFile())) {
+                                      Files.createTempDirectory(stageDir, "plugins-").toFile(),
+                                      false)) {
           pluginInstantiator.addArtifact(artifactLocation, artifactId.toArtifactId());
           inspectPlugins(builder, artifactFile, artifactId.toArtifactId(), pluginInstantiator);
         }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginClassLoader.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.plugin;
 
+import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.common.lang.CombineClassLoader;
 import co.cask.cdap.common.lang.DirectoryClassLoader;
@@ -52,7 +53,7 @@ import java.util.jar.Manifest;
  * ClassLoader as the Combine ClassLoader.
  */
 public class PluginClassLoader extends DirectoryClassLoader {
-
+  private final ArtifactId artifactId;
   private final Set<String> exportPackages;
 
   static ClassLoader createParent(ClassLoader templateClassLoader) {
@@ -77,9 +78,17 @@ public class PluginClassLoader extends DirectoryClassLoader {
     return new CombineClassLoader(programClassLoader.getParent(), ImmutableList.of(filteredTemplateClassLoader));
   }
 
-  PluginClassLoader(File directory, ClassLoader parent) {
+  PluginClassLoader(ArtifactId artifactId, File directory, ClassLoader parent) {
     super(directory, parent, "lib");
+    this.artifactId = artifactId;
     this.exportPackages = ManifestFields.getExportPackages(getManifest());
+  }
+
+  /**
+   * @return the plugin's artifact id
+   */
+  public ArtifactId getArtifactId() {
+    return artifactId;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginClassLoaders.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginClassLoaders.java
@@ -64,7 +64,7 @@ public final class PluginClassLoaders {
 
       List<ClassLoader> pluginClassLoaders = new ArrayList<>();
       for (Plugin plugin : plugins.values()) {
-        ClassLoader pluginClassLoader = pluginInstantiator.getArtifactClassLoader(plugin.getArtifactId());
+        ClassLoader pluginClassLoader = pluginInstantiator.getPluginClassLoader(plugin);
         if (pluginClassLoader instanceof PluginClassLoader) {
 
           // A ClassLoader to allow loading of all plugin classes used by the program.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginService.java
@@ -19,7 +19,9 @@ import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.artifact.ArtifactRange;
 import co.cask.cdap.api.artifact.CloseableClassLoader;
 import co.cask.cdap.api.plugin.EndpointPluginContext;
+import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.common.NotFoundException;
@@ -56,6 +58,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -316,10 +319,12 @@ public class PluginService extends AbstractIdleService {
                                            final DefaultEndpointPluginContext endpointPluginContext)
     throws IOException, ClassNotFoundException, NotFoundException {
 
-    ClassLoader pluginClassLoader = pluginInstantiator.getArtifactClassLoader(artifact.toArtifactId());
+    Plugin plugin = new Plugin(new ArrayList<ArtifactId>(), artifact.toArtifactId(),
+                               pluginClass, PluginProperties.builder().build());
+    ClassLoader pluginClassLoader = pluginInstantiator.getPluginClassLoader(plugin);
     Class pluginClassLoaded = pluginClassLoader.loadClass(pluginClass.getClassName());
 
-    final Object pluginInstance = pluginInstantiator.newInstanceWithoutConfig(artifact.toArtifactId(), pluginClass);
+    final Object pluginInstance = pluginInstantiator.newInstanceWithoutConfig(plugin);
 
     Method[] methods = pluginClassLoaded.getMethods();
     for (final Method method : methods) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -35,6 +35,7 @@ import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.security.impersonation.DefaultImpersonator;
 import co.cask.cdap.security.impersonation.EntityImpersonator;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
@@ -79,8 +80,8 @@ public class ArtifactInspectorTest {
     Location artifactLocation = Locations.toLocation(appFile);
     try (CloseableClassLoader artifactClassLoader =
            classLoaderFactory.createClassLoader(
-             artifactLocation, new EntityImpersonator(artifactId.toEntityId(),
-                                                      new DefaultImpersonator(CConfiguration.create(), null)))) {
+             ImmutableList.of(artifactLocation).iterator(),
+             new EntityImpersonator(artifactId.toEntityId(), new DefaultImpersonator(CConfiguration.create(), null)))) {
       artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader);
     }
   }
@@ -96,8 +97,8 @@ public class ArtifactInspectorTest {
     Location artifactLocation = Locations.toLocation(appFile);
     try (CloseableClassLoader artifactClassLoader =
            classLoaderFactory.createClassLoader(
-             artifactLocation, new EntityImpersonator(artifactId.toEntityId(),
-                                                      new DefaultImpersonator(CConfiguration.create(), null)))) {
+             ImmutableList.of(artifactLocation).iterator(),
+             new EntityImpersonator(artifactId.toEntityId(), new DefaultImpersonator(CConfiguration.create(), null)))) {
 
       ArtifactClasses classes = artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader);
 


### PR DESCRIPTION
Changes the plugin model so that a plugin can itself export some
api classes that other plugins can implement. For example, this
will allow a transform for the data-pipeline app to define its own
interface that other plugins can implement.

At configure time, when a plugin declares that it uses another
plugin, the platform will first try to find a plugin that extends
the calling plugin before finding a plugin that extends the
application. Capping it to just two levels for now to avoid some
possible complex dependency graphs and limit the number of lookups
required. When a plugin of a plugin is instantiated, its parent
classloader will be the classloader of the parent plugin.