### PR TITLE
[CDAP-12526] Changes for tephra-0.13

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/TransactionHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/TransactionHttpHandlerTest.java
@@ -51,7 +51,7 @@ public class TransactionHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
     Transaction tx2 = txClient.startShort();
-    txClient.commit(tx2);
+    txClient.commitOrThrow(tx2);
     response = doPost("/v3/transactions/" + tx2.getWritePointer() + "/invalidate");
     Assert.assertEquals(409, response.getStatusLine().getStatusCode());
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
@@ -191,7 +191,7 @@ public class FlowTest {
 
     // commit tx
     ((TransactionAware) producer).commitTx();
-    txSystemClient.commit(tx);
+    txSystemClient.commitOrThrow(tx);
 
     // Query the service for at most 10 seconds for the expected result
     Gson gson = new Gson();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
@@ -141,7 +141,7 @@ public class OpenCloseDataSetTest {
 
     // commit tx
     ((TransactionAware) producer).commitTx();
-    txSystemClient.commit(tx);
+    txSystemClient.commitOrThrow(tx);
 
     while (TrackingTable.getTracker(tableName, "write") < 4) {
       TimeUnit.MILLISECONDS.sleep(50);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -398,9 +398,9 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
       for (int i = 0; i < numRows; i++) {
         myTable1.put(new Put("" + i, "x", "y"));
       }
-      Assert.assertTrue(txClient.canCommit(tx1, ((TransactionAware) myTable1).getTxChanges()));
+      txClient.canCommitOrThrow(tx1, ((TransactionAware) myTable1).getTxChanges());
       Assert.assertTrue(((TransactionAware) myTable1).commitTx());
-      Assert.assertTrue(txClient.commit(tx1));
+      txClient.commitOrThrow(tx1);
 
       try {
         testScannerCache(numRows, tableName, null, null, null);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -92,7 +92,8 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
     hBaseTestingUtility.startMiniDFSCluster(1);
     Configuration hConf = hBaseTestingUtility.getConfiguration();
     hConf.setBoolean("fs.hdfs.impl.disable.cache", true);
-
+    hConf = getCommonConfiguration(hConf);
+    
     zkServer = InMemoryZKServer.builder().build();
     zkServer.startAndWait();
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/DelegatingTransactionSystemClientService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/DelegatingTransactionSystemClientService.java
@@ -21,6 +21,7 @@ import com.google.inject.Inject;
 import org.apache.tephra.InvalidTruncateTimeException;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionNotInProgressException;
 import org.apache.tephra.TransactionSystemClient;
 
@@ -58,12 +59,24 @@ public class DelegatingTransactionSystemClientService
 
   @Override
   public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    //noinspection deprecation
     return delegate.canCommit(tx, changeIds);
   }
 
   @Override
+  public void canCommitOrThrow(Transaction tx, Collection<byte[]> changeIds) throws TransactionFailureException {
+    delegate.canCommitOrThrow(tx, changeIds);
+  }
+
+  @Override
   public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    //noinspection deprecation
     return delegate.commit(tx);
+  }
+
+  @Override
+  public void commitOrThrow(Transaction tx) throws TransactionFailureException {
+    delegate.commitOrThrow(tx);
   }
 
   @Override
@@ -109,6 +122,11 @@ public class DelegatingTransactionSystemClientService
   @Override
   public int getInvalidSize() {
     return delegate.getInvalidSize();
+  }
+
+  @Override
+  public void pruneNow() {
+    delegate.pruneNow();
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/DistributedTransactionSystemClientService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/DistributedTransactionSystemClientService.java
@@ -24,6 +24,7 @@ import com.google.inject.Inject;
 import org.apache.tephra.InvalidTruncateTimeException;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionNotInProgressException;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -111,12 +112,24 @@ public class DistributedTransactionSystemClientService
 
   @Override
   public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    //noinspection deprecation
     return delegate.canCommit(tx, changeIds);
   }
 
   @Override
+  public void canCommitOrThrow(Transaction tx, Collection<byte[]> changeIds) throws TransactionFailureException {
+    delegate.canCommitOrThrow(tx, changeIds);
+  }
+
+  @Override
   public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    //noinspection deprecation
     return delegate.commit(tx);
+  }
+
+  @Override
+  public void commitOrThrow(Transaction tx) throws TransactionFailureException {
+    delegate.commitOrThrow(tx);
   }
 
   @Override
@@ -162,5 +175,10 @@ public class DistributedTransactionSystemClientService
   @Override
   public int getInvalidSize() {
     return delegate.getInvalidSize();
+  }
+
+  @Override
+  public void pruneNow() {
+    delegate.pruneNow();
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingLongTransactionSystemClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingLongTransactionSystemClient.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.service.Retries;
 import co.cask.cdap.common.service.RetryStrategy;
 import com.google.common.base.Supplier;
 import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionNotInProgressException;
 import org.apache.tephra.TransactionSystemClient;
 
@@ -50,7 +51,20 @@ public class RetryingLongTransactionSystemClient extends RetryingTransactionSyst
     return callWithRetries(new Retries.Callable<Boolean, TransactionNotInProgressException>() {
       @Override
       public Boolean call() throws TransactionNotInProgressException {
+        //noinspection deprecation
         return delegate.canCommit(tx, changeIds);
+      }
+    });
+  }
+
+  @Override
+  public void canCommitOrThrow(final Transaction tx,
+                               final Collection<byte[]> changeIds) throws TransactionFailureException {
+    callWithRetries(new Retries.Callable<Void, TransactionFailureException>() {
+      @Override
+      public Void call() throws TransactionFailureException {
+        delegate.canCommitOrThrow(tx, changeIds);
+        return null;
       }
     });
   }
@@ -60,7 +74,19 @@ public class RetryingLongTransactionSystemClient extends RetryingTransactionSyst
     return callWithRetries(new Retries.Callable<Boolean, TransactionNotInProgressException>() {
       @Override
       public Boolean call() throws TransactionNotInProgressException {
+        //noinspection deprecation
         return delegate.commit(tx);
+      }
+    });
+  }
+
+  @Override
+  public void commitOrThrow(final Transaction tx) throws TransactionFailureException {
+    callWithRetries(new Retries.Callable<Void, TransactionFailureException>() {
+      @Override
+      public Void call() throws TransactionFailureException {
+        delegate.commitOrThrow(tx);
+        return null;
       }
     });
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingTransactionSystemClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingTransactionSystemClient.java
@@ -23,6 +23,7 @@ import com.google.common.base.Supplier;
 import org.apache.tephra.InvalidTruncateTimeException;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionNotInProgressException;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.thrift.TException;
@@ -72,12 +73,24 @@ public abstract class RetryingTransactionSystemClient implements TransactionSyst
 
   @Override
   public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    //noinspection deprecation
     return delegate.canCommit(tx, changeIds);
   }
 
   @Override
+  public void canCommitOrThrow(Transaction tx, Collection<byte[]> changeIds) throws TransactionFailureException {
+    delegate.canCommitOrThrow(tx, changeIds);
+  }
+
+  @Override
   public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    //noinspection deprecation
     return delegate.commit(tx);
+  }
+
+  @Override
+  public void commitOrThrow(Transaction tx) throws TransactionFailureException {
+    delegate.commitOrThrow(tx);
   }
 
   @Override
@@ -123,6 +136,11 @@ public abstract class RetryingTransactionSystemClient implements TransactionSyst
   @Override
   public int getInvalidSize() {
     return delegate.getInvalidSize();
+  }
+
+  @Override
+  public void pruneNow() {
+    delegate.pruneNow();
   }
 
   protected <V> V supplyWithRetries(Supplier<V> supplier) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionSystemClientAdapter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionSystemClientAdapter.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.conf.Constants;
 import org.apache.tephra.InvalidTruncateTimeException;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionNotInProgressException;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.thrift.TException;
@@ -71,7 +72,17 @@ public class TransactionSystemClientAdapter implements TransactionSystemClient {
   @Override
   public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
     try {
+      //noinspection deprecation
       return delegate.canCommit(tx, changeIds);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public void canCommitOrThrow(Transaction tx, Collection<byte[]> changeIds) throws TransactionFailureException {
+    try {
+      delegate.canCommitOrThrow(tx, changeIds);
     } catch (RuntimeException e) {
       throw handleException(e);
     }
@@ -80,7 +91,17 @@ public class TransactionSystemClientAdapter implements TransactionSystemClient {
   @Override
   public boolean commit(Transaction tx) throws TransactionNotInProgressException {
     try {
+      //noinspection deprecation
       return delegate.commit(tx);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public void commitOrThrow(Transaction tx) throws TransactionFailureException {
+    try {
+      delegate.commitOrThrow(tx);
     } catch (RuntimeException e) {
       throw handleException(e);
     }
@@ -162,6 +183,15 @@ public class TransactionSystemClientAdapter implements TransactionSystemClient {
   public int getInvalidSize() {
     try {
       return delegate.getInvalidSize();
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public void pruneNow() {
+    try {
+      delegate.pruneNow();
     } catch (RuntimeException e) {
       throw handleException(e);
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
@@ -111,7 +111,7 @@ public class CubeDatasetTest extends AbstractCubeTest {
 
       // let's pretend we had conflict and rollback it
       ((TransactionAware) cube1).commitTx();
-      txClient.commit(tx);
+      txClient.commitOrThrow(tx);
       ((TransactionAware) cube1).postTxCommit();
 
       // 3) read using different cube instance
@@ -125,7 +125,7 @@ public class CubeDatasetTest extends AbstractCubeTest {
 
       // let's pretend we had conflict and rollback it
       ((TransactionAware) cube2).commitTx();
-      txClient.commit(tx);
+      txClient.commitOrThrow(tx);
       ((TransactionAware) cube2).postTxCommit();
     } finally {
       txManager.stopAndWait();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTableTest.java
@@ -122,9 +122,9 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
                                 a(C1, V1)),
                              table1.scan(Bytes.toBytes("1_"), Bytes.toBytes("2_")));
 
-      Assert.assertTrue(txClient.canCommit(tx1, ((TransactionAware) table1).getTxChanges()));
+      txClient.canCommitOrThrow(tx1, ((TransactionAware) table1).getTxChanges());
       Assert.assertTrue(((TransactionAware) table1).commitTx());
-      Assert.assertTrue(txClient.commit(tx1));
+      txClient.commitOrThrow(tx1);
 
       Transaction tx2 = txClient.startShort();
       ((TransactionAware) table1).startTx(tx2);
@@ -136,7 +136,7 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
                                 a(C1, V1)),
                              table1.scan(Bytes.toBytes("1_"), Bytes.toBytes("2_")));
 
-      txClient.commit(tx2);
+      txClient.commitOrThrow(tx2);
 
       Transaction tx3 = txClient.startShort();
       ((TransactionAware) table1).startTx(tx3);
@@ -168,9 +168,9 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
                                 a(C2, V2)),        // 1_04
                              table1.scan(Bytes.toBytes("1_"), Bytes.toBytes("2_")));
 
-      Assert.assertTrue(txClient.canCommit(tx3, ((TransactionAware) table1).getTxChanges()));
+      txClient.canCommitOrThrow(tx3, ((TransactionAware) table1).getTxChanges());
       Assert.assertTrue(((TransactionAware) table1).commitTx());
-      txClient.commit(tx3);
+      txClient.commitOrThrow(tx3);
 
       Transaction tx4 = txClient.startShort();
       ((TransactionAware) table1).startTx(tx4);
@@ -187,7 +187,7 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
                                 a(C2, V2)),        // 1_04
                              table1.scan(Bytes.toBytes("1_"), Bytes.toBytes("2_")));
 
-      txClient.commit(tx4);
+      txClient.commitOrThrow(tx4);
     } finally {
       admin.drop();
     }
@@ -211,7 +211,7 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
       table.put(new byte[] {0}, new byte[] {9}, new byte[] {8});
 
       table.commitTx();
-      txClient.commit(tx);
+      txClient.commitOrThrow(tx);
 
       // start new for in-mem buffer behavior testing
       tx = txClient.startShort();
@@ -402,9 +402,9 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
       table1.startTx(tx1);
       table1.put(R1, a(C1), a(V1));
       Collection<byte []> tx1Changes = table1.getTxChanges();
-      Assert.assertTrue(txClient.canCommit(tx1, tx1Changes));
+      txClient.canCommitOrThrow(tx1, tx1Changes);
       Assert.assertTrue(table1.commitTx());
-      Assert.assertTrue(txClient.commit(tx1));
+      txClient.commitOrThrow(tx1);
       table1.postTxCommit();
 
       // write some values in table2
@@ -412,9 +412,9 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
       table2.startTx(tx2);
       table2.put(R1, a(C1), a(V1));
       Collection<byte []> tx2Changes = table2.getTxChanges();
-      Assert.assertTrue(txClient.canCommit(tx2, tx2Changes));
+      txClient.canCommitOrThrow(tx2, tx2Changes);
       Assert.assertTrue(table2.commitTx());
-      Assert.assertTrue(txClient.commit(tx2));
+      txClient.commitOrThrow(tx2);
       table1.postTxCommit();
 
       String tx1ChangePrefix = new String(table1.getNameAsTxChangePrefix());
@@ -462,9 +462,9 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
 
       // persist changes
       Collection<byte []> txChanges = table.getTxChanges();
-      Assert.assertTrue(txClient.canCommit(tx1, txChanges));
+      txClient.canCommitOrThrow(tx1, txChanges);
       Assert.assertTrue(table.commitTx());
-      Assert.assertTrue(txClient.commit(tx1));
+      txClient.commitOrThrow(tx1);
       table.postTxCommit();
 
       // start another transaction

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/TransactionContextTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/TransactionContextTest.java
@@ -630,21 +630,31 @@ public class TransactionContextTest {
 
     @Override
     public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+      throw new RuntimeException("This should never be called)");
+    }
+
+    @Override
+    public void canCommitOrThrow(Transaction tx, Collection<byte[]> changeIds) throws TransactionFailureException {
       if (failCanCommitOnce) {
         failCanCommitOnce = false;
-        return false;
+        throw new TransactionConflictException(tx.getTransactionId(), null, null);
       } else {
-        return super.canCommit(tx, changeIds);
+        super.canCommitOrThrow(tx, changeIds);
       }
     }
 
     @Override
     public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+      throw new RuntimeException("This should never be called)");
+    }
+
+    @Override
+    public void commitOrThrow(Transaction tx) throws TransactionFailureException {
       if (failCommits-- > 0) {
-        return false;
+        throw new TransactionConflictException(tx.getTransactionId(), null, null);
       } else {
         state = CommitState.Committed;
-        return super.commit(tx);
+        super.commitOrThrow(tx);
       }
     }
 
@@ -693,10 +703,15 @@ public class TransactionContextTest {
     }
 
     @Override
-    public void abort(Transaction transaction) {
+    public void canCommitOrThrow(Transaction transaction,
+                                 Collection<byte[]> collection) throws TransactionFailureException {
       throw new RuntimeException();
     }
 
+    @Override
+    public void abort(Transaction transaction) {
+      throw new RuntimeException();
+    }
   }
 
   /**

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
@@ -101,7 +101,7 @@ public class LevelDBQueueTest extends QueueTest {
     QueueEvictor evictor = ((LevelDBQueueClientFactory) queueClientFactory).createEvictor(queueName, numGroups);
     Transaction tx = txSystemClient.startShort();
     // There is no change, just to get the latest transaction for eviction
-    txSystemClient.commit(tx);
+    txSystemClient.commitOrThrow(tx);
     Uninterruptibles.getUninterruptibly(evictor.evict(tx));
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -92,6 +92,7 @@ import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.SessionHandle;
 import org.apache.hive.service.cli.TableSchema;
 import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.thrift.TException;
 import org.apache.twill.common.Threads;
@@ -1523,7 +1524,9 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
       if (opInfo.isReadOnly() ||
         (opInfo.getStatus() != null && opInfo.getStatus().getStatus() == QueryStatus.OpStatus.FINISHED))  {
-        if (!(txClient.commit(tx))) {
+        try {
+          txClient.commitOrThrow(tx);
+        } catch (TransactionFailureException e) {
           txClient.invalidate(tx.getWritePointer());
           LOG.info("Invalidating transaction: {}", tx);
         }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -160,8 +160,8 @@ public class ExploreDisabledTest {
 
     Assert.assertTrue(table.commitTx());
 
-    transactionManager.canCommit(tx1, table.getTxChanges());
-    transactionManager.commit(tx1);
+    transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+    transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
     table.postTxCommit();
 
@@ -200,8 +200,8 @@ public class ExploreDisabledTest {
 
     Assert.assertTrue(table.commitTx());
 
-    transactionManager.canCommit(tx1, table.getTxChanges());
-    transactionManager.commit(tx1);
+    transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+    transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
     table.postTxCommit();
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
@@ -83,8 +83,8 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
 
     Assert.assertTrue(table.commitTx());
 
-    transactionManager.canCommit(tx1, table.getTxChanges());
-    transactionManager.commit(tx1);
+    transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+    transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
     table.postTxCommit();
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreObjectMappedTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreObjectMappedTableTestRun.java
@@ -96,8 +96,8 @@ public class HiveExploreObjectMappedTableTestRun extends BaseHiveExploreServiceT
 
     Assert.assertTrue(txTable.commitTx());
 
-    transactionManager.canCommit(tx1, txTable.getTxChanges());
-    transactionManager.commit(tx1);
+    transactionManager.canCommit(tx1.getTransactionId(), txTable.getTxChanges());
+    transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
     txTable.postTxCommit();
   }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -103,8 +103,8 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
 
     Assert.assertTrue(table.commitTx());
 
-    transactionManager.canCommit(tx1, table.getTxChanges());
-    transactionManager.commit(tx1);
+    transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+    transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
     table.postTxCommit();
 
@@ -664,8 +664,8 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
 
       Assert.assertTrue(table.commitTx());
 
-      transactionManager.canCommit(tx1, table.getTxChanges());
-      transactionManager.commit(tx1);
+      transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+      transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
       table.postTxCommit();
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
@@ -90,8 +90,8 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
 
     Assert.assertTrue(table.commitTx());
 
-    transactionManager.canCommit(tx1, table.getTxChanges());
-    transactionManager.commit(tx1);
+    transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+    transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
     table.postTxCommit();
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreTableTestRun.java
@@ -123,8 +123,8 @@ public class HiveExploreTableTestRun extends BaseHiveExploreServiceTest {
 
     Assert.assertTrue(txTable.commitTx());
 
-    transactionManager.canCommit(tx1, txTable.getTxChanges());
-    transactionManager.commit(tx1);
+    transactionManager.canCommit(tx1.getTransactionId(), txTable.getTxChanges());
+    transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
     txTable.postTxCommit();
 
@@ -442,8 +442,8 @@ public class HiveExploreTableTestRun extends BaseHiveExploreServiceTest {
     List<byte[]> changes = new ArrayList<>();
     changes.addAll(txUserTable.getTxChanges());
     changes.addAll(txPurchaseTable.getTxChanges());
-    transactionManager.canCommit(tx1, changes);
-    transactionManager.commit(tx1);
+    transactionManager.canCommit(tx1.getTransactionId(), changes);
+    transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
 
     txUserTable.postTxCommit();
     txPurchaseTable.postTxCommit();

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
@@ -99,8 +99,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
 
     Assert.assertTrue(table.commitTx());
 
-    transactionManager.canCommit(tx, table.getTxChanges());
-    transactionManager.commit(tx);
+    transactionManager.canCommit(tx.getTransactionId(), table.getTxChanges());
+    transactionManager.commit(tx.getTransactionId(), tx.getWritePointer());
 
     table.postTxCommit();
   }
@@ -135,8 +135,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
                           table.get("2_2"));
 
       Assert.assertTrue(table.commitTx());
-      transactionManager.canCommit(tx, table.getTxChanges());
-      transactionManager.commit(tx);
+      transactionManager.canCommit(tx.getTransactionId(), table.getTxChanges());
+      transactionManager.commit(tx.getTransactionId(), tx.getWritePointer());
       table.postTxCommit();
 
       // Make sure Hive also sees those values
@@ -203,8 +203,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       Assert.assertEquals(value1, table.get("10"));
 
       Assert.assertTrue(table.commitTx());
-      transactionManager.canCommit(tx1, table.getTxChanges());
-      transactionManager.commit(tx1);
+      transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+      transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
       table.postTxCommit();
 
       String query = String.format("insert into table %s select key,value from %s",
@@ -264,8 +264,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       Assert.assertEquals(value1, table.get("10"));
 
       Assert.assertTrue(table.commitTx());
-      transactionManager.canCommit(tx1, table.getTxChanges());
-      transactionManager.commit(tx1);
+      transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+      transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
       table.postTxCommit();
 
       String query = "insert into table " + writableTableName + " select key,value from " + extendedTableName;
@@ -284,8 +284,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
                           table2.get("10_2"));
 
       Assert.assertTrue(table.commitTx());
-      transactionManager.canCommit(tx, table.getTxChanges());
-      transactionManager.commit(tx);
+      transactionManager.canCommit(tx.getTransactionId(), table.getTxChanges());
+      transactionManager.commit(tx.getTransactionId(), tx.getWritePointer());
       table.postTxCommit();
 
     } finally {
@@ -396,8 +396,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       Assert.assertEquals("ten", table.get(10));
 
       Assert.assertTrue(table.commitTx());
-      transactionManager.canCommit(tx1, table.getTxChanges());
-      transactionManager.commit(tx1);
+      transactionManager.canCommit(tx1.getTransactionId(), table.getTxChanges());
+      transactionManager.commit(tx1.getTransactionId(), tx1.getWritePointer());
       table.postTxCommit();
 
       exploreClient.submit(NAMESPACE_ID,
@@ -439,8 +439,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       table.put(1, "one");
 
       Assert.assertTrue(table.commitTx());
-      transactionManager.canCommit(tx, table.getTxChanges());
-      transactionManager.commit(tx);
+      transactionManager.canCommit(tx.getTransactionId(), table.getTxChanges());
+      transactionManager.commit(tx.getTransactionId(), tx.getWritePointer());
       table.postTxCommit();
 
       String query = String.format("insert into table %s select * from cdap_namespace.%s",
@@ -461,8 +461,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       table.put(2, "two");
 
       Assert.assertTrue(table.commitTx());
-      transactionManager.canCommit(tx, table.getTxChanges());
-      transactionManager.commit(tx);
+      transactionManager.canCommit(tx.getTransactionId(), table.getTxChanges());
+      transactionManager.commit(tx.getTransactionId(), tx.getWritePointer());
       table.postTxCommit();
 
       assertSelectAll(OTHER_NAMESPACE_ID, otherSimpleTableName, ImmutableList.<List<Object>>of(

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseTableExporter.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseTableExporter.java
@@ -240,7 +240,7 @@ public class HBaseTableExporter {
 
       // Always commit the transaction, since we are not doing any data update
       // operation in this tool.
-      txClient.commit(tx);
+      txClient.commitOrThrow(tx);
       System.out.println("Export operation complete. HFiles are stored at location " + bulkloadDir.toString());
     } finally {
       stop();

--- a/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/cdap/CDAPOperationalStatsTest.java
+++ b/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/cdap/CDAPOperationalStatsTest.java
@@ -58,9 +58,9 @@ public class CDAPOperationalStatsTest {
     AppFabricTestHelper.deployApplication(NAMESPACE.toId(), AllProgramsApp.class, null, cConf);
     TransactionSystemClient txClient = injector.getInstance(TransactionSystemClient.class);
     Transaction tx1 = txClient.startShort();
-    txClient.canCommit(tx1, Collections.singleton(Bytes.toBytes("foo")));
+    txClient.canCommitOrThrow(tx1, Collections.singleton(Bytes.toBytes("foo")));
     Transaction tx2 = txClient.startShort();
-    txClient.commit(tx2);
+    txClient.commitOrThrow(tx2);
     Transaction tx3 = txClient.startShort();
     txClient.invalidate(tx3.getTransactionId());
   }

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionHandler.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionHandler.java
@@ -287,11 +287,7 @@ public final class SparkTransactionHandler extends AbstractHttpHandler {
         if (succeeded) {
           LOG.debug("Committing transaction for job {}", jobId);
           try {
-            if (!txClient.commit(jobTx)) {
-              // If failed to commit (which it shouldn't since there is no conflict detection), throw exception
-              throw new TransactionFailureException("Failed to commit transaction on job success. JobId: "
-                                                      + jobId + ", transaction: " + jobTx);
-            }
+            txClient.commitOrThrow(jobTx);
             transactionInfo.onTransactionCompleted(succeeded, null);
           } catch (Throwable t) {
             // Any failure will invalidate the transaction

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
@@ -209,10 +209,7 @@ final class SparkTransactional implements Transactional {
       txDatasetContext.flush();
 
       if (needCommit) {
-        // Commit transaction
-        if (!txClient.commit(transaction)) {
-          throw new TransactionFailureException("Failed to commit explicit transaction " + transaction);
-        }
+        txClient.commitOrThrow(transaction);
         activeDatasetContext.remove();
         txDatasetContext.postCommit();
         txDatasetContext.discardDatasets();

--- a/cdap-spark-core-base/src/test/java/co/cask/cdap/app/runtime/spark/SparkTransactionHandlerTest.java
+++ b/cdap-spark-core-base/src/test/java/co/cask/cdap/app/runtime/spark/SparkTransactionHandlerTest.java
@@ -162,7 +162,7 @@ public class SparkTransactionHandlerTest {
     testRunJob(jobIdGen.getAndIncrement(), generateStages(stageIdGen, 3), true, transaction);
 
     // Should be able to commit the transaction
-    Assert.assertTrue(txClient.commit(transaction));
+    txClient.commitOrThrow(transaction);
   }
 
   /**

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseTableCoprocessorTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseTableCoprocessorTestRun.java
@@ -46,7 +46,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.tephra.ChangeId;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.TxConstants;
@@ -67,7 +66,6 @@ import org.junit.rules.TemporaryFolder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
@@ -136,7 +134,7 @@ public class HBaseTableCoprocessorTestRun extends DataCleanupTest {
       // this will set visibility upper bound to V[6]
       Maps.newTreeMap(ImmutableSortedMap.of(V[6], new TransactionManager.InProgressTx(
         V[6] - 1, Long.MAX_VALUE, TransactionManager.InProgressType.SHORT))),
-      new HashMap<Long, Set<ChangeId>>(), new TreeMap<Long, Set<ChangeId>>());
+      new HashMap<Long, TransactionManager.ChangeSet>(), new TreeMap<Long, TransactionManager.ChangeSet>());
     HDFSTransactionStateStorage tmpStorage =
       new HDFSTransactionStateStorage(hConf, new SnapshotCodecProvider(hConf), new TxMetricsCollector());
     tmpStorage.startAndWait();

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/RevealingTxSystemClient.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/RevealingTxSystemClient.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import org.apache.tephra.InvalidTruncateTimeException;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionNotInProgressException;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.tephra.inmemory.InMemoryTxSystemClient;
@@ -57,12 +58,24 @@ public class RevealingTxSystemClient implements TransactionSystemClient {
 
   @Override
   public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    //noinspection deprecation
     return txClient.canCommit(tx, changeIds);
   }
 
   @Override
+  public void canCommitOrThrow(Transaction tx, Collection<byte[]> changeIds) throws TransactionFailureException {
+    txClient.canCommitOrThrow(tx, changeIds);
+  }
+
+  @Override
   public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    //noinspection deprecation
     return txClient.commit(tx);
+  }
+
+  @Override
+  public void commitOrThrow(Transaction tx) throws TransactionFailureException {
+    txClient.commitOrThrow(tx);
   }
 
   @Override
@@ -108,6 +121,11 @@ public class RevealingTxSystemClient implements TransactionSystemClient {
   @Override
   public int getInvalidSize() {
     return txClient.getInvalidSize();
+  }
+
+  @Override
+  public void pruneNow() {
+    txClient.pruneNow();
   }
 
   /**


### PR DESCRIPTION
Makes all changes needed or upgrade to tephra-0.13:
- add new methods to all implementations of TransactionSystemClient
- change all invocations of TransactionSystemClient.c(anC)ommit() to c(anC)ommitOrThrow()
- change all direct invocations of TransactionManager.c(anC)ommit()
- some call to TransactionSnapshot that now wants a ChageSet instead of a Set<ChangeaId>
- changed our copy of TransactionContext to have the same changes as Tephra's
