### PR TITLE
[CDAP-12274] Adds 'Import' button to allow importing pipelines directly from 'Add Entity' modal

### DIFF
--- a/cdap-ui/app/cdap/components/ResourceCenter/index.js
+++ b/cdap-ui/app/cdap/components/ResourceCenter/index.js
@@ -13,47 +13,26 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import ResourceCenterEntity from 'components/ResourceCenterEntity';
+import ResourceCenterPipelineEntity from 'components/ResourceCenterEntity/ResourceCenterPipelineEntity';
 import CreateStreamWithUploadStore from 'services/WizardStores/CreateStreamWithUpload/CreateStreamWithUploadStore';
-import NamespaceStore from 'services/NamespaceStore';
 import AbstractWizard from 'components/AbstractWizard';
+import CardActionFeedback from 'components/CardActionFeedback';
 import T from 'i18n-react';
 import StreamCreateWithUploadWizard from 'components/CaskWizards/StreamCreateWithUpload';
 
 require('./ResourceCenter.scss');
-/*
-  TODO: Stream views:
-  {
-    title: T.translate('features.Resource-Center.Stream-View.label'),
-    description: T.translate('features.Resource-Center.Stream-View.description'),
-    actionLabel: T.translate('features.Resource-Center.Stream-View.actionbtn0'),
-    iconClassName: 'fa icon-streamview',
-    disabled: true
-  }
-*/
+
 export default class ResourceCenter extends Component {
   constructor(props) {
     super(props);
     this.state = {
       createStreamWizard: false,
+      error: null,
       entities: [
-        {
-          // Pipeline
-          title: T.translate('features.Resource-Center.HydratorPipeline.label'),
-          description: T.translate('features.Resource-Center.HydratorPipeline.description'),
-          actionLabel: T.translate('features.Resource-Center.HydratorPipeline.actionbtn0'),
-          iconClassName: 'icon-pipelines',
-          disabled: false,
-          actionLink: window.getHydratorUrl({
-            stateName: 'hydrator.create',
-            stateParams: {
-              namespace: NamespaceStore.getState().selectedNamespace,
-              artifactType: 'cdap-data-pipeline'
-            }
-          })
-        },
         {
           // Application
           title: T.translate('features.Resource-Center.Application.label'),
@@ -105,9 +84,15 @@ export default class ResourceCenter extends Component {
       ]
     };
   }
+  onError = (error) => {
+    this.setState({
+      error
+    });
+  };
   toggleWizard(wizardName) {
     this.setState({
-      [wizardName]: !this.state[wizardName]
+      [wizardName]: !this.state[wizardName],
+      error: null
     });
   }
   closeWizard(wizardContainer) {
@@ -175,10 +160,23 @@ export default class ResourceCenter extends Component {
       );
     }
   }
+  renderError() {
+    if (!this.state.error) { return null; }
+
+    return (
+      <CardActionFeedback
+        type="DANGER"
+        message={this.state.error}
+      />
+    );
+  }
   render() {
     return (
       <div>
         <div className="cask-resource-center">
+          <ResourceCenterPipelineEntity
+            onError={this.onError}
+          />
           {
             this.state
               .entities
@@ -189,13 +187,12 @@ export default class ResourceCenter extends Component {
                   actionLabel={entity.actionLabel}
                   iconClassName={entity.iconClassName}
                   key={index}
-                  disabled={entity.disabled}
                   onClick={this.toggleWizard.bind(this, entity.wizardId)}
-                  actionLink={entity.actionLink}
                 />
               ))
           }
         </div>
+        {this.renderError()}
         { this.getWizardToBeDisplayed() }
       </div>
     );

--- a/cdap-ui/app/cdap/components/ResourceCenterEntity/ResourceCenterEntity.scss
+++ b/cdap-ui/app/cdap/components/ResourceCenterEntity/ResourceCenterEntity.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@ $height-of-image: 75px;
 
 .resourcecenter-entity-card {
   width: 280px;
-  height: 130px;
+  height: 140px;
   padding: 10px;
   padding-bottom: 0;
   margin: 10px 5px;
@@ -30,22 +30,11 @@ $height-of-image: 75px;
   .image-button-container {
     display: inline-flex;
     flex-direction: column;
-    .entity-image {
-      width: $height-of-image;
-      height: $height-of-image;
-      display: inline-block;
-      vertical-align: top;
-      font-size: $height-of-image;
-      &.empty {
-        background: gray;
-      }
+    position: relative;
 
-      .icon-svg {
-        vertical-align: inherit;
-      }
-    }
     .btn.btn-primary {
-      margin-top: 5px;
+      position: absolute;
+      bottom: 8px;
       width: 100%;
     }
   }
@@ -67,6 +56,20 @@ $height-of-image: 75px;
     .content-action-label {
       color: $cdap-orange;
       cursor: pointer;
+    }
+  }
+  .entity-image {
+    width: $height-of-image;
+    height: $height-of-image;
+    display: inline-block;
+    vertical-align: top;
+    font-size: $height-of-image;
+    &.empty {
+      background: gray;
+    }
+
+    .icon-svg {
+      vertical-align: inherit;
     }
   }
 }

--- a/cdap-ui/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.js
+++ b/cdap-ui/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import PlusButtonStore from 'services/PlusButtonStore';
+import NamespaceStore from 'services/NamespaceStore';
+import {objectQuery} from 'services/helpers';
+import IconSVG from 'components/IconSVG';
+import { Input, Label } from 'reactstrap';
+import T from 'i18n-react';
+import uuid from 'node-uuid';
+
+require('./ResourceCenterPipelineEntity.scss');
+
+const PREFIX = 'features.Resource-Center.HydratorPipeline';
+
+export default function ResourceCenterPipelineEntity({onError}) {
+  const title = T.translate(`${PREFIX}.label`);
+  const description = T.translate(`${PREFIX}.description`);
+  const primaryActionLabel = T.translate(`${PREFIX}.actionbtn0`);
+  const secondaryActionLabel = T.translate(`${PREFIX}.actionbtn1`);
+  const iconClassName = 'icon-pipelines';
+
+  const resourceCenterId = uuid.v4();
+  const hydratorLinkStateName = 'hydrator.create';
+  const hydratorLinkStateParams = {
+    namespace: NamespaceStore.getState().selectedNamespace,
+    artifactType: 'cdap-data-pipeline'
+  };
+
+  const hydratorCreateLink = window.getHydratorUrl({
+    stateName: hydratorLinkStateName,
+    stateParams: hydratorLinkStateParams
+  });
+  const hydratorImportLink = window.getHydratorUrl({
+    stateName: hydratorLinkStateName,
+    stateParams: {
+      ...hydratorLinkStateParams,
+      resourceCenterId
+    }
+  });
+
+  const createBtnHandler = () => {
+    PlusButtonStore.dispatch({
+      type: 'TOGGLE_PLUSBUTTON_MODAL',
+      payload: {
+        modalState: false
+      }
+    });
+  };
+
+  const importBtnHandler = (event) => {
+    if (!objectQuery(event, 'target', 'files', 0)) {
+      return;
+    }
+
+    let uploadedFile = event.target.files[0];
+
+    if (uploadedFile.type !== 'application/json') {
+      onError(T.translate(`${PREFIX}.nonJSONError`));
+      return;
+    }
+
+    // still have to do this because JSON.stringify(uploadedFile) doesn't work
+    onError(null);
+    let reader = new FileReader();
+    reader.readAsText(uploadedFile, 'UTF-8');
+
+    reader.onload =  (evt) => {
+      let fileDataString = evt.target.result;
+      window.localStorage.setItem(resourceCenterId, fileDataString);
+      window.location.href = hydratorImportLink;
+    };
+  };
+
+  return (
+    <div className="resourcecenter-entity-card resourcecenter-entity-card-pipeline">
+      <div className="image-content-container">
+        <div className="image-container">
+          <div className="entity-image">
+            <IconSVG name={iconClassName} />
+          </div>
+        </div>
+        <div className="content-container">
+          <div className="content-text">
+            <h4>{title}</h4>
+            <p>{description}</p>
+          </div>
+        </div>
+      </div>
+      <div className="buttons-container">
+        <a href={hydratorCreateLink}>
+          <button
+            id={(primaryActionLabel + "-" + title).toLowerCase()}
+            className="btn btn-primary"
+            onClick={createBtnHandler}
+          >
+            {primaryActionLabel}
+          </button>
+        </a>
+        <Label
+          for="resource-center-import-pipeline"
+          id={(secondaryActionLabel + "-" + title).toLowerCase()}
+          className="btn btn-secondary"
+        >
+          {secondaryActionLabel}
+          <Input
+            type="file"
+            accept='.json'
+            id="resource-center-import-pipeline"
+            onChange={importBtnHandler}
+          />
+        </Label>
+      </div>
+    </div>
+  );
+}
+ResourceCenterPipelineEntity.propTypes = {
+  onError: PropTypes.func
+};

--- a/cdap-ui/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.scss
+++ b/cdap-ui/app/cdap/components/ResourceCenterEntity/ResourceCenterPipelineEntity.scss
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import './ResourceCenterEntity.scss';
+@import '../../styles/variables.scss';
+
+$button-width: $height-of-image;
+
+.resourcecenter-entity-card {
+  &.resourcecenter-entity-card-pipeline {
+    display: inline-block;
+    position: relative;
+
+    .image-content-container {
+      display: flex;
+    }
+
+    .buttons-container {
+      position: absolute;
+      bottom: 8px;
+
+      .btn {
+        width: $button-width;
+
+        &.btn-secondary {
+          color: $brand-primary;
+          margin-left: 10px;
+          margin-bottom: 0;
+        }
+      }
+
+      #resource-center-import-pipeline {
+        display: none;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/ResourceCenterEntity/index.js
+++ b/cdap-ui/app/cdap/components/ResourceCenterEntity/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,24 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 */
-import PropTypes from 'prop-types';
 
+import PropTypes from 'prop-types';
 import React from 'react';
-import PlusButtonStore from 'services/PlusButtonStore';
 import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';
 
 require('./ResourceCenterEntity.scss');
 
-export default function ResourceCenterEntity({className, iconClassName, title, description, actionLabel, onClick, disabled, actionLink}) {
-  const closeResourceCenter = () => {
-    PlusButtonStore.dispatch({
-      type: 'TOGGLE_PLUSBUTTON_MODAL',
-      payload: {
-        modalState: false
-      }
-    });
-  };
+export default function ResourceCenterEntity({className, iconClassName, title, description, actionLabel, onClick}) {
   return (
     <div className={classnames('resourcecenter-entity-card', className)}>
       <div className="image-button-container">
@@ -44,31 +35,13 @@ export default function ResourceCenterEntity({className, iconClassName, title, d
           :
             <div className="entity-image empty" />
         }
-        {
-          actionLink ?
-            (
-              <a href={actionLink}>
-                <button
-                  className={classnames("btn btn-primary")}
-                  onClick={closeResourceCenter}
-                  disabled={disabled}
-                >
-                  {actionLabel}
-                </button>
-              </a>
-            )
-          :
-            (
-              <button
-                id={(actionLabel + "-" + title).toLowerCase()}
-                className={classnames("btn btn-primary")}
-                onClick={onClick}
-                disabled={disabled}
-              >
-                {actionLabel}
-              </button>
-            )
-        }
+        <button
+          id={(actionLabel + "-" + title).toLowerCase()}
+          className="btn btn-primary"
+          onClick={onClick}
+        >
+          {actionLabel}
+        </button>
       </div>
       <div className="content-container">
         <div className="content-text">
@@ -85,7 +58,5 @@ ResourceCenterEntity.propTypes = {
   description: PropTypes.string,
   actionLabel: PropTypes.string,
   onClick: PropTypes.func.isRequired,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  actionLink: PropTypes.string
+  className: PropTypes.string
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1521,8 +1521,10 @@ features:
       modalheadertitle: Add Driver
     HydratorPipeline:
       actionbtn0: Create
+      actionbtn1: Import
       description: A pipeline allows you to ingest, egress, and process data either to, from, or within Hadoop.
       label: Pipeline
+      nonJSONError: "There was a problem with the pipeline you were trying to upload: File should be in JSON format. Please upload a file with '.json' extension."
     Library:
       actionbtn0: Upload
       description: A library is a JAR file that can contains reusable third-party code (e.g. External Spark Programs).
@@ -1542,12 +1544,7 @@ features:
       actionbtn0: Create
       description: A stream is used to ingest data into HDFS in real-time or batch.
       label: Stream
-    Stream-View:
-      actionbtn0: Create
-      description: A stream view is non-materialized view over a stream with schema-on-read capability. Creates a view over an existing stream.
-      label: Stream View
   RulesEngine:
-
     AddRulesEngineToPipelineModal:
       batchPipelineBtn: Batch Pipeline
       error: Unable to find Rules Engine Plugin. Please install Rules Engine plugin before adding to pipeline

--- a/cdap-ui/app/directives/fileselect/fileselect.js
+++ b/cdap-ui/app/directives/fileselect/fileselect.js
@@ -37,7 +37,7 @@ angular.module(PKG.name + '.commons')
 
         scope.isDropdown = attrs.dropdown;
 
-        var fileElement = angular.element('<input class="sr-only" type="file" multiple="true">');
+        var fileElement = angular.element('<input class="sr-only" type="file" accept=".json">');
         element.append(fileElement);
         element.bind('click', function() {
           fileElement[0].click();

--- a/cdap-ui/app/hydrator/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/create-studio-ctrl.js
@@ -16,9 +16,9 @@
 
 class HydratorPlusPlusStudioCtrl {
   // Holy cow. Much DI. Such angular.
-  constructor(HydratorPlusPlusConfigActions, $stateParams, rConfig, $rootScope, $scope, DAGPlusPlusNodesActionsFactory, HydratorPlusPlusHydratorService, HydratorPlusPlusConsoleActions, rSelectedArtifact, rArtifacts, myLocalStorage, HydratorPlusPlusConfigStore, $window, HydratorPlusPlusConsoleTabService) {
+  constructor(HydratorPlusPlusConfigActions, $stateParams, rConfig, $rootScope, $scope, DAGPlusPlusNodesActionsFactory, HydratorPlusPlusHydratorService, HydratorPlusPlusConsoleActions, rSelectedArtifact, rArtifacts, myLocalStorage, HydratorPlusPlusConfigStore, $window, HydratorPlusPlusConsoleTabService, HydratorUpgradeService) {
+    'ngInject';
     // This is required because before we fireup the actions related to the store, the store has to be initialized to register for any events.
-
     this.myLocalStorage = myLocalStorage;
     this.myLocalStorage
         .get('hydrator++-leftpanel-isExpanded')
@@ -63,6 +63,15 @@ class HydratorPlusPlusStudioCtrl {
       let config = {};
       config.artifact = artifact;
       HydratorPlusPlusConfigActions.initializeConfigStore(config);
+    }
+
+    if ($stateParams.resourceCenterId) {
+      let inputFile = $window.localStorage.getItem($stateParams.resourceCenterId);
+      if (inputFile) {
+        HydratorUpgradeService.validateAndUpgradeConfig(inputFile);
+        $window.localStorage.removeItem($stateParams.resourceCenterId);
+      }
+
     }
 
     function customConfirm(message) {
@@ -120,8 +129,6 @@ class HydratorPlusPlusStudioCtrl {
     this.myLocalStorage.set('hydrator++-leftpanel-isExpanded', this.isExpanded);
   }
 }
-
-HydratorPlusPlusStudioCtrl.$inject = ['HydratorPlusPlusConfigActions', '$stateParams', 'rConfig', '$rootScope', '$scope', 'DAGPlusPlusNodesActionsFactory', 'HydratorPlusPlusHydratorService', 'HydratorPlusPlusConsoleActions','rSelectedArtifact', 'rArtifacts', 'myLocalStorage', 'HydratorPlusPlusConfigStore', '$window', 'HydratorPlusPlusConsoleTabService'];
 
 angular.module(PKG.name + '.feature.hydrator')
   .controller('HydratorPlusPlusStudioCtrl', HydratorPlusPlusStudioCtrl);

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -688,41 +688,25 @@ class HydratorPlusPlusTopPanelCtrl {
   }
 
   importFile(files) {
-    if (files[0].name.indexOf('.json') === -1) {
+    if (!files.length) {
+      return;
+    }
+
+    let uploadedFile = files[0];
+    if (uploadedFile.type !== 'application/json') {
       this.myAlertOnValium.show({
         type: 'danger',
-        content: 'Pipeline configuration should be JSON.'
+        content: "There was a problem with the pipeline you were trying to upload: File should be in JSON format. Please upload a file with '.json' extension."
       });
       return;
     }
 
-    var reader = new FileReader();
-    reader.readAsText(files[0], 'UTF-8');
+    let reader = new FileReader();
+    reader.readAsText(uploadedFile, 'UTF-8');
 
     reader.onload =  (evt) => {
-      var data = evt.target.result;
-      var jsonData;
-      try {
-        jsonData = JSON.parse(data);
-      } catch (e) {
-        this.myAlertOnValium.show({
-          type: 'danger',
-          content: 'Syntax Error. Ill-formed pipeline configuration.'
-        });
-        return;
-      }
-
-      let isNotValid = this.NonStorePipelineErrorFactory.validateImportJSON(jsonData);
-
-      if (isNotValid) {
-        this.myAlertOnValium.show({
-          type: 'danger',
-          content: isNotValid
-        });
-        return;
-      }
-
-      this.HydratorUpgradeService.validateAndUpgradeConfig(jsonData);
+      let fileData = evt.target.result;
+      this.HydratorUpgradeService.validateAndUpgradeConfig(fileData);
     };
   }
 

--- a/cdap-ui/app/hydrator/routes.js
+++ b/cdap-ui/app/hydrator/routes.js
@@ -49,7 +49,7 @@ angular.module(PKG.name + '.feature.hydrator')
         }
       })
         .state('hydrator.create', {
-          url: '/studio?artifactType&draftId&workspaceId&configParams&rulesengineid',
+          url: '/studio?artifactType&draftId&workspaceId&configParams&rulesengineid&resourceCenterId',
           onEnter: function() {
             document.title = 'CDAP | Studio';
           },


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12274

**Things done in this PR**: 
- Extracted the Pipeline card in the 'Add Entity' modal to its own component, since its behavior is quite different from the rest of the cards.
- Moved some validation functions from `toppanel-ctrl.js` to the `validateAndUpgradeConfig()` service function, so that we can just call the latter to both validate and upgrade.
- Added 'Import' button that will open up a file input allowing user to select a pipeline. No matter what the format of the json file uploaded, the user will be taken to Studio. If the json is valid, then we show the Upgrade modal, else we show the error similar to how other errors are shown in Studio.

**Things that can be improved on**:
- ~~Currently the import file selector defaults to showing JSON files only, but if the user still tries to import a non-json file from the 'Add Entity' modal, then we don't have a way to show this error. We can't show this error in Studio because we need to get the `type` of a File object, and we can't stringify a File object to be saved to local storage. We need to decide on how to show this error in the 'Add Entity' modal.~~ We now show this error in the footer of the 'Add Entity' modal.