### PR TITLE
Revert "Merge branch 'feature_release/cdap-12774-no-tx-limits' into r…

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -701,17 +701,16 @@
 
   <property>
     <name>data.tx.changeset.count.limit</name>
-    <value>9223372036854775807</value>
+    <value>10000</value>
     <description>
       Hard limit for the number of entries in a transaction's change set;
-      if exceeded, the transaction fails. By default, this is unlimited
-      (that is, Long.MAX_VALUE).
+      if exceeded, the transaction fails.
     </description>
   </property>
 
   <property>
     <name>data.tx.changeset.count.warn.threshold</name>
-    <value>50000</value>
+    <value>5000</value>
     <description>
       Soft limit for the number of entries in a transaction's change set;
       if exceeded, a warning is logged.
@@ -720,17 +719,16 @@
 
   <property>
     <name>data.tx.changeset.size.limit</name>
-    <value>9223372036854775807</value>
+    <value>1000000</value>
     <description>
       Hard limit for the aggregate size in bytes of a transaction's change set;
-      if exceeded, the transaction fails. By default, this is unlimited
-      (that is, Long.MAX_VALUE).
+      if exceeded, the transaction fails.
     </description>
   </property>
 
   <property>
     <name>data.tx.changeset.size.warn.threshold</name>
-    <value>5000000</value>
+    <value>500000</value>
     <description>
       Soft limit for the aggregate size in bytes of a transaction's change set;
       if exceeded, a warning is logged.

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="4522b39e168ca23534d73056021f516b"
+DEFAULT_XML_MD5_HASH="3726f82c8b0f6ec897549098c78d9b7b"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
- This reverts commit 1e5dce99ab02135cc4312a8f9bfcd6c89bc7eca8, reversing
changes made to a52a0f4e031eafa2ffa6340efc2fb8dde8c2e747.

Reverting this PR since the Tx manager reads the change set size as int and it is a long value. The unit tests fail because of this change and this will fail on the cluster too since Tx manager won't start
Start of failure: https://builds.cask.co/browse/CDAP-RUT1212-144/test