### PR TITLE
Feature/shrink vm

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -141,7 +141,7 @@
     {
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
-      "run_list": "recipe[maven],recipe[hadoop::flume_agent],recipe[idea],recipe[eclipse]",
+      "run_list": "recipe[maven],recipe[idea],recipe[eclipse]",
       "skip_install": true,
       "json": {
         "eclipse": {

--- a/cdap-distributions/src/packer/scripts/apt-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/apt-cleanup.sh
@@ -30,6 +30,6 @@ apt-get purge -y fuse
 
 # Autoremove and clean
 apt-get autoremove -y
-apt-get autoclean
+apt-get clean
 
 exit 0


### PR DESCRIPTION
This reduces the size of the VM by 1Gb by:
- [x] running ``apt-get clean`` to remove more cache files than ``autoclean``
- [x] removing the ``flume`` agent install as it is no longer relevant