### PR TITLE
Fix AppMetadataStoreTest by only recording valid run status

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -584,12 +584,17 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    */
   private boolean validateExistingRecords(List<RunRecordMeta> existingRecords, ProgramId programId, String pid,
                                           byte[] sourceId, String recordType, ProgramRunStatus status) {
-    Set<ProgramRunStatus> allowedStatuses = ALLOWED_STATUSES.get(status);
-    Set<ProgramRunStatus> allowedWithLogStatuses = ALLOWED_WITH_LOG_STATUSES.get(status);
     if (existingRecords.size() > 1) {
       // This should never happen
       LOG.warn("Found more than 1 existing run record meta '{}' for program '{}' run id '{}'. " +
                  "Skip recording program {}.", existingRecords, programId, pid, recordType);
+      return false;
+    }
+    Set<ProgramRunStatus> allowedStatuses = ALLOWED_STATUSES.get(status);
+    Set<ProgramRunStatus> allowedWithLogStatuses = ALLOWED_WITH_LOG_STATUSES.get(status);
+    if (allowedStatuses == null || allowedWithLogStatuses == null) {
+      LOG.error("Run status '{}' is not allowed to be persisted for program '{}' run id '{}'.",
+                status, programId, pid);
       return false;
     }
     // If existing record is not allowed, only empty existing records is valid

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -32,6 +32,7 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.base.Function;
 import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.inject.Injector;
@@ -62,6 +63,8 @@ public class AppMetadataStoreTest {
   private static DatasetFramework datasetFramework;
   private static CConfiguration cConf;
   private static TransactionExecutorFactory txExecutorFactory;
+  private static final List<ProgramRunStatus> STOP_STATUSES =
+    ImmutableList.of(ProgramRunStatus.COMPLETED, ProgramRunStatus.FAILED, ProgramRunStatus.KILLED);
 
   private final AtomicInteger sourceId = new AtomicInteger();
 
@@ -204,7 +207,7 @@ public class AppMetadataStoreTest {
             AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
           metadataStoreDataset.recordProgramStop(
             program, runId.getId(), RunIds.getTime(runId, TimeUnit.SECONDS),
-            ProgramRunStatus.values()[j % ProgramRunStatus.values().length],
+            STOP_STATUSES.get(j % STOP_STATUSES.size()),
             null, AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
         }
       });


### PR DESCRIPTION
Failure in https://builds.cask.co/browse/CDAP-RUT1291-5
`AppMetadataStoreTest` is trying to persist invalid run statuses which are no longer allowed to be persisted in `AppMetadataStore`. Fix by adding additional check in `AppMetadataStore` and only persist valid run status in `AppMetadataStoreTest`