### PR TITLE
quote cdap_apply_pack arguments to allow for spaces

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -75,7 +75,7 @@ test -f "${CDAP_CONF}"/cdap-env.sh && source "${CDAP_CONF}"/cdap-env.sh
 
 # Main script, handles options and Does the Right Thing™
 case ${1} in
-  apply-pack) shift; cdap_apply_pack ${@}; __ret=${?} ;;
+  apply-pack) shift; cdap_apply_pack "${@}"; __ret=${?} ;;
   auth-server|kafka-server|master|router|ui) CDAP_SERVICE=${1}; shift; cdap_service ${CDAP_SERVICE} ${@}; __ret=${?} ;;
   classpath) cdap_service master classpath; __ret=${?} ;;
   cli) shift; cdap_cli "${@}"; __ret=${?} ;;


### PR DESCRIPTION
before:
```
$ ./bin/cdap apply-pack ~/Downloads/cdap-ui-pack-4.2.0_p5\ \(1\).zip 
[ERROR] UI pack must be an absolute path to a zip file
```

after (npm error expected):
```
$ ./bin/cdap apply-pack ~/Downloads/cdap-ui-pack-4.2.0_p5\ \(1\).zip 
/home/derek/sdk/cdap-sandbox-4.3.0/bin/functions.sh: line 738: npm: command not found
```