### PR TITLE
Adds rulebookid as hidden property while navigating between rulesengine and pipeline

### DIFF
--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/AddRulesEngineToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/AddRulesEngineToPipelineModal.js
@@ -95,7 +95,8 @@ export default class AddRulesEngineToPipelineModal extends Component {
               "label": "RulesEngine",
               artifact: yareArtifact,
               "properties": {
-                "rulebook": rulebook
+                "rulebook": rulebook,
+                "rulebookid": this.props.rulebookid
               }
             }
           };

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/index.js
@@ -124,7 +124,7 @@ export default class RuleBookDetails extends Component {
       .subscribe(
         (res) => {
           let rulebook = res.values[0];
-          this.props.onApply(rulebook);
+          this.props.onApply(rulebook, rulebookid);
         }
       );
   };

--- a/cdap-ui/app/cdap/components/RulesEngineHome/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/index.js
@@ -15,7 +15,7 @@
 */
 
 import React, {Component, PropTypes} from 'react';
-import {getRuleBooks, resetStore, getRules} from 'components/RulesEngineHome/RulesEngineStore/RulesEngineActions';
+import {getRuleBooks, resetStore, getRules, setActiveRulebook} from 'components/RulesEngineHome/RulesEngineStore/RulesEngineActions';
 import RulesEngineStore, {RULESENGINEACTIONS} from 'components/RulesEngineHome/RulesEngineStore';
 import RulesEngineAlert from 'components/RulesEngineHome/RulesEngineAlert';
 import NamespaceStore from 'services/NamespaceStore';
@@ -25,6 +25,8 @@ import RulesEngineServiceControl from 'components/RulesEngineHome/RulesEngineSer
 import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import RulesEngineWrapper from 'components/RulesEngineHome/RulesEngineWrapper';
+import isNil from 'lodash/isNil';
+
 const PREFIX = 'features.RulesEngine.Home';
 
 export default class RulesEngineHome extends Component {
@@ -82,6 +84,9 @@ export default class RulesEngineHome extends Component {
   fetchRulesAndRulebooks = () => {
     getRuleBooks();
     getRules();
+    if (!isNil(this.props.rulebookid)) {
+      setActiveRulebook(this.props.rulebookid);
+    }
   };
 
   checkIfBackendUp() {

--- a/cdap-ui/app/directives/widget-container/widget-rulesengine-editor/rules-engine-modal-ctrl.js
+++ b/cdap-ui/app/directives/widget-container/widget-rulesengine-editor/rules-engine-modal-ctrl.js
@@ -16,12 +16,13 @@
 
 angular.module(PKG.name + '.commons')
   .controller('RulesEngineModalController', function(rPlugin, $uibModalInstance) {
-    // FIXME: UI doesn't have a rulebookid when navigating into rulesengine from pipelines.
     this.$uibModalInstance = $uibModalInstance;
+    this.rulebookid = rPlugin.properties.rulebookid;
     this.node = rPlugin;
-    this.onApply = (rulebook) => {
+    this.onApply = (rulebook, rulebookid) => {
       if (rulebook) {
         this.node.properties.rulebook = rulebook;
+        this.node.properties.rulebookid = rulebookid;
       }
       this.$uibModalInstance.close();
     };

--- a/cdap-ui/app/directives/widget-container/widget-rulesengine-editor/rules-engine-modal.html
+++ b/cdap-ui/app/directives/widget-container/widget-rulesengine-editor/rules-engine-modal.html
@@ -22,6 +22,11 @@
   </a>
 </div>
 <div class="modal-body">
-  <rules-engine-home embedded="true" rulebookid="RulesEngineModalCtrl.rulebookid" on-apply="RulesEngineModalCtrl.onApply" watch-depth="reference">
+  <rules-engine-home
+    embedded="true"
+    rulebookid="RulesEngineModalCtrl.rulebookid"
+    on-apply="RulesEngineModalCtrl.onApply"
+    watch-depth="reference"
+  >
   </rules-engine-home>
 </div>


### PR DESCRIPTION
- Adds `rulebookid` to be passed between `RulesEngineHome` and `rules-engine-editor` in pipeline.
- Corresponding RulesEngine [PR here](https://github.com/cask-solutions/yare/pull/2). This needs to be merged before the UI PR is merged.