### PR TITLE
Migrating React.PropTypes to PropTypes standalone module

### DIFF
--- a/cdap-ui/app/cdap/components/404/index.js
+++ b/cdap-ui/app/cdap/components/404/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {Link} from 'react-router-dom';
 import NamespaceStore from 'services/NamespaceStore';
 import isEmpty from 'lodash/isEmpty';

--- a/cdap-ui/app/cdap/components/AbsLinkTo/index.js
+++ b/cdap-ui/app/cdap/components/AbsLinkTo/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 export default function AbsLinkTo({context, linkLabel, className, children}) {
   return (

--- a/cdap-ui/app/cdap/components/AbstractWizard/index.js
+++ b/cdap-ui/app/cdap/components/AbstractWizard/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import StreamCreateWizard from 'components/CaskWizards/StreamCreate';
 import UploadDataWizard from 'components/CaskWizards/UploadData';
 import UploadDataUsecaseWizard from 'components/CaskWizards/UploadDataUsecase';

--- a/cdap-ui/app/cdap/components/AdminConfigurePane/index.js
+++ b/cdap-ui/app/cdap/components/AdminConfigurePane/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import ConfigureButton from '../ConfigureButton';
 import shortid from 'shortid';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/AdminOverviewPane/index.js
+++ b/cdap-ui/app/cdap/components/AdminOverviewPane/index.js
@@ -14,7 +14,8 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 require('./AdminOverviewPane.scss');
 import OverviewPaneCard from '../OverviewPaneCard/index.js';
 var shortid = require('shortid');

--- a/cdap-ui/app/cdap/components/Administration/PlatformsDetails/Genericdetails.js
+++ b/cdap-ui/app/cdap/components/Administration/PlatformsDetails/Genericdetails.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import RenderObjectAsTable from 'components/RenderObjectAsTable';
 import capitalize from 'lodash/capitalize';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/Administration/PlatformsDetails/index.js
+++ b/cdap-ui/app/cdap/components/Administration/PlatformsDetails/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { TabContent, TabPane, Nav, NavItem, NavLink } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/Alert/index.js
+++ b/cdap-ui/app/cdap/components/Alert/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal} from 'reactstrap';
 require('./Alert.scss');
 

--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyProgramApi} from 'api/program';
 import {convertProgramToApi} from 'services/program-api-converter';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/PropertiesTab.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/PropertiesTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import PropertiesEditor from 'components/PropertiesEditor';
 import T from 'i18n-react';
 

--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/index.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Nav, NavItem, NavLink, TabContent} from 'reactstrap';
 import ProgramTab from 'components/Overview/Tabs/ProgramTab';
 import DatasetTab from 'components/Overview/Tabs/DatasetTab';

--- a/cdap-ui/app/cdap/components/AppDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {objectQuery} from 'services/helpers';
 import {MyAppApi} from 'api/app';
 import ExploreTablesStore from 'services/ExploreTables/ExploreTablesStore';

--- a/cdap-ui/app/cdap/components/BreadCrumb/index.js
+++ b/cdap-ui/app/cdap/components/BreadCrumb/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import IconSVG from 'components/IconSVG';
 import {Link} from 'react-router-dom';
 require('./BreadCrumb.scss');

--- a/cdap-ui/app/cdap/components/Card/index.js
+++ b/cdap-ui/app/cdap/components/Card/index.js
@@ -33,7 +33,9 @@
     </Card>
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 require('./Card.scss');
 
 var classNames = require('classnames');

--- a/cdap-ui/app/cdap/components/CardActionFeedback/index.js
+++ b/cdap-ui/app/cdap/components/CardActionFeedback/index.js
@@ -22,7 +22,9 @@
       extendedMessage='stack trace message that will get rendered in <pre>'
     />
 */
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 require('./CardActionFeedback.scss');
 import isObject from 'lodash/isObject';
 

--- a/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import AddNamespaceStore from 'services/WizardStores/AddNamespace/AddNamespaceStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/ApplicationUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/ApplicationUpload/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';

--- a/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/UploadStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/UploadStep/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect, Provider } from 'react-redux';
 import ArtifactUploadStore from 'services/WizardStores/ArtifactUpload/ArtifactUploadStore';
 import ArtifactUploadActions from 'services/WizardStores/ArtifactUpload/ArtifactUploadActions';

--- a/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import ArtifactUploadWizardConfig from 'services/WizardConfigs/ArtifactUploadWizardConfig';

--- a/cdap-ui/app/cdap/components/CaskWizards/Informational/ShowInfo/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/Informational/ShowInfo/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect, Provider } from 'react-redux';
 import InformationalWizardStore from 'services/WizardStores/Informational/InformationalStore';
 require('./ShowInfo.scss');

--- a/cdap-ui/app/cdap/components/CaskWizards/Informational/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/Informational/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import InformationalWizardConfig from 'services/WizardConfigs/InformationalWizardConfig';

--- a/cdap-ui/app/cdap/components/CaskWizards/LibraryUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/LibraryUpload/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import LibraryUploadWizardConfig from 'services/WizardConfigs/LibraryUploadWizardConfig';

--- a/cdap-ui/app/cdap/components/CaskWizards/LicenseStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/LicenseStep/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyMarketApi} from 'api/market';
 import T from 'i18n-react';
 require('./LicenseStep.scss');

--- a/cdap-ui/app/cdap/components/CaskWizards/MarketArtifactUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/MarketArtifactUpload/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import ArtifactUploadWizard from 'components/CaskWizards/ArtifactUpload';
 import ArtifactUploadStore from 'services/WizardStores/ArtifactUpload/ArtifactUploadStore';
 import ArtifactUploadActions from 'services/WizardStores/ArtifactUpload/ArtifactUploadActions';

--- a/cdap-ui/app/cdap/components/CaskWizards/MarketHydratorPluginUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/MarketHydratorPluginUpload/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import MarketPluginArtifactUploadWizardConfig from 'services/WizardConfigs/MarketPluginArtifactUploadWizardConfig';

--- a/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/ConfigureStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/ConfigureStep/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect, Provider } from 'react-redux';
 import MicroserviceUploadStore from 'services/WizardStores/MicroserviceUpload/MicroserviceUploadStore';
 import MicroserviceUploadActions from 'services/WizardStores/MicroserviceUpload/MicroserviceUploadActions';

--- a/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/GeneralInfoStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/GeneralInfoStep/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect, Provider } from 'react-redux';
 import MicroserviceUploadActions  from 'services/WizardStores/MicroserviceUpload/MicroserviceUploadActions';
 import MicroserviceUploadStore from 'services/WizardStores/MicroserviceUpload/MicroserviceUploadStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/MicroserviceQueue.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/MicroserviceQueue.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Col, FormGroup, Label, Form, Input} from 'reactstrap';
 import {defaultQueueTypes} from 'services/WizardStores/MicroserviceUpload/MicroserviceQueueStore';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/MicroserviceQueueEditor.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/MicroserviceQueueEditor.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect, Provider } from 'react-redux';
 import MicroserviceQueueActions from 'services/WizardStores/MicroserviceUpload/MicroserviceQueueActions';
 import {createMicroserviceQueueStore} from 'services/WizardStores/MicroserviceUpload/MicroserviceQueueStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/MicroserviceUpload/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import Rx from 'rx';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';

--- a/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployApp.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployApp.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import OneStepDeployStore from 'services/WizardStores/OneStepDeploy/OneStepDeployStore';
 import OneStepDeployActions from 'services/WizardStores/OneStepDeploy/OneStepDeployActions';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployAppUsecase.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployAppUsecase.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import OneStepDeployApp from 'components/CaskWizards/OneStepDeploy/OneStepDeployApp';
 
 export default function OneStepDeployAppUsecase({input, onClose, isOpen}) {

--- a/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployPlugin.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployPlugin.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import OneStepDeployStore from 'services/WizardStores/OneStepDeploy/OneStepDeployStore';
 import OneStepDeployActions from 'services/WizardStores/OneStepDeploy/OneStepDeployActions';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployPluginUsecase.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/OneStepDeployPluginUsecase.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import OneStepDeployPlugin from 'components/CaskWizards/OneStepDeploy/OneStepDeployPlugin';
 
 export default function OneStepDeployPluginUsecase({input, onClose, isOpen}) {

--- a/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/OneStepDeploy/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import OneStepDeployAppConfig from 'services/WizardConfigs/OneStepDeployAppConfig';
 import OneStepDeployPluginConfig from 'services/WizardConfigs/OneStepDeployPluginConfig';
 import OneStepDeployStore from 'services/WizardStores/OneStepDeploy/OneStepDeployStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/UploadJarStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/UploadJarStep/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect, Provider } from 'react-redux';
 import PluginArtifactUploadStore from 'services/WizardStores/PluginArtifactUpload/PluginArtifactUploadStore';
 import PluginArtifactUploadActions from 'services/WizardStores/PluginArtifactUpload/PluginArtifactUploadActions';

--- a/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/UploadJsonStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/UploadJsonStep/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect, Provider } from 'react-redux';
 import PluginArtifactUploadStore from 'services/WizardStores/PluginArtifactUpload/PluginArtifactUploadStore';
 import PluginArtifactUploadActions from 'services/WizardStores/PluginArtifactUpload/PluginArtifactUploadActions';

--- a/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import PluginArtifactUploadWizardConfig from 'services/WizardConfigs/PluginArtifactUploadWizardConfig';

--- a/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import PublishPipelineWizardStore from 'services/WizardStores/PublishPipeline/PublishPipelineStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/PublishPipelineUsecase/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PublishPipelineUsecase/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import PublishPipelineWizard from 'components/CaskWizards/PublishPipeline';
 
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/CaskWizards/StreamCreate/ThresholdStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/StreamCreate/ThresholdStep/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect, Provider} from 'react-redux';
 import {Input, FormGroup, Form, Col} from 'reactstrap';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/CaskWizards/StreamCreate/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/StreamCreate/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import CreateStreamStore from 'services/WizardStores/CreateStream/CreateStreamStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/StreamCreateWithUpload/ThresholdStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/StreamCreateWithUpload/ThresholdStep/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect, Provider} from 'react-redux';
 import {Input, FormGroup, Form} from 'reactstrap';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/CaskWizards/StreamCreateWithUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/StreamCreateWithUpload/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import CreateStreamWithUploadStore from 'services/WizardStores/CreateStreamWithUpload/CreateStreamWithUploadStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/UploadData/SelectDestination/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/UploadData/SelectDestination/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect, Provider } from 'react-redux';
 import UploadDataStore from 'services/WizardStores/UploadData/UploadDataStore';
 import UploadDataActions from 'services/WizardStores/UploadData/UploadDataActions';

--- a/cdap-ui/app/cdap/components/CaskWizards/UploadData/ViewDataStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/UploadData/ViewDataStep/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect, Provider } from 'react-redux';
 import UploadDataStore from 'services/WizardStores/UploadData/UploadDataStore';
 import UploadDataActionCreator from 'services/WizardStores/UploadData/ActionCreator';

--- a/cdap-ui/app/cdap/components/CaskWizards/UploadData/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/UploadData/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import UploadDataStore from 'services/WizardStores/UploadData/UploadDataStore';

--- a/cdap-ui/app/cdap/components/CaskWizards/UploadDataUsecase/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/UploadDataUsecase/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import UploadDataWizard from 'components/CaskWizards/UploadData';
 
 export default function UploadDataUsecaseWizard({input, onClose, isOpen}) {

--- a/cdap-ui/app/cdap/components/CollapsibleSidebar/index.js
+++ b/cdap-ui/app/cdap/components/CollapsibleSidebar/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import ee from 'event-emitter';
 import {preventPropagation} from 'services/helpers';

--- a/cdap-ui/app/cdap/components/ConfigurableTab/index.js
+++ b/cdap-ui/app/cdap/components/ConfigurableTab/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 import Tabs from '../Tabs';
 import TabHeaders from '../TabHeaders';

--- a/cdap-ui/app/cdap/components/ConfigureButton/index.js
+++ b/cdap-ui/app/cdap/components/ConfigureButton/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 require('./ConfigureButton.scss');
 
 function ConfigureButton({label, onClick, iconClass}) {

--- a/cdap-ui/app/cdap/components/ConfirmationModal/index.js
+++ b/cdap-ui/app/cdap/components/ConfirmationModal/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import CardActionFeedback from 'components/CardActionFeedback';
 import Mousetrap from 'mousetrap';

--- a/cdap-ui/app/cdap/components/CustomDropdownMenu/index.js
+++ b/cdap-ui/app/cdap/components/CustomDropdownMenu/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classNames from 'classnames';
 
 const CustomDropdownMenu = (props, context) => {

--- a/cdap-ui/app/cdap/components/DSVEditor/DSVRow.js
+++ b/cdap-ui/app/cdap/components/DSVEditor/DSVRow.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import { preventPropagation } from 'services/helpers';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/DSVEditor/index.js
+++ b/cdap-ui/app/cdap/components/DSVEditor/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {connect , Provider} from 'react-redux';
 import DSVActions from 'components/DSVEditor/DSVActions';
 import {createDSVStore} from 'components/DSVEditor/DSVStore';

--- a/cdap-ui/app/cdap/components/DataPrep/AutoComplete/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/AutoComplete/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import MyDataPrepApi from 'api/dataprep';
 import Fuse from 'fuse.js';
 import shortid from 'shortid';

--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {isDescendant} from 'services/helpers';
 import {Popover, PopoverContent} from 'reactstrap';
 import Rx from 'rx';

--- a/cdap-ui/app/cdap/components/DataPrep/ColumnTextSelection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnTextSelection/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepStore from 'components/DataPrep/store';
 import classnames from 'classnames';
 import shortid from 'shortid';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import DataPrepApi from 'api/dataprep';
 import isNil from 'lodash/isNil';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import DatabaseBrowser from 'components/DataPrep/DataPrepBrowser/DatabaseBrowser';
 import FileBrowser from 'components/FileBrowser';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepContentWrapper/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepTable from 'components/DataPrep/DataPrepTable';
 import DataPrepCLI from 'components/DataPrep/DataPrepCLI';
 import isNil from 'lodash/isNil';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
 import T from 'i18n-react';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabDetail.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabDetail.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import T from 'i18n-react';
 
 const PREFIX = 'features.DataPrep.DataPrepSidePanel.ColumnsTab.ColumnDetail';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {preventPropagation} from 'services/helpers';
 import isEqual from 'lodash/isEqual';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DirectivesTab/DirectivesTabRow.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DirectivesTab/DirectivesTabRow.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 
 export default class DirectivesTabRow extends Component {

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/DataQuality/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/DataQuality/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 require('./DataQuality.scss');
 

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Calculate/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Calculate/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import {Input} from 'reactstrap';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/Bulkset/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/Bulkset/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import T from 'i18n-react';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/ReplaceColumns/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/ReplaceColumns/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import T from 'i18n-react';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/CopyColumn/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/CopyColumn/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/CustomTransform/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import IconSVG from 'components/IconSVG';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Decode/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Decode/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import EncodeDecode from 'components/DataPrep/Directives/EncodeDecode';
 import T from 'i18n-react';
 

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/DefineVariable/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/DefineVariable/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import classnames from 'classnames';
 import DataPrepStore from 'components/DataPrep/store';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/DropColumn/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/DropColumn/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/EncodeDecode/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import classnames from 'classnames';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Explode/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Explode/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 const PREFIX = 'features.DataPrep.Directives.Explode';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingDelimiterModal/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingDelimiterModal/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 */
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import T from 'i18n-react';
 import isNil from 'lodash/isNil';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import ColumnTextSelection from 'components/DataPrep/ColumnTextSelection';
 import { Popover, PopoverTitle, PopoverContent } from 'reactstrap';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutMenuItem.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutMenuItem.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 const PREFIX = 'features.DataPrep.Directives.ExtractFields';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/FillNullOrEmpty/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/FillNullOrEmpty/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/FindAndReplace/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Format/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Format/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import {Input} from 'reactstrap';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/KeepColumn/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/KeepColumn/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/MarkAsError/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import {setPopoverOffset} from 'components/DataPrep/helper';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/MaskData/MaskSelection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/MaskData/MaskSelection/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import ColumnTextSelection from 'components/DataPrep/ColumnTextSelection';
 import { Popover, PopoverTitle, PopoverContent } from 'reactstrap';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/MaskData/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/MaskData/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import {setPopoverOffset} from 'components/DataPrep/helper';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/MergeColumns/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/MergeColumns/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import {isCustomOption} from 'components/DataPrep/helper';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter,FormGroup, Label, Input } from 'reactstrap';
 import isNil from 'lodash/isNil';
 import MouseTrap from 'mousetrap';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/LogModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/LogModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SimpleDateModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SimpleDateModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import classnames from 'classnames';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import T from 'i18n-react';
 import MouseTrap from 'mousetrap';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import SingleFieldModal from 'components/DataPrep/Directives/Parse/Modals/SingleFieldModal';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/SetCharacterEncoding/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/SetCharacterEncoding/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import EncodeDecode from 'components/DataPrep/Directives/EncodeDecode';
 import DataPrepStore from 'components/DataPrep/store';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/SetCounter/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/SetCounter/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import classnames from 'classnames';
 import DataPrepStore from 'components/DataPrep/store';

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/SwapColumns/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepStore from 'components/DataPrep/store';

--- a/cdap-ui/app/cdap/components/DataPrep/ErrorMessageContainer/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ErrorMessageContainer/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 require('./ErrorMessageContainer.scss');
 import T from 'i18n-react';
 

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import {MyArtifactApi} from 'api/artifact';
 import find from 'lodash/find';

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/CreateDatasetBtn/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/CreateDatasetBtn/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import {Modal, ModalHeader, ModalBody, ModalFooter, Button, ButtonGroup, Form, FormGroup, Label, Col, Input} from 'reactstrap';
 import {UncontrolledTooltip} from 'components/UncontrolledComponents';

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/SchemaModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/SchemaModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import SchemaStore from 'components/SchemaEditor/SchemaStore';
 import SchemaEditor from 'components/SchemaEditor';

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepStore from 'components/DataPrep/store';
 import SchemaModal from 'components/DataPrep/TopPanel/SchemaModal';
 import AddToPipelineModal from 'components/DataPrep/TopPanel/AddToPipelineModal';

--- a/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTab/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTab/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Link} from 'react-router-dom';
 import NamespaceStore from 'services/NamespaceStore';
 import IconSVG from 'components/IconSVG';

--- a/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepStore from 'components/DataPrep/store';
 import MyDataPrepApi from 'api/dataprep';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrepTopPanel from 'components/DataPrep/TopPanel';
 import DataPrepContentWrapper from 'components/DataPrep/DataPrepContentWrapper';
 import DataPrepLoading from 'components/DataPrep/DataPrepLoading';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/AddConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/AddConnection/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import { Popover, PopoverTitle, PopoverContent } from 'reactstrap';
 import DatabaseConnection from 'components/DataPrepConnections/DatabaseConnection';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/ConnectionPopover/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/ConnectionPopover/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import UncontrolledPopover from 'components/UncontrolledComponents/Popover';
 import MyDataPrepApi from 'api/dataprep';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import MyDataPrepApi from 'api/dataprep';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseOptions.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseOptions.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
 import LoadingSVG from 'components/LoadingSVG';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import DatabaseOptions from 'components/DataPrepConnections/DatabaseConnection/DatabaseOptions';
 import DatabaseDetail from 'components/DataPrepConnections/DatabaseConnection/DatabaseDetail';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortRow.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortRow.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 export default class HostPortRow extends Component {
   constructor(props) {

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/HostPortEditor/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {connect , Provider} from 'react-redux';
 import HostPortActions from 'components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortActions';
 import HostPortStore from 'components/DataPrepConnections/KafkaConnection/HostPortEditor/HostPortStore';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import {objectQuery} from 'services/helpers';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/UploadFile/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/UploadFile/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import FileDnD from 'components/FileDnD';
 import NamespaceStore from 'services/NamespaceStore';
 import cookie from 'react-cookie';

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';
 import DataPrepBrowser from 'components/DataPrep/DataPrepBrowser';

--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DataPrep from 'components/DataPrep';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/AuditTab.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/AuditTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 
 export default function AuditTab({entity}) {

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/LineageTab.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/LineageTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 
 export default function UsageTab({entity}) {

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/PropertiesTab.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/PropertiesTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import PropertiesEditor from 'components/PropertiesEditor';
 import T from 'i18n-react';
 

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/UsageTab.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/UsageTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 
 export default function UsageTab({entity}) {

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Nav, NavItem, NavLink, TabContent} from 'reactstrap';
 import isNil from 'lodash/isNil';
 import {Route, Switch, NavLink as RouterNavLink} from 'react-router-dom';

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
@@ -14,7 +14,8 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import OverviewMetaSection from 'components/Overview/OverviewMetaSection';
 import ExploreTablesStore from 'services/ExploreTables/ExploreTablesStore';
 import {fetchTables} from 'services/ExploreTables/ActionCreator';

--- a/cdap-ui/app/cdap/components/DatasetStreamCards/index.js
+++ b/cdap-ui/app/cdap/components/DatasetStreamCards/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import EntityCard from 'components/EntityCard';
 import NamespaceStore from 'services/NamespaceStore';
 import {parseMetadata} from 'services/metadata-parser';

--- a/cdap-ui/app/cdap/components/DatasetStreamTable/index.js
+++ b/cdap-ui/app/cdap/components/DatasetStreamTable/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 import SortableTable from 'components/SortableTable';
 import {Link} from 'react-router-dom';

--- a/cdap-ui/app/cdap/components/Description/index.js
+++ b/cdap-ui/app/cdap/components/Description/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 require('./Description.scss');
 import T from 'i18n-react';
 

--- a/cdap-ui/app/cdap/components/EntityCard/ApplicationMetrics/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/ApplicationMetrics/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyAppApi} from 'api/app';
 import NamespaceStore from 'services/NamespaceStore';
 import {humanReadableNumber} from 'services/helpers';

--- a/cdap-ui/app/cdap/components/EntityCard/ArtifactMetrics/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/ArtifactMetrics/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyAppApi} from 'api/app';
 import {MyArtifactApi} from 'api/artifact';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/EntityCard/DatasetMetrics/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/DatasetMetrics/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyMetricApi} from 'api/metric';
 import {MyDatasetApi} from 'api/dataset';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 require('./EntityCardHeader.scss');

--- a/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import FastAction from 'components/FastAction';
 import {objectQuery} from 'services/helpers';
 import isNil from 'lodash/isNil';

--- a/cdap-ui/app/cdap/components/EntityCard/ProgramMetrics/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/ProgramMetrics/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyProgramApi} from 'api/program';
 import NamespaceStore from 'services/NamespaceStore';
 import {convertProgramToApi} from 'services/program-api-converter';

--- a/cdap-ui/app/cdap/components/EntityCard/StreamMetrics/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/StreamMetrics/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyMetricApi} from 'api/metric';
 import {MyStreamApi} from 'api/stream';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import Card from '../Card';
 import EntityCardHeader from './EntityCardHeader';
 import ApplicationMetrics from './ApplicationMetrics';

--- a/cdap-ui/app/cdap/components/EntityListView/EntityListInfo/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/EntityListInfo/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import ReactPaginate from 'react-paginate';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/EntityListView/ErrorMessage/PageErrorMessage.js
+++ b/cdap-ui/app/cdap/components/EntityListView/ErrorMessage/PageErrorMessage.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 import {Link} from 'react-router-dom';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/EntityListView/ErrorMessage/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/ErrorMessage/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import Timer from 'components/Timer';
 

--- a/cdap-ui/app/cdap/components/EntityListView/JustAddedSection/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/JustAddedSection/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MySearchApi} from 'api/search';
 import NamespaceStore from 'services/NamespaceStore';
 import {parseMetadata} from 'services/metadata-parser';

--- a/cdap-ui/app/cdap/components/EntityListView/ListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/ListView/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import EntityCard from 'components/EntityCard';
 import classnames from 'classnames';
 import JustAddedSection from 'components/EntityListView/JustAddedSection';

--- a/cdap-ui/app/cdap/components/EntityListView/NoEntitiesMessage/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/NoEntitiesMessage/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import T from 'i18n-react';
 import NamespaceStore from 'services/NamespaceStore';
 import PlusButtonStore from 'services/PlusButtonStore';

--- a/cdap-ui/app/cdap/components/EntityListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/index.js
@@ -14,7 +14,8 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
 import SearchStore from 'components/EntityListView/SearchStore';
 import {search, updateQueryString} from 'components/EntityListView/SearchStore/ActionCreator';
 import HomeListView from 'components/EntityListView/ListView';
@@ -389,5 +390,6 @@ EntityListView.propTypes = {
   match: PropTypes.object,
   location: PropTypes.object,
   history: PropTypes.object,
-  pathname: PropTypes.string
+  pathname: PropTypes.string,
+  currentPage: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 import {MyAppApi} from 'api/app';
 import {MyArtifactApi} from 'api/artifact';

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody} from 'reactstrap';
 import myExploreApi from 'api/explore';
 import isObject from 'lodash/isObject';

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import ExploreTablesStore from 'services/ExploreTables/ExploreTablesStore';
 import FastActionButton from '../FastActionButton';
 import {Tooltip} from 'reactstrap';

--- a/cdap-ui/app/cdap/components/FastAction/FastActionButton/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/FastActionButton/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import IconSVG from 'components/IconSVG';
 
 export default function FastActionButton({icon, action, disabled, id, iconClasses}) {

--- a/cdap-ui/app/cdap/components/FastAction/FastActionLink/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/FastActionLink/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 export default function FastActionLink({icon, link}) {
   return (

--- a/cdap-ui/app/cdap/components/FastAction/LogAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/LogAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import {MyProgramApi} from 'api/program';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/SendEventModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/SendEventModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody} from 'reactstrap';
 import FileDataUpload from 'components/FileDataUpload';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import FastActionButton from '../FastActionButton';
 import T from 'i18n-react';
 import { Tooltip } from 'reactstrap';

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import isObject from 'lodash/isObject';
 import upperFirst from 'lodash/upperFirst';
 import orderBy from 'lodash/orderBy';

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import FastActionButton from '../FastActionButton';
 import T from 'i18n-react';
 import {Tooltip} from 'reactstrap';

--- a/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 import {MyProgramApi} from 'api/program';
 import FastActionButton from '../FastActionButton';

--- a/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 import {MyDatasetApi} from 'api/dataset';
 import {MyStreamApi} from 'api/stream';

--- a/cdap-ui/app/cdap/components/FastAction/ViewEventsAction/ViewEventsModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/ViewEventsAction/ViewEventsModal.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import T from 'i18n-react';
 import Datetime from 'react-datetime';

--- a/cdap-ui/app/cdap/components/FastAction/ViewEventsAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/ViewEventsAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import FastActionButton from '../FastActionButton';
 import T from 'i18n-react';
 import { Tooltip } from 'reactstrap';

--- a/cdap-ui/app/cdap/components/FastAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import DeleteAction from 'components/FastAction/DeleteAction';
 import TruncateAction from 'components/FastAction/TruncateAction';
 import StartStopAction from 'components/FastAction/StartStopAction';

--- a/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import shortid from 'shortid';
 import {Link} from 'react-router-dom';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import MyDataPrepApi from 'api/dataprep';
 import NamespaceStore from 'services/NamespaceStore';
 import shortid from 'shortid';

--- a/cdap-ui/app/cdap/components/FileDataUpload/index.js
+++ b/cdap-ui/app/cdap/components/FileDataUpload/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import Dropzone from 'react-dropzone';
 import T from 'i18n-react';
 

--- a/cdap-ui/app/cdap/components/FileDnD/index.js
+++ b/cdap-ui/app/cdap/components/FileDnD/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import Dropzone from 'react-dropzone';
 require('./FileDnD.scss');
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/Footer/index.js
+++ b/cdap-ui/app/cdap/components/Footer/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 
 require('./Footer.scss');
 
@@ -43,6 +45,6 @@ export default class Footer extends Component {
   }
 }
 Footer.propTypes = {
-  version: React.PropTypes.string,
-  copyrightYear: React.PropTypes.string
+  version: PropTypes.string,
+  copyrightYear: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/Header/CaskMarketButton/index.js
+++ b/cdap-ui/app/cdap/components/Header/CaskMarketButton/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import PlusButtonModal from 'components/PlusButtonModal';
 import classnames from 'classnames';
 import ee from 'event-emitter';

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/AboutPageModal/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/AboutPageModal/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {Modal, ModalBody} from 'reactstrap';
 import T from 'i18n-react';
 import {getModeWithCloudProvider} from 'components/Header/ProductDropdown/helper';

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/AccessTokenModal/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/AccessTokenModal/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import CardActionFeedback from 'components/CardActionFeedback';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 import {Dropdown, DropdownToggle, DropdownItem} from 'reactstrap';
 import CustomDropdownMenu from 'components/CustomDropdownMenu';

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import NamespaceStore from 'services/NamespaceStore';
 import NamespaceDropdown from 'components/NamespaceDropdown';

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Route, Switch} from 'react-router-dom';
 import Page404 from 'components/404';
 import EntityListView from 'components/EntityListView';

--- a/cdap-ui/app/cdap/components/HttpExecutor/HttpResponse/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/HttpResponse/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect} from 'react-redux';
 
 const mapStateToProps = (state) => {

--- a/cdap-ui/app/cdap/components/HttpExecutor/InputPath/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/InputPath/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect} from 'react-redux';
 import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/HttpExecutor/MethodSelector/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/MethodSelector/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect} from 'react-redux';
 import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
 

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestMetadata/Body/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestMetadata/Body/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect} from 'react-redux';
 import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
 

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestMetadata/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestMetadata/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import Body from 'components/HttpExecutor/RequestMetadata/Body';
 import Header from 'components/HttpExecutor/RequestMetadata/Header';
 import {connect} from 'react-redux';

--- a/cdap-ui/app/cdap/components/HttpExecutor/StatusCode/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/StatusCode/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect} from 'react-redux';
 import classnames from 'classnames';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/HydratorModal/index.js
+++ b/cdap-ui/app/cdap/components/HydratorModal/index.js
@@ -17,7 +17,9 @@
 // THIS IS A COPY-PASTE OF MODAL FROM REACTSTRAP. WE NEED TO ADD CLASSNAME ALONGSIDE WITH 'modal' AND 3.9.4 OF
 // REACTSTRAP DOESN'T ALLOW THAT. HENCE THIS HORROR.
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import TransitionGroup from 'react-addons-transition-group';

--- a/cdap-ui/app/cdap/components/IconSVG/index.js
+++ b/cdap-ui/app/cdap/components/IconSVG/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classnames from 'classnames';
 require('./IconSVG.scss');
 require('../../styles/fonts/symbol-defs.svg');

--- a/cdap-ui/app/cdap/components/InputWithValidations/index.js
+++ b/cdap-ui/app/cdap/components/InputWithValidations/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { Input } from 'reactstrap';
 
 export default function InputWithValidations(props) {

--- a/cdap-ui/app/cdap/components/KeyValuePairs/KeyValuePair.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/KeyValuePair.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 require('./KeyValuePairs.scss');
 import T from 'i18n-react';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/KeyValuePairs/index.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/index.js
@@ -14,7 +14,9 @@
 * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {connect , Provider} from 'react-redux';
 import KeyValueStore from './KeyValueStore';
 import KeyValueStoreActions from './KeyValueStoreActions';

--- a/cdap-ui/app/cdap/components/LoadingSVG/index.js
+++ b/cdap-ui/app/cdap/components/LoadingSVG/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 require('./LoadingSVG.scss');
 
 export default function LoadingSVG({height = "30px", width ="24px"}) {

--- a/cdap-ui/app/cdap/components/MarketActionsContainer/index.js
+++ b/cdap-ui/app/cdap/components/MarketActionsContainer/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import getIcon from 'services/market-action-icon-map';
 import shortid from 'shortid';

--- a/cdap-ui/app/cdap/components/MarketEntityModal/index.js
+++ b/cdap-ui/app/cdap/components/MarketEntityModal/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import {MyMarketApi} from 'api/market';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/MarketPlaceEntity/index.js
+++ b/cdap-ui/app/cdap/components/MarketPlaceEntity/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import Card from '../Card';
 import {MyMarketApi} from 'api/market';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/MarketPlaceUsecaseEntity/index.js
+++ b/cdap-ui/app/cdap/components/MarketPlaceUsecaseEntity/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyMarketApi} from 'api/market';
 import Card from 'components/Card';
 import moment from 'moment';

--- a/cdap-ui/app/cdap/components/MultipleSelectWithOptions/index.js
+++ b/cdap-ui/app/cdap/components/MultipleSelectWithOptions/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {Input} from 'reactstrap';
 import shortid from 'shortid';
 

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Dropdown, DropdownMenu} from 'reactstrap';
 import AbstractWizard from 'components/AbstractWizard';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/NavLinkWrapper/index.js
+++ b/cdap-ui/app/cdap/components/NavLinkWrapper/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {NavLink} from 'react-router-dom';
 
 const NavLinkWrapper = ({children, to, isNativeLink, ...attributes}) => {

--- a/cdap-ui/app/cdap/components/Overview/AppOverview/AppOverviewTab.js
+++ b/cdap-ui/app/cdap/components/Overview/AppOverview/AppOverviewTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col } from 'reactstrap';
 import ProgramTab from 'components/Overview/Tabs/ProgramTab';
 import DatasetTab from 'components/Overview/Tabs/DatasetTab';

--- a/cdap-ui/app/cdap/components/Overview/AppOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/AppOverview/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import isNil from 'lodash/isNil';
 import OverviewHeader from 'components/Overview/OverviewHeader';
 import OverviewMetaSection from 'components/Overview/OverviewMetaSection';

--- a/cdap-ui/app/cdap/components/Overview/DatasetOverview/DatasetOverviewTab.js
+++ b/cdap-ui/app/cdap/components/Overview/DatasetOverview/DatasetOverviewTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col } from 'reactstrap';
 import ProgramTab from 'components/Overview/Tabs/ProgramTab';
 import SchemaTab from 'components/Overview/Tabs/SchemaTab';

--- a/cdap-ui/app/cdap/components/Overview/DatasetOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/DatasetOverview/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import OverviewHeader from 'components/Overview/OverviewHeader';
 import OverviewMetaSection from 'components/Overview/OverviewMetaSection';
 import DatasetOverviewTab from 'components/Overview/DatasetOverview/DatasetOverviewTab';

--- a/cdap-ui/app/cdap/components/Overview/OverviewHeader/index.js
+++ b/cdap-ui/app/cdap/components/Overview/OverviewHeader/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';
 import {Link} from 'react-router-dom';

--- a/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
+++ b/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {objectQuery} from 'services/helpers';
 import FastActions from 'components/EntityCard/FastActions';
 import isNil from 'lodash/isNil';

--- a/cdap-ui/app/cdap/components/Overview/StreamOverview/StreamOverviewTab.js
+++ b/cdap-ui/app/cdap/components/Overview/StreamOverview/StreamOverviewTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { TabContent, TabPane, Nav, NavItem, NavLink, Row, Col } from 'reactstrap';
 import ProgramTab from 'components/Overview/Tabs/ProgramTab';
 import SchemaTab from 'components/Overview/Tabs/SchemaTab';

--- a/cdap-ui/app/cdap/components/Overview/StreamOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/StreamOverview/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import OverviewHeader from 'components/Overview/OverviewHeader';
 import OverviewMetaSection from 'components/Overview/OverviewMetaSection';
 import StreamOverviewTab from 'components/Overview/StreamOverview/StreamOverviewTab';

--- a/cdap-ui/app/cdap/components/Overview/Tabs/DatasetTab/index.js
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/DatasetTab/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 require('./DatasetTab.scss');
 import {objectQuery} from 'services/helpers';

--- a/cdap-ui/app/cdap/components/Overview/Tabs/ProgramTab/index.js
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/ProgramTab/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {objectQuery} from 'services/helpers';
 import isNil from 'lodash/isNil';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/Overview/Tabs/SchemaTab/index.js
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/SchemaTab/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import SchemaStore from 'components/SchemaEditor/SchemaStore';
 import SchemaEditor from 'components/SchemaEditor';
 import {Tooltip} from 'reactstrap';

--- a/cdap-ui/app/cdap/components/Overview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import AppOverview from 'components/Overview/AppOverview';
 import DatasetOverview from 'components/Overview/DatasetOverview';
 import StreamOverview from 'components/Overview/StreamOverview';

--- a/cdap-ui/app/cdap/components/OverviewPaneCard/index.js
+++ b/cdap-ui/app/cdap/components/OverviewPaneCard/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 require('./OverviewPaneCard.scss');
 
 const propTypes = {

--- a/cdap-ui/app/cdap/components/Pagination/PaginationDropdown.js
+++ b/cdap-ui/app/cdap/components/Pagination/PaginationDropdown.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 import T from 'i18n-react';
 import shortid from 'shortid';

--- a/cdap-ui/app/cdap/components/Pagination/index.js
+++ b/cdap-ui/app/cdap/components/Pagination/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import Mousetrap from 'mousetrap';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraph.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraph.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {XYPlot, AreaSeries, makeVisFlexible, XAxis, YAxis, HorizontalGridLines, LineSeries, DiscreteColorLegend} from 'react-vis';
 import {getYAxisProps} from 'components/PipelineSummary/RunsGraphHelpers';
 

--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyMetricApi} from 'api/metric';
 import T from 'i18n-react';
 import Rx from 'rx';

--- a/cdap-ui/app/cdap/components/PipelineSummary/CopyableRunID/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/CopyableRunID/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {UncontrolledTooltip} from 'components/UncontrolledComponents';
 import Clipboard from 'clipboard';
 import IconSVG from 'components/IconSVG';

--- a/cdap-ui/app/cdap/components/PipelineSummary/EmptyMessageContainer/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/EmptyMessageContainer/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import T from 'i18n-react';
 import LoadingSVG from 'components/LoadingSVG';
 

--- a/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {objectQuery} from 'services/helpers';
 import {XYPlot, makeVisFlexible, XAxis, YAxis, HorizontalGridLines, Hint, DiscreteColorLegend, VerticalBarSeries as BarSeries} from 'react-vis';
 import moment from 'moment';

--- a/cdap-ui/app/cdap/components/PipelineSummary/NodesMetricsGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/NodesMetricsGraph/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import NodesRecordsGraph from 'components/PipelineSummary/NodesRecordsGraph';
 import {UncontrolledDropdown} from 'components/UncontrolledComponents';
 import {DropdownToggle, DropdownItem} from 'reactstrap';

--- a/cdap-ui/app/cdap/components/PipelineSummary/NodesRecordsGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/NodesRecordsGraph/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {XYPlot, AreaSeries, makeVisFlexible, XAxis, YAxis, HorizontalGridLines, LineSeries, MarkSeries, Hint} from 'react-vis';
 import {
   getXDomain,

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {XYPlot, makeVisFlexible, XAxis, YAxis, HorizontalGridLines, LineSeries, MarkSeries, DiscreteColorLegend, Hint} from 'react-vis';
 import moment from 'moment';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/PipelineSummary/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {fetchSummary} from 'components/PipelineSummary/Store/PipelineSummaryActions';
 import PipelineSummaryStore from 'components/PipelineSummary/Store/PipelineSummaryStore';
 import {convertProgramToApi} from 'services/program-api-converter';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledTriggerRow.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledTriggerRow.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import PipelineTriggersStore from 'components/PipelineTriggers/store/PipelineTriggersStore';
 import {disableSchedule, getPipelineInfo} from 'components/PipelineTriggers/store/PipelineTriggersActionCreator';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/EnabledTriggersTab/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/EnabledTriggersTab/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect} from 'react-redux';
 import EnabledTriggerRow from 'components/PipelineTriggers/EnabledTriggersTab/EnabledTriggerRow';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/PayloadConfigModal/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/PayloadConfigModal/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { ModalHeader, ModalBody } from 'reactstrap';
 import HydratorModal from 'components/HydratorModal';
 import ScheduleRuntimeArgs from 'components/PipelineTriggers/ScheduleRuntimeArgs';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/PipelineListTab/PipelineTriggersRow.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/PipelineListTab/PipelineTriggersRow.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import PipelineTriggersStore from 'components/PipelineTriggers/store/PipelineTriggersStore';
 import {enableSchedule} from 'components/PipelineTriggers/store/PipelineTriggersActionCreator';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/PipelineListTab/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/PipelineListTab/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 import {changeNamespace} from 'components/PipelineTriggers/store/PipelineTriggersActionCreator';
 import {connect} from 'react-redux';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/RuntimeArgsTab/RuntimeArgRow.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/RuntimeArgsTab/RuntimeArgRow.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import ScheduleRuntimeArgsStore, {DEFAULTRUNTIMEARGSMESSAGE, DEFAULTTRIGGEREDMACROMESSAGE} from 'components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsStore';
 import {setArgMapping} from 'components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions';
 import {Row, Col} from 'reactstrap';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/StagePropertiesTab/StagePropertiesRow.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/StagePropertiesTab/StagePropertiesRow.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import ScheduleRuntimeArgsStore, {DEFAULTSTAGEMESSAGE, DEFAULTPROPERTYMESSAGE, DEFAULTTRIGGEREDMACROMESSAGE} from 'components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsStore';
 import {setArgMapping} from 'components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions';
 import {Row, Col} from 'reactstrap';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {fetchPipelineMacroDetails, resetStore, bulkSetArgMapping} from 'components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions';
 import ScheduleRuntimeArgsStore, {SCHEDULERUNTIMEARGSACTIONS} from 'components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsStore';
 import ConfigurableTab from 'components/ConfigurableTab';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import CollapsibleSidebar from 'components/CollapsibleSidebar';
 import classnames from 'classnames';
 import PipelineListTab from 'components/PipelineTriggers/PipelineListTab';

--- a/cdap-ui/app/cdap/components/PipelineTriggersSidebars/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggersSidebars/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import PipelineTriggers from 'components/PipelineTriggers';
 import TriggeredPipelines from 'components/TriggeredPipelines';
 

--- a/cdap-ui/app/cdap/components/PlusButtonModal/index.js
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 
 import Market from 'components/Market';

--- a/cdap-ui/app/cdap/components/ProgramCards/index.js
+++ b/cdap-ui/app/cdap/components/ProgramCards/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import EntityCard from 'components/EntityCard';
 import {parseMetadata} from 'services/metadata-parser';
 import shortid from 'shortid';

--- a/cdap-ui/app/cdap/components/ProgramTable/index.js
+++ b/cdap-ui/app/cdap/components/ProgramTable/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import FastActions from 'components/EntityCard/FastActions';
 import SortableTable from 'components/SortableTable';
 import IconSVG from 'components/IconSVG';

--- a/cdap-ui/app/cdap/components/PropertiesEditor/AddPropertyModal/index.js
+++ b/cdap-ui/app/cdap/components/PropertiesEditor/AddPropertyModal/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import CardActionFeedback from 'components/CardActionFeedback';
 import {MyMetadataApi} from 'api/metadata';

--- a/cdap-ui/app/cdap/components/PropertiesEditor/DeleteConfirmation/index.js
+++ b/cdap-ui/app/cdap/components/PropertiesEditor/DeleteConfirmation/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import ConfirmationModal from 'components/ConfirmationModal';
 import {MyMetadataApi} from 'api/metadata';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/PropertiesEditor/EditProperty/index.js
+++ b/cdap-ui/app/cdap/components/PropertiesEditor/EditProperty/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import CardActionFeedback from 'components/CardActionFeedback';
 import {MyMetadataApi} from 'api/metadata';

--- a/cdap-ui/app/cdap/components/PropertiesEditor/index.js
+++ b/cdap-ui/app/cdap/components/PropertiesEditor/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyMetadataApi} from 'api/metadata';
 import NamespaceStore from 'services/NamespaceStore';
 import map from 'lodash/map';

--- a/cdap-ui/app/cdap/components/RenderObjectAsTable/index.js
+++ b/cdap-ui/app/cdap/components/RenderObjectAsTable/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 const RenderObjectAsTable = ({obj}) => {
   return (

--- a/cdap-ui/app/cdap/components/ResourceCenterButton/index.js
+++ b/cdap-ui/app/cdap/components/ResourceCenterButton/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import PlusButtonModal from 'components/PlusButtonModal';
 import PlusButtonStore from 'services/PlusButtonStore';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/ResourceCenterEntity/index.js
+++ b/cdap-ui/app/cdap/components/ResourceCenterEntity/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import PlusButtonStore from 'services/PlusButtonStore';
 import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/CreateRule/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/CreateRule/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Row, Col, Input, Form, FormGroup, Label} from 'reactstrap';
 import {preventPropagation} from 'services/helpers';
 import DSVEditor from 'components/DSVEditor';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/CreateRulebook/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/CreateRulebook/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Input, Button} from 'reactstrap';
 import isEmpty from 'lodash/isEmpty';
 import {createNewRuleBook} from 'components/RulesEngineHome/RulesEngineStore/RulesEngineActions';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/ImportRulebookWizard/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/ImportRulebookWizard/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import WizardModal from 'components/WizardModal';
 import Wizard from 'components/Wizard';
 import UploadFile from 'services/upload-file';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBook/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBook/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import moment from 'moment';
 import RulesEngineStore from 'components/RulesEngineHome/RulesEngineStore';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/AddRulesEngineToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/AddRulesEngineToPipelineModal.js
@@ -20,7 +20,9 @@
   3. Make a batch and realtime config with yare in its stage.
   4. Show the modal.
 */
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyArtifactApi} from 'api/artifact';
 import NamespaceStore from 'services/NamespaceStore';
 import {findHighestVersion} from 'services/VersionRange/VersionUtilities';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookMenu/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {UncontrolledDropdown} from 'components/UncontrolledComponents';
 import { DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 import IconSVG from 'components/IconSVG';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookRule/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulebookRule/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Col} from 'reactstrap';
 import { DragSource, DropTarget } from 'react-dnd';
 import flow from 'lodash/flow';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulesList/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/RulesList/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {DragTypes} from 'components/RulesEngineHome/RulesTab/Rule';
 import { DropTarget } from 'react-dnd';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RuleBookDetails/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import RulesEngineStore from 'components/RulesEngineHome/RulesEngineStore';
 import isNil from 'lodash/isNil';
 import MyRulesEngine from 'api/rulesengine';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import MyRuleEngineApi from 'api/rulesengine';
 import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
 import LoadingSVG from 'components/LoadingSVG';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineTabCounters/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineTabCounters/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {connect} from 'react-redux';
 import isNil from 'lodash/isNil';
 

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineWrapper.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineWrapper.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Nav, NavItem, TabPane, TabContent, NavLink} from 'reactstrap';
 import classnames from 'classnames';
 import RuleBookDetails from 'components/RulesEngineHome/RuleBookDetails';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/RulebooksPopover/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/RulebooksPopover/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import RulesEngineStore from 'components/RulesEngineHome/RulesEngineStore';
 import Rx from 'rx';
 import {isDescendant} from 'services/helpers';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesTab/Rule/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Col, Form, FormGroup, Label, Row} from 'reactstrap';
 import IconSVG from 'components/IconSVG';
 import moment from 'moment';

--- a/cdap-ui/app/cdap/components/RulesEngineHome/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {getRuleBooks, resetStore, getRules, setActiveRulebook} from 'components/RulesEngineHome/RulesEngineStore/RulesEngineActions';
 import RulesEngineStore, {RULESENGINEACTIONS} from 'components/RulesEngineHome/RulesEngineStore';
 import RulesEngineAlert from 'components/RulesEngineHome/RulesEngineAlert';

--- a/cdap-ui/app/cdap/components/SchemaEditor/AbstractSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/AbstractSchemaRow/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import ArraySchemaRow from 'components/SchemaEditor/ArraySchemaRow';
 import MapSchemaRow from 'components/SchemaEditor/MapSchemaRow';
 import UnionSchemaRow from 'components/SchemaEditor/UnionSchemaRow';

--- a/cdap-ui/app/cdap/components/SchemaEditor/ArraySchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/ArraySchemaRow/index.js
@@ -14,8 +14,10 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
-  import {parseType, SCHEMA_TYPES, checkComplexType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
+import {parseType, SCHEMA_TYPES, checkComplexType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
 import SelectWithOptions from 'components/SelectWithOptions';
 import AbstractSchemaRow from 'components/SchemaEditor/AbstractSchemaRow';
 // import {Input} from 'reactstrap';
@@ -97,7 +99,7 @@ export default class ArraySchemaRow extends Component {
       this.setState({error});
       return;
     }
-    this.parsedType = this.state.displayType.nullable ? [cloneDeep(itemsState): 'null'] : cloneDeep(itemsState);
+    this.parsedType = this.state.displayType.nullable ? [cloneDeep(itemsState), 'null'] : cloneDeep(itemsState);
     this.updateParent();
   }
   updateParent() {

--- a/cdap-ui/app/cdap/components/SchemaEditor/EnumSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/EnumSchemaRow/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {parseType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
 import {Input} from 'reactstrap';
 import {insertAt, removeAt} from 'services/helpers';

--- a/cdap-ui/app/cdap/components/SchemaEditor/MapSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/MapSchemaRow/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import SelectWithOptions from 'components/SelectWithOptions';
 import {parseType, SCHEMA_TYPES, checkComplexType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
 import AbstractSchemaRow from 'components/SchemaEditor/AbstractSchemaRow';

--- a/cdap-ui/app/cdap/components/SchemaEditor/RecordSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/RecordSchemaRow/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {SCHEMA_TYPES, checkComplexType, getParsedSchema, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
 import AbstractSchemaRow from 'components/SchemaEditor/AbstractSchemaRow';
 require('./RecordSchemaRow.scss');

--- a/cdap-ui/app/cdap/components/SchemaEditor/UnionSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/UnionSchemaRow/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {parseType, SCHEMA_TYPES, checkComplexType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
 import SelectWithOptions from 'components/SelectWithOptions';
 import AbstractSchemaRow from 'components/SchemaEditor/AbstractSchemaRow';

--- a/cdap-ui/app/cdap/components/ScrollableList/index.js
+++ b/cdap-ui/app/cdap/components/ScrollableList/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import findIndex from 'lodash/findIndex';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/components/SearchTextBox/index.js
+++ b/cdap-ui/app/cdap/components/SearchTextBox/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 var classnames = require('classnames');
 require('./SearchTextBox.scss');
 

--- a/cdap-ui/app/cdap/components/SelectWithOptions/index.js
+++ b/cdap-ui/app/cdap/components/SelectWithOptions/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {Input} from 'reactstrap';
 
 export default function SelectWithOptions({className, value, onChange, options}) {

--- a/cdap-ui/app/cdap/components/SimpleSchema/FieldRow.js
+++ b/cdap-ui/app/cdap/components/SimpleSchema/FieldRow.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { Input } from 'reactstrap';
 import SelectWithOptions from 'components/SelectWithOptions';
 

--- a/cdap-ui/app/cdap/components/SimpleSchema/index.js
+++ b/cdap-ui/app/cdap/components/SimpleSchema/index.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { connect, Provider } from 'react-redux';
 import {createSchemaStore} from './SchemaStore';
 import SchemaStoreActions from './SchemaStoreActions';

--- a/cdap-ui/app/cdap/components/SortableTable/index.js
+++ b/cdap-ui/app/cdap/components/SortableTable/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import orderBy from 'lodash/orderBy';
 import classnames from 'classnames';
 require('./SortableTable.scss');

--- a/cdap-ui/app/cdap/components/SplashScreen/index.js
+++ b/cdap-ui/app/cdap/components/SplashScreen/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import 'whatwg-fetch';
 import CaskVideo from 'components/CaskVideo';
 require('./SplashScreen.scss');

--- a/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModalHeader.js
+++ b/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModalHeader.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import T from 'i18n-react';
 import PaginationDropdown from 'components/Pagination/PaginationDropdown';
 import {
@@ -23,69 +25,69 @@ import {
 
 require('./SpotlightModal.scss');
 
- export default class SpotlightModalHeader extends Component {
-   constructor(props) {
-     super(props);
-     this.state = {
-       isDropdownExpanded : false
-     };
-     this.toggleExpansion = this.toggleExpansion.bind(this);
-   }
+export default class SpotlightModalHeader extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isDropdownExpanded : false
+    };
+    this.toggleExpansion = this.toggleExpansion.bind(this);
+  }
 
-   toggleExpansion() {
-     this.setState({
-       isDropdownExpanded : !this.state.isDropdownExpanded
-     });
-   }
+  toggleExpansion() {
+    this.setState({
+      isDropdownExpanded : !this.state.isDropdownExpanded
+    });
+  }
 
-   render() {
-     return (
-       <ModalHeader>
-         <span className="float-xs-left">
-           {
-             T.translate('features.SpotlightSearch.SpotlightModal.headerTagResults', {
-               tag: this.props.tag
-             })
-           }
-         </span>
-         <div
-           className="close-section float-xs-right text-xs-right"
-         >
-           <span className="search-results-total">
-             {
-              this.props.total === 1 ?
-                T.translate('features.SpotlightSearch.SpotlightModal.numResult', {
-                 total: this.props.total
-                })
-              :
-                T.translate('features.SpotlightSearch.SpotlightModal.numResults', {
-                 total: this.props.total
-                })
-             }
-           </span>
-           <span>
-           <PaginationDropdown
-            numberOfPages={this.props.numPages}
-            currentPage={this.props.currentPage}
-            onPageChange={this.props.handleSearch.bind(this)}
-           />
-           </span>
-           <span
-             className="fa fa-times"
-             onClick={this.props.toggle}
-           />
-         </div>
-       </ModalHeader>
-     );
+  render() {
+    return (
+      <ModalHeader>
+        <span className="float-xs-left">
+          {
+            T.translate('features.SpotlightSearch.SpotlightModal.headerTagResults', {
+              tag: this.props.tag
+            })
+          }
+        </span>
+        <div
+          className="close-section float-xs-right text-xs-right"
+        >
+          <span className="search-results-total">
+            {
+             this.props.total === 1 ?
+               T.translate('features.SpotlightSearch.SpotlightModal.numResult', {
+                total: this.props.total
+               })
+             :
+               T.translate('features.SpotlightSearch.SpotlightModal.numResults', {
+                total: this.props.total
+               })
+            }
+          </span>
+          <span>
+          <PaginationDropdown
+           numberOfPages={this.props.numPages}
+           currentPage={this.props.currentPage}
+           onPageChange={this.props.handleSearch.bind(this)}
+          />
+          </span>
+          <span
+            className="fa fa-times"
+            onClick={this.props.toggle}
+          />
+        </div>
+      </ModalHeader>
+    );
 
-   }
- }
+  }
+}
 
- SpotlightModalHeader.propTypes = {
-   toggle: PropTypes.func,
-   handleSearch: PropTypes.func,
-   currentPage: PropTypes.number,
-   tag: PropTypes.string,
-   numPages: PropTypes.number,
-   total: PropTypes.number
- };
+SpotlightModalHeader.propTypes = {
+  toggle: PropTypes.func,
+  handleSearch: PropTypes.func,
+  currentPage: PropTypes.number,
+  tag: PropTypes.string,
+  numPages: PropTypes.number,
+  total: PropTypes.number
+};

--- a/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/index.js
+++ b/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MySearchApi} from 'api/search';
 import NamespaceStore from 'services/NamespaceStore';
 import {parseMetadata} from 'services/metadata-parser';

--- a/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/AuditTab.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/AuditTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 
 export default function UsageTab({entity}) {

--- a/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/LineageTab.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/LineageTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 
 export default function UsageTab({entity}) {

--- a/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/PropertiesTab.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/PropertiesTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import PropertiesEditor from 'components/PropertiesEditor';
 import T from 'i18n-react';
 

--- a/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/UsageTab.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/UsageTab.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import NamespaceStore from 'services/NamespaceStore';
 
 export default function UsageTab({entity}) {

--- a/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/index.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Nav, NavItem, NavLink, TabContent} from 'reactstrap';
 import isNil from 'lodash/isNil';
 import {Route, NavLink as RouterNavLink} from 'react-router-dom';

--- a/cdap-ui/app/cdap/components/StreamDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/index.js
@@ -14,7 +14,8 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import OverviewMetaSection from 'components/Overview/OverviewMetaSection';
 import ExploreTablesStore from 'services/ExploreTables/ExploreTablesStore';
 import {fetchTables} from 'services/ExploreTables/ActionCreator';

--- a/cdap-ui/app/cdap/components/TabHead/index.js
+++ b/cdap-ui/app/cdap/components/TabHead/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 var classnames = require('classnames');
 require('./TabHead.scss');
 export default class TabHead extends Component {

--- a/cdap-ui/app/cdap/components/TabHeaders/index.js
+++ b/cdap-ui/app/cdap/components/TabHeaders/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 
 require('./TabHeaders.scss');
 

--- a/cdap-ui/app/cdap/components/Tabs/index.js
+++ b/cdap-ui/app/cdap/components/Tabs/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 var classnames = require('classnames');
 
 require('./Tabs.scss');

--- a/cdap-ui/app/cdap/components/Tags/Tag/index.js
+++ b/cdap-ui/app/cdap/components/Tags/Tag/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import SpotlightModal from 'components/SpotlightSearch/SpotlightModal';
 import classnames from 'classnames';
 

--- a/cdap-ui/app/cdap/components/Tags/index.js
+++ b/cdap-ui/app/cdap/components/Tags/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {MyMetadataApi} from 'api/metadata';
 import isObject from 'lodash/isObject';
 import Mousetrap from 'mousetrap';

--- a/cdap-ui/app/cdap/components/TextboxOnValium/index.js
+++ b/cdap-ui/app/cdap/components/TextboxOnValium/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 export default class TextboxOnValium extends Component {
   constructor(props) {
     super(props);

--- a/cdap-ui/app/cdap/components/TimeToLive/index.js
+++ b/cdap-ui/app/cdap/components/TimeToLive/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { Input, Label } from 'reactstrap';
 require('./TimeToLive.scss');
 import shortid from 'shortid';

--- a/cdap-ui/app/cdap/components/Timer/index.js
+++ b/cdap-ui/app/cdap/components/Timer/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import isNil from 'lodash/isNil';
 require('./Timer.scss');
 

--- a/cdap-ui/app/cdap/components/TriggeredPipelines/TriggeredPipelineRow.js
+++ b/cdap-ui/app/cdap/components/TriggeredPipelines/TriggeredPipelineRow.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import LoadingSVG from 'components/LoadingSVG';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';

--- a/cdap-ui/app/cdap/components/TriggeredPipelines/index.js
+++ b/cdap-ui/app/cdap/components/TriggeredPipelines/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import CollapsibleSidebar from 'components/CollapsibleSidebar';
 import {MyScheduleApi} from 'api/schedule';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/UncontrolledComponents/ExpandableMenu.js
+++ b/cdap-ui/app/cdap/components/UncontrolledComponents/ExpandableMenu.js
@@ -20,7 +20,9 @@
   now and we can't make that change at this point in the release. So this artifact stays here until we have
   upgraded reactstrap.
 */
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import IconSVG from 'components/IconSVG';
 require('./ExpandableMenu.scss');

--- a/cdap-ui/app/cdap/components/UncontrolledComponents/Popover.js
+++ b/cdap-ui/app/cdap/components/UncontrolledComponents/Popover.js
@@ -14,7 +14,9 @@
  * the License.
 */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {Popover, PopoverContent} from 'reactstrap';
 import {isDescendant} from 'services/helpers';
 import Mousetrap from 'mousetrap';

--- a/cdap-ui/app/cdap/components/VersionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/VersionsDropdown/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { ButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 import {MyAppApi} from 'api/app';
 import NamespaceStore from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/ViewSwitch/index.js
+++ b/cdap-ui/app/cdap/components/ViewSwitch/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { Nav, NavItem, NavLink, TabContent, TabPane} from 'reactstrap';
 import classnames from 'classnames';
 import IconSVG from 'components/IconSVG';

--- a/cdap-ui/app/cdap/components/WarningContainer/index.js
+++ b/cdap-ui/app/cdap/components/WarningContainer/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import T from 'i18n-react';
 
 require('./WarningContainer.scss');

--- a/cdap-ui/app/cdap/components/Wizard/WizardStepContent/index.js
+++ b/cdap-ui/app/cdap/components/Wizard/WizardStepContent/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 require('./WizardStepContent.scss');
 
 export default function WizardStepContent(props) {

--- a/cdap-ui/app/cdap/components/Wizard/WizardStepHeader/index.js
+++ b/cdap-ui/app/cdap/components/Wizard/WizardStepHeader/index.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import classnames from 'classnames';
 require('./WizardStepHeader.scss');
 

--- a/cdap-ui/app/cdap/components/Wizard/index.js
+++ b/cdap-ui/app/cdap/components/Wizard/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import Rx from 'rx';
 import findIndex from 'lodash/findIndex';
 import first from 'lodash/head';

--- a/cdap-ui/app/cdap/components/WizardModal/index.js
+++ b/cdap-ui/app/cdap/components/WizardModal/index.js
@@ -13,7 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {Modal, ModalBody, ModalHeader} from 'reactstrap';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import classnames from 'classnames';

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -14,7 +14,9 @@
  * the License.
  */
 
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
 require('../ui-utils/url-generator');

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -118,6 +118,7 @@
     "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
     "numeral": "1.5.3",
     "object-hash": "1.1.0",
+    "prop-types": "15.5.10",
     "q": "1.4.1",
     "query-string": "4.3.2",
     "react": "15.3.1",


### PR DESCRIPTION
### Do not merge until 4.3.1 release is cut.
#### Note:
- This is the first step in migrating from React 15.* to React 16. As mentioned in the [React docs](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html)
- [react-codemod](https://github.com/reactjs/react-codemod/blob/master/transforms/React-PropTypes-to-prop-types.js) used for this modification.
- This PR only does the first step of using `prop-types` module for `PropTypes` validation instead of getting it from `React`. 
-Harmless modifications:
  -`SpotlightModalHeader` alone has space changes 
  - `ArraySchemaRow/index.js`. There was a syntax error which has been fixed.