### PR TITLE
CDAP-12946 simplify action planning

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -167,229 +166,94 @@ public class PipelinePlanner {
     }
 
     Map<String, String> connectorNodes = new HashMap<>();
-    Set<Dag> splittedDags = split(spec.getConnections(), conditionBranches.keySet(), reduceNodes, isolationNodes,
-                                  actionNodes, connectorNodes);
-
-    // convert to objects the programs expect.
-    Map<String, PipelinePhase> phases = new HashMap<>();
-
     // now split the logical pipeline into pipeline phases, using the connectors as split points
-    Map<String, Dag> subdags = new HashMap<>();
-    // assign some name to each subdag
-    for (Dag subdag : splittedDags) {
-      String name = getPhaseName(subdag.getSources(), subdag.getSinks());
-      subdags.put(name, subdag);
-      // create control phases (Condition and Action) if there are any
-      addControlPhasesIfRequired(controlNodes, subdag, specs, phases);
-    }
-
-    // Maintain the control nodes for which phase connections have been added.
-    // Since we include phase connection based on the common sinks between the two dags,
-    // it is possible that we do not get chance to process some control phases.
-    // For example if dag1 is Action1->someNode-->Condition and dag2 is Condition->Action2.
-    // We will process Condition here, however phase connections for Action1 and Action2 will
-    // be added later.
-    Set<String> processedControlNodes = new HashSet<>();
-
-    // build connections between phases
-    Set<Connection> phaseConnections = new HashSet<>();
-    for (Map.Entry<String, Dag> subdagEntry1 : subdags.entrySet()) {
-      String dag1Name = subdagEntry1.getKey();
-      Dag dag1 = subdagEntry1.getValue();
-
-      for (Map.Entry<String, Dag> subdagEntry2: subdags.entrySet()) {
-        String dag2Name = subdagEntry2.getKey();
-        Dag dag2 = subdagEntry2.getValue();
-        if (dag1Name.equals(dag2Name)) {
-          continue;
-        }
-
-        // if dag1 has any sinks that are a source in dag2, add a connection between the dags
-        if (Sets.intersection(dag1.getSinks(), dag2.getSources()).size() > 0) {
-
-          // check if common node is control node
-          Set<String> controlAsSink = Sets.intersection(dag1.getSinks(), controlNodes);
-          if (controlAsSink.isEmpty()) {
-            // Common node is not control add connection between dag1Name and dag2Name.
-            phaseConnections.add(new Connection(dag1Name, dag2Name));
-            continue;
-          }
-
-          String controlNodeName = controlAsSink.iterator().next();
-          // Add current control node to the processed set
-          processedControlNodes.add(controlNodeName);
-
-          if (!controlNodes.containsAll(dag1.getNodes())) {
-            // Only add connection from dag 1 to the current control stage,
-            // if dag 1 contains stages other than control stages. If dag 1 only contains
-            // the control stages, then instead of using dagName as source of connection
-            // we would need the name of the control stage in dag1's sources. For example consider
-            // the following dags -
-            //
-            //  dag1: condition.to.action with nodes as condition--->action
-            //  dag2: action.to.somenode with nodes as action--->somenode
-            //
-            // Currently we are processing common nodes between dag1 sink and dag2 source which is action
-            // Now we cannot add connection from condition.to.action to action, since the dag 1 only contains
-            // control nodes, it would get filtered out later. We need connection of the form condition->action.
-            // This connection gets added when for some dag0: file->csv-sink->condition we process the
-            // common condition node.
-            phaseConnections.add(new Connection(dag1Name, controlNodeName));
-          }
-
-          ConditionBranches branches = conditionBranches.get(controlNodeName);
-          Boolean condition = branches == null ?  null : dag2.getNodes().contains(branches.getTrueOutput());
-          // check if dag 2 only contains control stages. if so dag1 sink(which is a control node) will
-          // connect to dag2 sink(which is another control node) dag1 sink is same as dag 2 source
-          // which is control node, otherwise current control node will connect to whole dag2Name
-          String connectTo = controlNodes.containsAll(dag2.getNodes()) ? dag2.getSinks().iterator().next() : dag2Name;
-          phaseConnections.add(new Connection(controlNodeName, connectTo, condition));
-
-        } else if (Sets.intersection(dag1.getSources(), dag2.getSources()).size() > 0) {
-          // Two subdags have common sources
-          // Consider the scenario below
-          //            |----Action2
-          // Action1--->|
-          //            |----Action3
-          // In this case the splits would be (Action1, Action2) and (Action1, Action3).
-          // There wont be any common sinks however sources would be common. We need to process
-          // that as well. Logic is similar to above if block except it operates on the sources now.
-
-          Set<String> controlAsSource = Sets.intersection(dag1.getSources(), controlNodes);
-
-          if (controlAsSource.isEmpty()) {
-            phaseConnections.add(new Connection(dag1Name, dag2Name));
-            continue;
-          }
-
-          String controlNodeName = controlAsSource.iterator().next();
-          processedControlNodes.add(controlNodeName);
-
-          ConditionBranches branches = conditionBranches.get(controlNodeName);
-          Boolean condition = branches == null ?  null : dag2.getNodes().contains(branches.getTrueOutput());
-          // check if dag 2 only contains control stages. if so dag1 sink(which is a control node) will
-          // connect to dag2 sink(which is another control node) dag1 sink is same as dag 2 source
-          // which is control node, otherwise current control node will connect to whole dag2Name
-          String connectTo = controlNodes.containsAll(dag2.getNodes()) ? dag2.getSinks().iterator().next() : dag2Name;
-          phaseConnections.add(new Connection(controlNodeName, connectTo, condition));
-        }
-      }
-    }
-
+    Set<Dag> splittedDag = split(spec.getConnections(), conditionBranches.keySet(), reduceNodes, isolationNodes,
+                                 actionNodes, connectorNodes);
     Map<String, String> controlConnectors = getConnectorsAssociatedWithConditions(conditionBranches.keySet(),
                                                                                   conditionChildToParent,
                                                                                   conditionInputs, conditionOutputs,
                                                                                   actionNodes);
 
-    // At this point we have added phase connections between subdags, processing control nodes if they are
-    // common to the two dags as either source or sink. However subdag can only contain control nodes
-    // when two control nodes are chained together for example Action-->Condition. We need to add connection
-    // between them. Also we need to process any control nodes which are NOT yet in the processedControlNodes set.
-    // For example if we have two splitted dags
-    // dag1: Action-->Condition
-    // dag2: Condition->N0
-    // Now we processed connections from Condition, since its common between dag 1 sink and dag 2 source.
-    // However we have not process Action yet, since there is not dag0 with which it is common. So the Action
-    // will not be in processedControlNode set.
-    for (Map.Entry<String, Dag> dagEntry : subdags.entrySet()) {
-      Dag dag = dagEntry.getValue();
-      if (controlNodes.containsAll(dag.getSources())) {
-        String source = dag.getSources().iterator().next();
-        String sink = dagEntry.getKey();
-        if (controlNodes.containsAll(dag.getNodes())) {
-          // Current dag only contain control nodes.
-          sink = dag.getSinks().iterator().next();
+    Map<String, Dag> subdags = new HashMap<>();
+    for (Dag subdag : splittedDag) {
+      String name = getPhaseName(subdag.getSources(), subdag.getSinks());
+      subdags.put(name, subdag);
+    }
+
+    // build connections between phases and convert dags to PipelinePhase.
+    Set<Connection> phaseConnections = new HashSet<>();
+    Map<String, PipelinePhase> phases = new HashMap<>();
+    for (Map.Entry<String, Dag> dagEntry1 : subdags.entrySet()) {
+      String dag1Name = dagEntry1.getKey();
+      Dag dag1 = dagEntry1.getValue();
+
+      // convert the dag to a PipelinePhase
+      // add a separate pipeline phase for each control node in the subdag
+      Set<String> dag1ControlNodes = Sets.intersection(controlNodes, dag1.getNodes());
+      for (String dag1ControlNode : dag1ControlNodes) {
+        if (!phases.containsKey(dag1ControlNode)) {
+          phases.put(dag1ControlNode,
+                     PipelinePhase.builder(supportedPluginTypes).addStage(specs.get(dag1ControlNode)).build());
         }
-        if (!processedControlNodes.contains(source)) {
-          // This control node is not processed yet, because it is first in the pipeline.
-          ConditionBranches branches = conditionBranches.get(source);
-          Boolean condition = branches == null ? null : dag.getNodes().contains(branches.getTrueOutput());
-          phaseConnections.add(new Connection(source, sink, condition));
-          processedControlNodes.add(source);
+      }
+      // if there are non-control nodes in the subdag, add a pipeline phase for it
+      if (!controlNodes.containsAll(dag1.getNodes())) {
+        // the updated dag replaces conditions with the corresponding connector if applicable.
+        Dag updatedDag = getUpdatedDag(dag1, controlConnectors);
+        // Remove any control nodes from this dag
+        if (!Sets.intersection(updatedDag.getNodes(), controlNodes).isEmpty()) {
+          Set<String> nodes = Sets.difference(updatedDag.getNodes(), controlNodes);
+          updatedDag = updatedDag.createSubDag(nodes);
+        }
+        phases.put(dag1Name, dagToPipeline(updatedDag, connectorNodes, specs, controlConnectors));
+      }
+
+      for (String controlSource : Sets.intersection(controlNodes, dag1.getSources())) {
+        ConditionBranches branches = conditionBranches.get(controlSource);
+        Boolean condition = branches == null ?  null : dag1.getNodes().contains(branches.getTrueOutput());
+        for (String output : dag1.getNodeOutputs(controlSource)) {
+          if (controlNodes.contains(output)) {
+            // control source -> control node, add a phase connection between the control phases
+            phaseConnections.add(new Connection(controlSource, output, condition));
+          } else {
+            // control source -> non-control nodes, add a phase connection from the control phase to this dag
+            phaseConnections.add(new Connection(controlSource, dag1Name, condition));
+          }
         }
       }
 
-      if (controlNodes.containsAll(dag.getSinks())) {
-        String source = dagEntry.getKey();
-        if (controlNodes.containsAll(dag.getNodes())) {
-          source = dag.getSources().iterator().next();
-        }
-        String sink = dag.getSinks().iterator().next();
-        if (!processedControlNodes.contains(sink)) {
-          // This control node is not processed yet, because it is last in the pipeline.
-          // Conditions cannot be last however action nodes can be
-          ConditionBranches branches = conditionBranches.get(source);
-          Boolean condition = branches == null ? null : dag.getNodes().contains(branches.getTrueOutput());
-          phaseConnections.add(new Connection(source, sink, condition));
-          processedControlNodes.add(sink);
+      // If we have a non-control node -> control sink, we need to add a phase connection
+      // from this dag to the control phase
+      for (String controlSink : Sets.intersection(controlNodes, dag1.getSinks())) {
+        for (String input : dag1.getNodeInputs(controlSink)) {
+          if (controlNodes.contains(input)) {
+            // control node -> control-sink, add a phase connection between the control phases
+            ConditionBranches branches = conditionBranches.get(input);
+            Boolean condition = branches == null ?  null : dag1.getNodes().contains(branches.getTrueOutput());
+            phaseConnections.add(new Connection(input, controlSink, condition));
+          } else {
+            // non-control node -> control-sink, add a phase connection from this dag to the control phase
+            phaseConnections.add(new Connection(dag1Name, controlSink));
+          }
         }
       }
 
-      // If dag only contains control nodes then ignore it, since all of its connections are processed already
-      if (controlNodes.containsAll(dag.getNodes())) {
-        continue;
-      }
-
-      Dag updatedDag = getUpdatedDag(dag, controlConnectors);
-      // Remove any control nodes from this dag
-      if (!Sets.intersection(updatedDag.getNodes(), controlNodes).isEmpty()) {
-        Set<String> nodes = Sets.difference(updatedDag.getNodes(), controlNodes);
-        if (nodes.size() < 2) {
-          // if the subdag only contains one non-control node, it is used purely to connect a control phase to
-          // a non-control phase.
+      // find connected subdags (they have a source that is a sink in dag1)
+      Set<String> nonControlSinks = Sets.difference(dag1.getSinks(), controlNodes);
+      for (Map.Entry<String, Dag> dagEntry2 : subdags.entrySet()) {
+        String dag2Name = dagEntry2.getKey();
+        Dag dag2 = dagEntry2.getValue();
+        if (dag1Name.equals(dag2Name)) {
           continue;
         }
-        updatedDag = updatedDag.createSubDag(nodes);
-      }
 
-      phases.put(dagEntry.getKey(), dagToPipeline(updatedDag, connectorNodes, specs, controlConnectors));
+        if (!Sets.intersection(nonControlSinks, dag2.getSources()).isEmpty()) {
+          phaseConnections.add(new Connection(dag1Name, dag2Name));
+        }
+      }
     }
 
     return new PipelinePlan(phases, phaseConnections);
-  }
-
-  /**
-   * This method is responsible for creating control(Condition and Action) phases if the stages are present in the Dag.
-   */
-  private void addControlPhasesIfRequired(Set<String> controlNodes, Dag dag, Map<String, StageSpec> stageSpecs,
-                                          Map<String, PipelinePhase> phases) {
-    // Add control phases corresponding to the subdag source
-    if (controlNodes.containsAll(dag.getSources())) {
-      if (dag.getSources().size() != 1) {
-        // sources should only have a single stage if its control
-        throw new IllegalStateException(String.format("Dag '%s' to '%s' cannot have multiple sources when one of the" +
-                                                        "source is a control (Condition or Action).", dag.getSources(),
-                                                      dag.getSinks()));
-      }
-
-      String controlNode = dag.getSources().iterator().next();
-      if (!phases.containsKey(controlNode)) {
-        PipelinePhase.Builder phaseBuilder = PipelinePhase.builder(supportedPluginTypes);
-        PipelinePhase controlPhase = phaseBuilder
-          .addStage(stageSpecs.get(controlNode))
-          .build();
-        phases.put(controlNode, controlPhase);
-      }
-    }
-
-    // Add control phases corresponding to the subdag sink
-    if (controlNodes.containsAll(dag.getSinks())) {
-      if (dag.getSinks().size() != 1) {
-        // sinks should only have a single stage if its control
-        throw new IllegalStateException(String.format("Dag '%s' to '%s' cannot have multiple sinks when one of the" +
-                                                        "sink is a control (Condition or Action).", dag.getSources(),
-                                                      dag.getSinks()));
-      }
-
-      String controlNode = dag.getSinks().iterator().next();
-      if (!phases.containsKey(controlNode)) {
-        PipelinePhase.Builder phaseBuilder = PipelinePhase.builder(supportedPluginTypes);
-        PipelinePhase controlPhase = phaseBuilder
-          .addStage(stageSpecs.get(controlNode))
-          .build();
-        phases.put(controlNode, controlPhase);
-      }
-    }
   }
 
   /**
@@ -519,7 +383,7 @@ public class PipelinePlanner {
   static Set<Dag> split(Set<Connection> connections, Set<String> conditions, Set<String> reduceNodes,
                         Set<String> isolationNodes, Set<String> actionNodes, Map<String, String> connectorNodes) {
     Dag dag = new Dag(connections);
-    Set<Dag> subdags = dag.splitByControlNodes(Sets.union(conditions, actionNodes));
+    Set<Dag> subdags = dag.splitByControlNodes(conditions, actionNodes);
 
     Set<Dag> result = new HashSet<>();
     for (Dag subdag : subdags) {


### PR DESCRIPTION
Simplifications to the action pipeline planner and adding more
unit tests. Modified the Dag split by control logic to handle
actions and conditions a little differently in order to remove
a lot of the complicated logic in the pipeline planner. When
the dag is split by control nodes, it will now make sure all
connected non-control nodes will be placed within the same subdag
and can include multiple actions in the same subdag.