### PR TITLE
use latest ubuntu 16.04 patch

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -7,8 +7,8 @@
     {
       "type": "virtualbox-iso",
       "guest_os_type": "Ubuntu_64",
-      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
-      "iso_checksum": "2bce60d18248df9980612619ff0b34e6",
+      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-server-amd64.iso",
+      "iso_checksum": "10fcd20619dce11fe094e960c85ba4a9",
       "iso_checksum_type": "md5",
       "ssh_username": "cdap",
       "ssh_password": "cdap",


### PR DESCRIPTION
backport of https://github.com/caskdata/cdap/pull/9526, no conflicts