### PR TITLE
CDAP-12460 fix remote authorization enforcer due to the UnAuthorizedE…

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesTestBase.java
@@ -37,6 +37,7 @@ import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.authorization.RemoteAuthorizationEnforcer;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.cdap.security.spi.authorization.PrivilegesManager;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
@@ -145,6 +146,12 @@ public abstract class RemotePrivilegesTestBase {
     authorizationEnforcer.enforce(NS, ALICE, EnumSet.allOf(Action.class));
     authorizationEnforcer.enforce(APP, ALICE, Action.ADMIN);
     authorizationEnforcer.enforce(PROGRAM, ALICE, Action.EXECUTE);
+    try {
+      authorizationEnforcer.enforce(NS, BOB, Action.ADMIN);
+      Assert.fail();
+    } catch (UnauthorizedException e) {
+      // expected
+    }
 
     privilegesManager.revoke(PROGRAM);
     privilegesManager.revoke(APP);

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemoteAuthorizationEnforcer.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemoteAuthorizationEnforcer.java
@@ -176,7 +176,11 @@ public class RemoteAuthorizationEnforcer extends AbstractAuthorizationEnforcer {
     HttpRequest request = remoteClient.requestBuilder(HttpMethod.POST, "enforce")
       .withBody(GSON.toJson(authorizationPrivilege))
       .build();
-    return HttpURLConnection.HTTP_OK == remoteClient.execute(request).getResponseCode();
+    try {
+      return HttpURLConnection.HTTP_OK == remoteClient.execute(request).getResponseCode();
+    } catch (UnauthorizedException e) {
+      return false;
+    }
   }
 
   private Set<? extends EntityId> visibilityCheckCall(VisibilityRequest visibilityRequest) throws IOException {


### PR DESCRIPTION
…xception change

JIRA: https://issues.cask.co/browse/CDAP-12460

We change UnAuthorziedException to RuntimeException in #9431 . In RemoteClient, we are also throwing it if the code is 403. This makes the remote enforcer cache no longer works for auth failure, since the cache will wrap the exception as a UnCheckedExecutionEception and throw it instead of caching the boolean result. Also, it fails for ensureOnePrivilege, since this method is trying to catch UnAuthorizedException. 

This pr fixes it and adds a test for it