### PR TITLE
[CDAP-13022] Adds multi-select widget for plugin node configuration modal

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -246,6 +246,13 @@ angular.module(PKG.name + '.commons')
           'disabled': 'disabled',
           'node': 'node'
         }
+      },
+      'multi-select': {
+        element: '<my-multi-select-dropdown></my-multi-select-dropdown>',
+        attributes: {
+          'ng-model': 'model',
+          'config': 'myconfig'
+        }
       }
     };
     this.registry['__default__'] = this.registry['textbox'];

--- a/cdap-ui/app/directives/widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.html
+++ b/cdap-ui/app/directives/widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.html
@@ -1,0 +1,27 @@
+<!--
+  Copyright © 2017 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="my-multi-select-dropdown">
+  <div
+    ng-dropdown-multiselect=""
+    checkboxes="true"
+    options="options"
+    translation-texts="{dynamicButtonTextSuffix: 'Selected'}"
+    selected-model="selectedOptions"
+    extra-settings="extraSettings"
+  >
+  </div>
+</div>

--- a/cdap-ui/app/directives/widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.js
+++ b/cdap-ui/app/directives/widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+angular.module(PKG.name + '.commons')
+  .directive('myMultiSelectDropdown', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        model: '=ngModel',
+        config: '=',
+        radioBtnMode: '='
+      },
+      templateUrl: 'widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.html',
+      controller: function($scope, myHelpers) {
+        $scope.extraSettings = {
+          externalProp: '',
+          checkBoxes: true
+        };
+        $scope.selectedOptions = [];
+        $scope.delimiter = myHelpers.objectQuery($scope.config, 'widget-attributes', 'delimiter') || ',';
+        $scope.options = myHelpers.objectQuery($scope.config, 'widget-attributes', 'options') || [];
+        $scope.options = $scope.options.map(option => {
+          return {
+            id: option.id,
+            label: option.label || option.id
+          };
+        });
+        let defaultValue = myHelpers.objectQuery($scope.config, 'widget-attributes', 'defaultValue') || [];
+        if ($scope.model) {
+          $scope.model
+            .split($scope.delimiter)
+            .forEach(value => {
+              let valueInOption = $scope.options.find(op => op.id === value);
+              if (valueInOption) {
+                $scope.selectedOptions.push(valueInOption);
+              } else {
+                let unknownValue = {
+                  id: value,
+                  label: 'UnKnown Value (' + value + '). Not part of options'
+                };
+                $scope.options.push(unknownValue);
+                $scope.selectedOptions.push(unknownValue);
+              }
+            });
+        } else {
+          let defaultOption;
+          defaultOption = defaultValue
+            .map(value => $scope.options.find(op => op.id === value))
+            .filter(value => value);
+
+          if (defaultOption.length) {
+            $scope.selectedOptions = $scope.selectedOptions.concat(defaultOption);
+          }
+        }
+        $scope.$watch('selectedOptions', function() {
+          $scope.model = $scope.selectedOptions.map(o => o.id). join($scope.delimiter);
+        }, true);
+      }
+    };
+  });

--- a/cdap-ui/app/directives/widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.less
+++ b/cdap-ui/app/directives/widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.less
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+body.theme-cdap {
+  my-multi-select-dropdown {
+    .my-multi-select-dropdown {
+      .dropdown-menu.dropdown-menu-form {
+        overflow: auto !important; // This is because the lib makes overflow scroll and it looks bad.
+        background: white;
+      }
+    }
+    .dropdown-multiselect .btn-default.dropdown-toggle + .dropdown-menu > li > a {
+      background: white;
+      color: black;
+    }
+  }
+}


### PR DESCRIPTION
- Adds multi-select widget for use in node configuration in pipeline
- Have not added radio button widget as select dropdown right now solves that problem in a more concise manner.
- Format in widget json,
```
{
  "widget-type": "multi-select",
  "label": "Fields to keep",
  "name": "keep",
  "widget-attributes": {
    "options": [
      {
        "id": "value1",
        "label": "Value one"
      },
      {
        "id": "value2",
        "label": "Value Two"
      },
      {
        "id": "value3",
        "label": "Value Three"
      },
      {
        "id": "value4",
        "label": "Value Four"
      },
      {
        "id": "value5",
        "label": "Value Five"
      }
    ],
    "delimiter": ",",
    "defaultValue": [
      "value1",
      "value2"
    ]
  }
},
```

JIRA: https://issues.cask.co/browse/CDAP-13022
