### PR TITLE
Update cdap-docs/vars to fix build.

### DIFF
--- a/cdap-docs/developer-manual/build-pipelines.sh
+++ b/cdap-docs/developer-manual/build-pipelines.sh
@@ -270,8 +270,8 @@ function pipelines_download_includes() {
   download_md_file database-plugins Database-batchsource.md _includes/database-batchsource-append.md.txt
   download_md_file database-plugins Database-action.md
   download_md_file database-plugins DatabaseQuery-postaction.md
-  download_md_file elasticsearch-plugins Elasticsearch-batchsink.md
-  download_md_file elasticsearch-plugins Elasticsearch-batchsource.md
+  # download_md_file elasticsearch-plugins Elasticsearch-batchsink.md # Moved to https://github.com/hydrator/amazon-s3-plugins
+  # download_md_file elasticsearch-plugins Elasticsearch-batchsource.md # Moved to https://github.com/hydrator/amazon-s3-plugins
   download_md_file hbase-plugins HBase-batchsink.md
   download_md_file hbase-plugins HBase-batchsource.md
   download_md_file hdfs-plugins HDFS-batchsink.md


### PR DESCRIPTION
Follow up to https://github.com/caskdata/cdap/pull/9509.
Following the pattern here (https://github.com/caskdata/cdap/pull/8955) and removing the plugin that has been moved to marketplace.
Otherwise, docs build fails. For instance, see https://builds.cask.co/browse/CDAP-DBT28-64/

Here's a docs quick build for this branch: https://builds.cask.co/browse/CDAP-DQB378-1