### PR TITLE
[CDAP-12526] Upgrade to Apache Tephra 0.13.0-incubating

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <snappy.version>1.1.1.7</snappy.version>
     <spark1.version>1.6.1</spark1.version>
     <spark2.version>2.1.0</spark2.version>
-    <tephra.version>0.13.0-incubating-SNAPSHOT</tephra.version>
+    <tephra.version>0.13.0-incubating</tephra.version>
     <tez.version>0.8.4</tez.version>
     <thrift.version>0.9.3</thrift.version>
     <twill.version>0.12.0</twill.version>


### PR DESCRIPTION
Now that tephra-0.13 is released, we can upgrade to it and remove the snapshot.