### PR TITLE
Bring back ScheduleDetail's constructor from 4.2.

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ScheduleDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ScheduleDetail.java
@@ -52,6 +52,16 @@ public class ScheduleDetail {
   private final Long timeoutMillis;
   private final String status;
 
+  public ScheduleDetail(@Nullable String name,
+                        @Nullable String description,
+                        @Nullable ScheduleProgramInfo program,
+                        @Nullable Map<String, String> properties,
+                        @Nullable Trigger trigger,
+                        @Nullable List<? extends Constraint> constraints,
+                        @Nullable Long timeoutMillis) {
+    this(null, null, null, name, description, program, properties, trigger, constraints, timeoutMillis, null);
+  }
+
   public ScheduleDetail(@Nullable String namespace,
                         @Nullable String application,
                         @Nullable String applicationVersion,


### PR DESCRIPTION
In https://github.com/caskdata/cdap/pull/9404/files#diff-bb46e7c04b41792249cab81941834e87, the ScheduleDetail's constructor was modified. However, this class is used in some APIs, such as the user-facing ScheduleClient.
So, if anyone is using ScheduleClient to interact (create, update, etc.) schedules, then their code would then break with the above-referenced changes. This PR brings back the original constructor introduced in 4.2.0.