### PR TITLE
Adds bower cache clean step to pom.xml

### DIFF
--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -221,6 +221,15 @@
                 </configuration>
               </execution>
               <execution>
+                <id>bower-cache-clean</id>
+                <goals>
+                  <goal>bower</goal>
+                </goals>
+                <configuration>
+                  <arguments>cache clean</arguments>
+                </configuration>
+              </execution>
+              <execution>
                 <id>bower-install</id>
                 <goals>
                   <goal>bower</goal>


### PR DESCRIPTION
This was added once before (https://github.com/caskdata/cdap/pull/9781/files#diff-15fd52dff1f75929a9d49b99f7fc7cde) but got removed during a rebase/refactor. 

This is needed because we modified `cask-angular-eventpipe` (https://github.com/caskdata/ng-capsules/commit/2bfa56f76f0e63c508439c88e92db7233a097278). Since this module is loaded through bower, if bower cache is not cleaned then the old EventPipe will still be used, which will cause unintended behaviors.