### PR TITLE
increase memory for maven

### DIFF
--- a/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
+++ b/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
@@ -25,7 +25,7 @@ if [ -f /tmp/mavenrepo.tar.bz2 ]; then
 fi
 
 chown -R cdap ${__tmpdir} ~cdap
-su - cdap -c "cd ${__tmpdir}/examples && MAVEN_OPTS='-Xmx3072m -XX:MaxPermSize=256m' mvn package -DskipTests" || exit 1
+su - cdap -c "cd ${__tmpdir}/examples && MAVEN_OPTS='-Xmx4096m -XX:MaxPermSize=256m' mvn package -DskipTests" || exit 1
 rm -rf ${__tmpdir}
 
 exit 0


### PR DESCRIPTION
increasing the memory for maven when building the examples inside the vm build.  This matches the settings for the CDAP-BUT build.  It should fix the OOM here: https://builds.cask.co/download/CDAP-BA-VMI/build_logs/CDAP-BA-VMI-159.log

