### PR TITLE
[CDAP-12659] Implements metrics for splitter plugin in UI

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraph.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraph.js
@@ -16,9 +16,14 @@
 
 import PropTypes from 'prop-types';
 
-import React from 'react';
-import {XYPlot, AreaSeries, makeVisFlexible, XAxis, YAxis, HorizontalGridLines, LineSeries, DiscreteColorLegend} from 'react-vis';
+import React, { Component } from 'react';
+import {XYPlot, AreaSeries, makeVisFlexible, XAxis, YAxis, HorizontalGridLines, LineSeries} from 'react-vis';
+import NodeMetricsGraphLegends from 'components/PipelineNodeGraphs/NodeMetricsGraphLegends';
 import {getYAxisProps} from 'components/PipelineSummary/RunsGraphHelpers';
+import maxBy from 'lodash/maxBy';
+import findKey from 'lodash/findKey';
+import findIndex from 'lodash/findIndex';
+import capitalize from 'lodash/capitalize';
 
 const RECORDS_IN_COLOR = '#58B7F6';
 const RECORDS_OUT_COLOR = '#97A0BA';
@@ -27,113 +32,188 @@ const metricTypeToColorMap = {
   'recordsout': RECORDS_OUT_COLOR
 };
 
-function renderAreaChart(data, metricType) {
-  if (!Array.isArray(data) && typeof data === 'object') {
-    return Object
-      .keys(data)
-      .map(key => {
+const FPlot = makeVisFlexible(XYPlot);
+
+export default class NodeMetricsGraph extends Component {
+
+  static propTypes = {
+    xAxisTitle: PropTypes.string,
+    yAxisTitle: PropTypes.string,
+    data: PropTypes.arrayOf(PropTypes.object),
+    metricType: PropTypes.string,
+    isMultiplePorts: PropTypes.bool,
+    portsToShow: PropTypes.arrayOf(PropTypes.string)
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.data = this.props.data;
+
+    let dataToShow = Object.keys(this.data).map(dataKey => this.data[dataKey].label);
+
+    if (this.props.isMultiplePorts && this.props.portsToShow && this.props.portsToShow.length) {
+      let portsToShow = this.props.portsToShow;
+      // always show error records no matter what port the user clicks on
+      if (portsToShow.indexOf('errors') === -1) {
+        portsToShow.push('errors');
+      }
+      dataToShow = portsToShow.map(port => capitalize(port));
+    }
+
+    this.state = {
+      dataToShow
+    };
+
+    if (Array.isArray(this.data) && !this.data.length) {
+      return;
+    }
+
+    this.xDomain = [0, 10];
+    let {tickFormat, yDomain} = getYAxisProps(this.data);
+    this.tickFormat = tickFormat;
+    this.yDomain = yDomain;
+    this.dummyData = [{
+      x: 0,
+      y: 0
+    }];
+
+    this.colorLegend = [];
+
+    if (Array.isArray(this.data) && this.data.length > 10) {
+      this.xDomain[1] = this.data.length;
+      this.colorLegend = [{
+        title: this.data.label,
+        color: this.data.color
+      }];
+    } else if (!Array.isArray(this.data) && typeof this.data === 'object') {
+      let dataObjects = Object.keys(this.data).map((key) => this.data[key]);
+      let objectWithMaxLength = maxBy(dataObjects, (dataObject) => dataObject.data.length);
+      this.xDomain[1] = objectWithMaxLength.data.length;
+      Object
+        .keys(this.data)
+        .forEach(d => {
+          this.colorLegend.push({
+            title: this.data[d].label,
+            color: this.data[d].color
+          });
+        });
+    }
+  }
+
+  onLegendClick = (itemTitle) => {
+    let legendKey = findKey(this.data, (dataKey) => dataKey.label === itemTitle);
+    if (!legendKey) {
+      return;
+    }
+
+    let legendItem = this.data[legendKey];
+    let newDataToShow = [...this.state.dataToShow];
+    let legendItemIndex = findIndex(newDataToShow, (dataKey) => dataKey === legendItem.label);
+    if (legendItemIndex !== -1) {
+      newDataToShow.splice(legendItemIndex, 1);
+    } else {
+      newDataToShow.push(legendItem.label);
+    }
+    this.setState({
+      dataToShow: newDataToShow
+    });
+  };
+
+  renderAreaChart(data, metricType) {
+    if (!Array.isArray(data) && typeof data === 'object') {
+      let dataArrayToShow = Object.keys(data).filter(key => this.state.dataToShow.indexOf(data[key].label) !== -1);
+      if (!dataArrayToShow.length) {
         return (
           <AreaSeries
             curve="curveLinear"
-            color={data[key].color || metricTypeToColorMap[metricType]}
-            stroke={data[key].color || metricTypeToColorMap[metricType]}
-            data={data[key].data}
+            color={metricTypeToColorMap[metricType]}
+            stroke={metricTypeToColorMap[metricType]}
+            data={this.dummyData}
             opacity={0.2}
           />
         );
-      });
-  }
-  return (
-    <AreaSeries
-      curve="curveLinear"
-      color={metricTypeToColorMap[metricType]}
-      stroke={metricTypeToColorMap[metricType]}
-      data={data}
-      opacity={0.5}
-    />
-  );
-}
+      }
 
-function renderLineChart(data, metricType) {
-  if (!Array.isArray(data) && typeof data === 'object') {
-    return Object
-      .keys(data)
-      .map(key => {
-        return (
-          <LineSeries
-            color={data[key].color || metricTypeToColorMap[metricType]}
-            data={data[key].data}
-            strokeWidth={4}
-          />
-        );
-      });
-  }
-  return (
-    <LineSeries
-      color={metricTypeToColorMap[metricType]}
-      data={data}
-      strokeWidth={4}
-    />
-  );
-}
-
-export default function NodeMetricsGraph({data, xAxisTitle, yAxisTitle, metricType}) {
-  if (Array.isArray(data) && !data.length) {
-    return null;
-  }
-  let xDomain = [0, 10];
-  let {tickFormat, yDomain} = getYAxisProps(data);
-  var color_legend = [];
-  if (Array.isArray(data) && data.length > 10) {
-    xDomain[1] = data.length;
-    color_legend = [{
-      title: data.label,
-      color: data.color
-    }];
-  } else if (!Array.isArray(data) && typeof data === 'object') {
-    let firstKey = Object.keys(data)[0];
-    xDomain[1] = data[firstKey].data.length;
-    Object
-      .keys(data)
-      .forEach(d => {
-        color_legend.push({
-          title: data[d].label,
-          color: data[d].color
+      return dataArrayToShow
+        .map(key => {
+          let dataToPlot = data[key].data;
+          if (!dataToPlot || !dataToPlot.length) {
+            dataToPlot = this.dummyData;
+          }
+          return (
+            <AreaSeries
+              curve="curveLinear"
+              color={data[key].color || metricTypeToColorMap[metricType]}
+              stroke={data[key].color || metricTypeToColorMap[metricType]}
+              data={dataToPlot}
+              opacity={0.2}
+            />
+          );
         });
-      });
-  }
-  let FPlot = makeVisFlexible(XYPlot);
-  return (
-    <div className="graph-plot-container">
-      <FPlot
-        xType="linear"
-        yType="linear"
-        xDomain={xDomain}
-        yDomain={yDomain}
-        tickTotal={xDomain[1]}
-        className="run-history-fp-plot"
-      >
-        <XAxis />
-        <YAxis tickFormat={tickFormat} />
-        <HorizontalGridLines />
-        {renderAreaChart(data, metricType)}
-        {renderLineChart(data, metricType)}
-        <div className="x-axis-title">{xAxisTitle}</div>
-        <div className="y-axis-title">{yAxisTitle}</div>
-      </FPlot>
-      <DiscreteColorLegend
-        style={{position: 'absolute', left: '40px', top: '0px'}}
-        orientation="horizontal"
-        items={color_legend}
+    }
+    return (
+      <AreaSeries
+        curve="curveLinear"
+        color={metricTypeToColorMap[metricType]}
+        stroke={metricTypeToColorMap[metricType]}
+        data={data}
+        opacity={0.5}
       />
-    </div>
-  );
-}
+    );
+  }
 
-NodeMetricsGraph.propTypes = {
-  xAxisTitle: PropTypes.string,
-  yAxisTitle: PropTypes.string,
-  data: PropTypes.arrayOf(PropTypes.object),
-  metricType: PropTypes.string
-};
+  renderLineChart(data, metricType) {
+    if (!Array.isArray(data) && typeof data === 'object') {
+      return Object
+        .keys(data)
+        .filter(key => this.state.dataToShow.indexOf(data[key].label) !== -1)
+        .map(key => {
+          return (
+            <LineSeries
+              color={data[key].color || metricTypeToColorMap[metricType]}
+              data={data[key].data}
+              strokeWidth={4}
+            />
+          );
+        });
+    }
+    return (
+      <LineSeries
+        color={metricTypeToColorMap[metricType]}
+        data={data}
+        strokeWidth={4}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <div className="graph-plot-container">
+        <FPlot
+          xType="linear"
+          yType="linear"
+          xDomain={this.xDomain}
+          yDomain={this.yDomain}
+          tickTotal={this.xDomain[1]}
+          className="run-history-fp-plot"
+        >
+          <XAxis />
+          <YAxis tickFormat={this.tickFormat} />
+          <HorizontalGridLines />
+          {this.renderAreaChart(this.data, this.metricType)}
+          {this.renderLineChart(this.data, this.metricType)}
+          <div className="x-axis-title">{this.props.xAxisTitle}</div>
+          <div className="y-axis-title">{this.props.yAxisTitle}</div>
+        </FPlot>
+        <NodeMetricsGraphLegends
+          items={this.colorLegend}
+          checkedItems={this.state.dataToShow}
+          onLegendClick={this.onLegendClick}
+          isMultiplePorts={this.props.isMultiplePorts}
+        />
+      </div>
+    );
+  }
+}
 

--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraphLegend.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraphLegend.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+
+export default function NodeMetricsGraphLegend({item, orientation, showCheckbox, onLegendClick, itemChecked}) {
+  if (!showCheckbox) {
+    return (
+      <div className={classnames('rv-discrete-color-legend-item', orientation)}>
+        <span
+          className="rv-discrete-color-legend-item__color"
+          style={{background: item.color}}
+        />
+        <span className="rv-discrete-color-legend-item__title">
+          {item.title}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={classnames('rv-discrete-color-legend-item pointer', orientation)}
+      onClick={onLegendClick.bind(null, item.title)}
+    >
+      <span className={classnames('fa legend-item-checkbox', {
+          'fa-square-o': !itemChecked,
+          'fa-check-square': itemChecked
+        })}
+      />
+      <span
+        className="rv-discrete-color-legend-item__color"
+        style={{background: item.color}}
+      />
+      <span className="rv-discrete-color-legend-item__title">
+        {item.title}
+      </span>
+    </div>
+  );
+}
+
+NodeMetricsGraphLegend.propTypes = {
+  item: PropTypes.oneOfType([
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      color: PropTypes.string,
+      disabled: PropTypes.bool
+    }),
+    PropTypes.string.isRequired,
+    PropTypes.element
+  ]).isRequired,
+  orientation: PropTypes.string,
+  showCheckbox: PropTypes.bool,
+  onLegendClick: PropTypes.func,
+  itemChecked: PropTypes.bool
+};
+
+NodeMetricsGraphLegend.defaultProps = {
+  orientation: 'horizontal',
+  showCheckbox: false
+};

--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraphLegends.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraphLegends.js
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import T from 'i18n-react';
+import IconSVG from 'components/IconSVG';
+import NodeMetricsGraphLegend from 'components/PipelineNodeGraphs/NodeMetricsGraphLegend';
+
+const PREFIX = 'features.PipelineSummary.pipelineNodesMetricsGraph';
+
+// Need this because we want to show Errors separately instead of grouped together with Records Out/ports
+const recordsErrorTitle = T.translate(`${PREFIX}.recordsErrorTitle`);
+
+export default class NodeMetricsGraphLegends extends Component {
+  static propTypes = {
+    items: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.shape({
+          title: PropTypes.string.isRequired,
+          color: PropTypes.string,
+          disabled: PropTypes.bool
+        }),
+        PropTypes.string.isRequired,
+        PropTypes.element
+      ])
+    ).isRequired,
+    checkedItems: PropTypes.arrayOf(
+      PropTypes.string
+    ),
+    onLegendClick: PropTypes.func,
+    isMultiplePorts: PropTypes.bool
+  };
+
+  state = {
+    showLegendPopover: false
+  };
+
+  itemsWithoutErrorRecords = this.props.items.filter((item) => item.title !== recordsErrorTitle);
+
+  toggleLegendPopover = () => {
+    this.setState({
+      showLegendPopover: !this.state.showLegendPopover
+    });
+  };
+
+  renderRecordsErrorLegend(showCheckbox = false, orientation = 'horizontal') {
+    let recordsErrorItem = this.props.items.find(item => item.title === recordsErrorTitle);
+    if (!recordsErrorItem) {
+      return null;
+    }
+
+    let itemChecked = this.props.checkedItems.indexOf(recordsErrorItem.title) !== -1;
+
+    return (
+      <NodeMetricsGraphLegend
+        item={recordsErrorItem}
+        showCheckbox={showCheckbox}
+        orientation={orientation}
+        itemChecked={itemChecked}
+        onLegendClick={this.props.onLegendClick}
+      />
+    );
+  }
+
+  renderNormalMetricsLegends() {
+    return (
+      <div className='rv-discrete-color-legend horizontal'>
+        {
+          this.itemsWithoutErrorRecords
+            .map((item, i) =>
+              <NodeMetricsGraphLegend
+                item={item}
+                key={i}
+              />
+            )
+        }
+        {this.renderRecordsErrorLegend()}
+      </div>
+    );
+  }
+
+  renderPortsMetricsLegends() {
+    return (
+      <div className='rv-discrete-color-legend horizontal'>
+        {
+          this.itemsWithoutErrorRecords
+            .map((item, i) => {
+              let itemChecked = this.props.checkedItems.indexOf(item.title) !== -1;
+
+              return (
+                <NodeMetricsGraphLegend
+                  item={item}
+                  key={i}
+                  showCheckbox={true}
+                  itemChecked={itemChecked}
+                  onLegendClick={this.props.onLegendClick}
+                />
+              );
+            })
+        }
+        {this.renderRecordsErrorLegend(true)}
+      </div>
+    );
+  }
+
+  renderPortsMetricsLegendsPopover() {
+    let checkedItemsWithoutErrorRecords = this.props.checkedItems.filter((item) => item !== recordsErrorTitle);
+    let itemToShowOnTop = this.itemsWithoutErrorRecords[0];
+    if (checkedItemsWithoutErrorRecords.length) {
+      itemToShowOnTop = this.itemsWithoutErrorRecords.find(item => item.title === checkedItemsWithoutErrorRecords[0]);
+    }
+    let showCheckedItemsCount = this.state.showLegendPopover || checkedItemsWithoutErrorRecords.length === 0 || checkedItemsWithoutErrorRecords.length >= 2;
+
+    return (
+      <div className='ports-legend-popover-with-errors'>
+        <div className='ports-legend-popover'>
+          <div
+            className="legend-popover-toggle"
+            onClick={this.toggleLegendPopover}
+          >
+            {
+              showCheckedItemsCount ?
+                (
+                  <span>
+                    {
+                      T.translate(`${PREFIX}.checkedPortLegendsCount`, {
+                        selected: checkedItemsWithoutErrorRecords.length,
+                        total: this.itemsWithoutErrorRecords.length
+                      })
+                    }
+                  </span>
+                )
+              :
+                (
+                  <div className='rv-discrete-color-legend horizontal'>
+                    <NodeMetricsGraphLegend item={itemToShowOnTop} />
+                  </div>
+                )
+            }
+            <span className="toggle-caret">
+              <IconSVG name="icon-caret-down" />
+            </span>
+          </div>
+          {
+            !this.state.showLegendPopover ?
+              null
+            :
+              (
+                <div className='legend-popover'>
+                  <div className='popover-content rv-discrete-color-legend'>
+                    {
+                      this.itemsWithoutErrorRecords
+                        .map((item, i) => {
+                          let itemChecked = this.props.checkedItems.indexOf(item.title) !== -1;
+                          return (
+                            <NodeMetricsGraphLegend
+                              item={item}
+                              key={i}
+                              showCheckbox={true}
+                              itemChecked={itemChecked}
+                              onLegendClick={this.props.onLegendClick}
+                              orientation='vertical'
+                            />
+                          );
+                        })
+                    }
+                  </div>
+                </div>
+              )
+          }
+        </div>
+        <div className='rv-discrete-color-legend horizontal error-item'>
+          {this.renderRecordsErrorLegend(true)}
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    if (!this.props.isMultiplePorts) {
+      return this.renderNormalMetricsLegends();
+    } else if (this.props.isMultiplePorts && this.itemsWithoutErrorRecords.length <= 2) {
+      return this.renderPortsMetricsLegends();
+    }
+    return this.renderPortsMetricsLegendsPopover();
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.js
@@ -15,7 +15,6 @@
 */
 
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import {MyMetricApi} from 'api/metric';
 import T from 'i18n-react';
@@ -25,6 +24,9 @@ import NodeMetricsGraph from 'components/PipelineNodeGraphs/NodeMetricsGraph';
 import isNil from 'lodash/isNil';
 require('./PipelineNodeMetricsGraph.scss');
 import findIndex from 'lodash/findIndex';
+import maxBy from 'lodash/maxBy';
+import capitalize from 'lodash/capitalize';
+import cloneDeep from 'lodash/cloneDeep';
 import {getGapFilledAccumulatedData} from 'components/PipelineSummary/RunsGraphHelpers';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import CopyableRunID from 'components/PipelineSummary/CopyableRunID';
@@ -34,6 +36,16 @@ const PREFIX = `features.PipelineSummary.pipelineNodesMetricsGraph`;
 const RECORDS_OUT_PATH_COLOR = '#97A0BA';
 const RECORDS_ERROR_PATH_COLOR = '#A40403';
 const RECORDS_IN_PATH_COLOR = '#58B7F6';
+const RECORDS_OUT_PORTS_PATH_COLORS = [
+  '#979FBB',
+  '#FFBA01',
+  '#5C6788',
+  '#FA6600',
+  '#7CD2EB',
+  '#999999',
+  '#FFA727'
+];
+
 const REGEXTOLABELLIST = [
   {
     id: 'processmintime',
@@ -52,6 +64,7 @@ const REGEXTOLABELLIST = [
     regex: /user.*.time.stddev$/
   }
 ];
+
 export default class PipelineNodeMetricsGraph extends Component {
 
   static propTypes = {
@@ -68,20 +81,24 @@ export default class PipelineNodeMetricsGraph extends Component {
       programId: PropTypes.string
     }),
     metrics: PropTypes.arrayOf(PropTypes.string),
-    plugin: PropTypes.object
+    plugin: PropTypes.object,
+    portsToShow: PropTypes.arrayOf(PropTypes.string)
   };
 
   state = {
     recordsInData: [],
     recordsOutData: [],
     recordsErrorData: [],
+    recordsOutPortsData: [],
     totalRecordsIn: null,
     totalRecordsOut: null,
     totalRecordsError: null,
+    totalRecordsOutPorts: null,
     processTimeMetrics: {},
     resolution: 'hours',
     aggregate: false,
-    loading: true
+    loading: true,
+    showPortsRecordsCountPopover: false
   };
 
   componentDidMount() {
@@ -100,107 +117,166 @@ export default class PipelineNodeMetricsGraph extends Component {
     }
   }
 
-  constructData = ({qid: data}) => {
+  formatData = (records, numOfDataPoints) => {
+    let totalRecords = 0;
+    let formattedRecords = [];
+    if (Array.isArray(records.data)) {
+      formattedRecords = records.data.map((d) => {
+        totalRecords += d.value;
+        return {
+          x: d.time,
+          y: totalRecords
+        };
+      });
+      formattedRecords = getGapFilledAccumulatedData(formattedRecords, numOfDataPoints)
+        .map((data, i) => ({
+          x: i,
+          y: data.y
+        }));
+    }
+    return formattedRecords;
+  };
+
+  filterData = ({qid: data}) => {
     let resolution = this.getResolution(data.resolution);
     let recordsInRegex = new RegExp(/user.*.records.in/);
     let recordsOutRegex = new RegExp(/user.*.records.out/);
     let recordsErrorRegex = new RegExp(/user.*.records.error/);
+    let recordsOutPortsRegex = new RegExp(/user.*.records.out./);
+
     let recordsInData = data.series.find(d => recordsInRegex.test (d.metricName)) || [];
     let recordsOutData = data.series.find(d => recordsOutRegex.test(d.metricName)) || [];
     let recordsErrorData = data.series.find(d => recordsErrorRegex.test(d.metricName)) || [];
-    const formatData = (records, numOfDataPoints) => {
-      let totalRecords = 0;
-      let formattedRecords = [];
-      if (Array.isArray(records.data)) {
-        formattedRecords = records.data.map((d) => {
-          totalRecords += d.value;
-          return {
-            x: d.time,
-            y: totalRecords
-          };
-        });
-        formattedRecords = getGapFilledAccumulatedData(formattedRecords, numOfDataPoints)
-          .map((data, i) => ({
-            x: i,
-            y: data.y
-          }));
-      }
-      return formattedRecords;
-    };
-    let numOfDataPoints = Math.max(
-      Array.isArray(recordsOutData.data) ? recordsOutData.data.length : 0,
-      Array.isArray(recordsInData.data) ? recordsInData.data.length : 0,
-      Array.isArray(recordsErrorData.data) ? recordsErrorData.data.length : 0
-    );
-    recordsOutData = formatData(recordsOutData, numOfDataPoints);
-    recordsInData = formatData(recordsInData, numOfDataPoints);
-    recordsErrorData = formatData(recordsErrorData, numOfDataPoints);
+    let recordsOutPortsData = data.series.filter(d => recordsOutPortsRegex.test(d.metricName)) || [];
 
-    this.setState({
+    let newState = {
       recordsInData,
-      recordsOutData,
       recordsErrorData,
       resolution
-    });
-  }
-
-  getRecordsInOut({qid: data}) {
-    let recordsInRegex = new RegExp(/user.*.records.in/);
-    let recordsOutRegex = new RegExp(/user.*.records.out/);
-    let recordsErrorRegex = new RegExp(/user.*.records.error/);
-    if (!data.series.length) {
-      return {
-        recordsInData: null,
-        recordsOutData: null
-      };
-    }
-    let recordsInData = data.series.find(d => recordsInRegex.test (d.metricName)) || {};
-    let recordsOutData = data.series.find(d => recordsOutRegex.test(d.metricName)) || {};
-    let recordsErrorData = data.series.find(d => recordsErrorRegex.test(d.metricName)) || {};
-    recordsInData = (recordsInData.data || []).length ? recordsInData.data[0].value : 0;
-    recordsOutData = (recordsOutData.data || []).length ? recordsOutData.data[0].value : 0;
-    recordsErrorData = (recordsErrorData.data || []).length ? recordsErrorData.data[0].value : 0;
-
-    return {
-      recordsInData,
-      recordsOutData,
-      recordsErrorData
     };
+
+    if (!recordsOutPortsData.length) {
+      newState.recordsOutData = recordsOutData;
+    } else {
+      newState.recordsOutPortsData = recordsOutPortsData;
+    }
+
+    return newState;
   }
 
   getOutputRecordsForCharting() {
-    return {
-      'recordsOut': {
-        data: this.state.recordsOutData,
-        label: T.translate(`${PREFIX}.recordsOutTitle`),
-        color: RECORDS_OUT_PATH_COLOR
-      },
+    let {
+      recordsInData,
+      recordsOutData,
+      recordsErrorData,
+      recordsOutPortsData
+    } = cloneDeep(this.state);
+
+    if (!this.state.aggregate) {
+      let numOfDataPoints = this.getNumOfDataPoints(recordsInData, recordsOutData, recordsErrorData, recordsOutPortsData);
+      recordsOutData = this.formatData(recordsOutData, numOfDataPoints);
+      recordsErrorData = this.formatData(recordsErrorData, numOfDataPoints);
+      for (let i = 0; i < recordsOutPortsData.length; i++) {
+        recordsOutPortsData[i] = this.formatData(recordsOutPortsData[i], numOfDataPoints);
+      }
+    } else {
+      recordsOutData = (recordsOutData.data || []).length ? recordsOutData.data[0].value : 0;
+      recordsErrorData = (recordsErrorData.data || []).length ? recordsErrorData.data[0].value : 0;
+      for (let i = 0; i < recordsOutPortsData.length; i++) {
+        let portData = recordsOutPortsData[i];
+        recordsOutPortsData[i] = (portData.data || []).length ? portData.data[0].value : 0;
+      }
+    }
+
+    let outputRecordsObj = {
       'recordsError': {
-        data: this.state.recordsErrorData,
+        data: recordsErrorData,
         label: T.translate(`${PREFIX}.recordsErrorTitle`),
         color: RECORDS_ERROR_PATH_COLOR
       }
     };
+
+    if ((typeof recordsOutData === 'number' && recordsOutData !== 0) || (Array.isArray(recordsOutData) && recordsOutData.length)) {
+      return {
+        ...outputRecordsObj,
+        'recordsOut': {
+          data: recordsOutData,
+          label: T.translate(`${PREFIX}.recordsOutTitle`),
+          color: RECORDS_OUT_PATH_COLOR
+        }
+      };
+    }
+
+    for (let i = 0; i < recordsOutPortsData.length; i++) {
+      let portData = this.state.recordsOutPortsData[i];
+      let portName = capitalize(portData.metricName.split('.').pop());
+      outputRecordsObj = {
+        ...outputRecordsObj,
+        [portName]: {
+          data: recordsOutPortsData[i],
+          label: portName,
+          color: this.state.totalRecordsOutPorts[portName].color
+        }
+      };
+    }
+    return outputRecordsObj;
   }
 
-  getInputRecordsForCharting () {
-    let defaultMap = {
+  getInputRecordsForCharting() {
+    let {
+      recordsInData,
+      recordsOutData,
+      recordsErrorData,
+      recordsOutPortsData
+    } = cloneDeep(this.state);
+
+    if (!this.state.aggregate) {
+      let numOfDataPoints = this.getNumOfDataPoints(recordsInData, recordsOutData, recordsErrorData, recordsOutPortsData);
+      recordsInData = this.formatData(recordsInData, numOfDataPoints);
+      recordsErrorData = this.formatData(recordsErrorData, numOfDataPoints);
+    } else {
+      recordsInData = (recordsInData.data || []).length ? recordsInData.data[0].value : 0;
+      recordsErrorData = (recordsErrorData.data || []).length ? recordsErrorData.data[0].value : 0;
+    }
+
+    let inputRecordsObj = {
       'recordsIn': {
-        data: this.state.recordsInData,
+        data: recordsInData,
         label: T.translate(`${PREFIX}.recordsInTitle`),
         color: RECORDS_IN_PATH_COLOR
       }
     };
     if (isPluginSink(this.props.plugin.type)) {
-      return Object.assign({}, defaultMap, {
+      return {
+        ...inputRecordsObj,
         'recordsError': {
-          data: this.state.recordsErrorData,
+          data: recordsErrorData,
           label: T.translate(`${PREFIX}.recordsErrorTitle`),
           color: RECORDS_ERROR_PATH_COLOR
         }
-      });
+      };
     }
-    return defaultMap;
+    return inputRecordsObj;
+  }
+
+  getNumOfDataPoints(recordsInData, recordsOutData, recordsErrorData, recordsOutPortsData) {
+    let maxRecordsOutDataPoints = 0;
+    if (recordsOutData && recordsOutData.data && Array.isArray(recordsOutData.data)) {
+      maxRecordsOutDataPoints = recordsOutData.data.length;
+    } else if (recordsOutPortsData.length) {
+      let portWithMaxDataPoints = maxBy(recordsOutPortsData, (portData) => portData.data.length);
+      if (portWithMaxDataPoints && portWithMaxDataPoints.data && Array.isArray(portWithMaxDataPoints.data)) {
+        maxRecordsOutDataPoints = portWithMaxDataPoints.data.length;
+      }
+    }
+
+    let numOfDataPoints = Math.max(
+      Array.isArray(recordsInData.data) ? recordsInData.data.length : 0,
+      Array.isArray(recordsErrorData.data) ? recordsErrorData.data.length : 0,
+      maxRecordsOutDataPoints
+    );
+
+    return numOfDataPoints;
   }
 
   fetchProcessTimeMetrics = () => {
@@ -224,28 +300,41 @@ export default class PipelineNodeMetricsGraph extends Component {
       .subscribe(
         (res) => {
           let data = res.qid.series;
-          let recordsOut, recordsIn, recordsError;
+          let recordsOut, recordsIn, recordsError, recordsOutPorts;
+          recordsOut = recordsIn = recordsError = 0;
+          recordsOutPorts = {};
           let processTimeMetrics = {};
           data.forEach(d => {
             let metricName = d.metricName;
+            let dataValue = (d.data || []).length ? d.data[0].value : 0;
             let specificMetric = REGEXTOLABELLIST.find(metricObj => metricObj.regex.test(d.metricName));
             if (specificMetric) {
               metricName = specificMetric.id;
             }
             if (d.metricName.match(/user.*records.in/)) {
-              recordsIn = d.data[0].value;
+              recordsIn += dataValue;
             } else if (d.metricName.match(/user.*records.out/)) {
-              recordsOut = d.data[0].value;
+              recordsOut += dataValue;
             } else if (d.metricName.match(/user.*.records.error/)) {
-              recordsError = d.data[0].value;
+              recordsError += dataValue;
             }
-            processTimeMetrics[metricName] = d.data[0].value;
+            if (d.metricName.match(/user.*records.out./)) {
+              let portName = capitalize(d.metricName.split('.').pop());
+              let portColor = RECORDS_OUT_PORTS_PATH_COLORS[Object.keys(recordsOutPorts).length % 7];
+
+              recordsOutPorts[portName] = {
+                value: dataValue,
+                color: portColor
+              };
+            }
+            processTimeMetrics[metricName] = dataValue;
           });
           this.setState({
             processTimeMetrics,
             totalRecordsIn: recordsIn,
             totalRecordsOut: recordsOut,
-            totalRecordsError: recordsError
+            totalRecordsError: recordsError,
+            totalRecordsOutPorts: recordsOutPorts
           });
         }
       );
@@ -278,7 +367,7 @@ export default class PipelineNodeMetricsGraph extends Component {
             return MyMetricApi.query(null, postBody);
           }
           this.setState({
-            data: this.constructData(res),
+            ...this.filterData(res),
             loading: false
           });
           return Rx.Observable.create((observer) => {
@@ -292,7 +381,7 @@ export default class PipelineNodeMetricsGraph extends Component {
           }
           this.setState({
             aggregate: true,
-            ...this.getRecordsInOut(res),
+            ...this.filterData(res),
             loading: false
           });
         },
@@ -302,19 +391,29 @@ export default class PipelineNodeMetricsGraph extends Component {
           });
         }
       );
+  };
 
+  togglePortsRecordsCountPopover = () => {
+    this.setState({
+      showPortsRecordsCountPopover: !this.state.showPortsRecordsCountPopover
+    });
   };
 
   renderChart = (data, type) => {
     if (Array.isArray(data) && !data.length) {
       return <EmptyMessageContainer message={T.translate(`${PREFIX}.nodata`)} />;
     }
+
+    let isMultiplePorts = type === 'recordsout' && Object.keys(this.state.totalRecordsOutPorts).length > 0;
+
     return (
       <NodeMetricsGraph
         xAxisTitle={this.state.resolution}
         yAxisTitle={T.translate(`${PREFIX}.numberOfRecords`)}
         data={data}
         metricType={type}
+        isMultiplePorts={isMultiplePorts}
+        portsToShow={this.props.portsToShow}
       />
     );
   }
@@ -437,6 +536,70 @@ export default class PipelineNodeMetricsGraph extends Component {
     });
   };
 
+  renderPortsRecordsCount() {
+    if (Object.keys(this.state.totalRecordsOutPorts).length <= 2) {
+      return (
+        Object.keys(this.state.totalRecordsOutPorts)
+          .map(key => {
+            return (
+              <span>
+                { this.renderPortCount(key) }
+              </span>
+            );
+          })
+      );
+    }
+
+    return (
+      <a className="toggle-records-count-popover"
+          onClick={this.togglePortsRecordsCountPopover}
+      >
+        {
+          this.state.showPortsRecordsCountPopover ?
+            <span>{T.translate(`${PREFIX}.portRecordsCountPopover.hide`)}</span>
+          :
+            <span>{T.translate(`${PREFIX}.portRecordsCountPopover.view`)}</span>
+        }
+      </a>
+    );
+  }
+
+  rendePortsRecordsCountPopover() {
+    if (!this.state.showPortsRecordsCountPopover) {
+      return null;
+    }
+
+    return (
+      <div className="port-records-count-popover">
+        <div className="popover-content">
+          <strong>{T.translate(`${PREFIX}.portRecordsCountPopover.title`)}</strong>
+          {
+            Object.keys(this.state.totalRecordsOutPorts)
+              .map(key => {
+                let colorStyle = { backgroundColor: this.state.totalRecordsOutPorts[key].color };
+                return (
+                  <div className="port-count-container">
+                    <span
+                      className="port-legend-circle"
+                      style={colorStyle}
+                    />
+                    { this.renderPortCount(key) }
+                  </div>
+                );
+              })
+          }
+        </div>
+      </div>
+    );
+  }
+
+  renderPortCount = (port) => {
+    return T.translate(`${PREFIX}.totalRecordsOutPorts`, {
+      port,
+      recordCount: this.state.totalRecordsOutPorts[port].value || '0'
+    });
+  };
+
   renderContent() {
     return (
       <div className="node-metrics-container">
@@ -483,14 +646,16 @@ export default class PipelineNodeMetricsGraph extends Component {
                     this.state.aggregate ?
                       null
                     :
-                      <strong>
-                        <span>
+                      <span>
+                        <strong>
                           { this.renderRecordsCount('totalRecordsOut') }
-                        </span>
-                        <span className="error-records-count">
+                        </strong>
+                        { this.renderPortsRecordsCount() }
+                        <strong className="error-records-count">
                           { this.renderRecordsCount('totalRecordsError') }
-                        </span>
-                      </strong>
+                        </strong>
+                        { this.rendePortsRecordsCountPopover() }
+                      </span>
                   }
                 </div>
               </div>

--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.scss
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.scss
@@ -17,6 +17,7 @@
 $graph_container_border_color: lightgray;
 $table_header_border: #c9ccd6;
 $error_records_label_color: #a40403;
+$legend-checkbox-bg-color: rgb(88, 183, 286);
 
 .pipeline-node-metrics-graph {
   height: 100%;
@@ -36,7 +37,11 @@ $error_records_label_color: #a40403;
       cursor: pointer;
     }
     .total-records {
-      strong {
+      > strong,
+      > span {
+        position: relative;
+
+        strong,
         span {
           margin: 0 10px 0 0;
           &.error-records-count {
@@ -50,6 +55,39 @@ $error_records_label_color: #a40403;
     }
     > div:not(.title) {
       font-size: 14px;
+    }
+
+    .port-records-count-popover {
+      position: absolute;
+      background: white;
+      z-index: 1;
+      border: 1px solid black;
+
+      .popover-content {
+        padding: 10px 15px 15px 15px;
+
+        .port-count-container {
+          display: flex;
+          align-items: center;
+          margin-top: 3px;
+
+          .port-legend-circle {
+            margin: 0 3px 0 0;
+            height: 15px;
+            width: 15px;
+            display: inline-block;
+            border-radius: 50%;
+          }
+        }
+      }
+    }
+
+    a.toggle-records-count-popover {
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
   .node-metrics-container {
@@ -91,22 +129,101 @@ $error_records_label_color: #a40403;
             bottom: -10px;
             left: 50%;
           }
-          .rv-discrete-color-legend.horizontal {
+          .ports-legend-popover-with-errors {
+            width: 100%;
+            min-width: 200px;
+            padding-top: 10px;
+
+            .ports-legend-popover {
+              width: 70%;
+              max-width: 170px;
+              position: relative;
+              display: inline-block;
+
+              .legend-popover-toggle {
+                cursor: pointer;
+                border-bottom: 1px solid;
+                padding-bottom: 2px;
+                display: flex;
+                align-items: center;
+
+                .rv-discrete-color-legend {
+                  padding: 0;
+                }
+
+                .toggle-caret {
+                  margin-left: auto;
+                  font-size: 18px;
+                }
+              }
+
+              .legend-popover {
+                position: absolute;
+                background: white;
+                border: 1px solid black;
+                top: 35px;
+              }
+
+              .popover-content.rv-discrete-color-legend {
+                padding: 10px 0 15px 15px;
+
+                .rv-discrete-color-legend-item.vertical {
+                  margin-top: 5px;
+
+                  .legend-item-checkbox {
+                    margin-right: 10px;
+                    transform: translateY(1px);
+                  }
+                }
+              }
+            }
+
+            .rv-discrete-color-legend.error-item {
+              padding: 0;
+              width: initial;
+              display: inline-block;
+              float: right;
+            }
+
+          }
+          .rv-discrete-color-legend {
             width: 100%;
             padding: 10px 0 0;
-            .rv-discrete-color-legend-item.horizontal {
-              display: inline-block;
+
+            .rv-discrete-color-legend-item {
+              display: inline-flex;
+              align-items: center;
               margin: 0 40px 0 0;
+
+              &.vertical {
+                display: flex;
+              }
+
+              &.pointer {
+                cursor: pointer;
+              }
+
+              .legend-item-checkbox {
+                font-size: 20px;
+                width: 17px;
+                margin-right: 5px;
+
+                &.fa-check-square {
+                  color: $legend-checkbox-bg-color;
+                }
+              }
+
               .rv-discrete-color-legend-item__title {
                 font-size: 14px;
               }
               .rv-discrete-color-legend-item__color {
                 display: inline-block;
                 vertical-align: bottom;
-                width: 30px;
+                width: 18px;
+                height: 18px;
                 border: 1px solid $graph_container_border_color;
-                height: 20px;
                 margin: 0 5px 0 0;
+                border-radius: 50%;
               }
             }
           }
@@ -116,10 +233,11 @@ $error_records_label_color: #a40403;
         }
       }
       .node-metrics-single-datapoint {
-        font-size: 4em;
+        font-size: 3em;
         height: calc(100% - 50px);
         display: flex;
         flex-direction: column;
+        flex-wrap: wrap;
 
         > span {
           display: flex;

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1333,10 +1333,15 @@ features:
       xAxisTitle: "Pipeline run #"
       yAxisTitle: "Number of Records"
     pipelineNodesMetricsGraph:
+      checkedPortLegendsCount: "{selected} of {total} Metrics Displayed"
       hours: Hours
       minutes: Minutes
       nodata: No Data
       numberOfRecords: Number of Records
+      portRecordsCountPopover:
+        hide: Hide All
+        title: Total Records Out
+        view: View All
       processTimeTable:
         avgProcessTime: Average Processing Time
         minProcessTime: Min Process Time (one record)
@@ -1346,11 +1351,12 @@ features:
         stddevProcessTime: Standard Deviation
       recordsInTitle: Records In
       recordsOutTitle: Records Out
-      recordsErrorTitle: Records Error # Error Records??
+      recordsErrorTitle: Errors
       runOfTitle: Run {runNumber} of {totalRun}
       seconds: Seconds
       totalRecordsIn: "Total Records In: {totalRecordsIn}"
       totalRecordsOut: "Total Records Out: {totalRecordsOut}"
+      totalRecordsOutPorts: "{port}: {recordCount}"
       totalRecordsError: "Total Errors: {totalRecordsError}"
     runsHistoryGraph:
       hint:

--- a/cdap-ui/app/directives/complex-schema/complex-schema.html
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.html
@@ -68,7 +68,7 @@
                        ng-blur="ComplexSchema.formatOutput()"
                        ng-keypress="$event.keyCode === 13 && ComplexSchema.addField($index)"
                        placeholder="Field Name"
-                       ng-paste="ComplexSchema.pasteFields($event)"
+                       ng-paste="ComplexSchema.pasteFields($event, $index)"
                        ng-class="{'disabled': ComplexSchema.isDisabled }">
               </div>
             </div>

--- a/cdap-ui/app/directives/complex-schema/complex-schema.js
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.js
@@ -68,7 +68,8 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
     field.nested = SchemaHelper.checkComplexType(field.displayType);
   };
 
-  vm.pasteFields = (event) => {
+  vm.pasteFields = (event, index) => {
+    event.preventDefault();
     let data = [];
     let pastedData = event.clipboardData.getData('text/plain');
     let pastedDataArr = pastedData.replace(/[\n\r\t,| ]/g, '$').split('$');
@@ -86,6 +87,11 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
     });
 
     document.getElementsByClassName('bottompanel-body')[0].scrollTop = 0;
+    // This happens when the user adds a new field, then paste the data.
+    // In that case we should delete the empty before pasting.
+    if (!vm.parsedSchema[index].name) {
+      vm.parsedSchema.splice(index, 1);
+    }
 
     vm.parsedSchema = vm.parsedSchema.concat(data);
     vm.formatOutput();

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -127,9 +127,12 @@
               <div class="node-splitter-popover"
                     ng-if="node.outputSchema.length && node.outputSchema[0].name !== 'etlSchemaBody'"
                     my-splitter-popover
-                    node-name="node.name"
+                    node="node"
                     ports="node.outputSchema"
-                    is-disabled="DAGPlusPlusCtrl.isDisabled">
+                    is-disabled="DAGPlusPlusCtrl.isDisabled"
+                    on-metrics-click="DAGPlusPlusCtrl.onMetricsClick"
+                    disable-metrics-click="disableMetricsClick"
+                    metrics-data="metricsData">
               </div>
             </div>
             <div class="endpoint-circle endpoint-circle-bottom"
@@ -193,7 +196,7 @@
               </div>
             </div>
             <div class="node-metrics"
-                  ng-if="DAGPlusPlusCtrl.isDisabled && node.type !== 'condition' && node.type !== 'splittertransform'">
+                  ng-if="DAGPlusPlusCtrl.isDisabled && node.type !== 'condition'">
               <my-node-metrics
                 on-click="DAGPlusPlusCtrl.onMetricsClick"
                 node="node"

--- a/cdap-ui/app/directives/node-metrics/node-metrics.html
+++ b/cdap-ui/app/directives/node-metrics/node-metrics.html
@@ -16,22 +16,37 @@
 
 <div class="metrics-content" ng-class="{'disabled': disabled}">
   <a class="node-metrics-labels"
-    ng-click="onClick($event, node)">
+    ng-click="onClick($event, node)"
+    ng-if="node.type !== 'splittertransform'">
     <span class="metric-records-out">
       <span ng-if="node.type.indexOf('sink') === -1">
         <span class="metric-records-out-label">Out</span>
-        <span ng-bind="metricsData[node.name].recordsOut || '0' | myLeadingEllipsis: 13:8 | myNumberWithEllipsis">
-        </span>
+        <span ng-bind="metricsData[node.name].recordsOut || '0' | myLeadingEllipsis: 13:8 | myNumberWithEllipsis"></span>
       </span>
       <span ng-if="node.type.indexOf('sink') !== -1">
         <span class="metric-records-out-label">In</span>
-        <span ng-bind="metricsData[node.name].recordsIn || '0' | myLeadingEllipsis: 13:8 | myNumberWithEllipsis">
-        </span>
+        <span ng-bind="metricsData[node.name].recordsIn || '0' | myLeadingEllipsis: 13:8 | myNumberWithEllipsis"></span>
+      </span>
+      <span>/</span>
+    </span>
+    <span class="metric-errors">
+      <span class="metric-errors-label">Errors</span>
+      <span ng-bind="metricsData[node.name].recordsError || '0' | myLeadingEllipsis: 13:8 | myNumberWithEllipsis">
       </span>
     </span>
-    <span>/</span>
-    <span class="metric-errors">
-      <span class="metric-errors-label">Error</span>
+  </a>
+  <a class="node-metrics-labels"
+    ng-if="node.type === 'splittertransform'">
+    <span class="metric-records-out"
+      ng-if="portName"
+      ng-click="onClick($event, node, portName)">
+      <span class="metric-records-out-label">Out</span>
+      <span ng-bind="metricsData[node.name].recordsOut[portName] || '0' | myLeadingEllipsis: 13:8 | myNumberWithEllipsis"></span>
+    </span>
+    <span class="metric-errors"
+      ng-if="!portName"
+      ng-click="onClick($event, node)">
+      <span class="metric-errors-label">Errors</span>
       <span ng-bind="metricsData[node.name].recordsError || '0' | myLeadingEllipsis: 13:8 | myNumberWithEllipsis">
       </span>
     </span>

--- a/cdap-ui/app/directives/node-metrics/node-metrics.js
+++ b/cdap-ui/app/directives/node-metrics/node-metrics.js
@@ -23,7 +23,8 @@ angular.module(PKG.name+'.commons')
       onClick: '&',
       node: '=',
       metricsData: '=',
-      disabled: '='
+      disabled: '=',
+      portName: '='
     },
     link: function(scope) {
       let metricsTimeout = null;

--- a/cdap-ui/app/directives/splitter-popover/splitter-popover.html
+++ b/cdap-ui/app/directives/splitter-popover/splitter-popover.html
@@ -19,8 +19,17 @@
   <div ng-repeat="port in SplitterPopoverCtrl.ports">
     <span class="port-name">{{ port.name | caskCapitalizeFilter }}</span>
     <div class="endpoint-circle"
-          ng-class="['{{nodeName}}_port_{{port.name}}', {'disabled': isDisabled}]">
+          ng-class="['{{node.name || node.plugin.label}}_port_{{port.name}}', {'disabled': isDisabled}]">
       <div class="endpoint-caret" ng-if="!isDisabled"></div>
+    </div>
+    <div class="port-metrics" ng-if="isDisabled">
+      <my-node-metrics
+        on-click="onMetricsClick"
+        node="node"
+        disabled="disableMetricsClick"
+        metrics-data="metricsData"
+        port-name="port.name">
+      </my-node-metrics>
     </div>
   </div>
 </div>

--- a/cdap-ui/app/directives/splitter-popover/splitter-popover.js
+++ b/cdap-ui/app/directives/splitter-popover/splitter-popover.js
@@ -19,9 +19,12 @@ angular.module(PKG.name + '.commons')
     return {
       restrict: 'A',
       scope: {
-        nodeName: '=',
+        node: '=',
         ports: '=',
-        isDisabled: '='
+        isDisabled: '=',
+        onMetricsClick: '=',
+        disableMetricsClick: '=',
+        metricsData: '='
       },
       templateUrl: 'splitter-popover/splitter-popover.html',
       controller: function ($scope) {

--- a/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
@@ -182,7 +182,7 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
 
   EventPipe.on('schema.export', exportSchema);
   EventPipe.on('schema.clear', () => {
-    vm.schemas = '';
+    vm.schemas = [HydratorPlusPlusNodeService.getOutputSchemaObj('')];
     reRenderComplexSchema();
   });
 
@@ -191,6 +191,10 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
     vm.error = '';
     if (typeof schemas === 'string') {
       schemas = JSON.parse(schemas);
+    }
+
+    if (!Array.isArray(schemas)) {
+      schemas = [HydratorPlusPlusNodeService.getOutputSchemaObj(schemas)];
     }
 
     vm.schemas = schemas.map((schema) => {

--- a/cdap-ui/app/directives/widget-container/widget-output-schema/widget-output-schema-ctrl.js
+++ b/cdap-ui/app/directives/widget-container/widget-output-schema/widget-output-schema-ctrl.js
@@ -14,7 +14,10 @@
  * the License.
 */
 angular.module(PKG.name + '.commons')
-  .controller('MyOutputSchemaCtrl', function($scope, GLOBALS) {
+  .controller('MyOutputSchemaCtrl', function($scope, GLOBALS, HydratorPlusPlusNodeService) {
+    if (typeof $scope.node.outputSchema === 'string') {
+      $scope.node.outputSchema = [HydratorPlusPlusNodeService.getOutputSchemaObj($scope.node.outputSchema)];
+    }
     this.outputSchemas = $scope.node.outputSchema
       .map((node) => {
         var schema = node.schema;

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -65,7 +65,6 @@ class HydratorPlusPlusNodeConfigCtrl {
     if (this.metricsContext) {
       this.nodeMetrics = [
         `user.${this.state.node.name}.records.in`,
-        `user.${this.state.node.name}.records.out`,
         `user.${this.state.node.name}.records.error`,
         `user.${this.state.node.name}.process.time.total`,
         `user.${this.state.node.name}.process.time.avg`,
@@ -73,6 +72,16 @@ class HydratorPlusPlusNodeConfigCtrl {
         `user.${this.state.node.name}.process.time.min`,
         `user.${this.state.node.name}.process.time.stddev`
       ];
+      let nodeType = this.state.node.type || this.state.node.plugin.type;
+      if (nodeType === 'splittertransform') {
+        if (this.state.node.outputSchema && Array.isArray(this.state.node.outputSchema))   {
+          angular.forEach(this.state.node.outputSchema, (port) => {
+            this.nodeMetrics.push(`user.${this.state.node.name}.records.out.${port.name}`);
+          });
+        }
+      } else {
+        this.nodeMetrics.push(`user.${this.state.node.name}.records.out`);
+      }
     } else {
       this.nodeMetrics = [];
     }
@@ -94,6 +103,8 @@ class HydratorPlusPlusNodeConfigCtrl {
     } else if (this.HydratorPlusPlusDetailMetricsStore.state.metricsTabActive) {
       this.activeTab = 4;
     }
+
+    this.portMetricsToShow = this.HydratorPlusPlusDetailMetricsStore.state.portsToShow;
 
     this.$scope.$on('modal.closing', () => {
       this.updateNodeStateIfDirty();

--- a/cdap-ui/app/hydrator/services/detail/actions/pipeline-detail-metrics-actions.js
+++ b/cdap-ui/app/hydrator/services/detail/actions/pipeline-detail-metrics-actions.js
@@ -113,8 +113,8 @@ angular.module(PKG.name + '.feature.hydrator')
       dispatcher.dispatch('onReset');
     };
 
-    this.setMetricsTabActive = function(active) {
-      dispatcher.dispatch('onSetMetricsTabActive', active);
+    this.setMetricsTabActive = function(active, portToShow) {
+      dispatcher.dispatch('onSetMetricsTabActive', active, portToShow);
     };
 
   });

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/metrics-tab.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/metrics-tab.html
@@ -18,4 +18,5 @@
   run-context="HydratorPlusPlusNodeConfigCtrl.metricsContext"
   metrics="HydratorPlusPlusNodeConfigCtrl.nodeMetrics"
   plugin="HydratorPlusPlusNodeConfigCtrl.state.node"
+  ports-to-show="HydratorPlusPlusNodeConfigCtrl.portMetricsToShow"
 ></pipeline-node-metrics-graph>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12659

**Things done in this PR:**
- Show error records count inside the splitter node, and appropriate records out count under each port name.
- When these metrics are clicked on, open up the Metrics tab and show all the records out charts in the same graph, with different colors to distinguish them.
- The count of records out for each port are displayed at the top (under the 'Records Out' title). When there are more than 2 ports, collapse them, and show a 'View All' label, which when clicked on will show a popover with all the ports and their records out count.
- Added a checkbox next to each color legend to allow showing or hiding the corresponding records out chart.
- Collapse the color legends to a dropdown when there are more than 2 ports.
- Fixed duplicating of fields when copying and pasting to complex schema editor (https://issues.cask.co/browse/CDAP-12803)