### PR TITLE
Fix flaky test related to failing in stopping program

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -208,6 +208,13 @@ public interface Store extends RuntimeStore {
   Map<ProgramRunId, RunRecordMeta> getActiveRuns(ApplicationId applicationId);
 
   /**
+   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records against a given ProgramId.
+   * @param programId the program id to match against
+   * @return map of logged runs
+   */
+  Map<ProgramRunId, RunRecordMeta> getActiveRuns(ProgramId programId);
+
+  /**
    * Fetches the run record for particular run of a program.
    *
    * @param id        id of the program

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -686,6 +686,19 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     return activeRuns;
   }
 
+  public Map<ProgramRunId, RunRecordMeta> getActiveRuns(ProgramId programId) {
+    Predicate<RunRecordMeta> timePredicate = getTimeRangePredicate(0, Long.MAX_VALUE);
+    MDSKey key = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTING, programId).build();
+    Map<ProgramRunId, RunRecordMeta> activeRuns = getProgramRunIdMap(listKV(key, null, RunRecordMeta.class,
+                                                                            Integer.MAX_VALUE, timePredicate));
+
+    key = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, programId).build();
+    activeRuns.putAll(getProgramRunIdMap(listKV(key, null, RunRecordMeta.class, Integer.MAX_VALUE, timePredicate)));
+    key = getProgramKeyBuilder(TYPE_RUN_RECORD_SUSPENDED, programId).build();
+    activeRuns.putAll(getProgramRunIdMap(listKV(key, null, RunRecordMeta.class, Integer.MAX_VALUE, timePredicate)));
+    return activeRuns;
+  }
+
   private Map<ProgramRunId, RunRecordMeta> getRuns(Set<ProgramRunId> programRunIds, int limit) {
     Map<ProgramRunId, RunRecordMeta> resultMap = new LinkedHashMap<>();
     for (String type : Arrays.asList(TYPE_RUN_RECORD_STARTING, TYPE_RUN_RECORD_STARTED,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
@@ -56,6 +56,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -84,7 +85,7 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
   }
 
   @Test
-  public void testFixProgram() {
+  public void testFixProgram() throws Exception {
     final AtomicInteger sourceId = new AtomicInteger(0);
 
     // Write 10 services with starting state
@@ -209,10 +210,11 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
     }
   }
 
-  private void validateExpectedState(ProgramRunId programRunId, ProgramRunStatus expectedStatus) {
-    RunRecordMeta runRecord = store.getRun(programRunId.getParent(), programRunId.getRun());
-    Assert.assertNotNull(runRecord);
-    Assert.assertEquals(expectedStatus, runRecord.getStatus());
+  private void validateExpectedState(ProgramRunId programRunId, ProgramRunStatus expectedStatus) throws Exception {
+    Tasks.waitFor(true, () -> {
+      RunRecordMeta runRecord = store.getRun(programRunId.getParent(), programRunId.getRun());
+      return runRecord != null && Objects.equals(expectedStatus, runRecord.getStatus());
+    }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -458,7 +458,7 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     // stop run of the program that is not running
     stopProgram(Id.Program.from(TEST_NAMESPACE1, WORDCOUNT_APP_NAME, ProgramType.FLOW, WORDCOUNT_FLOW_NAME),
-                runId, 404); // active run not found
+                runId, 400); // active run not found
 
     // cleanup
     response = doDelete(getVersionedAPIPath("apps/", Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1));

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/RuntimeArgumentTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/RuntimeArgumentTestRun.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.gateway.handlers;
 
+import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.gateway.GatewayFastTestsSuite;
 import co.cask.cdap.gateway.GatewayTestBase;
 import co.cask.cdap.gateway.apps.HighPassFilterApp;
@@ -111,6 +112,12 @@ public class RuntimeArgumentTestRun extends GatewayTestBase {
 
     // Check the count. Gives it couple trials as it takes time for flow to process and write to the table
     checkCount("3");
+
+    // Make sure the programs are in running state before stopping
+    Tasks.waitFor("RUNNING", () -> getState("flows", "HighPassFilterApp", "FilterFlow"),
+                  5, TimeUnit.SECONDS, 200, TimeUnit.MILLISECONDS);
+    Tasks.waitFor("RUNNING", () -> getState("services", "HighPassFilterApp", "Count"),
+                  5, TimeUnit.SECONDS, 200, TimeUnit.MILLISECONDS);
 
     //Stop all flows and services and reset the state of the cdap
     response = GatewayFastTestsSuite.doPost(

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -18,14 +18,12 @@ package co.cask.cdap.test.internal;
 
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NamespaceNotFoundException;
-import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.internal.AppFabricClient;
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramRunStatus;
-import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ScheduleDetail;
@@ -51,10 +49,6 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * A default implementation of {@link ApplicationManager}.


### PR DESCRIPTION
- This can happen if the update of the runtime info is slower that the testing thread that already sees the program state changed (via. Run record) and attempt to stop the program