### PR TITLE
Fixes left sidebar overflowing footer in Docs page

### DIFF
--- a/cdap-docs/_common/_themes/cdap-bootstrap/static/js/cdap-onload-javascript.js
+++ b/cdap-docs/_common/_themes/cdap-bootstrap/static/js/cdap-onload-javascript.js
@@ -31,7 +31,6 @@
         // Bootstrap break point
         if (window.matchMedia('(min-width: 992px)').matches) {
             s_margin_left = '-16px';
-            s_position = 'fixed';
             s_width = parseInt($('div.main-container.container > .row').width() * 0.1666666667) + 'px';
 
             var maxRightSidebarHeight;


### PR DESCRIPTION
Before on the Reference home page in the docs, we had this issue:

![left-sidebar-overflowing](https://user-images.githubusercontent.com/6516002/34235989-19843d4c-e5aa-11e7-948c-fc737a4ca4f3.gif)

You can verify the fix at this page which was built for this branch: https://builds.cask.co/artifact/CDAP-DQB396/shared/build-1/Docs-HTML/html/reference-manual/index.html
