### PR TITLE
Make IntegrationTestBase work with SSL-enabled cluster and with self-signed certificates.

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -226,10 +226,13 @@ public abstract class IntegrationTestBase {
     Properties properties = new Properties();
     properties.setProperty("security.auth.client.username", username);
     properties.setProperty("security.auth.client.password", password);
+    properties.setProperty("security.auth.client.verify.ssl.cert",
+                           Boolean.toString(getClientConfig().isVerifySSLCert()));
     final AuthenticationClient authClient = new BasicAuthenticationClient();
     authClient.configure(properties);
     ConnectionConfig connectionConfig = getClientConfig().getConnectionConfig();
-    authClient.setConnectionInfo(connectionConfig.getHostname(), connectionConfig.getPort(), false);
+    authClient.setConnectionInfo(connectionConfig.getHostname(), connectionConfig.getPort(),
+                                 connectionConfig.isSSLEnabled());
     checkServicesWithRetry(new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {


### PR DESCRIPTION
Cherry-pick of https://github.com/caskdata/cdap/pull/9706