### PR TITLE
CDAP-12599 Enforce transaction max lifetime for CDAP table updates

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -733,7 +733,6 @@
     <description>
       Time in seconds used to pad transaction maximum lifetime while pruning
     </description>
-    <final>true</final>
   </property>
 
   <property>

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -558,6 +558,118 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     Assert.assertEquals(4, encodeCount.get());
   }
 
+  @Test
+  public void testEnforceTxLifetime() throws Exception {
+    String tableName = "enforce-tx-lifetime";
+    DatasetProperties datasetProperties = TableProperties.builder()
+      .setReadlessIncrementSupport(true)
+      .setConflictDetection(ConflictDetection.COLUMN)
+      .build();
+
+    DatasetAdmin admin = getTableAdmin(CONTEXT1, tableName, datasetProperties);
+    admin.create();
+
+    DetachedTxSystemClient txSystemClient = new DetachedTxSystemClient();
+    DatasetSpecification spec =
+      DatasetSpecification.builder(tableName, HBaseTable.class.getName())
+        .properties(datasetProperties.getProperties())
+        .build();
+    try {
+      final HBaseTable table = new HBaseTable(CONTEXT1, spec, Collections.<String, String>emptyMap(),
+                                              cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
+      Transaction tx = txSystemClient.startShort();
+      table.startTx(tx);
+      table.put(b("row1"), b("col1"), b("val1"));
+      table.put(b("inc1"), b("col1"), Bytes.toBytes(10L));
+      table.commitTx();
+      table.postTxCommit();
+      table.close();
+
+      CConfiguration testCConf = CConfiguration.copy(cConf);
+      // No mutations on tables using testCConf will succeed.
+      testCConf.setInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME, 0);
+      try (final HBaseTable failTable = new HBaseTable(CONTEXT1, spec, Collections.<String, String>emptyMap(),
+                                                       testCConf, TEST_HBASE.getConfiguration(), hBaseTableUtil)) {
+        // A put should fail
+        assertTxFail(txSystemClient, failTable, new Runnable() {
+          @Override
+          public void run() {
+            failTable.put(b("row2"), b("col1"), b("val1"));
+          }
+        });
+
+        // A delete should also fail
+        assertTxFail(txSystemClient, failTable, new Runnable() {
+          @Override
+          public void run() {
+            failTable.delete(b("row1"));
+          }
+        });
+
+        assertTxFail(txSystemClient, failTable, new Runnable() {
+          @Override
+          public void run() {
+            failTable.delete(b("row1"), b("col1"));
+          }
+        });
+
+        // So should an increment
+        assertTxFail(txSystemClient, failTable, new Runnable() {
+          @Override
+          public void run() {
+            failTable.increment(b("inc1"), b("col1"), 10);
+          }
+        });
+
+        // incrementAndGet gets converted to a put internally
+        assertTxFail(txSystemClient, failTable, new Runnable() {
+          @Override
+          public void run() {
+            failTable.incrementAndGet(b("inc1"), b("col1"), 10);
+          }
+        });
+      }
+
+      // Even safe increments should fail (this happens when readless increment is done from a mapreduce job)
+      try (final HBaseTable failTable =
+             new HBaseTable(CONTEXT1, spec, ImmutableMap.of(HBaseTable.SAFE_INCREMENTS, "true"),
+                            testCConf, TEST_HBASE.getConfiguration(), hBaseTableUtil)) {
+        // So should an increment
+        assertTxFail(txSystemClient, failTable, new Runnable() {
+          @Override
+          public void run() {
+            failTable.increment(b("inc1"), b("col1"), 10);
+          }
+        });
+
+        // incrementAndGet gets converted to a put internally
+        assertTxFail(txSystemClient, failTable, new Runnable() {
+          @Override
+          public void run() {
+            failTable.incrementAndGet(b("inc1"), b("col1"), 10);
+          }
+        });
+      }
+    } finally {
+      admin.drop();
+      admin.close();
+    }
+  }
+
+  private void assertTxFail(TransactionSystemClient txSystemClient, HBaseTable table, Runnable op)
+    throws Exception {
+    Transaction tx = txSystemClient.startShort();
+    table.startTx(tx);
+    op.run();
+    try {
+      table.commitTx();
+      Assert.fail("Expected the mutation to fail due to tx max lifetime check");
+    } catch (IOException e) {
+      // Expected to fail due to tx max lifetime check
+      table.rollbackTx();
+    }
+  }
+
   /**
    * Only overrides (and delegates) the methods used by HTable.
    */

--- a/cdap-docs/tools/cdap-default/cdap-default-exclusions.txt
+++ b/cdap-docs/tools/cdap-default/cdap-default-exclusions.txt
@@ -5,6 +5,7 @@ log.process.pipeline.logger.cache.expiration.ms
 log.process.pipeline.logger.cache.size
 log.saver.status.bind.address
 metrics.query.bind.address
+data.tx.grace.period
 
 # Deprecated properties
 

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -169,6 +169,9 @@ public class IncrementHandler extends BaseRegionObserver {
       Result result = region.get(get);
 
       Put put = new Put(increment.getRow());
+      put.setAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY,
+                       increment.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY));
+      put.setAttribute(HBaseTable.TX_ID, increment.getAttribute(HBaseTable.TX_ID));
       for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
         byte[] family = entry.getKey();
         for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -158,6 +158,9 @@ public class IncrementHandler extends BaseRegionObserver {
     Result result = region.get(get);
 
     Put put = new Put(increment.getRow());
+    put.setAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY,
+                     increment.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY));
+    put.setAttribute(HBaseTable.TX_ID, increment.getAttribute(HBaseTable.TX_ID));
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
       byte[] family = entry.getKey();
       for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandler.java
@@ -158,6 +158,9 @@ public class IncrementHandler extends BaseRegionObserver {
     Result result = region.get(get);
 
     Put put = new Put(increment.getRow());
+    put.setAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY,
+                     increment.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY));
+    put.setAttribute(HBaseTable.TX_ID, increment.getAttribute(HBaseTable.TX_ID));
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
       byte[] family = entry.getKey();
       for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementHandler.java
@@ -158,6 +158,9 @@ public class IncrementHandler extends BaseRegionObserver {
     Result result = region.get(get);
 
     Put put = new Put(increment.getRow());
+    put.setAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY,
+                     increment.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY));
+    put.setAttribute(HBaseTable.TX_ID, increment.getAttribute(HBaseTable.TX_ID));
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
       byte[] family = entry.getKey();
       for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementHandler.java
@@ -158,6 +158,9 @@ public class IncrementHandler extends BaseRegionObserver {
     Result result = region.get(get);
 
     Put put = new Put(increment.getRow());
+    put.setAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY,
+                     increment.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY));
+    put.setAttribute(HBaseTable.TX_ID, increment.getAttribute(HBaseTable.TX_ID));
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
       byte[] family = entry.getKey();
       for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/increment/hbase11/IncrementHandler.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/increment/hbase11/IncrementHandler.java
@@ -158,6 +158,9 @@ public class IncrementHandler extends BaseRegionObserver {
     Result result = region.get(get);
 
     Put put = new Put(increment.getRow());
+    put.setAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY,
+                     increment.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY));
+    put.setAttribute(HBaseTable.TX_ID, increment.getAttribute(HBaseTable.TX_ID));
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
       byte[] family = entry.getKey();
       for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandler.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandler.java
@@ -158,6 +158,9 @@ public class IncrementHandler extends BaseRegionObserver {
     Result result = region.get(get);
 
     Put put = new Put(increment.getRow());
+    put.setAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY,
+                     increment.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY));
+    put.setAttribute(HBaseTable.TX_ID, increment.getAttribute(HBaseTable.TX_ID));
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
       byte[] family = entry.getKey();
       for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-12599
Build - https://builds.cask.co/browse/CDAP-RUT1377-6

Changes:
1. Add transaction id as an attribute into the operation, and use that to enforce the lifetime check.
2. Make data.tx.grace.period configurable for testsl
3. Fix warnings.
