### PR TITLE
CDAP-12742 fix dataframe csv read/write in pipeline plugins

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
@@ -39,6 +39,14 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-batch</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- CDAP-12742: avoid packaging commons-lang3, which is a dependency of cdap-formats (from grok),
+                           but clashes with the one from Spark -->
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
@@ -71,6 +79,14 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.10</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <!-- CDAP-12742: avoid packaging commons-lang3, which is a dependency of cdap-formats (from grok),
+                           but clashes with the one from Spark -->
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
@@ -44,6 +44,12 @@
           <groupId>co.cask.cdap</groupId>
           <artifactId>hydrator-spark-core</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- CDAP-12742: avoid packaging commons-lang3, which is a dependency of cdap-formats (from grok),
+                           but clashes with the one from Spark -->
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -77,6 +83,14 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.11</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <!-- CDAP-12742: avoid packaging commons-lang3, which is a dependency of cdap-formats (from grok),
+                           but clashes with the one from Spark -->
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
Exclude commons-lang3 from the data pipeline jars. This dependency
is pulled in from cdap-formats, which pulls it in from the grok
dependency. Since it's not actually used by the app, and since it
conflicts with the commons-lang3 from Spark, it should not be
packaged in the app jar.