### PR TITLE
Restructures Dataprep Toppanel to be consistent with Rules Engine

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import DataPrepTable from 'components/DataPrep/DataPrepTable';
+import DataPrepCLI from 'components/DataPrep/DataPrepCLI';
+import isNil from 'lodash/isNil';
+import {createStore, combineReducers} from 'redux';
+import {connect} from 'react-redux';
+import {defaultAction} from 'services/helpers';
+import {Provider} from 'react-redux';
+
+const DEFAULTSTORESTATE = {view: 'data'};
+const view = (state = 'data', action = defaultAction) => {
+  switch (action.type) {
+    case 'SETVIEW':
+      return action.payload.view || state;
+    default:
+      return state;
+  }
+};
+
+const ViewStore = createStore(
+  combineReducers({view}),
+  DEFAULTSTORESTATE,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+function ContentSwitch({onSwitchChange}) {
+  return (
+    <div className="btn-group">
+      <div className="btn btn-secondary" onClick={onSwitchChange.bind(null, 'data')}>
+        Data
+      </div>
+      <div className="btn btn-secondary" onClick={onSwitchChange.bind(null, 'viz')}>
+        Visualization
+      </div>
+    </div>
+  );
+}
+ContentSwitch.propTypes = {
+  onSwitchChange: PropTypes.func.isRequired
+};
+
+const mapStateToProps = () => {
+  return {};
+};
+const mapDispatchToProps = (dispatch) => {
+  return {
+    onSwitchChange: (view) => {
+      dispatch({
+        type: 'SETVIEW',
+        payload: {view}
+      });
+    }
+  };
+};
+
+const SwitchWrapper = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ContentSwitch);
+const Switch = () => (
+  <Provider store={ViewStore}>
+    <SwitchWrapper />
+  </Provider>
+);
+
+
+export default class DataPrepContentWrapper extends Component {
+
+  componentDidMount() {
+    this.viewStoreSubscription = ViewStore.subscribe(() => {
+      let {view} = ViewStore.getState();
+      this.onSwitchChange(view);
+    });
+  }
+
+  componentWillUnmount() {
+    if (this.viewStoreSubscription) {
+      this.viewStoreSubscription();
+    }
+  }
+  onSwitchChange = (view) => {
+    if (isNil(view) || (!isNil(view) && this.state.view === view)) {
+      return;
+    }
+    this.setState({
+      view
+    });
+  }
+
+  state = {
+    view: 'data'
+  };
+  render() {
+    if (this.state.view === 'data') {
+      return (
+        <span>
+          <DataPrepTable />
+          <DataPrepCLI />
+        </span>
+      );
+    }
+    if (this.state.view === 'viz') {
+      return (
+        <h1> Visualization Coming Soon </h1>
+      );
+    }
+    return null;
+  }
+}
+
+export {Switch, ViewStore};

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -19,6 +19,9 @@ $action-btn-inactive-color: #aaaaaa;
 
 @import '../../../styles/variables.scss';
 
+$dropdown_menu_icon_color: #999999;
+$dropdown_item_font_color: black;
+
 .dataprep-container {
   .top-panel {
     height: 50px;
@@ -97,21 +100,68 @@ $action-btn-inactive-color: #aaaaaa;
     }
 
     .action-buttons {
-      padding: 0;
-      margin-top: 10px;
-      margin-right: 30px;
+      display: flex;
+      margin-right: 20px;
+      align-items: center;
 
-      .secondary-actions {
-        display: inline-flex;
-        flex-direction: column;
-        align-items: flex-start;
-        vertical-align: top;
-        line-height: 1;
+      .btn-primary {
+        margin: 0 10px;
+        .icon-spinner {
+          margin: 0 5px;
+        }
+      }
 
-        .btn.btn-link {
+      .dropdown {
+        .btn.btn-secondary {
+          border: 0;
+          height: 31px;
+          display: flex;
+          align-items: flex-end;
+          color: $dropdown_menu_icon_color;
           padding: 0;
-          margin-left: 10px;
-          font-size: 12px;
+          background: transparent;
+          box-shadow: none;
+          &:focus,
+          &:active,
+          &hover {
+            outline: none;
+          }
+          .icon-bars {
+            font-size: 24px;
+          }
+          .icon-caret-down {
+            font-size: 18px;
+          }
+        }
+        &.open {
+          hr {
+            margin-top: 2px;
+            margin-bottom: 2px;
+            margin-left: -10px;
+            margin-right: -1.5rem;
+          }
+          .dropdown-item {
+            cursor: pointer;
+            padding-left: 10px;
+            border: 0;
+            background: transparent;
+            svg.icon-svg {
+              margin-right: 10px;
+            }
+            &[disabled] {
+              cursor: not-allowed;
+            }
+            .btn-link,
+            .btn-link:hover,
+            .btn-link:active,
+            .btn-link:focus {
+              line-height: 1;
+              padding: 0;
+              text-decoration: none;
+              outline: none;
+              color: $dropdown_item_font_color;
+            }
+          }
         }
       }
     }

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -16,9 +16,8 @@
 
 import React, { Component, PropTypes } from 'react';
 import DataPrepTopPanel from 'components/DataPrep/TopPanel';
-import DataPrepTable from 'components/DataPrep/DataPrepTable';
+import DataPrepContentWrapper from 'components/DataPrep/DataPrepContentWrapper';
 import DataPrepSidePanel from 'components/DataPrep/DataPrepSidePanel';
-import DataPrepCLI from 'components/DataPrep/DataPrepCLI';
 import DataPrepLoading from 'components/DataPrep/DataPrepLoading';
 import DataPrepErrorAlert from 'components/DataPrep/DataPrepErrorAlert';
 import MyDataPrepApi from 'api/dataprep';
@@ -281,7 +280,6 @@ export default class DataPrep extends Component {
 
           <div className="top-section-content float-xs-left">
             {this.renderTabs()}
-
             <DataPrepTopPanel
               singleWorkspaceMode={this.props.singleWorkspaceMode}
               onSubmit={this.onSubmitToListener.bind(this)}
@@ -291,8 +289,7 @@ export default class DataPrep extends Component {
 
         <div className="row dataprep-body">
           <div className="dataprep-main col-xs-9">
-            <DataPrepTable />
-            <DataPrepCLI />
+            <DataPrepContentWrapper />
           </div>
 
           <DataPrepSidePanel />

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RuleBookDetails.scss
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RuleBookDetails.scss
@@ -45,6 +45,15 @@ $header-bg-color: #f5f5f5;
     align-items: center;
   }
   .rule-book-name-header {
+    .rulebook-menu-container {
+      display: inline-flex;
+      align-items: flex-start;
+      .rule-book-menu {
+        display: inline-flex;
+        align-items: flex-end;
+        height: 28px;
+      }
+    }
     .rule-book-name-version {
       max-width: 100%;
       line-height: 1;

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/RulebookMenu.scss
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/RulebookMenu.scss
@@ -17,8 +17,8 @@
 $icon-color: #999999;
 
 .rule-book-menu {
-  display: inline-block;
-  vertical-align: top;
+  display: inline-flex;
+  align-items: flex-end;
 
   .dropdown {
     > .btn.btn-secondary {
@@ -28,6 +28,7 @@ $icon-color: #999999;
       align-items: flex-end;
       background-color: transparent;
       color: $icon-color;
+      padding: 0 0 0 10px;
 
       &:focus,
       &:hover,

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/index.js
@@ -95,12 +95,6 @@ export default class RulebookMenu extends Component {
       iconName: 'icon-download'
     },
     {
-      label: T.translate(`${PREFIX}.createPipeline`),
-      onClick: this.toggleRulesEngineToPipelineModal,
-      iconName: 'icon-pipelines',
-      skipInPipelines: true
-    },
-    {
       label: 'divider'
     },
     {
@@ -131,6 +125,17 @@ export default class RulebookMenu extends Component {
     }
     return (
       <div className="rule-book-menu">
+        {
+          this.props.embedded ?
+            null
+          :
+            <button
+              className="btn btn-primary"
+              onClick={this.toggleRulesEngineToPipelineModal}
+            >
+              {T.translate(`${PREFIX}.createPipeline`)}
+            </button>
+        }
         <UncontrolledDropdown>
           <DropdownToggle>
             <IconSVG name="icon-bars" />

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/index.js
@@ -255,7 +255,7 @@ export default class RuleBookDetails extends Component {
               {T.translate(`${PREFIX}.version`, {version: rulebookDetails.version})}
             </p>
           </div>
-          <div>
+          <div className="rulebook-menu-container">
             {
               integration.embedded ?
                 <button

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -787,7 +787,7 @@ features:
       expand: Expand the side panel
     TopPanel:
       applyBtnLabel: Apply
-      addToPipelineBtnLabel: Create Pipeline
+      addToPipelineBtnLabel: Create a Pipeline
       database: Database
       databaseTitle: "Table: {name}"
       file: File System

--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
@@ -72,8 +72,19 @@ body.state-hydrator-create.state-hydrator {
           }
           .action-buttons {
             min-width: auto;
-            .secondary-actions {
-              vertical-align: middle;
+            padding: 12px 20px 10px 10px;
+            display: flex;
+            align-items: center;
+            > span.text-danger {
+              margin-right: 10px;
+            }
+            .dropdown {
+              .dropdown-menu {
+                > button,
+                &:focus {
+                  outline: none;
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
- Adds Dataprep Wrapper to toggle between data and visualization views.
- Based on https://issues.cask.co/browse/CDAP-12512 
  - Moves `Ingest Data` and `View Schema` links to a dropdown menu to be consistent with Rules Engine 
  - Moves 'Create Pipeline` from the dropdown menu to be a button to be consistent with Dataprep.

<img width="1680" alt="screen shot 2017-08-29 at 1 44 25 pm" src="https://user-images.githubusercontent.com/1452845/29843243-35b0a318-8cc0-11e7-9f2e-388c186fd3c6.png">

<img width="1680" alt="screen shot 2017-08-29 at 1 42 50 pm" src="https://user-images.githubusercontent.com/1452845/29843190-069794d8-8cc0-11e7-893e-7ac25009dc60.png">


- Minor i18n cleanup.

Build: https://builds.cask.co/browse/CDAP-DRC7309/latest