### PR TITLE
CDAP-7243 Service to delete the local datasets periodically.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -84,10 +84,10 @@ import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
 import co.cask.cdap.internal.app.runtime.schedule.store.TriggerMisfireLogger;
 import co.cask.cdap.internal.app.services.AppFabricServer;
-import co.cask.cdap.internal.app.services.DistributedRunRecordCorrectorService;
-import co.cask.cdap.internal.app.services.LocalRunRecordCorrectorService;
+import co.cask.cdap.internal.app.services.DistributedRunFixerService;
+import co.cask.cdap.internal.app.services.LocalRunFixerService;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
-import co.cask.cdap.internal.app.services.RunRecordCorrectorService;
+import co.cask.cdap.internal.app.services.RunFixerService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.internal.pipeline.SynchronousPipelineFactory;
@@ -165,7 +165,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new AbstractModule() {
                              @Override
                              protected void configure() {
-                               bind(RunRecordCorrectorService.class).to(LocalRunRecordCorrectorService.class)
+                               bind(RunFixerService.class).to(LocalRunFixerService.class)
                                  .in(Scopes.SINGLETON);
                                bind(SchedulerService.class).to(LocalSchedulerService.class).in(Scopes.SINGLETON);
                                bind(Scheduler.class).to(SchedulerService.class);
@@ -210,7 +210,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                              @Override
                              protected void configure() {
                                bind(AppFabricServer.class).to(StandaloneAppFabricServer.class).in(Scopes.SINGLETON);
-                               bind(RunRecordCorrectorService.class).to(LocalRunRecordCorrectorService.class)
+                               bind(RunFixerService.class).to(LocalRunFixerService.class)
                                  .in(Scopes.SINGLETON);
                                bind(SchedulerService.class).to(LocalSchedulerService.class).in(Scopes.SINGLETON);
                                bind(Scheduler.class).to(SchedulerService.class);
@@ -289,7 +289,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new AbstractModule() {
                              @Override
                              protected void configure() {
-                               bind(RunRecordCorrectorService.class).to(DistributedRunRecordCorrectorService.class)
+                               bind(RunFixerService.class).to(DistributedRunFixerService.class)
                                  .in(Scopes.SINGLETON);
                                bind(SchedulerService.class).to(DistributedSchedulerService.class).in(Scopes.SINGLETON);
                                bind(Scheduler.class).to(SchedulerService.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/LocalDatasetDeleterRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/LocalDatasetDeleterRunnable.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime;
+
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.service.Retries;
+import co.cask.cdap.common.service.RetryStrategies;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class responsible for deleting the local datasets associated with the completed, failed, or killed workflow runs.
+ */
+public class LocalDatasetDeleterRunnable implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(LocalDatasetDeleterRunnable.class);
+  private final NamespaceAdmin namespaceAdmin;
+  private final Store store;
+  private final DatasetFramework datasetFramework;
+  private final Map<String, String> properties;
+
+  public LocalDatasetDeleterRunnable(NamespaceAdmin namespaceAdmin, Store store, DatasetFramework datasetFramework) {
+    this.namespaceAdmin = namespaceAdmin;
+    this.store = store;
+    this.datasetFramework = datasetFramework;
+    this.properties = ImmutableMap.of(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY, "true");
+  }
+
+  @Override
+  public void run() {
+    try {
+      List<NamespaceMeta> list = namespaceAdmin.list();
+      for (NamespaceMeta namespaceMeta : list) {
+        Collection<DatasetSpecificationSummary> specs
+          = datasetFramework.getInstances(namespaceMeta.getNamespaceId(), properties);
+
+        Set<String> activeRuns = getActiveRuns(namespaceMeta.getNamespaceId());
+        for (DatasetSpecificationSummary spec : specs) {
+          deleteLocalDataset(namespaceMeta.getName(), spec.getName(), activeRuns, spec.getProperties());
+        }
+      }
+    } catch (Throwable t) {
+      LOG.warn("Failed to delete the local datasets.", t);
+    }
+  }
+
+  private Set<String> getActiveRuns(NamespaceId namespaceId) {
+    Map<ProgramRunId, RunRecordMeta> activeRuns = store.getActiveRuns(namespaceId);
+    Set<String> runs = new HashSet<>();
+    for (Map.Entry<ProgramRunId, RunRecordMeta> entry : activeRuns.entrySet()) {
+      runs.add(entry.getValue().getPid());
+    }
+    return runs;
+  }
+
+  private void deleteLocalDataset(final String namespaceName, final String datasetName, Set<String> activeRuns,
+                                  Map<String, String> properties)
+    throws Exception {
+    String[] split = datasetName.split("\\.");
+    String runId = split[split.length - 1];
+
+    if (activeRuns.contains(runId)
+      || Boolean.parseBoolean(properties.get(Constants.AppFabric.WORKFLOW_KEEP_LOCAL))) {
+      return;
+    }
+
+    final DatasetId datasetId = new DatasetId(namespaceName, datasetName);
+    try {
+      Retries.callWithRetries(new Retries.Callable<Void, Exception>() {
+        @Override
+        public Void call() throws Exception {
+          datasetFramework.deleteInstance(datasetId);
+          LOG.info("Deleted local dataset instance {}", datasetId);
+          return null;
+        }
+      }, RetryStrategies.fixDelay(Constants.Retry.LOCAL_DATASET_OPERATION_RETRY_DELAY_SECONDS, TimeUnit.SECONDS));
+    } catch (Exception e) {
+      LOG.warn("Failed to delete the Workflow local dataset instance {}", datasetId, e);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -539,13 +539,28 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     executeAll(iterator, appSpec, instantiator, classLoader, token);
   }
 
-  private DatasetProperties addLocalDatasetProperty(DatasetProperties properties) {
+  private DatasetProperties addLocalDatasetProperty(DatasetProperties properties, boolean keepLocal) {
     String dsDescription = properties.getDescription();
     DatasetProperties.Builder builder = DatasetProperties.builder();
     builder.addAll(properties.getProperties());
     builder.add(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY, "true");
+    builder.add(Constants.AppFabric.WORKFLOW_NAMESPACE_NAME, workflowRunId.getNamespace());
+    builder.add(Constants.AppFabric.WORKFLOW_APPLICATION_NAME, workflowRunId.getApplication());
+    builder.add(Constants.AppFabric.WORKFLOW_APPLICATION_VERSION, workflowRunId.getVersion());
+    builder.add(Constants.AppFabric.WORKFLOW_PROGRAM_NAME, workflowRunId.getProgram());
+    builder.add(Constants.AppFabric.WORKFLOW_RUN_ID, workflowRunId.getRun());
+    if (keepLocal) {
+      builder.add(Constants.AppFabric.WORKFLOW_KEEP_LOCAL, "true");
+    }
     builder.setDescription(dsDescription);
     return builder.build();
+  }
+
+  private boolean keepLocal(String originalDatasetName) {
+    Map<String, String> datasetArguments = RuntimeArguments.extractScope(Scope.DATASET, originalDatasetName,
+                                                                         basicWorkflowContext.getRuntimeArguments());
+
+    return Boolean.parseBoolean(datasetArguments.get("keep.local"));
   }
 
   private void createLocalDatasets() throws IOException, DatasetManagementException {
@@ -566,7 +581,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
         Retries.callWithRetries(new Retries.Callable<Void, Exception>() {
           @Override
           public Void call() throws Exception {
-            DatasetProperties properties = addLocalDatasetProperty(instanceSpec.getProperties());
+            DatasetProperties properties = addLocalDatasetProperty(instanceSpec.getProperties(),
+                                                                   keepLocal(entry.getKey()));
             // we have to do this check since addInstance method can only be used when app impersonation is enabled
             if (finalPrincipalId != null) {
               datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId, properties, finalPrincipalId);
@@ -587,9 +603,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
 
   private void deleteLocalDatasets() {
     for (final Map.Entry<String, String> entry : datasetFramework.getDatasetNameMapping().entrySet()) {
-      final Map<String, String> datasetArguments = RuntimeArguments.extractScope(Scope.DATASET, entry.getKey(),
-                                                                           basicWorkflowContext.getRuntimeArguments());
-      if (Boolean.parseBoolean(datasetArguments.get("keep.local"))) {
+      if (keepLocal(entry.getKey())) {
         continue;
       }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractRunFixerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractRunFixerService.java
@@ -228,13 +228,13 @@ public class AbstractRunFixerService extends AbstractIdleService implements RunF
     localDatasetDeleterService = Executors.newScheduledThreadPool(1);
     long interval = cConf.getLong(Constants.AppFabric.LOCAL_DATASET_DELETER_INTERVAL_SECONDS);
     if (interval <= 0) {
-      LOG.debug("Invalid interval specified for the local dataset deleter {}. Setting it to 3600 seconds.", interval);
+      LOG.warn("Invalid interval specified for the local dataset deleter {}. Setting it to 3600 seconds.", interval);
       interval = 3600L;
     }
 
     long initialDelay = cConf.getLong(Constants.AppFabric.LOCAL_DATASET_DELETER_INITIAL_DELAY_SECONDS);
     if (initialDelay <= 0) {
-      LOG.debug("Invalid initial delay specified for the local dataset deleter {}. Setting it to 300 seconds.",
+      LOG.warn("Invalid initial delay specified for the local dataset deleter {}. Setting it to 300 seconds.",
                 initialDelay);
       initialDelay = 300L;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractRunFixerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractRunFixerService.java
@@ -231,9 +231,16 @@ public class AbstractRunFixerService extends AbstractIdleService implements RunF
       LOG.debug("Invalid interval specified for the local dataset deleter {}. Setting it to 3600 seconds.", interval);
       interval = 3600L;
     }
-    // Schedule the local dataset deleter with 5 minutes initial delay
+
+    long initialDelay = cConf.getLong(Constants.AppFabric.LOCAL_DATASET_DELETER_INITIAL_DELAY_SECONDS);
+    if (initialDelay <= 0) {
+      LOG.debug("Invalid initial delay specified for the local dataset deleter {}. Setting it to 300 seconds.",
+                initialDelay);
+      initialDelay = 300L;
+    }
+
     Runnable runnable = new LocalDatasetDeleterRunnable(namespaceAdmin, store, datasetFramework);
-    localDatasetDeleterService.scheduleWithFixedDelay(runnable, 300L, interval, TimeUnit.SECONDS);
+    localDatasetDeleterService.scheduleWithFixedDelay(runnable, initialDelay, interval, TimeUnit.SECONDS);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -83,7 +83,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final Set<String> handlerHookNames;
   private final StreamCoordinatorClient streamCoordinatorClient;
   private final ProgramLifecycleService programLifecycleService;
-  private final RunRecordCorrectorService runRecordCorrectorService;
+  private final RunFixerService runFixerService;
   private final SystemArtifactLoader systemArtifactLoader;
   private final PluginService pluginService;
   private final CoreSchedulerService coreSchedulerService;
@@ -110,7 +110,7 @@ public class AppFabricServer extends AbstractIdleService {
                          @Named(Constants.AppFabric.HANDLERS_BINDING) Set<HttpHandler> handlers,
                          @Nullable MetricsCollectionService metricsCollectionService,
                          ProgramRuntimeService programRuntimeService,
-                         RunRecordCorrectorService runRecordCorrectorService,
+                         RunFixerService runFixerService,
                          ApplicationLifecycleService applicationLifecycleService,
                          ProgramLifecycleService programLifecycleService,
                          StreamCoordinatorClient streamCoordinatorClient,
@@ -135,7 +135,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.applicationLifecycleService = applicationLifecycleService;
     this.streamCoordinatorClient = streamCoordinatorClient;
     this.programLifecycleService = programLifecycleService;
-    this.runRecordCorrectorService = runRecordCorrectorService;
+    this.runFixerService = runFixerService;
     this.systemArtifactLoader = systemArtifactLoader;
     this.pluginService = pluginService;
     this.appVersionUpgradeService = appVersionUpgradeService;
@@ -161,7 +161,7 @@ public class AppFabricServer extends AbstractIdleService {
         programRuntimeService.start(),
         streamCoordinatorClient.start(),
         programLifecycleService.start(),
-        runRecordCorrectorService.start(),
+        runFixerService.start(),
         pluginService.start(),
         coreSchedulerService.start()
       )
@@ -280,7 +280,7 @@ public class AppFabricServer extends AbstractIdleService {
     systemArtifactLoader.stopAndWait();
     notificationService.stopAndWait();
     programLifecycleService.stopAndWait();
-    runRecordCorrectorService.stopAndWait();
+    runFixerService.stopAndWait();
     pluginService.stopAndWait();
     if (appVersionUpgradeService != null) {
       appVersionUpgradeService.stopAndWait();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DistributedRunFixerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DistributedRunFixerService.java
@@ -21,6 +21,8 @@ import co.cask.cdap.app.runtime.ProgramStateWriter;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
@@ -33,17 +35,18 @@ import java.util.concurrent.TimeUnit;
 /**
  * A distributed-mode only run record corrector service that corrects run records at a scheduled, configurable rate.
  */
-public class DistributedRunRecordCorrectorService extends AbstractRunRecordCorrectorService {
-  private static final Logger LOG = LoggerFactory.getLogger(DistributedRunRecordCorrectorService.class);
+public class DistributedRunFixerService extends AbstractRunFixerService {
+  private static final Logger LOG = LoggerFactory.getLogger(DistributedRunFixerService.class);
 
   private final CConfiguration cConf;
   private ScheduledExecutorService scheduledExecutorService;
 
   @Inject
-  public DistributedRunRecordCorrectorService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
-                                              ProgramLifecycleService programLifecycleService,
-                                              ProgramRuntimeService runtimeService) {
-    super(cConf, store, programStateWriter, programLifecycleService, runtimeService);
+  public DistributedRunFixerService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
+                                    ProgramLifecycleService programLifecycleService,
+                                    ProgramRuntimeService runtimeService, NamespaceAdmin namespaceAdmin,
+                                    DatasetFramework datasetFramework) {
+    super(cConf, store, programStateWriter, programLifecycleService, runtimeService, namespaceAdmin, datasetFramework);
     this.cConf = cConf;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/LocalRunFixerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/LocalRunFixerService.java
@@ -20,18 +20,21 @@ import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.runtime.ProgramStateWriter;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import com.google.inject.Inject;
 
 /**
  * A local-mode only run record corrector that corrects run records once upon app fabric server startup.
  */
-public class LocalRunRecordCorrectorService extends AbstractRunRecordCorrectorService {
+public class LocalRunFixerService extends AbstractRunFixerService {
 
   @Inject
-  public LocalRunRecordCorrectorService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
-                                        ProgramLifecycleService programLifecycleService,
-                                        ProgramRuntimeService runtimeService) {
-    super(cConf, store, programStateWriter, programLifecycleService, runtimeService);
+  public LocalRunFixerService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
+                              ProgramLifecycleService programLifecycleService,
+                              ProgramRuntimeService runtimeService, NamespaceAdmin namespaceAdmin,
+                              DatasetFramework datasetFramework) {
+    super(cConf, store, programStateWriter, programLifecycleService, runtimeService, namespaceAdmin, datasetFramework);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunFixerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunFixerService.java
@@ -22,5 +22,5 @@ import com.google.common.util.concurrent.Service;
 /**
  * A service interface that defines the behavior when run records are corrected
  */
-public interface RunRecordCorrectorService extends Service {
+public interface RunFixerService extends Service {
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -60,7 +60,7 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    ProgramRuntimeService programRuntimeService,
                                    ApplicationLifecycleService applicationLifecycleService,
                                    ProgramLifecycleService programLifecycleService,
-                                   RunRecordCorrectorService runRecordCorrectorService,
+                                   RunFixerService runFixerService,
                                    StreamCoordinatorClient streamCoordinatorClient,
                                    @Named("appfabric.services.names") Set<String> servicesNames,
                                    @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
@@ -71,7 +71,7 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    RouteStore routeStore,
                                    CoreSchedulerService coreSchedulerService) {
     super(cConf, sConf, discoveryService, notificationService, hostname, handlers,
-          metricsCollectionService, programRuntimeService, runRecordCorrectorService, applicationLifecycleService,
+          metricsCollectionService, programRuntimeService, runFixerService, applicationLifecycleService,
           programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, namespaceAdmin,
           systemArtifactLoader, pluginService, null, routeStore, coreSchedulerService);
     this.metricStore = metricStore;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithLocalDataset.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithLocalDataset.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.customaction.AbstractCustomAction;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+
+/**
+ * App with local dataset.
+ */
+public class WorkflowAppWithLocalDataset extends AbstractApplication {
+  public static final String APP_NAME = "WorkflowAppWithLocalDataset";
+  public static final String WORKFLOW_NAME = "WorkflowWithLocalDataset";
+  @Override
+  public void configure() {
+    addWorkflow(new WorkflowWithLocalDataset());
+  }
+
+  /**
+   * Workflow with local dataset.
+   */
+  public static class WorkflowWithLocalDataset extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      createLocalDataset("testdataset", Table.class);
+      addAction(new MyCustomAction());
+    }
+  }
+
+  /**
+   * Custom action in the Workflow which does nothing
+   */
+  public static class MyCustomAction extends AbstractCustomAction {
+
+    @Override
+    public void run() throws Exception {
+      // no-op
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunFixerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunFixerServiceTest.java
@@ -24,7 +24,9 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.internal.app.store.RunRecordMeta;
@@ -33,8 +35,6 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.Service;
 import org.apache.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -47,14 +47,16 @@ import java.util.concurrent.TimeUnit;
 
 
 /**
- * Unit test for {@link RunRecordCorrectorService}
+ * Unit test for {@link RunFixerService}
  */
-public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
+public class RunFixerServiceTest extends AppFabricTestBase {
 
   private static Store store;
   private static ProgramStateWriter programStateWriter;
   private static ProgramLifecycleService programLifecycleService;
   private static ProgramRuntimeService runtimeService;
+  private static NamespaceAdmin namespaceAdmin;
+  private static DatasetFramework datasetFramework;
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -62,6 +64,8 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
     programStateWriter = getInjector().getInstance(ProgramStateWriter.class);
     runtimeService = getInjector().getInstance(ProgramRuntimeService.class);
     programLifecycleService = getInjector().getInstance(ProgramLifecycleService.class);
+    namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
+    datasetFramework = getInjector().getInstance(DatasetFramework.class);
   }
 
   @Test
@@ -131,8 +135,8 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
     CConfiguration testConf = CConfiguration.create();
     // set threshold to 0 so that it will actually correct the record
     testConf.set(Constants.AppFabric.PROGRAM_MAX_START_SECONDS, "0");
-    new LocalRunRecordCorrectorService(testConf, store, programStateWriter, programLifecycleService,
-                                       runtimeService).startUp();
+    new LocalRunFixerService(testConf, store, programStateWriter, programLifecycleService,
+                                       runtimeService, namespaceAdmin, datasetFramework).startUp();
 
     // Wait for the FAILED run record for the application
     Tasks.waitFor(1, new Callable<Integer>() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -180,6 +180,8 @@ public final class Constants {
     public static final String MAPREDUCE_STATUS_REPORT_INTERVAL_SECONDS = "mapreduce.status.report.interval.seconds";
     public static final String PROGRAM_RUNID_CORRECTOR_INTERVAL_SECONDS = "app.program.runid.corrector.interval";
     public static final String LOCAL_DATASET_DELETER_INTERVAL_SECONDS = "app.program.local.dataset.deleter.interval";
+    public static final String LOCAL_DATASET_DELETER_INITIAL_DELAY_SECONDS
+      = "app.program.local.dataset.deleter.initial.delay";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String PROGRAM_EXTRA_CLASSPATH = "app.program.extra.classpath";
     public static final String SPARK_YARN_CLIENT_REWRITE = "app.program.spark.yarn.client.rewrite.enabled";

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -179,6 +179,7 @@ public final class Constants {
     public static final String MAPREDUCE_INCLUDE_CUSTOM_CLASSES = "mapreduce.include.custom.format.classes";
     public static final String MAPREDUCE_STATUS_REPORT_INTERVAL_SECONDS = "mapreduce.status.report.interval.seconds";
     public static final String PROGRAM_RUNID_CORRECTOR_INTERVAL_SECONDS = "app.program.runid.corrector.interval";
+    public static final String LOCAL_DATASET_DELETER_INTERVAL_SECONDS = "app.program.local.dataset.deleter.interval";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String PROGRAM_EXTRA_CLASSPATH = "app.program.extra.classpath";
     public static final String SPARK_YARN_CLIENT_REWRITE = "app.program.spark.yarn.client.rewrite.enabled";
@@ -232,6 +233,18 @@ public final class Constants {
      * Name of the property used to identify whether the dataset is local or not.
      */
     public static final String WORKFLOW_LOCAL_DATASET_PROPERTY = "workflow.local.dataset";
+
+    public static final String WORKFLOW_NAMESPACE_NAME = "workflow.namespace.name";
+
+    public static final String WORKFLOW_APPLICATION_NAME = "workflow.application.name";
+
+    public static final String WORKFLOW_APPLICATION_VERSION = "workflow.application.version";
+
+    public static final String WORKFLOW_PROGRAM_NAME = "workflow.program.name";
+
+    public static final String WORKFLOW_RUN_ID = "workflow.run.id";
+
+    public static final String WORKFLOW_KEEP_LOCAL = "workflow.keep.local";
 
     /**
      * Configuration setting to localize extra jars to every program container and to be

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -402,6 +402,15 @@
   </property>
 
   <property>
+    <name>app.program.local.dataset.deleter.interval</name>
+    <value>3600</value>
+    <description>
+      Interval in seconds of how often the local dataset deletion thread will run;
+      this value should be greater than 0
+    </description>
+  </property>
+
+  <property>
     <name>app.program.runtime.extensions.dir</name>
     <value>/opt/cdap/master/ext/runtimes</value>
     <description>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -402,6 +402,15 @@
   </property>
 
   <property>
+    <name>app.program.local.dataset.deleter.initial.delay</name>
+    <value>300</value>
+    <description>
+      Interval in seconds for initial delay for the local dataset deletion thread;
+      this value should be greater than 0
+    </description>
+  </property>
+
+  <property>
     <name>app.program.local.dataset.deleter.interval</name>
     <value>3600</value>
     <description>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -59,6 +59,7 @@ import java.lang.reflect.Type;
 import java.net.ConnectException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -139,6 +140,17 @@ class DatasetServiceClient {
 
   Collection<DatasetSpecificationSummary> getAllInstances() throws DatasetManagementException {
     HttpResponse response = doGet("datasets");
+    if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
+      throw new DatasetManagementException(String.format("Cannot retrieve all dataset instances, details: %s",
+                                                         response));
+    }
+
+    return GSON.fromJson(response.getResponseBodyAsString(), SUMMARY_LIST_TYPE);
+  }
+
+  Collection<DatasetSpecificationSummary> getAllInstances(Map<String, String> properties)
+    throws DatasetManagementException {
+    HttpResponse response = doPost("datasets", GSON.toJson(properties));
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Cannot retrieve all dataset instances, details: %s",
                                                          response));
@@ -298,6 +310,10 @@ class DatasetServiceClient {
 
   private HttpResponse doPost(String resource) throws DatasetManagementException {
     return doRequest(remoteClient.requestBuilder(HttpMethod.POST, resource));
+  }
+
+  private HttpResponse doPost(String resource, String body) throws DatasetManagementException {
+    return doRequest(remoteClient.requestBuilder(HttpMethod.POST, resource).withBody(body));
   }
 
   private HttpResponse doDelete(String resource) throws DatasetManagementException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -148,9 +148,9 @@ class DatasetServiceClient {
     return GSON.fromJson(response.getResponseBodyAsString(), SUMMARY_LIST_TYPE);
   }
 
-  Collection<DatasetSpecificationSummary> getAllInstances(Map<String, String> properties)
+  Collection<DatasetSpecificationSummary> getInstances(Map<String, String> properties)
     throws DatasetManagementException {
-    HttpResponse response = doPost("datasets", GSON.toJson(properties));
+    HttpResponse response = doPut("datasets", GSON.toJson(properties));
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Cannot retrieve all dataset instances, details: %s",
                                                          response));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -166,6 +166,12 @@ public class RemoteDatasetFramework implements DatasetFramework {
     return clientCache.getUnchecked(namespaceId).getAllInstances();
   }
 
+  @Override
+  public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId, Map<String, String> properties)
+    throws DatasetManagementException {
+    return clientCache.getUnchecked(namespaceId).getAllInstances(properties);
+  }
+
   @Nullable
   @Override
   public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -169,7 +169,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
   @Override
   public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId, Map<String, String> properties)
     throws DatasetManagementException {
-    return clientCache.getUnchecked(namespaceId).getAllInstances(properties);
+    return clientCache.getUnchecked(namespaceId).getInstances(properties);
   }
 
   @Nullable

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
@@ -98,7 +98,14 @@ public class DatasetInstanceManager {
    * @return collection of {@link DatasetSpecification} of all dataset instances in the given namespace
    */
   public Collection<DatasetSpecification> getAll(final NamespaceId namespaceId) {
-    return getAll(namespaceId, new HashMap<String, String>());
+    final DatasetInstanceMDS instanceMDS = datasetCache.getDataset(DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
+    return txExecutorFactory.createExecutor(datasetCache)
+      .executeUnchecked(new Callable<Collection<DatasetSpecification>>() {
+        @Override
+        public Collection<DatasetSpecification> call() throws Exception {
+          return instanceMDS.getAll(namespaceId);
+        }
+      });
   }
 
   /**
@@ -107,13 +114,13 @@ public class DatasetInstanceManager {
    * @return collection of {@link DatasetSpecification} of all dataset instances in the given namespace which
    * are having the specified properties
    */
-  public Collection<DatasetSpecification> getAll(final NamespaceId namespaceId, final Map<String, String> properties) {
+  public Collection<DatasetSpecification> get(final NamespaceId namespaceId, final Map<String, String> properties) {
     final DatasetInstanceMDS instanceMDS = datasetCache.getDataset(DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
     return txExecutorFactory.createExecutor(datasetCache)
       .executeUnchecked(new Callable<Collection<DatasetSpecification>>() {
         @Override
         public Collection<DatasetSpecification> call() throws Exception {
-          return instanceMDS.getAll(namespaceId, properties);
+          return instanceMDS.get(namespaceId, properties);
         }
       });
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
@@ -35,6 +35,7 @@ import org.apache.tephra.TransactionExecutor;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
@@ -97,12 +98,22 @@ public class DatasetInstanceManager {
    * @return collection of {@link DatasetSpecification} of all dataset instances in the given namespace
    */
   public Collection<DatasetSpecification> getAll(final NamespaceId namespaceId) {
+    return getAll(namespaceId, new HashMap<String, String>());
+  }
+
+  /**
+   * @param namespaceId {@link NamespaceId} for which dataset instances are required
+   * @param properties {@link Map} of dataset properties
+   * @return collection of {@link DatasetSpecification} of all dataset instances in the given namespace which
+   * are having the specified properties
+   */
+  public Collection<DatasetSpecification> getAll(final NamespaceId namespaceId, final Map<String, String> properties) {
     final DatasetInstanceMDS instanceMDS = datasetCache.getDataset(DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
     return txExecutorFactory.createExecutor(datasetCache)
       .executeUnchecked(new Callable<Collection<DatasetSpecification>>() {
         @Override
         public Collection<DatasetSpecification> call() throws Exception {
-          return instanceMDS.getAll(namespaceId);
+          return instanceMDS.getAll(namespaceId, properties);
         }
       });
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -29,10 +29,19 @@ import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
+import com.google.common.base.Charsets;
+import com.google.gson.Gson;
 import com.google.inject.Inject;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBufferInputStream;
+import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.DELETE;
@@ -51,6 +60,7 @@ import javax.ws.rs.QueryParam;
 public class DatasetInstanceHandler extends AbstractHttpHandler {
 
   private final DatasetInstanceService instanceService;
+  private static final Gson GSON = new Gson();
 
   @Inject
   public DatasetInstanceHandler(DatasetInstanceService instanceService) {
@@ -61,8 +71,17 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   @Path("/data/datasets/")
   public void list(HttpRequest request, HttpResponder responder,
                    @PathParam("namespace-id") String namespaceId) throws Exception {
+
     responder.sendJson(HttpResponseStatus.OK, ConversionHelpers.spec2Summary(
-      instanceService.list(ConversionHelpers.toNamespaceId(namespaceId))));
+      instanceService.list(ConversionHelpers.toNamespaceId(namespaceId), new HashMap<String, String>())));
+  }
+
+  @PUT
+  @Path("/data/datasets/")
+  public void listWithSpecifiedProperties(HttpRequest request, HttpResponder responder,
+                                          @PathParam("namespace-id") String namespaceId) throws Exception {
+    responder.sendJson(HttpResponseStatus.OK, ConversionHelpers.spec2Summary(
+      instanceService.list(ConversionHelpers.toNamespaceId(namespaceId), getDatasetProperties(request))));
   }
 
   /**
@@ -200,5 +219,24 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
                             @PathParam("name") String name, @PathParam("method") String method) {
     // todo: execute data operation
     responder.sendStatus(HttpResponseStatus.NOT_IMPLEMENTED);
+  }
+
+  private Map<String, String> getDatasetProperties(HttpRequest request) {
+    ChannelBuffer content = request.getContent();
+
+    if (content == ChannelBuffers.EMPTY_BUFFER) {
+      return new HashMap<>();
+    }
+
+    Reader reader = new InputStreamReader(new ChannelBufferInputStream(request.getContent()), Charsets.UTF_8);
+    try {
+      return GSON.fromJson(reader, new TypeToken<Map<String, String>>() { }.getType());
+    } finally {
+      try {
+        reader.close();
+      } catch (IOException e) {
+        // no-op
+      }
+    }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.id.DatasetId;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
+import com.google.common.io.Closeables;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -71,9 +72,8 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   @Path("/data/datasets/")
   public void list(HttpRequest request, HttpResponder responder,
                    @PathParam("namespace-id") String namespaceId) throws Exception {
-
     responder.sendJson(HttpResponseStatus.OK, ConversionHelpers.spec2Summary(
-      instanceService.list(ConversionHelpers.toNamespaceId(namespaceId), new HashMap<String, String>())));
+      instanceService.list(ConversionHelpers.toNamespaceId(namespaceId))));
   }
 
   @PUT
@@ -232,11 +232,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
     try {
       return GSON.fromJson(reader, new TypeToken<Map<String, String>>() { }.getType());
     } finally {
-      try {
-        reader.close();
-      } catch (IOException e) {
-        // no-op
-      }
+      Closeables.closeQuietly(reader);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -132,13 +132,15 @@ public class DatasetInstanceService {
    * dataset instances that the current user has access to.
    *
    * @param namespace the namespace to list datasets for
-   * @return the dataset instances in the provided namespace
+   * @param properties the dataset properties
+   * @return the dataset instances in the provided namespace satisfying the given properties.
+   * If no property is specified all instances are returned
    * @throws NotFoundException if the namespace was not found
    * @throws IOException if there is a problem in making an HTTP request to check if the namespace exists
    */
-  Collection<DatasetSpecification> list(final NamespaceId namespace) throws Exception {
+  Collection<DatasetSpecification> list(final NamespaceId namespace, Map<String, String> properties) throws Exception {
     ensureNamespaceExists(namespace);
-    List<DatasetSpecification> datasets = new ArrayList<>(instanceManager.getAll(namespace));
+    List<DatasetSpecification> datasets = new ArrayList<>(instanceManager.getAll(namespace, properties));
 
     return AuthorizationUtil.isVisible(datasets, authorizationEnforcer, authenticationContext.getPrincipal(),
                                        new Function<DatasetSpecification, EntityId>() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -132,6 +132,28 @@ public class DatasetInstanceService {
    * dataset instances that the current user has access to.
    *
    * @param namespace the namespace to list datasets for
+   * @return the dataset instances in the provided namespace
+   * @throws NotFoundException if the namespace was not found
+   * @throws IOException if there is a problem in making an HTTP request to check if the namespace exists
+   */
+  Collection<DatasetSpecification> list(final NamespaceId namespace) throws Exception {
+    ensureNamespaceExists(namespace);
+    List<DatasetSpecification> datasets = new ArrayList<>(instanceManager.getAll(namespace));
+
+    return AuthorizationUtil.isVisible(datasets, authorizationEnforcer, authenticationContext.getPrincipal(),
+                                       new Function<DatasetSpecification, EntityId>() {
+                                         @Override
+                                         public EntityId apply(DatasetSpecification input) {
+                                           return namespace.dataset(input.getName());
+                                         }
+                                       }, null);
+  }
+
+  /**
+   * Lists all dataset instances in a namespace having specified properties. If perimeter security and authorization
+   * are enabled, only returns the dataset instances that the current user has access to.
+   *
+   * @param namespace the namespace to list datasets for
    * @param properties the dataset properties
    * @return the dataset instances in the provided namespace satisfying the given properties.
    * If no property is specified all instances are returned
@@ -140,7 +162,7 @@ public class DatasetInstanceService {
    */
   Collection<DatasetSpecification> list(final NamespaceId namespace, Map<String, String> properties) throws Exception {
     ensureNamespaceExists(namespace);
-    List<DatasetSpecification> datasets = new ArrayList<>(instanceManager.getAll(namespace, properties));
+    List<DatasetSpecification> datasets = new ArrayList<>(instanceManager.get(namespace, properties));
 
     return AuthorizationUtil.isVisible(datasets, authorizationEnforcer, authenticationContext.getPrincipal(),
                                        new Function<DatasetSpecification, EntityId>() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetInstanceMDS.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetInstanceMDS.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -68,32 +69,28 @@ public final class DatasetInstanceMDS extends MetadataStoreDataset {
   }
 
   public Collection<DatasetSpecification> getAll(NamespaceId namespaceId) {
-    return getAll(namespaceId, new HashMap<String, String>());
-  }
-
-  public Collection<DatasetSpecification> getAll(NamespaceId namespaceId, final Map<String, String> properties) {
-    Predicate<DatasetSpecification> filter = new Predicate<DatasetSpecification>() {
+    Predicate<DatasetSpecification> localDatasetFilter = new Predicate<DatasetSpecification>() {
       @Override
       public boolean apply(@Nullable DatasetSpecification input) {
-        if (input == null) {
-          return false;
-        }
-        if (properties.isEmpty()) {
-          // Filter local datasets when no explicit property based filter is specified
-          // We do not want to show the local datasets on the UI
-          return !Boolean.parseBoolean(input.getProperty(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY));
-        }
+        return input != null
+          && !Boolean.parseBoolean(input.getProperty(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY));
+      }
+    };
+    return getAll(namespaceId, localDatasetFilter);
+  }
 
-        for (Map.Entry<String, String> property : properties.entrySet()) {
-          String propertyValue = input.getProperties().get(property.getKey());
-          if (propertyValue == null || !propertyValue.equals(property.getValue())) {
-            return false;
-          }
-        }
-        return true;
+  public Collection<DatasetSpecification> get(NamespaceId namespaceId, final Map<String, String> properties) {
+    Predicate<DatasetSpecification> propertyFilter = new Predicate<DatasetSpecification>() {
+      @Override
+      public boolean apply(@Nullable DatasetSpecification input) {
+        return input != null && Maps.difference(properties, input.getProperties()).entriesOnlyOnLeft().isEmpty();
       }
     };
 
+    return getAll(namespaceId, propertyFilter);
+  }
+
+  private Collection<DatasetSpecification> getAll(NamespaceId namespaceId, Predicate<DatasetSpecification> filter) {
     Map<MDSKey, DatasetSpecification> instances = listKV(getInstanceKey(namespaceId), null, DatasetSpecification.class,
                                                          Integer.MAX_VALUE, filter);
     return instances.values();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -187,6 +187,17 @@ public interface DatasetFramework {
   Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId) throws DatasetManagementException;
 
   /**
+   * Get all dataset instances in the specified namespace
+   *
+   * @param namespaceId the specified namespace id
+   * @param properties the map of dataset properties
+   * @return a collection of {@link DatasetSpecification}s for all datasets in the specified namespace
+   * having specified properties
+   */
+  Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId, Map<String, String> properties)
+    throws DatasetManagementException;
+
+  /**
    * Gets the {@link DatasetSpecification} for the specified dataset instance id
    *
    * @param datasetInstanceId the {@link DatasetId} for which the {@link DatasetSpecification} is desired

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
@@ -97,6 +97,12 @@ public class ForwardingDatasetFramework implements DatasetFramework {
     return delegate.getInstances(namespaceId);
   }
 
+  @Override
+  public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId, Map<String, String> properties)
+    throws DatasetManagementException {
+    return delegate.getInstances(namespaceId, properties);
+  }
+
   @Nullable
   @Override
   public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -315,15 +315,8 @@ public class InMemoryDatasetFramework implements DatasetFramework {
       Collection<DatasetSpecification> specs = instances.row(namespaceId).values();
       ImmutableList.Builder<DatasetSpecificationSummary> specSummaries = ImmutableList.builder();
       for (DatasetSpecification spec : specs) {
-        if (properties.isEmpty()) {
+        if (properties.isEmpty() || Maps.difference(properties, spec.getProperties()).entriesOnlyOnLeft().isEmpty()) {
           specSummaries.add(new DatasetSpecificationSummary(spec.getName(), spec.getType(), spec.getProperties()));
-        } else {
-          for (Map.Entry<String, String> property : properties.entrySet()) {
-            String propertyValue = spec.getProperty(property.getKey());
-            if (propertyValue != null && propertyValue.equals(property.getValue())) {
-              specSummaries.add(new DatasetSpecificationSummary(spec.getName(), spec.getType(), spec.getProperties()));
-            }
-          }
         }
       }
       return specSummaries.build();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/preview/PreviewDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/preview/PreviewDatasetFramework.java
@@ -171,6 +171,12 @@ public class PreviewDatasetFramework implements DatasetFramework {
     return localDatasetFramework.getInstances(namespaceId);
   }
 
+  @Override
+  public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId, Map<String, String> properties)
+    throws DatasetManagementException {
+    return localDatasetFramework.getInstances(namespaceId, properties);
+  }
+
   @Nullable
   @Override
   public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="f3deaf06ba36bed449729144d94d51d5"
+DEFAULT_XML_MD5_HASH="85cf45ea10a60f68487bde1910a67881"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="85cf45ea10a60f68487bde1910a67881"
+DEFAULT_XML_MD5_HASH="ad6e3755a83393d854f720d40772d607"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Opening PR to get feedback. Pending tests

In this PR -
1. Renamed `RunRecordCorrectorService` to `RunFixerServer` so that multiple inconsistencies can be fixed rather than just fixing the run record.
2. Added new thread which will run the `LocalDatasetDeleterRunnable` by default every 3600 seconds.
3. `LocalDatasetDeleterRunnable`  during each run
 - get list of namespaces
 - for each namespace gets the running runs and also all local datasets in the namespace using dataset framework 
 - figures the runid from the local dataset name
 - delete the dataset if run is not running and `keep.local` is false