### PR TITLE
[CDAP-12479, 12608] Minor DataPrep/Connections bugfixes

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -60,10 +60,6 @@ $dropdown_item_font_color: black;
         padding: 0 10px;
         width: 100%;
 
-        &.upgrade {
-          width: calc(100% - 100px);
-        }
-
         .title {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -249,7 +245,6 @@ $dropdown_item_font_color: black;
     }
 
     .action-buttons {
-      margin-top: 10px;
       width: 100%;
       display: inline-flex;
 

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
@@ -15,12 +15,15 @@
  */
 
 import React, { Component, PropTypes } from 'react';
+import T from 'i18n-react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
 import CardActionFeedback from 'components/CardActionFeedback';
 import ee from 'event-emitter';
 import {i18nPrefix, MIN_DATAPREP_VERSION, artifactName} from 'components/DataPrep';
 import MyDataPrepApi from 'api/dataprep';
+
+const PREFIX = `features.DataPrep.TopPanel.UpgradeModal`;
 
 export default class UpgradeModal extends Component {
   constructor(props) {
@@ -91,24 +94,22 @@ export default class UpgradeModal extends Component {
       content = (
         <div>
           <div className="message">
-            Are you sure you want to upgrade Data Preparation?
+            {T.translate(`${PREFIX}.confirmation`)}
           </div>
 
           <div className="action-buttons">
-            <div className="action-buttons">
-              <button
-                className="btn btn-secondary"
-                onClick={this.upgradeClick}
-              >
-                Yes
-              </button>
-              <button
-                className="btn btn-secondary"
-                onClick={this.attemptClose}
-              >
-                No
-              </button>
-            </div>
+            <button
+              className="btn btn-secondary"
+              onClick={this.upgradeClick}
+            >
+              {T.translate('commons.yesLabel')}
+            </button>
+            <button
+              className="btn btn-secondary"
+              onClick={this.attemptClose}
+            >
+              {T.translate('commons.noLabel')}
+            </button>
           </div>
         </div>
       );
@@ -123,7 +124,7 @@ export default class UpgradeModal extends Component {
       >
         <ModalHeader>
           <span>
-            Upgrade Data Preparation
+            {T.translate(`${PREFIX}.modalHeader`)}
           </span>
           {
             this.state.loading ? null : (

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -28,7 +28,6 @@ import T from 'i18n-react';
 import isNil from 'lodash/isNil';
 import CreateDatasetBtn from 'components/DataPrep/TopPanel/CreateDatasetBtn';
 import {Switch} from 'components/DataPrep/DataPrepContentWrapper';
-import classnames from 'classnames';
 import {UncontrolledDropdown} from 'components/UncontrolledComponents';
 import { DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 import IconSVG from 'components/IconSVG';
@@ -178,7 +177,7 @@ export default class DataPrepTopPanel extends Component {
     if (info) {
       if (info.properties.connection === 'file') {
         return (
-          <div className={classnames("data-prep-name", {"upgrade": this.state.higherVersion})}>
+          <div className="data-prep-name">
             <div className="connection-type">
               {T.translate(`${PREFIX}.file`)}
             </div>
@@ -192,7 +191,7 @@ export default class DataPrepTopPanel extends Component {
         );
       } else if (info.properties.connection === 'database') {
         return (
-          <div className={classnames("data-prep-name", {"upgrade": this.state.higherVersion})}>
+          <div className="data-prep-name">
             <div className="connection-type">
               {T.translate(`${PREFIX}.database`)}
               <span className="connection-name">{info.properties.connectionid}</span>
@@ -207,7 +206,7 @@ export default class DataPrepTopPanel extends Component {
         );
       } else if (info.properties.connection === 'upload') {
         return (
-          <div className={classnames("data-prep-name", {"upgrade": this.state.higherVersion})}>
+          <div className="data-prep-name">
             <div className="connection-type">
               {T.translate(`${PREFIX}.upload`)}
               <span className="connection-name">{info.properties.connectionid}</span>
@@ -222,7 +221,7 @@ export default class DataPrepTopPanel extends Component {
         );
       } else if (info.properties.connection === 'kafka') {
         return (
-          <div className={classnames("data-prep-name", {"upgrade": this.state.higherVersion})}>
+          <div className="data-prep-name">
             <div className="connection-type">
               {T.translate(`${PREFIX}.kafka`)}
             </div>
@@ -320,27 +319,27 @@ export default class DataPrepTopPanel extends Component {
     );
   }
 
+  renderUpgradeBtn() {
+    return (
+      <div className="upgrade-button">
+        <button
+          className="btn btn-info"
+          onClick={this.toggleUpgradeModal}
+        >
+          <span className="fa fa-wrench fa-fw" />
+          {T.translate(`${PREFIX}.upgradeBtnLabel`)}
+        </button>
+        {this.renderUpgradeModal()}
+      </div>
+    );
+  }
+
   render() {
     return (
       <div className="row top-panel clearfix">
         <div className="left-title">
           <div className="upper-section">
             {this.renderTopPanelDisplay()}
-
-            <div className="upgrade-button">
-              {
-                this.state.higherVersion ? (
-                  <button
-                    className="btn btn-info btn-sm"
-                    onClick={this.toggleUpgradeModal}
-                  >
-                    <span className="fa fa-wrench fa-fw" />
-                    {T.translate(`${PREFIX}.upgradeBtnLabel`)}
-                  </button>
-                ) : null
-              }
-              {this.renderUpgradeModal()}
-            </div>
           </div>
         </div>
         {
@@ -354,6 +353,12 @@ export default class DataPrepTopPanel extends Component {
           {
             this.state.onSubmitError ?
               <span className="text-danger">{this.state.onSubmitError}</span>
+            :
+              null
+          }
+          {
+            this.state.higherVersion ?
+              this.renderUpgradeBtn()
             :
               null
           }

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
@@ -139,8 +139,7 @@ export default class DatabaseDetail extends Component {
   handleChange(key, e) {
     this.setState({
       [key]: e.target.value,
-      connectionResult: null,
-      databaseList: ['', this.state.customId]
+      connectionResult: null
     });
   }
 
@@ -345,7 +344,7 @@ export default class DatabaseDetail extends Component {
             onClick={this.testConnection}
             disabled={disabled}
           >
-            Test Connection
+            {T.translate(`${PREFIX}.testConnection`)}
           </button>
 
           {

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -84,6 +84,7 @@ commons:
   market: Cask Market
   milliSecondsShortLabel: ms
   nameLabel: Name
+  noLabel: No
   notAvailable: 'N/A'
   please: Please
   resource-center: Add Entity
@@ -96,6 +97,7 @@ commons:
   typeLabel: Type
   when: When
   wrangler: Cask Wrangler
+  yesLabel: Yes
 features:
   AboutPage:
     copyright:
@@ -789,38 +791,17 @@ features:
       collapse: Collapse the side panel
       expand: Expand the side panel
     TopPanel:
-      applyBtnLabel: Apply
       addToPipelineBtnLabel: Create a Pipeline
-      database: Database
-      databaseTitle: "Table: {name}"
-      file: File System
-      invalidFieldNameMessage: Invalid column name "{fieldName}"
-      invalidFieldNameRemedies1: "Spaces and special characters other than - or _ are not allowed in column names."
-      invalidFieldNameRemedies2: "You can try to "
+      applyBtnLabel: Apply
       cleanseLinkLabel: "cleanse "
-      invalidFieldNameRemedies3: column names.
-      kafka: Kafka
-      SchemaModal:
-        defaultErrorMessage: Error generating schema.
-      PipelineModal:
-        defaultErrorMessage: Error adding to pipeline
-      realtimeDisabledTooltip: "Importing data from databases in realtime is currently not supported."
-      Tabs:
-        dataprep: Data
-        dataviz: Insights
-      title: Data Preparation
-      upgradeBtnLabel: Upgrade
-      upload: Local File Upload
-      viewSchemaBtnLabel: View Schema
       copyToCDAPDatasetBtn:
-        uploadDisabledMessage: Ingesting data from a locally uploaded file is not supported.
         btnLabel: Ingest Data
-        createBtnLabel: Ingest Data
         copyingSteps:
           Step1: 'Preparing to copy...'
           Step1Error: 'Unable to copy data.'
           Step2: 'Submitting copy task...'
           Step2Error: 'Unable to submit copy task.'
+        createBtnLabel: Ingest Data
         description: You are creating a new Dataset, select a type and enter information about this new entity
         Form:
           datasetNameLabel: Dataset Name
@@ -839,6 +820,30 @@ features:
           parquet: Parquet
         modalTitle: Ingest Data
         monitorBtnLabel: Explore Data
+        uploadDisabledMessage: Ingesting data from a locally uploaded file is not supported.
+      database: Database
+      databaseTitle: "Table: {name}"
+      file: File System
+      invalidFieldNameMessage: Invalid column name "{fieldName}"
+      invalidFieldNameRemedies1: "Spaces and special characters other than - or _ are not allowed in column names."
+      invalidFieldNameRemedies2: "You can try to "
+      invalidFieldNameRemedies3: column names.
+      kafka: Kafka
+      PipelineModal:
+        defaultErrorMessage: Error adding to pipeline
+      realtimeDisabledTooltip: "Importing data from databases in realtime is currently not supported."
+      SchemaModal:
+        defaultErrorMessage: Error generating schema.
+      Tabs:
+        dataprep: Data
+        dataviz: Insights
+      title: Data Preparation
+      upgradeBtnLabel: Upgrade
+      UpgradeModal:
+        confirmation: Are you sure you want to upgrade Data Preparation?
+        modalHeader: Upgrade Data Preparation
+      upload: Local File Upload
+      viewSchemaBtnLabel: View Schema
       WorkspaceModal:
         create: Create
         createModalTitle: Create Workspace
@@ -882,6 +887,7 @@ features:
           password: Password
           port: Port
           required: Required
+          testConnection: Test Connection
           username: Username
         DatabaseOptions:
           install: "Install Driver: "

--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
@@ -77,6 +77,7 @@ body.state-hydrator-create.state-hydrator {
             min-width: auto;
             padding: 12px 20px 10px 10px;
             display: flex;
+            flex: 0.6;
             align-items: center;
             > span.text-danger {
               margin-right: 10px;
@@ -86,6 +87,15 @@ body.state-hydrator-create.state-hydrator {
                 > button,
                 &:focus {
                   outline: none;
+                }
+              }
+            }
+            .upgrade-button {
+              .btn-info {
+                background-color: @btn-info;
+
+                &:hover {
+                  background-color: darken(@btn-info, 12%);
                 }
               }
             }

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -39,6 +39,8 @@
 @brand-warning:         rgb(244, 180, 0);   // #f4b400
 @brand-danger:          rgb(209, 86, 104);  // #d15668
 
+@btn-info:              #5bc0de;
+
 @cdap-light-grey:       #999999;
 @cdap-lighter-grey:     #eeeeee;
 @cdap-light-green:      #00C853;


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-12479
- https://issues.cask.co/browse/CDAP-12608

For CDAP-12479, in Wrangler plugin in studio, not just the alignment of Upgrade button but also the alignment of Apply button and the actions menu had to be fixed, since we added the Data viz switch in the middle of the top panel. 

For CDAP-12608, the fix was simply to not reset the `databaseList` state when we modify any of the connection properties. Not sure why we were doing that in the first place.