### PR TITLE
fix in - twill log entry adapter to include className, method…

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/TwillLogEntryAdapter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/TwillLogEntryAdapter.java
@@ -91,7 +91,16 @@ final class TwillLogEntryAdapter implements ILoggingEvent {
 
   @Override
   public StackTraceElement[] getCallerData() {
-    return entry.getStackTraces();
+    StackTraceElement[] stackTraceElements = entry.getStackTraces();
+    if (stackTraceElements.length == 0) {
+      stackTraceElements = new StackTraceElement[1];
+      StackTraceElement stackTraceElement =
+        new StackTraceElement(entry.getSourceClassName(), entry.getSourceMethodName(),
+                              entry.getFileName(), entry.getLineNumber());
+      stackTraceElements[0] = stackTraceElement;
+
+    }
+    return stackTraceElements;
   }
 
   @Override


### PR DESCRIPTION
…eName, lineNumber in caller data writing to master logs

JIRA : https://issues.cask.co/browse/CDAP-12559