### PR TITLE
[CDAP-13002] Table dataset incorrectly handles non-ASCII string values

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Result.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Result.java
@@ -62,7 +62,7 @@ public class Result implements Row, Serializable {
   @Nullable
   public String getString(byte[] column) {
     byte[] val = get(column);
-    return val == null ? null : Bytes.toStringBinary(columns.get(column));
+    return val == null ? null : Bytes.toString(columns.get(column));
   }
 
   @Override


### PR DESCRIPTION
Result.getString(String column) incorrectly uses Bytes.toStringBinary() to convert column values to String. That creates escape sequences in the resulting String, if it is not ASCII or not printable. For example, the French character ç is returned as "\xC3\xA7", which is incorrect. Clients rely on retrieving string values exactly as they were stored. 

This includes a 1-line fix in Result, plus a test case for the Table dataset, and another test case for explore (where this was observed). 
