### PR TITLE
enable ui compression

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -17,7 +17,6 @@
       "zookeeper.quorum": "{{ZK_QUORUM}}"
     },
     "cdap_env": {
-      "cdap_ui_compression_enabled": "false",
       "tez_home": "/usr/hdp/{{HDP_VERSION}}/tez",
       "tez_conf_dir": "/etc/tez/conf"
     },


### PR DESCRIPTION
compression was disabled for the original rollout of HDInsights, due to issues with their gateway proxy.  They resolved it in the same timeframe but we never turned it on.  Enabling it now.