### PR TITLE
CDAP-12673 Fix the config property that the UI (namespace's scheduler queue name)

### DIFF
--- a/cdap-ui/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
@@ -50,10 +50,6 @@ const PublishNamespace = () => {
     putParams["config"]["principal"] = state.security.principal;
   }
 
-  if (state.preferences.schedulerQueueName) {
-    putParams["config"]["scheduler.queue.name"] = state.preferences.schedulerQueueName;
-  }
-
   return MyNamespaceApi
     .create(urlParams, putParams);
 };

--- a/cdap-ui/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
@@ -51,7 +51,7 @@ const PublishNamespace = () => {
   }
 
   if (state.preferences.schedulerQueueName) {
-    putParams["config"]["scheduluer.queue.name"] = state.preferences.schedulerQueueName;
+    putParams["config"]["scheduler.queue.name"] = state.preferences.schedulerQueueName;
   }
 
   return MyNamespaceApi


### PR DESCRIPTION
CDAP-12673 Fix the config property that the UI is using for a namespace's scheduler queue name.

This fix is intended for CDAP 4.3.2.