### PR TITLE
cdap client removing deprecated methods

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.client;
 
-import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.client.app.FakeApp;
 import co.cask.cdap.client.app.FakeWorkflow;
 import co.cask.cdap.client.common.ClientTestBase;
@@ -76,9 +75,7 @@ public class ScheduleClientTestRun extends ClientTestBase {
   @Test
   public void testAll() throws Exception {
     List<ScheduleDetail> list = scheduleClient.listSchedules(workflow);
-    List<ScheduleSpecification> specs = scheduleClient.list(workflow);
     Assert.assertEquals(2, list.size());
-    Assert.assertEquals(specs, ScheduleDetail.toScheduleSpecs(list));
 
     ScheduleDetail timeSchedule;
     ScheduleDetail streamSchedule;

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -27,7 +27,6 @@ import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.ApplicationRecord;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
@@ -96,21 +95,6 @@ public class ApplicationClient {
    * @return list of {@link ApplicationRecord ApplicationRecords}.
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #list(NamespaceId)} instead
-   */
-  @Deprecated
-  public List<ApplicationRecord> list(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return list(namespace.toEntityId());
-  }
-
-  /**
-   * Lists all applications currently deployed.
-   *
-   * @param namespace the namespace to list applications from
-   * @return list of {@link ApplicationRecord ApplicationRecords}.
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationRecord> list(NamespaceId namespace)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -118,25 +102,6 @@ public class ApplicationClient {
                                                config.resolveNamespacedURLV3(namespace, "apps"),
                                                config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<ApplicationRecord>>() { }).getResponseObject();
-  }
-
-  /**
-   * Lists all applications currently deployed, optionally filtering to only include applications that use the
-   * specified artifact name and version.
-   *
-   * @param namespace the namespace to list applications from
-   * @param artifactName the name of the artifact to filter by. If null, no filtering will be done.
-   * @param artifactVersion the version of the artifact to filter by. If null, no filtering will be done.
-   * @return list of {@link ApplicationRecord ApplicationRecords}.
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #list(NamespaceId, String, String)}.
-   */
-  @Deprecated
-  public List<ApplicationRecord> list(
-    Id.Namespace namespace, @Nullable String artifactName,
-    @Nullable String artifactVersion) throws IOException, UnauthenticatedException, UnauthorizedException {
-    return list(namespace.toEntityId(), artifactName, artifactVersion);
   }
 
   /**
@@ -158,25 +123,6 @@ public class ApplicationClient {
       names.add(artifactName);
     }
     return list(namespace, names, artifactVersion);
-  }
-
-  /**
-   * Lists all applications currently deployed, optionally filtering to only include applications that use one of
-   * the specified artifact names and the specified artifact version.
-   *
-   * @param namespace the namespace to list applications from
-   * @param artifactNames the set of artifact names to allow. If empty, no filtering will be done.
-   * @param artifactVersion the version of the artifact to filter by. If null, no filtering will be done.
-   * @return list of {@link ApplicationRecord ApplicationRecords}.
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #list(NamespaceId, Set, String)} instead.
-   */
-  @Deprecated
-  public List<ApplicationRecord> list(
-    Id.Namespace namespace, Set<String> artifactNames, @Nullable String artifactVersion)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return list(namespace.toEntityId(), artifactNames, artifactVersion);
   }
 
   /**
@@ -245,22 +191,6 @@ public class ApplicationClient {
    * @throws ApplicationNotFoundException if the application with the given ID was not found
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #get(ApplicationId) ()} instead
-   */
-  @Deprecated
-  public ApplicationDetail get(Id.Application appId)
-    throws ApplicationNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return get(appId.toEntityId());
-  }
-
-  /**
-   * Get details about the specified application.
-   *
-   * @param appId the id of the application to get
-   * @return details about the specified application
-   * @throws ApplicationNotFoundException if the application with the given ID was not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public ApplicationDetail get(ApplicationId appId)
     throws ApplicationNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
@@ -307,21 +237,6 @@ public class ApplicationClient {
    * @throws ApplicationNotFoundException if the application with the given ID was not found
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #delete(ApplicationId) ()} instead
-   */
-  @Deprecated
-  public void delete(Id.Application app)
-    throws ApplicationNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    delete(app.toEntityId());
-  }
-
-  /**
-   * Deletes an application.
-   *
-   * @param app the application to delete
-   * @throws ApplicationNotFoundException if the application with the given ID was not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void delete(ApplicationId app)
     throws ApplicationNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
@@ -339,35 +254,9 @@ public class ApplicationClient {
    *
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #deleteAll(NamespaceId)} instead.
-   */
-  @Deprecated
-  public void deleteAll(Id.Namespace namespace) throws IOException, UnauthenticatedException, UnauthorizedException {
-    deleteAll(namespace.toEntityId());
-  }
-
-  /**
-   * Deletes all applications in a namespace.
-   *
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void deleteAll(NamespaceId namespace) throws IOException, UnauthenticatedException, UnauthorizedException {
     restClient.execute(HttpMethod.DELETE, config.resolveNamespacedURLV3(namespace, "apps"), config.getAccessToken());
-  }
-
-  /**
-   * Checks if an application exists.
-   *
-   * @param app the application to check
-   * @return true if the application exists
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #exists(ApplicationId)} instead.
-   */
-  @Deprecated
-  public boolean exists(Id.Application app) throws IOException, UnauthenticatedException, UnauthorizedException {
-    return exists(app.toEntityId());
   }
 
   /**
@@ -396,24 +285,6 @@ public class ApplicationClient {
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws TimeoutException if the application was not yet deployed before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
-   * @deprecated since 4.0.0. Use {@link #waitForDeployed(ApplicationId, long, TimeUnit)} instead.
-   */
-  @Deprecated
-  public void waitForDeployed(final Id.Application app, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
-    waitForDeployed(app.toEntityId(), timeout, timeoutUnit);
-  }
-
-  /**
-   * Waits for an application to be deployed.
-   *
-   * @param app the application to check
-   * @param timeout time to wait before timing out
-   * @param timeoutUnit time unit of timeout
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the application was not yet deployed before {@code timeout} milliseconds
-   * @throws InterruptedException if interrupted while waiting
    */
   public void waitForDeployed(final ApplicationId app, long timeout, TimeUnit timeoutUnit)
     throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
@@ -430,23 +301,6 @@ public class ApplicationClient {
     }
   }
 
-  /**
-   * Waits for an application to be deleted.
-   *
-   * @param app the application to check
-   * @param timeout time to wait before timing out
-   * @param timeoutUnit time unit of timeout
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the application was not yet deleted before {@code timeout} milliseconds
-   * @throws InterruptedException if interrupted while waiting
-   * @deprecated since 4.0.0. Use {@link #waitForDeleted(ApplicationId, long, TimeUnit)} instead.
-   */
-  @Deprecated
-  public void waitForDeleted(final Id.Application app, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
-    waitForDeleted(app.toEntityId(), timeout, timeoutUnit);
-  }
 
   /**
    * Waits for an application to be deleted.
@@ -479,38 +333,10 @@ public class ApplicationClient {
    *
    * @param jarFile JAR file of the application to deploy
    * @throws IOException if a network error occurred
-   * @deprecated since 4.0.0. Use {@link #deploy(NamespaceId, File)} instead.
-   */
-  @Deprecated
-  public void deploy(Id.Namespace namespace, File jarFile) throws IOException, UnauthenticatedException {
-    deploy(namespace.toEntityId(), jarFile);
-  }
-
-  /**
-   * Deploys an application.
-   *
-   * @param jarFile JAR file of the application to deploy
-   * @throws IOException if a network error occurred
    */
   public void deploy(NamespaceId namespace, File jarFile) throws IOException, UnauthenticatedException {
     Map<String, String> headers = ImmutableMap.of("X-Archive-Name", jarFile.getName());
     deployApp(namespace, jarFile, headers);
-  }
-
-  /**
-   * Deploys an application with a serialized application configuration string.
-   *
-   * @param namespace namespace to which the application should be deployed
-   * @param jarFile JAR file of the application to deploy
-   * @param appConfig serialized application configuration
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #deploy(NamespaceId, File, String)} instead.
-   */
-  @Deprecated
-  public void deploy(Id.Namespace namespace, File jarFile,
-                     String appConfig) throws IOException, UnauthenticatedException {
-    deploy(namespace.toEntityId(), jarFile, appConfig);
   }
 
   /**
@@ -559,40 +385,10 @@ public class ApplicationClient {
    * @param appConfig application configuration object
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #deploy(NamespaceId, File, Config)} instead.
-   */
-  @Deprecated
-  public void deploy(Id.Namespace namespace, File jarFile,
-                     Config appConfig) throws IOException, UnauthenticatedException {
-    deploy(namespace.toEntityId(), jarFile, appConfig);
-  }
-
-  /**
-   * Deploys an application with an application configuration object.
-   *
-   * @param namespace namespace to which the application should be deployed
-   * @param jarFile JAR file of the application to deploy
-   * @param appConfig application configuration object
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void deploy(NamespaceId namespace, File jarFile,
                      Config appConfig) throws IOException, UnauthenticatedException {
     deploy(namespace, jarFile, GSON.toJson(appConfig));
-  }
-
-  /**
-   * Deploys an application using an existing artifact.
-   *
-   * @param appId the id of the application to add
-   * @param createRequest the request body, which contains the artifact to use and any application config
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #deploy(ApplicationId, AppRequest)} instead
-   */
-  @Deprecated
-  public void deploy(Id.Application appId, AppRequest<?> createRequest) throws IOException, UnauthenticatedException {
-    deploy(appId.toEntityId(), createRequest);
   }
 
   /**
@@ -613,24 +409,6 @@ public class ApplicationClient {
       .build();
     restClient.upload(request, config.getAccessToken());
   }
-
-  /**
-   * Update an existing app to use a different artifact version or config.
-   *
-   * @param appId the id of the application to update
-   * @param updateRequest the request to update the application with
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the app or requested artifact could not be found
-   * @throws BadRequestException if the request is invalid
-   * @deprecated since 4.0.0. Use {@link #update(ApplicationId, AppRequest)} instead.
-   */
-  @Deprecated
-  public void update(Id.Application appId, AppRequest<?> updateRequest)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    update(appId.toEntityId(), updateRequest);
-  }
-
 
   /**
    * Update an existing app to use a different artifact version or config.
@@ -678,21 +456,6 @@ public class ApplicationClient {
    * @return list of {@link ProgramRecord}s
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #listAllPrograms(NamespaceId, ProgramType)} instead.
-   */
-  @Deprecated
-  public List<ProgramRecord> listAllPrograms(Id.Namespace namespace, ProgramType programType)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return listAllPrograms(namespace.toEntityId(), programType);
-  }
-
-  /**
-   * Lists all programs of a type.
-   *
-   * @param programType type of the programs to list
-   * @return list of {@link ProgramRecord}s
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ProgramRecord> listAllPrograms(NamespaceId namespace, ProgramType programType)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -715,20 +478,6 @@ public class ApplicationClient {
    * @return list of {@link ProgramRecord}s
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #listAllPrograms(NamespaceId)} instead.
-   */
-  @Deprecated
-  public Map<ProgramType, List<ProgramRecord>> listAllPrograms(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return listAllPrograms(namespace.toEntityId());
-  }
-
-  /**
-   * Lists all programs.
-   *
-   * @return list of {@link ProgramRecord}s
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public Map<ProgramType, List<ProgramRecord>> listAllPrograms(NamespaceId namespace)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -742,23 +491,6 @@ public class ApplicationClient {
       }
     }
     return allPrograms.build();
-  }
-
-  /**
-   * Lists programs of a type belonging to an application.
-   *
-   * @param app the application
-   * @param programType type of the programs to list
-   * @return list of {@link ProgramRecord}s
-   * @throws ApplicationNotFoundException if the application with the given ID was not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #listPrograms(ApplicationId, ProgramType)} instead.
-   */
-  @Deprecated
-  public List<ProgramRecord> listPrograms(Id.Application app, ProgramType programType)
-    throws ApplicationNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return listPrograms(app.toEntityId(), programType);
   }
 
   /**
@@ -793,22 +525,6 @@ public class ApplicationClient {
    * @throws ApplicationNotFoundException if the application with the given ID was not found
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #listProgramsByType(ApplicationId)} instead.
-   */
-  @Deprecated
-  public Map<ProgramType, List<ProgramRecord>> listProgramsByType(Id.Application app)
-    throws ApplicationNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return listProgramsByType(app.toEntityId());
-  }
-
-  /**
-   * Lists programs of a type belonging to an application.
-   *
-   * @param app the application
-   * @return Map of {@link ProgramType} to list of {@link ProgramRecord}s
-   * @throws ApplicationNotFoundException if the application with the given ID was not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public Map<ProgramType, List<ProgramRecord>> listProgramsByType(ApplicationId app)
     throws ApplicationNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
@@ -821,22 +537,6 @@ public class ApplicationClient {
       result.get(program.getType()).add(program);
     }
     return result;
-  }
-
-  /**
-   * Lists all programs belonging to an application.
-   *
-   * @param app the application
-   * @return List of all {@link ProgramRecord}s
-   * @throws ApplicationNotFoundException if the application with the given ID was not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #listPrograms(ApplicationId)} instead
-   */
-  @Deprecated
-  public List<ProgramRecord> listPrograms(Id.Application app)
-    throws ApplicationNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return listPrograms(app.toEntityId());
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -32,7 +32,6 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ApplicationClassInfo;
 import co.cask.cdap.proto.artifact.ApplicationClassSummary;
 import co.cask.cdap.proto.artifact.PluginInfo;

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -98,43 +98,10 @@ public class ArtifactClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the namespace could not be found
-   * @deprecated since 4.0.0. Use {@link #list(NamespaceId)} instead.
-   */
-  @Deprecated
-  public List<ArtifactSummary> list(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return list(namespace.toEntityId());
-  }
-
-  /**
-   * Lists all artifacts in the given namespace, including all system artifacts.
-   *
-   * @param namespace the namespace to list artifacts in
-   * @return list of {@link ArtifactSummary}
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the namespace could not be found
    */
   public List<ArtifactSummary> list(NamespaceId namespace)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
     return list(namespace, null);
-  }
-
-  /**
-   * Lists all artifacts in the given namespace, optionally including system artifacts.
-   *
-   * @param namespace the namespace to list artifacts in
-   * @param scope the scope of the artifacts to get. If null, both user and system artifacts are listed
-   * @return list of {@link ArtifactSummary}
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the namespace could not be found
-   * @deprecated since 4.0.0. Use {@link #list(NamespaceId, ArtifactScope)} instead.
-   */
-  @Deprecated
-  public List<ArtifactSummary> list(Id.Namespace namespace, @Nullable ArtifactScope scope)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return list(namespace.toEntityId(), scope);
   }
 
   /**
@@ -170,45 +137,10 @@ public class ArtifactClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the given artifact does not exist
-   * @deprecated since 4.0.0. Use {@link #listVersions(NamespaceId, String)} instead.
-   */
-  @Deprecated
-  public List<ArtifactSummary> listVersions(Id.Namespace namespace, String artifactName)
-    throws UnauthenticatedException, IOException, ArtifactNotFoundException, UnauthorizedException {
-    return listVersions(namespace.toEntityId(), artifactName);
-  }
-
-  /**
-   * Lists all versions of the given artifact in the given namespace.
-   *
-   * @param namespace the namespace to list artifact versions in
-   * @param artifactName the name of the artifact
-   * @return list of {@link ArtifactSummary}
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ArtifactNotFoundException if the given artifact does not exist
    */
   public List<ArtifactSummary> listVersions(NamespaceId namespace, String artifactName)
     throws UnauthenticatedException, IOException, ArtifactNotFoundException, UnauthorizedException {
     return listVersions(namespace, artifactName, null);
-  }
-
-  /**
-   * Lists all versions of the given artifact in the given namespace.
-   *
-   * @param namespace the namespace to list artifact versions in
-   * @param artifactName the name of the artifact
-   * @param scope the scope of artifacts to get. If none is given, the scope defaults to the user scope
-   * @return list of {@link ArtifactSummary}
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ArtifactNotFoundException if the given artifact does not exist
-   * @deprecated since 4.0.0. Use {@link #listVersions(NamespaceId, String, ArtifactScope)} instead.
-   */
-  @Deprecated
-  public List<ArtifactSummary> listVersions(Id.Namespace namespace, String artifactName, @Nullable ArtifactScope scope)
-    throws UnauthenticatedException, IOException, ArtifactNotFoundException, UnauthorizedException {
-    return listVersions(namespace.toEntityId(), artifactName, scope);
   }
 
   /**
@@ -244,22 +176,6 @@ public class ArtifactClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the given artifact does not exist
-   * @deprecated since 4.0.0. Use {@link #getArtifactInfo(ArtifactId)} instead.
-   */
-  @Deprecated
-  public ArtifactInfo getArtifactInfo(Id.Artifact artifactId)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
-    return getArtifactInfo(artifactId.toEntityId());
-  }
-
-  /**
-   * Gets information about a specific artifact version.
-   *
-   * @param artifactId the id of the artifact to get
-   * @return information about the given artifact
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ArtifactNotFoundException if the given artifact does not exist
    */
   public ArtifactInfo getArtifactInfo(ArtifactId artifactId)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
@@ -270,23 +186,6 @@ public class ArtifactClient {
       info = getArtifactInfo(artifactId, ArtifactScope.USER);
     }
     return info;
-  }
-
-  /**
-   * Gets information about a specific artifact version.
-   *
-   * @param artifactId the id of the artifact to get
-   * @param scope the scope of the artifact
-   * @return information about the given artifact
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ArtifactNotFoundException if the given artifact does not exist
-   * @deprecated since 4.0.0. Use {@link #getArtifactInfo(ArtifactId, ArtifactScope)} instead.
-   */
-  @Deprecated
-  public ArtifactInfo getArtifactInfo(Id.Artifact artifactId, ArtifactScope scope)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
-    return getArtifactInfo(artifactId.toEntityId(), scope);
   }
 
   /**
@@ -321,43 +220,10 @@ public class ArtifactClient {
    * @return summaries of all application classes in the given namespace, including classes from system artifacts
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getApplicationClasses(NamespaceId)} instead.
-   */
-  @Deprecated
-  public List<ApplicationClassSummary> getApplicationClasses(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return getApplicationClasses(namespace.toEntityId());
-  }
-
-  /**
-   * Get summaries of all application classes in the given namespace, including classes from system artifacts.
-   *
-   * @param namespace the namespace to list application classes from
-   * @return summaries of all application classes in the given namespace, including classes from system artifacts
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationClassSummary> getApplicationClasses(NamespaceId namespace)
     throws IOException, UnauthenticatedException, UnauthorizedException {
     return getApplicationClasses(namespace, (ArtifactScope) null);
-  }
-
-  /**
-   * Get summaries of all application classes in the given namespace,
-   * optionally including classes from system artifacts.
-   *
-   * @param namespace the namespace to list application classes from
-   * @param scope the scope to list application classes in. If null, classes from all scopes are returned
-   * @return summaries of all application classes in the given namespace, including classes from system artifacts
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getApplicationClasses(NamespaceId, ArtifactScope)} instead.
-   */
-  @Deprecated
-  public List<ApplicationClassSummary> getApplicationClasses(Id.Namespace namespace,
-                                                             @Nullable ArtifactScope scope)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return getApplicationClasses(namespace.toEntityId(), scope);
   }
 
   /**
@@ -389,41 +255,10 @@ public class ArtifactClient {
    * @return summaries of all application classes in the given namespace, including classes from system artifacts
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getApplicationClasses(NamespaceId, String)} instead.
-   */
-  @Deprecated
-  public List<ApplicationClassInfo> getApplicationClasses(Id.Namespace namespace, String className)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return getApplicationClasses(namespace.toEntityId(), className);
-  }
-
-  /**
-   * Get information about all application classes in the specified namespace, of the specified class name.
-   *
-   * @param namespace the namespace to list application classes from
-   * @return summaries of all application classes in the given namespace, including classes from system artifacts
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationClassInfo> getApplicationClasses(NamespaceId namespace, String className)
     throws IOException, UnauthenticatedException, UnauthorizedException {
     return getApplicationClasses(namespace, className, ArtifactScope.USER);
-  }
-
-  /**
-   * Get information about all application classes in the specified namespace, of the specified class name.
-   *
-   * @param namespace the namespace to list application classes from
-   * @param scope the scope to list application classes in
-   * @return summaries of all application classes in the given namespace, including classes from system artifacts
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getApplicationClasses(NamespaceId, String, ArtifactScope)} instead.
-   */
-  @Deprecated
-  public List<ApplicationClassInfo> getApplicationClasses(Id.Namespace namespace, String className, ArtifactScope scope)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return getApplicationClasses(namespace.toEntityId(), className, scope);
   }
 
   /**
@@ -454,22 +289,6 @@ public class ArtifactClient {
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getPluginTypes(ArtifactId)} instead.
-   */
-  @Deprecated
-  public List<String> getPluginTypes(Id.Artifact artifactId)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
-    return getPluginTypes(artifactId.toEntityId());
-  }
-
-  /**
-   * Gets all the plugin types available to a specific artifact.
-   *
-   * @param artifactId the id of the artifact to get
-   * @return list of plugin types available to the given artifact.
-   * @throws ArtifactNotFoundException if the given artifact does not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<String> getPluginTypes(ArtifactId artifactId)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
@@ -480,23 +299,6 @@ public class ArtifactClient {
       pluginTypes = getPluginTypes(artifactId, ArtifactScope.USER);
     }
     return pluginTypes;
-  }
-
-  /**
-   * Gets all the plugin types available to a specific artifact.
-   *
-   * @param artifactId the id of the artifact to get
-   * @param scope the scope of the artifact
-   * @return list of plugin types available to the given artifact.
-   * @throws ArtifactNotFoundException if the given artifact does not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getPluginTypes(ArtifactId, ArtifactScope)} instead.
-   */
-  @Deprecated
-  public List<String> getPluginTypes(Id.Artifact artifactId, ArtifactScope scope)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
-    return getPluginTypes(artifactId.toEntityId(), scope);
   }
 
   /**
@@ -533,23 +335,6 @@ public class ArtifactClient {
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getPluginSummaries(ArtifactId, String)} instead.
-   */
-  @Deprecated
-  public List<PluginSummary> getPluginSummaries(Id.Artifact artifactId, String pluginType)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
-    return getPluginSummaries(artifactId.toEntityId(), pluginType);
-  }
-
-  /**
-   * Gets all the plugins of the given type available to the given artifact.
-   *
-   * @param artifactId the id of the artifact to get
-   * @param pluginType the type of plugins to get
-   * @return list of {@link PluginSummary}
-   * @throws ArtifactNotFoundException if the given artifact does not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<PluginSummary> getPluginSummaries(ArtifactId artifactId, String pluginType)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
@@ -560,24 +345,6 @@ public class ArtifactClient {
       pluginSummary = getPluginSummaries(artifactId, pluginType, ArtifactScope.USER);
     }
     return pluginSummary;
-  }
-
-  /**
-   * Gets all the plugins of the given type available to the given artifact.
-   *
-   * @param artifactId the id of the artifact to get
-   * @param pluginType the type of plugins to get
-   * @param scope the scope of the artifact
-   * @return list of {@link PluginSummary}
-   * @throws ArtifactNotFoundException if the given artifact does not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getPluginSummaries(ArtifactId, String, ArtifactScope)} instead.
-   */
-  @Deprecated
-  public List<PluginSummary> getPluginSummaries(Id.Artifact artifactId, String pluginType, ArtifactScope scope)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException, UnauthorizedException {
-    return getPluginSummaries(artifactId.toEntityId(), pluginType, scope);
   }
 
   /**
@@ -616,24 +383,6 @@ public class ArtifactClient {
    * @throws NotFoundException if the given artifact does not exist or plugins for that artifact do not exist
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getPluginInfo(ArtifactId, String, String)} instead.
-   */
-  @Deprecated
-  public List<PluginInfo> getPluginInfo(Id.Artifact artifactId, String pluginType, String pluginName)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return getPluginInfo(artifactId.toEntityId(), pluginType, pluginName);
-  }
-
-  /**
-   * Gets all the plugins of the given type and name available to the given artifact.
-   *
-   * @param artifactId the id of the artifact to get
-   * @param pluginType the type of plugins to get
-   * @param pluginName the name of the plugins to get
-   * @return list of {@link PluginInfo}
-   * @throws NotFoundException if the given artifact does not exist or plugins for that artifact do not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<PluginInfo> getPluginInfo(ArtifactId artifactId, String pluginType, String pluginName)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
@@ -644,26 +393,6 @@ public class ArtifactClient {
       pluginInfo = getPluginInfo(artifactId, pluginType, pluginName, ArtifactScope.USER);
     }
     return pluginInfo;
-  }
-
-  /**
-   * Gets all the plugins of the given type and name available to the given artifact.
-   *
-   * @param artifactId the id of the artifact to get
-   * @param pluginType the type of plugins to get
-   * @param pluginName the name of the plugins to get
-   * @param scope the scope of the artifact
-   * @return list of {@link PluginInfo}
-   * @throws NotFoundException if the given artifact does not exist or plugins for that artifact do not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getPluginInfo(ArtifactId, String, String, ArtifactScope)} instead.
-   */
-  @Deprecated
-  public List<PluginInfo> getPluginInfo(Id.Artifact artifactId, String pluginType, String pluginName,
-                                        ArtifactScope scope)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return getPluginInfo(artifactId.toEntityId(), pluginType, pluginName, scope);
   }
 
   /**
@@ -706,27 +435,6 @@ public class ArtifactClient {
    * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #add(ArtifactId, Set, InputSupplier)} instead.
-   */
-  @Deprecated
-  public void add(Id.Artifact artifactId, @Nullable Set<ArtifactRange> parentArtifacts,
-                  InputSupplier<? extends InputStream> artifactContents)
-    throws UnauthenticatedException, BadRequestException, ArtifactRangeNotFoundException,
-    ArtifactAlreadyExistsException, IOException, UnauthorizedException {
-    add(artifactId.toEntityId(), parentArtifacts, artifactContents);
-  }
-
-  /**
-   * Add an artifact.
-   *
-   * @param artifactId the id of the artifact to add
-   * @param parentArtifacts the set of artifacts this artifact extends
-   * @param artifactContents an input supplier for the contents of the artifact
-   * @throws ArtifactAlreadyExistsException if the artifact already exists
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(ArtifactId artifactId, @Nullable Set<ArtifactRange> parentArtifacts,
                   InputSupplier<? extends InputStream> artifactContents)
@@ -735,31 +443,6 @@ public class ArtifactClient {
 
     add(artifactId.getParent(), artifactId.getArtifact(), artifactContents,
         artifactId.getVersion(), parentArtifacts);
-  }
-
-  /**
-   * Add an artifact.
-   *
-   * @param namespace the namespace to add the artifact to
-   * @param artifactName the name of the artifact to add
-   * @param artifactContents an input supplier for the contents of the artifact
-   * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
-   *                        manifest of the artifact.
-   * @throws ArtifactAlreadyExistsException if the artifact already exists
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #add(NamespaceId, String, InputSupplier, String)} instead.
-   */
-  @Deprecated
-  public void add(Id.Namespace namespace, String artifactName,
-                  InputSupplier<? extends InputStream> artifactContents,
-                  @Nullable String artifactVersion)
-    throws ArtifactAlreadyExistsException, BadRequestException, IOException,
-    UnauthenticatedException, ArtifactRangeNotFoundException, UnauthorizedException {
-
-    add(namespace.toEntityId(), artifactName, artifactContents, artifactVersion);
   }
 
   /**
@@ -799,31 +482,6 @@ public class ArtifactClient {
    * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #add(NamespaceId, String, InputSupplier, String, Set)} insetad.
-   */
-  @Deprecated
-  public void add(Id.Namespace namespace, String artifactName, InputSupplier<? extends InputStream> artifactContents,
-                  @Nullable String artifactVersion, @Nullable Set<ArtifactRange> parentArtifacts)
-    throws ArtifactAlreadyExistsException, BadRequestException, IOException,
-    UnauthenticatedException, ArtifactRangeNotFoundException, UnauthorizedException {
-
-    add(namespace.toEntityId(), artifactName, artifactContents, artifactVersion, parentArtifacts);
-  }
-
-  /**
-   * Add an artifact.
-   *
-   * @param namespace the namespace to add the artifact to
-   * @param artifactName the name of the artifact to add
-   * @param artifactContents an input supplier for the contents of the artifact
-   * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
-   *                        manifest of the artifact
-   * @param parentArtifacts the set of artifacts this artifact extends
-   * @throws ArtifactAlreadyExistsException if the artifact already exists
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(NamespaceId namespace, String artifactName, InputSupplier<? extends InputStream> artifactContents,
                   @Nullable String artifactVersion, @Nullable Set<ArtifactRange> parentArtifacts)
@@ -831,38 +489,6 @@ public class ArtifactClient {
     UnauthenticatedException, ArtifactRangeNotFoundException, UnauthorizedException {
 
     add(namespace, artifactName, artifactContents, artifactVersion, parentArtifacts, null);
-  }
-
-  /**
-   * Add an artifact.
-   *
-   * @param namespace the namespace to add the artifact to
-   * @param artifactName the name of the artifact to add
-   * @param artifactContents an input supplier for the contents of the artifact
-   * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
-   *                        manifest of the artifact
-   * @param parentArtifacts the set of artifacts this artifact extends
-   * @param additionalPlugins the set of plugins contained in the artifact that cannot be determined
-   *                          through jar inspection. This set should include any classes that are plugins but could
-   *                          not be annotated as such. For example, 3rd party classes like jdbc drivers fall into
-   *                          this category.
-   * @throws ArtifactAlreadyExistsException if the artifact already exists
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #add(NamespaceId, String, InputSupplier, String, Set, Set)} instead.
-   */
-  @Deprecated
-  public void add(Id.Namespace namespace, String artifactName,
-                  InputSupplier<? extends InputStream> artifactContents,
-                  @Nullable String artifactVersion,
-                  @Nullable Set<ArtifactRange> parentArtifacts,
-                  @Nullable Set<PluginClass> additionalPlugins)
-    throws ArtifactAlreadyExistsException, BadRequestException, IOException,
-    UnauthenticatedException, ArtifactRangeNotFoundException, UnauthorizedException {
-
-    add(namespace.toEntityId(), artifactName, artifactContents, artifactVersion, parentArtifacts, additionalPlugins);
   }
 
   /**
@@ -927,22 +553,6 @@ public class ArtifactClient {
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #delete(ArtifactId)} instead.
-   */
-  @Deprecated
-  public void delete(Id.Artifact artifactId)
-    throws IOException, UnauthenticatedException, BadRequestException, UnauthorizedException {
-    delete(artifactId.toEntityId());
-  }
-
-  /**
-   * Delete an artifact.
-   *
-   * @param artifactId the artifact to delete
-   *
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void delete(ArtifactId artifactId)
     throws IOException, UnauthenticatedException, BadRequestException, UnauthorizedException {
@@ -958,24 +568,6 @@ public class ArtifactClient {
     if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
       throw new BadRequestException(response.getResponseBodyAsString());
     }
-  }
-
-  /**
-   * Write properties for an artifact. Any existing properties will be overwritten.
-   *
-   * @param artifactId the artifact to add properties to
-   * @param properties the properties to add
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ArtifactNotFoundException if the artifact does not exist
-   * @throws IOException if a network error occurred
-   * @deprecated since 4.0.0. Use {@link #writeProperties(ArtifactId, Map)} instead.
-   */
-  @Deprecated
-  public void writeProperties(Id.Artifact artifactId, Map<String, String> properties)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException,
-    BadRequestException, UnauthorizedException {
-    writeProperties(artifactId.toEntityId(), properties);
   }
 
   /**
@@ -1007,23 +599,6 @@ public class ArtifactClient {
     } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
       throw new BadRequestException(response.getResponseBodyAsString());
     }
-  }
-
-  /**
-   * Delete all properties for an artifact. If no properties exist, this will be a no-op.
-   *
-   * @param artifactId the artifact to delete properties from
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ArtifactNotFoundException if the artifact does not exist
-   * @throws IOException if a network error occurred
-   * @deprecated since 4.0.0. Use {@link #deleteProperties(ArtifactId)} instead.
-   */
-  @Deprecated
-  public void deleteProperties(Id.Artifact artifactId)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException,
-    BadRequestException, UnauthorizedException {
-    deleteProperties(artifactId.toEntityId());
   }
 
   /**
@@ -1067,26 +642,6 @@ public class ArtifactClient {
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ArtifactNotFoundException if the artifact does not exist
    * @throws IOException if a network error occurred
-   * @deprecated since 4.0.0. Use {@link #writeProperty(ArtifactId, String, String)} instead.
-   */
-  @Deprecated
-  public void writeProperty(Id.Artifact artifactId, String key, String value)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException,
-    BadRequestException, UnauthorizedException {
-    writeProperty(artifactId.toEntityId(), key, value);
-  }
-
-  /**
-   * Write a property for an artifact. If the property already exists, it will be overwritten. If the property
-   * does not exist, it will be added.
-   *
-   * @param artifactId the artifact to write the property to
-   * @param key the property key to write
-   * @param value the property value to write
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ArtifactNotFoundException if the artifact does not exist
-   * @throws IOException if a network error occurred
    */
   public void writeProperty(ArtifactId artifactId, String key, String value)
     throws IOException, UnauthenticatedException, ArtifactNotFoundException,
@@ -1108,24 +663,6 @@ public class ArtifactClient {
     } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
       throw new BadRequestException(response.getResponseBodyAsString());
     }
-  }
-
-  /**
-   * Delete a property for an artifact. If the property does not exist, this will be a no-op.
-   *
-   * @param artifactId the artifact to delete a property from
-   * @param key the property to delete
-   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ArtifactNotFoundException if the artifact does not exist
-   * @throws IOException if a network error occurred
-   * @deprecated since 4.0.0. Use {@link #deleteProperty(ArtifactId, String)} instead.
-   */
-  @Deprecated
-  public void deleteProperty(Id.Artifact artifactId, String key)
-    throws IOException, UnauthenticatedException, ArtifactNotFoundException,
-    BadRequestException, UnauthorizedException {
-    deleteProperty(artifactId.toEntityId(), key);
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
@@ -25,11 +25,9 @@ import co.cask.cdap.common.DatasetNotFoundException;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -37,7 +35,6 @@ import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
@@ -48,10 +45,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 
 /**
@@ -81,20 +74,6 @@ public class DatasetClient {
    * @return list of {@link DatasetSpecificationSummary}.
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #list(NamespaceId)}.
-   */
-  @Deprecated
-  public List<DatasetSpecificationSummary> list(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return list(namespace.toEntityId());
-  }
-
-  /**
-   * Lists all datasets.
-   *
-   * @return list of {@link DatasetSpecificationSummary}.
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<DatasetSpecificationSummary> list(NamespaceId namespace)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -102,22 +81,6 @@ public class DatasetClient {
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response,
                                        new TypeToken<List<DatasetSpecificationSummary>>() { }).getResponseObject();
-  }
-
-  /**
-   * Gets information about a dataset.
-   *
-   * @param instance ID of the dataset instance
-   * @return a {@link DatasetSpecificationSummary}.
-   * @throws NotFoundException if the dataset is not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #get(DatasetId)} instead.
-   */
-  @Deprecated
-  public DatasetMeta get(Id.DatasetInstance instance)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return get(instance.toEntityId());
   }
 
   /**
@@ -139,24 +102,6 @@ public class DatasetClient {
       throw new NotFoundException(instance);
     }
     return ObjectResponse.fromJsonBody(response, DatasetMeta.class).getResponseObject();
-  }
-
-  /**
-   * Creates a dataset.
-   *
-   * @param instance ID of the dataset instance
-   * @param properties properties of the dataset to create
-   * @throws DatasetTypeNotFoundException if the desired dataset type was not found
-   * @throws DatasetAlreadyExistsException if a dataset by the same name already exists
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #create(DatasetId, DatasetInstanceConfiguration)} instead.
-   */
-  @Deprecated
-  public void create(Id.DatasetInstance instance, DatasetInstanceConfiguration properties)
-    throws DatasetTypeNotFoundException, DatasetAlreadyExistsException, IOException,
-    UnauthenticatedException, UnauthorizedException {
-    create(instance.toEntityId(), properties);
   }
 
   /**
@@ -195,45 +140,11 @@ public class DatasetClient {
    * @throws DatasetAlreadyExistsException if a dataset by the same name already exists
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #create(DatasetId, String)} instead.
-   */
-  @Deprecated
-  public void create(Id.DatasetInstance instance, String typeName)
-    throws DatasetTypeNotFoundException, DatasetAlreadyExistsException, IOException,
-    UnauthenticatedException, UnauthorizedException {
-    create(instance.toEntityId(), typeName);
-  }
-
-  /**
-   * Creates a dataset.
-   *
-   * @param instance ID of the dataset instance
-   * @param typeName type of dataset to create
-   * @throws DatasetTypeNotFoundException if the desired dataset type was not found
-   * @throws DatasetAlreadyExistsException if a dataset by the same name already exists
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void create(DatasetId instance, String typeName)
     throws DatasetTypeNotFoundException, DatasetAlreadyExistsException, IOException,
     UnauthenticatedException, UnauthorizedException {
     create(instance, new DatasetInstanceConfiguration(typeName, ImmutableMap.<String, String>of()));
-  }
-
-  /**
-   * Updates the properties of a dataset.
-   *
-   * @param instance the dataset to update
-   * @param properties properties to set
-   * @throws NotFoundException if the dataset is not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #update(DatasetId, Map)} instead.
-   */
-  @Deprecated
-  public void update(Id.DatasetInstance instance, Map<String, String> properties)
-    throws NotFoundException, IOException, UnauthenticatedException, ConflictException, UnauthorizedException {
-    update(instance.toEntityId(), properties);
   }
 
   /**
@@ -268,22 +179,6 @@ public class DatasetClient {
    * @throws NotFoundException if the dataset is not found
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #updateExisting(DatasetId, Map)} instead.
-   */
-  @Deprecated
-  public void updateExisting(Id.DatasetInstance instance, Map<String, String> properties)
-    throws NotFoundException, IOException, UnauthenticatedException, ConflictException, UnauthorizedException {
-    updateExisting(instance.toEntityId(), properties);
-  }
-
-  /**
-   * Updates the existing properties of a dataset.
-   *
-   * @param instance the dataset to update
-   * @param properties properties to set
-   * @throws NotFoundException if the dataset is not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void updateExisting(DatasetId instance, Map<String, String> properties)
     throws NotFoundException, IOException, UnauthenticatedException, ConflictException, UnauthorizedException {
@@ -296,21 +191,6 @@ public class DatasetClient {
     resolvedProperties.putAll(properties);
 
     update(instance, resolvedProperties);
-  }
-
-  /**
-   * Deletes a dataset.
-   *
-   * @param instance the dataset to delete
-   * @throws DatasetNotFoundException if the dataset with the specified name could not be found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #delete(DatasetId)} instead.
-   */
-  @Deprecated
-  public void delete(Id.DatasetInstance instance)
-    throws DatasetNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    delete(instance.toEntityId());
   }
 
   /**
@@ -339,21 +219,6 @@ public class DatasetClient {
    * @return true if the dataset exists
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #exists(DatasetId)} instead.
-   */
-  @Deprecated
-  public boolean exists(Id.DatasetInstance instance)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return exists(instance.toEntityId());
-  }
-
-  /**
-   * Checks if a dataset exists.
-   *
-   * @param instance the dataset to check
-   * @return true if the dataset exists
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public boolean exists(DatasetId instance)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -362,74 +227,6 @@ public class DatasetClient {
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     return response.getResponseCode() != HttpURLConnection.HTTP_NOT_FOUND;
-  }
-
-  /**
-   * Waits for a dataset to exist.
-   *
-   * @param instance the dataset to check
-   * @param timeout time to wait before timing out
-   * @param timeoutUnit time unit of timeout
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the dataset was not yet existent before {@code timeout} milliseconds
-   * @throws InterruptedException if interrupted while waiting
-   * @deprecated since 4.0.0.
-   */
-  @Deprecated
-  public void waitForExists(final Id.DatasetInstance instance, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
-    try {
-      Tasks.waitFor(true, new Callable<Boolean>() {
-        @Override
-        public Boolean call() throws Exception {
-          return exists(instance.toEntityId());
-        }
-      }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
-    } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
-    }
-  }
-
-  /**
-   * Waits for a dataset to be deleted.
-   *
-   * @param instance the dataset to check
-   * @param timeout time to wait before timing out
-   * @param timeoutUnit time unit of timeout
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the dataset was not yet deleted before {@code timeout} milliseconds
-   * @throws InterruptedException if interrupted while waiting
-   * @deprecated since 4.0.0.
-   */
-  @Deprecated
-  public void waitForDeleted(final Id.DatasetInstance instance, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
-    try {
-      Tasks.waitFor(false, new Callable<Boolean>() {
-        @Override
-        public Boolean call() throws Exception {
-          return exists(instance.toEntityId());
-        }
-      }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
-    } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
-    }
-  }
-
-  /**
-   * Truncates a dataset. This will clear all data belonging to the dataset.
-   *
-   * @param instance the dataset to truncate
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #truncate(DatasetId)} instead.
-   */
-  @Deprecated
-  public void truncate(Id.DatasetInstance instance)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    truncate(instance.toEntityId());
   }
 
   /**
@@ -444,18 +241,6 @@ public class DatasetClient {
     URL url = config.resolveNamespacedURLV3(instance.getParent(),
                                             String.format("data/datasets/%s/admin/truncate", instance.getDataset()));
     restClient.execute(HttpMethod.POST, url, config.getAccessToken());
-  }
-
-  /**
-   * Retrieve the properties with which a dataset was created or updated.
-   * @param instance the dataset instance
-   * @return the properties as a map
-   * @deprecated since 4.0.0. Use {@link #getProperties(DatasetId)} instead.
-   */
-  @Deprecated
-  public Map<String, String> getProperties(Id.DatasetInstance instance)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return getProperties(instance.toEntityId());
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetModuleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetModuleClient.java
@@ -25,9 +25,7 @@ import co.cask.cdap.common.DatasetModuleAlreadyExistsException;
 import co.cask.cdap.common.DatasetModuleCannotBeDeletedException;
 import co.cask.cdap.common.DatasetModuleNotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.DatasetModuleMeta;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetModuleId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -35,7 +33,6 @@ import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 
@@ -45,10 +42,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 
 /**
@@ -76,43 +69,12 @@ public class DatasetModuleClient {
    * @return list of {@link DatasetModuleMeta}s.
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #list(NamespaceId)} instead.
-   */
-  @Deprecated
-  public List<DatasetModuleMeta> list(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return list(namespace.toEntityId());
-  }
-
-  /**
-   * Lists all dataset modules.
-   *
-   * @return list of {@link DatasetModuleMeta}s.
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<DatasetModuleMeta> list(NamespaceId namespace)
     throws IOException, UnauthenticatedException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3(namespace, "data/modules");
     return ObjectResponse.fromJsonBody(restClient.execute(HttpMethod.GET, url, config.getAccessToken()),
                                        new TypeToken<List<DatasetModuleMeta>>() { }).getResponseObject();
-  }
-
-  /**
-   * Adds a new dataset module.
-   *
-   * @param module the new dataset module
-   * @param className name of the dataset module class within the moduleJarFile
-   * @param moduleJarFile Jar file containing the dataset module class and dependencies
-   * @throws BadRequestException if the moduleJarFile does not exist
-   * @throws AlreadyExistsException if a dataset module with the same name already exists
-   * @throws IOException if a network error occurred
-   * @deprecated since 4.0.0. Use {@link #add(DatasetModuleId, String, File)} instead.
-   */
-  @Deprecated
-  public void add(Id.DatasetModule module, String className, File moduleJarFile)
-    throws BadRequestException, AlreadyExistsException, IOException, UnauthenticatedException {
-    add(module.toEntityId(), className, moduleJarFile);
   }
 
   /**
@@ -151,24 +113,6 @@ public class DatasetModuleClient {
    * @throws DatasetModuleNotFoundException if the dataset module with the specified name was not found
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #delete(DatasetModuleId)} instead.
-   */
-  @Deprecated
-  public void delete(Id.DatasetModule module)
-    throws DatasetModuleCannotBeDeletedException, DatasetModuleNotFoundException,
-    IOException, UnauthenticatedException, UnauthorizedException {
-    delete(module.toEntityId());
-  }
-
-  /**
-   * Deletes a dataset module.
-   *
-   * @param module the dataset module to delete
-   * @throws DatasetModuleCannotBeDeletedException if the dataset module cannot be deleted,
-   * usually due to other dataset modules or dataset instances using the dataset module
-   * @throws DatasetModuleNotFoundException if the dataset module with the specified name was not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void delete(DatasetModuleId module)
     throws DatasetModuleCannotBeDeletedException, DatasetModuleNotFoundException,
@@ -191,94 +135,12 @@ public class DatasetModuleClient {
    * @param module the dataset module to check
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #exists(DatasetModuleId)} instead.
-   */
-  @Deprecated
-  public boolean exists(Id.DatasetModule module) throws IOException, UnauthenticatedException, UnauthorizedException {
-    return exists(module.toEntityId());
-  }
-
-  /**
-   * Checks if a dataset module exists.
-   *
-   * @param module the dataset module to check
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public boolean exists(DatasetModuleId module) throws IOException, UnauthenticatedException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3(module.getParent(), String.format("data/modules/%s", module.getModule()));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     return response.getResponseCode() != HttpURLConnection.HTTP_NOT_FOUND;
-  }
-
-  /**
-   * Waits for a dataset module to exist.
-   *
-   * @param module the dataset module to check
-   * @param timeout time to wait before timing out
-   * @param timeoutUnit time unit of timeout
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the dataset module was not yet existent before {@code timeout} milliseconds
-   * @throws InterruptedException if interrupted while waiting
-   * @deprecated since 4.0.0.
-   */
-  @Deprecated
-  public void waitForExists(final Id.DatasetModule module, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
-    try {
-      Tasks.waitFor(true, new Callable<Boolean>() {
-        @Override
-        public Boolean call() throws Exception {
-          return exists(module.toEntityId());
-        }
-      }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
-    } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
-    }
-  }
-
-  /**
-   * Waits for a dataset module to be deleted.
-   *
-   * @param module the dataset module to check
-   * @param timeout time to wait before timing out
-   * @param timeoutUnit time unit of timeout
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the dataset module was not yet deleted before {@code timeout} milliseconds
-   * @throws InterruptedException if interrupted while waiting
-   * @deprecated since 4.0.0.
-   */
-  @Deprecated
-  public void waitForDeleted(final Id.DatasetModule module, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
-    try {
-      Tasks.waitFor(false, new Callable<Boolean>() {
-        @Override
-        public Boolean call() throws Exception {
-          return exists(module.toEntityId());
-        }
-      }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
-    } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
-    }
-  }
-
-  /**
-   * Deletes all dataset modules in a namespace.
-   *
-   * @throws DatasetModuleCannotBeDeletedException if one of the dataset modules cannot be deleted,
-   * usually due to existing dataset instances using the dataset module
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #delete(DatasetModuleId)} instead.
-   */
-  @Deprecated
-  public void deleteAll(Id.Namespace namespace)
-    throws DatasetModuleCannotBeDeletedException, IOException, UnauthenticatedException, UnauthorizedException {
-    deleteAll(namespace.toEntityId());
   }
 
   /**
@@ -299,22 +161,6 @@ public class DatasetModuleClient {
       // TODO: exception for all modules
       throw new DatasetModuleCannotBeDeletedException(null);
     }
-  }
-
-  /**
-   * Gets information about a dataset module.
-   *
-   * @param module the dataset module
-   * @return {@link DatasetModuleMeta} of the dataset module
-   * @throws DatasetModuleNotFoundException if the dataset module with the specified name was not found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #get(DatasetModuleId)} instead.
-   */
-  @Deprecated
-  public DatasetModuleMeta get(Id.DatasetModule module)
-    throws DatasetModuleNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return get(module.toEntityId());
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetTypeClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetTypeClient.java
@@ -21,26 +21,19 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetTypeId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
-import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 
 /**
@@ -68,20 +61,6 @@ public class DatasetTypeClient {
    * @return list of {@link DatasetTypeMeta}s.
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #list(NamespaceId)} instead.
-   */
-  @Deprecated
-  public List<DatasetTypeMeta> list(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return list(namespace.toEntityId());
-  }
-
-  /**
-   * Lists all dataset types.
-   *
-   * @return list of {@link DatasetTypeMeta}s.
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<DatasetTypeMeta> list(NamespaceId namespace)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -90,21 +69,6 @@ public class DatasetTypeClient {
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<DatasetTypeMeta>>() { }).getResponseObject();
   }
 
-  /**
-   * Gets information about a dataset type.
-   *
-   * @param type the dataset type
-   * @return {@link DatasetTypeMeta} of the dataset type
-   * @throws DatasetTypeNotFoundException if the dataset type could not be found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #get(DatasetTypeId)} instead.
-   */
-  @Deprecated
-  public DatasetTypeMeta get(Id.DatasetType type)
-    throws DatasetTypeNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return get(type.toEntityId());
-  }
   /**
    * Gets information about a dataset type.
    *
@@ -134,21 +98,6 @@ public class DatasetTypeClient {
    * @return true if the dataset type exists
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #exists(DatasetTypeId)} instead.
-   */
-  @Deprecated
-  public boolean exists(Id.DatasetType type)
-    throws DatasetTypeNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return exists(type.toEntityId());
-  }
-
-  /**
-   * Checks if a dataset type exists.
-   *
-   * @param type the dataset type to check
-   * @return true if the dataset type exists
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public boolean exists(DatasetTypeId type)
     throws DatasetTypeNotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
@@ -157,59 +106,4 @@ public class DatasetTypeClient {
                                                HttpURLConnection.HTTP_NOT_FOUND);
     return response.getResponseCode() != HttpURLConnection.HTTP_NOT_FOUND;
   }
-
-  /**
-   * Waits for a dataset type to exist.
-   *
-   * @param type the dataset type to check
-   * @param timeout time to wait before timing out
-   * @param timeoutUnit time unit of timeout
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the dataset type was not yet existent before {@code timeout} milliseconds
-   * @throws InterruptedException if interrupted while waiting
-   * @deprecated since 4.0.0.
-   */
-  @Deprecated
-  public void waitForExists(final Id.DatasetType type, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
-    try {
-      Tasks.waitFor(true, new Callable<Boolean>() {
-        @Override
-        public Boolean call() throws Exception {
-          return exists(type.toEntityId());
-        }
-      }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
-    } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
-    }
-  }
-
-  /**
-   * Waits for a dataset type to be deleted.
-   *
-   * @param type the dataset type to check
-   * @param timeout time to wait before timing out
-   * @param timeoutUnit time unit of timeout
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the dataset type was not yet deleted before {@code timeout} milliseconds
-   * @throws InterruptedException if interrupted while waiting
-   * @deprecated since 4.0.0.
-   */
-  @Deprecated
-  public void waitForDeleted(final Id.DatasetType type, long timeout, TimeUnit timeoutUnit)
-    throws IOException, UnauthenticatedException, TimeoutException, InterruptedException {
-    try {
-      Tasks.waitFor(false, new Callable<Boolean>() {
-        @Override
-        public Boolean call() throws Exception {
-          return exists(type.toEntityId());
-        }
-      }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
-    } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, UnauthenticatedException.class);
-    }
-  }
-
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
@@ -76,45 +76,11 @@ public class LineageClient {
    * @param endTime end time for the query, in seconds
    * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
    * @return {@link LineageRecord} for the specified dataset.
-   * @deprecated since 4.0.0. Use {@link #getLineage(DatasetId, long, long, Integer)} instead.
-   */
-  @Deprecated
-  public LineageRecord getLineage(Id.DatasetInstance datasetInstance, long startTime, long endTime,
-                                  @Nullable Integer levels)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    return getLineage(datasetInstance.toEntityId(), startTime, endTime, levels);
-  }
-
-  /**
-   * Retrieves Lineage for a given dataset.
-   *
-   * @param datasetInstance the dataset for which to retrieve lineage
-   * @param startTime start time for the query, in seconds
-   * @param endTime end time for the query, in seconds
-   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
-   * @return {@link LineageRecord} for the specified dataset.
    */
   public LineageRecord getLineage(DatasetId datasetInstance, long startTime, long endTime,
                                   @Nullable Integer levels)
     throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
     return getLineage(datasetInstance, Long.toString(startTime), Long.toString(endTime), levels);
-  }
-
-  /**
-   * Retrieves Lineage for a given dataset.
-   *
-   * @param datasetInstance the dataset for which to retrieve lineage
-   * @param startTime start time for the query, in seconds, or in 'now - xs' format
-   * @param endTime end time for the query, in seconds, or in 'now - xs' format
-   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
-   * @return {@link LineageRecord} for the specified dataset.
-   * @deprecated since 4.0.0. Use {@link #getLineage(DatasetId, String, String, Integer)} instead.
-   */
-  @Deprecated
-  public LineageRecord getLineage(Id.DatasetInstance datasetInstance, String startTime, String endTime,
-                                  @Nullable Integer levels)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    return getLineage(datasetInstance.toEntityId(), startTime, endTime, levels);
   }
 
   /**
@@ -141,47 +107,11 @@ public class LineageClient {
    * @param collapseTypes fields on which lineage relations can be collapsed on
    * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
    * @return {@link LineageRecord} for the specified dataset.
-   * @deprecated since 4.0.0. Use {@link #getLineage(DatasetId, long, long, Set, Integer)} instead.
-   */
-  @Deprecated
-  public LineageRecord getLineage(Id.DatasetInstance datasetInstance, long startTime, long endTime,
-                                  Set<CollapseType> collapseTypes, @Nullable Integer levels)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    return getLineage(datasetInstance.toEntityId(), startTime, endTime, collapseTypes, levels);
-  }
-
-  /**
-   * Retrieves Lineage for a given dataset.
-   *
-   * @param datasetInstance the dataset for which to retrieve lineage
-   * @param startTime start time for the query, in seconds
-   * @param endTime end time for the query, in seconds
-   * @param collapseTypes fields on which lineage relations can be collapsed on
-   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
-   * @return {@link LineageRecord} for the specified dataset.
    */
   public LineageRecord getLineage(DatasetId datasetInstance, long startTime, long endTime,
                                   Set<CollapseType> collapseTypes, @Nullable Integer levels)
     throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
     return getLineage(datasetInstance, Long.toString(startTime), Long.toString(endTime), collapseTypes, levels);
-  }
-
-  /**
-   * Retrieves Lineage for a given dataset.
-   *
-   * @param datasetInstance the dataset for which to retrieve lineage
-   * @param startTime start time for the query, in seconds, or in 'now - xs' format
-   * @param endTime end time for the query, in seconds, or in 'now - xs' format
-   * @param collapseTypes fields on which lineage relations can be collapsed on
-   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
-   * @return {@link LineageRecord} for the specified dataset.
-   * @deprecated since 4.0.0. Use {@link #getLineage(DatasetId, String, String, Set, Integer)} instead.
-   */
-  @Deprecated
-  public LineageRecord getLineage(Id.DatasetInstance datasetInstance, String startTime, String endTime,
-                                  Set<CollapseType> collapseTypes, @Nullable Integer levels)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    return getLineage(datasetInstance.toEntityId(), startTime, endTime, collapseTypes, levels);
   }
 
   /**
@@ -216,44 +146,10 @@ public class LineageClient {
    * @param endTime end time for the query, in seconds
    * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
    * @return {@link LineageRecord} for the specified stream.
-   * @deprecated since 4.0.0. Use {@link #getLineage(StreamId, long, long, Integer)} instead.
-   */
-  @Deprecated
-  public LineageRecord getLineage(Id.Stream streamId, long startTime, long endTime, @Nullable Integer levels)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    return getLineage(streamId.toEntityId(), startTime, endTime, levels);
-  }
-
-  /**
-   * Retrieves Lineage for a given stream.
-   *
-   * @param streamId the stream for which to retrieve lineage
-   * @param startTime start time for the query, in seconds
-   * @param endTime end time for the query, in seconds
-   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
-   * @return {@link LineageRecord} for the specified stream.
    */
   public LineageRecord getLineage(StreamId streamId, long startTime, long endTime, @Nullable Integer levels)
     throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
     return getLineage(streamId, Long.toString(startTime), Long.toString(endTime), levels);
-  }
-
-  /**
-   * Retrieves Lineage for a given stream.
-   *
-   * @param streamId the stream for which to retrieve lineage
-   * @param startTime start time for the query, in seconds
-   * @param endTime end time for the query, in seconds
-   * @param collapseTypes fields on which lineage relations can be collapsed on
-   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
-   * @return {@link LineageRecord} for the specified stream.
-   * @deprecated since 4.0.0. Use {@link #getLineage(StreamId, long, long, Set, Integer)} instead.
-   */
-  @Deprecated
-  public LineageRecord getLineage(Id.Stream streamId, long startTime, long endTime,
-                                  Set<CollapseType> collapseTypes, @Nullable Integer levels)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    return getLineage(streamId.toEntityId(), startTime, endTime, collapseTypes, levels);
   }
 
   /**
@@ -280,44 +176,10 @@ public class LineageClient {
    * @param endTime end time for the query, in seconds, or in 'now - xs' format
    * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
    * @return {@link LineageRecord} for the specified stream.
-   * @deprecated since 4.0.0. Use {@link #getLineage(StreamId, String, String, Integer)} instead.
-   */
-  @Deprecated
-  public LineageRecord getLineage(Id.Stream streamId, String startTime, String endTime, @Nullable Integer levels)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    return getLineage(streamId.toEntityId(), startTime, endTime, levels);
-  }
-
-  /**
-   * Retrieves Lineage for a given stream.
-   *
-   * @param streamId the stream for which to retrieve lineage
-   * @param startTime start time for the query, in seconds, or in 'now - xs' format
-   * @param endTime end time for the query, in seconds, or in 'now - xs' format
-   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
-   * @return {@link LineageRecord} for the specified stream.
    */
   public LineageRecord getLineage(StreamId streamId, String startTime, String endTime, @Nullable Integer levels)
     throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
     return getLineage(streamId, startTime, endTime, Collections.<CollapseType>emptySet(), levels);
-  }
-
-  /**
-   * Retrieves Lineage for a given stream.
-   *
-   * @param streamId the stream for which to retrieve lineage
-   * @param startTime start time for the query, in seconds, or in 'now - xs' format
-   * @param endTime end time for the query, in seconds, or in 'now - xs' format
-   * @param collapseTypes fields on which lineage relations can be collapsed on
-   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
-   * @return {@link LineageRecord} for the specified stream.
-   * @deprecated since 4.0.0. Use {@link #getLineage(StreamId, String, String, Set, Integer)} instead.
-   */
-  @Deprecated
-  public LineageRecord getLineage(Id.Stream streamId, String startTime, String endTime,
-                                  Set<CollapseType> collapseTypes, @Nullable Integer levels)
-    throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    return getLineage(streamId.toEntityId(), startTime, endTime, collapseTypes, levels);
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
@@ -21,9 +21,7 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
-import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
@@ -51,7 +49,6 @@ import javax.inject.Inject;
 public class LineageClient {
 
   private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
     .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .create();
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -20,7 +20,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.metadata.AbstractMetadataClient;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
@@ -59,8 +59,8 @@ public class MetadataClient extends AbstractMetadataClient {
   }
 
   @Override
-  protected URL resolve(Id.Namespace namespace, String resource) throws MalformedURLException {
-    return config.resolveNamespacedURLV3(namespace.toEntityId(), resource);
+  protected URL resolve(NamespaceId namespace, String resource) throws MalformedURLException {
+    return config.resolveNamespacedURLV3(namespace, resource);
   }
 
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -60,7 +60,7 @@ public class MetadataClient extends AbstractMetadataClient {
 
   @Override
   protected URL resolve(Id.Namespace namespace, String resource) throws MalformedURLException {
-    return config.resolveNamespacedURLV3(namespace, resource);
+    return config.resolveNamespacedURLV3(namespace.toEntityId(), resource);
   }
 
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
@@ -192,21 +192,11 @@ public class MetricsClient {
     }
   }
 
-  @Deprecated
-  public RuntimeMetrics getFlowletMetrics(Id.Program flowId, String flowletId) {
-    return getFlowletMetrics(flowId.toEntityId().flowlet(flowletId));
-  }
-
   public RuntimeMetrics getFlowletMetrics(FlowletId flowletId) {
     return getMetrics(MetricsTags.flowlet(flowletId),
                       Constants.Metrics.Name.Flow.FLOWLET_INPUT,
                       Constants.Metrics.Name.Flow.FLOWLET_PROCESSED,
                       Constants.Metrics.Name.Flow.FLOWLET_EXCEPTIONS);
-  }
-
-  @Deprecated
-  public RuntimeMetrics getServiceMetrics(Id.Program serviceId) {
-    return getServiceMetrics(serviceId.getApplication().toEntityId().service(serviceId.getId()));
   }
 
   public RuntimeMetrics getServiceMetrics(ServiceId serviceId) {
@@ -221,7 +211,6 @@ public class MetricsClient {
       outQueryParts.add(key + "=" + value);
     }
   }
-
   private void addTags(Map<String, String> tags, List<String> outQueryParts) {
     for (Map.Entry<String, String> tag : tags.entrySet()) {
       outQueryParts.add("tag=" + tag.getKey() + ":" + tag.getValue());

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
@@ -23,7 +23,6 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.metrics.MetricsTags;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.MetricQueryResult;
 import co.cask.cdap.proto.MetricTagValue;
 import co.cask.cdap.proto.id.FlowletId;

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
@@ -211,6 +211,7 @@ public class MetricsClient {
       outQueryParts.add(key + "=" + value);
     }
   }
+
   private void addTags(Map<String, String> tags, List<String> outQueryParts) {
     for (Map.Entry<String, String> tag : tags.entrySet()) {
       outQueryParts.add("tag=" + tag.getKey() + ":" + tag.getValue());

--- a/cdap-client/src/main/java/co/cask/cdap/client/PreferencesClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/PreferencesClient.java
@@ -23,7 +23,6 @@ import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
@@ -108,23 +107,6 @@ public class PreferencesClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the requested namespace is not found
-   * @deprecated since 4.0.0. Use {@link #getNamespacePreferences(NamespaceId, boolean)} instead.
-   */
-  @Deprecated
-  public Map<String, String> getNamespacePreferences(Id.Namespace namespace, boolean resolved)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return getNamespacePreferences(namespace.toEntityId(), resolved);
-  }
-
-  /**
-   * Returns the Preferences stored at the Namespace Level.
-   *
-   * @param namespace Namespace Id
-   * @param resolved Set to True if collapsed/resolved properties are desired
-   * @return map of key-value pairs
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the requested namespace is not found
    */
   public Map<String, String> getNamespacePreferences(NamespaceId namespace, boolean resolved)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
@@ -138,22 +120,6 @@ public class PreferencesClient {
       throw new NotFoundException(namespace);
     }
     return ObjectResponse.fromJsonBody(response, new TypeToken<Map<String, String>>() { }).getResponseObject();
-  }
-
-  /**
-   * Sets Preferences at the Namespace Level.
-   *
-   * @param namespace Namespace Id
-   * @param preferences map of key-value pairs
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the requested namespace is not found
-   * @deprecated since 4.0.0. Use {@link #setNamespacePreferences(NamespaceId, Map)} instead.
-   */
-  @Deprecated
-  public void setNamespacePreferences(Id.Namespace namespace, Map<String, String> preferences) throws IOException,
-    UnauthenticatedException, NotFoundException, UnauthorizedException {
-    setNamespacePreferences(namespace.toEntityId(), preferences);
   }
 
   /**
@@ -182,21 +148,6 @@ public class PreferencesClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the requested namespace is not found
-   * @deprecated since 4.0.0. Use {@link #deleteNamespacePreferences(NamespaceId)} instead.
-   */
-  @Deprecated
-  public void deleteNamespacePreferences(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    deleteNamespacePreferences(namespace.toEntityId());
-  }
-
-  /**
-   * Deletes Preferences at the Namespace Level.
-   *
-   * @param namespace Namespace Id
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the requested namespace is not found
    */
   public void deleteNamespacePreferences(NamespaceId namespace)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
@@ -207,23 +158,6 @@ public class PreferencesClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotFoundException(namespace);
     }
-  }
-
-  /**
-   * Returns the Preferences stored at the Application Level.
-   *
-   * @param application Application Id
-   * @param resolved Set to True if collapsed/resolved properties are desired
-   * @return map of key-value pairs
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ApplicationNotFoundException if the requested application is not found
-   * @deprecated since 4.0.0. Use {@link #getApplicationPreferences(ApplicationId, boolean)} instead.
-   */
-  @Deprecated
-  public Map<String, String> getApplicationPreferences(Id.Application application, boolean resolved)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return getApplicationPreferences(application.toEntityId(), resolved);
   }
 
   /**
@@ -259,22 +193,6 @@ public class PreferencesClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the requested application or namespace is not found
-   * @deprecated since 4.0.0. Use {@link #setApplicationPreferences(ApplicationId, Map)} instead.
-   */
-  @Deprecated
-  public void setApplicationPreferences(Id.Application application, Map<String, String> preferences)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    setApplicationPreferences(application.toEntityId(), preferences);
-  }
-
-  /**
-   * Sets Preferences at the Application Level.
-   *
-   * @param application Application Id
-   * @param preferences map of key-value pairs
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the requested application or namespace is not found
    */
   public void setApplicationPreferences(ApplicationId application, Map<String, String> preferences)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
@@ -295,21 +213,6 @@ public class PreferencesClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the request application or namespace is not found
-   * @deprecated since 4.0.0. Use {@link #deleteApplicationPreferences(ApplicationId)} instead.
-   */
-  @Deprecated
-  public void deleteApplicationPreferences(Id.Application application)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    deleteApplicationPreferences(application.toEntityId());
-  }
-
-  /**
-   * Deletes Preferences at the Application Level.
-   *
-   * @param application Application Id
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the request application or namespace is not found
    */
   public void deleteApplicationPreferences(ApplicationId application)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
@@ -321,23 +224,6 @@ public class PreferencesClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotFoundException(application);
     }
-  }
-
-  /**
-   * Returns the Preferences stored at the Program Level.
-   *
-   * @param program Program Id
-   * @param resolved Set to True if collapsed/resolved properties are desired
-   * @return map of key-value pairs
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ProgramNotFoundException if the requested program is not found
-   * @deprecated since 4.0.0. Use {@link #getProgramPreferences(ProgramId, boolean)} instead.
-   */
-  @Deprecated
-  public Map<String, String> getProgramPreferences(Id.Program program, boolean resolved)
-    throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
-    return getProgramPreferences(program.toEntityId(), resolved);
   }
 
   /**
@@ -375,22 +261,6 @@ public class PreferencesClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws ProgramNotFoundException if the requested program is not found
-   * @deprecated since 4.0.0. Use {@link #setProgramPreferences(ProgramId, Map)} instead.
-   */
-  @Deprecated
-  public void setProgramPreferences(Id.Program program, Map<String, String> preferences)
-    throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
-    setProgramPreferences(program.toEntityId(), preferences);
-  }
-
-  /**
-   * Sets Preferences at the Program Level.
-   *
-   * @param program Program Id
-   * @param preferences map of key-value pairs
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ProgramNotFoundException if the requested program is not found
    */
   public void setProgramPreferences(ProgramId program, Map<String, String> preferences)
     throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
@@ -403,21 +273,6 @@ public class PreferencesClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ProgramNotFoundException(program);
     }
-  }
-
-  /**
-   * Deletes Preferences at the Program Level.
-   *
-   * @param program Program Id
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws ProgramNotFoundException if the requested program is not found
-   * @deprecated since 4.0.0. Use {@link #deleteProgramPreferences(ProgramId)} instead.
-   */
-  @Deprecated
-  public void deleteProgramPreferences(Id.Program program)
-    throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
-    deleteProgramPreferences(program.toEntityId());
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -116,23 +116,6 @@ public class ProgramClient {
    * @param program the program to start
    * @param debug true to start in debug mode
    * @param runtimeArgs runtime arguments to pass to the program
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #start(ProgramId, boolean, Map)} instead
-   */
-  @Deprecated
-  public void start(Id.Program program, boolean debug, @Nullable Map<String, String> runtimeArgs)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, UnauthorizedException {
-    start(program.toEntityId(), debug, runtimeArgs);
-  }
-
-  /**
-   * Starts a program using specified runtime arguments.
-   *
-   * @param program the program to start
-   * @param debug true to start in debug mode
-   * @param runtimeArgs runtime arguments to pass to the program
    * @throws IOException
    * @throws ProgramNotFoundException
    * @throws UnauthenticatedException
@@ -163,41 +146,11 @@ public class ProgramClient {
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #start(ProgramId, boolean)} instead
-   */
-  @Deprecated
-  public void start(Id.Program program, boolean debug)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, UnauthorizedException {
-    start(program.toEntityId(), debug);
-  }
-
-  /**
-   * Starts a program using the stored runtime arguments.
-   *
-   * @param program the program to start
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void start(ProgramId program, boolean debug)
     throws IOException, ProgramNotFoundException, UnauthenticatedException, UnauthorizedException {
 
     start(program, debug, null);
-  }
-
-  /**
-   * Starts a program using the stored runtime arguments.
-   *
-   * @param program the program to start
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #start(ProgramId)} instead
-   */
-  @Deprecated
-  public void start(Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, UnauthorizedException {
-    start(program.toEntityId());
   }
 
   /**
@@ -221,22 +174,6 @@ public class ProgramClient {
    * @return the result of starting each program
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #start(NamespaceId, List)} instead
-   */
-  @Deprecated
-  public List<BatchProgramResult> start(Id.Namespace namespace, List<BatchProgramStart> programs)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return start(namespace.toEntityId(), programs);
-  }
-
-  /**
-   * Starts a batch of programs in the same call.
-   *
-   * @param namespace the namespace of the programs
-   * @param programs the programs to start, including any runtime arguments to start them with
-   * @return the result of starting each program
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<BatchProgramResult> start(NamespaceId namespace, List<BatchProgramStart> programs)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -248,21 +185,6 @@ public class ProgramClient {
     HttpResponse response = restClient.execute(request, config.getAccessToken());
     return ObjectResponse.<List<BatchProgramResult>>fromJsonBody(response, BATCH_RESULTS_TYPE, GSON)
       .getResponseObject();
-  }
-
-  /**
-   * Stops a program.
-   *
-   * @param program the program to stop
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #stop(ProgramId)} instead
-   */
-  @Deprecated
-  public void stop(Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, UnauthorizedException {
-    stop(program.toEntityId());
   }
 
   /**
@@ -293,22 +215,6 @@ public class ProgramClient {
    * @return the result of stopping each program
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #stop(NamespaceId, List)} instead
-   */
-  @Deprecated
-  public List<BatchProgramResult> stop(Id.Namespace namespace, List<BatchProgram> programs)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return stop(namespace.toEntityId(), programs);
-  }
-
-  /**
-   * Stops a batch of programs in the same call.
-   *
-   * @param namespace the namespace of the programs
-   * @param programs the programs to stop
-   * @return the result of stopping each program
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<BatchProgramResult> stop(NamespaceId namespace, List<BatchProgram> programs)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -320,22 +226,6 @@ public class ProgramClient {
     HttpResponse response = restClient.execute(request, config.getAccessToken());
     return ObjectResponse.<List<BatchProgramResult>>fromJsonBody(response, BATCH_RESULTS_TYPE, GSON)
       .getResponseObject();
-  }
-
-  /**
-   * Stops all currently running programs.
-   *
-   * @throws IOException
-   * @throws UnauthenticatedException
-   * @throws InterruptedException
-   * @throws TimeoutException
-   * @deprecated since 4.0.0. Use {@link #stopAll(NamespaceId)} instead
-   */
-  @Deprecated
-  public void stopAll(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, InterruptedException, TimeoutException, UnauthorizedException,
-    ApplicationNotFoundException {
-    stopAll(namespace.toEntityId());
   }
 
   /**
@@ -375,22 +265,6 @@ public class ProgramClient {
   }
 
   /**
-   * Gets the status of a program.
-   *
-   * @param program the program
-   * @return the status of the program (e.g. STOPPED, STARTING, RUNNING)
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #getStatus(ProgramId)} instead
-   */
-  @Deprecated
-  public String getStatus(Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getStatus(program.toEntityId());
-  }
-
-  /**
    * Gets the status of a program
    * @param programId the program
    * @return the status of the program (e.g. STOPPED, STARTING, RUNNING)
@@ -420,20 +294,6 @@ public class ProgramClient {
    * @param namespace the namespace of the programs
    * @param programs the list of programs to get status for
    * @return the status of each program
-   * @deprecated since 4.0.0. Use {@link #getStatus(NamespaceId, List)} instead
-   */
-  @Deprecated
-  public List<BatchProgramStatus> getStatus(Id.Namespace namespace, List<BatchProgram> programs)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return getStatus(namespace.toEntityId(), programs);
-  }
-
-  /**
-   * Gets the status of multiple programs.
-   *
-   * @param namespace the namespace of the programs
-   * @param programs the list of programs to get status for
-   * @return the status of each program
    */
   public List<BatchProgramStatus> getStatus(NamespaceId namespace, List<BatchProgram> programs)
     throws IOException, UnauthenticatedException, UnauthorizedException {
@@ -445,26 +305,6 @@ public class ProgramClient {
 
     return ObjectResponse.<List<BatchProgramStatus>>fromJsonBody(response, BATCH_STATUS_RESPONSE_TYPE, GSON)
       .getResponseObject();
-  }
-
-  /**
-   * Waits for a program to have a certain status.
-   *
-   * @param program the program
-   * @param status the desired status
-   * @param timeout how long to wait in milliseconds until timing out
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws TimeoutException if the program did not achieve the desired program status before the timeout
-   * @throws InterruptedException if interrupted while waiting for the desired program status
-   * @deprecated since 4.0.0. Please use {@link #waitForStatus(ProgramId, ProgramStatus, long, TimeUnit)} instead
-   */
-  @Deprecated
-  public void waitForStatus(final Id.Program program, String status, long timeout, TimeUnit timeoutUnit)
-    throws UnauthenticatedException, IOException, ProgramNotFoundException,
-    TimeoutException, InterruptedException {
-    waitForStatus(program.toEntityId(), ProgramStatus.valueOf(status), timeout, timeoutUnit);
   }
 
   /**
@@ -507,23 +347,6 @@ public class ProgramClient {
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the program with the specified name could not be found
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getLiveInfo(ProgramId)} instead
-   */
-  @Deprecated
-  public DistributedProgramLiveInfo getLiveInfo(Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getLiveInfo(program.toEntityId());
-  }
-
-  /**
-   * Gets the live information of a program. In distributed CDAP,
-   * this will contain IDs of the YARN applications that are running the program.
-   *
-   * @param program the program
-   * @return {@link ProgramLiveInfo} of the program
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the program with the specified name could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public DistributedProgramLiveInfo getLiveInfo(ProgramId program)
     throws IOException, ProgramNotFoundException, UnauthenticatedException, UnauthorizedException {
@@ -538,22 +361,6 @@ public class ProgramClient {
     }
 
     return ObjectResponse.fromJsonBody(response, DistributedProgramLiveInfo.class).getResponseObject();
-  }
-
-  /**
-   * Gets the number of instances that a flowlet is currently running on.
-   *
-   * @param flowlet the flowlet
-   * @return number of instances that the flowlet is currently running on
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application, flow, or flowlet could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getFlowletInstances(FlowletId)} instead
-   */
-  @Deprecated
-  public int getFlowletInstances(Id.Flow.Flowlet flowlet)
-    throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getFlowletInstances(flowlet.toEntityId());
   }
 
   /**
@@ -590,22 +397,6 @@ public class ProgramClient {
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application, flow, or flowlet could not be found
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #setFlowletInstances(FlowletId, int)} instead
-   */
-  @Deprecated
-  public void setFlowletInstances(Id.Flow.Flowlet flowlet, int instances)
-    throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
-    setFlowletInstances(flowlet.toEntityId(), instances);
-  }
-
-  /**
-   * Sets the number of instances that a flowlet will run on.
-   *
-   * @param flowlet the flowlet
-   * @param instances number of instances for the flowlet to run on
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application, flow, or flowlet could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void setFlowletInstances(FlowletId flowlet, int instances)
     throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
@@ -621,22 +412,6 @@ public class ProgramClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotFoundException(flowlet);
     }
-  }
-
-  /**
-   * Gets the number of instances that a worker is currently running on.
-   *
-   * @param worker the worker
-   * @return number of instances that the worker is currently running on
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application or worker could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getWorkerInstances(ProgramId)} instead
-   */
-  @Deprecated
-  public int getWorkerInstances(Id.Worker worker) throws IOException, NotFoundException,
-    UnauthenticatedException, UnauthorizedException {
-    return getWorkerInstances(worker.toEntityId());
   }
 
   /**
@@ -668,21 +443,6 @@ public class ProgramClient {
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or worker could not be found
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #setWorkerInstances(ProgramId, int)} instead
-   */
-  @Deprecated
-  public void setWorkerInstances(Id.Worker worker, int instances) throws IOException, NotFoundException,
-    UnauthenticatedException, UnauthorizedException {
-    setWorkerInstances(worker.toEntityId(), instances);
-  }
-
-  /**
-   * Sets the number of instances that a worker will run on.
-   *
-   * @param instances number of instances for the worker to run on
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application or worker could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void setWorkerInstances(ProgramId worker, int instances) throws IOException, NotFoundException,
     UnauthenticatedException, UnauthorizedException {
@@ -696,22 +456,6 @@ public class ProgramClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotFoundException(worker);
     }
-  }
-
-  /**
-   * Gets the number of instances of a service.
-   *
-   * @param service the service
-   * @return number of instances of the service handler
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application or service could not found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getServiceInstances(ServiceId)} instead
-   */
-  @Deprecated
-  public int getServiceInstances(Id.Service service)
-    throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getServiceInstances(service.toEntityId());
   }
 
   /**
@@ -745,22 +489,6 @@ public class ProgramClient {
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or service could not be found
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #setServiceInstances(ServiceId, int)} instead
-   */
-  @Deprecated
-  public void setServiceInstances(Id.Service service, int instances)
-    throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
-    setServiceInstances(service.toEntityId(), instances);
-  }
-
-  /**
-   * Sets the number of instances of a service.
-   *
-   * @param service the service
-   * @param instances number of instances for the service
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application or service could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void setServiceInstances(ServiceId service, int instances)
     throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
@@ -774,23 +502,6 @@ public class ProgramClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotFoundException(service);
     }
-  }
-
-  /**
-   * Get the current run information for the Workflow based on the runid
-   * @param appId ID of the application
-   * @param workflowId ID of the workflow
-   * @param runId ID of the run for which the details are to be returned
-   * @return list of {@link WorkflowActionNode} currently running for the given runid
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application, workflow, or runid could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getWorkflowCurrent(WorkflowId, String)} instead
-   */
-  @Deprecated
-  public List<WorkflowActionNode> getWorkflowCurrent(Id.Application appId, String workflowId, String runId)
-    throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getWorkflowCurrent(appId.toEntityId().workflow(workflowId), runId);
   }
 
   /**
@@ -819,24 +530,6 @@ public class ProgramClient {
       response, new TypeToken<List<WorkflowActionNode>>() { }.getType(), GSON);
 
     return objectResponse.getResponseObject();
-  }
-
-  /**
-   * Gets the run records of a program.
-   *
-   * @param program the program
-   * @param state - filter by status of the program
-   * @return the run records of the program
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application or program could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getProgramRuns(ProgramId, String, long, long, int)} instead
-   */
-  @Deprecated
-  public List<RunRecord> getProgramRuns(Id.Program program, String state,
-                                        long startTime, long endTime, int limit)
-    throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getProgramRuns(program.toEntityId(), state, startTime, endTime, limit);
   }
 
   /**
@@ -882,44 +575,10 @@ public class ProgramClient {
    * @throws IOException if a network error occurred
    * @throws NotFoundException if the application or program could not be found
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getAllProgramRuns(ProgramId, long, long, int)} instead
-   */
-  @Deprecated
-  public List<RunRecord> getAllProgramRuns(Id.Program program, long startTime, long endTime, int limit)
-    throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getAllProgramRuns(program.toEntityId(), startTime, endTime, limit);
-  }
-
-  /**
-   * Gets the run records of a program.
-   *
-   * @param program ID of the program
-   * @return the run records of the program
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application or program could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public List<RunRecord> getAllProgramRuns(ProgramId program, long startTime, long endTime, int limit)
     throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
     return getProgramRuns(program, ProgramRunStatus.ALL.name(), startTime, endTime, limit);
-  }
-
-  /**
-   * Gets the logs of a program.
-   *
-   * @param program the program
-   * @param start start time of the time range of desired logs
-   * @param stop end time of the time range of desired logs
-   * @return the logs of the program
-   * @throws IOException if a network error occurred
-   * @throws NotFoundException if the application or program could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Use {@link #getProgramLogs(ProgramId, long, long)} instead
-   */
-  @Deprecated
-  public String getProgramLogs(Id.Program program, long start, long stop)
-    throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getProgramLogs(program.toEntityId(), start, stop);
   }
 
   /**
@@ -956,23 +615,6 @@ public class ProgramClient {
    * @throws IOException if a network error occurred
    * @throws ProgramNotFoundException if the application or program could not be found
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #getRuntimeArgs(ProgramId)} instead
-   */
-  @Deprecated
-  public Map<String, String> getRuntimeArgs(Id.Program program)
-    throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
-
-    return getRuntimeArgs(program.toEntityId());
-  }
-
-  /**
-   * Gets the runtime args of a program.
-   *
-   * @param program the program
-   * @return runtime args of the program
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the application or program could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public Map<String, String> getRuntimeArgs(ProgramId program)
     throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
@@ -987,23 +629,6 @@ public class ProgramClient {
       throw new ProgramNotFoundException(program);
     }
     return ObjectResponse.fromJsonBody(response, new TypeToken<Map<String, String>>() { }).getResponseObject();
-  }
-
-  /**
-   * Sets the runtime args of a program.
-   *
-   * @param program the program
-   * @param runtimeArgs args of the program
-   * @throws IOException if a network error occurred
-   * @throws ProgramNotFoundException if the application or program could not be found
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #setRuntimeArgs(ProgramId, Map)} instead
-   */
-  @Deprecated
-  public void setRuntimeArgs(Id.Program program, Map<String, String> runtimeArgs)
-    throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
-
-    setRuntimeArgs(program.toEntityId(), runtimeArgs);
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -35,7 +35,6 @@ import co.cask.cdap.proto.BatchProgramResult;
 import co.cask.cdap.proto.BatchProgramStart;
 import co.cask.cdap.proto.BatchProgramStatus;
 import co.cask.cdap.proto.DistributedProgramLiveInfo;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.Instances;
 import co.cask.cdap.proto.ProgramLiveInfo;
 import co.cask.cdap.proto.ProgramRecord;

--- a/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
@@ -114,6 +114,7 @@ public class ScheduleClient {
     UnauthenticatedException, NotFoundException, UnauthorizedException, AlreadyExistsException {
     doUpdate(scheduleId, GSON.toJson(config));
   }
+
   public void update(ScheduleId scheduleId, ScheduleDetail detail) throws IOException,
     UnauthenticatedException, NotFoundException, UnauthorizedException, AlreadyExistsException {
     doUpdate(scheduleId, GSON.toJson(detail));

--- a/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
@@ -26,7 +26,6 @@ import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.internal.schedule.constraint.Constraint;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProtoConstraintCodec;
 import co.cask.cdap.proto.ProtoTriggerCodec;
 import co.cask.cdap.proto.ScheduleDetail;
@@ -115,34 +114,9 @@ public class ScheduleClient {
     UnauthenticatedException, NotFoundException, UnauthorizedException, AlreadyExistsException {
     doUpdate(scheduleId, GSON.toJson(config));
   }
-
   public void update(ScheduleId scheduleId, ScheduleDetail detail) throws IOException,
     UnauthenticatedException, NotFoundException, UnauthorizedException, AlreadyExistsException {
     doUpdate(scheduleId, GSON.toJson(detail));
-  }
-
-  /**
-   * List all schedules for an existing workflow.
-   *
-   * @param workflow the ID of the workflow
-   * @deprecated as of 4.2.0. Use {@link #listSchedules(WorkflowId)} instead.
-   */
-  @Deprecated
-  public List<ScheduleSpecification> list(Id.Workflow workflow)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return ScheduleDetail.toScheduleSpecs(doList(workflow.toEntityId()));
-  }
-
-  /**
-   * List all schedules for an existing workflow.
-   *
-   * @param workflow the ID of the workflow
-   * @deprecated as of 4.2.0. Use {@link #listSchedules(WorkflowId)} instead.
-   */
-  @Deprecated
-  public List<ScheduleSpecification> list(WorkflowId workflow)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return ScheduleDetail.toScheduleSpecs(doList(workflow));
   }
 
   /**
@@ -153,21 +127,6 @@ public class ScheduleClient {
   public List<ScheduleDetail> listSchedules(WorkflowId workflow)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
     return doList(workflow);
-  }
-
-  /**
-   * Get the next scheduled run time of the program. A program may contain multiple schedules.
-   * This method returns the next scheduled runtimes for all the schedules. This method only takes
-   + into account {@link Schedule}s based on time. Schedules based on data are ignored.
-   *
-   * @param workflow Id of the Workflow for which to fetch next run times.
-   * @return list of Scheduled runtimes for the Workflow. Empty list if there are no schedules.
-   * @deprecated use {@link #nextRuntimes(WorkflowId)} instead
-   */
-  @Deprecated
-  public List<ScheduledRuntime> nextRuntimes(Id.Workflow workflow)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return nextRuntimes(workflow.toEntityId());
   }
 
   /**
@@ -194,17 +153,11 @@ public class ScheduleClient {
     return objectResponse.getResponseObject();
   }
 
-  @Deprecated
-  public void suspend(Id.Schedule schedule)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    suspend(schedule.toEntityId());
-  }
-
   public void suspend(ScheduleId scheduleId) throws IOException, UnauthenticatedException, NotFoundException,
     UnauthorizedException {
     String path = String.format("apps/%s/versions/%s/schedules/%s/suspend", scheduleId.getApplication(),
                                 scheduleId.getVersion(), scheduleId.getSchedule());
-    URL url = config.resolveNamespacedURLV3(scheduleId.toId().getNamespace(), path);
+    URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == response.getResponseCode()) {
@@ -212,17 +165,11 @@ public class ScheduleClient {
     }
   }
 
-  @Deprecated
-  public void resume(Id.Schedule schedule)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    resume(schedule.toEntityId());
-  }
-
   public void resume(ScheduleId scheduleId) throws IOException, UnauthenticatedException, NotFoundException,
     UnauthorizedException {
     String path = String.format("apps/%s/versions/%s/schedules/%s/resume", scheduleId.getApplication(),
                                 scheduleId.getVersion(), scheduleId.getSchedule());
-    URL url = config.resolveNamespacedURLV3(scheduleId.toId().getNamespace(), path);
+    URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == response.getResponseCode()) {
@@ -239,7 +186,7 @@ public class ScheduleClient {
     UnauthorizedException {
     String path = String.format("apps/%s/versions/%s/schedules/%s", scheduleId.getApplication(),
                                 scheduleId.getVersion(), scheduleId.getSchedule());
-    URL url = config.resolveNamespacedURLV3(scheduleId.toId().getNamespace(), path);
+    URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == response.getResponseCode()) {

--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -26,7 +26,6 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ServiceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -137,24 +136,6 @@ public class ServiceClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_UNAVAILABLE) {
       throw new ServiceUnavailableException(service.getProgram());
     }
-  }
-
-  /**
-   * Gets a {@link URL} to call methods for a {@link Service}. If multiple versions exist, traffic to the {@link URL}
-   * will be distributed to each version according to routing strategy. If only one version exists, this version
-   * will always be reached with the {@link URL}.
-   *
-   * @param service ID of the service
-   * @return a URL to call methods of the service
-   * @throws NotFoundException @throws NotFoundException if the app or service could not be found
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #getServiceURL(ServiceId)} or
-   *             {@link #getVersionedServiceURL(ServiceId)} instead
-   */
-  public URL getServiceURL(Id.Service service)
-    throws NotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return getServiceURL(service.toEntityId());
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -76,22 +76,6 @@ public class ServiceClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the app or service could not be found
-   * @deprecated since 4.0.0. Please use {@link #get(ProgramId)} instead
-   */
-  @Deprecated
-  public ServiceSpecification get(Id.Service service)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return get(service.toEntityId());
-  }
-
-  /**
-   * Gets a {@link ServiceSpecification} for a {@link Service}.
-   *
-   * @param service ID of the service
-   * @return {@link ServiceSpecification} representing the service
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the app or service could not be found
    */
   public ServiceSpecification get(ProgramId service)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
@@ -116,22 +100,6 @@ public class ServiceClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the app or service could not be found
-   * @deprecated since 4.0.0. Please use {@link #getEndpoints(ServiceId)} instead
-   */
-  @Deprecated
-  public List<ServiceHttpEndpoint> getEndpoints(Id.Service service)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return getEndpoints(service.toEntityId());
-  }
-
-  /**
-   * Gets a list of {@link ServiceHttpEndpoint} that a {@link Service} exposes.
-   *
-   * @param service ID of the service
-   * @return A list of {@link ServiceHttpEndpoint}
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the app or service could not be found
    */
   public List<ServiceHttpEndpoint> getEndpoints(ServiceId service)
     throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
@@ -142,22 +110,6 @@ public class ServiceClient {
       builder.addAll(handlerSpecification.getEndpoints());
     }
     return builder.build();
-  }
-
-  /**
-   * Checks whether the {@link Service} is active. Returns without throwing any exception if it is active.
-   *
-   * @param service ID of the service
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @throws NotFoundException if the app or service could not be found
-   * @throws ServiceUnavailableException if the service is not available
-   * @deprecated since 4.0.0. Please use {@link #checkAvailability(ServiceId)} instead
-   */
-  @Deprecated
-  public void checkAvailability(Id.Service service) throws IOException, UnauthenticatedException, NotFoundException,
-    ServiceUnavailableException, UnauthorizedException {
-    checkAvailability(service.toEntityId());
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -27,7 +27,6 @@ import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
 import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamDetail;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -95,20 +94,6 @@ public class StreamClient {
    * @param stream ID of the stream
    * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream was not found
-   * @deprecated since 4.0.0. Use {@link #getConfig(StreamId)} instead.
-   */
-  @Deprecated
-  public StreamProperties getConfig(Id.Stream stream)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getConfig(stream.toEntityId());
-  }
-
-  /**
-   * Gets the configuration of a stream.
-   *
-   * @param stream ID of the stream
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream was not found
    */
   public StreamProperties getConfig(StreamId stream)
     throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
@@ -120,23 +105,6 @@ public class StreamClient {
       throw new StreamNotFoundException(stream);
     }
     return GSON.fromJson(response.getResponseBodyAsString(Charsets.UTF_8), StreamProperties.class);
-  }
-
-  /**
-   * Sets properties of a stream.
-   *
-   * @param stream ID of the stream
-   * @param properties properties to set
-   * @throws IOException if a network error occurred
-   * @throws UnauthenticatedException if the client is unauthorized
-   * @throws BadRequestException if the request is bad
-   * @throws StreamNotFoundException if the stream was not found
-   * @deprecated since 4.0.0. Use {@link #setStreamProperties(StreamId, StreamProperties)} instead.
-   */
-  @Deprecated
-  public void setStreamProperties(Id.Stream stream, StreamProperties properties)
-    throws IOException, UnauthenticatedException, BadRequestException, StreamNotFoundException, UnauthorizedException {
-    setStreamProperties(stream.toEntityId(), properties);
   }
 
   /**
@@ -173,39 +141,10 @@ public class StreamClient {
    * @param newStreamId ID of the new stream to create
    * @throws IOException if a network error occurred
    * @throws BadRequestException if the provided stream ID was invalid
-   * @deprecated since 4.0.0. Use {@link #create(StreamId)} instead.
-   */
-  @Deprecated
-  public void create(Id.Stream newStreamId)
-    throws IOException, BadRequestException, UnauthenticatedException, UnauthorizedException {
-    create(newStreamId.toEntityId());
-  }
-
-  /**
-   * Creates a stream.
-   *
-   * @param newStreamId ID of the new stream to create
-   * @throws IOException if a network error occurred
-   * @throws BadRequestException if the provided stream ID was invalid
    */
   public void create(StreamId newStreamId)
     throws IOException, BadRequestException, UnauthenticatedException, UnauthorizedException {
     create(newStreamId, null);
-  }
-
-  /**
-   * Creates a stream with {@link StreamProperties} properties.
-   *
-   * @param newStreamId ID of the new stream to create
-   * @param properties {@link StreamProperties} for the new stream
-   * @throws IOException if a network error occurred
-   * @throws BadRequestException if the provided stream ID was invalid
-   * @deprecated since 4.0.0. Use {@link #create(StreamId, StreamProperties)} instead.
-   */
-  @Deprecated
-  public void create(Id.Stream newStreamId, @Nullable StreamProperties properties)
-    throws IOException, BadRequestException, UnauthenticatedException, UnauthorizedException {
-    create(newStreamId.toEntityId(), properties);
   }
 
   /**
@@ -238,21 +177,6 @@ public class StreamClient {
    * @param description description of the stream
    * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
-   * @deprecated since 4.0.0. Use {@link #setDescription(StreamId, String)} instead.
-   */
-  @Deprecated
-  public void setDescription(Id.Stream stream, String description)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    setDescription(stream.toEntityId(), description);
-  }
-
-  /**
-   * Sets the description of a stream.
-   *
-   * @param stream ID of the stream
-   * @param description description of the stream
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void setDescription(StreamId stream, String description)
     throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
@@ -274,42 +198,11 @@ public class StreamClient {
    * @param event event to send to the stream
    * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
-   * @deprecated since 4.0.0. Use {@link #sendEvent(StreamId, String)} instead.
-   */
-  @Deprecated
-  public void sendEvent(Id.Stream stream, String event) throws IOException,
-    StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    sendEvent(stream.toEntityId(), event);
-  }
-
-  /**
-   * Sends an event to a stream.
-   *
-   * @param stream ID of the stream
-   * @param event event to send to the stream
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendEvent(StreamId stream, String event) throws IOException,
     StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3(stream.getParent(), String.format("streams/%s", stream.getStream()));
     writeEvent(url, stream, event);
-  }
-
-  /**
-   * Sends an event to a stream. The write is asynchronous, meaning when this method returns, it only guarantees
-   * the event has been received by the server, but may not get persisted.
-   *
-   * @param stream ID of the stream
-   * @param event event to send to the stream
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream with the specified ID was not found
-   * @deprecated since 4.0.0. Use {@link #asyncSendEvent(StreamId, String)} instead.
-   */
-  @Deprecated
-  public void asyncSendEvent(Id.Stream stream, String event) throws IOException,
-    StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    asyncSendEvent(stream.toEntityId(), event);
   }
 
   /**
@@ -335,43 +228,10 @@ public class StreamClient {
    * @param file the file to upload
    * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
-   * @deprecated since 4.0.0. Use {@link #sendFile(StreamId, String, File)} instead.
-   */
-  @Deprecated
-  public void sendFile(Id.Stream stream, String contentType,
-                       File file) throws IOException, StreamNotFoundException, UnauthenticatedException {
-    sendFile(stream.toEntityId(), contentType, file);
-  }
-
-  /**
-   * Sends a file of the given content type to a stream batch endpoint.
-   *
-   * @param stream ID of the stream
-   * @param contentType content type of the file
-   * @param file the file to upload
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendFile(StreamId stream, String contentType,
                        File file) throws IOException, StreamNotFoundException, UnauthenticatedException {
     sendBatch(stream, contentType, Files.newInputStreamSupplier(file));
-  }
-
-  /**
-   * Sends a batch request to a stream batch endpoint.
-   *
-   * @param stream ID of the stream
-   * @param contentType content type of the data
-   * @param inputSupplier provides content for the batch request
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream with the specified ID was not found
-   * @deprecated since 4.0.0. Use {@link #sendBatch(StreamId, String, InputSupplier)} instead.
-   */
-  @Deprecated
-  public void sendBatch(Id.Stream stream, String contentType,
-                        InputSupplier<? extends InputStream> inputSupplier)
-    throws IOException, StreamNotFoundException, UnauthenticatedException {
-    sendBatch(stream.toEntityId(), contentType, inputSupplier);
   }
 
   /**
@@ -404,20 +264,6 @@ public class StreamClient {
    * @param stream ID of the stream to truncate
    * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
-   * @deprecated since 4.0.0. Use {@link #truncate(StreamId)} instead.
-   */
-  @Deprecated
-  public void truncate(Id.Stream stream)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    truncate(stream.toEntityId());
-  }
-
-  /**
-   * Truncates a stream, deleting all stream events belonging to the stream.
-   *
-   * @param stream ID of the stream to truncate
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void truncate(StreamId stream)
     throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
@@ -436,20 +282,6 @@ public class StreamClient {
    * @param stream ID of the stream to truncate
    * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
-   * @deprecated since 4.0.0. Use {@link #delete(StreamId)} instead.
-   */
-  @Deprecated
-  public void delete(Id.Stream stream)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    delete(stream.toEntityId());
-  }
-
-  /**
-   * Deletes a stream.
-   *
-   * @param stream ID of the stream to truncate
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void delete(StreamId stream)
     throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
@@ -460,22 +292,6 @@ public class StreamClient {
       throw new StreamNotFoundException(stream);
     }
   }
-
-  /**
-   * Sets the Time-to-Live (TTL) of a stream. TTL governs how long stream events are readable.
-   *
-   * @param stream ID of the stream
-   * @param ttlInSeconds desired TTL, in seconds
-   * @throws IOException if a network error occurred
-   * @throws StreamNotFoundException if the stream with the specified name was not found
-   * @deprecated since 4.0.0. Use {@link #setTTL(StreamId, long)} instead.
-   */
-  @Deprecated
-  public void setTTL(Id.Stream stream, long ttlInSeconds)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    setTTL(stream.toEntityId(), ttlInSeconds);
-  }
-
 
   /**
    * Sets the Time-to-Live (TTL) of a stream. TTL governs how long stream events are readable.
@@ -503,46 +319,12 @@ public class StreamClient {
    *
    * @return list of {@link StreamDetail}s
    * @throws IOException if a network error occurred
-   * @deprecated since 4.0.0. Use {@link #list(NamespaceId)} instead.
-   */
-  @Deprecated
-  public List<StreamDetail> list(Id.Namespace namespace)
-    throws IOException, UnauthenticatedException, UnauthorizedException {
-    return list(namespace.toEntityId());
-  }
-
-  /**
-   * Lists all streams.
-   *
-   * @return list of {@link StreamDetail}s
-   * @throws IOException if a network error occurred
    */
   public List<StreamDetail> list(NamespaceId namespace)
     throws IOException, UnauthenticatedException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3(namespace, "streams");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, STREAM_DETAIL_LIST_TYPE).getResponseObject();
-  }
-
-  /**
-   * Reads events from a stream
-   *
-   * @param streamId ID of the stream
-   * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit Maximum number of events to read
-   * @param results Collection for storing the resulting stream events
-   * @param <T> Type of the collection for storing results
-   * @return The same collection object as passed in the {@code results} parameter
-   * @throws IOException If fails to read from stream
-   * @throws StreamNotFoundException If the given stream does not exists
-   * @deprecated since 4.0.0. Use {@link #getEvents(StreamId, long, long, int, Collection)} instead.
-   */
-  @Deprecated
-  public <T extends Collection<? super StreamEvent>> T getEvents(Id.Stream streamId, String startTime,
-                                                                 String endTime, int limit, final T results)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getEvents(streamId.toEntityId(), startTime, endTime, limit, results);
   }
 
   /**
@@ -583,27 +365,6 @@ public class StreamClient {
    * @return The same collection object as passed in the {@code results} parameter
    * @throws IOException If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
-   * @deprecated since 4.0.0. Use {@link #getEvents(StreamId, long, long, int, Collection)} instead.
-   */
-  @Deprecated
-  public <T extends Collection<? super StreamEvent>> T getEvents(Id.Stream streamId, long startTime,
-                                                                 long endTime, int limit, final T results)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    return getEvents(streamId.toEntityId(), startTime, endTime, limit, results);
-  }
-
-  /**
-   * Reads events from a stream
-   *
-   * @param streamId ID of the stream
-   * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit Maximum number of events to read
-   * @param results Collection for storing the resulting stream events
-   * @param <T> Type of the collection for storing results
-   * @return The same collection object as passed in the {@code results} parameter
-   * @throws IOException If fails to read from stream
-   * @throws StreamNotFoundException If the given stream does not exists
    */
   public <T extends Collection<? super StreamEvent>> T getEvents(StreamId streamId, long startTime,
                                                                  long endTime, int limit, final T results)
@@ -611,26 +372,6 @@ public class StreamClient {
     return getEvents(streamId, String.valueOf(startTime), String.valueOf(endTime), limit, results);
   }
 
-  /**
-   * Reads events from a stream
-   *
-   * @param streamId ID of the stream
-   * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit Maximum number of events to read
-   * @param callback Callback to invoke for each stream event read. If the callback function returns {@code false}
-   *                  upon invocation, it will stops the reading
-   * @throws IOException If fails to read from stream
-   * @throws StreamNotFoundException If the given stream does not exists
-   * @deprecated since 4.0.0. Use {@link #getEvents(StreamId, long, long, int, Function)} instead.
-   */
-  @Deprecated
-  public void getEvents(Id.Stream streamId, long startTime, long endTime, int limit,
-                        Function<? super StreamEvent, Boolean> callback)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-
-    getEvents(streamId.toEntityId(), startTime, endTime, limit, callback);
-  }
 
   /**
    * Reads events from a stream
@@ -649,26 +390,6 @@ public class StreamClient {
     throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
 
     getEvents(streamId, String.valueOf(startTime), String.valueOf(endTime), limit, callback);
-  }
-
-  /**
-   * Reads events from a stream
-   *
-   * @param streamId ID of the stream
-   * @param start Timestamp in milliseconds or now-xs format to start reading event from (inclusive)
-   * @param end Timestamp in milliseconds or now-xs format for the last event to read (exclusive)
-   * @param limit Maximum number of events to read
-   * @param callback Callback to invoke for each stream event read. If the callback function returns {@code false}
-   *                 upon invocation, it will stops the reading
-   * @throws IOException If fails to read from stream
-   * @throws StreamNotFoundException If the given stream does not exists
-   * @deprecated since 4.0.0. Use {@link #getEvents(StreamId, String, String, int, Function)} instead.
-   */
-  @Deprecated
-  public void getEvents(Id.Stream streamId, String start, String end, int limit,
-                        Function<? super StreamEvent, Boolean> callback)
-    throws IOException, StreamNotFoundException, UnauthenticatedException, UnauthorizedException {
-    getEvents(streamId.toEntityId(), start, end, limit, callback);
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamViewClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamViewClient.java
@@ -23,7 +23,6 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ViewDetail;
 import co.cask.cdap.proto.ViewSpecification;
 import co.cask.cdap.proto.id.StreamId;
@@ -72,20 +71,6 @@ public class StreamViewClient {
    * @param id the view
    * @param viewSpecification the view config
    * @return true if a view was created, false if updated
-   * @deprecated since 4.0.0. Use {@link #createOrUpdate(StreamViewId, ViewSpecification)} instead.
-   */
-  @Deprecated
-  public boolean createOrUpdate(Id.Stream.View id, ViewSpecification viewSpecification)
-    throws NotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return createOrUpdate(id.toEntityId(), viewSpecification);
-  }
-
-  /**
-   * Creates or updates a view.
-   *
-   * @param id the view
-   * @param viewSpecification the view config
-   * @return true if a view was created, false if updated
    */
   public boolean createOrUpdate(StreamViewId id, ViewSpecification viewSpecification)
     throws NotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
@@ -95,19 +80,6 @@ public class StreamViewClient {
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(viewSpecification)).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken());
     return response.getResponseCode() == 201;
-  }
-
-  /**
-   * Deletes a view.
-   *
-   * @param id the view
-   * @throws NotFoundException if the view was not found
-   * @deprecated since 4.0.0. Use {@link #delete(StreamViewId)} instead.
-   */
-  @Deprecated
-  public void delete(Id.Stream.View id)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    delete(id.toEntityId());
   }
 
   /**
@@ -131,36 +103,11 @@ public class StreamViewClient {
    * Lists all views associated with a stream.
    *
    * @return the list of views associated with a stream
-   * @deprecated since 4.0.0. Use {@link #list(StreamId)} instead.
-   */
-  @Deprecated
-  public List<String> list(Id.Stream stream) throws IOException, UnauthenticatedException, UnauthorizedException {
-    return list(stream.toEntityId());
-  }
-
-  /**
-   * Lists all views associated with a stream.
-   *
-   * @return the list of views associated with a stream
    */
   public List<String> list(StreamId stream) throws IOException, UnauthenticatedException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3(stream.getParent(), String.format("streams/%s/views", stream.getStream()));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, LIST_TYPE).getResponseObject();
-  }
-
-  /**
-   * Gets detailed information about a view.
-   *
-   * @param id the view
-   * @return the detailed information about the view
-   * @throws NotFoundException if the view was not found
-   * @deprecated since 4.0.0. Use {@link #get(StreamViewId)} instead.
-   */
-  @Deprecated
-  public ViewDetail get(Id.Stream.View id)
-    throws NotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
-    return get(id.toEntityId());
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/WorkflowClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/WorkflowClient.java
@@ -22,7 +22,6 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
@@ -72,40 +71,12 @@ public class WorkflowClient {
   /**
    * Retrieve the entire {@link WorkflowToken} for the specified workflow run.
    *
-   * @param workflowRunId the {@link Id.Run} of the workflow
-   * @return {@link WorkflowTokenDetail} for the specified workflow run
-   * @deprecated since 4.0.0. Use {@link #getWorkflowToken(ProgramRunId)} instead.
-   */
-  @Deprecated
-  public WorkflowTokenDetail getWorkflowToken(Id.Run workflowRunId)
-    throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    return getWorkflowToken(workflowRunId.toEntityId());
-  }
-
-  /**
-   * Retrieve the entire {@link WorkflowToken} for the specified workflow run.
-   *
    * @param workflowRunId the run id of the workflow
    * @return {@link WorkflowTokenDetail} for the specified workflow run
    */
   public WorkflowTokenDetail getWorkflowToken(ProgramRunId workflowRunId)
     throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
     return getWorkflowToken(workflowRunId, null, null);
-  }
-
-  /**
-   * Retrieve all the keys in the {@link WorkflowToken} with the specified scope for the specified workflow run.
-   *
-   * @param workflowRunId the {@link Id.Run} of the workflow
-   * @param scope the specified {@link WorkflowToken.Scope}
-   * @return {@link WorkflowTokenDetail} containing all the keys in the specified {@link WorkflowToken.Scope}
-   * for the specified workflow run
-   * @deprecated since 4.0.0. Use {@link #getWorkflowToken(ProgramRunId, WorkflowToken.Scope)} instead.
-   */
-  @Deprecated
-  public WorkflowTokenDetail getWorkflowToken(Id.Run workflowRunId, WorkflowToken.Scope scope)
-    throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    return getWorkflowToken(workflowRunId.toEntityId(), scope);
   }
 
   /**
@@ -124,20 +95,6 @@ public class WorkflowClient {
   /**
    * Retrieve the specified key from the {@link WorkflowToken} for the specified workflow run.
    *
-   * @param workflowRunId the {@link Id.Run} of the workflow
-   * @param key the specified key
-   * @return {@link WorkflowTokenDetail} containing all the values for the specified key
-   * @deprecated since 4.0.0. Use {@link #getWorkflowToken(ProgramRunId, WorkflowToken.Scope, String)} instead.
-   */
-  @Deprecated
-  public WorkflowTokenDetail getWorkflowToken(Id.Run workflowRunId, String key)
-    throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    return getWorkflowToken(workflowRunId.toEntityId(), key);
-  }
-
-  /**
-   * Retrieve the specified key from the {@link WorkflowToken} for the specified workflow run.
-   *
    * @param workflowRunId the run id of the workflow
    * @param key the specified key
    * @return {@link WorkflowTokenDetail} containing all the values for the specified key
@@ -145,24 +102,6 @@ public class WorkflowClient {
   public WorkflowTokenDetail getWorkflowToken(ProgramRunId workflowRunId, String key)
     throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
     return getWorkflowToken(workflowRunId, null, key);
-  }
-
-  /**
-   * Retrieve the {@link WorkflowToken} for the specified workflow run filtered by the specified
-   * {@link WorkflowToken.Scope} and key.
-   *
-   * @param workflowRunId the {@link Id.Run} of the workflow
-   * @param scope the specified {@link WorkflowToken.Scope}. If null, it returns keys for
-   * {@link WorkflowToken.Scope#USER}
-   * @param key the specified key. If null, it returns all keys in the specified {@link WorkflowToken.Scope}
-   * @return {@link WorkflowTokenDetail} with the specified filters
-   * @deprecated since 4.0.0. Use {@link #getWorkflowToken(ProgramRunId, WorkflowToken.Scope, String)} instead.
-   */
-  @Deprecated
-  public WorkflowTokenDetail getWorkflowToken(Id.Run workflowRunId, @Nullable WorkflowToken.Scope scope,
-                                              @Nullable String key)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return getWorkflowToken(workflowRunId.toEntityId(), scope, key);
   }
 
   /**
@@ -198,21 +137,6 @@ public class WorkflowClient {
   /**
    * Retrieve all the key-value pairs in a workflow run's {@link WorkflowToken} that were set by the specified node.
    *
-   * @param workflowRunId the {@link Id.Run} of the workflow
-   * @param nodeName the name of the node
-   * @return {@link WorkflowTokenNodeDetail} containing all the key-value pairs set by the specified node in the
-   * specified workflow run's {@link WorkflowToken}
-   * @deprecated since 4.0.0. Use {@link #getWorkflowTokenAtNode(ProgramRunId, String)} instead.
-   */
-  @Deprecated
-  public WorkflowTokenNodeDetail getWorkflowTokenAtNode(Id.Run workflowRunId, String nodeName)
-    throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    return getWorkflowTokenAtNode(workflowRunId.toEntityId(), nodeName);
-  }
-
-  /**
-   * Retrieve all the key-value pairs in a workflow run's {@link WorkflowToken} that were set by the specified node.
-   *
    * @param workflowRunId the run id of the workflow
    * @param nodeName the name of the node
    * @return {@link WorkflowTokenNodeDetail} containing all the key-value pairs set by the specified node in the
@@ -221,24 +145,6 @@ public class WorkflowClient {
   public WorkflowTokenNodeDetail getWorkflowTokenAtNode(ProgramRunId workflowRunId, String nodeName)
     throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
     return getWorkflowTokenAtNode(workflowRunId, nodeName, null, null);
-  }
-
-  /**
-   * Retrieve all the key-value pairs in a workflow run's {@link WorkflowToken} that were set by the specified node
-   * in the specified {@link WorkflowToken.Scope}.
-   *
-   * @param workflowRunId the {@link Id.Run} of the workflow
-   * @param nodeName the name of the node
-   * @param scope the specified {@link WorkflowToken.Scope}
-   * @return {@link WorkflowTokenNodeDetail} containing all the keys set by the specified node with the
-   * specified {@link WorkflowToken.Scope}in the specified workflow run's {@link WorkflowToken}
-   * @deprecated since 4.0.0. Use {@link #getWorkflowTokenAtNode(ProgramRunId, String, WorkflowToken.Scope)} instead.
-   */
-  @Deprecated
-  public WorkflowTokenNodeDetail getWorkflowTokenAtNode(Id.Run workflowRunId, String nodeName,
-                                                        WorkflowToken.Scope scope)
-    throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    return getWorkflowTokenAtNode(workflowRunId.toEntityId(), nodeName, scope);
   }
 
   /**
@@ -260,22 +166,6 @@ public class WorkflowClient {
   /**
    * Retrieve the specified key set by the specified node in a specified workflow run's {@link WorkflowToken}.
    *
-   * @param workflowRunId the {@link Id.Run} of the workflow
-   * @param nodeName the name of the node
-   * @param key the specified key
-   * @return {@link WorkflowTokenNodeDetail} containing the specified key set by the specified node with the
-   * specified {@link WorkflowToken.Scope}in the specified workflow run's {@link WorkflowToken}
-   * @deprecated since 4.0.0. Use {@link #getWorkflowTokenAtNode(ProgramRunId, String, String)} instead.
-   */
-  @Deprecated
-  public WorkflowTokenNodeDetail getWorkflowTokenAtNode(Id.Run workflowRunId, String nodeName, String key)
-    throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    return getWorkflowTokenAtNode(workflowRunId.toEntityId(), nodeName, key);
-  }
-
-  /**
-   * Retrieve the specified key set by the specified node in a specified workflow run's {@link WorkflowToken}.
-   *
    * @param workflowRunId the run id of the workflow
    * @param nodeName the name of the node
    * @param key the specified key
@@ -285,25 +175,6 @@ public class WorkflowClient {
   public WorkflowTokenNodeDetail getWorkflowTokenAtNode(ProgramRunId workflowRunId, String nodeName, String key)
     throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
     return getWorkflowTokenAtNode(workflowRunId, nodeName, null, key);
-  }
-
-  /**
-   * Retrieve the keys set by the specified node in the {@link WorkflowToken} for the specified workflow run
-   * filtered by the specified {@link WorkflowToken.Scope} and key.
-   *
-   * @param workflowRunId the {@link Id.Run} of the workflow
-   * @param nodeName the name of the node
-   * @param scope the specified {@link WorkflowToken.Scope}
-   * @param key the specified key
-   * @return {@link WorkflowTokenDetail} with the specified filters
-   * @deprecated since 4.0.0.
-   *   Use {@link #getWorkflowTokenAtNode(ProgramRunId, String, WorkflowToken.Scope, String)} instead.
-   */
-  @Deprecated
-  public WorkflowTokenNodeDetail getWorkflowTokenAtNode(Id.Run workflowRunId, String nodeName,
-                                                        @Nullable WorkflowToken.Scope scope, @Nullable String key)
-    throws IOException, UnauthenticatedException, NotFoundException, UnauthorizedException {
-    return getWorkflowTokenAtNode(workflowRunId.toEntityId(), nodeName, scope, key);
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
@@ -122,20 +122,6 @@ public class ClientConfig {
    *             in a URL like "http://example.com:11015/v3/&lt;namespace&gt;/apps".
    * @return URL of the resolved path
    * @throws MalformedURLException
-   * @deprecated since 4.0.0. Please use {@link #resolveNamespacedURLV3(NamespaceId, String)} instead
-   */
-  @Deprecated
-  public URL resolveNamespacedURLV3(Id.Namespace namespace, String path) throws MalformedURLException {
-    return resolveNamespacedURLV3(namespace.toEntityId(), path);
-  }
-
-  /**
-   * Resolves a path against the target CDAP server with the provided namespace, using V3 APIs
-   *
-   * @param path Path to the HTTP endpoint. For example, "apps" would result
-   *             in a URL like "http://example.com:11015/v3/&lt;namespace&gt;/apps".
-   * @return URL of the resolved path
-   * @throws MalformedURLException
    */
   public URL resolveNamespacedURLV3(NamespaceId namespace, String path) throws MalformedURLException {
     return getConnectionConfig().resolveNamespacedURI(namespace, Constants.Gateway.API_VERSION_3_TOKEN, path).toURL();

--- a/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
@@ -18,7 +18,6 @@ package co.cask.cdap.client.config;
 
 import co.cask.cdap.client.exception.DisconnectedException;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.common.http.HttpRequestConfig;

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
@@ -23,6 +23,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
@@ -67,7 +68,7 @@ public abstract class AbstractMetadataClient {
   /**
    * Resolves the specified URL.
    */
-  protected abstract URL resolve(Id.Namespace namesapace, String resource) throws IOException;
+  protected abstract URL resolve(NamespaceId namesapace, String resource) throws IOException;
 
   /**
    * Searches entities in the specified namespace whose metadata matches the specified query.
@@ -141,7 +142,7 @@ public abstract class AbstractMetadataClient {
     if (showHidden) {
       path += "&showHidden=" + true;
     }
-    URL searchURL = resolve(namespace, path);
+    URL searchURL = resolve(namespace.toEntityId(), path);
     HttpResponse response = execute(HttpRequest.get(searchURL).build(), HttpResponseStatus.BAD_REQUEST.code());
     if (HttpResponseStatus.BAD_REQUEST.code() == response.getResponseCode()) {
       throw new BadRequestException(response.getResponseBodyAsString());
@@ -1152,7 +1153,7 @@ public abstract class AbstractMetadataClient {
   private HttpResponse makeRequest(Id.NamespacedId namespacedId, String path,
                                    HttpMethod httpMethod, @Nullable String body)
     throws IOException, UnauthenticatedException, NotFoundException, BadRequestException, UnauthorizedException {
-    URL url = resolve(namespacedId.getNamespace(), path);
+    URL url = resolve(namespacedId.getNamespace().toEntityId(), path);
     HttpRequest.Builder builder = HttpRequest.builder(httpMethod, url);
     if (body != null) {
       builder.withBody(body);

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.test.remote;
 
-import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.client.ScheduleClient;
 import co.cask.cdap.client.WorkflowClient;
@@ -56,15 +55,6 @@ public class RemoteWorkflowManager extends AbstractProgramManager<WorkflowManage
     this.workflowId = programId;
     this.workflowClient = new WorkflowClient(clientConfig, restClient);
     this.scheduleClient = new ScheduleClient(clientConfig, restClient);
-  }
-
-  @Override
-  public List<ScheduleSpecification> getSchedules() {
-    try {
-      return scheduleClient.list(workflowId);
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
   }
 
   @Override

--- a/cdap-test/src/main/java/co/cask/cdap/test/WorkflowManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/WorkflowManager.java
@@ -41,16 +41,6 @@ public interface WorkflowManager extends ProgramManager<WorkflowManager> {
   List<ScheduleDetail> getProgramSchedules();
 
   /**
-   * Get the list of schedules of the workflow.
-   *
-   * @return List of {@link ScheduleSpecification}.
-   *
-   * @deprecated since release 4.2. Use {@link #getProgramSchedules()} instead.
-   */
-  @Deprecated
-  List<ScheduleSpecification> getSchedules();
-
-  /**
    * Get the {@link ScheduleManager} instance to manage the schedule
    *
    * @param scheduleId of the workflow to retrieve

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultWorkflowManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultWorkflowManager.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.test.internal;
 
-import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.internal.AppFabricClient;
@@ -55,19 +54,6 @@ public class DefaultWorkflowManager extends AbstractProgramManager<WorkflowManag
   public List<ScheduleDetail> getProgramSchedules() {
     try {
       return appFabricClient.getProgramSchedules(
-        programId.getNamespaceId(), programId.getApplicationId(), programId.getId());
-    } catch (NotFoundException e) {
-      // this can only happen if the workflow was deleted, unlikely during a test but if so, empty list is correct
-      return Collections.emptyList();
-    }
-  }
-
-  @Deprecated
-  @Override
-  public List<ScheduleSpecification> getSchedules() {
-    try {
-      //noinspection deprecation
-      return appFabricClient.getSchedules(
         programId.getNamespaceId(), programId.getApplicationId(), programId.getId());
     } catch (NotFoundException e) {
       // this can only happen if the workflow was deleted, unlikely during a test but if so, empty list is correct


### PR DESCRIPTION
Except for couple of methods in ScheduleClient, other methods in cdap-client which were deprecated earlier have been removed.

Will address ScheduleClient deprecated removal as part of https://issues.cask.co/browse/CDAP-12692. 

Build : https://builds.cask.co/browse/CDAP-DUT6146

After merging this, dependent changes on cdap integration tests have to be made. 