### PR TITLE
[CDAP-12945] Fix connection not removed properly when moved to another node

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -488,9 +488,9 @@ angular.module(PKG.name + '.commons')
 
     function removeConnection(detachedConnObj, updateStore = true) {
       let connObj = Object.assign({}, detachedConnObj);
-      if (detachedConnObj.sourceId.indexOf('_condition_') !== -1) {
+      if (myHelpers.objectQuery(detachedConnObj, 'sourceId') && detachedConnObj.sourceId.indexOf('_condition_') !== -1) {
         connObj.sourceId = detachedConnObj.sourceId.split('_')[0];
-      } else if (detachedConnObj.source.className.indexOf('_port_') !== -1) {
+      } else if (myHelpers.objectQuery(detachedConnObj, 'source', 'className') && detachedConnObj.source.className.indexOf('_port_') !== -1) {
         let portClass = getPortEndpointClass(detachedConnObj.source.classList);
         connObj.sourceId = portClass.split('_')[0];
       }
@@ -510,6 +510,12 @@ angular.module(PKG.name + '.commons')
         sourceId: moveInfo.originalSourceId,
         targetId: moveInfo.originalTargetId
       };
+      if (myHelpers.objectQuery(moveInfo, 'originalSourceEndpoint', 'element')) {
+        oldConnection.source = moveInfo.originalSourceEndpoint.element;
+      }
+      if (myHelpers.objectQuery(moveInfo, 'originalTargetEndpoint', 'element')) {
+        oldConnection.target = moveInfo.originalTargetEndpoint.element;
+      }
       // don't need to call addConnection for the new connection, since that will be done
       // automatically as part of the 'connection' event
       removeConnection(oldConnection, false);

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 
     <cask.packages.snapshot.repo>http://cask.invalid.snapshot.repo.co</cask.packages.snapshot.repo>
     <cask.packages.release.repo>http://cask.invalid.release.repo.co</cask.packages.release.repo>
-    <release.iteration>0.rc1</release.iteration>
+    <release.iteration>0.rc2</release.iteration>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12945

The root of the problem was in the line 493 before the code changes, because `source` was an undefined property of `detachedConnObj`. When the user removes a connection directly then this property is available through the jsPlumb object, however when we move a connection, we construct an object manually inside the `moveConnection` fn to pass to `removeConnection`, and this object did not have `source` property.

Also added objectQuery to be safer when accessing object properties.