### PR TITLE
set mavenrc to honor environment maven_opts

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -165,6 +165,11 @@
         "java": {
           "install_flavor": "openjdk",
           "jdk_version": 8
+        },
+        "maven": {
+          "mavenrc": {
+            "opts": "${MAVEN_OPTS:--Dmaven.repo.local=$HOME/.m2/repository -Xmx384m}"
+          }
         }
       },
       "only": ["cdap-sdk-vm"]


### PR DESCRIPTION
this should fix [CDAP-12910](https://issues.cask.co/browse/CDAP-12910).  The maven cookbook by default hardcodes Xmx via a mavenrc file.  This changes it to first honor any `MAVEN_OPTS` already set in the environment (for example https://github.com/caskdata/cdap/pull/9786), and is the same thing we do internally in coopr autobuilds.