### PR TITLE
(CDAP-12888) Use COMPUTE_MAXS instead of COMPUTE_FRAME

### DIFF
--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
@@ -842,7 +842,7 @@ public class SparkClassRewriter implements ClassRewriter {
   @Nullable
   private byte[] rewriteSparkNetworkClass(InputStream byteCodeStream) throws IOException {
     ClassReader cr = new ClassReader(byteCodeStream);
-    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
 
     // Scan for class type and methods to see if the rewriting is needed
     final AtomicBoolean rewritten = new AtomicBoolean(false);


### PR DESCRIPTION
- The code we generated doesn't contains jump, hence no need to compute frame
- This avoid the need of the ASM library to load classes, which can causes ClassNotFoundException.
  This is because ASM library uses getClass().getClassLoader() instead of the context class loader,
  which doesn't have Scala/Spark classes there