### PR TITLE
(CDAP-12623) Wrap Errors with Exception in service startup call.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -625,9 +625,10 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
           try {
             //noinspection unchecked
             program.initialize((T) AbstractContext.this);
-          } catch (LinkageError e) {
-            // Need to wrap LinkageError. Otherwise, listeners of this Guava Service may not be called if the
-            // initialization of the user program is missing dependencies (CDAP-2543)
+          } catch (Error e) {
+            // Need to wrap Error. Otherwise, listeners of this Guava Service may not be called if the
+            // initialization of the user program is missing dependencies (CDAP-2543).
+            // Guava 15.0+ have this condition fixed, hence wrapping is no longer needed if upgrade to later Guava.
             throw new Exception(e.getMessage(), e);
           }
         }

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -320,12 +320,14 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
           return sparkSubmitter.submit(runtimeContext, configs, localizeResources, jobFile, runtimeContext.getRunId());
         }
       };
-    } catch (LinkageError e) {
-      // Need to wrap LinkageError. Otherwise, listeners of this Guava Service may not be called if the initialization
-      // of the user program is missing dependencies (CDAP-2543)
-      throw new Exception(e.getMessage(), e);
     } catch (Throwable t) {
       cleanupTask.run();
+      if (t instanceof Error) {
+        // Need to wrap Error. Otherwise, listeners of this Guava Service may not be called if the
+        // initialization of the user program is missing dependencies (CDAP-2543).
+        // Guava 15.0+ have this condition fixed, hence wrapping is no longer needed if upgrade to later Guava.
+        throw new Exception(t);
+      }
       throw t;
     }
   }


### PR DESCRIPTION
If not, it terminates the Service listener chains.
This is a wrong behavior in Guava 13 which get fixed in Guava 15