### PR TITLE
CDAP-7257 REST API for generating stack traces for CDAP system services.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/CommonHandlers.java
+++ b/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/CommonHandlers.java
@@ -26,6 +26,7 @@ public class CommonHandlers {
 
   public static void add(Multibinder<HttpHandler> handlerBinder) {
     handlerBinder.addBinding().to(PingHandler.class);
+    handlerBinder.addBinding().to(StackHandler.class);
   }
 
 }

--- a/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/StackHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/StackHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpResponder;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * Returns information about threads, including their stack traces.
+ */
+public class StackHandler extends AbstractHttpHandler {
+
+  private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+
+  @Path(Constants.Gateway.API_VERSION_3 + "/system/services/{service-name}/stacks")
+  @GET
+  public void stacks(HttpRequest request, HttpResponder responder,
+                     @PathParam("service-name") String serviceName,
+                     @QueryParam("depth") @DefaultValue("20") int depth) {
+    StringWriter stringWriter = new StringWriter();
+    getThreadInfo(new PrintWriter(stringWriter), serviceName, depth);
+    responder.sendString(HttpResponseStatus.OK, stringWriter.toString());
+  }
+
+  /**
+   * Print all of the thread's information and stack traces.
+   */
+  private synchronized void getThreadInfo(PrintWriter stream, String serviceName, int depth) {
+    boolean contention = THREAD_MX_BEAN.isThreadContentionMonitoringEnabled();
+    long[] threadIds = THREAD_MX_BEAN.getAllThreadIds();
+    println(stream, "Process Thread Dump: %s", serviceName);
+    println(stream, "%s active threads", threadIds.length);
+    for (long tid : threadIds) {
+      ThreadInfo info = THREAD_MX_BEAN.getThreadInfo(tid, depth);
+      if (info == null) {
+        stream.println("  Inactive");
+        continue;
+      }
+      println(stream, "Thread %s",
+              getTaskName(info.getThreadId(), info.getThreadName()) + ":");
+      Thread.State state = info.getThreadState();
+      println(stream, "  State: %s", state);
+      println(stream, "  Blocked count: %s", info.getBlockedCount());
+      println(stream, "  Waited count: %s", info.getWaitedCount());
+      if (contention) {
+        println(stream, "  Blocked time: %s", info.getBlockedTime());
+        println(stream, "  Waited time: %s", info.getWaitedTime());
+      }
+      if (state == Thread.State.WAITING) {
+        println(stream, "  Waiting on %s", info.getLockName());
+      } else if (state == Thread.State.BLOCKED) {
+        println(stream, "  Blocked on %s", info.getLockName());
+        println(stream, "  Blocked by %s",
+                         getTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
+      }
+      println(stream, "  Stack:");
+      for (StackTraceElement frame : info.getStackTrace()) {
+        println(stream, "    %s", frame.toString());
+      }
+    }
+    stream.flush();
+  }
+
+  private void println(PrintWriter stream, String format, Object... args) {
+    stream.printf(format, args).println();
+  }
+
+  private String getTaskName(long id, String name) {
+    if (name == null) {
+      return Long.toString(id);
+    }
+    return id + " (" + name + ")";
+  }
+}

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -160,7 +160,8 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       return EXPLORE_HTTP_USER_SERVICE;
     } else if ((uriParts.length == 3) && uriParts[1].equals("explore") && uriParts[2].equals("status")) {
       return EXPLORE_HTTP_USER_SERVICE;
-    } else if (matches(uriParts, "v3", "system", "services", null, "status")) {
+    } else if (matches(uriParts, "v3", "system", "services", null, "status")
+      || matches(uriParts, "v3", "system", "services", null, "stacks")) {
       switch (uriParts[3]) {
         case Constants.Service.LOGSAVER: return LOG_SAVER;
         case Constants.Service.TRANSACTION: return TRANSACTION;

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -443,8 +443,60 @@ public class RouterPathTest {
   @Test
   public void testServiceProviderStatsPaths() {
     assertRouting("/v3/system/////serviceproviders", RouterPathLookup.APP_FABRIC_HTTP);
-    assertRouting("/v3/system/////serviceproviders/serviceprovider/stats", RouterPathLookup.APP_FABRIC_HTTP);
-    assertRouting("/v3/system/////serviceproviders///////", RouterPathLookup.APP_FABRIC_HTTP);
+  }
+
+  @Test
+  public void testSystemServiceStatusPaths() {
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.LOGSAVER),
+                  RouterPathLookup.LOG_SAVER);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.TRANSACTION),
+                  RouterPathLookup.TRANSACTION);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.METRICS_PROCESSOR),
+                  RouterPathLookup.METRICS_PROCESSOR);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.METRICS),
+                  RouterPathLookup.METRICS);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.APP_FABRIC_HTTP),
+                  RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.STREAMS),
+                  RouterPathLookup.STREAMS_SERVICE);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.DATASET_EXECUTOR),
+                  RouterPathLookup.DATASET_EXECUTOR);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.REMOTE_SYSTEM_OPERATION),
+                  RouterPathLookup.DATASET_EXECUTOR);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.METADATA_SERVICE),
+                  RouterPathLookup.METADATA_SERVICE);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.EXPLORE_HTTP_USER_SERVICE),
+                  RouterPathLookup.EXPLORE_HTTP_USER_SERVICE);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.MESSAGING_SERVICE),
+                  RouterPathLookup.MESSAGING);
+    assertRouting(String.format("/v3/system/services/%s/status", "unknown.service"), null);
+  }
+
+  @Test
+  public void testSystemServiceStacksPaths() {
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.LOGSAVER),
+                  RouterPathLookup.LOG_SAVER);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.TRANSACTION),
+                  RouterPathLookup.TRANSACTION);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.METRICS_PROCESSOR),
+                  RouterPathLookup.METRICS_PROCESSOR);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.METRICS),
+                  RouterPathLookup.METRICS);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.APP_FABRIC_HTTP),
+                  RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.STREAMS),
+                  RouterPathLookup.STREAMS_SERVICE);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.DATASET_EXECUTOR),
+                  RouterPathLookup.DATASET_EXECUTOR);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.REMOTE_SYSTEM_OPERATION),
+                  RouterPathLookup.DATASET_EXECUTOR);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.METADATA_SERVICE),
+                  RouterPathLookup.METADATA_SERVICE);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.EXPLORE_HTTP_USER_SERVICE),
+                  RouterPathLookup.EXPLORE_HTTP_USER_SERVICE);
+    assertRouting(String.format("/v3/system/services/%s/stacks", Constants.Service.MESSAGING_SERVICE),
+                  RouterPathLookup.MESSAGING);
+    assertRouting(String.format("/v3/system/services/%s/stacks", "unknown.service"), null);
   }
 
   private void assertRouting(String path, RouteDestination destination) {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-7257

This makes it easier for us to get stack traces for CDAP system services, instead of requiring the user to get the process ID and then using jstack (or `kill -3`) on that process. The previous approach is also difficult for system services, which could be running on any node manager in the cluster.

https://builds.cask.co/browse/CDAP-RUT1446-1