### PR TITLE
Fixes updating properties of a workspace on refresh to avoid overwriting directives

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/store/DataPrepActionCreator.js
+++ b/cdap-ui/app/cdap/components/DataPrep/store/DataPrepActionCreator.js
@@ -181,8 +181,8 @@ export function updateWorkspaceProperties() {
     );
 }
 function checkAndUpdateExistingWorkspaceProperties() {
-  let {workspaceId} = DataPrepStore.getState().dataprep;
-  if (!workspaceId) {
+  let {workspaceId, workspaceInfo} = DataPrepStore.getState().dataprep;
+  if (!workspaceId || !workspaceInfo) {
     return;
   }
   updateWorkspaceProperties();


### PR DESCRIPTION
#### Issue:
- On repeated refresh UI overwrites directives applied on a workspace

#### Cause:
 - We added dataprep visualization and it doesn't have a "Save" button which means it is implied that everything is saved.
 - Current behavior is,
   - On refresh save,
   - On tab switch save
- When we refresh we go through the same flow of updating properties of a workspace.
- There is a timing issue here where workspace info is not available yet and we overwrite it with empty values. This is what causes directives to be overwritten

#### Fix:
 - Before updating workspace check if all the workspace information is available before updating.

