### PR TITLE
Fixes connections lagging while dragging in Studio

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -260,6 +260,9 @@ angular.module(PKG.name + '.commons')
     }
 
     function initNodes() {
+      vm.instance.unmakeEverySource();
+      vm.instance.unmakeEveryTarget();
+
       angular.forEach($scope.nodes, function (node) {
         if (node.type !== 'condition') {
           let sourceObj = {
@@ -803,6 +806,8 @@ angular.module(PKG.name + '.commons')
         }
         return selectedConnObj.sourceId !== node.name && selectedConnObj.targetId !== node.name;
       });
+      vm.instance.unmakeSource(node.name);
+      vm.instance.unmakeTarget(node.name);
       vm.instance.remove(node.name);
       vm.instance.bind('connectionDetached', removeConnection);
     };


### PR DESCRIPTION
To reproduce the issue:
- Add a node/nodes in Studio
- Configure those nodes
- Try to drag a connection from any node

The connection will lag, and the more the user edited the nodes, the worse the lagging will become. The reason was we were calling `initNodes` inside `nodes` watch, which fires every time the user types something in the node config. Each `initNodes` will call `makeSource` and `makeTarget` on every node, which basically adds new jsPlumb endpoints for each node, without erasing the existing ones. After this, when the user tries to drag a connection, it will be from all of these endpoints, causing the lag.

The solution is to simply `unmake` these sources and targets before making them again, or before deleting a node.