### PR TITLE
[CDAP-12434] Removes debounce during sorting rules in rulebook detail view

### DIFF
--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBooksTab/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBooksTab/index.js
@@ -39,7 +39,7 @@ export default class RuleBooksTab extends Component {
   };
 
   componentDidMount() {
-    RulesEngineStore.subscribe(() => {
+    this.rulesStoreSubscription = RulesEngineStore.subscribe(() => {
       let {rulebooks} = RulesEngineStore.getState();
       if (Array.isArray(rulebooks.list)) {
         this.setState({
@@ -47,6 +47,12 @@ export default class RuleBooksTab extends Component {
         });
       }
     });
+  }
+
+  componentWillUnmount() {
+    if (this.rulesStoreSubscription) {
+      this.rulesStoreSubscription();
+    }
   }
 
   updateSearchStr = (e) => {

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineAlert/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineAlert/index.js
@@ -32,7 +32,7 @@ export default class RulesEngineAlert extends Component {
   state = this.getDefaultState();
 
   componentDidMount() {
-    RulesEngineStore.subscribe(() => {
+    this.rulesStoreSubscription = RulesEngineStore.subscribe(() => {
       let {error} = RulesEngineStore.getState();
       if (error.showError) {
         this.setState({
@@ -44,6 +44,12 @@ export default class RulesEngineAlert extends Component {
         this.setState(this.getDefaultState());
       }
     });
+  }
+
+  componentWillUnmount() {
+    if (this.rulesStoreSubscription) {
+      this.rulesStoreSubscription();
+    }
   }
 
   render() {

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineWrapper.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineWrapper.js
@@ -41,7 +41,7 @@ class RulesEngineWrapper extends Component {
   };
 
   componentDidMount() {
-    RulesEngineStore.subscribe(() => {
+    this.rulesStoreSubscription = RulesEngineStore.subscribe(() => {
       let {rulebooks} = RulesEngineStore.getState();
       if (rulebooks.activeTab && rulebooks.activeTab !== this.state.activeTab) {
         this.setState({
@@ -49,6 +49,12 @@ class RulesEngineWrapper extends Component {
         });
       }
     });
+  }
+
+  componentWillUnmount() {
+    if (this.rulesStoreSubscription) {
+      this.rulesStoreSubscription();
+    }
   }
 
   toggleTab = (activeTab) => {

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/index.js
@@ -74,7 +74,7 @@ class Rule extends Component {
   };
 
   componentDidMount() {
-    RulesEngineStore.subscribe(() => {
+    this.rulesStoreSubscription = RulesEngineStore.subscribe(() => {
       let {rules} = RulesEngineStore.getState();
       if (rules.activeRuleId === this.props.rule.id) {
         this.fetchRuleDetails();
@@ -86,6 +86,12 @@ class Rule extends Component {
         }
       }
     });
+  }
+
+  componentWillUnmount() {
+    if (this.rulesStoreSubscription) {
+      this.rulesStoreSubscription();
+    }
   }
 
   viewDetails = () => {

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/index.js
@@ -55,7 +55,7 @@ export default class RulesTab extends Component {
   };
 
   componentDidMount() {
-    RulesEngineStore.subscribe(() => {
+    this.rulesStoreSubscription = RulesEngineStore.subscribe(() => {
       let {rules} = RulesEngineStore.getState();
       if (Array.isArray(rules.list)) {
         this.setState({
@@ -63,6 +63,12 @@ export default class RulesTab extends Component {
         });
       }
     });
+  }
+
+  componentWillUnmount() {
+    if (this.rulesStoreSubscription) {
+      this.rulesStoreSubscription();
+    }
   }
 
   getFilteredRules() {


### PR DESCRIPTION
Issue:
- On sorting rules in rulebook while in pipeline the sorted rules for the rulebook are not updated.

Fix:
- On sort fetch sorted rules again from backend to reflect the sort order in rules engine plugin.
- Removed `debounce` delay of 2 seconds to avoid timing issues while navigating between rules engine and pipeline.
- Properly unsubscribe from rules engine store on unmount.
 