### PR TITLE
CDAP-7651 Escape conf object while encoding it into hive's session conf.

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/CConfCodec.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/CConfCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,16 +17,16 @@
 package co.cask.cdap.hive.context;
 
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.io.Codec;
+import org.apache.commons.io.input.ReaderInputStream;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
  * Codec to encode/decode CConfiguration object.
  */
-public class CConfCodec implements Codec<CConfiguration> {
+public class CConfCodec extends ConfCodec<CConfiguration> {
   public static final CConfCodec INSTANCE = new CConfCodec();
 
   private CConfCodec() {
@@ -34,20 +34,12 @@ public class CConfCodec implements Codec<CConfiguration> {
   }
 
   @Override
-  public byte[] encode(CConfiguration object) throws IOException {
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    object.writeXml(bos);
-    bos.close();
-    return bos.toByteArray();
+  public void encode(CConfiguration object, StringWriter stringWriter) throws IOException {
+    object.writeXml(stringWriter);
   }
 
   @Override
-  public CConfiguration decode(byte[] data) throws IOException {
-    if (data == null) {
-      return CConfiguration.create();
-    }
-
-    ByteArrayInputStream bin = new ByteArrayInputStream(data);
-    return CConfiguration.create(bin);
+  public CConfiguration decode(StringReader stringReader) {
+    return CConfiguration.create(new ReaderInputStream(stringReader));
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ConfCodec.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ConfCodec.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hive.context;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.io.Codec;
+import org.apache.hadoop.util.StringUtils;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+/**
+ * Base codec class for encoding/deciding hConf and cConf.
+ * We need to escape and unescape '{', so that getting the encoded conf from an hConf does not try to expand the
+ * variables in the value of the Configuration, and avoid triggering of  an
+ * IllegalStateException 'Variable substitution depth too large: 20'. See CDAP-7651 for more details.
+ */
+abstract class ConfCodec<T> implements Codec<T> {
+
+  /**
+   * Encodes the object to the given StringWriter.
+   */
+  public abstract void encode(T object, StringWriter stringWriter) throws IOException;
+
+  /**
+   * Returns an object decoded from the given StringReader
+   */
+  public abstract T decode(StringReader stringReader);
+
+  @Override
+  public byte[] encode(T object) throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    encode(object, stringWriter);
+    stringWriter.flush();
+    String objectString = stringWriter.toString();
+    String escapedString = StringUtils.escapeString(objectString, StringUtils.ESCAPE_CHAR, '{');
+    return Bytes.toBytes(escapedString);
+  }
+
+  @Override
+  public T decode(byte[] data) throws IOException {
+    if (data == null) {
+      // in all the places that ConfCodec is used, the serialized data should not be null.
+      throw new IllegalStateException("data is null, while deserializing configuration.");
+    }
+    String objectString = Bytes.toString(data);
+    String unescapedString = StringUtils.unEscapeString(objectString, StringUtils.ESCAPE_CHAR, '{');
+
+    StringReader stringReader = new StringReader(unescapedString);
+    return decode(stringReader);
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/HConfCodec.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/HConfCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,18 +16,17 @@
 
 package co.cask.cdap.hive.context;
 
-import co.cask.cdap.common.io.Codec;
+import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
- * Codec to encode/decode HBase Configuration object.
+ * Codec to encode/decode Hadoop Configuration object.
  */
-public class HConfCodec implements Codec<Configuration> {
+public class HConfCodec extends ConfCodec<Configuration> {
   public static final HConfCodec INSTANCE = new HConfCodec();
 
   private HConfCodec() {
@@ -35,22 +34,14 @@ public class HConfCodec implements Codec<Configuration> {
   }
 
   @Override
-  public byte[] encode(Configuration object) throws IOException {
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    object.writeXml(bos);
-    bos.close();
-    return bos.toByteArray();
+  public void encode(Configuration object, StringWriter stringWriter) throws IOException {
+    object.writeXml(stringWriter);
   }
 
   @Override
-  public Configuration decode(byte[] data) throws IOException {
-    if (data == null) {
-      return HBaseConfiguration.create();
-    }
-
-    ByteArrayInputStream bin = new ByteArrayInputStream(data);
+  public Configuration decode(StringReader stringReader) {
     Configuration hConfiguration = new Configuration();
-    hConfiguration.addResource(bin);
+    hConfiguration.addResource(new ReaderInputStream(stringReader));
     return hConfiguration;
   }
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-7651
Fix an error (due to how the CConf/HConf is encoded) for hive-on-spark, if there are too many macros.

Otherwise, a failure like the following can happen (see JIRA for other error scenarios):
```
17/08/23 20:32:53 INFO client.RemoteDriver: Failed to run job 9e94e1ed-a1dd-45bb-9e90-93e61220e437
java.lang.IllegalStateException: Variable substitution depth too large: 20 <?xml version="1.0" encoding="UTF-8" standalone="no"?><configuration> ... </configuration>
        at org.apache.hadoop.conf.Configuration.substituteVars(Configuration.java:963)
        at org.apache.hadoop.conf.Configuration.get(Configuration.java:983)
        at org.apache.hadoop.hive.conf.HiveConfUtil.dumpConfig(HiveConfUtil.java:140)
        at org.apache.hadoop.hive.ql.exec.spark.RemoteHiveSparkClient$JobStatusJob.logConfigurations(RemoteHiveSparkClient.java:360)
        at org.apache.hadoop.hive.ql.exec.spark.RemoteHiveSparkClient$JobStatusJob.call(RemoteHiveSparkClient.java:329)
        at org.apache.hive.spark.client.RemoteDriver$JobWrapper.call(RemoteDriver.java:366)
        at org.apache.hive.spark.client.RemoteDriver$JobWrapper.call(RemoteDriver.java:335)
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
```