### PR TITLE
CDAP-12946 fix the pipeline action planner

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -422,8 +422,7 @@ public class DataPipelineTest extends HydratorTestBase {
                          ImmutableMap.of(SmartWorkflow.TRIGGERING_PROPERTIES_MAPPING, GSON.toJson(propertyMapping)),
                          completeTrigger, ImmutableList.<Constraint>of(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null));
     appManager.enableSchedule(scheduleId);
-    WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    return manager;
+    return appManager.getWorkflowManager(SmartWorkflow.NAME);
   }
 
   private void assertTriggeredPipelinesResult(WorkflowManager workflowManager, String pipelineName, Engine engine,


### PR DESCRIPTION
Fixing a bug that caused pipeline actions to form incorrect
workflows. In some scenarios, actions could cause pipelines to
fail to deploy. In other scenarios, actions could cause some
parts of the pipeline to be excluded from execution.

These issues usually arise when there are multiple sources and
an action is placed in front of the sources.

The problem was in the logic that splits up a pipeline based on
the control nodes (actions are a control node). The planner was
incorrectly creating a subdag for each source connected to an
action, instead of a single subdag for all sources connected to
the action.