### PR TITLE
CDAP-12525 Wait for Schedulers to be started before running migration.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DistributedSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DistributedSchedulerService.java
@@ -27,6 +27,7 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -36,11 +37,13 @@ public final class DistributedSchedulerService extends AbstractSchedulerService 
 
   private static final Logger LOG = LoggerFactory.getLogger(DistributedSchedulerService.class);
   private final Service serviceDelegate;
+  private final CountDownLatch startUpLatch;
 
   @Inject
   public DistributedSchedulerService(TimeScheduler timeScheduler, StreamSizeScheduler streamSizeScheduler,
                                      Store store) {
     super(timeScheduler, streamSizeScheduler, store);
+    this.startUpLatch = new CountDownLatch(1);
     this.serviceDelegate = new RetryOnStartFailureService(new Supplier<Service>() {
       @Override
       public Service get() {
@@ -50,6 +53,7 @@ public final class DistributedSchedulerService extends AbstractSchedulerService 
             try {
               startSchedulers();
               notifyStarted();
+              startUpLatch.countDown();
             } catch (ServiceUnavailableException e) {
               // This is expected during startup. Log with a debug without the stacktrace
               LOG.debug("Service not available for schedule to start due to {}", e.getMessage());
@@ -77,7 +81,9 @@ public final class DistributedSchedulerService extends AbstractSchedulerService 
   @Override
   protected void startUp() throws Exception {
     LOG.info("Starting scheduler.");
+    // RetryOnStartFailureservice#startAndWait returns before its service's startAndWait completes
     serviceDelegate.startAndWait();
+    startUpLatch.await();
   }
 
   @Override


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12525

Wait for Schedulers to be started before running migration. Otherwise, when the Migration runs (executed in CoreSchedulerService), the scheduler may not have started yet.

https://builds.cask.co/browse/CDAP-RUT1403-1
Integration tests: https://builds.cask.co/browse/CDAP-ITM19-36