### PR TITLE
[CDAP-12920] Shows Connections view as full page when wrangling directly from Wrangler plugin

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -231,13 +231,18 @@ export default class DataPrepHome extends Component {
           :
             null
         }
-        <DataPrep
-          workspaceId={workspaceId}
-          onConnectionsToggle={this.toggleConnectionsView}
-          onWorkspaceDelete={this.props.singleWorkspaceMode ? null : this.updateWorkspaceList}
-          onSubmit={this.props.onSubmit}
-          singleWorkspaceMode={this.props.singleWorkspaceMode}
-        />
+        {
+          !workspaceId && this.props.singleWorkspaceMode ?
+            null
+          :
+            <DataPrep
+              workspaceId={workspaceId}
+              onConnectionsToggle={this.toggleConnectionsView}
+              onWorkspaceDelete={this.props.singleWorkspaceMode ? null : this.updateWorkspaceList}
+              onSubmit={this.props.onSubmit}
+              singleWorkspaceMode={this.props.singleWorkspaceMode}
+            />
+        }
       </div>
     );
   }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-12920

Currently when the user clicks Wrangle directly in the Wrangler transform plugin, we show the Connections view as half of the window, while on the other half we show an empty DataPrep page with "Unable to show data." message in the center, since we don't have an associated workspace ID. This PR fixes this by showing the Connections view as the full window in the above case.