### PR TITLE
Fixes regression where helper text doesn't show up even when user doesn't have microservice-core artifact

### DIFF
--- a/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/index.js
@@ -45,13 +45,13 @@ export default class MicroserviceUploadWizard extends Component {
     return MicroserviceUploadActionCreator
       .findMicroserviceArtifact()
       .flatMap((artifact) => {
-        if (isEmpty(artifact)) {
-          return Rx.Observable.of([]);
-        }
         MicroserviceUploadStore.dispatch({
           type: MicroserviceUploadActions.setMicroserviceArtifact,
           payload: { artifact }
         });
+        if (isEmpty(artifact)) {
+          return Rx.Observable.of([]);
+        }
         return MicroserviceUploadActionCreator.listMicroservicePlugins(artifact);
       })
       .flatMap((plugins) => {

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
@@ -107,12 +107,9 @@ export default class RulesEngineServiceControl extends Component {
     }
     if (this.state.rulesEngineNotAvailable) {
       return (
-        <a
-          href="mailto:Sales@cask.co"
-          className="btn-link mail-to-link"
-        >
+        <span className="mail-to-link">
           {T.translate(`${PREFIX}.contactMessage`)}
-        </a>
+        </span>
       );
     }
     if (this.state.showEnableButton) {

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1464,7 +1464,7 @@ features:
         b5: "Easy governance: The Rules engine provides a centralized repository for policies and transformations"
         title: "Benefits of the Cask Rules Engine include:"
       checkMessage: Checking if Rules Engine is available...
-      contactMessage: Contact Cask Data for a Demo
+      contactMessage: Contact support@cask.co to enable
       description: Cask Distributed Rules Engine provides an easy way to create and manage a knowledge base that is executable in your big data environment.
                   The intuitive UI allows business analysts to set up business rules and use them within a data pipeline.
       enableBtnLabel: Enable Rules Engine
@@ -1702,7 +1702,7 @@ features:
       Step1:
         description: Provide name, description and version for a microservice you would like to create.
         descriptionPlaceholder: Description of the microservice
-        helperText: Please load the microservice-app artifact for creating and managing microservices using the _load artifact <artifact-jar-file>_ CLI command.
+        helperText: Microservice Core is not available. Please contact support@cask.co to enable.
         instanceNameLabel: Instance Name
         instanceNamePlaceholder: Name of the microservice instance
         microserviceOptionLabel: Microservice Name


### PR DESCRIPTION
Before we used to have a message telling the user to load the `microservice-core` artifact to be able to use the Create Microservice wizard, if they didn't have it loaded yet. But in the current build the message is gone. 

The problem was because I added the code to return an empty observable right away if the artifact was missing. It was not getting to the `MicroserviceUploadActions.setMicroserviceArtifact` dispatch call, which sets the helper text and disable all the tabs if the artifact is empty. I have moved this code down below the dispatch call, and now it's working correctly as shown in screenshot.

![screen shot 2017-08-25 at 1 47 46 pm](https://user-images.githubusercontent.com/6516002/29732101-0583de20-899c-11e7-9f5c-fd9218284b27.png)


