### PR TITLE
[CDAP-12492] Add tests for the new design of AppMetadataStore

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -346,8 +346,10 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * @param twillRunId Twill run id
    * @param runtimeArgs the runtime arguments for this program run
    * @param systemArgs the system arguments for this program run
-   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
-   *                 when the current program run status is reached, e.g. a message id from TMS
+   * @param sourceId unique id representing the source of program run status, such as the message id of the program
+   *                 run status notification in TMS. The source id must increase as the recording time of the program
+   *                 run status increases, so that the attempt to persist program run status older than the existing
+   *                 program run status will be ignored
    * @return {@link ProgramRunStatus#STARTING} if it is successfully persisted, {@code null} otherwise.
    */
   public ProgramRunStatus recordProgramStart(ProgramId programId, String pid, long startTs, String twillRunId,
@@ -386,8 +388,10 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * @param pid run id
    * @param stateChangeTime start timestamp in seconds
    * @param twillRunId Twill run id
-   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
-   *                 when the current program run status is reached, e.g. a message id from TMS
+   * @param sourceId unique id representing the source of program run status, such as the message id of the program
+   *                 run status notification in TMS. The source id must increase as the recording time of the program
+   *                 run status increases, so that the attempt to persist program run status older than the existing
+   *                 program run status will be ignored
    * @return {@link ProgramRunStatus#RUNNING} if it is successfully persisted, {@code null} otherwise.
    */
   public ProgramRunStatus recordProgramRunning(ProgramId programId, String pid, long stateChangeTime, String twillRunId,
@@ -442,8 +446,10 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * Logs suspend of a program run and sets the run status to {@link ProgramRunStatus#SUSPENDED}.
    * @param programId id of the program
    * @param pid run id
-   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
-   *                 when the current program run status is reached, e.g. a message id from TMS
+   * @param sourceId unique id representing the source of program run status, such as the message id of the program
+   *                 run status notification in TMS. The source id must increase as the recording time of the program
+   *                 run status increases, so that the attempt to persist program run status older than the existing
+   *                 program run status will be ignored
    * @return {@link ProgramRunStatus#SUSPENDED} if it is successfully persisted, {@code null} otherwise.
    */
   @Nullable
@@ -465,8 +471,10 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * Logs resume of a program run and sets the run status to {@link ProgramRunStatus#RUNNING}.
    * @param programId id of the program
    * @param pid run id
-   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
-   *                 when the current program run status is reached, e.g. a message id from TMS
+   * @param sourceId unique id representing the source of program run status, such as the message id of the program
+   *                 run status notification in TMS. The source id must increase as the recording time of the program
+   *                 run status increases, so that the attempt to persist program run status older than the existing
+   *                 program run status will be ignored
    * @return {@link ProgramRunStatus#RUNNING} if it is successfully persisted, {@code null} otherwise.
    */
   @Nullable
@@ -529,8 +537,10 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * @param stopTs stop timestamp in seconds
    * @param runStatus {@link ProgramRunStatus} of program run
    * @param failureCause failure cause if the program failed to execute
-   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
-   *                 when the current program run status is reached, e.g. a message id from TMS
+   * @param sourceId unique id representing the source of program run status, such as the message id of the program
+   *                 run status notification in TMS. The source id must increase as the recording time of the program
+   *                 run status increases, so that the attempt to persist program run status older than the existing
+   *                 program run status will be ignored
    * @return the program run status that is successfully persisted, {@code null} otherwise.
    */
   public ProgramRunStatus recordProgramStop(ProgramId programId, String pid, long stopTs, ProgramRunStatus runStatus,
@@ -595,7 +605,10 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * @param existingRecords the existing run record metas of the given program run
    * @param programId id of the program
    * @param pid run id
-   * @param sourceId the source id of the current program status
+   * @param sourceId unique id representing the source of program run status, such as the message id of the program
+   *                 run status notification in TMS. The source id must increase as the recording time of the program
+   *                 run status increases, so that the attempt to persist program run status older than the existing
+   *                 program run status will be ignored
    * @param recordType the type of record corresponding to the current status
    * @param status the status that the program run is transitioning into
    * @return {@code true} if the program run is allowed to persist the given status, {@code false} otherwise

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -45,7 +45,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -55,6 +54,8 @@ import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Test AppMetadataStore.
@@ -67,6 +68,7 @@ public class AppMetadataStoreTest {
     ImmutableList.of(ProgramRunStatus.COMPLETED, ProgramRunStatus.FAILED, ProgramRunStatus.KILLED);
 
   private final AtomicInteger sourceId = new AtomicInteger();
+  private final AtomicLong runIdTime = new AtomicLong();
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -133,57 +135,192 @@ public class AppMetadataStoreTest {
     });
   }
 
-  @Test
-  public void testSmallerSourceIdRecords() throws Exception {
-    DatasetId storeTable = NamespaceId.DEFAULT.dataset("testRandomSourceIdRecords");
+  private AppMetadataStore getMetadataStore(String tableName) throws Exception {
+    DatasetId storeTable = NamespaceId.DEFAULT.dataset(tableName);
     datasetFramework.addInstance(Table.class.getName(), storeTable, DatasetProperties.EMPTY);
 
     Table table = datasetFramework.getDataset(storeTable, ImmutableMap.<String, String>of(), null);
     Assert.assertNotNull(table);
-    final AppMetadataStore metadataStoreDataset = new AppMetadataStore(table, cConf, new AtomicBoolean(false));
-    TransactionExecutor txnl = txExecutorFactory.createExecutor(
-      Collections.singleton((TransactionAware) metadataStoreDataset));
+    return new AppMetadataStore(table, cConf, new AtomicBoolean(false));
+  }
 
-    // Add some run records
-    TreeSet<Long> expected = new TreeSet<>();
+  private TransactionExecutor getTxExecutor(AppMetadataStore metadataStoreDataset) {
+    return txExecutorFactory.createExecutor(Collections.singleton((TransactionAware) metadataStoreDataset));
+  }
+
+  @Test
+  public void testSmallerSourceIdRecords() throws Exception {
+    AppMetadataStore metadataStoreDataset = getMetadataStore("testSmallerSourceIdRecords");
+    TransactionExecutor txnl = getTxExecutor(metadataStoreDataset);
+    // STARTING status is persisted with the largest sourceId
+    assertPersistedStatus(metadataStoreDataset, txnl, 100L, 10L, 1L, ProgramRunStatus.STARTING);
+    assertPersistedStatus(metadataStoreDataset, txnl, 100L, 1L, 10L, ProgramRunStatus.STARTING);
+    // RUNNING status is persisted with the largest sourceId
+    assertPersistedStatus(metadataStoreDataset, txnl, 1L, 100L, 10L, ProgramRunStatus.RUNNING);
+    // KILLED status is persisted with the largest sourceId
+    assertPersistedStatus(metadataStoreDataset, txnl, 1L, 10L, 100L, ProgramRunStatus.KILLED);
+  }
+
+  @Test
+  public void testInvalidStatusPersistence() throws Exception {
+    final AppMetadataStore metadataStoreDataset = getMetadataStore("testInvalidStatusPersistence");
+    TransactionExecutor txnl = getTxExecutor(metadataStoreDataset);
     ApplicationId application = NamespaceId.DEFAULT.app("app");
     final ProgramId program = application.program(ProgramType.WORKFLOW, "program");
-    final RunId runId = RunIds.generate(10000);
-    // Program completed status is not recorded with a smaller sourceId
+    final RunId runId1 = RunIds.generate(runIdTime.incrementAndGet());
+    final AtomicLong sourceId = new AtomicLong();
+    // No status can be persisted if STARTING is not present
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        metadataStoreDataset.recordProgramRunning(program, runId1.getId(), RunIds.getTime(runId1, TimeUnit.SECONDS),
+                                                  null,
+                                                  AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStop(program, runId1.getId(), RunIds.getTime(runId1, TimeUnit.SECONDS),
+                                               ProgramRunStatus.COMPLETED, null,
+                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(program, runId1.getId());
+        // no run record is expected to be persisted without STARTING persisted
+        Assert.assertNull(runRecordMeta);
+      }
+    });
+    final RunId runId2 = RunIds.generate(runIdTime.incrementAndGet());
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        metadataStoreDataset.recordProgramSuspend(program, runId2.getId(),
+                                                  AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramResumed(program, runId2.getId(),
+                                                  AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(program, runId2.getId());
+        // no run record is expected to be persisted without STARTING persisted
+        Assert.assertNull(runRecordMeta);
+      }
+    });
+    final RunId runId3 = RunIds.generate(runIdTime.incrementAndGet());
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        metadataStoreDataset.recordProgramStop(program, runId3.getId(), RunIds.getTime(runId3, TimeUnit.SECONDS),
+                                               ProgramRunStatus.COMPLETED, null,
+                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStop(program, runId3.getId(), RunIds.getTime(runId3, TimeUnit.SECONDS),
+                                               ProgramRunStatus.KILLED, null,
+                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStop(program, runId3.getId(), RunIds.getTime(runId3, TimeUnit.SECONDS),
+                                               ProgramRunStatus.FAILED, null,
+                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(program, runId3.getId());
+        // no run record is expected to be persisted without STARTING persisted
+        Assert.assertNull(runRecordMeta);
+      }
+    });
+    final RunId runId4 = RunIds.generate(runIdTime.incrementAndGet());
+    // Once a stop status is reached, any incoming status will be ignored
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        metadataStoreDataset.recordProgramStart(program, runId4.getId(), RunIds.getTime(runId4, TimeUnit.SECONDS),
+                                                null, ImmutableMap.of(), ImmutableMap.of(),
+                                                AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStop(program, runId4.getId(), RunIds.getTime(runId4, TimeUnit.SECONDS),
+                                               ProgramRunStatus.COMPLETED, null,
+                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStop(program, runId4.getId(), RunIds.getTime(runId4, TimeUnit.SECONDS),
+                                               ProgramRunStatus.KILLED, null,
+                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(program, runId4.getId());
+        // KILLED after COMPLETED is ignored
+        Assert.assertEquals(ProgramRunStatus.COMPLETED, runRecordMeta.getStatus());
+      }
+    });
+    final RunId runId5 = RunIds.generate(runIdTime.incrementAndGet());
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        metadataStoreDataset.recordProgramStart(program, runId5.getId(), RunIds.getTime(runId5, TimeUnit.SECONDS),
+                                                null, ImmutableMap.of(), ImmutableMap.of(),
+                                                AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStop(program, runId5.getId(), RunIds.getTime(runId5, TimeUnit.SECONDS),
+                                               ProgramRunStatus.FAILED, null,
+                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStop(program, runId5.getId(), RunIds.getTime(runId5, TimeUnit.SECONDS),
+                                               ProgramRunStatus.COMPLETED, null,
+                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(program, runId5.getId());
+        // COMPLETED after FAILED is ignored
+        Assert.assertEquals(ProgramRunStatus.FAILED, runRecordMeta.getStatus());
+      }
+    });
+    final RunId runId6 = RunIds.generate(runIdTime.incrementAndGet());
+    // STARTING status will be ignored if there's any existing record
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        metadataStoreDataset.recordProgramStart(program, runId6.getId(), RunIds.getTime(runId6, TimeUnit.SECONDS),
+                                                null, ImmutableMap.of(), ImmutableMap.of(),
+                                                AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramSuspend(program, runId6.getId(),
+                                                  AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStart(program, runId6.getId(), RunIds.getTime(runId6, TimeUnit.SECONDS),
+                                                null, ImmutableMap.of(), ImmutableMap.of(),
+                                                AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(program, runId6.getId());
+        // STARTING status is ignored since there's an existing SUSPENDED record
+        Assert.assertEquals(ProgramRunStatus.SUSPENDED, runRecordMeta.getStatus());
+      }
+    });
+    final RunId runId7 = RunIds.generate(runIdTime.incrementAndGet());
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        metadataStoreDataset.recordProgramStart(program, runId7.getId(), RunIds.getTime(runId7, TimeUnit.SECONDS),
+                                                null, ImmutableMap.of(), ImmutableMap.of(),
+                                                AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramRunning(program, runId7.getId(), RunIds.getTime(runId7, TimeUnit.SECONDS),
+                                                  null,
+                                                  AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        metadataStoreDataset.recordProgramStart(program, runId7.getId(), RunIds.getTime(runId7, TimeUnit.SECONDS),
+                                                null, ImmutableMap.of(), ImmutableMap.of(),
+                                                AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
+        RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(program, runId7.getId());
+        // STARTING status is ignored since there's an existing RUNNING record
+        Assert.assertEquals(ProgramRunStatus.RUNNING, runRecordMeta.getStatus());
+      }
+    });
+  }
+
+  private void assertPersistedStatus(final AppMetadataStore metadataStoreDataset, TransactionExecutor txnl,
+                                     final long startSourceId, final long runningSourceId,
+                                     final long killedSourceId, final ProgramRunStatus expectedRunStatus)
+    throws Exception {
+    // Add some run records
+    ApplicationId application = NamespaceId.DEFAULT.app("app");
+    final ProgramId program = application.program(ProgramType.WORKFLOW, "program");
+    final AtomicReference<RunRecordMeta> resultRecord = new AtomicReference<>();
+    final RunId runId = RunIds.generate(runIdTime.incrementAndGet());
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
         metadataStoreDataset.recordProgramStart(program, runId.getId(), RunIds.getTime(runId, TimeUnit.SECONDS),
                                                 null, ImmutableMap.<String, String>of(),
                                                 ImmutableMap.<String, String>of(),
-                                                AppFabricTestHelper.createSourceId(10000));
+                                                AppFabricTestHelper.createSourceId(startSourceId));
+        metadataStoreDataset.recordProgramRunning(program, runId.getId(), RunIds.getTime(runId, TimeUnit.SECONDS),
+                                                  null, AppFabricTestHelper.createSourceId(runningSourceId));
         metadataStoreDataset.recordProgramStop(program, runId.getId(), RunIds.getTime(runId, TimeUnit.SECONDS),
                                                ProgramRunStatus.KILLED,
-                                               null, AppFabricTestHelper.createSourceId(10));
+                                               null, AppFabricTestHelper.createSourceId(killedSourceId));
+        resultRecord.set(metadataStoreDataset.getRun(program, runId.getId()));
       }
     });
-
-    final List<RunRecordMeta> runRecordMetas = new ArrayList<>();
-    txnl.execute(new TransactionExecutor.Subroutine() {
-      @Override
-      public void apply() throws Exception {
-        runRecordMetas.add(metadataStoreDataset.getRun(program, runId.getId()));
-      }
-    });
-    // Run full scan
-    runScan(txnl, metadataStoreDataset, expected, 0, Long.MAX_VALUE);
+    Assert.assertEquals(expectedRunStatus, resultRecord.get().getStatus());
   }
 
   @Test
   public void testScanRunningInRangeWithBatch() throws Exception {
-    DatasetId storeTable = NamespaceId.DEFAULT.dataset("testScanRunningInRange");
-    datasetFramework.addInstance(Table.class.getName(), storeTable, DatasetProperties.EMPTY);
-
-    Table table = datasetFramework.getDataset(storeTable, ImmutableMap.<String, String>of(), null);
-    Assert.assertNotNull(table);
-    final AppMetadataStore metadataStoreDataset = new AppMetadataStore(table, cConf, new AtomicBoolean(false));
-    TransactionExecutor txnl = txExecutorFactory.createExecutor(
-      Collections.singleton((TransactionAware) metadataStoreDataset));
+    final AppMetadataStore metadataStoreDataset = getMetadataStore("testScanRunningInRange");
+    TransactionExecutor txnl = getTxExecutor(metadataStoreDataset);
 
     // Add some run records
     TreeSet<Long> expected = new TreeSet<>();
@@ -191,7 +328,7 @@ public class AppMetadataStoreTest {
       ApplicationId application = NamespaceId.DEFAULT.app("app" + i);
       final ProgramId program = application.program(ProgramType.values()[i % ProgramType.values().length],
                                                     "program" + i);
-      final RunId runId = RunIds.generate((i + 1) * 10000);
+      final RunId runId = RunIds.generate(runIdTime.incrementAndGet());
       expected.add(RunIds.getTime(runId, TimeUnit.MILLISECONDS));
       // Start the program and stop it
       final int j = i;
@@ -276,15 +413,8 @@ public class AppMetadataStoreTest {
 
   @Test
   public void testgetRuns() throws Exception {
-    DatasetId storeTable = NamespaceId.DEFAULT.dataset("testgetRuns");
-    datasetFramework.addInstance(Table.class.getName(), storeTable, DatasetProperties.EMPTY);
-
-    Table table = datasetFramework.getDataset(storeTable, ImmutableMap.<String, String>of(), null);
-    Assert.assertNotNull(table);
-    final AppMetadataStore metadataStoreDataset = new AppMetadataStore(table, cConf, new AtomicBoolean(false));
-
-    TransactionExecutor txnl = txExecutorFactory.createExecutor(
-      Collections.singleton((TransactionAware) metadataStoreDataset));
+    final AppMetadataStore metadataStoreDataset = getMetadataStore("testgetRuns");
+    TransactionExecutor txnl = getTxExecutor(metadataStoreDataset);
 
     // Add some run records
     final Set<String> expected = new TreeSet<>();
@@ -295,7 +425,7 @@ public class AppMetadataStoreTest {
     for (int i = 0; i < 100; ++i) {
       ApplicationId application = NamespaceId.DEFAULT.app("app");
       final ProgramId program = application.program(ProgramType.FLOW, "program");
-      final RunId runId = RunIds.generate((i + 1) * 10000);
+      final RunId runId = RunIds.generate(runIdTime.incrementAndGet());
       expected.add(runId.toString());
       final int index = i;
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12492
https://builds.cask.co/browse/CDAP-DUT6205-1
New tests added to verify the AppMetadataStore changes are consistent with the design https://wiki.cask.co/display/CE/Program+State+Transition+for+4.3

testSmallerSourceIdRecords tests the sourceId comparison when persisting new run status records.

testInvalidStatusPersistence tests invalid run status transition are not persisted