### PR TITLE
[MMDS][CDAP-12776] - Adds Experiment Create View

### DIFF
--- a/cdap-ui/app/cdap/api/experiments.js
+++ b/cdap-ui/app/cdap/api/experiments.js
@@ -18,8 +18,11 @@ import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
 import {apiCreator} from 'services/resource-helper';
 
 let dataSrc = DataSourceConfigurer.getInstance();
-let basePath = '/namespaces/:namespace/apps/ModelPrepApp/services/ModelManagerService/methods';
+let basePath = '/namespaces/:namespace/apps/ModelManagementApp/services/ModelManagerService/methods';
 export const myExperimentsApi = {
   list: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments`),
-  getModelsInExperiment: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/models`)
+  getModelsInExperiment: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/models`),
+  createExperiment: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basePath}/experiments/:experimentId`),
+  createSplit: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/experiments/:experimentId/splits`),
+  createModelInExperiment: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/experiments/:experimentId/models`)
 };

--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -244,7 +244,7 @@ export default class ColumnActionsDropdown extends Component {
 
     if (newState) {
       let element = document.getElementById('app-container');
-      if (this.singleWorkspaceMode) {
+      if (!element && this.singleWorkspaceMode) {
         element = document.getElementsByClassName('wrangler-modal')[0];
       }
       this.documentClick$ = Rx.Observable.fromEvent(element, 'click')

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -361,12 +361,7 @@ export default class DataPrepTopPanel extends Component {
             {this.renderTopPanelDisplay()}
           </div>
         </div>
-        {
-          !this.props.singleWorkspaceMode ?
-            <Switch />
-          :
-            null
-        }
+        <Switch />
 
         <div className="action-buttons">
           {

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -87,7 +87,7 @@ export default class DataPrepConnections extends Component {
 
     let {workspaceInfo} = DataPrepStore.getState().dataprep;
     this.state = {
-      sidePanelExpanded: this.props.enableRouting ? true : false,
+      sidePanelExpanded: this.props.sidePanelExpanded || (this.props.enableRouting ? true : false),
       backendChecking: true,
       backendDown: false,
       loading: this.props.enableRouting ? true : false,
@@ -665,7 +665,7 @@ export default class DataPrepConnections extends Component {
     if (this.state.backendChecking) {
       return (
         <div className="text-xs-center">
-          {pageTitle}
+          {this.props.singleWorkspaceMode || this.props.enableRouting ? null : pageTitle}
           <LoadingSVG />
         </div>
       );
@@ -674,7 +674,7 @@ export default class DataPrepConnections extends Component {
     if (this.state.backendDown) {
       return (
         <div>
-          {pageTitle}
+          {this.props.singleWorkspaceMode || this.props.enableRouting ? null : pageTitle}
           <DataPrepServiceControl
             onServiceStart={this.onServiceStart}
           />
@@ -688,7 +688,7 @@ export default class DataPrepConnections extends Component {
     }
     return (
       <div className="dataprep-connections-container">
-        {pageTitle}
+        {this.props.singleWorkspaceMode || this.props.enableRouting ? null : pageTitle}
         {this.renderPanel()}
 
         <div className={classnames('connections-content', {
@@ -716,5 +716,6 @@ DataPrepConnections.propTypes = {
   location: PropTypes.object,
   enableRouting: PropTypes.bool,
   onWorkspaceCreate: PropTypes.func,
-  singleWorkspaceMode: PropTypes.bool
+  singleWorkspaceMode: PropTypes.bool,
+  sidePanelExpanded: PropTypes.bool
 };

--- a/cdap-ui/app/cdap/components/EmptyMessageContainer/index.js
+++ b/cdap-ui/app/cdap/components/EmptyMessageContainer/index.js
@@ -22,12 +22,14 @@ require('./EmptyMessageContainer.scss');
 
 const PREFIX = 'features.EmptyMessageContainer';
 
-export default function EmptyMessageContainer({searchText, children}) {
+export default function EmptyMessageContainer({title, searchText, children}) {
   return (
     <div className="empty-search-container">
       <div className="empty-search">
         <strong>
-          {T.translate(`${PREFIX}.title`, {searchText})}
+          {
+            title ? title : T.translate(`${PREFIX}.title`, {searchText})
+          }
         </strong>
         <hr />
         <span> {T.translate(`${PREFIX}.suggestionTitle`)} </span>
@@ -37,6 +39,7 @@ export default function EmptyMessageContainer({searchText, children}) {
   );
 }
 EmptyMessageContainer.propTypes = {
+  title: PropTypes.string,
   searchText: PropTypes.string,
   children: PropTypes.node.isRequired
 };

--- a/cdap-ui/app/cdap/components/EntityListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/index.js
@@ -40,6 +40,7 @@ import Page404 from 'components/404';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import queryString from 'query-string';
+import Helmet from 'react-helmet';
 
 import {
   DEFAULT_SEARCH_FILTERS, DEFAULT_SEARCH_SORT,
@@ -345,6 +346,7 @@ export default class EntityListView extends Component {
 
     return (
       <div>
+        <Helmet title={T.translate('features.EntityListView.Title')} />
         <EntityListHeader />
         <div className="entity-list-view">
           {

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/CreateView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/CreateView.scss
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../styles/variables.scss";
+
+.experiments-create-view {
+  height: 100%;
+  overflow-y: hidden;
+  position: relative;
+  .experiments-toppanel {
+    margin-left: 0;
+    margin-right: 0;
+    border-bottom: 1px solid $grey-04;
+    .icon-svg.icon-close {
+      font-size: 20px;
+      cursor: pointer;
+      color: black;
+    }
+  }
+  .dataprep-connections-container {
+    height: calc(100% - 50px);
+    overflow-y: auto;
+    .file-browser-container {
+      height: 100%;
+    }
+  }
+  .dataprephome-wrapper {
+    height: calc(100vh - 154px); // header + footer + workspace tab
+    .dataprep-container {
+      .dataprep-body {
+        height: calc(100% - 50px);
+      }
+    }
+    .dataprep-container {
+      .top-section {
+        .top-section-content {
+          .top-panel {
+            .action-buttons {
+              > .btn.btn-primary {
+                visibility: hidden;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  .experiments-model-panel {
+    height: 50px;
+    position: absolute;
+    right: 80px;
+    top: 59px;
+    > .btn.btn-primary {
+      padding-right: 30px;
+      padding-left: 30px;
+    }
+  }
+  .algorithm-selection-step {
+    .experiment-metadata {
+      display: flex;
+      flex-wrap: wrap;
+      padding: 20px;
+      > div {
+        margin: 0 20px 0 0;
+        &.grayed {
+          color: $grey-05;
+        }
+        > * {
+          margin: 0 5px;
+        }
+      }
+    }
+  }
+  > :not([class*="experiments-"]) {
+    height: calc(100% - 50px);
+  }
+}

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component} from 'react';
+import TopPanel from 'components/Experiments/TopPanel';
+import IconSVG from 'components/IconSVG';
+import DataPrepConnections from 'components/DataPrepConnections';
+import DataPrepHome from 'components/DataPrepHome';
+import {Prompt, Link} from 'react-router-dom';
+import createExperimentStore from 'components/Experiments/store/createExperimentStore';
+import MyDataPrepApi from 'api/dataprep';
+import NamespaceStore from 'services/NamespaceStore';
+import UncontrolledPopover from 'components/UncontrolledComponents/Popover';
+import ExperimentPopovers from 'components/Experiments/Popovers';
+import DataPrepStore from 'components/DataPrep/store';
+import {setOutcomeColumns, setDirectives, setSrcPath, setWorkspace} from 'components/Experiments/store/ActionCreator';
+import MLAlgorithmSelection from 'components/Experiments/MLAlgorithmSelection';
+import ExperimentMetadata from 'components/Experiments/ExperimentMetadata';
+import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import Helmet from 'react-helmet';
+
+require('./CreateView.scss');
+
+export default class ExperimentCreateView extends Component {
+  state = {
+    workspaceId: '',
+    isModelCreated: createExperimentStore.getState().model_create.isModelCreated
+  };
+  componentDidMount() {
+    this.dataprepsubscription = DataPrepStore.subscribe(() => {
+      let {dataprep} = DataPrepStore.getState();
+      let {headers = [], directives, workspaceInfo = {}} = dataprep;
+      if (!headers.length) {
+        return;
+      }
+      setSrcPath(workspaceInfo.properties.path);
+      setOutcomeColumns(headers);
+      setDirectives(directives);
+    });
+    this.createExperimentStoreSubscription = createExperimentStore.subscribe(() => {
+      let {model_create, experiments_create} = createExperimentStore.getState();
+      let {isModelCreated} = model_create;
+      if (this.state.isModelCreated !== isModelCreated) {
+        this.setState({ isModelCreated });
+      }
+      if (experiments_create.loading) {
+        this.setState({
+          loading: true
+        });
+      }
+    });
+  }
+  componentWillUnmount() {
+    if (this.dataprepsubscription) {
+      this.dataprepsubscription();
+    }
+    let {isExperimentCreated} = createExperimentStore.getState().experiments_create;
+    let {selectedNamespace: namespace} = NamespaceStore.getState();
+    let workspaceId = this.state.workspaceId;
+    if (!isExperimentCreated) {
+      MyDataPrepApi
+        .delete({
+          namespace,
+          workspaceId
+        }).subscribe();
+    }
+  }
+  renderTopPanel = (title) => {
+    let {selectedNamespace: namespace} = NamespaceStore.getState();
+    return (
+      <TopPanel>
+        <h4>{title}</h4>
+        <Link to={`/ns/${namespace}/experiments`} ><IconSVG name="icon-close" /></Link>
+      </TopPanel>
+    );
+  };
+  renderConnections() {
+    return (
+      <span>
+        {this.renderTopPanel('Create a New Experiment')}
+        <DataPrepConnections
+          sidePanelExpanded={true}
+          enableRouting={false}
+          singleWorkspaceMode={true}
+          onWorkspaceCreate={(workspaceId) => {
+            setWorkspace(workspaceId);
+            this.setState({workspaceId});
+          }}
+        />
+      </span>
+    );
+  }
+  renderDataPrep() {
+    let popoverElement = (
+      <div className="btn btn-primary">
+        Add a model
+      </div>
+    );
+    return (
+      <span>
+        {this.renderTopPanel('Create a New Experiment')}
+        <div className="experiments-model-panel">
+          <UncontrolledPopover
+            popoverElement={popoverElement}
+            tag="div"
+            tetherOption={{
+              classPrefix: 'create_new_experiment_popover',
+            }}
+          >
+            <ExperimentPopovers />
+          </UncontrolledPopover>
+        </div>
+        <DataPrepHome
+          singleWorkspaceMode={true}
+          enableRouting={false}
+          workspaceId={this.state.workspaceId}
+        />
+      </span>
+    );
+  }
+  renderAlgorithmSelectionStep() {
+    let {name} = createExperimentStore.getState().experiments_create;
+    return (
+      <span className="algorithm-selection-step">
+        {this.renderTopPanel(`Add a Model to '${name}'`)}
+        <ExperimentMetadata />
+        <hr />
+        <MLAlgorithmSelection />
+      </span>
+    );
+  }
+  renderSteps() {
+    if (!this.state.workspaceId) {
+      return this.renderConnections();
+    }
+
+    let {algorithm} = createExperimentStore.getState().model_create;
+    if (this.state.workspaceId && !this.state.isModelCreated) {
+      return this.renderDataPrep();
+    }
+
+    if (this.state.isModelCreated && !algorithm.length) {
+      return this.renderAlgorithmSelectionStep();
+    }
+
+    return null;
+  }
+  render() {
+    return (
+      <div className="experiments-create-view">
+        <Helmet title="CDAP | Create Experiment" />
+        {this.renderSteps()}
+        {this.state.loading ? <LoadingSVGCentered /> : null}
+        <Prompt message={"Are you sure you want to navigate away?"} />
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentMetadata/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentMetadata/index.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect, Provider} from 'react-redux';
+import createExperimentStore from 'components/Experiments/store/createExperimentStore';
+import classnames from 'classnames';
+import isNil from 'lodash/isNil';
+
+const ExperimentMetadataWrapper = ({modelName, modelDescription, directives, algorithm}) => {
+  let isAlgorithmEmpty = () => isNil(algorithm) || !algorithm.length;
+  return (
+    <div className="experiment-metadata">
+      <div>
+        <strong>Model Name: </strong>
+        <span>{modelName}</span>
+        <div>
+          <strong>Model Description: </strong>
+          <span>{modelDescription}</span>
+        </div>
+      </div>
+      <div>
+        <strong>No of Directives: </strong>
+        <span>{directives.length}</span>
+      </div>
+      <div>
+        <strong>Split Method: </strong>
+        <span>Random</span>
+      </div>
+      <div className={classnames({
+        "grayed": isAlgorithmEmpty()
+      })}
+        >
+        <strong>ML Algorithm: </strong>
+        <span>
+          { isAlgorithmEmpty() ? '--' : algorithm }
+        </span>
+      </div>
+    </div>
+  );
+};
+ExperimentMetadataWrapper.propTypes = {
+  modelName: PropTypes.string,
+  modelDescription: PropTypes.string,
+  directives: PropTypes.array,
+  algorithm: PropTypes.string
+};
+const mapStateToProps = (state) => ({
+  modelName: state.model_create.name,
+  modelDescription: state.model_create.description,
+  directives: state.model_create.directives,
+  algorithm: !state.model_create.algorithm.name.length
+    ? '' :
+    state.model_create.algorithmsList
+      .find(algo => algo.name === state.model_create.algorithm.name)
+      .label
+});
+const ConnectedExperimentMetadata = connect(mapStateToProps, null)(ExperimentMetadataWrapper);
+
+export default function ExperimentMetadata() {
+  return (
+    <Provider store={createExperimentStore}>
+      <ConnectedExperimentMetadata />
+    </Provider>
+  );
+}

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsListBarChart/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsListBarChart/index.js
@@ -33,26 +33,37 @@ const customEncoding = {
     "header": {"title": ""}
   },
   "x": {
-    "field": "type", "type": "nominal",
+    "field": "type",
+    "type": "nominal",
     "axis": {
       "labels": false,
       "title": ""
+    }
+  },
+  "y": {
+    "field": "count",
+    "type": "quantitative",
+    "axis": {
+      "title": "Models",
+      "grid": false
     }
   }
 };
 export default function ExperimentsListBarChart({data}) {
   return (
-    <GroupedBarChart
-      data={data}
-      customEncoding={customEncoding}
-    />
+    <div className="experiment-list-chart">
+      <h5>Models Created and Deployed </h5>
+      <GroupedBarChart
+        data={data}
+        customEncoding={customEncoding}
+      />
+    </div>
   );
 }
 
 ExperimentsListBarChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,
-    type: PropTypes.string,
-    count: PropTypes.number
+    type: PropTypes.string
   })).isRequired
 };

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsPlusButton/ExperimentsPlusButton.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsPlusButton/ExperimentsPlusButton.scss
@@ -14,16 +14,32 @@
  * the License.
 */
 
-@import "../../../styles/variables.scss";
-@import "../ListView/ListView.scss";
+#experiments-plus-btn {
+  &.button-container {
+    height: 58px;
+    width: 58px;
 
-.experiments-toppanel {
-  background: $cdap-gray;
-  height: 50px;
-  margin-left: -$listview-padding;
-  margin-right: -$listview-padding;
-  padding: 0 20px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+    h1 {
+      font-size: 3em;
+    }
+  }
+}
+
+.popover {
+  margin-top: 10px;
+  &.add-experiment-popover-element {
+    margin-left: 0;
+    &:before,
+    &:after {
+      display: none;
+    }
+    .popover-content {
+      padding: 9px 14px;
+      a[href] {
+        text-decoration: none;
+        color: black;
+        cursor: pointer;
+      }
+    }
+  }
 }

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsPlusButton/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsPlusButton/index.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import {Link} from 'react-router-dom';
+import NamespaceStore from 'services/NamespaceStore';
+import UncontrolledPopover from 'components/UncontrolledComponents/Popover.js';
+
+require('./ExperimentsPlusButton.scss');
+
+export default function ExperimentsPlusButton () {
+  let popoverElement = (
+    <img
+      className="button-container"
+      src="/cdap_assets/img/plus_ico.svg"
+      id="experiments-plus-btn"
+  />
+  );
+  let {selectedNamespace: namespace} = NamespaceStore.getState();
+  return (
+    <UncontrolledPopover
+      popoverElement={popoverElement}
+      tag="span"
+      className="experiments-plus-btn"
+      tetherOption={{
+        classPrefix: 'add-experiment-popover'
+      }}
+    >
+      <Link to={`/ns/${namespace}/experiments/create`}>
+        Create a new Experiment
+      </Link>
+      <hr />
+      <div> More </div>
+    </UncontrolledPopover>
+  );
+}

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
@@ -20,10 +20,39 @@ $listview-padding: 20px;
 
 .experiments-listview {
   padding: 0 $listview-padding;
+  height: 100%;
+  overflow: hidden;
+
+  .empty-search-container {
+    a[href] {
+      color: $cdap-orange;
+    }
+  }
+  .experiments-toppanel {
+    position: relative;
+
+    .experiments-plus-btn {
+      position: absolute;
+      right: 20px;
+      top: 20px;
+      width: 58px;
+    }
+  }
+  .experiment-list-chart {
+    margin-top: 20px;
+  }
   > .clearfix {
     margin-top: 20px;
+    height: calc(100% - 380px); // 50px (top panel) + 307 for chart + 20px margin top in this element
     .pagination-with-title {
       margin-right: 0;
+    }
+    .table-container {
+      height: 100%;
+    }
+    .table-scroll {
+      height: calc(100% - 70px); // 70px for pagination + table header. .table-scroll is the table body
+      overflow-y: auto;
     }
   }
   .table {

--- a/cdap-ui/app/cdap/components/Experiments/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/index.js
@@ -24,6 +24,12 @@ import PieChart from 'components/PieChart';
 import PaginationWithTitle from 'components/PaginationWithTitle';
 import d3 from 'd3';
 import ExperimentsListBarChart from 'components/Experiments/ExperimentsListBarChart';
+import ExperimentsPlusButton from 'components/Experiments/ExperimentsPlusButton';
+import EmptyMessageContainer from 'components/EmptyMessageContainer';
+import NamespaceStore from 'services/NamespaceStore';
+import {Link} from 'react-router-dom';
+import Helmet from 'react-helmet';
+
 require('./ListView.scss');
 
 const tableHeaders = [
@@ -144,9 +150,35 @@ function ExperimentsListView({loading, list}) {
   if (loading) {
     return <LoadingSVGCentered />;
   }
+  let {selectedNamespace: namespace} = NamespaceStore.getState();
+  if (!list.length) {
+    return (
+      <div className="experiments-listview">
+        <TopPanel>
+          <h4>Analytics - All Experiments</h4>
+          <ExperimentsPlusButton />
+        </TopPanel>
+        <EmptyMessageContainer title="You have not created any experiments">
+          <ul>
+            <li>
+              <Link
+                to={`/ns/${namespace}/experiments/create`}
+              >
+                Create
+              </Link>
+              <span> a new experiment</span>
+            </li>
+          </ul>
+        </EmptyMessageContainer>
+      </div>
+    );
+  }
   return (
     <div className="experiments-listview">
-      <TopPanel message="Analytics - All Experiments" />
+      <TopPanel>
+        <h4>Analytics - All Experiments</h4>
+        <ExperimentsPlusButton />
+      </TopPanel>
       <ExperimentsListBarChart
         data={getDataForGroupedChart(list)}
       />
@@ -182,4 +214,12 @@ const mapStateToProps = (state) => {
 
 const ExperimentsListViewWrapper = connect(mapStateToProps)(ExperimentsListView);
 
-export default ExperimentsListViewWrapper;
+const ExperimentsWithTitle = () => (
+  <div>
+    <Helmet title="CDAP | All Experiments" />
+    <ExperimentsListViewWrapper />
+  </div>
+);
+
+
+export default ExperimentsWithTitle;

--- a/cdap-ui/app/cdap/components/Experiments/MLAlgorithmSelection/MLAlgorithmSelection.scss
+++ b/cdap-ui/app/cdap/components/Experiments/MLAlgorithmSelection/MLAlgorithmSelection.scss
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../styles/variables.scss";
+
+.ml-algorithm-selection {
+  .btn.btn-primary {
+    margin: 20px;
+  }
+  .ml-algorithm-list-details {
+    display: flex;
+    .ml-algorithm-list-view {
+      margin: 0 20px;
+      .ml-algorithm-category-title {
+        color: $grey-05;
+      }
+      .ml-algorithm-list-item {
+        border-top: 1px solid $grey-05;
+        cursor: pointer;
+        display: flex;
+        padding: 8px;
+        align-items: center;
+        &:hover {
+          background: $orange-05;
+        }
+        &:last-child {
+          border-bottom: 1px solid $grey-05;
+        }
+        input[type="radio"] {
+          margin-right: 5px;
+          cursor: pointer;
+        }
+        .control-label {
+          cursor: pointer;
+          margin: 0;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/Experiments/MLAlgorithmSelection/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/MLAlgorithmSelection/index.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Provider, connect} from 'react-redux';
+import createExperimentStore from 'components/Experiments/store/createExperimentStore';
+import {setModelAlgorithm, createExperimentAndModel} from 'components/Experiments/store/ActionCreator';
+import {Label} from 'reactstrap';
+
+require('./MLAlgorithmSelection.scss');
+
+const MLAlgorithmsList = ({algorithmsList, setModelAlgorithm, selectedAlgorithm}) => {
+  return (
+    <div className="ml-algorithm-list-view">
+      <h3>Select a Machine Learning Algorithm</h3>
+      <div className="ml-algorithm-category-title">Continous</div>
+      {
+        algorithmsList.map((algo, i) => {
+          return (
+            <div
+              key={i}
+              className="ml-algorithm-list-item"
+              onClick={setModelAlgorithm.bind(null, algo)}
+            >
+              <input
+                type="radio"
+                name="algo-radio"
+                value={algo.name}
+                checked={selectedAlgorithm.name === algo.name}
+                onChange={setModelAlgorithm.bind(null, algo)}
+              />
+              <Label className="control-label">
+                {algo.label}
+              </Label>
+            </div>
+          );
+        })
+      }
+    </div>
+  );
+};
+MLAlgorithmsList.propTypes = {
+  algorithmsList: PropTypes.arrayOf(PropTypes.object),
+  setModelAlgorithm: PropTypes.func,
+  selectedAlgorithm: PropTypes.object
+};
+// Will be used post demo.
+const MLAlgorithmDetails = ({algorithm}) => {
+  if (!algorithm.name.length) {
+    return null;
+  }
+  return (
+    <pre>
+      {JSON.stringify(algorithm, null, 2)}
+    </pre>
+  );
+};
+MLAlgorithmDetails.propTypes = {
+  algorithm: PropTypes.object
+};
+const AddModelBtn = ({algorithm, createExperimentAndModel}) => {
+  return (
+    <button
+      className="btn btn-primary"
+      disabled={!algorithm.name.length}
+      onClick={createExperimentAndModel}
+    >
+      Add a Model and Train
+    </button>
+  );
+};
+AddModelBtn.propTypes = {
+  algorithm: PropTypes.object,
+  createExperimentAndModel: PropTypes.func
+};
+
+const mapStateToAddModelBtnProps = (state) => ({ algorithm: state.model_create.algorithm});
+const mapDispatchToAddModelBtnProps = () => ({createExperimentAndModel});
+const mapStateToMLAlgorithmsListProps = (state) => ({
+  algorithmsList: state.model_create.algorithmsList,
+  selectedAlgorithm: state.model_create.algorithm
+});
+const mapDispatchToMLAlgorithmsListProps = () => ({setModelAlgorithm});
+// const mapStateToMLAlgorithmDetailsProps = (state) => ({ algorithm: state.model_create.algorithm });
+
+const ConnectedMLAlgorithmsList = connect(mapStateToMLAlgorithmsListProps, mapDispatchToMLAlgorithmsListProps)(MLAlgorithmsList);
+// const ConnectedMLAlgorithmDetails = connect(mapStateToMLAlgorithmDetailsProps)(MLAlgorithmDetails);
+const ConnectedAddModelBtn = connect(mapStateToAddModelBtnProps, mapDispatchToAddModelBtnProps)(AddModelBtn);
+
+
+export default function MLAlgorithmSelection() {
+  return (
+    <Provider store={createExperimentStore}>
+      <div className="ml-algorithm-selection">
+        <div className="ml-algorithm-list-details">
+          <ConnectedMLAlgorithmsList />
+          {/* <ConnectedMLAlgorithmDetails /> */}
+          <br />
+        </div>
+        <ConnectedAddModelBtn />
+      </div>
+    </Provider>
+  );
+}

--- a/cdap-ui/app/cdap/components/Experiments/Popovers/ExperimentPopovers.scss
+++ b/cdap-ui/app/cdap/components/Experiments/Popovers/ExperimentPopovers.scss
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../styles/variables.scss";
+
+$popover_container_border_color: $grey-05;
+
+.new-experiment-popover {
+  padding: 0;
+  min-width: 270px;
+  .popover-container {
+    margin: 10px;
+    border: 1px solid $popover_container_border_color;
+    padding: 0 10px 10px;
+    .popover-heading {
+      padding: 10px;
+      display: block;
+      margin: 0 -10px 10px -10px;
+      background: $cdap-gray;
+      font-size: 14px;
+    }
+    .form-control {
+      &.btn {
+        margin: 0;
+      }
+    }
+    .form-group {
+      .control-label {
+        font-size: 13px;
+        font-weight: 500;
+      }
+      textarea {
+        min-height: 100px;
+        max-height: 250px;
+      }
+    }
+    button {
+      width: 100%;
+    }
+  }
+}
+
+.new-model-popover {
+  padding: 20px;
+  .form-group {
+    .control-label {
+      font-size: 13px;
+      font-weight: 500;
+    }
+    textarea {
+      min-height: 100px;
+      max-height: 250px;
+    }
+  }
+  .experiment-metadata {
+    color: $popover_container_border_color;
+    .btn-link {
+      cursor: pointer;
+    }
+  }
+  button {
+    width: 100%;
+  }
+}
+.popover {
+  &.create_new_experiment_popover-element {
+    margin: 10px;
+    &:before,
+    &after {
+      display: none;
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/Experiments/Popovers/NewExperimentPopover.js
+++ b/cdap-ui/app/cdap/components/Experiments/Popovers/NewExperimentPopover.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import {FormGroup, Label, Col, Input} from 'reactstrap';
+import {
+  onExperimentNameChange,
+  onExperimentDescriptionChange,
+  onExperimentOutcomeChange,
+  setExperimentCreated
+} from 'components/Experiments/store/ActionCreator';
+
+const ExperimentName = ({name, onNameChange}) => {
+  return (
+    <FormGroup row>
+      <Col xs="12">
+        <Label className="control-label">Experiment Name</Label>
+        <Input
+          value={name}
+          onChange={onNameChange}
+          placeholder="Add a name for this Experiment"
+        />
+      </Col>
+    </FormGroup>
+  );
+};
+ExperimentName.propTypes = {
+  name: PropTypes.string,
+  onNameChange: PropTypes.func
+};
+
+const ExperimentDescription = ({description, onDescriptionChange}) => {
+  return (
+    <FormGroup row>
+      <Col xs="12">
+        <Label className="control-label">Description</Label>
+        <Input
+          type="textarea"
+          value={description}
+          placeholder="Add a description for this Experiment"
+          onChange={onDescriptionChange}
+        />
+      </Col>
+    </FormGroup>
+  );
+};
+ExperimentDescription.propTypes = {
+  description: PropTypes.string,
+  onDescriptionChange: PropTypes.func
+};
+
+const ExperimentOutcome = ({outcome, columns, onOutcomeChange}) => {
+  return (
+    <FormGroup row>
+      <Col xs="12">
+        <Label className="control-label">Set Outcome for this Experiment </Label>
+        <Input
+          type="select"
+          value={outcome}
+          onChange={onOutcomeChange}
+        >
+          <option key="default">Select an Outcome </option>
+          {
+            columns.map((column, i) => (
+              <option key={i}>{column}</option>
+            ))
+          }
+        </Input>
+      </Col>
+    </FormGroup>
+  );
+};
+ExperimentOutcome.propTypes = {
+  outcome: PropTypes.string,
+  columns: PropTypes.arrayOf(PropTypes.object),
+  onOutcomeChange: PropTypes.func
+};
+
+const CreateExperimentBtn = ({state, setExperimentCreated}) => {
+  const isAddExperimentBtnEnabled = () => {
+    return state.name.length && state.description.length && state.outcome.length;
+  };
+  return (
+    <button
+      className="btn btn-primary"
+      disabled={!isAddExperimentBtnEnabled()}
+      onClick={setExperimentCreated}
+    >
+      Create Experiment
+    </button>
+  );
+};
+CreateExperimentBtn.propTypes = {
+  state: PropTypes.object,
+  setExperimentCreated: PropTypes.func
+};
+
+const NewExperimentPopoverWrapper = ({isExperimentCreated}) => {
+  if (isExperimentCreated) {
+    return null;
+  }
+  return (
+    <div className="new-experiment-popover">
+      <div className="popover-container">
+        <strong className="popover-heading">
+          Create a new Experiment
+        </strong>
+        <ExperimentOutcomeWrapper />
+        <hr />
+        <ExperimentNameWrapper />
+        <ExperiementDescriptionWrapper />
+        <ConnectedCreateExperimentBtn />
+      </div>
+    </div>
+  );
+};
+NewExperimentPopoverWrapper.propTypes = {
+  isExperimentCreated: PropTypes.bool
+};
+const mapDispatchToCreateExperimentBtnProps = () => ({ setExperimentCreated});
+const mapStateToCreateExperimentBtnProps = (state) => ({ state: {...state.experiments_create} });
+const mapStateToNameProps = (state) => ({ name: state.experiments_create.name });
+const mapDispatchToNameProps = () => ({ onNameChange: onExperimentNameChange });
+const mapStateToDescriptionProps = (state) => ({ description: state.experiments_create.description });
+const mapDispatchToDescriptionToProps = () => ({ onDescriptionChange: onExperimentDescriptionChange });
+const mapStateToOutcomeProps = (state) => ({ outcome: state.experiments_create.outcome, columns: state.model_create.columns });
+const mapDispatchToOutcomeProps = () => ({onOutcomeChange: onExperimentOutcomeChange});
+const mapNEPWStateToProps = (state) => ({ isExperimentCreated: state.experiments_create.isExperimentCreated });
+const mapNEPWDispatchToProps = () => ({ setExperimentCreated });
+
+const ExperiementDescriptionWrapper = connect(mapStateToDescriptionProps, mapDispatchToDescriptionToProps)(ExperimentDescription);
+const ExperimentNameWrapper = connect(mapStateToNameProps, mapDispatchToNameProps)(ExperimentName);
+const ExperimentOutcomeWrapper = connect(mapStateToOutcomeProps, mapDispatchToOutcomeProps)(ExperimentOutcome);
+const ConnectedNewExperimentPopoverWrapper = connect(mapNEPWStateToProps, mapNEPWDispatchToProps)(NewExperimentPopoverWrapper);
+const ConnectedCreateExperimentBtn = connect(mapStateToCreateExperimentBtnProps, mapDispatchToCreateExperimentBtnProps)(CreateExperimentBtn);
+
+export default ConnectedNewExperimentPopoverWrapper;

--- a/cdap-ui/app/cdap/components/Experiments/Popovers/NewModelPopover.js
+++ b/cdap-ui/app/cdap/components/Experiments/Popovers/NewModelPopover.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import {FormGroup, Label, Col, Input, Row} from 'reactstrap';
+import {
+  setExperimentCreated,
+  onModelNameChange,
+  onModelDescriptionChange,
+  setModelCreated
+} from 'components/Experiments/store/ActionCreator';
+
+const ModelName = ({modelName, onModelNameChange}) => {
+  return (
+    <FormGroup row>
+      <Col xs="12">
+        <Label className="control-label">Model Name </Label>
+      </Col>
+      <Col xs="12">
+        <Input value={modelName} onChange={onModelNameChange} />
+      </Col>
+    </FormGroup>
+  );
+};
+ModelName.propTypes = {
+  modelName: PropTypes.string,
+  onModelNameChange: PropTypes.func
+};
+
+const ModelDescription = ({modelDescription, onModelDescriptionChange}) => {
+  return (
+    <FormGroup row>
+      <Col xs="12">
+        <Label className="control-label">Model Description </Label>
+      </Col>
+      <Col xs="12">
+        <Input
+          type="textarea"
+          value={modelDescription}
+          onChange={onModelDescriptionChange}
+        />
+      </Col>
+    </FormGroup>
+  );
+};
+ModelDescription.propTypes = {
+  modelDescription: PropTypes.string,
+  onModelDescriptionChange: PropTypes.func
+};
+
+const CreateModelBtn = ({state, setModelCreated}) => {
+  const isAddModelBtnEnabled = () => state.name.length && state.description.length;
+  return (
+    <button
+      className="btn btn-primary"
+      onClick={setModelCreated}
+      disabled={!isAddModelBtnEnabled()}
+    >
+      Create Model
+    </button>
+  );
+};
+CreateModelBtn.propTypes = {
+  state: PropTypes.object,
+  setModelCreated: PropTypes.func
+};
+
+const ExperimentMetadata = ({experimentOutcome, experimentDescription, setExperimentCreated}) => {
+  return (
+    <div className="experiment-metadata">
+      <Col xs="12">
+        <Row>
+          <Col xs="6">Outcome:</Col>
+          <Col xs="6">{experimentOutcome}</Col>
+        </Row>
+        <Row>
+          <Col xs="6">Description:</Col>
+          <Col xs="6">{experimentDescription}</Col>
+        </Row>
+        <div
+          className="btn-link"
+          onClick={setExperimentCreated.bind(null, false)}
+        >
+          Edit
+        </div>
+      </Col>
+    </div>
+  );
+};
+ExperimentMetadata.propTypes = {
+  experimentOutcome: PropTypes.string,
+  experimentDescription: PropTypes.string,
+  setExperimentCreated: PropTypes.func
+};
+
+const NewModelPopoverWrapper = ({isExperimentCreated, experimentName}) => {
+  if (!isExperimentCreated) {
+    return null;
+  }
+  return (
+    <div className="new-model-popover">
+      <FormGroup row>
+        <Col xs="12">
+          <Label className="control-label"> Select where you want to add this model </Label>
+        </Col>
+        <Col xs="12">
+          <Input value={experimentName} />
+        </Col>
+        <ConnectedExperimentMetadata />
+      </FormGroup>
+      <hr />
+      <ConnectedModelName />
+      <ConnectedModelDescription />
+      <ConnectedCreateModelBtn />
+    </div>
+  );
+};
+NewModelPopoverWrapper.propTypes = {
+  isExperimentCreated: PropTypes.bool,
+  experimentName: PropTypes.string
+};
+
+const mapStateToModelNameProps = (state) => ({modelName: state.model_create.name});
+const mapDispatchToModelNameProps = () => ({ onModelNameChange });
+const mapStateToModelDescriptionProps = (state) => ({ modelDescription: state.model_create.description });
+const mapDispatchToModelDescriptionProps = () => ({ onModelDescriptionChange });
+const mapStateToCreateModelBtnProps = (state) => ({ state: state.model_create});
+const mapDispatchToCreateModelBtnProps = () => ({ setModelCreated });
+const mapStateToExperimentMetadataProps = (state) => ({
+  experimentOutcome: state.experiments_create.outcome,
+  experimentDescription: state.experiments_create.description
+});
+const mapDispatchToExperimentMetadataProps = () => ({ setExperimentCreated });
+const mapNMPWStateToProps = (state) => ({
+  isExperimentCreated: state.experiments_create.isExperimentCreated,
+  experimentName: state.experiments_create.name
+});
+
+const ConnectedModelName = connect(mapStateToModelNameProps, mapDispatchToModelNameProps)(ModelName);
+const ConnectedModelDescription = connect(mapStateToModelDescriptionProps, mapDispatchToModelDescriptionProps)(ModelDescription);
+const ConnectedCreateModelBtn = connect(mapStateToCreateModelBtnProps, mapDispatchToCreateModelBtnProps)(CreateModelBtn);
+const ConnectedExperimentMetadata = connect(mapStateToExperimentMetadataProps, mapDispatchToExperimentMetadataProps)(ExperimentMetadata);
+const ConnectedNewModelPopoverWrapper = connect(mapNMPWStateToProps)(NewModelPopoverWrapper);
+
+export default ConnectedNewModelPopoverWrapper;

--- a/cdap-ui/app/cdap/components/Experiments/Popovers/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/Popovers/index.js
@@ -12,17 +12,23 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
-body {
-  .cdap-container {
-    height: 100%;
-    .container-fluid {
-      height: 100%;
-      padding: 0;
-      > div {
-        height: 100%;
-      }
-    }
-  }
+import React from 'react';
+import {Provider} from 'react-redux';
+import createExperimentStore from 'components/Experiments/store/createExperimentStore';
+import NewExperimentPopover from 'components/Experiments/Popovers/NewExperimentPopover';
+import NewModelPopover from 'components/Experiments/Popovers/NewModelPopover';
+
+require('./ExperimentPopovers.scss');
+
+export default function ExperimentPopovers() {
+  return (
+    <Provider store={createExperimentStore}>
+      <div>
+        <NewExperimentPopover />
+        <NewModelPopover />
+      </div>
+    </Provider>
+  );
 }

--- a/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
@@ -15,8 +15,11 @@
 */
 
 import experimentsStore, {ACTIONS} from 'components/Experiments/store';
+import createExperimentStore, {ACTIONS as CREATEEXPERIMENTACTIONS} from 'components/Experiments/store/createExperimentStore';
 import {myExperimentsApi} from 'api/experiments';
 import NamespaceStore from 'services/NamespaceStore';
+import MyDataPrepApi from 'api/dataprep';
+import {directiveRequestBodyCreator} from 'components/DataPrep/helper';
 
 function setExperimentsLoading() {
   experimentsStore.dispatch({
@@ -55,9 +58,177 @@ function getModelsListInExperiment(experimentId) {
     });
 }
 
+function onExperimentNameChange(e) {
+  let value = e.target.value;
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_EXPERIMENT_NAME,
+    payload: {name: value}
+  });
+}
+
+function onExperimentDescriptionChange(e) {
+  let value = e.target.value;
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_EXPERIMENT_DESCRIPTION,
+    payload: {description: value}
+  });
+}
+
+function onExperimentOutcomeChange(e) {
+  let value = e.target.value;
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_EXPERIMENT_OUTCOME,
+    payload: {outcome: value}
+  });
+}
+
+function setSrcPath(srcpath) {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_EXPERIMENT_SRC_PATH,
+    payload: {srcpath}
+  });
+}
+
+function setOutcomeColumns(columns) {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_OUTCOME_COLUMNS,
+    payload: {columns}
+  });
+}
+
+function setDirectives(directives) {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_DIRECTIVES,
+    payload: {directives}
+  });
+}
+
+function setExperimentCreated(value) {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_NEW_EXPERIMENT_CREATED,
+    payload: {
+      isExperimentCreated: typeof value === 'boolean' ? value : true
+    }
+  });
+}
+
+function setExperimentLoading(value = true) {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_CREATE_EXPERIMENT_LOADING,
+    payload: {loading: value}
+  });
+}
+
+function onModelNameChange(e) {
+  let value = e.target.value;
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_MODEL_NAME,
+    payload: {name: value}
+  });
+}
+
+function onModelDescriptionChange(e) {
+  let value = e.target.value;
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_MODEL_DESCRIPTION,
+    payload: {description: value}
+  });
+}
+
+function setModelCreated() {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_MODEL_CREATED
+  });
+}
+
+function setModelAlgorithm(algorithm) {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_MODEL_ML_ALGORITHM,
+    payload: {algorithm}
+  });
+}
+
+function setWorkspace(workspaceId) {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_WORKSPACE_ID,
+    payload: {workspaceId}
+  });
+}
+
+function createExperiment(experiment) {
+  let {selectedNamespace: namespace} = NamespaceStore.getState();
+  return myExperimentsApi.createExperiment({namespace, experimentId: experiment.name}, experiment);
+}
+
+function createModel(experiment, model) {
+  let {selectedNamespace: namespace} = NamespaceStore.getState();
+  return myExperimentsApi.createModelInExperiment({namespace, experimentId: experiment.name}, model);
+}
+
+function createExperimentAndModel() {
+  let {experiments_create, model_create} = createExperimentStore.getState();
+  let {selectedNamespace: namespace} = NamespaceStore.getState();
+  let {workspaceId, directives} = model_create;
+  let requestBody = directiveRequestBodyCreator(directives);
+  let experiment = {
+    name: experiments_create.name,
+    description: experiments_create.description,
+    outcome: experiments_create.outcome,
+    srcpath: experiments_create.srcpath
+  };
+
+  let model = {
+    name: model_create.name,
+    description: model_create.description,
+    algorithm: model_create.algorithm.name,
+    hyperparameters: {},
+    split: 'random',
+    directives: model_create.directives,
+    features: model_create.columns.filter(column => column !== experiments_create.outcome)
+  };
+  createExperiment(experiment)
+    .combineLatest(
+      MyDataPrepApi.getSchema({ namespace, workspaceId}, requestBody)
+    )
+    .flatMap((res) => {
+      let tempSchema = {
+        name: 'avroSchema',
+        type: 'record',
+        fields: res[1]
+      };
+      let splitInfo = {
+        schema: tempSchema,
+        directives,
+        type: 'random',
+        parameters: { percent: "80"},
+        description: `Default Random split created for model: ${model_create.name}`
+      };
+      return myExperimentsApi.createSplit({namespace, experimentId: experiments_create.name}, splitInfo);
+    })
+    .flatMap(({id: split}) => createModel(experiment, {...model, split}))
+    .subscribe(() => {
+      let {selectedNamespace: namespace} = NamespaceStore.getState();
+      window.location.href = `${window.location.origin}/cdap/ns/${namespace}/experiments`;
+    });
+}
+
 export {
   setExperimentsLoading,
   getExperimentsList,
-  getModelsListInExperiment
+  getModelsListInExperiment,
+  onExperimentNameChange,
+  onExperimentDescriptionChange,
+  onExperimentOutcomeChange,
+  setExperimentLoading,
+  setOutcomeColumns,
+  setDirectives,
+  setWorkspace,
+  setExperimentCreated,
+  onModelNameChange,
+  onModelDescriptionChange,
+  setModelCreated,
+  setModelAlgorithm,
+  createExperimentAndModel,
+  setSrcPath
 };
 

--- a/cdap-ui/app/cdap/components/Experiments/store/createExperimentStore.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/createExperimentStore.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {createStore, combineReducers} from 'redux';
+import {defaultAction} from 'services/helpers';
+
+const ACTIONS = {
+  SET_EXPERIMENT_NAME: 'SET_EXPERIMENT_NAME',
+  SET_EXPERIMENT_DESCRIPTION: 'SET_EXPERIMENT_DESCRIPTION',
+  SET_EXPERIMENT_OUTCOME: 'SET_EXPERIMENT_OUTCOME',
+  SET_EXPERIMENT_SRC_PATH: 'SET_EXPERIMENT_SRC_PATH',
+  SET_NEW_EXPERIMENT_CREATED: 'SET_NEW_EXPERIMENT_CREATED',
+  SET_CREATE_EXPERIMENT_LOADING: 'SET_CREATE_EXPERIMENT_LOADING',
+
+  SET_OUTCOME_COLUMNS: 'SET_OUTCOME_COLUMNS',
+  SET_DIRECTIVES: 'SET_DIRECTIVES',
+  SET_MODEL_NAME: 'SET_MODEL_NAME',
+  SET_MODEL_DESCRIPTION: 'SET_MODEL_DESCRIPTION',
+  SET_MODEL_CREATED: 'SET_MODEL_CREATED',
+  SET_MODEL_ML_ALGORITHM: 'SET_MODEL_ML_ALGORITHM',
+  SET_WORKSPACE_ID: 'SET_WORKSPACE_ID'
+};
+
+const DEFAULT_EXPERIMENTS_CREATE_VALUE = {
+  name: '',
+  description: '',
+  outcome: '',
+  srcpath: '',
+  loading: false,
+  isExperimentCreated: false
+};
+
+const DEFAULT_MODEL_CREATE_VALUE = {
+  name: '',
+  description: '',
+  directives: [],
+  columns: [],
+  workspaceId: '',
+  splitMethod: 'random',
+  algorithm: {
+    name: ''
+  },
+  algorithmsList: [
+    {
+      name: 'linear.regression',
+      label: 'Linear Regression'
+    },
+    {
+      name: 'generalized.linear.regression',
+      label: 'Generalized Linear Regression'
+    },
+    {
+      name: 'decision.tree.regression',
+      label: 'Decision Tree Regression'
+    },
+    {
+      name: 'random.forest.regression',
+      label: 'Random Forest Regression'
+    },
+    {
+      name: 'gradient.boosted.tree.regression',
+      label: 'Gradient Boosted Tree Regression'
+    }
+  ],
+  isModelCreated: false
+};
+
+const experiments_create = (state = DEFAULT_EXPERIMENTS_CREATE_VALUE, action = defaultAction) => {
+  switch (action.type) {
+    case ACTIONS.SET_EXPERIMENT_NAME:
+      return {
+        ...state,
+        name: action.payload.name
+      };
+    case ACTIONS.SET_EXPERIMENT_DESCRIPTION:
+      return {
+        ...state,
+        description: action.payload.description
+      };
+    case ACTIONS.SET_EXPERIMENT_OUTCOME:
+      return {
+        ...state,
+        outcome: action.payload.outcome
+      };
+    case ACTIONS.SET_EXPERIMENT_SRC_PATH:
+      return {
+        ...state,
+        srcpath: action.payload.srcpath
+      };
+    case ACTIONS.SET_NEW_EXPERIMENT_CREATED:
+      return {
+        ...state,
+        isExperimentCreated: action.payload.isExperimentCreated
+      };
+    case ACTIONS.SET_CREATE_EXPERIMENT_LOADING:
+      return {
+        ...state,
+        loading: action.payload.loading
+      };
+    default:
+      return state;
+  }
+};
+const model_create = (state = DEFAULT_MODEL_CREATE_VALUE, action = defaultAction) => {
+  switch (action.type) {
+    case ACTIONS.SET_MODEL_NAME:
+      return {
+        ...state,
+        name: action.payload.name
+      };
+    case ACTIONS.SET_MODEL_DESCRIPTION:
+      return {
+        ...state,
+        description: action.payload.description
+      };
+    case ACTIONS.SET_MODEL_CREATED:
+      return {
+        ...state,
+        isModelCreated: true
+      };
+    case ACTIONS.SET_OUTCOME_COLUMNS:
+      return {
+        ...state,
+        columns: action.payload.columns
+      };
+    case ACTIONS.SET_DIRECTIVES:
+      return {
+        ...state,
+        directives: action.payload.directives
+      };
+    case ACTIONS.SET_MODEL_ML_ALGORITHM:
+      return {
+        ...state,
+        algorithm: action.payload.algorithm
+      };
+    case ACTIONS.SET_WORKSPACE_ID:
+      return {
+        ...state,
+        workspaceId: action.payload.workspaceId
+      };
+    default:
+      return state;
+  }
+};
+
+const createExperimentStore = createStore(
+  combineReducers({
+    experiments_create,
+    model_create
+  }),
+  {
+    experiments_create: DEFAULT_EXPERIMENTS_CREATE_VALUE
+  },
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+export {ACTIONS};
+export default createExperimentStore;

--- a/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
@@ -125,9 +125,10 @@ export default class FilePath extends Component {
           </DropdownToggle>
           <DropdownMenu>
             {
-              collapsedLinks.map((path) => {
+              collapsedLinks.map((path, i) => {
                 return (
                   <DropdownItem
+                    key={i}
                     title={path.name}
                   >
                     <LinkWrapper

--- a/cdap-ui/app/cdap/components/GroupedBarChart/index.js
+++ b/cdap-ui/app/cdap/components/GroupedBarChart/index.js
@@ -61,6 +61,8 @@ export default function GroupedBarChart({data, customEncoding = {}}) {
   );
 }
 
+// TODO: Should have options to change axis style. Right now customEncoding has to provide everything.
+// Might be useful if we could identify just the props that we will be changing
 GroupedBarChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -58,6 +58,11 @@ const Experiments = Loadable({
   loader: () => import(/* webpackChunkName: "Experiments" */ 'components/Experiments'),
   loading: LoadingSVGCentered
 });
+const ExperimentsCreateView = Loadable({
+  loader: () => import(/* webpackChunkName: "ExperimentsCreateView" */ 'components/Experiments/CreateView'),
+  loading: LoadingSVGCentered
+});
+
 export default class Home extends Component {
   componentWillMount() {
     NamespaceStore.dispatch({
@@ -93,6 +98,7 @@ export default class Home extends Component {
             );
           }} />
           <Route path="/ns/:namespace/connections" component={DataPrepConnections} />
+          <Route exact path="/ns/:namespace/experiments/create" component={ExperimentsCreateView} />
           <Route path="/ns/:namespace/experiments" component={Experiments} />
           <Route component={Page404} />
         </Switch>

--- a/cdap-ui/app/cdap/components/PaginationWithTitle/index.js
+++ b/cdap-ui/app/cdap/components/PaginationWithTitle/index.js
@@ -20,7 +20,7 @@ import React, { Component } from 'react';
 require('./PaginationWithTitle.scss');
 
 export default class PaginationWithTitle extends Component {
-  propTypes = {
+  static propTypes = {
     currentPage: PropTypes.number,
     totalPages: PropTypes.number,
     title: PropTypes.string,

--- a/cdap-ui/app/cdap/components/PieChart/index.js
+++ b/cdap-ui/app/cdap/components/PieChart/index.js
@@ -21,7 +21,7 @@ import shortid from 'shortid';
 import isNil from 'lodash/isNil';
 
 export default class PieChart extends Component {
-  propTypes = {
+  static propTypes = {
     data: PropTypes.arrayOf(PropTypes.shape({
       color: PropTypes.string,
       value: PropTypes.string

--- a/cdap-ui/app/cdap/components/UncontrolledComponents/Popover.js
+++ b/cdap-ui/app/cdap/components/UncontrolledComponents/Popover.js
@@ -31,7 +31,6 @@ export default class UncontrolledPopover extends Component {
       id: shortid.generate()
     };
     this.togglePopover = this.togglePopover.bind(this);
-    this.itemClicked = this.itemClicked.bind(this);
   }
   componentWillUnmount() {
     if (this.documentClick$) {
@@ -61,9 +60,6 @@ export default class UncontrolledPopover extends Component {
       Mousetrap.unbind('esc');
     }
   }
-  itemClicked() {
-    this.togglePopover();
-  }
   renderPopover() {
     let tetherOption = this.props.tetherOption || {};
     return (
@@ -75,7 +71,7 @@ export default class UncontrolledPopover extends Component {
         className="dataprep-toggle-all-dropdown"
         tether={tetherOption}
       >
-        <PopoverContent onClick={this.itemClicked}>
+        <PopoverContent>
           {this.props.children}
         </PopoverContent>
       </Popover>
@@ -83,10 +79,24 @@ export default class UncontrolledPopover extends Component {
   }
   render() {
     let iconName = this.props.icon || 'fa-caret-square-o-down';
+    let Tag = this.props.tag || 'span';
+    if (this.props.popoverElement) {
+      return (
+        <Tag
+          id={this.state.id}
+          className={this.props.className}
+          onClick={this.togglePopover}
+          ref={(ref) => this.popover = ref}
+        >
+          {this.props.popoverElement}
+          {this.renderPopover()}
+        </Tag>
+      );
+    }
 
     return (
       <span
-        className={classnames(`fa ${iconName}`, {
+        className={classnames(`fa ${iconName}`, this.props.className, {
           'expanded': this.state.dropdownOpen
         })}
         id={this.state.id}
@@ -99,9 +109,12 @@ export default class UncontrolledPopover extends Component {
   }
 }
 UncontrolledPopover.propTypes = {
+  tag: PropTypes.string,
   children: PropTypes.node.isRequired,
+  popoverElement: PropTypes.node,
   dropdownOpen: PropTypes.bool,
   tetherOption: PropTypes.object,
   documentElement: PropTypes.node,
-  icon: PropTypes.string
+  icon: PropTypes.string,
+  className: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/VegaLiteChart/index.js
+++ b/cdap-ui/app/cdap/components/VegaLiteChart/index.js
@@ -65,7 +65,7 @@ export default class GroupedBarChart extends Component {
       const dimension = el.getBoundingClientRect();
       const vlSpec = {
         ...this.props.spec,
-        "width": (dimension.width - 200) / (this.state.data.length / 2), // FIXME: This will not be generic. See if we can abstract this out.
+        "width": (dimension.width - 250) / (this.state.data.length / 2), // FIXME: This will not be generic. See if we can abstract this out.
         data: {
           name: this.state.id
         }

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -103,9 +103,7 @@ class CDAP extends Component {
     return (
       <BrowserRouter basename="/cdap">
         <div className="cdap-container">
-          <Helmet
-            title={T.translate('features.EntityListView.Title')}
-          />
+          <Helmet title={T.translate('commons.cdap')} />
           <Header />
           <SplashScreen openVideo={this.openCaskVideo}/>
           <LoadingIndicator />

--- a/cdap-ui/app/cdap/styles/variables.scss
+++ b/cdap-ui/app/cdap/styles/variables.scss
@@ -25,7 +25,10 @@ $cdap-darkorange:       rgb(138, 56, 0);    // #8A3800
 $cdap-header:           rgb(60, 67, 85);    // #3c4355
 $cdap-darkness:         rgb(102, 110, 130); // #666e82
 $cdap-bluegray:         rgb(111, 124, 157); // #6f7c9d
-$cdap-gray:             rgb(111, 124, 159); // #6f7c9f
+// until today we were defining the same name twice with different colors.
+// rgray represents regular gray and its not even gray. Its bluegray from above :sigh:
+// We should remove all these colors soon and use the ones from style guide
+$cdap-rgray:             rgb(111, 124, 159); // #6f7c9f
 $cdap-lightgray:        rgb(102, 110, 131); // #666e83
 $cdap-darkblue:         rgb(44, 73, 138);   // #2c498a
 $cdap-header-icons:     rgb(121, 127, 141); // #797f8d
@@ -125,3 +128,21 @@ $orange-02: #fa8a00;
 $orange-03: #ffa727;
 $orange-04: #ffcc80;
 $orange-05: #ffe0b2;
+// Different shades of grey.
+// huh - that didn't sound correct.
+$grey-01: #333333;
+$grey-02: #666666;
+$grey-03: #999999;
+$grey-04: #bbbbbb;
+$grey-05: #cccccc;
+$grey-06: #dbdbdb;
+$grey-07: #eeeeee;
+$grey-08: #f5f5f5;
+$red-01: #a40403;
+$red-02: #d40001;
+$red-03: #d15668;
+$yellow-01: #ffba01;
+$yellow-02: #ffd500;
+$green-01: #01b133;
+$green-02: #3cc801;
+$green-03: #8af302;


### PR DESCRIPTION
#### Things done in this PR:

- Adds end-to-end flow for creating an experiment/model from UI
- Adds the ability to choose data from the list of available connections
- Wrangle the chosen data
- Choose the ML algorithm to build the model
- Behind the scenes UI creates a pipeline and run to train the model and creates a dataset to store the training data
- Have made minor modifications to `DataPrepConnection` and `Dataprep-TopPanel`
- The pipeline config added serves as just a reference while creating a pipeline to train the model. The artifact and plugin properties are being modified before deployed.

#### TODO:

- The current flow is very streamlined in that it always makes user create an experiment and create a model. The ability to just create a model under an existing experiment is not there yet. Will be added in the subsequent PR.
- No i18n yet.
- No Error handling done yet. Experiment/Model creation could fail at different points. Need to surface them up in a better way.

JIRA: https://issues.cask.co/browse/CDAP-12776