### PR TITLE
CDAP-12505 fix bug in run corrector for starting runs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DistributedRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DistributedRunRecordCorrectorService.java
@@ -43,7 +43,7 @@ public class DistributedRunRecordCorrectorService extends AbstractRunRecordCorre
   public DistributedRunRecordCorrectorService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
                                               ProgramLifecycleService programLifecycleService,
                                               ProgramRuntimeService runtimeService) {
-    super(store, programStateWriter, programLifecycleService, runtimeService);
+    super(cConf, store, programStateWriter, programLifecycleService, runtimeService);
     this.cConf = cConf;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/LocalRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/LocalRunRecordCorrectorService.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.services;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.runtime.ProgramStateWriter;
 import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.CConfiguration;
 import com.google.inject.Inject;
 
 /**
@@ -27,10 +28,10 @@ import com.google.inject.Inject;
 public class LocalRunRecordCorrectorService extends AbstractRunRecordCorrectorService {
 
   @Inject
-  public LocalRunRecordCorrectorService(Store store, ProgramStateWriter programStateWriter,
+  public LocalRunRecordCorrectorService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
                                         ProgramLifecycleService programLifecycleService,
                                         ProgramRuntimeService runtimeService) {
-    super(store, programStateWriter, programLifecycleService, runtimeService);
+    super(cConf, store, programStateWriter, programLifecycleService, runtimeService);
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
@@ -127,7 +127,8 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
     Assert.assertEquals(0, runRecords.size());
 
     // Start the RunRecordCorrectorService, which will fix the run record
-    new LocalRunRecordCorrectorService(store, programStateWriter, programLifecycleService, runtimeService).startUp();
+    new LocalRunRecordCorrectorService(CConfiguration.create(), store, programStateWriter, programLifecycleService,
+                                       runtimeService).startUp();
 
     // Wait for the FAILED run record for the application
     Tasks.waitFor(1, new Callable<Integer>() {


### PR DESCRIPTION
Fixes a bug where runs could get 'corrected' from starting to
failed when they're actually being started.