### PR TITLE
CDAP-12537 Error out if realm file configuration is misconfigured

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -84,6 +84,8 @@ public class AuthorizationCLITest extends CLITestBase {
 
     private static String[] getAuthConfigs(File tmpDir) throws IOException {
       LocationFactory locationFactory = new LocalLocationFactory(tmpDir);
+      Location realmfile = locationFactory.create("realmfile");
+      realmfile.createNew();
       File file = new File(AppJarHelper.createDeploymentJar(locationFactory,
                                                             InMemoryAuthorizer.AuthorizableEntityId.class).toURI());
       Location authExtensionJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class, file);
@@ -91,6 +93,8 @@ public class AuthorizationCLITest extends CLITestBase {
         // We want to enable security, but bypass it for only testing authorization commands
         Constants.Security.ENABLED, "true",
         Constants.Security.AUTH_HANDLER_CLASS, BasicAuthenticationHandler.class.getName(),
+        // we bypass authentication, but BasicAuthenticationHandler requires a valid file upon initialization
+        Constants.Security.BASIC_REALM_FILE, realmfile.toString(),
         Constants.Security.Router.BYPASS_AUTHENTICATION_REGEX, ".*",
         Constants.Security.Authorization.ENABLED, "true",
         Constants.Security.Authorization.CACHE_MAX_ENTRIES, "0",

--- a/cdap-security/src/main/java/co/cask/cdap/security/runtime/AuthenticationServerMain.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/runtime/AuthenticationServerMain.java
@@ -88,9 +88,7 @@ public class AuthenticationServerMain extends DaemonMain {
         if (rootCause instanceof ServiceBindException) {
           LOG.error("Failed to start Authentication Server: {}", rootCause.getMessage());
         } else {
-          // exception stack trace will be logged by
-          // UncaughtExceptionIdleService.UNCAUGHT_EXCEPTION_HANDLER
-          LOG.error("Failed to start Authentication Server");
+          LOG.error("Failed to start Authentication Server", e);
         }
       }
     } else {

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/BasicAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/BasicAuthenticationHandler.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.security.server;
 
 import co.cask.cdap.common.conf.Constants;
+import com.google.common.base.Preconditions;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.HashLoginService;
@@ -24,6 +25,9 @@ import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import javax.security.auth.login.Configuration;
 
 /**
@@ -35,6 +39,9 @@ public class BasicAuthenticationHandler extends AbstractAuthenticationHandler {
   @Override
   protected LoginService getHandlerLoginService() {
     String realmFile = handlerProps.get(Constants.Security.BASIC_REALM_FILE);
+    Path realmFilePath = Paths.get(realmFile);
+    Preconditions.checkArgument(Files.exists(realmFilePath), "File does not exist: %s", realmFilePath);
+    Preconditions.checkArgument(Files.isReadable(realmFilePath), "File is not readable: %s", realmFilePath);
     HashLoginService loginService = new HashLoginService();
     loginService.setConfig(realmFile);
     loginService.setIdentityService(getHandlerIdentityService());


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12537
https://builds.cask.co/browse/CDAP-RUT1337-6

A CDAP admin might misconfigure the realmfile, in which case there will be no such warning/error, and the file will simply not be used (if it doesn't exist), due to how [jetty-security handles this](https://github.com/dekellum/jetty/blob/master/jetty-security/src/main/java/org/eclipse/jetty/security/PropertyUserStore.java#L117). Previously, the behavior was that if the configured file does not exist, it will start up and users that try to log in will get an Unauthorized exception.

The change in ExternalAuthenticationServer is just removal of the try-catch-log wrapping.
So, instead of catching the exception and suppress+logging it, it will be allowed to be thrown upwards. Otherwise, an exception like the following is thrown:
```
Exception in thread "ExternalAuthenticationServer-1" 2017-08-31 19:57:43,996 - ERROR [main:c.c.c.s.r.AuthenticationServerMain@93] - Failed to start Authentication Server
java.lang.NullPointerException
        at co.cask.cdap.security.server.ExternalAuthenticationServer.startUp(ExternalAuthenticationServer.java:226)
        at com.google.common.util.concurrent.AbstractIdleService$1$1.run(AbstractIdleService.java:43)
        at java.lang.Thread.run(Thread.java:745)
```

Now, if the file is not readable:
```
Exception in thread "ExternalAuthenticationServer-1" java.lang.IllegalArgumentException: File is not readable exist: /tmp/tmp/realm.conf2
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:119)
        at co.cask.cdap.security.server.BasicAuthenticationHandler.getHandlerLoginService(BasicAuthenticationHandler.java:44)
        at co.cask.cdap.security.server.AbstractAuthenticationHandler.init(AbstractAuthenticationHandler.java:61)
        at co.cask.cdap.security.server.ExternalAuthenticationServer.initHandlers(ExternalAuthenticationServer.java:248)
        at co.cask.cdap.security.server.ExternalAuthenticationServer.startUp(ExternalAuthenticationServer.java:143)
        at com.google.common.util.concurrent.AbstractIdleService$1$1.run(AbstractIdleService.java:43)
        at java.lang.Thread.run(Thread.java:745)
2017-08-31 20:10:29,562 - ERROR [main:c.c.c.s.r.AuthenticationServerMain@91] - Failed to start Authentication Server
com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: File is not readable exist: /tmp/tmp/realm.conf2
        at com.google.common.util.concurrent.Futures.wrapAndThrowUnchecked(Futures.java:1015) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.util.concurrent.Futures.getUnchecked(Futures.java:1001) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.util.concurrent.AbstractService.startAndWait(AbstractService.java:220) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.util.concurrent.AbstractIdleService.startAndWait(AbstractIdleService.java:106) ~[com.google.guava.guava-13.0.1.jar:na]
        at co.cask.cdap.security.runtime.AuthenticationServerMain.start(AuthenticationServerMain.java:85) [cdap-security-4.3.0.jar:na]
        at co.cask.cdap.common.runtime.DaemonMain.doMain(DaemonMain.java:59) [co.cask.cdap.cdap-common-4.3.0.jar:na]
        at co.cask.cdap.security.runtime.AuthenticationServerMain.main(AuthenticationServerMain.java:115) [cdap-security-4.3.0.jar:na]
java.lang.IllegalArgumentException: File is not readable exist: /tmp/tmp/realm.conf2
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:119) ~[com.google.guava.guava-13.0.1.jar:na]
        at co.cask.cdap.security.server.BasicAuthenticationHandler.getHandlerLoginService(BasicAuthenticationHandler.java:44) ~[cdap-security-4.3.0.jar:na]
        at co.cask.cdap.security.server.AbstractAuthenticationHandler.init(AbstractAuthenticationHandler.java:61) ~[cdap-security-4.3.0.jar:na]
        at co.cask.cdap.security.server.ExternalAuthenticationServer.initHandlers(ExternalAuthenticationServer.java:248) ~[cdap-security-4.3.0.jar:na]
        at co.cask.cdap.security.server.ExternalAuthenticationServer.startUp(ExternalAuthenticationServer.java:143) ~[cdap-security-4.3.0.jar:na]
        at com.google.common.util.concurrent.AbstractIdleService$1$1.run(AbstractIdleService.java:43) ~[com.google.guava.guava-13.0.1.jar:na]
        at java.lang.Thread.run(Thread.java:745) ~[na:1.7.0_75]
```

If file does not exist:
```
Exception in thread "ExternalAuthenticationServer-1" java.lang.IllegalArgumentException: File does not exist: /tmp/tmp/realm.conf2
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:119)
        at co.cask.cdap.security.server.BasicAuthenticationHandler.getHandlerLoginService(BasicAuthenticationHandler.java:43)
        at co.cask.cdap.security.server.AbstractAuthenticationHandler.init(AbstractAuthenticationHandler.java:61)
        at co.cask.cdap.security.server.ExternalAuthenticationServer.initHandlers(ExternalAuthenticationServer.java:248)
        at co.cask.cdap.security.server.ExternalAuthenticationServer.startUp(ExternalAuthenticationServer.java:143)
        at com.google.common.util.concurrent.AbstractIdleService$1$1.run(AbstractIdleService.java:43)
        at java.lang.Thread.run(Thread.java:745)
2017-08-31 20:09:39,494 - ERROR [main:c.c.c.s.r.AuthenticationServerMain@91] - Failed to start Authentication Server
com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: File does not exist: /tmp/tmp/realm.conf2
        at com.google.common.util.concurrent.Futures.wrapAndThrowUnchecked(Futures.java:1015) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.util.concurrent.Futures.getUnchecked(Futures.java:1001) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.util.concurrent.AbstractService.startAndWait(AbstractService.java:220) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.util.concurrent.AbstractIdleService.startAndWait(AbstractIdleService.java:106) ~[com.google.guava.guava-13.0.1.jar:na]
        at co.cask.cdap.security.runtime.AuthenticationServerMain.start(AuthenticationServerMain.java:85) [cdap-security-4.3.0.jar:na]
        at co.cask.cdap.common.runtime.DaemonMain.doMain(DaemonMain.java:59) [co.cask.cdap.cdap-common-4.3.0.jar:na]
        at co.cask.cdap.security.runtime.AuthenticationServerMain.main(AuthenticationServerMain.java:115) [cdap-security-4.3.0.jar:na]
java.lang.IllegalArgumentException: File does not exist: /tmp/tmp/realm.conf2
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:119) ~[com.google.guava.guava-13.0.1.jar:na]
        at co.cask.cdap.security.server.BasicAuthenticationHandler.getHandlerLoginService(BasicAuthenticationHandler.java:43) ~[cdap-security-4.3.0.jar:na]
        at co.cask.cdap.security.server.AbstractAuthenticationHandler.init(AbstractAuthenticationHandler.java:61) ~[cdap-security-4.3.0.jar:na]
        at co.cask.cdap.security.server.ExternalAuthenticationServer.initHandlers(ExternalAuthenticationServer.java:248) ~[cdap-security-4.3.0.jar:na]
        at co.cask.cdap.security.server.ExternalAuthenticationServer.startUp(ExternalAuthenticationServer.java:143) ~[cdap-security-4.3.0.jar:na]
        at com.google.common.util.concurrent.AbstractIdleService$1$1.run(AbstractIdleService.java:43) ~[com.google.guava.guava-13.0.1.jar:na]
        at java.lang.Thread.run(Thread.java:745) ~[na:1.7.0_75]
```