### PR TITLE
[CDAP-12839] Implements alert/error ports and connections in UI

### DIFF
--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -21,7 +21,7 @@ const pluginLabels = {
   'analytics': 'Analytics',
   'sink': 'Sink',
   'action': 'Conditions and Actions',
-  'errortransform': 'Error Handlers'
+  'erroralert': 'Error Handlers and Alerts'
 };
 export const NUMBER_TYPES = ['integer', 'short', 'long', 'float', 'double'];
 const GLOBALS = {
@@ -91,9 +91,9 @@ const GLOBALS = {
     'action': pluginLabels['action'],
     'streamingsource': pluginLabels['source'],
     'windower': pluginLabels['transform'],
-    'errortransform': pluginLabels['errortransform'],
+    'errortransform': pluginLabels['erroralert'],
     'sparkprogram': pluginLabels['action'],
-    'alertpublisher': pluginLabels['sink'],
+    'alertpublisher': pluginLabels['erroralert'],
     'condition': pluginLabels['action'],
     'splittertransform': pluginLabels['transform']
   },

--- a/cdap-ui/app/directives/dag-plus/color-constants.less
+++ b/cdap-ui/app/directives/dag-plus/color-constants.less
@@ -14,27 +14,30 @@
  * the License.
  */
 
+@import "../../styles/variables.less";
+
 @source-plugins-color: #48c038;
 @transform-plugins-color: #4586f3;
 @action-plugins-color: #988470;
-@spark-plugins-color: #34495e;
+@spark-plugins-color: @blue-grey01;
 @sink-plugins-color: #8367df;
-@error-transform: #e74c3c;
-@condition-plugin-color: #4e5568;
+@error-transform: @red-02;
+@alertpublisher-plugins-color: @yellow-01;
+@condition-plugin-color: @blue-grey02;
 @condition-label-color: #dddddd;
-@endpoint-circle-bg-color: #4e5568;
-@condition-true-endpoint-bg-color: #0099ff;
-@condition-false-endpoint-bg-color: #999999;
-@endpoint-connection-hover-stroke-color: #58b7f6;
+@endpoint-circle-bg-color: @blue-grey02;
+@condition-true-endpoint-bg-color: @blue-03;
+@condition-false-endpoint-bg-color: @grey-03;
+@endpoint-connection-hover-stroke-color: @blue-04;
 @endpoint-caret-bg-color: #bac0d6;
 @configure-btn-label-color: #5c6788;
-@configure-btn-label-hover-color: #454a57;
-@configure-btn-bg-hover-color: #f5f5f5;
+@configure-btn-label-hover-color: @blue-grey01;
+@configure-btn-bg-hover-color: @grey-08;
 @hamburger-menu-color: #b9c0d8;
 @hamburger-node-hover-color: #5c6788;
-@hamburger-hover-color: #454a57;
+@hamburger-hover-color: @blue-grey01;
 @node-menu-delete-color: #cc0821;
-@node-menu-action-bg-color: #eeeeee;
+@node-menu-action-bg-color: @grey-07;
 @badge-warning-color: #ffcc00;
 @badge-danger-color: #e33d3d;
 @comment-box-color: lighten(#ffff99, 10%);

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -113,7 +113,7 @@
             <div class="endpoint-circle"
                   ng-if="node.type !== 'splittertransform'"
                   ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled, 'endpoint-circle-right': node.type === 'condition'}"
-                  ng-attr-id="{{node.type === 'condition' ? node.name + '_condition_true' : ''}}"
+                  ng-attr-id="{{node.type === 'condition' ? 'endpoint_' + node.name + '_condition_true' : 'endpoint_' + node.name}}"
                   ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)">
               <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
             </div>
@@ -139,7 +139,7 @@
                   ng-if="node.type === 'condition'"
                   ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
                   ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
-                  ng-attr-id="{{node.name + '_condition_false'}}">
+                  ng-attr-id="{{'endpoint_' + node.name + '_condition_false'}}">
               <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
             </div>
             <div ng-if="node.error">
@@ -203,6 +203,29 @@
                 disabled="disableMetricsClick"
                 metrics-data="metricsData">
               </my-node-metrics>
+            </div>
+            <div class="node-alerts-errors"
+                  ng-if="DAGPlusPlusCtrl.shouldShowAlertsPort(node) || DAGPlusPlusCtrl.shouldShowErrorsPort(node)">
+              <div class="node-alerts"
+                    ng-if="DAGPlusPlusCtrl.shouldShowAlertsPort(node)">
+                <span>Alert</span>
+                <div class="endpoint-circle endpoint-circle-bottom"
+                      ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
+                      ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
+                      ng-attr-id="{{'endpoint_' + node.name + '_alert'}}">
+                  <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
+                </div>
+              </div>
+              <div class="node-errors"
+                    ng-if="DAGPlusPlusCtrl.shouldShowErrorsPort(node)">
+                <div class="endpoint-circle endpoint-circle-bottom"
+                      ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
+                      ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
+                      ng-attr-id="{{'endpoint_' + node.name + '_error'}}">
+                  <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
+                </div>
+                <span>Error</span>
+              </div>
             </div>
             <div class="node-actions">
               <span ng-if="DAGPlusPlusCtrl.nodeMenuOpen !== node.name"

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -127,25 +127,11 @@ my-dag-plus {
             top: 41px;
           }
         }
-
-        &.condition {
-          .node {
-            .endpoint-circle-bottom {
-              top: initial;
-            }
-          }
-        }
       }
 
-      .jsplumb-connector {
-        cursor: initial;
-      }
-
+      .jsplumb-connector,
       .jsplumb-endpoint {
-        &.condition-endpoint,
-        &.splitter-endpoint {
-          cursor: initial;
-        }
+        cursor: initial;
       }
     }
 
@@ -175,8 +161,7 @@ my-dag-plus {
         background-clip: border-box;
         z-index: 1;
 
-        .endpoint-circle,
-        .endpoint-circle-bottom {
+        .endpoint-circle {
           width: @endpoint-circle-radius * 2;
           height: @endpoint-circle-radius * 2;
           background-color: @endpoint-circle-bg-color;
@@ -238,6 +223,33 @@ my-dag-plus {
               color: @endpoint-caret-bg-color;
             }
           }
+
+          &.endpoint-circle-bottom {
+            bottom: -@endpoint-circle-radius;
+            right: 43px;
+
+            &:before {
+              left: 6px;
+              top: 100%;
+              border-bottom: none;
+              border-left: 2px solid;
+              height: 5px;
+            }
+
+            &:after {
+              border-top: @endpoint-circle-radius solid @endpoint-connection-hover-stroke-color;
+              border-left: @endpoint-circle-radius solid transparent;
+              border-right: @endpoint-circle-radius solid transparent;
+              transform: translate(-4px, 19px);
+            }
+
+            .endpoint-caret {
+              border-left: 4px solid transparent;
+              border-right: 4px solid transparent;
+              border-top: @endpoint-circle-radius solid @endpoint-caret-bg-color;
+              transform: translateY(3px);
+            }
+          }
         }
 
         .node-info {
@@ -288,13 +300,36 @@ my-dag-plus {
           width: ~"calc(100% - 24px)";
         }
 
+        .node-alerts-errors {
+          position: absolute;
+          bottom: 3px;
+          color: @hamburger-menu-color;
+
+          .node-alerts,
+          .node-errors {
+            display: inline-block;
+            position: relative;
+
+            .endpoint-circle {
+              &.endpoint-circle-bottom {
+                right: 6px;
+                top: 16px;
+                bottom: 0;
+              }
+            }
+          }
+
+          .node-errors {
+            margin-left: 5px;
+          }
+        }
+
         .node-actions {
           display: flex;
           position: absolute;
-          width: 100%;
           bottom: 0;
+          right: 0;
           padding-bottom: 10px;
-          padding-right: 12px;
           align-items: center;
 
           .menu-icon-node {
@@ -387,16 +422,19 @@ my-dag-plus {
         left: 10vw;
       }
 
-      &.errortransform {
-        color: @error-transform;
-        left: 30vw;
-      }
-
       &.realtimesink,
       &.batchsink,
-      &.alertpublisher,
       &.sparksink {
         color: @sink-plugins-color;
+      }
+
+      &.errortransform {
+        color: @error-transform;
+        left: 50vw;
+      }
+
+      &.alertpublisher {
+        color: @alertpublisher-plugins-color;
         left: 50vw;
       }
 
@@ -443,41 +481,27 @@ my-dag-plus {
                 background-color: @condition-true-endpoint-bg-color;
               }
             }
-          }
 
-          .endpoint-circle-bottom {
-            top: initial;
-            bottom: -@endpoint-circle-radius;
-            right: 43px;
-            background-color: @condition-false-endpoint-bg-color;
+            &.endpoint-circle-bottom {
+              top: initial;
+              background-color: @condition-false-endpoint-bg-color;
 
-            &:before {
-              left: 6px;
-              top: 100%;
-              border-bottom: none;
-              border-left: 2px solid @condition-false-endpoint-bg-color;
-              height: 5px;
-            }
-
-            &:after {
-              border-top: 7px solid @condition-false-endpoint-bg-color;
-              border-left: 7px solid transparent;
-              border-right: 7px solid transparent;
-              transform: translate(-4px, 19px);
-            }
-
-            &:hover,
-            &.hover {
-              &:not(.disabled) {
-                background-color: @condition-false-endpoint-bg-color;
+              &:before {
+                border-left-color: @condition-false-endpoint-bg-color;
+                border-bottom-color: transparent;
               }
-            }
 
-            .endpoint-caret {
-              border-left: 4px solid transparent;
-              border-right: 4px solid transparent;
-              border-top: @endpoint-circle-radius solid @endpoint-caret-bg-color;
-              transform: translateY(2px);
+              &:after {
+                border-top-color: @condition-false-endpoint-bg-color;
+                border-left-color: transparent;
+              }
+
+              &:hover,
+              &.hover {
+                &:not(.disabled) {
+                  background-color: @condition-false-endpoint-bg-color;
+                }
+              }
             }
           }
 
@@ -636,13 +660,8 @@ my-dag-plus {
     }
 
     .jsplumb-endpoint {
-      z-index: 1;
-
-      &.condition-endpoint,
-      &.splitter-endpoint {
-        cursor: pointer;
-        z-index: 2;
-      }
+      cursor: pointer;
+      z-index: 2;
 
       svg * {
         fill: transparent;

--- a/cdap-ui/app/directives/splitter-popover/splitter-popover.html
+++ b/cdap-ui/app/directives/splitter-popover/splitter-popover.html
@@ -19,7 +19,7 @@
   <div ng-repeat="port in SplitterPopoverCtrl.ports">
     <span class="port-name">{{ port.name | caskCapitalizeFilter }}</span>
     <div class="endpoint-circle"
-          ng-class="['{{node.name || node.plugin.label}}_port_{{port.name}}', {'disabled': isDisabled}]">
+          ng-class="['endpoint_{{node.name || node.plugin.label}}_port_{{port.name}}', {'disabled': isDisabled}]">
       <div class="endpoint-caret" ng-if="!isDisabled"></div>
     </div>
     <div class="port-metrics" ng-if="isDisabled">

--- a/cdap-ui/app/directives/widget-container/widget-number/widget-number.js
+++ b/cdap-ui/app/directives/widget-container/widget-number/widget-number.js
@@ -63,7 +63,7 @@ angular.module(PKG.name + '.commons')
             return false;
           }
           if (newValue > $scope.max) {
-            $scope.error = newValue + ' exceeds the maximum: ' + scope.max;
+            $scope.error = newValue + ' exceeds the maximum: ' + $scope.max;
             return false;
           }
           $scope.error = '';

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -532,5 +532,8 @@ body.theme-cdap {
   .action.sparkprogram {
     color: @spark-plugins-color;
   }
+  .alertpublisher {
+    color: @alertpublisher-plugins-color;
+  }
 
 }

--- a/cdap-ui/app/hydrator/services/hydrator-plus-ordering-factory.js
+++ b/cdap-ui/app/hydrator/services/hydrator-plus-ordering-factory.js
@@ -32,8 +32,7 @@ function HydratorPlusPlusOrderingFactory(GLOBALS) {
     let transform = pluginsMap.filter( p => { return p.name === GLOBALS.pluginLabels['transform']; });
     let sink = pluginsMap.filter( p => { return p.name === GLOBALS.pluginLabels['sink']; });
     let analytics = pluginsMap.filter( p => { return p.name === GLOBALS.pluginLabels['analytics']; });
-    let errorHandlers = pluginsMap.filter( p => { return p.name === GLOBALS.pluginLabels['errortransform']; });
-    let conditions = pluginsMap.filter( p => { return p.name === GLOBALS.pluginLabels['condition']; });
+    let errorHandlers = pluginsMap.filter( p => { return p.name === GLOBALS.pluginLabels['erroralert']; });
 
     if (source.length) {
       orderedTypes.push(source[0]);
@@ -52,9 +51,6 @@ function HydratorPlusPlusOrderingFactory(GLOBALS) {
     }
     if (errorHandlers.length) {
       orderedTypes.push(errorHandlers[0]);
-    }
-    if (conditions.length) {
-      orderedTypes.push(conditions[0]);
     }
 
     // Doing this so that the SidePanel does not lose the reference of the original

--- a/cdap-ui/app/hydrator/services/plugin-config-factory.js
+++ b/cdap-ui/app/hydrator/services/plugin-config-factory.js
@@ -78,6 +78,7 @@ class HydratorPlusPlusPluginConfigFactory {
       case '1.3':
       case '1.4':
       case '1.5':
+      case '1.6':
         return this.generateConfigFor13Spec(backendProperties, nodeConfig);
       default: // No spec version which means
         throw 'NO_JSON_FOUND';

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -120,3 +120,42 @@
 @tracker-green: #35c853;
 @hydrator-blue: #098cf9;
 @success-bg: rgb(126, 211, 33); // #7ed321;
+
+
+/*
+  New start. Define colors used throughout CDAP. Use these colors from now on.
+*/
+
+@blue-01: #045599;
+@blue-02: #0076dc;
+@blue-03: #0099ff;
+@blue-04: #58b7f6;
+@blue-05: #7cd2eb;
+@blue-06: #caE7ef;
+@blue-grey01: #454a57;
+@blue-grey02: #4e5568;
+@blue-grey03: #5d6789;
+@blue-grey04: #979fbb;
+@blue-grey05: #bac1d8;
+@blue-grey06: #dce0ea;
+@orange-01: #ff6600;
+@orange-02: #fa8a00;
+@orange-03: #ffa727;
+@orange-04: #ffcc80;
+@orange-05: #ffe0b2;
+@grey-01: #333333;
+@grey-02: #666666;
+@grey-03: #999999;
+@grey-04: #bbbbbb;
+@grey-05: #cccccc;
+@grey-06: #dbdbdb;
+@grey-07: #eeeeee;
+@grey-08: #f5f5f5;
+@red-01: #a40403;
+@red-02: #d40001;
+@red-03: #d15668;
+@yellow-01: #ffba01;
+@yellow-02: #ffd500;
+@green-01: #01b133;
+@green-02: #3cc801;
+@green-03: #8af302;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12839

This PR does the following:
- Adds "Error" and "Alert" labels and endpoints on the plugin nodes that have `"emit-errors": true` and `"emit-alerts": true` properties defined inside `metadata` in their widget json. (PRs to add these: https://github.com/caskdata/hydrator-plugins/pull/757, https://github.com/hydrator/wrangler/pull/192)
- Adds validation so that an Error endpoint can only connect to an ErrorCollector node, an Alert endpoint can only connect to an AlertPublisher node, and no other endpoints can connect to either of these nodes. The only exception to the last case is when the user imports a pipeline with an existing connection to ErrorCollector/AlertPublisher nodes, then still allow the connection be shown so that it doesn't look broken.
- Changes the Align/cleanUpGraph() algorithm to move alert and error nodes to be below and right of the node that connects to them.

Currently on-hold because:
- ~~Need to confirm with the backend that we want to specify `emit-errors` and `emit-alerts` in the widget json.~~ Will keep these in the widget json, backend will let us know if there are changes in the future
- ~~Need to improve the ordering of the `connections` array in the pipeline json so that connections to ErrorCollector and AlertPublisher are always below other connections from the same source node.~~ Fixed