### PR TITLE
[CDAP-12526] Add new configurations introduced in Tephra 0.13.0

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -666,6 +666,42 @@
   </property>
 
   <property>
+    <name>data.tx.changeset.count.limit</name>
+    <value>10000</value>
+    <description>
+      Hard limit for the number of entries in a transaction's change set;
+      if exceeded, the transaction fails.
+    </description>
+  </property>
+
+  <property>
+    <name>data.tx.changeset.count.warn.threshold</name>
+    <value>5000</value>
+    <description>
+      Soft limit for the number of entries in a transaction's change set;
+      if exceeded, a warning is logged.
+    </description>
+  </property>
+
+  <property>
+    <name>data.tx.changeset.size.limit</name>
+    <value>1000000</value>
+    <description>
+      Hard limit for the aggregate size in bytes of a transaction's change set;
+      if exceeded, the transaction fails.
+    </description>
+  </property>
+
+  <property>
+    <name>data.tx.changeset.size.warn.threshold</name>
+    <value>500000</value>
+    <description>
+      Soft limit for the aggregate size in bytes of a transaction's change set;
+      if exceeded, a warning is logged.
+    </description>
+  </property>
+
+  <property>
     <name>data.tx.client.count</name>
     <value>50</value>
     <description>
@@ -689,6 +725,15 @@
     <description>
       Name in discovery service for the transaction service
     </description>
+  </property>
+
+  <property>
+    <name>data.tx.grace.period</name>
+    <value>86400</value>
+    <description>
+      Time in seconds used to pad transaction maximum lifetime while pruning
+    </description>
+    <final>true</final>
   </property>
 
   <property>
@@ -777,19 +822,23 @@
   </property>
 
   <property>
-    <name>data.tx.grace.period</name>
-    <value>86400</value>
-    <description>
-      Time in seconds used to pad transaction maximum lifetime while pruning
-    </description>
-    <final>true</final>
-  </property>
-
-  <property>
     <name>data.tx.pruning.plugin.class</name>
     <value>co.cask.data2.txprune.DefaultHBaseTransactionPruningPlugin</value>
     <description>
       Class name for the default transaction pruning plugin
+    </description>
+  </property>
+
+  <property>
+    <name>data.tx.retain.client.id</name>
+    <value>committed</value>
+    <description>
+      Whether and how long to retain the client id of a transaction. Valid values are:
+      "off" to disable retention of the client id; "active" to retain the client id until
+      a transaction is committed; or "committed" to retain the client id as long as its
+      change set participates in conflict detection. Retaining the client id slightly
+      increases the memory footprint of the transaction service. Client ids are never
+      retained past a restart or fail-over of the transaction manager.
     </description>
   </property>
 
@@ -938,6 +987,14 @@
   </property>
 
   <property>
+    <name>dataset.service.boss.threads</name>
+    <value>1</value>
+    <description>
+      Number of Netty service boss threads for the dataset service
+    </description>
+  </property>
+
+  <property>
     <name>dataset.service.connection.backlog</name>
     <value>20000</value>
     <description>
@@ -954,10 +1011,10 @@
   </property>
 
   <property>
-    <name>dataset.service.boss.threads</name>
-    <value>1</value>
+    <name>dataset.service.output.dir</name>
+    <value>/datasets</value>
     <description>
-      Number of Netty service boss threads for the dataset service
+      Directory where all dataset modules archives are stored
     </description>
   </property>
 
@@ -966,14 +1023,6 @@
     <value>4</value>
     <description>
       Number of Netty service worker threads for the dataset service
-    </description>
-  </property>
-
-  <property>
-    <name>dataset.service.output.dir</name>
-    <value>/datasets</value>
-    <description>
-      Directory where all dataset modules archives are stored
     </description>
   </property>
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -68,6 +68,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * Testing HA for {@link TransactionService}.
@@ -228,9 +229,15 @@ public class TransactionServiceTest {
     InMemoryTableService.drop(tableName);
   }
 
+  private static TransactionService createTxService(String zkConnectionString, int txServicePort,
+                                                    Configuration hConf, final File outPath) {
+    return createTxService(zkConnectionString, txServicePort, hConf, outPath, null);
+  }
+
   static TransactionService createTxService(String zkConnectionString, int txServicePort,
-                                             Configuration hConf, final File outPath) {
-    final CConfiguration cConf = CConfiguration.create();
+                                            Configuration hConf, final File outPath,
+                                            @Nullable CConfiguration cConfig) {
+    final CConfiguration cConf = cConfig == null ? CConfiguration.create() : cConfig;
     // tests should use the current user for HDFS
     cConf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
     cConf.set(Constants.Zookeeper.QUORUM, zkConnectionString);

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="ef8153d1670cc3885226c416ab48687f"
+DEFAULT_XML_MD5_HASH="a666558998c3f81448ff7339ec29d647"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/index.js
@@ -31,7 +31,7 @@ const PREFIX = 'features.DataPrep.Directives.Filter';
 
 const DIRECTIVES_MAP = {
   'KEEP': {
-    'EMPTY': 'filter-row-if-not-matched',
+    'EMPTY': 'filter-rows-on condition-false',
     'TEXTEXACTLY': 'filter-rows-on regex-not-match',
     'TEXTCONTAINS': 'filter-rows-on regex-not-match',
     'TEXTSTARTSWITH': 'filter-rows-on condition-false',
@@ -40,7 +40,7 @@ const DIRECTIVES_MAP = {
     'CUSTOMCONDITION': 'filter-rows-on condition-false'
   },
   'REMOVE': {
-    'EMPTY': 'filter-row-if-matched',
+    'EMPTY': 'filter-rows-on condition-true',
     'TEXTEXACTLY': 'filter-rows-on regex-match',
     'TEXTCONTAINS': 'filter-rows-on regex-match',
     'TEXTSTARTSWITH': 'filter-rows-on condition-true',
@@ -155,7 +155,7 @@ export default class FilterDirective extends Component {
 
     switch (this.state.selectedCondition) {
       case 'EMPTY':
-        directive = `${condition} ${column} ^\\s*$`;
+        directive = `${condition} ${column} == null || ${column} =~ "^\s*$"`;
         break;
       case 'TEXTCONTAINS':
         if (this.state.ignoreCase) {
@@ -225,7 +225,7 @@ export default class FilterDirective extends Component {
     return (
       <div>
         <div className="custom-condition-container">
-          <strong>{T.translate(`${PREFIX}.customconditionlabel`)}</strong>
+          <strong>{this.props.column}</strong>
           <div id="customConditionTooltip">
             <IconSVG
               name="icon-info-circle"

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -528,7 +528,6 @@ features:
           TEXTEXACTLY: value is
           TEXTREGEX: value matches regex
           TEXTSTARTSWITH: value starts with
-        customconditionlabel: 'equals to: '
         customconditiontooltiptitle: JEXL expressions
         customconditiontooltip: "A custom condition can be defined using JEXL expressions. For more details regarding JEXL, please refer to  "
         customconditiontooltiplink: JEXL Expressions


### PR DESCRIPTION
New configurations from Tephra 13:
- limits and warn thresholds for the size (number of changes and size in bytes) of a change set
- how long to retain the client id of a tx (to include it in log messages and conflict exceptions)
