### PR TITLE
CDAP-12599 Fix test failure due to a merge race.

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -38,8 +38,6 @@ import co.cask.cdap.data2.dataset2.lib.table.BufferingTableTest;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.increment.hbase98.IncrementHandler;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.data2.util.hbase.ConfigurationReader;
-import co.cask.cdap.data2.util.hbase.ConfigurationWriter;
 import co.cask.cdap.data2.util.hbase.HBaseDDLExecutorFactory;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
@@ -127,12 +125,8 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     hBaseTableUtil = new HBaseTableUtilFactory(cConf, new SimpleNamespaceQueryAdmin()).get();
     // TODO: CDAP-1634 - Explore a way to not have every HBase test class do this.
     ddlExecutor = new HBaseDDLExecutorFactory(cConf, TEST_HBASE.getConfiguration()).get();
-    ddlExecutor.createNamespaceIfNotExists(hBaseTableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
     ddlExecutor.createNamespaceIfNotExists(hBaseTableUtil.getHBaseNamespace(NAMESPACE1));
     ddlExecutor.createNamespaceIfNotExists(hBaseTableUtil.getHBaseNamespace(NAMESPACE2));
-
-    ConfigurationWriter writer = new ConfigurationWriter(TEST_HBASE.getConfiguration(), cConf);
-    writer.write(ConfigurationReader.Type.DEFAULT, cConf);
   }
 
   @AfterClass


### PR DESCRIPTION
Another PR (https://github.com/caskdata/cdap/pull/9635) updated the same test setup to write cConf into config table,
which fails testEnforceTxLifetime() test. The setup change is not really required.