### PR TITLE
[CDAP-12333] Handles backend error when navigating to DataPrep

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/index.js
@@ -22,7 +22,7 @@ import ee from 'event-emitter';
 import classnames from 'classnames';
 import ColumnActionsDropdown from 'components/DataPrep/ColumnActionsDropdown';
 require('./DataPrepTable.scss');
-import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
+import {execute, setWorkspace} from 'components/DataPrep/store/DataPrepActionCreator';
 import TextboxOnValium from 'components/TextboxOnValium';
 import WarningContainer from 'components/WarningContainer';
 import ColumnHighlighter from 'components/DataPrep/ColumnHighlighter';
@@ -31,6 +31,8 @@ import T from 'i18n-react';
 import DataQuality from 'components/DataPrep/DataPrepTable/DataQuality';
 import captialize from 'lodash/capitalize';
 import ErrorMessageContainer from 'components/DataPrep/ErrorMessageContainer';
+
+const PREFIX = 'features.DataPrep.DataPrepTable';
 
 export default class DataPrepTable extends Component {
   constructor(props) {
@@ -258,7 +260,7 @@ export default class DataPrepTable extends Component {
                             {
                               head.showWarning ?
                                 <WarningContainer
-                                  message={T.translate('features.DataPrep.DataPrepTable.copyToNewColumn.inputDuplicate')}
+                                  message={T.translate(`${PREFIX}.copyToNewColumn.inputDuplicate`)}
                                 >
                                   <div className="warning-btns-container">
                                     <div
@@ -328,7 +330,7 @@ export default class DataPrepTable extends Component {
     let headers = this.state.headers;
     let data = this.state.data;
 
-    if (!this.state.workspaceId) {
+    if (!this.state.workspaceId && !this.state.error) {
       return (
         <div className="dataprep-table empty">
           <div>
@@ -339,10 +341,17 @@ export default class DataPrepTable extends Component {
     }
 
     if (this.state.error) {
+      let workspaceName, refreshFn;
+      if (this.state.currentWorkspaceName && this.state.workspaceId) {
+        workspaceName = this.state.currentWorkspaceName;
+        refreshFn = () => setWorkspace(this.state.workspaceId).subscribe();
+      } else {
+        refreshFn = () => window.location.reload();
+      }
       return (
         <ErrorMessageContainer
-          workspaceName={this.state.currentWorkspaceName}
-          workspaceId={this.state.workspaceId}
+          workspaceName={workspaceName}
+          refreshFn={refreshFn}
         />
       );
     }
@@ -356,14 +365,14 @@ export default class DataPrepTable extends Component {
               (
                 <div>
                   <h5 className="text-xs-center">
-                    {T.translate('features.DataPrep.DataPrepTable.emptyWorkspace')}
+                    {T.translate(`${PREFIX}.emptyWorkspace`)}
                   </h5>
                 </div>
               ) :
               (
                 <div>
                   <h5 className="text-xs-center">
-                    {T.translate('features.DataPrep.DataPrepTable.noData')}
+                    {T.translate(`${PREFIX}.noData`)}
                   </h5>
                 </div>
               )

--- a/cdap-ui/app/cdap/components/DataPrep/ErrorMessageContainer/ErrorMessageContainer.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/ErrorMessageContainer/ErrorMessageContainer.scss
@@ -23,7 +23,7 @@ $hr_color: #999999;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  max-width: 40%;
+  max-width: 35%;
   margin: 0 auto;
   margin-left: auto;
   margin-right: auto;

--- a/cdap-ui/app/cdap/components/DataPrep/ErrorMessageContainer/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ErrorMessageContainer/index.js
@@ -15,30 +15,36 @@
 */
 
 import React, {PropTypes} from 'react';
-import {setWorkspace} from 'components/DataPrep/store/DataPrepActionCreator';
 require('./ErrorMessageContainer.scss');
 import T from 'i18n-react';
 
-export default function ErrorMessageContainer({workspaceId, workspaceName}) {
+export default function ErrorMessageContainer({workspaceName, refreshFn}) {
+  const prefix = 'features.DataPrep.DataPrepTable';
+
+  let errorMessageTitle = T.translate(`${prefix}.dataErrorMessageTitle`);
+  if (workspaceName) {
+    errorMessageTitle = T.translate(`${prefix}.dataErrorMessageTitle2`, {workspaceName});
+  }
+
   return (
     <div className="dataprep-error-container">
       <h4>
         <strong>
-          {T.translate(`features.DataPrep.DataPrepTable.dataErrorMessageTitle`, {workspaceName})}
+          {errorMessageTitle}
         </strong>
       </h4>
       <hr />
       <div className="message-container">
-        <div> {T.translate(`features.DataPrep.DataPrepTable.suggestionTitle`)} </div>
+        <div> {T.translate(`${prefix}.suggestionTitle`)} </div>
         <span>
           <span
             className="btn-link"
-            onClick={() => setWorkspace(workspaceId).subscribe()}
+            onClick={refreshFn}
           >
-            {T.translate(`features.DataPrep.DataPrepTable.refreshBtnLinkLabel`)}
+            {T.translate(`${prefix}.refreshBtnLinkLabel`)}
           </span>
 
-          {T.translate(`features.DataPrep.DataPrepTable.suggestion1`)}
+          {T.translate(`${prefix}.suggestion1`)}
         </span>
       </div>
     </div>
@@ -46,6 +52,6 @@ export default function ErrorMessageContainer({workspaceId, workspaceName}) {
 }
 
 ErrorMessageContainer.propTypes = {
-  workspaceId: PropTypes.string,
-  workspaceName: PropTypes.string
+  workspaceName: PropTypes.string,
+  refreshFn: PropTypes.func
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -319,12 +319,13 @@ features:
         inputPlaceholder: Destination Column
         inputSuffix: _copy
         label: Copy to a new column
-      dataErrorMessageTitle: Sorry, we could not load data for "{workspaceName}"
+      dataErrorMessageTitle: Unable to load data.
+      dataErrorMessageTitle2: Unable to load data for "{workspaceName}".
       emptyWorkspace: No data
-      refreshBtnLinkLabel: Refresh
-      suggestionTitle: "You can try to:"
-      suggestion1: the page
       noData: No data. Try removing some directives.
+      refreshBtnLinkLabel: Refresh
+      suggestion1: the page
+      suggestionTitle: "You can try to:"
     DataPrepBrowser:
       DatabaseBrowser:
         EmptyMessage:


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-12333
- https://issues.cask.co/browse/CDAP-12406 (this seems related, but haven't been able to reproduce either on cluster or on local sandbox)

The root cause here is that sometimes UI gets a backend error while querying for the list of workspaces, when the user navigates to DataPrep. However, we were not handling that error at all, causing the user to be stuck as detailed in the CDAP-12333 JIRA. This PR handles the error and displays this when the error happens:

![screen shot 2017-08-31 at 3 55 07 pm](https://user-images.githubusercontent.com/6516002/29949291-97395310-8e68-11e7-89a2-d573fb36a3eb.png)

Have also filed a backend JIRA for the error response: https://issues.cask.co/browse/CDAP-12538
