### PR TITLE
Updates cask-datavoyager fixing fixing layout issue + passing vegalite config to voyager

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -96,7 +96,7 @@
     "babel-polyfill": "6.16.0",
     "body-parser": "1.14.2",
     "bootstrap": "4.0.0-alpha.5",
-    "cask-datavoyager": "2.0.0-alpha.12.4",
+    "cask-datavoyager": "2.0.0-alpha.12.5",
     "cdap-avsc": "4.1.12",
     "classnames": "2.2.5",
     "clipboard": "1.7.1",


### PR DESCRIPTION
#### Issue:
  - onMouseOver on vega-lite charts the charts update to dynamically change height and width of the charts. This is incorrect as now the UI becomes too jumpy with charts going up and down on hover.

#### Fix:
  - The way we pass vega-lite config to voyager seems to be incorrect causing the parent component for chart to update frequently thereby causing chart dimension to change on hover. The commit mentioned below fixes this issue so that the charts remain with same height and width on hover.

Corresponding changes in voyager project: https://github.com/ajainarayanan/voyager/commit/7d09026eb110ffeb045177e004e10376182be43a