### PR TITLE
CDAP-13021 Store HBase version in the table properties and use it to determine if the coprocessor upgrade is required.

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -235,6 +235,9 @@ public abstract class AbstractHBaseTableUtilTest {
     desc = getTableDescriptor("namespace", "table2");
     Assert.assertNull(desc.getValue("myKey"));
 
+    // Make sure that HBase version is added
+    Assert.assertNotNull(desc.getValue(HBaseTableUtil.CDAP_HBASE_VERSION));
+
     if (namespacesSupported()) {
       try {
         deleteNamespace("namespace");

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -70,6 +70,8 @@ public abstract class HBaseTableUtil {
 
   public static final String CDAP_VERSION = "cdap.version";
 
+  public static final String CDAP_HBASE_VERSION = "cdap.hbase.version";
+
   /**
    * Represents the compression types supported for HBase tables.
    */
@@ -188,6 +190,12 @@ public abstract class HBaseTableUtil {
     return builder.build();
   }
 
+  public HTableDescriptor setHBaseVersion(HTableDescriptor tableDescriptor) {
+    HTableDescriptorBuilder builder = buildHTableDescriptor(tableDescriptor);
+    setHBaseVersion(builder);
+    return builder.build();
+  }
+
   public HTableDescriptor setTablePrefix(HTableDescriptor tableDescriptor) {
     HTableDescriptorBuilder builder = buildHTableDescriptor(tableDescriptor);
     builder.setValue(Constants.Dataset.TABLE_PREFIX, tablePrefix);
@@ -226,7 +234,9 @@ public abstract class HBaseTableUtil {
                                                                   tableName.getQualifierAsString());
     tdBuilder
       .addProperty(Constants.Dataset.TABLE_PREFIX, tablePrefix)
-      .addProperty(HBaseTableUtil.CDAP_VERSION, ProjectInfo.getVersion().toString());
+      .addProperty(HBaseTableUtil.CDAP_VERSION, ProjectInfo.getVersion().toString())
+      .addProperty(HBaseTableUtil.CDAP_HBASE_VERSION, HBaseVersion.get().getMajorVersion());
+
 
     return tdBuilder;
   }
@@ -248,6 +258,15 @@ public abstract class HBaseTableUtil {
 
   public static ProjectInfo.Version getVersion(HTableDescriptor tableDescriptor) {
     return new ProjectInfo.Version(tableDescriptor.getValue(CDAP_VERSION));
+  }
+
+  public static void setHBaseVersion(HTableDescriptorBuilder tableDescriptorBuilder) {
+    tableDescriptorBuilder.setValue(CDAP_HBASE_VERSION, HBaseVersion.get().getMajorVersion());
+  }
+
+  @Nullable
+  public static String getHBaseVersion(HTableDescriptor tableDescriptor) {
+    return tableDescriptor.getValue(CDAP_HBASE_VERSION);
   }
 
   public static byte[][] getSplitKeys(int splits, int buckets, AbstractRowKeyDistributor keyDistributor) {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -247,6 +247,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
 
   private void updateTableDesc(HTableDescriptor desc, HBaseDDLExecutor ddlExecutor) throws IOException {
     hBaseTableUtil.setVersion(desc);
+    hBaseTableUtil.setHBaseVersion(desc);
     hBaseTableUtil.setTablePrefix(desc);
     hBaseTableUtil.modifyTable(ddlExecutor, desc);
   }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13021
Added `hbase.version` property to the table descriptors. This property is used to check if the HBase version is changed after the table is created, based on which table upgrade is performed.

Pending testing on the cluster.