### PR TITLE
CDAP-12727 Support CDH 5.13.0.

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -99,7 +99,8 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.10.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.11.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.12.0");
-    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.2.0-cdh5.13.0");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.13.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.2.0-cdh5.14.0");
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.11.0");
     assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.12.0");
 

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -46,6 +46,7 @@ public class HBaseVersion {
   private static final String CDH510_CLASSIFIER = "cdh5.10.";
   private static final String CDH511_CLASSIFIER = "cdh5.11.";
   private static final String CDH512_CLASSIFIER = "cdh5.12.";
+  private static final String CDH513_CLASSIFIER = "cdh5.13.";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -297,7 +298,8 @@ public class HBaseVersion {
         ver.getClassifier().startsWith(CDH59_CLASSIFIER) ||
         ver.getClassifier().startsWith(CDH510_CLASSIFIER) ||
         ver.getClassifier().startsWith(CDH511_CLASSIFIER) ||
-        ver.getClassifier().startsWith(CDH512_CLASSIFIER)) {
+        ver.getClassifier().startsWith(CDH512_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH513_CLASSIFIER)) {
         return Version.HBASE_12_CDH57;
       }
       return Version.UNKNOWN_CDH;


### PR DESCRIPTION
[CDAP-12727](https://issues.cask.co/browse/CDAP-12727) CDH 5.13.0 is running with HBase 1.2.0, which is the same version of HBase as CDH 5.12.0, so it can reuse the same compat module.

Running integration tests against a 4.3.1 cluster, using CDH 5.13.0, with `hbase.version.resolution.strategy` set to `auto.latest`: https://builds.cask.co/browse/CDAP-ITCC33-29