### PR TITLE
[CDAP-13028] Fixes alignment issue related to error/alert connections when clicking Align

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2017 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -1035,40 +1035,12 @@ angular.module(PKG.name + '.commons')
         DAGPlusPlusNodesActionsFactory.setConnections($scope.connections);
       }
 
-      var graphNodes = DAGPlusPlusFactory.getGraphLayout($scope.nodes, $scope.connections, separation)._nodes;
+      let graphNodesNetworkSimplex = DAGPlusPlusFactory.getGraphLayout($scope.nodes, $scope.connections, separation)._nodes;
+      let graphNodesLongestPath = DAGPlusPlusFactory.getGraphLayout($scope.nodes, $scope.connections, separation, 'longest-path')._nodes;
+
       angular.forEach($scope.nodes, function (node) {
-        var location = graphNodes[node.name];
-
-        var locationX = location.x;
-        var locationY = location.y;
-
-        if (node.type === 'alertpublisher' || node.type === 'errortransform') {
-
-          // If the node connecting to this alert publisher/error transform node only has connections
-          // to these types of nodes, then have to push the alert publisher/error transform down a bit more
-          let connToThisNode = $scope.connections.find(conn => conn.to === node.name);
-          if (connToThisNode) {
-            let sourceNode = connToThisNode.from;
-            let onlyConnectedToErrorsAlerts = true;
-            for (let i = 0; i < $scope.connections.length; i++) {
-              let conn = $scope.connections[i];
-              if (conn.from === sourceNode) {
-                let targetNode = $scope.nodes.find(node => node.name === conn.to);
-                if (targetNode.type !== 'alertpublisher' && targetNode.type !== 'errortransform') {
-                  onlyConnectedToErrorsAlerts = false;
-                  break;
-                }
-              }
-            }
-            if (onlyConnectedToErrorsAlerts) {
-              locationY += 200;
-            } else {
-              locationY += 70;
-            }
-            locationX -= 150;
-          }
-        }
-
+        let locationX = graphNodesNetworkSimplex[node.name].x;
+        let locationY = graphNodesLongestPath[node.name].y;
         node._uiPosition = {
           left: locationX - 50 + 'px',
           top: locationY + 'px'

--- a/cdap-ui/app/hydrator/services/canvas-factory.js
+++ b/cdap-ui/app/hydrator/services/canvas-factory.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,15 +21,15 @@
     /*
       This is the inner utility function that is used once we have a source node to start our traversal.
     */
-    function addConnectionsInOrder(node, finalConnections, originalConnections) {
-      if (node.visited) {
+    function addConnectionsInOrder(sourceConn, finalConnections, originalConnections) {
+      if (sourceConn.visited) {
         return finalConnections;
       }
 
-      node.visited = true;
-      finalConnections.push(node);
+      sourceConn.visited = true;
+      finalConnections.push(sourceConn);
       var nextConnections = originalConnections.filter(function(conn) {
-        if (node.to === conn.from) {
+        if (sourceConn.to === conn.from) {
           return conn;
         }
       });
@@ -56,7 +56,7 @@
           return c;
         }
       }
-      for (var i =0; i<originalConnections.length; i++) {
+      for (var i = 0; i < originalConnections.length; i++) {
         var connection = originalConnections[i];
         var isSoureATarget = originalConnections.filter(isSource);
         if (!isSoureATarget.length) {
@@ -92,7 +92,6 @@
       };
 
       const orderAlertErrorConnections = (alertOrErrorNodes, isErrorNodes = true) => {
-
         angular.forEach(alertOrErrorNodes, (node) => {
           let lastConnToThisNodeIndex = _.findLastIndex(finalConnections, conn => conn.to === node);
 
@@ -149,17 +148,17 @@
           errorNodes.push(nodeName);
         }
       });
-      var source = connections.filter(function(conn) {
+      let sourceConns = connections.filter(function(conn) {
         if (nodesMap[conn.from].type === GLOBALS.pluginTypes[appType].source) {
           return conn;
         }
       });
 
-      if (!source.length) {
-        source = [findTransformThatIsSource(originalConnections)];
+      if (!sourceConns.length) {
+        sourceConns = [findTransformThatIsSource(originalConnections)];
       }
 
-      addConnectionsInOrder(source[0], finalConnections, originalConnections);
+      addConnectionsInOrder(sourceConns[0], finalConnections, originalConnections);
       if (finalConnections.length < originalConnections.length) {
         originalConnections.forEach(function(oConn) {
           var match = finalConnections.filter(fConn => fConn.from === oConn.from && fConn.to === oConn.to).length === 0;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13028

When the user clicks on Align, we reorder the connections by calling `addConnectionsInOrder`. Based on this order, dagre will render the graph. 

Before, we were using DFS, so for example if we start from source A, and A has two connections: A -> Error Collector (EC), and A -> B (in that order in the our internal `connections` array). Suppose there's another connection from EC to C, then EC -> C will be placed above A -> B in the array, because of DFS. Later in the code we have a function that moves all connections to Error Collectors/Alert Publishers from one node to be below other connections from that same node, so A -> EC will below A -> B, but EC -> C will still be above A -> B.

This PR switches the graph traversal to be using BFS. So for the same example above, EC -> C will be placed below A -> B, which will make the graph render correctly.