### PR TITLE
[CDAP-12351] Fix FileSet.truncate() to preserve the base path

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
@@ -439,10 +439,21 @@ public class FileSetTest {
                                      .build());
     Assert.assertTrue(someFile.exists());
 
+    // get the base location, and toggle its group write flag.
+    // we will use this to test whether truncate() preserves the original base dir
+    FileSet fs = dsFrameworkUtil.getInstance(testFileSetInstance5);
+    Location base = fs.getBaseLocation();
+    String permissions = base.getPermissions();
+    char groupWriteFlag = permissions.charAt(4); // rwxrwxrwx
+    char toggledGroupWriteFlag = groupWriteFlag == 'w' ? '-' : 'w';
+    String toggledPermissions = permissions.substring(0, 4) + toggledGroupWriteFlag + permissions.substring(5, 9);
+    base.setPermissions(toggledPermissions);
+
     // truncate the file set
     dsFrameworkUtil.getFramework().truncateInstance(testFileSetInstance5);
     Assert.assertFalse(someFile.exists());
     Assert.assertTrue(existingDir.exists());
+    Assert.assertEquals(toggledPermissions, base.getPermissions());
     someFile.createNewFile();
 
     // truncate the file set


### PR DESCRIPTION
When truncating, we can't simply delete and recreate the base location, because it may have pre-existed:
- we might create it with different permissions/ownership than the original
- we might not even have permission to create (write in the parent dir)

Hence: delete all contents (all children) of the base location.