### PR TITLE
Fixes schema propagation in UI, and disables Propagate in Advanced mode

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
@@ -196,6 +196,9 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
 
     if (!Array.isArray(schemas)) {
       schemas = [HydratorPlusPlusNodeService.getOutputSchemaObj(schemas)];
+    // this is for converting old schemas (pre 4.3.2) to new format
+    } else if (Array.isArray(schemas) && schemas.length && !schemas[0].hasOwnProperty('schema')) {
+      schemas = [HydratorPlusPlusNodeService.getOutputSchemaObj(HydratorPlusPlusNodeService.getSchemaObj(schemas))];
     }
 
     vm.schemas = schemas.map((schema) => {

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -624,6 +624,34 @@ class HydratorPlusPlusNodeConfigCtrl {
 
     this.state.schemaAdvance = !this.state.schemaAdvance;
   }
+
+  // TOOLTIPS FOR DISABLED SCHEMA ACTIONS
+  getImportDisabledTooltip() {
+    if (this.datasetAlreadyExists) {
+      return `The dataset '${this.datasetId}' already exists. Its schema cannot be modified.`;
+    } else if (this.state.schemaAdvance) {
+      return 'Importing a schema in Advanced mode is not supported';
+    }
+    return '';
+  }
+
+  getPropagateDisabledTooltip() {
+    if (this.state.node.type === 'splittertransform') {
+      return 'Propagating a schema with Splitter plugins is currently not supported';
+    } else if (this.state.schemaAdvance) {
+      return 'Propagating a schema in Advanced mode is not supported';
+    }
+    return '';
+  }
+
+  getClearDisabledTooltip() {
+    if (this.datasetAlreadyExists) {
+      return `The dataset '${this.datasetId}' already exists. Its schema cannot be cleared.`;
+    } else if (this.state.schemaAdvance) {
+      return 'Clearing a schema in Advanced mode is not supported';
+    }
+    return '';
+  }
 }
 
 angular.module(PKG.name + '.feature.hydrator')

--- a/cdap-ui/app/hydrator/services/hydrator-node-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-node-service.js
@@ -15,12 +15,14 @@
  */
 
 class HydratorPlusPlusNodeService {
-  constructor($q, HydratorPlusPlusHydratorService, IMPLICIT_SCHEMA, myHelpers, GLOBALS) {
+  constructor($q, HydratorPlusPlusHydratorService, IMPLICIT_SCHEMA, myHelpers, GLOBALS, avsc) {
+    'ngInject';
     this.$q = $q;
     this.HydratorPlusPlusHydratorService = HydratorPlusPlusHydratorService;
     this.myHelpers = myHelpers;
     this.IMPLICIT_SCHEMA = IMPLICIT_SCHEMA;
     this.GLOBALS = GLOBALS;
+    this.avsc = avsc;
   }
   getPluginInfo(node, appType, sourceConnections, sourceNodes, artifactVersion) {
     var promise;
@@ -31,18 +33,17 @@ class HydratorPlusPlusNodeService {
     }
     return promise.then((node) => this.configurePluginInfo(node, appType, sourceConnections, sourceNodes));
   }
+  isFieldExistsInSchema(field, schema) {
+    if(angular.isObject(schema) && Array.isArray(schema.fields)) {
+      return schema.fields.filter(schemaField => schemaField.name === field.name).length;
+    }
+    return false;
+  }
   configurePluginInfo(node, appType, sourceConnections, sourceNodes) {
     const getInputSchema = (sourceNode, targetNode, sourceConnections) => {
       let schema = '';
       let isStreamSource = sourceNode.plugin.name === 'Stream';
       let inputSchema;
-
-      const isFieldExists = (field, schema) => {
-        if(angular.isObject(schema) && Array.isArray(schema.fields)) {
-          return schema.fields.filter(schemaField => schemaField.name === field.name).length;
-        }
-        return false;
-      };
 
       if (!sourceNode.outputSchema || typeof sourceNode.outputSchema === 'string') {
         sourceNode.outputSchema = [this.getOutputSchemaObj(sourceNode.outputSchema)];
@@ -78,27 +79,7 @@ class HydratorPlusPlusNodeService {
       }
 
       if (isStreamSource) {
-        let streamSchemaPrefix = [];
-        const tsField = {
-          name: 'ts',
-          type: 'long'
-        };
-        const headersField = {
-          name: 'headers',
-          type: {
-            type: 'map',
-            keys: 'string',
-            values: 'string'
-          }
-        };
-
-        if (!isFieldExists(tsField, inputSchema)) {
-          streamSchemaPrefix.push(tsField);
-        }
-
-        if (!isFieldExists(headersField, inputSchema)) {
-          streamSchemaPrefix.push(headersField);
-        }
+        let streamSchemaPrefix = this.getStreamSchemaPrefix(inputSchema);
 
         inputSchema = this.HydratorPlusPlusHydratorService.formatSchemaToAvro({
           fields: streamSchemaPrefix.concat(this.myHelpers.objectQuery(inputSchema, 'fields') || [])
@@ -117,18 +98,68 @@ class HydratorPlusPlusNodeService {
     return node;
   }
 
-  getOutputSchemaObj(schema, schemaObjName) {
-    if (!schemaObjName) {
-      schemaObjName = this.GLOBALS.defaultSchemaName;
+  getStreamSchemaPrefix(existingSchema) {
+    let streamSchemaPrefix = [];
+    const tsField = {
+      name: 'ts',
+      type: 'long'
+    };
+    const headersField = {
+      name: 'headers',
+      type: {
+        type: 'map',
+        keys: 'string',
+        values: 'string'
+      }
+    };
+
+    if (!this.isFieldExistsInSchema(tsField, existingSchema)) {
+      streamSchemaPrefix.push(tsField);
     }
 
+    if (!this.isFieldExistsInSchema(headersField, existingSchema)) {
+      streamSchemaPrefix.push(headersField);
+    }
+    return streamSchemaPrefix;
+  }
+
+  getOutputSchemaObj(schema, schemaObjName = this.GLOBALS.defaultSchemaName) {
     return {
       name: schemaObjName,
       schema
     };
   }
+
+  getSchemaObj(fields = [], name = this.GLOBALS.defaultSchemaName, type = 'record') {
+    return {
+      type,
+      name,
+      fields
+    };
+  }
+
+  shouldPropagateSchemaToNode(targetNode) {
+    if (targetNode.implicitSchema || targetNode.type === 'batchjoiner' || targetNode.type === 'splittertransform') {
+      return false;
+    }
+
+    // If we encounter a macro schema, stop propagataion
+    let schema = targetNode.outputSchema;
+    try {
+      if (Array.isArray(schema)) {
+        if (!_.isEmpty(schema[0].schema)) {
+          this.avsc.parse(schema[0].schema);
+        }
+      } else if (typeof schema === 'string') {
+        this.avsc.parse(schema);
+      }
+    } catch (e) {
+      return false;
+    }
+
+    return true;
+  }
 }
-HydratorPlusPlusNodeService.$inject = ['$q', 'HydratorPlusPlusHydratorService', 'IMPLICIT_SCHEMA', 'myHelpers', 'GLOBALS'];
 
 angular.module(PKG.name + '.feature.hydrator')
   .service('HydratorPlusPlusNodeService', HydratorPlusPlusNodeService);

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
@@ -48,7 +48,7 @@
         <li
           ng-if="(!HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)"
           ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists || HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance}"
-          uib-tooltip-html="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists ? 'The dataset \'' + HydratorPlusPlusNodeConfigCtrl.datasetId + '\' already exists. Its schema cannot be modified.' : HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance ? 'Importing a schema in Advanced mode is not supported' : ''"
+          uib-tooltip="{{HydratorPlusPlusNodeConfigCtrl.getImportDisabledTooltip()}}"
           tooltip-placement="top"
           tooltip-enable="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists || HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
           tooltip-append-to-body="true">
@@ -62,13 +62,18 @@
           tooltip-append-to-body="true">
           <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.exportSchema()">Export</a>
         </li>
-        <li ng-if="!isDisabled && !HydratorPlusPlusNodeConfigCtrl.state.isSink">
+        <li
+          ng-if="!isDisabled && !HydratorPlusPlusNodeConfigCtrl.state.isSink"
+          ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance || HydratorPlusPlusNodeConfigCtrl.state.node.type === 'splittertransform'}"
+          uib-tooltip="{{HydratorPlusPlusNodeConfigCtrl.getPropagateDisabledTooltip()}}"
+          tooltip-placement="top"
+          tooltip-enable="HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance || HydratorPlusPlusNodeConfigCtrl.state.node.type === 'splittertransform'">
           <a href="" ng-click="HydratorPlusPlusNodeConfigCtrl.showPropagateConfirm = true">Propagate</a>
         </li>
         <li
           ng-if="(!HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.implicitSchema && !isDisabled)"
           ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists || HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance}"
-          uib-tooltip-html="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists ? 'The dataset \'' + HydratorPlusPlusNodeConfigCtrl.datasetId + '\' already exists. Its schema cannot be cleared.' : HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance ? 'Clearing a schema in Advanced mode is not supported' : ''"
+          uib-tooltip="{{HydratorPlusPlusNodeConfigCtrl.getClearDisabledTooltip()}}"
           tooltip-placement="top"
           tooltip-enable="HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists || HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
           tooltip-append-to-body="true">


### PR DESCRIPTION
Before, schema propagation was broken, due to line 671 in `config-store.js` before changes, because `this.state.node` was undefined.

This PR did the following:
- Fixes schema propagation to work with the new way we handle output schemas in the UI
- Stops propagation when the plugin has multiple schemas (e.g. Splitter node) or a macro schema (already supported in original code)
- Disables "Propagate" button in Advanced mode for schemas, since the subsequent plugins' schemas might not be macro-enabled