### PR TITLE
[CDAP-12656] Fix Dataprep Visualization for empty data

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
@@ -29,12 +29,14 @@ import T from 'i18n-react';
 require('./DataPrepContentWrapper.scss');
 
 const PREFIX = 'features.DataPrep.TopPanel';
-
-const DEFAULTSTORESTATE = {view: 'data'};
-const view = (state = 'data', action = defaultAction) => {
+const DEFAULTVIEW = 'data';
+const DEFAULTSTORESTATE = {view: DEFAULTVIEW};
+const view = (state = DEFAULTVIEW, action = defaultAction) => {
   switch (action.type) {
     case 'SETVIEW':
       return action.payload.view || state;
+    case 'RESET':
+      return DEFAULTVIEW;
     default:
       return state;
   }
@@ -111,6 +113,9 @@ export default class DataPrepContentWrapper extends Component {
 
   componentWillUnmount() {
     if (this.viewStoreSubscription) {
+      ViewStore.dispatch({
+        type: 'RESET'
+      });
       this.viewStoreSubscription();
     }
   }

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepVisualization/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepVisualization/index.js
@@ -106,7 +106,7 @@ export default class DataPrepVisualization extends Component {
       let {dataprep} = DataPrepStore.getState();
       let properties = dataprep.properties || {};
       let visualization = properties.visualization || {};
-      if (!localData || !this.isArrayEqual(dataprep.data, localData)) {
+      if (!localData || dataprep.data.length !== localData.length || !this.isArrayEqual(localData, dataprep.data)) {
         if (!Object.keys(visualization).length) {
           this.voyagerInstance.updateData({
             values: dataprep.data

--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -177,6 +177,9 @@ export default class DataPrepHome extends Component {
     let namespace = NamespaceStore.getState().selectedNamespace;
 
     this.workspaceListRetries = 0;
+    DataPrepStore.dispatch({
+      type: DataPrepActions.reset
+    });
     this.updateWorkspaceListRetry(namespace);
   }
 


### PR DESCRIPTION
### Issue:
- While switching between dataprep workspace tabs if a particular workspace didn't have any data the visualization would not reflect it.
- While navigating in and out of data preparation we don't maintain correct state of the data/insights tab. 
  ##### Steps to reproduce:
    - Go to Dataprep workspace 
    - Switch to Insights tab in the workspace
    - Click on Control Center in navbar
    - Now go back to Dataprep.
  After the last step the tabs inside the workspace highlight insights but show data table.
- On deleting workspace the deleted workspace information is still preset in UI which is then being used by the visualization component to update the workspace properties. This is wrong as it will write properties of one workspace to another.

### Fix:
- Fix difference in data check while switching between empty workspace and a workspace with some data
- Fix the state of switch to be reset to data when navigating away from dataprep.
- Reset dataprep store on workspace delete.