### PR TITLE
[CDAP-12774] Remove hard limits and increase soft limits for change set size

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -701,16 +701,17 @@
 
   <property>
     <name>data.tx.changeset.count.limit</name>
-    <value>10000</value>
+    <value>9223372036854775807</value>
     <description>
       Hard limit for the number of entries in a transaction's change set;
-      if exceeded, the transaction fails.
+      if exceeded, the transaction fails. By default, this is unlimited
+      (that is, Long.MAX_VALUE).
     </description>
   </property>
 
   <property>
     <name>data.tx.changeset.count.warn.threshold</name>
-    <value>5000</value>
+    <value>50000</value>
     <description>
       Soft limit for the number of entries in a transaction's change set;
       if exceeded, a warning is logged.
@@ -719,16 +720,17 @@
 
   <property>
     <name>data.tx.changeset.size.limit</name>
-    <value>1000000</value>
+    <value>9223372036854775807</value>
     <description>
       Hard limit for the aggregate size in bytes of a transaction's change set;
-      if exceeded, the transaction fails.
+      if exceeded, the transaction fails. By default, this is unlimited
+      (that is, Long.MAX_VALUE).
     </description>
   </property>
 
   <property>
     <name>data.tx.changeset.size.warn.threshold</name>
-    <value>500000</value>
+    <value>5000000</value>
     <description>
       Soft limit for the aggregate size in bytes of a transaction's change set;
       if exceeded, a warning is logged.

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="3726f82c8b0f6ec897549098c78d9b7b"
+DEFAULT_XML_MD5_HASH="4522b39e168ca23534d73056021f516b"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
The hard limits already default to Long.MAX_VALUE in tephra. Increasing soft limits to 50K/5MB. 