### PR TITLE
[MMDS][CDAP-12749] Adds Experiments List View

### DIFF
--- a/cdap-ui/app/cdap/api/experiments.js
+++ b/cdap-ui/app/cdap/api/experiments.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
+import {apiCreator} from 'services/resource-helper';
+
+let dataSrc = DataSourceConfigurer.getInstance();
+let basePath = '/namespaces/:namespace/apps/ModelPrepApp/services/ModelManagerService/methods';
+export const myExperimentsApi = {
+  list: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments`),
+  getModelsInExperiment: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/models`)
+};

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsListBarChart/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsListBarChart/index.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import GroupedBarChart from 'components/GroupedBarChart';
+
+const DEFAULT_DEPLOYED_COLOR = '#B9C0D8';
+const DEFAULT_TOTAL_COLOR = '#5B6787';
+const customEncoding = {
+  "color": {
+    "field": "type",
+    "type": "nominal",
+    "scale": {
+      "range": [DEFAULT_DEPLOYED_COLOR, DEFAULT_TOTAL_COLOR]
+      }
+  },
+  "column": {
+    "field": "name", "type": "ordinal",
+    "header": {"title": ""}
+  },
+  "x": {
+    "field": "type", "type": "nominal",
+    "axis": {
+      "labels": false,
+      "title": ""
+    }
+  }
+};
+export default function ExperimentsListBarChart({data}) {
+  return (
+    <GroupedBarChart
+      data={data}
+      customEncoding={customEncoding}
+    />
+  );
+}
+
+ExperimentsListBarChart.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+    type: PropTypes.string,
+    count: PropTypes.number
+  })).isRequired
+};

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../styles/variables.scss";
+
+$listview-padding: 20px;
+
+.experiments-listview {
+  padding: 0 $listview-padding;
+  > .clearfix {
+    margin-top: 20px;
+    .pagination-with-title {
+      margin-right: 0;
+    }
+  }
+  .table {
+    &:first-child {
+      margin-bottom: 0;
+    }
+    th,
+    td {
+      width: 20%;
+    }
+    td {
+      small {
+        color: $cdap-lightgray;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/Experiments/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/index.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import TopPanel from 'components/Experiments/TopPanel';
+import SortableStickyTable from 'components/SortableStickyTable';
+import PieChart from 'components/PieChart';
+import PaginationWithTitle from 'components/PaginationWithTitle';
+import d3 from 'd3';
+import ExperimentsListBarChart from 'components/Experiments/ExperimentsListBarChart';
+require('./ListView.scss');
+
+const tableHeaders = [
+  {
+    label: 'Experiment',
+    property: 'name'
+  },
+  {
+    label: '#Models',
+    property: 'numOfModels'
+  },
+  {
+    label: '#Deployed',
+    property: 'numOfDeployedModels'
+  },
+  {
+    label: 'Algorithm Types',
+    property: 'algorithmTypes'
+  },
+  {
+    label: 'Test Data',
+    property: 'testData'
+  }
+];
+
+const colorScale = d3.scale.category20();
+
+const getAlgoDistribution = (models) => {
+  if (!models.length) {
+    return null;
+  }
+  let modelsMap = {};
+  models.forEach(model => {
+    let algo = model.algorithm;
+    if (!modelsMap[algo]) {
+      modelsMap = {
+        ...modelsMap,
+        [algo]: {
+          value: algo,
+          count: 1,
+          color: colorScale(algo)
+        }
+      };
+    } else {
+      modelsMap = {
+        ...modelsMap,
+        [algo]: {
+          ...modelsMap[algo],
+          count: modelsMap[algo].count + 1
+        }
+      };
+    }
+  });
+  return Object.keys(modelsMap).map(m => modelsMap[m]);
+};
+
+const renderTableBody = (entities) => {
+  let list = entities.map(entity => {
+    let models = entity.models || [];
+    return {
+      name: entity.name,
+      description: entity.description,
+      numOfModels: models.length,
+      numOfDeployedModels: models.filter(model => model.deploytime).length,
+      testData: entity.srcpath.split('/').pop(),
+      algorithmTypes: getAlgoDistribution(models)
+    };
+  });
+  return (
+    <table className="table">
+      <tbody>
+        {
+          list.map(entity => {
+            return (
+              <tr>
+                <td>
+                  <h5>
+                    <div>{entity.name}</div>
+                    <small>{entity.description}</small>
+                  </h5>
+                </td>
+                <td>{entity.numOfModels}</td>
+                <td>{entity.numOfDeployedModels}</td>
+                <td>{!entity.algorithmTypes ? null : <PieChart data={entity.algorithmTypes} />}</td>
+                <td>{entity.testData}</td>
+              </tr>
+            );
+          })
+        }
+      </tbody>
+    </table>
+  );
+};
+
+const getDataForGroupedChart = (experiments) => {
+  if (!experiments.length) {
+    return null;
+  }
+  let data = [];
+  experiments.map(experiment => {
+    data.push(
+      {
+        name: experiment.name,
+        type: 'Models',
+        count: Array.isArray(experiment.models) ? experiment.models.length: 0
+      },
+      {
+        name: experiment.name,
+        type: 'Deployed',
+        count: Array.isArray(experiment.models) ? experiment.models.filter(model => model.deploytime).length : 0
+      }
+    );
+  });
+  return data;
+};
+
+function ExperimentsListView({loading, list}) {
+  if (loading) {
+    return <LoadingSVGCentered />;
+  }
+  return (
+    <div className="experiments-listview">
+      <TopPanel message="Analytics - All Experiments" />
+      <ExperimentsListBarChart
+        data={getDataForGroupedChart(list)}
+      />
+      <div className="clearfix">
+        <PaginationWithTitle
+          handlePageChange={(currentPage) => console.log(`Pagination coming soon. Right now in page # ${currentPage}`)}
+          currentPage={1}
+          totalPages={1}
+          title={"Experiments"}
+          numberOfEntities={list.length}
+        />
+        <SortableStickyTable
+          entities={list}
+          tableHeaders={tableHeaders}
+          renderTableBody={renderTableBody}
+        />
+      </div>
+    </div>
+  );
+}
+
+ExperimentsListView.propTypes = {
+  loading: PropTypes.bool,
+  list: PropTypes.arrayOf(PropTypes.object)
+};
+
+const mapStateToProps = (state) => {
+  return {
+    loading: state.experiments.loading,
+    list: state.experiments.list
+  };
+};
+
+const ExperimentsListViewWrapper = connect(mapStateToProps)(ExperimentsListView);
+
+export default ExperimentsListViewWrapper;

--- a/cdap-ui/app/cdap/components/Experiments/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/Experiments/TopPanel/TopPanel.scss
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../styles/variables.scss";
+@import "../ListView/ListView.scss";
+
+.experiments-toppanel {
+  background: $cdap-gray;
+  height: 50px;
+  margin-left: -$listview-padding;
+  margin-right: -$listview-padding;
+  padding: 0 20px;
+  display: flex;
+  align-items: center;
+}

--- a/cdap-ui/app/cdap/components/Experiments/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/TopPanel/index.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+require('./TopPanel.scss');
+
+export default function TopPanel({message, children}) {
+  return (
+    <div className="experiments-toppanel">
+      {
+        children ? children : <h4>{message}</h4>
+      }
+    </div>
+  );
+}
+
+TopPanel.propTypes = {
+  message: PropTypes.string,
+  children: PropTypes.node
+};

--- a/cdap-ui/app/cdap/components/Experiments/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/index.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component} from 'react';
+import {Provider} from 'react-redux';
+import experimentsStore from 'components/Experiments/store';
+import {getExperimentsList} from 'components/Experiments/store/ActionCreator';
+import ExperimentsListView from 'components/Experiments/ListView';
+
+class Experiments extends Component {
+  componentWillMount() {
+    getExperimentsList();
+  }
+  render() {
+    return (
+      <Provider store={experimentsStore}>
+        <ExperimentsListView />
+      </Provider>
+    );
+  }
+}
+
+export default Experiments;

--- a/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import experimentsStore, {ACTIONS} from 'components/Experiments/store';
+import {myExperimentsApi} from 'api/experiments';
+import NamespaceStore from 'services/NamespaceStore';
+
+function setExperimentsLoading() {
+  experimentsStore.dispatch({
+    type: ACTIONS.SET_EXPERIMENTS_LOADING
+  });
+}
+
+function getExperimentsList() {
+  setExperimentsLoading();
+  let {selectedNamespace: namespace} = NamespaceStore.getState();
+  myExperimentsApi
+    .list({namespace})
+    .subscribe(experiments => {
+      experiments.forEach(experiment => getModelsListInExperiment(experiment.name));
+      experimentsStore.dispatch({
+        type: ACTIONS.SET_EXPERIMENTS_LIST,
+        payload: {
+          experiments
+        }
+      });
+    });
+}
+
+function getModelsListInExperiment(experimentId) {
+  let {selectedNamespace: namespace} = NamespaceStore.getState();
+  myExperimentsApi
+    .getModelsInExperiment({experimentId, namespace})
+    .subscribe(models => {
+      experimentsStore.dispatch({
+        type: ACTIONS.SET_MODELS_IN_EXPERIMENT,
+        payload: {
+          experimentId,
+          models
+        }
+      });
+    });
+}
+
+export {
+  setExperimentsLoading,
+  getExperimentsList,
+  getModelsListInExperiment
+};
+

--- a/cdap-ui/app/cdap/components/Experiments/store/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/index.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {createStore, combineReducers} from 'redux';
+import {defaultAction} from 'services/helpers';
+
+const ACTIONS = {
+  SET_EXPERIMENTS_LIST: 'SET_EXPERIMENTS_LIST',
+  SET_EXPERIMENTS_LOADING: 'SET_EXPERIMENTS_LOADING',
+  SET_MODELS_IN_EXPERIMENT: 'SET_MODELS_IN_EXPERIMENT'
+};
+
+const DEFAULT_EXPERIMENTS = {
+  list: [],
+  loading: false
+};
+
+const experiments = (state = DEFAULT_EXPERIMENTS, action = defaultAction) => {
+  switch (action.type) {
+    case ACTIONS.SET_EXPERIMENTS_LIST:
+      return {
+        ...state,
+        list: action.payload.experiments,
+        loading: false
+      };
+    case ACTIONS.SET_EXPERIMENTS_LOADING:
+      return {
+        ...state,
+        loading: true
+      };
+    case ACTIONS.SET_MODELS_IN_EXPERIMENT:
+      return {
+        ...state,
+        list: state.list.map(experiment => {
+          if (experiment.name === action.payload.experimentId) {
+            return {
+              ...experiment,
+              models: action.payload.models
+            };
+          }
+          return experiment;
+        })
+      };
+    default:
+      return state;
+  }
+};
+
+const store = createStore(
+  combineReducers({experiments}),
+  {
+    experiments: DEFAULT_EXPERIMENTS
+  },
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+export default store;
+export {ACTIONS};

--- a/cdap-ui/app/cdap/components/GroupedBarChart/index.js
+++ b/cdap-ui/app/cdap/components/GroupedBarChart/index.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import VegaLiteChart from 'components/VegaLiteChart';
+
+const chartSpec = {
+  "data": {
+    "values": []
+  },
+  "mark": "bar",
+  "encoding": {
+    "column": {
+      "field": "name", "type": "ordinal",
+    },
+    "y": {
+      "field": "count", "type": "quantitative",
+      "axis": {"title": "Count", "grid": false}
+    },
+    "x": {
+      "field": "type", "type": "nominal",
+      "axis": {"title": ""}
+    },
+    "color": {
+      "field": "type",
+      "type": "nominal"
+    }
+  },
+  "config": {
+    "view": {"stroke": "transparent"}
+  }
+};
+
+export default function GroupedBarChart({data, customEncoding = {}}) {
+  let newSpec = {
+    ...chartSpec,
+    "encoding": {
+      ...chartSpec.encoding,
+      ...customEncoding
+    }
+  };
+  return (
+    <VegaLiteChart
+      spec={newSpec}
+      data={data}
+    />
+  );
+}
+
+GroupedBarChart.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+    type: PropTypes.string,
+    count: PropTypes.number
+  })).isRequired,
+  customEncoding: PropTypes.object
+};

--- a/cdap-ui/app/cdap/components/Header/Header.scss
+++ b/cdap-ui/app/cdap/components/Header/Header.scss
@@ -61,7 +61,7 @@
   .global-navbar-toggler {
     display: none;
 
-    @media(max-width: 1040px) {
+    @media(max-width: 1110px) {
       display: inline-flex;
       height: 50px;
       padding-top: 0;
@@ -88,7 +88,7 @@
   }
 
   .global-navbar-collapse {
-    @media(max-width: 1040px) {
+    @media(max-width: 1110px) {
       display: none;
       &.minimized {
         display: block;

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -116,21 +116,34 @@ export default class Header extends Component {
     let dataprepBasePath = `${basePath}/dataprep`;
     let connectionsBasePath = `${basePath}/connections`;
     let rulesenginepath = `${basePath}/rulesengine`;
+    let analytics = `${basePath}/experiments`;
     if (
       location.pathname.startsWith(basePath) &&
       !location.pathname.startsWith(dataprepBasePath) &&
       !location.pathname.startsWith(connectionsBasePath) &&
-      !location.pathname.startsWith(rulesenginepath)
+      !location.pathname.startsWith(rulesenginepath) &&
+      !location.pathname.startsWith(analytics)
     ) {
       return true;
     }
     return false;
   };
 
+  isMMDSActive = (match, location = window.location) => {
+    if (match && match.isExact) {
+      return true;
+    }
+    let {selectedNamespace: namespace} = NamespaceStore.getState();
+    let experimentsBasePath = `/ns/${namespace}/experiments`;
+    return location.pathname.startsWith(experimentsBasePath);
+  };
+
   render() {
     let baseCDAPURL = `/ns/${this.state.currentNamespace}`;
     let rulesengineUrl = `${baseCDAPURL}/rulesengine`;
     let dataprepUrl = `${baseCDAPURL}/dataprep`;
+    let mmdsurl = `${baseCDAPURL}/experiments`;
+
     let pipelinesListUrl =  window.getHydratorUrl({
       stateName: 'hydrator.list',
       stateParams: {
@@ -140,7 +153,6 @@ export default class Header extends Component {
       }
     });
     let isPipelinesViewActive = location.pathname.indexOf('/pipelines/') !== -1;
-
 
     return (
       <div className="global-navbar">
@@ -191,6 +203,15 @@ export default class Header extends Component {
             >
               {T.translate('features.Navbar.pipelinesLabel')}
             </a>
+          </li>
+          <li>
+            <NavLinkWrapper
+              isNativeLink={this.props.nativeLink}
+              to={this.props.nativeLink ? `/cdap${mmdsurl}` : mmdsurl}
+              isActive={this.isMMDSActive}
+              >
+              {T.translate(`features.Navbar.MMDS`)}
+            </NavLinkWrapper>
           </li>
           <li>
               <NavLinkWrapper

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -54,6 +54,10 @@ const AppDetailedView = Loadable({
   loader: () => import(/* webpackChunkName: "AppDetailedView" */ 'components/AppDetailedView'),
   loading: LoadingSVGCentered
 });
+const Experiments = Loadable({
+  loader: () => import(/* webpackChunkName: "Experiments" */ 'components/Experiments'),
+  loading: LoadingSVGCentered
+});
 export default class Home extends Component {
   componentWillMount() {
     NamespaceStore.dispatch({
@@ -89,6 +93,7 @@ export default class Home extends Component {
             );
           }} />
           <Route path="/ns/:namespace/connections" component={DataPrepConnections} />
+          <Route path="/ns/:namespace/experiments" component={Experiments} />
           <Route component={Page404} />
         </Switch>
       </div>

--- a/cdap-ui/app/cdap/components/PaginationWithTitle/PaginationWithTitle.scss
+++ b/cdap-ui/app/cdap/components/PaginationWithTitle/PaginationWithTitle.scss
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+$page-li-size: 22px;
+$current-page-background-color: rgba(93, 103, 137, 1);
+$hovered-page-background-color: rgba(219, 219, 219, 1);
+
+.pagination-with-title {
+  float: right;
+  margin-right: 50px;
+  margin-bottom: initial;
+
+  .total-entities {
+    display: inline-block;
+    vertical-align: top;
+
+    span {
+      font-weight: bold;
+      font-size: 12px;
+    }
+  }
+
+  .page-list {
+    padding-left: 16px;
+    list-style-type: none;
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: top;
+
+    li {
+      font-weight: bold;
+      display: inline-block;
+      border-radius: 100%;
+
+      a,
+      span {
+        display: flex;
+        height: $page-li-size;
+        width: $page-li-size;
+        justify-content: center;
+        align-items: center;
+        color: inherit;
+        user-select: none;
+
+        &:hover,
+        &:focus {
+          text-decoration: none;
+          outline: 0;
+        }
+      }
+
+      &:not(:first-child) {
+        margin-left: 15px;
+      }
+
+      &.current-page {
+        background-color: $current-page-background-color;
+
+        a {
+          color: #ffffff;
+        }
+      }
+
+      &.ellipsis {
+        margin-left: 5px;
+        margin-right: -10px;
+
+        span {
+          user-select: none;
+        }
+      }
+
+      &:hover {
+        &:not(.current-page):not(.ellipsis) {
+          cursor: pointer;
+          background-color: $hovered-page-background-color;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/PaginationWithTitle/index.js
+++ b/cdap-ui/app/cdap/components/PaginationWithTitle/index.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import PropTypes from 'prop-types';
+import ReactPaginate from 'react-paginate';
+import React, { Component } from 'react';
+require('./PaginationWithTitle.scss');
+
+export default class PaginationWithTitle extends Component {
+  propTypes = {
+    currentPage: PropTypes.number,
+    totalPages: PropTypes.number,
+    title: PropTypes.string,
+    numberOfEntities: PropTypes.number,
+    handlePageChange: PropTypes.func
+  };
+
+  state = {
+    title: this.props.title || 'Pages',
+    currentPage: this.props.currentPage,
+    totalPages: this.props.totalPages,
+  }
+  render() {
+    return (
+      <span className="pagination-with-title">
+        <ul className="total-entities">
+          <span>
+            {this.props.numberOfEntities} {this.state.title}
+          </span>
+        </ul>
+        <ReactPaginate
+          pageCount={this.props.totalPages}
+          pageRangeDisplayed={3}
+          marginPagesDisplayed={1}
+          breakLabel={<span>...</span>}
+          breakClassName={"ellipsis"}
+          previousLabel={<span className="fa fa-angle-left"></span>}
+          nextLabel={<span className="fa fa-angle-right"></span>}
+          onPageChange={this.props.handlePageChange.bind(this)}
+          disableInitialCallback={true}
+          initialPage={this.props.currentPage-1}
+          forcePage={this.props.currentPage-1}
+          containerClassName={"page-list"}
+          activeClassName={"current-page"}
+        />
+      </span>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/PieChart/index.js
+++ b/cdap-ui/app/cdap/components/PieChart/index.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import d3 from 'd3';
+import shortid from 'shortid';
+import isNil from 'lodash/isNil';
+
+export default class PieChart extends Component {
+  propTypes = {
+    data: PropTypes.arrayOf(PropTypes.shape({
+      color: PropTypes.string,
+      value: PropTypes.string
+    })),
+    width: PropTypes.number,
+    height: PropTypes.number
+  };
+  state = {
+    data: this.props.data,
+    id: shortid.generate()
+  };
+  componentDidMount() {
+    this.drawPie();
+  }
+  componentWillReceiveProps(nextProps) {
+    this.setState({data: nextProps.data});
+  }
+  drawPie() {
+    if (isNil(this.state.data) || (Array.isArray(this.state.data) && !this.state.data.length)) {
+      return;
+    }
+    var svg = d3.select(`#${this.state.id} svg`),
+        width = +svg.attr("width"),
+        height = +svg.attr("height"),
+        radius = Math.min(width, height) / 2,
+        g = svg.append("g").attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
+
+    var pie = d3.layout.pie()
+        .sort(null)
+        .value(function(d) { return d.count; });
+
+    var path = d3.svg.arc()
+        .outerRadius(radius - 10)
+        .innerRadius(0);
+
+    var arc = g.selectAll(".arc")
+        .data(pie(this.state.data))
+        .enter().append("g")
+          .attr("class", "arc");
+
+    arc.append('title')
+      .text((d) => `${d.data.value} (${d.data.count})`);
+    arc.append("path")
+        .attr("d", path)
+        .attr("fill", (d) => d.data.color);
+  }
+  render() {
+    return (
+      <div id={this.state.id}>
+        <svg
+          width={this.props.width || "50"}
+          height={this.props.height || "50"}
+        >
+        </svg>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/VegaLiteChart/index.js
+++ b/cdap-ui/app/cdap/components/VegaLiteChart/index.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import * as vl from 'vega-lite';
+import * as vega from 'vega';
+import * as vegaTooltip from 'vega-tooltip';
+import shortid from 'shortid';
+import LoadingSVG from 'components/LoadingSVG';
+import debounce from 'lodash/debounce';
+
+export default class GroupedBarChart extends Component {
+  propTypes = {
+    spec: PropTypes.object.isRequired,
+    data: PropTypes.object
+  };
+  state = {
+    data: this.props.data || [],
+    isLoading: true,
+    id: `chart-${shortid.generate()}`
+  };
+  componentDidMount() {
+    this.renderChart();
+    document.body.onresize = debounce(this.renderChart, 1);
+  }
+  componentWillReceiveProps(nextProps) {
+    this.setState({data: nextProps.data || []}, this.renderChart.bind(this, true));
+  }
+
+  renderChart = (isResize) => {
+    if (this.mountTimeout) {
+      clearTimeout(this.mountTimeout);
+    }
+    if (!isResize) {
+      this.setState({
+        isLoading: true
+      });
+    }
+    this.mountTimeout = window.setTimeout(() => {
+      this.updateSpec();
+      this.runView();
+      this.setState({
+        isLoading: false
+      });
+    });
+  };
+
+  updateSpec = () => {
+    try {
+      const el = document.getElementById(this.state.id);
+      const dimension = el.getBoundingClientRect();
+      const vlSpec = {
+        ...this.props.spec,
+        "width": (dimension.width - 200) / (this.state.data.length / 2), // FIXME: This will not be generic. See if we can abstract this out.
+        data: {
+          name: this.state.id
+        }
+      };
+      const spec = vl.compile(vlSpec).spec;
+      const runtime = vega.parse(spec);
+      this.view = new vega.View(runtime)
+        .logLevel(vega.Warn)
+        .initialize(el)
+        .renderer('svg')
+        .hover();
+      vegaTooltip.vega(this.view);
+      this.bindData();
+    } catch (err) {
+      console.log('ERROR: Failed to compile vega spec ', err);
+    }
+  };
+
+  bindData = () => {
+    const {data} = this.props;
+    if (data) {
+      this.view.change(this.state.id,
+        vega.changeset()
+            .remove(() => true) // remove previous data
+            .insert(data)
+      );
+    }
+  };
+
+  runView = () => {
+    try {
+      this.view.run();
+    } catch (err) {
+      console.log('ERROR: Rendering view');
+    }
+  };
+
+  render() {
+    return (
+      <div className="grouped-bar-chart">
+        {this.state.isLoading ? <LoadingSVG /> : null }
+        <div id={this.state.id}></div>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/styles/lib-styles.scss
+++ b/cdap-ui/app/cdap/styles/lib-styles.scss
@@ -62,3 +62,20 @@
 
 // Utility classes
 @import "~bootstrap/scss/utilities";
+
+// vega-tooltip styles
+:global .vg-tooltip {
+  visibility: hidden;
+  padding: 6px;
+  border-radius: 3px;
+  position: fixed;
+  z-index: 2000;
+  font-family: sans-serif;
+  font-size: 11px;
+
+  /* The default look of the tooltip is the same as .light-theme
+  but it can be overwritten by .dark-theme */
+  background-color: rgba(255, 255, 255, 0.9);
+  border: 1px solid #d9d9d9;
+  color: black;
+}

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1181,6 +1181,7 @@ features:
       integrationsLabel: Integrations
       searchLabel: Search
       tagsLabel: Tags
+    MMDS: Analytics
     NamespaceDropdown:
       addNS: "Add Namespace"
       applications: Applications


### PR DESCRIPTION
- Modifies `Header` to add link `Analytics` section
- Adds `ExperimentsListView` view under `Analytics`
- Adds a generic `VegaLiteChart` to be reused for any charts we need to render.
- Adds a generic `PieChart` as it is not part of `vega-lite`
- Adds a generic `Pagination` component for consistency. This should eventually replace the one in `EntityListView`. Will open a separate PR for it.

JIRA: https://issues.cask.co/browse/CDAP-12749

#### Note:
- No `i18n` added yet.
- Experiments list view bar graph needs more attention to detail as it right now expands to the full width.
- Sorting in table needs to be fine-tuned for sorting by algorithm types and source data.