### PR TITLE
CDAP-12838 update enabling spark2 docs

### DIFF
--- a/cdap-docs/admin-manual/source/installation/ambari.rst
+++ b/cdap-docs/admin-manual/source/installation/ambari.rst
@@ -499,6 +499,21 @@ CDAP Authentication Server
 Enabling Spark2
 ---------------
 In order to use Spark2, you must first install Spark2 on your cluster. If both Spark1
-and Spark2 are installed, you must set SPARK_MAJOR_VERSION to 2 in cdap-env.
+and Spark2 are installed, you must modify cdap-env to set SPARK_MAJOR_VERSION and SPARK_HOME::
+
+  export SPARK_MAJOR_VERSION=2
+  export SPARK_HOME=/usr/hdp/{{hdp_version}}/spark2
+
 When Spark2 is in use, Spark1 programs cannot be run. Similarly, when Spark1 is in use,
 Spark2 programs cannot be run.
+
+When CDAP starts up, it detects the spark version and uploads the corresponding pipeline
+system artifact. If you have already started CDAP with Spark1,
+you will also need to delete the pipeline system artifacts, then reload them in order
+to use the spark2 versions. After CDAP has been restarted with Spark2, use the RESTful API:
+
+.. parsed-literal::
+  |$| DELETE /v3/namespaces/system/artifacts/cdap-data-pipeline/versions/|release|
+  |$| DELETE /v3/namespaces/system/artifacts/cdap-data-streams/versions/|release|
+  |$| POST /v3/namespaces/system/artifacts
+

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -765,3 +765,14 @@ As the master is starting up, you should see a line with 'SPARK_COMPAT=spark2_2.
 
 When Spark2 is in use, Spark1 programs cannot be run. Similarly, when Spark1 is in use,
 Spark2 programs cannot be run.
+
+When CDAP starts up, it detects the spark version and uploads the corresponding pipeline
+system artifact. If you have already started CDAP with Spark1,
+you will also need to delete the pipeline system artifacts, then reload them in order
+to use the spark2 versions. After CDAP has been restarted with Spark2, use the RESTful API:
+
+.. parsed-literal::
+  |$| DELETE /v3/namespaces/system/artifacts/cdap-data-pipeline/versions/|release|
+  |$| DELETE /v3/namespaces/system/artifacts/cdap-data-streams/versions/|release|
+  |$| POST /v3/namespaces/system/artifacts
+


### PR DESCRIPTION
includes information about setting SPARK_HOME for ambari clusters
and for deleting and reloading system pipeline artifacts if CDAP
has already been started with spark1.