### PR TITLE
CDAP-12357 Log CDAP instance id when logging the transaction state cache reloaded message

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -38,6 +38,8 @@ import co.cask.cdap.data2.dataset2.lib.table.BufferingTableTest;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.increment.hbase98.IncrementHandler;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.ConfigurationReader;
+import co.cask.cdap.data2.util.hbase.ConfigurationWriter;
 import co.cask.cdap.data2.util.hbase.HBaseDDLExecutorFactory;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
@@ -125,8 +127,12 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     hBaseTableUtil = new HBaseTableUtilFactory(cConf, new SimpleNamespaceQueryAdmin()).get();
     // TODO: CDAP-1634 - Explore a way to not have every HBase test class do this.
     ddlExecutor = new HBaseDDLExecutorFactory(cConf, TEST_HBASE.getConfiguration()).get();
+    ddlExecutor.createNamespaceIfNotExists(hBaseTableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
     ddlExecutor.createNamespaceIfNotExists(hBaseTableUtil.getHBaseNamespace(NAMESPACE1));
     ddlExecutor.createNamespaceIfNotExists(hBaseTableUtil.getHBaseNamespace(NAMESPACE2));
+
+    ConfigurationWriter writer = new ConfigurationWriter(TEST_HBASE.getConfiguration(), cConf);
+    writer.write(ConfigurationReader.Type.DEFAULT, cConf);
   }
 
   @AfterClass

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCache.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCache.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.transaction.coprocessor;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.CConfigurationUtil;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.hbase.CConfigurationReader;
 import co.cask.cdap.data2.util.hbase.ConfigurationReader;
 import co.cask.cdap.data2.util.hbase.CoprocessorCConfigurationReader;
@@ -61,6 +62,9 @@ public class DefaultTransactionStateCache extends TransactionStateCache {
     CConfiguration cConf = configReader.read();
     Configuration txConf = HBaseConfiguration.create(getConf());
     CConfigurationUtil.copyTxProperties(cConf, txConf);
+
+    // Set the instance id so that it gets logged
+    setId(cConf.get(Constants.INSTANCE_NAME));
     return txConf;
   }
 }

--- a/cdap-hbase-compat-base/src/main/java/org/apache/tephra/coprocessor/TransactionStateCache.java
+++ b/cdap-hbase-compat-base/src/main/java/org/apache/tephra/coprocessor/TransactionStateCache.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.tephra.coprocessor;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tephra.TxConstants;
+import org.apache.tephra.metrics.TxMetricsCollector;
+import org.apache.tephra.persist.HDFSTransactionStateStorage;
+import org.apache.tephra.persist.TransactionStateStorage;
+import org.apache.tephra.persist.TransactionVisibilityState;
+import org.apache.tephra.snapshot.SnapshotCodecProvider;
+import org.apache.tephra.util.ConfigurationFactory;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Periodically refreshes transaction state from the latest stored snapshot.  This is implemented as a singleton
+ * to allow a single cache to be shared by all regions on a regionserver.
+ */
+public class TransactionStateCache extends AbstractIdleService implements Configurable {
+  private static final Log LOG = LogFactory.getLog(org.apache.tephra.coprocessor.TransactionStateCache.class);
+
+  // how frequently we should wake to check for changes (in seconds)
+  private static final long CHECK_FREQUENCY = 15;
+
+  private Configuration hConf;
+
+  private TransactionStateStorage storage;
+  private volatile TransactionVisibilityState latestState;
+
+  private Thread refreshService;
+  private long lastRefresh;
+  // snapshot refresh frequency in milliseconds
+  private long snapshotRefreshFrequency;
+  private boolean initialized;
+
+  public TransactionStateCache() {
+  }
+
+  @Override
+  public Configuration getConf() {
+    return hConf;
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.hConf = conf;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    try {
+      refreshState();
+    } catch (IOException ioe) {
+      LOG.info("Error refreshing transaction state cache.", ioe);
+    }
+    startRefreshService();
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (refreshService != null) {
+      refreshService.interrupt();
+    }
+
+    if (storage != null) {
+      storage.stop();
+    }
+  }
+
+  /**
+   * Try to initialize the Configuration and TransactionStateStorage instances.  Obtaining the Configuration may
+   * fail until ReactorServiceMain has been started.
+   */
+  private void tryInit() {
+    try {
+      Configuration conf = getSnapshotConfiguration();
+      if (conf != null) {
+        // Since this is only used for background loading of transaction snapshots, we use the no-op metrics collector,
+        // as there are no relevant metrics to report
+        this.storage = new HDFSTransactionStateStorage(conf, new SnapshotCodecProvider(conf),
+                                                       new TxMetricsCollector());
+        this.storage.startAndWait();
+        this.snapshotRefreshFrequency = conf.getLong(TxConstants.Manager.CFG_TX_SNAPSHOT_INTERVAL,
+                                                     TxConstants.Manager.DEFAULT_TX_SNAPSHOT_INTERVAL) * 1000;
+        this.initialized = true;
+      } else {
+        LOG.info("Could not load configuration");
+      }
+    } catch (Exception e) {
+      LOG.info("Failed to initialize TransactionStateCache due to: ", e);
+    }
+  }
+
+  protected Configuration getSnapshotConfiguration() throws IOException {
+    Configuration conf = new ConfigurationFactory().get(hConf);
+    conf.unset(TxConstants.Persist.CFG_TX_SNAPHOT_CODEC_CLASSES);
+    return conf;
+  }
+
+  private void reset() {
+    this.storage.stop();
+    this.lastRefresh = 0;
+    this.initialized = false;
+  }
+
+  private void startRefreshService() {
+    this.refreshService = new Thread("tx-state-refresh") {
+      @Override
+      public void run() {
+        while (!isInterrupted()) {
+          if (latestState == null || System.currentTimeMillis() > (lastRefresh + snapshotRefreshFrequency)) {
+            try {
+              refreshState();
+            } catch (IOException ioe) {
+              LOG.info("Error refreshing transaction state cache.", ioe);
+            }
+          }
+          try {
+            TimeUnit.SECONDS.sleep(CHECK_FREQUENCY);
+          } catch (InterruptedException ie) {
+            // reset status
+            interrupt();
+            break;
+          }
+        }
+        LOG.info("Exiting thread " + getName());
+      }
+    };
+    this.refreshService.setDaemon(true);
+    this.refreshService.start();
+  }
+
+  private void refreshState() throws IOException {
+    if (!initialized) {
+      tryInit();
+    }
+
+    // only continue if initialization was successful
+    if (initialized) {
+      long now = System.currentTimeMillis();
+      TransactionVisibilityState currentState = storage.getLatestTransactionVisibilityState();
+      if (currentState != null) {
+        if (currentState.getTimestamp() < (now - 2 * snapshotRefreshFrequency)) {
+          LOG.info("Current snapshot is old, will force a refresh on next run.");
+          reset();
+        } else {
+          latestState = currentState;
+          LOG.info("Transaction state reloaded with snapshot from " + latestState.getTimestamp());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Latest transaction snapshot: " + latestState.toString());
+          }
+          lastRefresh = now;
+        }
+      } else {
+        LOG.info("No transaction state found.");
+      }
+    }
+  }
+
+  @Nullable
+  public TransactionVisibilityState getLatestState() {
+    return latestState;
+  }
+}


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-12357
Build - https://builds.cask.co/browse/CDAP-RUT1384-2

Tried the approach of creating a wrapping logger that prepends the instance id to the log message. However HBase uses apache-commons-logging and I could not figure out how to exclude the caller class from the stack trace. I have filed Tephra JIRA https://issues.apache.org/jira/browse/TEPHRA-266 for a comprehensive fix for all co-processor classes. We can work on a better solution when implementing that JIRA.

The output log will be -
```
2017-09-19 00:24:31,882 - INFO  [tx-state-refresh:o.a.t.c.TransactionStateCache$1@134] - [cdap] Error refreshing transaction state cache.
```
Here, `[cdap]` is the instance id.
