### PR TITLE
Updates babel-core version to 6.26.0 to fix UI build process

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "autoprefixer": "6.5.0",
-    "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz",
+    "babel-core": "6.26.0",
     "babel-eslint": "6.1.2",
     "babel-jest": "16.0.0",
     "babel-loader": "6.2.5",


### PR DESCRIPTION
This was already added in https://github.com/caskdata/cdap/pull/9393, but was accidentally reverted last night: https://github.com/caskdata/cdap/commit/c879fed3844478b0d7d2f84b25dac4cc3e580d18#diff-2a6fcdb9188544bca171d7c513efabce.

Checked common build, full build, and incremental build.