### PR TITLE
Feature/12740 fix download links

### DIFF
--- a/cdap-docs/admin-manual/source/_includes/installation/installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/installation.txt
@@ -99,12 +99,12 @@ Download the appropriate CDAP tar file, and then unpack it to an appropriate dir
            
   .. RHEL
 
-  $ curl |http:|//repository.cask.co/downloads/co/cask/cdap/cdap-distributed-rpm-bundle/|short-version|/cdap-distributed-rpm-bundle-|version|.tgz
+  $ curl -O |http:|//downloads.cask.co/cdap-distributed-rpm-bundle/cdap-distributed-rpm-bundle-|version|.tgz
   $ tar xf cdap-distributed-rpm-bundle-|version|.tgz -C $dir
   
   .. Ubuntu
 
-  $ curl |http:|//repository.cask.co/downloads/co/cask/cdap/cdap-distributed-deb-bundle/|short-version|/cdap-distributed-deb-bundle-|version|.tgz
+  $ curl -O |http:|//downloads.cask.co/cdap-distributed-deb-bundle/cdap-distributed-deb-bundle-|version|.tgz
   $ tar xf cdap-distributed-deb-bundle-|version|.tgz -C $dir
 
 

--- a/cdap-docs/admin-manual/source/_includes/installation/installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/installation.txt
@@ -99,13 +99,13 @@ Download the appropriate CDAP tar file, and then unpack it to an appropriate dir
            
   .. RHEL
 
-  $ curl |http:|//repository.cask.co/downloads/co/cask/cdap/cdap-distributed-rpm-bundle/|short-version|/cdap-distributed-rpm-bundle-|short-version|.tgz
-  $ tar xf cdap-distributed-rpm-bundle-|short-version|.tgz -C $dir
+  $ curl |http:|//repository.cask.co/downloads/co/cask/cdap/cdap-distributed-rpm-bundle/|short-version|/cdap-distributed-rpm-bundle-|version|.tgz
+  $ tar xf cdap-distributed-rpm-bundle-|version|.tgz -C $dir
   
   .. Ubuntu
 
-  $ curl |http:|//repository.cask.co/downloads/co/cask/cdap/cdap-distributed-deb-bundle/|short-version|/cdap-distributed-deb-bundle-|short-version|.tgz
-  $ tar xf cdap-distributed-deb-bundle-|short-version|.tgz -C $dir
+  $ curl |http:|//repository.cask.co/downloads/co/cask/cdap/cdap-distributed-deb-bundle/|short-version|/cdap-distributed-deb-bundle-|version|.tgz
+  $ tar xf cdap-distributed-deb-bundle-|version|.tgz -C $dir
 
 
 .. _|distribution|-package-installation-title:


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-12740

- [x] replaces `short-version` macro with `version` macro
- [x] use `downloads.cask.co` instead of `repository.cask.co`
- [x] use `curl -O` instead of `curl` so that it doesn't dump binary to the terminal

Quick build failed for unrelated reasons but still produced artifact with these changes visible here:
https://builds.cask.co/artifact/CDAP-DQB394/shared/build-2/Docs-HTML/html/admin-manual/installation/packages.html