### PR TITLE
[CDAP-12483] Remove delete and add icons from rule details view in Rules Engine

### DIFF
--- a/cdap-ui/app/cdap/components/DSVEditor/DSVRow.js
+++ b/cdap-ui/app/cdap/components/DSVEditor/DSVRow.js
@@ -17,6 +17,7 @@
 import React, { Component, PropTypes } from 'react';
 import T from 'i18n-react';
 import { preventPropagation } from 'services/helpers';
+import classnames from 'classnames';
 
 export default class DSVRow extends Component {
   constructor(props) {
@@ -32,12 +33,34 @@ export default class DSVRow extends Component {
     }
   }
 
+  renderActionButtons() {
+    if (this.props.disabled) { return null; }
+
+    return (
+      <div className="action-buttons-container text-xs-right">
+        <button
+          className="btn add-row-btn btn-link"
+          onClick={this.props.addRow}
+        >
+          <i className="fa fa-plus" />
+        </button>
+        <button
+          className="btn remove-row-btn btn-link"
+          onClick={this.props.removeRow}
+        >
+          <i className="fa fa-trash text-danger" />
+        </button>
+      </div>
+    );
+  }
+
   render() {
     let placeholder = this.props.placeholder || T.translate('commons.DSVEditor.placeholder');
 
     return (
       <div className="dsv-row-container">
-        <div className="dsv-input-container">
+
+        <div className={classnames({ disabled: this.props.disabled }, "dsv-input-container")}>
           <input
             type="text"
             value={this.props.property}
@@ -48,21 +71,7 @@ export default class DSVRow extends Component {
             placeholder={placeholder}
           />
         </div>
-
-        <div className="action-buttons-container text-xs-right">
-          <button
-            className="btn add-row-btn btn-link"
-            onClick={this.props.addRow}
-          >
-            <i className="fa fa-plus" />
-          </button>
-          <button
-            className="btn remove-row-btn btn-link"
-            onClick={this.props.removeRow}
-          >
-            <i className="fa fa-trash text-danger" />
-          </button>
-        </div>
+        {this.renderActionButtons()}
       </div>
     );
   }
@@ -75,5 +84,6 @@ DSVRow.propTypes = {
   onChange: PropTypes.func,
   addRow: PropTypes.func,
   removeRow: PropTypes.func,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  disabled: PropTypes.bool
 };

--- a/cdap-ui/app/cdap/components/DSVEditor/index.js
+++ b/cdap-ui/app/cdap/components/DSVEditor/index.js
@@ -119,6 +119,7 @@ export default class DSVEditor extends Component {
                   <DSVRowWrapper
                     index={index}
                     placeholder={this.props.placeholder}
+                    disabled={this.props.disabled}
                   />
                 </Provider>
               </div>
@@ -133,5 +134,6 @@ export default class DSVEditor extends Component {
 DSVEditor.propTypes = {
   values: PropTypes.array,
   onChange: PropTypes.func,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  disabled: PropTypes.bool
 };

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/Rule.scss
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/Rule.scss
@@ -52,6 +52,10 @@ $drag_bars_color: gray;
         }
         .dsv-input-container {
           width: calc(100% - 50px);
+
+          &.disabled {
+            width: 100%;
+          }
         }
         .action-buttons-container {
           width: 50px;

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/index.js
@@ -192,6 +192,7 @@ class Rule extends Component {
                 <DSVEditor
                   values={rules}
                   onChange={this.onRulesChange}
+                  disabled={!this.state.edit}
                 />
               </fieldset>
             </Col>


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12483

Currently each rule uses the component `DSVEditor`, so I had to pass the `disabled` prop to it. However, currently the only other place that uses this component is the Create a New Rule section, which is not affected by this change as shown in the screenshot below.

Have also made the row field full width, since we don't show the buttons anymore.

<img width="430" alt="screen shot 2017-08-24 at 9 52 53 pm" src="https://user-images.githubusercontent.com/6516002/29700264-064cf6fe-8918-11e7-94ef-47c7025655d0.png">
<img width="426" alt="screen shot 2017-08-24 at 9 59 06 pm" src="https://user-images.githubusercontent.com/6516002/29700265-06500268-8918-11e7-894c-9aa2e72766ed.png">
