### PR TITLE
CDAP-7049 Better error message if kerberos principal is deleted or keytab is invalid

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/ServiceException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ServiceException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common;
+
+import co.cask.cdap.api.common.HttpErrorStatusProvider;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Similar to Exception, but responds with a custom error code.
+ */
+public class ServiceException extends Exception implements HttpErrorStatusProvider {
+
+  private final HttpResponseStatus httpResponseStatus;
+
+  public ServiceException(Throwable cause, HttpResponseStatus httpResponseStatus) {
+    super(cause);
+    this.httpResponseStatus = httpResponseStatus;
+  }
+
+  @Override
+  public int getStatusCode() {
+    return httpResponseStatus.getCode();
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/AbstractCachedUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/AbstractCachedUGIProvider.java
@@ -76,8 +76,7 @@ public abstract class AbstractCachedUGIProvider implements UGIProvider {
                                                                  info.getPrincipal(), info.getKeytabURI());
       return isCache ? ugiCache.get(new UGICacheKey(newRequest)) : createUGI(newRequest);
     } catch (ExecutionException e) {
-      // Get the root cause of the failure
-      Throwable cause = Throwables.getRootCause(e);
+      Throwable cause = e.getCause();
       // Propagate if the cause is an IOException or RuntimeException
       Throwables.propagateIfPossible(cause, IOException.class);
       // Otherwise always wrap it with IOException


### PR DESCRIPTION
[CDAP-7049](https://issues.cask.co/browse/CDAP-7049)
https://builds.cask.co/browse/CDAP-RUT1338-5

Better error message if kerberos principal is deleted or keytab is invalid.

Previous error message:
```
2017-08-31 22:48:55,015 - ERROR [OperationalStatsService:c.c.c.d.t.s.FileStreamAdmin@403] - Exception when check for stream exist.
java.io.IOException: KrbException: Identifier doesn't match expected value (906)
        at co.cask.cdap.security.impersonation.AbstractCachedUGIProvider.getConfiguredUGI(AbstractCachedUGIProvider.java:84) ~[na:na]
        at co.cask.cdap.security.impersonation.DefaultImpersonator.getUGI(DefaultImpersonator.java:86) ~[na:na]
        at co.cask.cdap.security.impersonation.DefaultImpersonator.doAs(DefaultImpersonator.java:65) ~[na:na]
        at co.cask.cdap.security.impersonation.DefaultImpersonator.doAs(DefaultImpersonator.java:59) ~[na:na]
        at co.cask.cdap.data2.transaction.stream.FileStreamAdmin.exists(FileStreamAdmin.java:396) [na:na]
        at co.cask.cdap.data2.transaction.stream.FileStreamAdmin.listViews(FileStreamAdmin.java:544) [na:na]
        at co.cask.cdap.operations.cdap.CDAPEntities.collect(CDAPEntities.java:127) [co.cask.cdap.cdap-operational-stats-core-4.3.0.jar:na]
        at co.cask.cdap.operations.OperationalStatsService.collectOperationalStats(OperationalStatsService.java:131) [na:na]
        at co.cask.cdap.operations.OperationalStatsService.run(OperationalStatsService.java:105) [na:na]
        at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52) [com.google.guava.guava-13.0.1.jar:na]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_75]
Caused by: sun.security.krb5.Asn1Exception: Identifier doesn't match expected value (906)
        at sun.security.krb5.internal.KDCRep.init(KDCRep.java:143) ~[na:1.7.0_75]
        at sun.security.krb5.internal.ASRep.init(ASRep.java:65) ~[na:1.7.0_75]
        at sun.security.krb5.internal.ASRep.<init>(ASRep.java:60) ~[na:1.7.0_75]
        at sun.security.krb5.KrbAsRep.<init>(KrbAsRep.java:60) ~[na:1.7.0_75]
        at sun.security.krb5.KrbAsReqBuilder.send(KrbAsReqBuilder.java:319) ~[na:1.7.0_75]
        at sun.security.krb5.KrbAsReqBuilder.action(KrbAsReqBuilder.java:364) ~[na:1.7.0_75]
        at com.sun.security.auth.module.Krb5LoginModule.attemptAuthentication(Krb5LoginModule.java:735) ~[na:1.7.0_75]
        at com.sun.security.auth.module.Krb5LoginModule.login(Krb5LoginModule.java:584) ~[na:1.7.0_75]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.7.0_75]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[na:1.7.0_75]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_75]
        at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext.invoke(LoginContext.java:762) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext.access$000(LoginContext.java:203) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext$4.run(LoginContext.java:690) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext$4.run(LoginContext.java:688) ~[na:1.7.0_75]
        at java.security.AccessController.doPrivileged(Native Method) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext.invokePriv(LoginContext.java:687) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext.login(LoginContext.java:595) ~[na:1.7.0_75]
        at org.apache.hadoop.security.UserGroupInformation.loginUserFromKeytabAndReturnUGI(UserGroupInformation.java:1135) ~[hadoop-common-2.7.1.2.3.4.7-4.jar:na]
        at co.cask.cdap.security.impersonation.DefaultUGIProvider.createUGI(DefaultUGIProvider.java:130) ~[na:na]
        at co.cask.cdap.security.impersonation.AbstractCachedUGIProvider$1.load(AbstractCachedUGIProvider.java:101) ~[na:na]
        at co.cask.cdap.security.impersonation.AbstractCachedUGIProvider$1.load(AbstractCachedUGIProvider.java:98) ~[na:na]
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3589) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2374) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2337) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2252) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache.get(LocalCache.java:3990) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3994) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4878) ~[com.google.guava.guava-13.0.1.jar:na]
        at co.cask.cdap.security.impersonation.AbstractCachedUGIProvider.getConfiguredUGI(AbstractCachedUGIProvider.java:77) ~[na:na]
        ... 10 common frames omitted
```

New error message:
```
2017-08-31 23:13:39,942 - ERROR [appfabric-executor-6:c.c.c.c.HttpExceptionHandler@70] - Unexpected error: request=POST /v1/impersonation/credentials user=<null>:
java.io.IOException: Failed to login for principal=ali/<HOSTNAME>@<REALM>, keytab=/home/cdap/aa.keytab. Check that the principal was not deleted and that t
he keytab is still valid.
        at co.cask.cdap.security.impersonation.DefaultUGIProvider.createUGI(DefaultUGIProvider.java:139) ~[na:na]
        at co.cask.cdap.security.impersonation.AbstractCachedUGIProvider$1.load(AbstractCachedUGIProvider.java:101) ~[na:na]
        at co.cask.cdap.security.impersonation.AbstractCachedUGIProvider$1.load(AbstractCachedUGIProvider.java:98) ~[na:na]
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3589) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2374) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2337) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2252) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache.get(LocalCache.java:3990) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3994) ~[com.google.guava.guava-13.0.1.jar:na]
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4878) ~[com.google.guava.guava-13.0.1.jar:na]
        at co.cask.cdap.security.impersonation.AbstractCachedUGIProvider.getConfiguredUGI(AbstractCachedUGIProvider.java:77) ~[na:na]
        at co.cask.cdap.gateway.handlers.ImpersonationHandler.getCredentials(ImpersonationHandler.java:84) ~[na:na]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.7.0_75]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[na:1.7.0_75]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_75]
        at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_75]
        at co.cask.http.HttpMethodInfo.invoke(HttpMethodInfo.java:80) ~[co.cask.http.netty-http-0.16.0.jar:na]
        at co.cask.http.HttpDispatcher.messageReceived(HttpDispatcher.java:38) [co.cask.http.netty-http-0.16.0.jar:na]
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70) [io.netty.netty-3.6.6.Final.jar:na]
        at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) [io.netty.netty-3.6.6.Final.jar:na]
        at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791) [io.netty.netty-3.6.6.Final.jar:na]
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.messageReceived(SimpleChannelUpstreamHandler.java:124) [io.netty.netty-3.6.6.Final.jar:na]
        at co.cask.cdap.common.http.AuthenticationChannelHandler.messageReceived(AuthenticationChannelHandler.java:64) [na:na]
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70) [io.netty.netty-3.6.6.Final.jar:na]
        at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) [io.netty.netty-3.6.6.Final.jar:na]
        at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791) [io.netty.netty-3.6.6.Final.jar:na]
        at org.jboss.netty.handler.execution.ChannelUpstreamEventRunnable.doRun(ChannelUpstreamEventRunnable.java:43) [io.netty.netty-3.6.6.Final.jar:na]
        at org.jboss.netty.handler.execution.ChannelEventRunnable.run(ChannelEventRunnable.java:67) [io.netty.netty-3.6.6.Final.jar:na]
        at org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor$ChildExecutor.run(OrderedMemoryAwareThreadPoolExecutor.java:314) [io.netty.netty-3.6.6.Final.jar:na]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_75]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_75]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_75]
Caused by: java.io.IOException: Login failure for ali/<HOSTNAME>@<REALM> from keytab /home/cdap/aa.keytab
        at org.apache.hadoop.security.UserGroupInformation.loginUserFromKeytabAndReturnUGI(UserGroupInformation.java:1146) ~[hadoop-common-2.7.1.2.3.4.7-4.jar:na]
        at co.cask.cdap.security.impersonation.DefaultUGIProvider.createUGI(DefaultUGIProvider.java:134) ~[na:na]
        ... 31 common frames omitted
Caused by: javax.security.auth.login.LoginException: Checksum failed
        at com.sun.security.auth.module.Krb5LoginModule.attemptAuthentication(Krb5LoginModule.java:763) ~[na:1.7.0_75]
        at com.sun.security.auth.module.Krb5LoginModule.login(Krb5LoginModule.java:584) ~[na:1.7.0_75]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.7.0_75]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[na:1.7.0_75]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_75]
        at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext.invoke(LoginContext.java:762) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext.access$000(LoginContext.java:203) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext$4.run(LoginContext.java:690) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext$4.run(LoginContext.java:688) ~[na:1.7.0_75]
        at java.security.AccessController.doPrivileged(Native Method) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext.invokePriv(LoginContext.java:687) ~[na:1.7.0_75]
        at javax.security.auth.login.LoginContext.login(LoginContext.java:595) ~[na:1.7.0_75]
        at org.apache.hadoop.security.UserGroupInformation.loginUserFromKeytabAndReturnUGI(UserGroupInformation.java:1135) ~[hadoop-common-2.7.1.2.3.4.7-4.jar:na]
        ... 32 common frames omitted
Caused by: sun.security.krb5.KrbCryptoException: Checksum failed
        at sun.security.krb5.internal.crypto.Aes256CtsHmacSha1EType.decrypt(Aes256CtsHmacSha1EType.java:102) ~[na:1.7.0_75]
        at sun.security.krb5.internal.crypto.Aes256CtsHmacSha1EType.decrypt(Aes256CtsHmacSha1EType.java:94) ~[na:1.7.0_75]
        at sun.security.krb5.EncryptedData.decrypt(EncryptedData.java:177) ~[na:1.7.0_75]
        at sun.security.krb5.KrbAsRep.decrypt(KrbAsRep.java:149) ~[na:1.7.0_75]
        at sun.security.krb5.KrbAsRep.decryptUsingKeyTab(KrbAsRep.java:121) ~[na:1.7.0_75]
        at sun.security.krb5.KrbAsReqBuilder.resolve(KrbAsReqBuilder.java:288) ~[na:1.7.0_75]
        at sun.security.krb5.KrbAsReqBuilder.action(KrbAsReqBuilder.java:364) ~[na:1.7.0_75]
        at com.sun.security.auth.module.Krb5LoginModule.attemptAuthentication(Krb5LoginModule.java:735) ~[na:1.7.0_75]
        ... 45 common frames omitted
Caused by: java.security.GeneralSecurityException: Checksum failed
        at sun.security.krb5.internal.crypto.dk.AesDkCrypto.decryptCTS(AesDkCrypto.java:451) ~[na:1.7.0_75]
        at sun.security.krb5.internal.crypto.dk.AesDkCrypto.decrypt(AesDkCrypto.java:272) ~[na:1.7.0_75]
        at sun.security.krb5.internal.crypto.Aes256.decrypt(Aes256.java:76) ~[na:1.7.0_75]
        at sun.security.krb5.internal.crypto.Aes256CtsHmacSha1EType.decrypt(Aes256CtsHmacSha1EType.java:100) ~[na:1.7.0_75]
        ... 52 common frames omitted
```