### PR TITLE
[CDAP-5105] Fixes i18n for scheduler queue name

### DIFF
--- a/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/MappingStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/MappingStep/index.js
@@ -85,7 +85,7 @@ const mapStateToSchedulerQueueNameProps = (state) => {
   return {
     value: state.mapping.schedulerQueueName,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.scheduler-queue-name')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.scheduler-queue-placeholder')
   };
 };
 const mapDispatchToSchedulerQueueNameProps = (dispatch) => {

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1688,7 +1688,6 @@ features:
         name-label: "Name"
         name-placeholder: "Namespace name"
         scheduler-queue-label: "Scheduler Queue"
-        scheduler-queue-placeholder: "Specify the Yarn queue name to be used for programs in this namespace"
         sld-desc:  "Specify the name and the description of the namespace."
         ssd-label: "General Information"
       Step2:
@@ -1699,6 +1698,7 @@ features:
         hive-db-name-label: "Hive Database Name"
         hive-db-name-placeholder: "Hive database for this namespace"
         scheduler-queue-name: "Scheduler Queue Name"
+        scheduler-queue-placeholder: "Yarn queue name to be used to submit programs in this namespace"
         sld-label: "Specify mapping of namespace resources to the existing underlying storage resources."
         ssd-label: "Namespace Mapping"
       Step3:


### PR DESCRIPTION
- Missed to push a commit in this PR https://github.com/caskdata/cdap/pull/9743. 
- Minor i18n fixes for `scheduler queue` in namespace wizard