### PR TITLE
CDAP-7243 Service to delete the local datasets periodically.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/LocalDatasetDeleterRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/LocalDatasetDeleterRunnable.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime;
+
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.service.Retries;
+import co.cask.cdap.common.service.RetryStrategies;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class responsible for deleting the local datasets associated with the completed, failed, or killed workflow runs.
+ */
+public class LocalDatasetDeleterRunnable implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(LocalDatasetDeleterRunnable.class);
+  private static final Map<String, String> PROPERTIES =
+    Collections.singletonMap(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY, Boolean.toString(true));
+  private final NamespaceAdmin namespaceAdmin;
+  private final Store store;
+  private final DatasetFramework datasetFramework;
+
+  public LocalDatasetDeleterRunnable(NamespaceAdmin namespaceAdmin, Store store, DatasetFramework datasetFramework) {
+    this.namespaceAdmin = namespaceAdmin;
+    this.store = store;
+    this.datasetFramework = datasetFramework;
+  }
+
+  @Override
+  public void run() {
+    try {
+      List<NamespaceMeta> list = namespaceAdmin.list();
+      for (NamespaceMeta namespaceMeta : list) {
+        Collection<DatasetSpecificationSummary> specs
+          = datasetFramework.getInstances(namespaceMeta.getNamespaceId(), PROPERTIES);
+
+        if (specs.isEmpty()) {
+          // avoid fetching run records
+          continue;
+        }
+        Set<String> activeRuns = getActiveRuns(namespaceMeta.getNamespaceId());
+        for (DatasetSpecificationSummary spec : specs) {
+          deleteLocalDataset(namespaceMeta.getName(), spec.getName(), activeRuns, spec.getProperties());
+        }
+      }
+    } catch (Throwable t) {
+      LOG.warn("Failed to delete the local datasets.", t);
+    }
+  }
+
+  private Set<String> getActiveRuns(NamespaceId namespaceId) {
+    Map<ProgramRunId, RunRecordMeta> activeRuns = store.getActiveRuns(namespaceId);
+    Set<String> runs = new HashSet<>();
+    for (Map.Entry<ProgramRunId, RunRecordMeta> entry : activeRuns.entrySet()) {
+      runs.add(entry.getValue().getPid());
+    }
+    return runs;
+  }
+
+  private void deleteLocalDataset(final String namespaceName, final String datasetName, Set<String> activeRuns,
+                                  Map<String, String> properties)
+    throws Exception {
+    String[] split = datasetName.split("\\.");
+    String runId = split[split.length - 1];
+
+    if (activeRuns.contains(runId)
+      || Boolean.parseBoolean(properties.get(Constants.AppFabric.WORKFLOW_KEEP_LOCAL))) {
+      return;
+    }
+
+    final DatasetId datasetId = new DatasetId(namespaceName, datasetName);
+    try {
+      Retries.callWithRetries(new Retries.Callable<Void, Exception>() {
+        @Override
+        public Void call() throws Exception {
+          datasetFramework.deleteInstance(datasetId);
+          LOG.info("Deleted local dataset instance {}", datasetId);
+          return null;
+        }
+      }, RetryStrategies.fixDelay(Constants.Retry.LOCAL_DATASET_OPERATION_RETRY_DELAY_SECONDS, TimeUnit.SECONDS));
+    } catch (Exception e) {
+      LOG.warn("Failed to delete the Workflow local dataset instance {}", datasetId, e);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DistributedRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DistributedRunRecordCorrectorService.java
@@ -21,6 +21,8 @@ import co.cask.cdap.app.runtime.ProgramStateWriter;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
@@ -41,8 +43,9 @@ public class DistributedRunRecordCorrectorService extends RunRecordCorrectorServ
 
   @Inject
   DistributedRunRecordCorrectorService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
-                                       ProgramRuntimeService runtimeService) {
-    super(cConf, store, programStateWriter, runtimeService);
+                                       ProgramRuntimeService runtimeService, NamespaceAdmin namespaceAdmin,
+                                       DatasetFramework datasetFramework) {
+    super(cConf, store, programStateWriter, runtimeService, namespaceAdmin, datasetFramework);
     this.cConf = cConf;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/LocalRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/LocalRunRecordCorrectorService.java
@@ -20,6 +20,8 @@ import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.runtime.ProgramStateWriter;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import com.google.inject.Inject;
 
 /**
@@ -29,8 +31,9 @@ public class LocalRunRecordCorrectorService extends RunRecordCorrectorService {
 
   @Inject
   LocalRunRecordCorrectorService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
-                                 ProgramRuntimeService runtimeService) {
-    super(cConf, store, programStateWriter, runtimeService);
+                                 ProgramRuntimeService runtimeService, NamespaceAdmin namespaceAdmin,
+                                 DatasetFramework datasetFramework) {
+    super(cConf, store, programStateWriter, runtimeService, namespaceAdmin, datasetFramework);
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithLocalDataset.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithLocalDataset.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.customaction.AbstractCustomAction;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+
+/**
+ * App with local dataset.
+ */
+public class WorkflowAppWithLocalDataset extends AbstractApplication {
+  public static final String APP_NAME = "WorkflowAppWithLocalDataset";
+  public static final String WORKFLOW_NAME = "WorkflowWithLocalDataset";
+  @Override
+  public void configure() {
+    addWorkflow(new WorkflowWithLocalDataset());
+  }
+
+  /**
+   * Workflow with local dataset.
+   */
+  public static class WorkflowWithLocalDataset extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      createLocalDataset("testdataset", Table.class);
+      addAction(new MyCustomAction());
+    }
+  }
+
+  /**
+   * Custom action in the Workflow which does nothing
+   */
+  public static class MyCustomAction extends AbstractCustomAction {
+
+    @Override
+    public void run() throws Exception {
+      // no-op
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -180,6 +180,9 @@ public final class Constants {
     public static final String MAPREDUCE_STATUS_REPORT_INTERVAL_SECONDS = "mapreduce.status.report.interval.seconds";
     public static final String PROGRAM_RUNID_CORRECTOR_INTERVAL_SECONDS = "app.program.runid.corrector.interval";
     public static final String PROGRAM_RUNID_CORRECTOR_TX_BATCH_SIZE = "app.program.runid.corrector.tx.batch.size";
+    public static final String LOCAL_DATASET_DELETER_INTERVAL_SECONDS = "app.program.local.dataset.deleter.interval";
+    public static final String LOCAL_DATASET_DELETER_INITIAL_DELAY_SECONDS
+      = "app.program.local.dataset.deleter.initial.delay";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String PROGRAM_EXTRA_CLASSPATH = "app.program.extra.classpath";
     public static final String SPARK_YARN_CLIENT_REWRITE = "app.program.spark.yarn.client.rewrite.enabled";
@@ -233,6 +236,18 @@ public final class Constants {
      * Name of the property used to identify whether the dataset is local or not.
      */
     public static final String WORKFLOW_LOCAL_DATASET_PROPERTY = "workflow.local.dataset";
+
+    public static final String WORKFLOW_NAMESPACE_NAME = "workflow.namespace.name";
+
+    public static final String WORKFLOW_APPLICATION_NAME = "workflow.application.name";
+
+    public static final String WORKFLOW_APPLICATION_VERSION = "workflow.application.version";
+
+    public static final String WORKFLOW_PROGRAM_NAME = "workflow.program.name";
+
+    public static final String WORKFLOW_RUN_ID = "workflow.run.id";
+
+    public static final String WORKFLOW_KEEP_LOCAL = "workflow.keep.local";
 
     /**
      * Configuration setting to localize extra jars to every program container and to be

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -411,6 +411,24 @@
   </property>
 
   <property>
+    <name>app.program.local.dataset.deleter.initial.delay</name>
+    <value>300</value>
+    <description>
+      Interval in seconds for initial delay for the local dataset deletion thread;
+      this value should be greater than 0
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.local.dataset.deleter.interval</name>
+    <value>3600</value>
+    <description>
+      Interval in seconds of how often the local dataset deletion thread will run;
+      this value should be greater than 0
+    </description>
+  </property>
+
+  <property>
     <name>app.program.runtime.extensions.dir</name>
     <value>/opt/cdap/master/ext/runtimes</value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="ea4fe5080d12cc55acb1027fb1aaadd8"
+DEFAULT_XML_MD5_HASH="3726f82c8b0f6ec897549098c78d9b7b"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Opening from #9610 with conflicts resolved.
JIRA - https://issues.cask.co/browse/CDAP-7243
In this PR -

1. Renamed `RunRecordCorrectorService` to `RunFixerService` so that multiple inconsistencies can be fixed rather than just fixing the run record.
Edit (ali): I undid this change.

2. Added new thread which will run the `LocalDatasetDeleterRunnable` by default every 3600 seconds.

3. `LocalDatasetDeleterRunnable` during each run
 - get list of namespaces
 - for each namespace gets the running runs and also all local datasets in the namespace using dataset framework
- figures the runid from the local dataset name
- delete the dataset if run is not running and keep.local is false