### PR TITLE
CDAP-11805 Support EMR 5.4.

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -82,7 +82,7 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_10_CDH56, "1.0.0-cdh5.6.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.1");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.2.0-IBM-7");
-    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN, "1.3.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN, "1.4.0");
 
     // hbase versions packaged with HDP
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_96, "0.96.1.2.0.13.0-43-hadoop2"); // hdp 2.0.13.0
@@ -100,12 +100,17 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.11.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.12.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.13.0");
-    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.2.0-cdh5.14.0");
-    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.11.0");
-    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.12.0");
 
     // bigtop 1.1.0
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.12-hadoop2");
+
+    // EMR 5.4.0 - 5.6.0
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.3.0");
+    // EMR 5.7.0+
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.3.1");
+    // make sure that if future CDH versions come out with hbase 1.3.0, don't assume they're compatible with HBASE_11
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.15.0");
+    assertCompatModuleMapping(HBaseVersion.Version.UNKNOWN_CDH, "1.3.0-cdh5.16.0");
   }
 
   private void assertCompatModuleMapping(HBaseVersion.Version expectedCompatModule,

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -38,6 +38,7 @@ public class HBaseVersion {
   private static final String HBASE_10_VERSION = "1.0";
   private static final String HBASE_11_VERSION = "1.1";
   private static final String HBASE_12_VERSION = "1.2";
+  private static final String HBASE_13_VERSION = "1.3";
   private static final String CDH55_CLASSIFIER = "cdh5.5.";
   private static final String CDH56_CLASSIFIER = "cdh5.6.";
   private static final String CDH57_CLASSIFIER = "cdh5.7.";
@@ -271,7 +272,13 @@ public class HBaseVersion {
     if (versionString.startsWith(HBASE_12_VERSION)) {
       return getHBase12VersionFromVersion(ver);
     }
-    if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+    boolean isCDH = ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER);
+    // hbase 1.3 packaged with any future CDH version will likely not be compatible, since the hbase 1.2 version with
+    // CDH is not compatible, whereas the HDP and OSS versions are
+    if (versionString.startsWith(HBASE_13_VERSION) && !isCDH) {
+      return Version.HBASE_11;
+    }
+    if (isCDH) {
       return Version.UNKNOWN_CDH;
     }
     return Version.UNKNOWN;


### PR DESCRIPTION
[CDAP-11805](https://issues.cask.co/browse/CDAP-11805) Support EMR 5.4.0. This likely also supports EMR 5.5, 5.6, 5.7. On the other hand, EMR 5.8 and 5.9 need hive support: https://issues.cask.co/browse/CDAP-12747.
HBase 1.3.0 seems to be backwards compatible with the HBase 1.1 compat module that we have.

Tested against EMR 5.4.0 and 5.7.0.

https://builds.cask.co/browse/CDAP-RUT1435-1