### PR TITLE
CDAP-13015 use hive-exec core in unit test instead of the fat jar

### DIFF
--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -78,6 +78,19 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-explore</artifactId>
       <version>${project.version}</version>
+      <!-- don't use the fat jar in unit test -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-exec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${hive.version}</version>
+      <classifier>core</classifier>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/FileUploadApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/FileUploadApp.java
@@ -32,7 +32,6 @@ import co.cask.cdap.api.service.http.HttpContentConsumer;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import com.google.common.base.Throwables;
-import com.google.common.io.BaseEncoding;
 import com.google.common.io.Closeables;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.twill.filesystem.Location;
@@ -43,6 +42,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.security.MessageDigest;
+import java.util.Base64;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -125,7 +125,7 @@ public class FileUploadApp extends AbstractApplication {
         @Override
         public void onFinish(HttpServiceResponder responder) throws Exception {
           channel.close();
-          String uploadedMd5 = BaseEncoding.base64().encode(messageDigest.digest());
+          String uploadedMd5 = Base64.getEncoder().encodeToString(messageDigest.digest());
           if (!md5.equals(uploadedMd5)) {
             throw new IllegalArgumentException("MD5 not match. Expected '" + md5 + "', received '" + uploadedMd5 + "'");
           }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/FileUploadServiceTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/FileUploadServiceTestRun.java
@@ -33,7 +33,6 @@ import co.cask.cdap.test.base.TestFrameworkTestBase;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.hash.Hashing;
-import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
@@ -44,6 +43,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -75,7 +75,7 @@ public class FileUploadServiceTestRun extends TestFrameworkTestBase {
       // Upload with right MD5, should get 200
       Assert.assertEquals(HttpURLConnection.HTTP_OK,
                           upload(serviceURI.resolve("upload/" + FileUploadApp.PFS_NAME + "/1").toURL(), content,
-                                 BaseEncoding.base64().encode(Hashing.md5().hashBytes(content).asBytes()), 20));
+                                 Base64.getEncoder().encodeToString(Hashing.md5().hashBytes(content).asBytes()), 20));
 
       // Inspect the partitioned file set and verify the content
       PartitionedFileSet pfs = (PartitionedFileSet) getDataset(FileUploadApp.PFS_NAME).get();

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaDynamicSpark.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaDynamicSpark.scala
@@ -19,12 +19,12 @@ package co.cask.cdap.spark.app
 import co.cask.cdap.api.spark.AbstractExtendedSpark
 import co.cask.cdap.api.spark.SparkExecutionContext
 import co.cask.cdap.api.spark.SparkMain
-import com.google.common.io.BaseEncoding
 import org.apache.spark.SparkContext
 
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
+import java.util.Base64
 
 import scala.collection.JavaConversions._
 
@@ -71,7 +71,7 @@ class ScalaDynamicSpark extends AbstractExtendedSpark with SparkMain {
       } finally {
         bos.close()
       }
-      setProperties(Map(("compiled.jar", BaseEncoding.base64().encode(bos.toByteArray))))
+      setProperties(Map(("compiled.jar", Base64.getEncoder().encodeToString(bos.toByteArray))))
     } finally {
       compiler.close()
     }
@@ -81,7 +81,7 @@ class ScalaDynamicSpark extends AbstractExtendedSpark with SparkMain {
     val sc = new SparkContext
 
     val depJar = new File(sec.getRuntimeArguments.get("tmpdir"), "compiled.jar")
-    Files.write(depJar.toPath, BaseEncoding.base64().decode(sec.getSpecification.getProperty("compiled.jar")))
+    Files.write(depJar.toPath, Base64.getDecoder.decode(sec.getSpecification.getProperty("compiled.jar")))
 
     val intp = sec.createInterpreter()
     try {


### PR DESCRIPTION
This will help alleviate some issues we get in unit tests due to
hive-exec packaging a bunch of dependencies like protobuf, guava,
and avro.