### PR TITLE
[CDAP-12900] Bugfixes related to Advanced mode/macros for output schema

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -366,6 +366,15 @@ angular.module(PKG.name + '.commons')
 
     function initSplitterNode(node) {
       if (!node.outputSchema || !Array.isArray(node.outputSchema) || (Array.isArray(node.outputSchema) && node.outputSchema[0].name === GLOBALS.defaultSchemaName)) {
+        let splitterPorts = splitterNodesPorts[node.name];
+        if (!_.isEmpty(splitterPorts)) {
+          angular.forEach(splitterPorts, (port) => {
+            let portElId = node.name + '_port_' + port;
+            deleteEndpoints(portElId);
+          });
+          DAGPlusPlusNodesActionsFactory.setConnections($scope.connections);
+          delete splitterNodesPorts[node.name];
+        }
         return;
       }
 

--- a/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
@@ -150,7 +150,7 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
     }
   }
 
-  EventPipe.on('dataset.selected', function (schema, format, isDisabled, datasetId) {
+  let datasetSelectedEvtListner = EventPipe.on('dataset.selected', function (schema, format, isDisabled, datasetId) {
     if (watchProperty && format) {
       vm.pluginProperties[watchProperty] = format;
     }
@@ -166,6 +166,7 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
 
     if (!_.isEmpty(schema) || (_.isEmpty(schema) && vm.isDisabled)) {
       vm.schemas[0].schema = schema;
+      vm.formatOutput();
     } else {
       // if dataset name is changed to a non-existing dataset, the schemaObj will be empty,
       // so assign to it the value of the input schema
@@ -240,7 +241,7 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
   });
 
   $scope.$on('$destroy', () => {
-    EventPipe.cancelEvent('dataset.selected');
+    datasetSelectedEvtListner();
     EventPipe.cancelEvent('schema.export');
     EventPipe.cancelEvent('schema.import');
     EventPipe.cancelEvent('schema.clear');

--- a/cdap-ui/app/directives/widget-container/widget-output-schema/widget-output-schema-ctrl.js
+++ b/cdap-ui/app/directives/widget-container/widget-output-schema/widget-output-schema-ctrl.js
@@ -15,32 +15,50 @@
 */
 angular.module(PKG.name + '.commons')
   .controller('MyOutputSchemaCtrl', function($scope, GLOBALS, HydratorPlusPlusNodeService) {
-    if (typeof $scope.node.outputSchema === 'string') {
-      $scope.node.outputSchema = [HydratorPlusPlusNodeService.getOutputSchemaObj($scope.node.outputSchema)];
-    }
-    this.outputSchemas = $scope.node.outputSchema
-      .map((node) => {
-        var schema = node.schema;
-        if (typeof schema === 'string') {
-          try {
-            schema = JSON.parse(schema);
-          } catch(e) {
-            schema = {
-              'name': GLOBALS.defaultSchemaName,
-              'type': 'record',
-              'fields': []
-            };
-          }
+    this.formatOutputSchema = () => {
+      if (!$scope.schemaAdvance) {
+        if (typeof $scope.node.outputSchema === 'string') {
+          $scope.node.outputSchema = [HydratorPlusPlusNodeService.getOutputSchemaObj($scope.node.outputSchema)];
         }
-        return {
-          name: node.name,
-          schema: schema
-        };
-      });
+        this.outputSchemas = $scope.node.outputSchema
+          .map((node) => {
+            var schema = node.schema;
+            if (typeof schema === 'string') {
+              try {
+                schema = JSON.parse(schema);
+              } catch(e) {
+                schema = {
+                  'name': GLOBALS.defaultSchemaName,
+                  'type': 'record',
+                  'fields': []
+                };
+              }
+            }
+            return {
+              name: node.name,
+              schema: schema
+            };
+          });
+      } else {
+        if ($scope.node.outputSchema.length > 0 && $scope.node.outputSchema[0].schema) {
+          let schema = $scope.node.outputSchema[0].schema;
+          if (typeof schema !== 'string') {
+            schema = JSON.stringify(schema);
+          }
+          this.outputSchemaString = schema;
+        } else {
+          this.outputSchemaString = '';
+        }
+      }
+    };
 
-    this.currentIndex = 0;
+    this.formatOutputSchema();
 
-    this.onOutputSchemaChange = (newOutputSchemas) => {
-      $scope.node.outputSchema = newOutputSchemas;
+    $scope.$watch('schemaAdvance', () => {
+      this.formatOutputSchema();
+    });
+
+    this.onOutputSchemaChange = (newValue) => {
+      $scope.node.outputSchema = newValue;
     };
   });

--- a/cdap-ui/app/directives/widget-container/widget-output-schema/widget-output-schema.html
+++ b/cdap-ui/app/directives/widget-container/widget-output-schema/widget-output-schema.html
@@ -39,7 +39,8 @@
 <div ng-if="schemaAdvance">
   <textarea
     class="form-control"
-    schemas="MyOutputSchemaCtrl.outputSchemas"
+    ng-model="MyOutputSchemaCtrl.outputSchemaString"
+    ng-change="MyOutputSchemaCtrl.onOutputSchemaChange(MyOutputSchemaCtrl.outputSchemaString)"
     ng-disabled="isDisabled">
   </textarea>
   <span class="badge macro-indicator pull-right"

--- a/cdap-ui/app/hydrator/adapters.less
+++ b/cdap-ui/app/hydrator/adapters.less
@@ -115,13 +115,24 @@ body.theme-cdap {
     .dropdown-menu.output-schema-actions {
       top: 0;
 
-      & > li > a {
-        background-color: white;
-        color: #666666;
+      & > li {
+        &.disabled {
+          cursor: not-allowed;
 
-        &:hover {
-          background-color: @hydrator-blue;
-          color: white;
+          & > a {
+            pointer-events: none;
+            color: #eeeeee;
+          }
+        }
+
+        & > a {
+          background-color: white;
+          color: #666666;
+
+          &:hover {
+            background-color: @hydrator-blue;
+            color: white;
+          }
         }
       }
     }

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
@@ -35,20 +35,43 @@
 
       <ul class="output-schema-actions" uib-dropdown-menu>
         <!-- If node is a sink and it's macro enabled -->
-        <li ng-if="!isDisabled && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties['schema'] && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties['schema'].macroSupported">
-          <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.toggleAdvance()">Advanced</a>
+        <li
+          ng-if="!isDisabled && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties['schema'] && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties['schema'].macroSupported"
+          ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists}"
+          uib-tooltip="The dataset '{{HydratorPlusPlusNodeConfigCtrl.datasetId}}' already exists. Its schema cannot be modified."
+          tooltip-placement="top"
+          tooltip-enable="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists"
+          tooltip-append-to-body="true">
+          <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.toggleAdvance()">Toggle Advanced</a>
         </li>
 
-        <li ng-if="(!HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)">
+        <li
+          ng-if="(!HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)"
+          ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists || HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance}"
+          uib-tooltip-html="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists ? 'The dataset \'' + HydratorPlusPlusNodeConfigCtrl.datasetId + '\' already exists. Its schema cannot be modified.' : HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance ? 'Importing a schema in Advanced mode is not supported' : ''"
+          tooltip-placement="top"
+          tooltip-enable="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists || HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
+          tooltip-append-to-body="true">
           <a href="#" onclick="document.getElementById('schema-import-link').click()">Import</a>
         </li>
-        <li>
+        <li
+          ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance}"
+          uib-tooltip="Exporting a schema in Advanced mode is not supported"
+          tooltip-placement="top"
+          tooltip-enable="HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
+          tooltip-append-to-body="true">
           <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.exportSchema()">Export</a>
         </li>
         <li ng-if="!isDisabled && !HydratorPlusPlusNodeConfigCtrl.state.isSink">
           <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.showPropagateConfirm = true">Propagate</a>
         </li>
-        <li ng-if="(!HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)">
+        <li
+          ng-if="(!HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)"
+          ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists || HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance}"
+          uib-tooltip-html="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists ? 'The dataset \'' + HydratorPlusPlusNodeConfigCtrl.datasetId + '\' already exists. Its schema cannot be cleared.' : HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance ? 'Clearing a schema in Advanced mode is not supported' : ''"
+          tooltip-placement="top"
+          tooltip-enable="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists || HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
+          tooltip-append-to-body="true">
           <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.schemaClear()">Clear</a>
         </li>
       </ul>
@@ -69,7 +92,7 @@
       node="HydratorPlusPlusNodeConfigCtrl.state.node"
       groups-config="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig"
       update-default-output-schema="HydratorPlusPlusNodeConfigCtrl.updateDefaultOutputSchema(outputSchema)"
-      is-disabled="isDisabled">
+      is-disabled="isDisabled || HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists">
     </my-output-schema>
   </fieldset>
 </div>

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -225,6 +225,21 @@
                 </configuration>
               </execution>
               <execution>
+                <id>bower-cache-clean</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>${project.basedir}/node/node</executable>
+                  <arguments>
+                    <executable>${project.basedir}/node_modules/bower/bin/bower</executable>
+                    <argument>cache clean</argument>
+                    <argument>--allow-root</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
                 <id>bower-install</id>
                 <phase>process-resources</phase>
                 <goals>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12900

This PR fixed the following bugs:
- While creating a pipeline its not possible to set a macro for output schema. UI overwrites the macro with the input schema when the user opens/closes the node configuration modal.
- ~~Changing the dataset name to an existing one with a schema, and then change output schema to Advanced. The schema is not disabled even though you're aren't supposed to be able to change the schema of an existing dataset.~~
- ~~Changing the dataset name to an existing one without a schema, and then changing output schema to Advanced causes a JS error and breaks the node config.~~ Working on these two, as previous commit broke earlier functionality
