### PR TITLE
[CDAP-12515] Modify schedules when triggering programs are deleted

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -50,7 +50,6 @@ import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.KerberosPrincipalId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
-import co.cask.cdap.scheduler.Scheduler;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
@@ -114,7 +113,6 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private final ProgramRuntimeService runtimeService;
 
   private final CConfiguration configuration;
-  private final Scheduler programScheduler;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final ApplicationLifecycleService applicationLifecycleService;
@@ -122,14 +120,12 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
   @Inject
   AppLifecycleHttpHandler(CConfiguration configuration,
-                          Scheduler programScheduler,
                           ProgramRuntimeService runtimeService,
                           NamespaceQueryAdmin namespaceQueryAdmin,
                           NamespacedLocationFactory namespacedLocationFactory,
                           ApplicationLifecycleService applicationLifecycleService) {
     this.configuration = configuration;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
-    this.programScheduler = programScheduler;
     this.runtimeService = runtimeService;
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.applicationLifecycleService = applicationLifecycleService;
@@ -518,17 +514,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       public void stop(ProgramId programId) throws Exception {
         switch (programId.getType()) {
           case FLOW:
-            stopProgramIfRunning(programId);
-            break;
-          case WORKFLOW:
-            programScheduler.deleteSchedules(programId);
-            break;
-          case MAPREDUCE:
-            //no-op
-            break;
           case SERVICE:
-            stopProgramIfRunning(programId);
-            break;
           case WORKER:
             stopProgramIfRunning(programId);
             break;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -54,6 +54,7 @@ import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.ConstraintCodec;
 import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.StreamSizeTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
@@ -171,6 +172,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private static final Gson GSON = ApplicationSpecificationAdapter
     .addTypeAdapters(new GsonBuilder())
     .registerTypeAdapter(Trigger.class, new TriggerCodec())
+    .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
     .registerTypeAdapter(Constraint.class, new ConstraintCodec())
     .create();
 
@@ -181,6 +183,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     .addTypeAdapters(new GsonBuilder())
     .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
     .registerTypeAdapter(Trigger.class, new TriggerCodec())
+    .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
     .registerTypeAdapter(Constraint.class, new ConstraintCodec())
     .create();
 
@@ -795,7 +798,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       Iterator<ProgramScheduleRecord> iterator = schedules.iterator();
       while (iterator.hasNext()) {
         // Remove the schedule if its trigger type does not match the given type
-        if (!((ProtoTrigger) iterator.next().getSchedule().getTrigger()).getType().equals(type)) {
+        if (!iterator.next().getSchedule().getTrigger().getType().equals(type)) {
           iterator.remove();
         }
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -43,6 +43,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.ConstraintCodec;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
@@ -108,6 +109,7 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
     .registerTypeAdapter(WorkflowTokenDetail.class, new WorkflowTokenDetailCodec())
     .registerTypeAdapter(WorkflowTokenNodeDetail.class, new WorkflowTokenNodeDetailCodec())
     .registerTypeAdapter(Trigger.class, new TriggerCodec())
+    .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
     .registerTypeAdapter(Constraint.class, new ConstraintCodec())
     .create();
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
@@ -33,6 +33,7 @@ import co.cask.cdap.api.workflow.ConditionSpecification;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.ConstraintCodec;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
@@ -103,6 +104,7 @@ public final class ApplicationSpecificationAdapter {
       .registerTypeAdapter(WorkerSpecification.class, new WorkerSpecificationCodec())
       .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec())
       .registerTypeAdapter(Trigger.class, new TriggerCodec())
+      .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
       .registerTypeAdapter(Constraint.class, new ConstraintCodec())
       .registerTypeAdapterFactory(new AppSpecTypeAdapterFactory());
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
@@ -42,6 +42,7 @@ import co.cask.cdap.pipeline.Context;
 import co.cask.cdap.pipeline.Pipeline;
 import co.cask.cdap.pipeline.PipelineFactory;
 import co.cask.cdap.pipeline.Stage;
+import co.cask.cdap.scheduler.Scheduler;
 import co.cask.cdap.security.impersonation.Impersonator;
 import co.cask.cdap.security.impersonation.OwnerAdmin;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
@@ -128,7 +129,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
                                                      authenticationContext));
     pipeline.addLast(new CreateStreamsStage(streamAdmin, ownerAdmin, authenticationContext));
     pipeline.addLast(new DeletedProgramHandlerStage(store, programTerminator, streamConsumerFactory, queueAdmin,
-                                                    metricStore, metadataStore, impersonator));
+                                                    metricStore, metadataStore, impersonator, programScheduler));
     pipeline.addLast(new ProgramGenerationStage());
     pipeline.addLast(new ApplicationRegistrationStage(store, usageRegistry, ownerAdmin));
     pipeline.addLast(new DeleteAndCreateSchedulesStage(programScheduler));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -18,7 +18,6 @@ package co.cask.cdap.internal.app.deploy.pipeline;
 
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
-import co.cask.cdap.api.flow.FlowletConnection;
 import co.cask.cdap.api.metrics.MetricDeleteQuery;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.app.store.Store;
@@ -32,22 +31,18 @@ import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ProgramTypes;
 import co.cask.cdap.proto.id.ApplicationId;
-import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.scheduler.Scheduler;
 import co.cask.cdap.security.impersonation.Impersonator;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 /**
  * Deleted program handler stage. Figures out which programs are deleted and handles callback.
@@ -63,11 +58,13 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
   private final MetricStore metricStore;
   private final MetadataStore metadataStore;
   private final Impersonator impersonator;
+  private final Scheduler programScheduler;
 
   public DeletedProgramHandlerStage(Store store, ProgramTerminator programTerminator,
                                     StreamConsumerFactory streamConsumerFactory,
                                     QueueAdmin queueAdmin, MetricStore metricStore,
-                                    MetadataStore metadataStore, Impersonator impersonator) {
+                                    MetadataStore metadataStore, Impersonator impersonator,
+                                    Scheduler programScheduler) {
     super(TypeToken.of(ApplicationDeployable.class));
     this.store = store;
     this.programTerminator = programTerminator;
@@ -76,6 +73,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
     this.metricStore = metricStore;
     this.metadataStore = metadataStore;
     this.impersonator = impersonator;
+    this.programScheduler = programScheduler;
   }
 
   @Override
@@ -91,35 +89,13 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
       ProgramType type = ProgramTypes.fromSpecification(spec);
       final ProgramId programId = appSpec.getApplicationId().program(type, spec.getName());
       programTerminator.stop(programId);
+      programScheduler.deleteSchedules(programId);
+      programScheduler.modifySchedulesTriggeredByDeletedProgram(programId);
 
-      // TODO: Unify with AppFabricHttpHandler.removeApplication
       // drop all queues and stream states of a deleted flow
       if (ProgramType.FLOW.equals(type)) {
-        FlowSpecification flowSpecification = (FlowSpecification) spec;
-
-        // Collects stream name to all group ids consuming that stream
-        final Multimap<String, Long> streamGroups = HashMultimap.create();
-        for (FlowletConnection connection : flowSpecification.getConnections()) {
-          if (connection.getSourceType() == FlowletConnection.Type.STREAM) {
-            long groupId = FlowUtils.generateConsumerGroupId(programId, connection.getTargetName());
-            streamGroups.put(connection.getSourceName(), groupId);
-          }
-        }
-        // Remove all process states and group states for each stream
-        final String namespace = String.format("%s.%s", programId.getApplication(), programId.getProgram());
-
-        final NamespaceId namespaceId = appSpec.getApplicationId().getParent();
-        impersonator.doAs(appSpec.getApplicationId(), new Callable<Void>() {
-
-          @Override
-          public Void call() throws Exception {
-            for (Map.Entry<String, Collection<Long>> entry : streamGroups.asMap().entrySet()) {
-              streamConsumerFactory.dropAll(namespaceId.stream(entry.getKey()), namespace, entry.getValue());
-            }
-            queueAdmin.dropAllForFlow(programId.getParent().flow(programId.getEntityName()));
-            return null;
-          }
-        });
+        FlowUtils.clearDeletedFlow(impersonator, queueAdmin, streamConsumerFactory, programId,
+                                   (FlowSpecification) spec);
         deletedFlows.add(programId.getEntityName());
       }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
@@ -25,7 +25,7 @@ import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ServiceUnavailableException;
-import co.cask.cdap.internal.app.runtime.schedule.trigger.AbstractCompositeTrigger;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.AbstractSatisfiableCompositeTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.StreamSizeTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import co.cask.cdap.internal.schedule.StreamSizeSchedule;
@@ -147,7 +147,8 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
 
   private boolean containsTimeTrigger(ProgramSchedule schedule) {
     // A composite trigger may contain a TimeTrigger
-    return schedule.getTrigger() instanceof TimeTrigger || schedule.getTrigger() instanceof AbstractCompositeTrigger;
+    return schedule.getTrigger() instanceof TimeTrigger
+      || schedule.getTrigger() instanceof AbstractSatisfiableCompositeTrigger;
   }
 
   private boolean containsStreamSizeTrigger(ProgramSchedule schedule) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -22,7 +22,7 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
-import co.cask.cdap.internal.app.runtime.schedule.trigger.AbstractCompositeTrigger;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.AbstractSatisfiableCompositeTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import co.cask.cdap.messaging.MessagingService;
@@ -399,9 +399,9 @@ public final class TimeScheduler implements Scheduler {
     co.cask.cdap.api.schedule.Trigger trigger = schedule.getTrigger();
     Map<String, TriggerKey> cronTriggerKeyMap = new HashMap<>();
     // Get a set of TimeTrigger if the schedule's trigger is a composite trigger
-    if (trigger instanceof AbstractCompositeTrigger) {
+    if (trigger instanceof AbstractSatisfiableCompositeTrigger) {
       Set<SatisfiableTrigger> triggerSet =
-        ((AbstractCompositeTrigger) trigger).getUnitTriggers().get(ProtoTrigger.Type.TIME);
+        ((AbstractSatisfiableCompositeTrigger) trigger).getUnitTriggers().get(ProtoTrigger.Type.TIME);
       if (triggerSet == null) {
         return ImmutableMap.of();
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/queue/JobQueueDataset.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/queue/JobQueueDataset.java
@@ -31,7 +31,7 @@ import co.cask.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.ConstraintCodec;
-import co.cask.cdap.internal.app.runtime.schedule.trigger.AbstractCompositeTrigger;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.AbstractSatisfiableCompositeTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
 import co.cask.cdap.internal.schedule.constraint.Constraint;
@@ -68,6 +68,7 @@ public class JobQueueDataset extends AbstractDataset implements JobQueue, TopicM
   private static final Gson GSON =
     new GsonBuilder()
       .registerTypeAdapter(Trigger.class, new TriggerCodec())
+      .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
       .registerTypeAdapter(Constraint.class, new ConstraintCodec())
       .create();
 
@@ -153,7 +154,7 @@ public class JobQueueDataset extends AbstractDataset implements JobQueue, TopicM
     // transaction. Add the schedule id to the transaction change set so that concurrent transactions of the same
     // schedule can have conflict and retry. This prevents concurrent transactions from creating duplicated jobs
     // for the same schedule.
-    if (schedule.getTrigger() instanceof AbstractCompositeTrigger) {
+    if (schedule.getTrigger() instanceof AbstractSatisfiableCompositeTrigger) {
       scheduleIds.add(getRowKeyPrefix(schedule.getScheduleId()));
     }
     try (CloseableIterator<Job> jobs = getJobsForSchedule(schedule.getScheduleId())) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/AbstractCompositeTriggerBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/AbstractCompositeTriggerBuilder.java
@@ -19,7 +19,7 @@ package co.cask.cdap.internal.app.runtime.schedule.trigger;
 import co.cask.cdap.api.schedule.Trigger;
 
 /**
- * A Trigger builder that builds a {@link AbstractCompositeTrigger}
+ * A Trigger builder that builds a {@link AbstractSatisfiableCompositeTrigger}
  */
 public abstract class AbstractCompositeTriggerBuilder implements TriggerBuilder {
   private final Type type;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/AndTrigger.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/AndTrigger.java
@@ -20,17 +20,26 @@ import co.cask.cdap.api.schedule.Trigger;
 import co.cask.cdap.api.schedule.TriggerInfo;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import co.cask.cdap.proto.Notification;
+import co.cask.cdap.proto.id.ProgramId;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * A Trigger that schedules a ProgramSchedule, when all internal triggers are satisfied.
  */
-public class AndTrigger extends AbstractCompositeTrigger implements SatisfiableTrigger {
+public class AndTrigger extends AbstractSatisfiableCompositeTrigger {
 
   public AndTrigger(SatisfiableTrigger... triggers) {
+    this(Arrays.asList(triggers));
+  }
+
+  public AndTrigger(List<SatisfiableTrigger> triggers) {
     super(Type.AND, triggers);
   }
+
 
   @Override
   public boolean isSatisfied(ProgramSchedule schedule, List<Notification> notifications) {
@@ -45,5 +54,37 @@ public class AndTrigger extends AbstractCompositeTrigger implements SatisfiableT
   @Override
   public List<TriggerInfo> getTriggerInfos(TriggerInfoContext context) {
     return getUnitTriggerInfosAddRuntimeArgs(context);
+  }
+
+  @Nullable
+  @Override
+  public SatisfiableTrigger getTriggerWithDeletedProgram(ProgramId programId) {
+    List<SatisfiableTrigger> updatedTriggers = new ArrayList<>();
+    for (SatisfiableTrigger trigger : getTriggers()) {
+      if (trigger instanceof ProgramStatusTrigger &&
+        programId.equals(((ProgramStatusTrigger) trigger).getProgramId())) {
+        // this program status trigger will never be satisfied, so the current AND trigger will never be satisfied
+        return null;
+      }
+      if (trigger instanceof AbstractSatisfiableCompositeTrigger) {
+        SatisfiableTrigger updatedTrigger =
+          ((AbstractSatisfiableCompositeTrigger) trigger).getTriggerWithDeletedProgram(programId);
+        if (updatedTrigger == null) {
+          // the updated composite trigger will never be satisfied, so the AND trigger will never be satisfied
+          return null;
+        }
+        // add the updated composite trigger into updatedTriggers
+        updatedTriggers.add(updatedTrigger);
+      } else {
+        // the trigger is not a composite trigger, add it to updatedTriggers directly
+        updatedTriggers.add(trigger);
+      }
+    }
+    // No need to wrap the only one remaining trigger with an AndTrigger
+    if (updatedTriggers.size() == 1) {
+      return updatedTriggers.get(0);
+    }
+    // return a new AND trigger constructed from the updated triggers
+    return new co.cask.cdap.internal.app.runtime.schedule.trigger.AndTrigger(updatedTriggers);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/CoreSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/CoreSchedulerService.java
@@ -413,6 +413,18 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
   }
 
   @Override
+  public void modifySchedulesTriggeredByDeletedProgram(final ProgramId programId) {
+    checkStarted();
+    execute(new StoreAndQueueTxRunnable<Void, RuntimeException>() {
+      @Override
+      public Void run(ProgramScheduleStoreDataset store, JobQueueDataset queue) {
+        store.modifySchedulesTriggeredByDeletedProgram(programId);
+        return null;
+      }
+    }, RuntimeException.class);
+  }
+
+  @Override
   public ProgramSchedule getSchedule(final ScheduleId scheduleId) throws NotFoundException {
     checkStarted();
     return execute(store -> store.getSchedule(scheduleId), NotFoundException.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/NoOpScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/NoOpScheduler.java
@@ -80,6 +80,11 @@ public class NoOpScheduler implements Scheduler {
   }
 
   @Override
+  public void modifySchedulesTriggeredByDeletedProgram(ProgramId programId) {
+
+  }
+
+  @Override
   public ProgramSchedule getSchedule(ScheduleId scheduleId) throws NotFoundException {
     return null;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/Scheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/Scheduler.java
@@ -109,6 +109,16 @@ public interface Scheduler {
   void deleteSchedules(ProgramId programId);
 
   /**
+   * Update all schedules that can be triggered by the given deleted program. Schedules will be removed if they
+   * contain single {@link co.cask.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger}. Schedules with
+   * composite triggers will be updated if the composite trigger can still be satisfied after the program is deleted,
+   * otherwise the schedules will be deleted.
+   *
+   * @param programId id of the deleted program
+   */
+  void modifySchedulesTriggeredByDeletedProgram(ProgramId programId);
+
+  /**
    * Read a schedule from the store.
    *
    * @param scheduleId the id of the schedule to read

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -39,6 +39,7 @@ import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ProtoConstraintCodec;
+import co.cask.cdap.proto.ProtoTrigger;
 import co.cask.cdap.proto.ProtoTriggerCodec;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ScheduleDetail;
@@ -97,6 +98,7 @@ public class AppFabricClient {
     .registerTypeAdapter(WorkflowTokenDetail.class, new WorkflowTokenDetailCodec())
     .registerTypeAdapter(WorkflowTokenNodeDetail.class, new WorkflowTokenNodeDetailCodec())
     .registerTypeAdapter(Trigger.class, new ProtoTriggerCodec())
+    .registerTypeAdapter(ProtoTrigger.class, new ProtoTriggerCodec())
     .registerTypeAdapter(Constraint.class, new ProtoConstraintCodec())
     .create();
   private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/trigger/TriggerCodecTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/trigger/TriggerCodecTest.java
@@ -39,10 +39,12 @@ public class TriggerCodecTest {
 
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Trigger.class, new TriggerCodec())
+    .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
     .create();
 
   private static final Gson GSON_PROTO = new GsonBuilder()
     .registerTypeAdapter(Trigger.class, new ProtoTriggerCodec())
+    .registerTypeAdapter(ProtoTrigger.class, new ProtoTriggerCodec())
     .create();
 
   @Test
@@ -103,14 +105,13 @@ public class TriggerCodecTest {
                              ImmutableSet.of(ProgramStatus.COMPLETED));
     testSerDeserYieldsTrigger(protoProgramStatus, programStatusTrigger);
 
-    ProtoTrigger.OrTrigger protoOr =
-      new ProtoTrigger.OrTrigger(protoPartition, new ProtoTrigger.AndTrigger(protoTime, protoProgramStatus));
+    ProtoTrigger.OrTrigger protoOr = ProtoTrigger.or(protoPartition, ProtoTrigger.and(protoTime, protoProgramStatus));
     OrTrigger orTrigger =
       new OrTrigger(partitionTrigger, new AndTrigger(timeTrigger, programStatusTrigger));
     testSerDeserYieldsTrigger(protoOr, orTrigger);
 
     ProtoTrigger.AndTrigger protoAnd =
-      new ProtoTrigger.AndTrigger(protoOr, protoTime, new ProtoTrigger.OrTrigger(protoPartition, protoProgramStatus));
+      ProtoTrigger.and(protoOr, protoTime, ProtoTrigger.or(protoPartition, protoProgramStatus));
     AndTrigger andTrigger =
       new AndTrigger(orTrigger, timeTrigger, new OrTrigger(partitionTrigger, programStatusTrigger));
     testSerDeserYieldsTrigger(protoAnd, andTrigger);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -49,6 +49,7 @@ import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
 import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
@@ -150,6 +151,7 @@ public abstract class AppFabricTestBase {
     .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
     .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
     .registerTypeAdapter(Trigger.class, new TriggerCodec())
+    .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
     .registerTypeAdapter(Constraint.class, new ProtoConstraintCodec())
     .create();
   private static final String API_KEY = "SampleTestApiKey";

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1340,7 +1340,7 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     ProtoTrigger.TimeTrigger protoTime = new ProtoTrigger.TimeTrigger("0 * * * ?");
     ProtoTrigger.PartitionTrigger protoPartition =
       new ProtoTrigger.PartitionTrigger(NamespaceId.DEFAULT.dataset("data"), 5);
-    ProtoTrigger.OrTrigger protoOr = new ProtoTrigger.OrTrigger(protoTime, protoPartition);
+    ProtoTrigger.OrTrigger protoOr = ProtoTrigger.or(protoTime, protoPartition);
     ScheduleProgramInfo programInfo = new ScheduleProgramInfo(SchedulableProgramType.WORKFLOW,
                                                               AppWithSchedule.WORKFLOW_NAME);
     ImmutableMap<String, String> properties = ImmutableMap.of("a", "b", "c", "d");

--- a/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.internal.schedule.constraint.Constraint;
 import co.cask.cdap.proto.ProtoConstraintCodec;
+import co.cask.cdap.proto.ProtoTrigger;
 import co.cask.cdap.proto.ProtoTriggerCodec;
 import co.cask.cdap.proto.ScheduleDetail;
 import co.cask.cdap.proto.ScheduleInstanceConfiguration;
@@ -60,6 +61,7 @@ public class ScheduleClient {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
     .registerTypeAdapter(Trigger.class, new ProtoTriggerCodec())
+    .registerTypeAdapter(ProtoTrigger.class, new ProtoTriggerCodec())
     .registerTypeAdapter(Constraint.class, new ProtoConstraintCodec())
     .create();
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/JobQueueDebugger.java
@@ -52,6 +52,7 @@ import co.cask.cdap.internal.app.runtime.schedule.queue.Job;
 import co.cask.cdap.internal.app.runtime.schedule.queue.JobQueue;
 import co.cask.cdap.internal.app.runtime.schedule.queue.JobQueueDataset;
 import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.internal.schedule.constraint.Constraint;
@@ -109,6 +110,7 @@ public class JobQueueDebugger extends AbstractIdleService {
 
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Trigger.class, new TriggerCodec())
+    .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
     .registerTypeAdapter(Constraint.class, new ConstraintCodec())
     .create();
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProtoTrigger.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProtoTrigger.java
@@ -142,17 +142,19 @@ public abstract class ProtoTrigger implements Trigger {
 
   /**
    * Abstract base class for composite trigger in REST requests/responses.
+   *
+   * @param <T> type of triggers contained in the composite trigger
    */
-  public abstract static class AbstractCompositeTrigger extends ProtoTrigger {
-    private final List<Trigger> triggers;
+  public abstract static class AbstractCompositeTrigger<T extends Trigger> extends ProtoTrigger {
+    private final List<T> triggers;
 
-    public AbstractCompositeTrigger(Type type, Trigger... triggers) {
+    public AbstractCompositeTrigger(Type type, List<T> triggers) {
       super(type);
-      this.triggers = Collections.unmodifiableList(new ArrayList<>(Arrays.asList(triggers)));
+      this.triggers = Collections.unmodifiableList(new ArrayList<>(triggers));
       validate();
     }
 
-    public List<Trigger> getTriggers() {
+    public List<T> getTriggers() {
       return triggers;
     }
 
@@ -161,12 +163,12 @@ public abstract class ProtoTrigger implements Trigger {
       if (!getType().equals(Type.AND) && !getType().equals(Type.OR)) {
         throw new IllegalArgumentException("Trigger type " + getType().name() + " is not a composite trigger.");
       }
-      List<Trigger> triggers = getTriggers();
+      List<T> triggers = getTriggers();
       if (triggers.isEmpty()) {
         throw new IllegalArgumentException(String.format("Triggers passed in to construct a trigger " +
                                                            "of type %s cannot be empty.", getType().name()));
       }
-      for (Trigger trigger : triggers) {
+      for (T trigger : triggers) {
         if (trigger == null) {
           throw new IllegalArgumentException(String.format("Triggers passed in to construct a trigger " +
                                                              "of type %s cannot contain null.", getType().name()));
@@ -191,27 +193,34 @@ public abstract class ProtoTrigger implements Trigger {
     public int hashCode() {
       return triggers.hashCode();
     }
+
+    @Override
+    public String toString() {
+      return getType() + "Trigger{" +
+        "triggers=" + triggers +
+        '}';
+    }
   }
 
   /**
    * Shorthand helper method to create an instance of {@link AndTrigger}
    */
-  public static AndTrigger and(Trigger... triggers) {
-    return new AndTrigger(triggers);
+  public static AndTrigger and(ProtoTrigger... triggers) {
+    return new AndTrigger(Arrays.asList(triggers));
   }
 
   /**
    * Shorthand helper method to create an instance of {@link OrTrigger}
    */
-  public static OrTrigger or(Trigger... triggers) {
-    return new OrTrigger(triggers);
+  public static OrTrigger or(ProtoTrigger... triggers) {
+    return new OrTrigger(Arrays.asList(triggers));
   }
 
   /**
    * Represents an AND trigger in REST requests/responses.
    */
-  public static class AndTrigger extends AbstractCompositeTrigger {
-    public AndTrigger(Trigger... triggers) {
+  public static class AndTrigger extends AbstractCompositeTrigger<ProtoTrigger> {
+    public AndTrigger(List<ProtoTrigger> triggers) {
       super(Type.AND, triggers);
     }
   }
@@ -219,8 +228,8 @@ public abstract class ProtoTrigger implements Trigger {
   /**
    * Represents an OR trigger in REST requests/responses.
    */
-  public static class OrTrigger extends AbstractCompositeTrigger {
-    public OrTrigger(Trigger... triggers) {
+  public static class OrTrigger extends AbstractCompositeTrigger<ProtoTrigger> {
+    public OrTrigger(List<ProtoTrigger> triggers) {
       super(Type.OR, triggers);
     }
   }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/ProtoTriggerCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/ProtoTriggerCodecTest.java
@@ -36,6 +36,7 @@ public class ProtoTriggerCodecTest {
 
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Trigger.class, new ProtoTriggerCodec())
+    .registerTypeAdapter(ProtoTrigger.class, new ProtoTriggerCodec())
     .create();
 
   @Test


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12515
https://builds.cask.co/browse/CDAP-DUT6212-8

Reopening #9595 against develop

When a program is deleted, update all schedules that can be triggered by the given deleted program. The schedules containing a single ProgramStatusTrigger triggered by the deleted program will be removed directly. 
Schedules with composite triggers will be updated or removed depending on whether it will be satisfied after the program is deleted.
For instance, if program X is deleted, for an AND trigger with condition (X completes AND Y fails), the trigger will never be satisfied, so this trigger will be deleted.
For an OR trigger with condition (X completes OR Y fails), the trigger will be updated as (Y fails). If program Y is also deleted in the future, the OR trigger will never be satisfied and the it will be deleted.
For more complex composite trigger that contains inner composite trigger such as (X completes AND (Y fails OR Z completes)) each inner composite trigger will be updated or deleted first. An AND trigger will be deleted if any of the inner trigger is deleted. An OR trigger will be deleted if all the inner triggers are deleted and the OR trigger is empty.
