### PR TITLE
[CDAP-12426] Enable update keytab location and reload keytab file of namespace

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -35,6 +35,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.stream.Collectors;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -61,14 +62,20 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/namespaces")
   public void getAllNamespaces(HttpRequest request, HttpResponder responder) throws Exception {
-    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(namespaceAdmin.list()));
+    // return keytab URI without version
+    responder.sendJson(HttpResponseStatus.OK,
+                       GSON.toJson(namespaceAdmin.list().stream()
+                                     .map(meta -> new NamespaceMeta.Builder(meta).buildWithoutKeytabURIVersion())
+                                     .collect(Collectors.toList())));
   }
 
   @GET
   @Path("/namespaces/{namespace-id}")
   public void getNamespace(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId) throws Exception {
-    NamespaceMeta ns = namespaceAdmin.get(new NamespaceId(namespaceId));
+    // return keytab URI without version
+    NamespaceMeta ns =
+      new NamespaceMeta.Builder(namespaceAdmin.get(new NamespaceId(namespaceId))).buildWithoutKeytabURIVersion();
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(ns));
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -108,6 +108,34 @@ public class NamespaceConfig {
     return keytabURI;
   }
 
+  /**
+   * @return the keytab URI without the fragment containing version.
+   */
+  @Nullable
+  public String getKeytabURIWithoutVersion() {
+    // try to get the keytab URI version if the keytab URI is not null
+    if (keytabURI != null) {
+      // find the position of the fragment containing the version in the keytab URI
+      int versionIdx = keytabURI.lastIndexOf("#");
+      return versionIdx < 0 ? keytabURI : keytabURI.substring(0, versionIdx);
+    }
+    return keytabURI;
+  }
+
+  /**
+   * @return the version of the keytab URI or 0 if no version is present in the keytab URI.
+   */
+  public int getKeytabURIVersion() {
+    // try to get the keytab URI version if the keytab URI is not null
+    if (keytabURI != null) {
+      // find the position where the fragment containing the version in the keytab URI
+      int versionIdx = keytabURI.lastIndexOf("#");
+      // if the version doesn't exist in the keytab URI, initialize it to 0
+      return versionIdx < 0 ? 0 : Integer.parseInt(keytabURI.substring(versionIdx + 1));
+    }
+    return 0;
+  }
+
   public Boolean isExploreAsPrincipal() {
     return exploreAsPrincipal == null || exploreAsPrincipal;
   }
@@ -137,10 +165,6 @@ public class NamespaceConfig {
 
     if (!Objects.equals(this.groupName, other.groupName)) {
       difference.add("groupName");
-    }
-
-    if (!Objects.equals(this.keytabURI, other.keytabURI)) {
-      difference.add("keytabURI");
     }
     return difference;
   }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12426
https://builds.cask.co/browse/CDAP-DUT6375-1

Verified on cluster with updating keytab URI to a different file and updating the same keytab URI file with updated content.