### PR TITLE
Fix TestFrameworkTestRun#testAppWithTxTimeout

### DIFF
--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -1240,18 +1240,24 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     int txDefaulTimeoutMapReduce = 23;
     int txDefaulTimeoutSpark = 24;
 
-    ApplicationManager appManager = deployApplication(testSpace, AppWithCustomTx.class);
+    final ApplicationManager appManager = deployApplication(testSpace, AppWithCustomTx.class);
     try {
       // attempt to start with a tx timeout that exceeds the max tx timeout
       try {
         appManager.getServiceManager(AppWithCustomTx.SERVICE)
           .start(txTimeoutArguments(100000));
       } catch (IllegalArgumentException e) {
-        //expected
+        //expected, this will finally cause AppWithCustomTx.SERVICE to have FAILED status
       }
-
       // now start all the programs with valid tx timeouts
       getStreamManager(testSpace.stream(AppWithCustomTx.INPUT)).send("hello");
+      // wait for the failed status of AppWithCustomTx.SERVICE to be persisted, so that it can be started again
+      Tasks.waitFor(1, new Callable<Integer>() {
+        @Override
+        public Integer call() throws Exception {
+          return appManager.getServiceManager(AppWithCustomTx.SERVICE).getHistory(ProgramRunStatus.FAILED).size();
+        }
+      }, 30L, TimeUnit.SECONDS, 1, TimeUnit.SECONDS);
       ServiceManager serviceManager = appManager.getServiceManager(AppWithCustomTx.SERVICE)
         .start(txTimeoutArguments(txDefaulTimeoutService));
       WorkerManager notxWorkerManager = appManager.getWorkerManager(AppWithCustomTx.WORKER_NOTX)


### PR DESCRIPTION
`AppWithCustomTx.SERVICE` is supposed to fail when it's first started because of invalid tx timeout. Wait for the FAILED status to be persisted so that `AppWithCustomTx.SERVICE` can be started the second time.