### PR TITLE
[MMDS][CDAP-12709][CDAP-13049] Adds Split Data Step while creating a model

### DIFF
--- a/cdap-ui/app/cdap/api/dataprep.js
+++ b/cdap-ui/app/cdap/api/dataprep.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/cdap/api/experiments.js
+++ b/cdap-ui/app/cdap/api/experiments.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,13 +18,18 @@ import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
 import {apiCreator} from 'services/resource-helper';
 
 let dataSrc = DataSourceConfigurer.getInstance();
-let basePath = '/namespaces/:namespace/apps/ModelManagementApp/services/ModelManagerService/methods';
+let basePath = '/namespaces/:namespace/apps/ModelManagementApp/spark/ModelManagerService/methods';
 export const myExperimentsApi = {
   list: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments`),
 
   getExperiment: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId`),
   getModelsInExperiment: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/models`),
+  getModel: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId`),
+  setSplitToModel: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId/split`),
+  getSplitDetails: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/splits/:splitId`),
+  getSplitStatus: apiCreator(dataSrc, 'GET', 'POLL', `${basePath}/experiments/:experimentId/splits/:splitId/status`),
   getModelStatus: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId/status`),
+  trainModel: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId/train`),
   getSplitsInExperiment: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/splits`),
 
   deleteModelInExperiment: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId`),

--- a/cdap-ui/app/cdap/components/EntityListView/EntityListHeader/EntityListHeader.scss
+++ b/cdap-ui/app/cdap/components/EntityListView/EntityListHeader/EntityListHeader.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -168,7 +168,6 @@ $margin-to-border: 0.5rem;
           top: 28px;
 
           .dropdown-item {
-            padding-right: 0;
 
             .fa-check {
               padding-right: $margin-to-border;

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/CreateView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/CreateView.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,6 +15,7 @@
 */
 
 @import "../../../styles/variables.scss";
+@import "./CreateViewVariables.scss";
 
 .experiments-create-view {
   height: 100%;
@@ -43,14 +44,19 @@
       .dataprep-body {
         height: calc(100% - 50px);
       }
-    }
-    .dataprep-container {
+
       .top-section {
         .top-section-content {
           .top-panel {
             .action-buttons {
+              .more-dropdown.dropdown {
+                display: none;
+              }
+              .dataprep-plus-button {
+                display: none;
+              }
               > .btn.btn-primary {
-                visibility: hidden;
+                display: none;
               }
             }
           }
@@ -59,28 +65,23 @@
     }
   }
   .experiments-model-panel {
-    height: 50px;
+    height: $height_of_header;
     position: absolute;
     right: 80px;
     top: 59px;
+    z-index: 1000;
     > .btn.btn-primary {
       padding-right: 30px;
       padding-left: 30px;
     }
   }
-  .algorithm-selection-step {
-    .experiment-metadata {
-      display: flex;
-      flex-wrap: wrap;
-      padding: 20px;
+  > .experiments-split-data {
+    > .experiment-metadata {
+      height: $height_of_metadata;
       > div {
-        margin: 0 20px 0 0;
-        &.grayed {
-          color: $grey-05;
-        }
-        > * {
-          margin: 0 5px;
-        }
+        width: 25%;
+        word-break: break-word;
+        margin: 0;
       }
     }
   }

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/CreateViewVariables.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/CreateViewVariables.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2018 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,11 +14,5 @@
  * the License.
 */
 
-.vega-lite-chart {
-  height: 100%;
-  width: 100%;
-  > div:first-of-type {
-    height: 100%;
-    overflow: auto;
-  }
-}
+$height_of_metadata: 80px;
+$height_of_header: 50px;

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/ExperimentMetadata/ExperimentMetadata.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/ExperimentMetadata/ExperimentMetadata.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2018 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,11 +14,20 @@
  * the License.
 */
 
-.vega-lite-chart {
-  height: 100%;
-  width: 100%;
-  > div:first-of-type {
-    height: 100%;
-    overflow: auto;
+@import "../../../../styles/variables.scss";
+
+.experiment-metadata {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 20px;
+  border-bottom: 1px solid $grey-05;
+  > div {
+    margin: 0 20px 0 0;
+    &.grayed {
+      color: $grey-05;
+    }
+    > * {
+      margin: 0 5px;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/ExperimentMetadata/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/ExperimentMetadata/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,8 @@ import {connect, Provider} from 'react-redux';
 import createExperimentStore from 'components/Experiments/store/createExperimentStore';
 import classnames from 'classnames';
 import isNil from 'lodash/isNil';
+
+require('./ExperimentMetadata.scss');
 
 const ExperimentMetadataWrapper = ({modelName, modelDescription, directives, algorithm}) => {
   let isAlgorithmEmpty = () => isNil(algorithm) || !algorithm.length;

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/MLAlgorithmSelection/MLAlgorithmSelection.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/MLAlgorithmSelection/MLAlgorithmSelection.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,16 +14,16 @@
  * the License.
 */
 
-@import "../../../styles/variables.scss";
+@import "../../../../styles/variables.scss";
 
 .ml-algorithm-selection {
+  padding: 20px;
   .btn.btn-primary {
     margin: 20px;
   }
   .ml-algorithm-list-details {
     display: flex;
     .ml-algorithm-list-view {
-      margin: 0 20px;
       .ml-algorithm-category-title {
         color: $grey-05;
       }

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/MLAlgorithmSelection/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/MLAlgorithmSelection/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Provider, connect} from 'react-redux';
 import createExperimentStore from 'components/Experiments/store/createExperimentStore';
-import {setModelAlgorithm, createExperimentAndModel} from 'components/Experiments/store/ActionCreator';
+import {setModelAlgorithm, trainModel, setAlgorithmList} from 'components/Experiments/store/ActionCreator';
 import {Label} from 'reactstrap';
 
 require('./MLAlgorithmSelection.scss');
@@ -72,24 +72,24 @@ const MLAlgorithmDetails = ({algorithm}) => {
 MLAlgorithmDetails.propTypes = {
   algorithm: PropTypes.object
 };
-const AddModelBtn = ({algorithm, createExperimentAndModel}) => {
+const AddModelBtn = ({algorithm, trainModel}) => {
   return (
     <button
       className="btn btn-primary"
       disabled={!algorithm.name.length}
-      onClick={createExperimentAndModel}
+      onClick={trainModel}
     >
-      Add a Model and Train
+      Train Model
     </button>
   );
 };
 AddModelBtn.propTypes = {
   algorithm: PropTypes.object,
-  createExperimentAndModel: PropTypes.func
+  trainModel: PropTypes.func
 };
 
 const mapStateToAddModelBtnProps = (state) => ({ algorithm: state.model_create.algorithm});
-const mapDispatchToAddModelBtnProps = () => ({createExperimentAndModel});
+const mapDispatchToAddModelBtnProps = () => ({trainModel});
 const mapStateToMLAlgorithmsListProps = (state) => ({
   algorithmsList: state.model_create.algorithmsList,
   selectedAlgorithm: state.model_create.algorithm
@@ -103,6 +103,7 @@ const ConnectedAddModelBtn = connect(mapStateToAddModelBtnProps, mapDispatchToAd
 
 
 export default function MLAlgorithmSelection() {
+  setAlgorithmList();
   return (
     <Provider store={createExperimentStore}>
       <div className="ml-algorithm-selection">

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/ExperimentPopovers.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/ExperimentPopovers.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
 */
 
-@import "../../../styles/variables.scss";
+@import "../../../../styles/variables.scss";
 
 $popover_container_border_color: $grey-05;
 
@@ -65,7 +65,7 @@ $popover_container_border_color: $grey-05;
       max-height: 250px;
     }
   }
-  .experiment-metadata {
+  .experiment-metadata-popover {
     color: $popover_container_border_color;
     .btn-link {
       cursor: pointer;

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/NewExperimentPopover.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/NewExperimentPopover.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,8 +22,9 @@ import {
   onExperimentNameChange,
   onExperimentDescriptionChange,
   onExperimentOutcomeChange,
-  setExperimentCreated
+  createExperiment
 } from 'components/Experiments/store/ActionCreator';
+import IconSVG from 'components/IconSVG';
 
 const ExperimentName = ({name, onNameChange, isEdit}) => {
   return (
@@ -95,27 +96,33 @@ ExperimentOutcome.propTypes = {
   isEdit: PropTypes.bool
 };
 
-const CreateExperimentBtn = ({state, setExperimentCreated}) => {
+const CreateExperimentBtn = ({state, createExperiment}) => {
   const isAddExperimentBtnEnabled = () => {
     return state.name.length && state.description.length && state.outcome.length;
+  };
+  const renderBtnContent = () => {
+    if (state.loading) {
+      return <IconSVG name="icon-spinner" className="fa-spin" />;
+    }
+    return state.isEdit ? 'Edit Experiment' : 'Create Experiment';
   };
   return (
     <button
       className="btn btn-primary"
       disabled={!isAddExperimentBtnEnabled()}
-      onClick={setExperimentCreated}
+      onClick={createExperiment}
     >
-      {state.isEdit ? 'Edit Experiment' : 'Create Experiment'}
+      {renderBtnContent()}
     </button>
   );
 };
 CreateExperimentBtn.propTypes = {
   state: PropTypes.object,
-  setExperimentCreated: PropTypes.func
+  createExperiment: PropTypes.func
 };
 
-const NewExperimentPopoverWrapper = ({isExperimentCreated}) => {
-  if (isExperimentCreated) {
+const NewExperimentPopoverWrapper = ({popover}) => {
+  if (popover !== 'experiment') {
     return null;
   }
   return (
@@ -134,9 +141,9 @@ const NewExperimentPopoverWrapper = ({isExperimentCreated}) => {
   );
 };
 NewExperimentPopoverWrapper.propTypes = {
-  isExperimentCreated: PropTypes.bool
+  popover: PropTypes.string
 };
-const mapDispatchToCreateExperimentBtnProps = () => ({ setExperimentCreated});
+const mapDispatchToCreateExperimentBtnProps = () => ({ createExperiment });
 const mapStateToCreateExperimentBtnProps = (state) => ({ state: {...state.experiments_create} });
 const mapStateToNameProps = (state) => ({ name: state.experiments_create.name, isEdit: state.experiments_create.isEdit });
 const mapDispatchToNameProps = () => ({ onNameChange: onExperimentNameChange });
@@ -144,13 +151,12 @@ const mapStateToDescriptionProps = (state) => ({ description: state.experiments_
 const mapDispatchToDescriptionToProps = () => ({ onDescriptionChange: onExperimentDescriptionChange });
 const mapStateToOutcomeProps = (state) => ({ outcome: state.experiments_create.outcome, columns: state.model_create.columns, isEdit: state.experiments_create.isEdit });
 const mapDispatchToOutcomeProps = () => ({onOutcomeChange: onExperimentOutcomeChange});
-const mapNEPWStateToProps = (state) => ({ isExperimentCreated: state.experiments_create.isExperimentCreated });
-const mapNEPWDispatchToProps = () => ({ setExperimentCreated });
+const mapNEPWStateToProps = (state) => ({ popover: state.experiments_create.popover });
 
 const ExperiementDescriptionWrapper = connect(mapStateToDescriptionProps, mapDispatchToDescriptionToProps)(ExperimentDescription);
 const ExperimentNameWrapper = connect(mapStateToNameProps, mapDispatchToNameProps)(ExperimentName);
 const ExperimentOutcomeWrapper = connect(mapStateToOutcomeProps, mapDispatchToOutcomeProps)(ExperimentOutcome);
-const ConnectedNewExperimentPopoverWrapper = connect(mapNEPWStateToProps, mapNEPWDispatchToProps)(NewExperimentPopoverWrapper);
+const ConnectedNewExperimentPopoverWrapper = connect(mapNEPWStateToProps)(NewExperimentPopoverWrapper);
 const ConnectedCreateExperimentBtn = connect(mapStateToCreateExperimentBtnProps, mapDispatchToCreateExperimentBtnProps)(CreateExperimentBtn);
 
 export default ConnectedNewExperimentPopoverWrapper;

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/NewModelPopover.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/NewModelPopover.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,10 +19,10 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {FormGroup, Label, Col, Input, Row} from 'reactstrap';
 import {
-  setExperimentCreated,
+  setVisiblePopover,
   onModelNameChange,
   onModelDescriptionChange,
-  setModelCreated
+  createModel
 } from 'components/Experiments/store/ActionCreator';
 
 const ModelName = ({modelName, onModelNameChange}) => {
@@ -63,12 +63,12 @@ ModelDescription.propTypes = {
   onModelDescriptionChange: PropTypes.func
 };
 
-const CreateModelBtn = ({state, setModelCreated}) => {
+const CreateModelBtn = ({state, createModel}) => {
   const isAddModelBtnEnabled = () => state.name.length && state.description.length;
   return (
     <button
       className="btn btn-primary"
-      onClick={setModelCreated}
+      onClick={createModel}
       disabled={!isAddModelBtnEnabled()}
     >
       Create Model
@@ -77,12 +77,12 @@ const CreateModelBtn = ({state, setModelCreated}) => {
 };
 CreateModelBtn.propTypes = {
   state: PropTypes.object,
-  setModelCreated: PropTypes.func
+  createModel: PropTypes.func
 };
 
-const ExperimentMetadata = ({experimentOutcome, experimentDescription, setExperimentCreated}) => {
+const ExperimentMetadata = ({experimentOutcome, experimentDescription, setVisiblePopover}) => {
   return (
-    <div className="experiment-metadata">
+    <div className="experiment-metadata-popover">
       <Col xs="12">
         <Row>
           <Col xs="6">Outcome:</Col>
@@ -94,7 +94,7 @@ const ExperimentMetadata = ({experimentOutcome, experimentDescription, setExperi
         </Row>
         <div
           className="btn-link"
-          onClick={setExperimentCreated.bind(null, false)}
+          onClick={setVisiblePopover.bind(null, 'experiment')}
         >
           Edit
         </div>
@@ -105,11 +105,11 @@ const ExperimentMetadata = ({experimentOutcome, experimentDescription, setExperi
 ExperimentMetadata.propTypes = {
   experimentOutcome: PropTypes.string,
   experimentDescription: PropTypes.string,
-  setExperimentCreated: PropTypes.func
+  setVisiblePopover: PropTypes.func
 };
 
-const NewModelPopoverWrapper = ({isExperimentCreated, experimentName}) => {
-  if (!isExperimentCreated) {
+const NewModelPopoverWrapper = ({popover, experimentName}) => {
+  if (popover !== 'model') {
     return null;
   }
   return (
@@ -131,7 +131,7 @@ const NewModelPopoverWrapper = ({isExperimentCreated, experimentName}) => {
   );
 };
 NewModelPopoverWrapper.propTypes = {
-  isExperimentCreated: PropTypes.bool,
+  popover: PropTypes.string,
   experimentName: PropTypes.string
 };
 
@@ -140,14 +140,14 @@ const mapDispatchToModelNameProps = () => ({ onModelNameChange });
 const mapStateToModelDescriptionProps = (state) => ({ modelDescription: state.model_create.description });
 const mapDispatchToModelDescriptionProps = () => ({ onModelDescriptionChange });
 const mapStateToCreateModelBtnProps = (state) => ({ state: state.model_create});
-const mapDispatchToCreateModelBtnProps = () => ({ setModelCreated });
+const mapDispatchToCreateModelBtnProps = () => ({ createModel });
 const mapStateToExperimentMetadataProps = (state) => ({
   experimentOutcome: state.experiments_create.outcome,
   experimentDescription: state.experiments_create.description
 });
-const mapDispatchToExperimentMetadataProps = () => ({ setExperimentCreated });
+const mapDispatchToExperimentMetadataProps = () => ({ setVisiblePopover });
 const mapNMPWStateToProps = (state) => ({
-  isExperimentCreated: state.experiments_create.isExperimentCreated,
+  popover: state.experiments_create.popover,
   experimentName: state.experiments_create.name
 });
 

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,8 @@
 import React from 'react';
 import {Provider} from 'react-redux';
 import createExperimentStore from 'components/Experiments/store/createExperimentStore';
-import NewExperimentPopover from 'components/Experiments/Popovers/NewExperimentPopover';
-import NewModelPopover from 'components/Experiments/Popovers/NewModelPopover';
+import NewExperimentPopover from 'components/Experiments/CreateView/Popovers/NewExperimentPopover';
+import NewModelPopover from 'components/Experiments/CreateView/Popovers/NewModelPopover';
 
 require('./ExperimentPopovers.scss');
 

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitDataStep.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitDataStep.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2018 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,11 +14,27 @@
  * the License.
 */
 
-.vega-lite-chart {
-  height: 100%;
-  width: 100%;
-  > div:first-of-type {
-    height: 100%;
-    overflow: auto;
+@import "../CreateViewVariables.scss";
+
+.split-data-step {
+  padding: 20px;
+  height: calc(100% - (#{$height_of_metadata} + #{$height_of_header}));
+  overflow: auto;
+  .btn.btn-primary {
+    .btn-inner-container {
+      display: flex;
+      align-items: center;
+      > svg {
+        margin-right: 10px;
+      }
+      > span {
+        line-height: 1;
+      }
+    }
+  }
+  .action-button-group {
+    button {
+      margin: 0 5px 0 0;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfo/SplitInfo.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfo/SplitInfo.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2018 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,11 +14,14 @@
  * the License.
 */
 
-.vega-lite-chart {
-  height: 100%;
-  width: 100%;
-  > div:first-of-type {
-    height: 100%;
-    overflow: auto;
+.split-info {
+  padding: 15px 0;
+  .split-info-graph-wrapper {
+    height: 300px;
+    margin-top: -10px;
+  }
+  .active-column-container {
+    font-size: 1.2rem;
+    margin: 5px 0 0 0;
   }
 }

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfo/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfo/index.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import {connect} from 'react-redux';
+import SplitInfoTable from 'components/Experiments/CreateView/SplitDataStep/SplitInfoTable';
+import SplitInfoGraph from 'components/Experiments/CreateView/SplitDataStep/SplitInfoGraph';
+
+require('./SplitInfo.scss');
+
+class SplitInfo extends Component {
+  static propTypes = {
+    splitInfo: PropTypes.object,
+    outcome: PropTypes.string,
+    activeColumn: PropTypes.string
+  };
+
+  state = {
+    activeColumn: this.props.outcome,
+    splitInfo: this.props.splitInfo
+  };
+
+  onActiveColumnChange = (activeColumn) => {
+    this.setState({activeColumn});
+  };
+
+  componentWillReceiveProps({splitInfo, outcome, schema}) {
+    this.setState({
+      splitInfo,
+      activeColumn: outcome,
+      schema
+    });
+  }
+
+  render() {
+    return (
+      <div className="split-info">
+        <h5> Verify Sample by Feature or Outcome </h5>
+        <div className="active-column-container">
+          Displaying column: <strong>{this.state.activeColumn}</strong>
+        </div>
+        <div className="split-info-graph-wrapper">
+          <SplitInfoGraph
+            splitInfo={this.state.splitInfo}
+            activeColumn={this.state.activeColumn}
+          />
+        </div>
+        <SplitInfoTable
+          splitInfo={this.state.splitInfo}
+          onActiveColumnChange={this.onActiveColumnChange}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToSplitInfoProps = (state) => {
+  return {
+    splitInfo: state.model_create.splitInfo,
+    outcome: state.experiments_create.outcome,
+    schema: state.model_create.schema
+  };
+};
+
+const ConnectedSplitInfo = connect(mapStateToSplitInfoProps)(SplitInfo);
+
+export default ConnectedSplitInfo;

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfoGraph/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfoGraph/index.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import GroupedBarChart from 'components/GroupedBarChart';
+
+export default class SplitInfoGraph extends Component {
+  static propTypes = {
+    splitInfo: PropTypes.object.isRequired,
+    activeColumn: PropTypes.string.isRequired
+  };
+
+  state = {
+    splitInfo: this.props.splitInfo,
+    activeColumn: this.props.activeColumn
+  };
+
+  customEncoding = {
+    "x": {
+      "field": "type", "type": "nominal",
+      "axis": null
+    },
+    "column": {
+      "field": "name", "type": "ordinal", "header": {"title": "values"}
+    },
+    "y": {
+      "field": "count", "type": "quantitative",
+      "axis": {"title": "Count (Percent)", "grid": false}
+    },
+  };
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      activeColumn: nextProps.activeColumn,
+      splitInfo: nextProps.splitInfo
+    });
+  }
+
+  getFormattedData = () => {
+    const matchingField = this.state.splitInfo.stats
+      .filter(stat => stat.field === this.state.activeColumn)
+      .pop();
+    if (!matchingField) {
+      return [];
+    }
+    const getTotalValues = (dataType = 'train') => {
+      const total = matchingField.numTotal[dataType];
+      const nulls = matchingField.numNull[dataType];
+      return total - nulls;
+    };
+    return matchingField
+      .histo
+      .reduce(
+        (prev, curr) => {
+          prev = prev || [];
+          return [
+            ...prev,
+            {
+              name: curr.bin,
+              count: curr.count.train / getTotalValues('train'),
+              type: 'train'
+            },
+            {
+              name: curr.bin,
+              count: curr.count.test / getTotalValues('test'),
+              type: 'test'
+            }
+          ];
+        }, []
+      );
+  };
+
+  render () {
+    if (!this.state.splitInfo.stats || !this.state.activeColumn) {
+      return null;
+    }
+    return (
+      <GroupedBarChart
+        customEncoding={this.customEncoding}
+        data={this.getFormattedData()}
+        width={(dimension, data) => {
+          if (!data.length) {
+            return (dimension.width - 260);
+          }
+          return ((dimension.width - 260) / (data.length / 2));
+        }}
+        heightOffset={80}
+        tooltipOptions={{
+          showAllFields: false,
+          fields: [
+            {
+              field: 'type',
+              title: 'Type'
+            },
+            {
+              field: 'count',
+              title: 'Percentage',
+              format: '.0%',
+              formatType: 'number'
+            }
+          ]
+        }}
+      />
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfoTable/SplitInfoTable.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfoTable/SplitInfoTable.scss
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../../../styles/variables.scss";
+
+.split-info-table {
+  .split-info-collapsable-section {
+    cursor: pointer;
+  }
+  .split-info-table-container {
+    .split-table-search {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      .filter-container {
+        display: flex;
+        > span {
+          margin: 0 5px;
+          display: flex;
+          align-items: center;
+          > input[type="checkbox"] {
+            margin: 0 5px;
+            position: static;
+          }
+        }
+      }
+    }
+    .split-info-numerical-table,
+    .split-info-categorical-table {
+      .table {
+        tbody tr {
+          cursor: pointer;
+          &:hover {
+            background: $grey-08;
+          }
+        }
+      }
+      .split-table-header {
+        width: 100%;
+        background: $grey-05;
+        padding: 5px;
+        border-radius: 2px;
+        color: white;
+        font-weight: 500;
+        margin: 10px 0;
+      }
+    }
+    .table-field-search {
+      width: 200px;
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfoTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfoTable/index.js
@@ -1,0 +1,344 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import IconSVG from 'components/IconSVG';
+import {Input} from 'reactstrap';
+import {NUMBER_TYPES} from 'services/global-constants';
+import SortableTable from 'components/SortableTable';
+import {objectQuery} from 'services/helpers';
+import findLast from 'lodash/findLast';
+
+require('./SplitInfoTable.scss');
+
+export default class SplitInfoTable extends Component {
+  static propTypes = {
+    splitInfo: PropTypes.object,
+    onActiveColumnChange: PropTypes.func
+  };
+
+  state = {
+    collapsed: true,
+    splitInfo: this.props.splitInfo,
+    search: '',
+    selectedTypes: [
+      'boolean',
+      'double',
+      'float',
+      'int',
+      'long',
+      'string'
+    ]
+  };
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({splitInfo: nextProps.splitInfo});
+  }
+
+  toggleCollapse = () => {
+    this.setState({collapsed: !this.state.collapsed});
+  };
+
+  isFieldNumberType = (type) => NUMBER_TYPES.indexOf(type) !== -1;
+
+  CATEGORICAL_FIELD_HEADERS = [
+    {
+      property: 'name',
+      label: 'Column Name'
+    },
+    {
+      property: 'numTotal',
+      label: 'Count'
+    },
+    {
+      property: 'numEmpty',
+      label: 'Missing'
+    },
+    {
+      property: 'unique',
+      label: 'Unique'
+    }
+  ];
+
+  NUMERICAL_FIELD_HEADERS = [
+    {
+      property: 'name',
+      label: 'Column Name'
+    },
+    {
+      property: 'numTotal',
+      label: 'Count'
+    },
+    {
+      property: 'numEmpty',
+      label: 'Missing'
+    },
+    {
+      property: 'numZero',
+      label: 'Zero'
+    },
+    {
+      property: 'mean',
+      label: 'Mean'
+    },
+    {
+      property: 'stddev',
+      label: 'Std Dev'
+    },
+    {
+      property: 'min',
+      label: 'Min'
+    },
+    {
+      property: 'max',
+      label: 'Max'
+    }
+  ];
+
+  onSearch = (e) => {
+    this.setState({search: e.target.value});
+  };
+
+  onToggleSelectedType = (e) => {
+    if (this.state.selectedTypes.indexOf(e.target.name) !== -1) {
+      this.setState({
+        selectedTypes: this.state.selectedTypes.filter(type => type !== e.target.name)
+      });
+    } else {
+      this.setState({
+        selectedTypes: [...this.state.selectedTypes, e.target.name]
+      });
+    }
+  };
+
+  renderNumericalTableBody = (fields) => {
+    return (
+      <tbody>
+        {
+          fields.map(field => {
+            return (
+              <tr
+                key={field.name}
+                onClick={this.props.onActiveColumnChange.bind(null, field.name)}
+              >
+                <td>{field.name}</td>
+                <td>{field.numTotal}</td>
+                <td>{field.numEmpty}</td>
+                <td>{field.numZero}</td>
+                <td>{field.mean}</td>
+                <td>{field.stddev}</td>
+                <td>{field.min}</td>
+                <td>{field.max}</td>
+              </tr>
+            );
+          })
+        }
+      </tbody>
+    );
+  };
+
+  renderCategoricalTableBody = (fields) => {
+    return (
+      <tbody>
+        {
+          fields.map(field => {
+            return (
+              <tr
+                key={field.name}
+                onClick={this.props.onActiveColumnChange.bind(null, field.name)}
+              >
+                <td>{field.name}</td>
+                <td>{field.numTotal}</td>
+                <td>{field.numEmpty}</td>
+                <td>{field.unique}</td>
+              </tr>
+            );
+          })
+        }
+      </tbody>
+    );
+  };
+
+  renderNumericalTable = (fields) => {
+    return (
+      <SortableTable
+        entities={fields}
+        tableHeaders={this.NUMERICAL_FIELD_HEADERS}
+        renderTableBody={this.renderNumericalTableBody}
+      />
+    );
+  };
+
+  renderCategoricalTable = (fields) => {
+    return (
+      <SortableTable
+        entities={fields}
+        tableHeaders={this.CATEGORICAL_FIELD_HEADERS}
+        renderTableBody={this.renderCategoricalTableBody}
+      />
+    );
+  };
+
+  renderTable = () => {
+    if (!objectQuery(this.state.splitInfo, 'schema', 'fields', 'length')) {
+      return null;
+    }
+    const schema = this.state.splitInfo.schema;
+    const getFieldType = (field) => {
+      let type;
+      // TODO: The assumption fields cannot have complex type coming from dataprep wrangler
+      // Need to verify this.
+      if (Array.isArray(field.type)) {
+        type = field.type.filter(t => t !== 'null').pop();
+      } else if (typeof field.type === 'string') {
+        type = field.type;
+      }
+      return type;
+    };
+    const getStats = ({name: fieldName}) => {
+      let stat = findLast(this.state.splitInfo.stats, stat => stat.field === fieldName);
+      stat = {
+        numTotal: objectQuery(stat, 'numTotal', 'total') || '--',
+        numNull: objectQuery(stat, 'numNull', 'total') || '--',
+        numEmpty: objectQuery(stat, 'numEmpty', 'total') || '--',
+        unique: objectQuery(stat, 'unique', 'total') || '--',
+        numZero: objectQuery(stat, 'numZero', 'total') || '--',
+        numPositive: objectQuery(stat, 'numPositive', 'total') || '--',
+        numNegative: objectQuery(stat, 'numNegative', 'total') || '--',
+        min: objectQuery(stat, 'min', 'total') || '--',
+        max: objectQuery(stat, 'max', 'total') || '--',
+        stddev: objectQuery(stat, 'stddev', 'total') || '--',
+        mean: objectQuery(stat, 'mean', 'total') || '--'
+      };
+      return {
+        name: fieldName,
+        ...stat
+      };
+    };
+    const searchMatchFilter = (field => {
+      if (this.state.search.length) {
+        return field.name.indexOf(this.state.search) !== -1 ? true : false;
+      }
+      return field;
+    });
+    const typeMatchFilter = (field => this.state.selectedTypes.indexOf(getFieldType(field)) !== -1);
+    const categoricalFields = schema.fields
+      .filter((field) => typeMatchFilter(field) && searchMatchFilter(field) && !this.isFieldNumberType(getFieldType(field)))
+      .map(getStats.bind(this));
+    const numericalFields = schema.fields
+      .filter((field) => typeMatchFilter(field) && searchMatchFilter(field) && this.isFieldNumberType(getFieldType(field)))
+      .map(getStats.bind(this));
+    const countOfType = (type) => schema.fields.filter(field => getFieldType(field) === type).length;
+    return (
+      <div className="split-info-table-container">
+        <div className="split-table-search">
+        <div className="filter-container">
+          <span> Data Type: </span>
+          <span>
+            <Input
+              type="checkbox"
+              checked={this.state.selectedTypes.indexOf('boolean') !== -1}
+              onChange={this.onToggleSelectedType}
+              name="boolean"
+            />
+            <span> Boolean ({countOfType('boolean')}) </span>
+          </span>
+          <span>
+            <Input
+              type="checkbox"
+              checked={this.state.selectedTypes.indexOf('double') !== -1}
+              onChange={this.onToggleSelectedType}
+              name="double"
+            />
+            <span> Double ({countOfType('double')}) </span>
+          </span>
+          <span>
+            <Input
+              type="checkbox"
+              checked={this.state.selectedTypes.indexOf('float') !== -1}
+              onChange={this.onToggleSelectedType}
+              name="float"
+            />
+            <span> Float ({countOfType('float')}) </span>
+          </span>
+          <span>
+            <Input
+              type="checkbox"
+              checked={this.state.selectedTypes.indexOf('int') !== -1}
+              onChange={this.onToggleSelectedType}
+              name="int"
+            />
+            <span> Integer ({countOfType('int')}) </span>
+          </span>
+          <span>
+            <Input
+              type="checkbox"
+              checked={this.state.selectedTypes.indexOf('long') !== -1}
+              onChange={this.onToggleSelectedType}
+              name="long"
+            />
+            <span> Long ({countOfType('long')}) </span>
+          </span>
+          <span>
+            <Input
+              type="checkbox"
+              checked={this.state.selectedTypes.indexOf('string') !== -1}
+              onChange={this.onToggleSelectedType}
+              name="string"
+            />
+            <span> String ({countOfType('string')}) </span>
+          </span>
+        </div>
+        <Input
+          className="table-field-search"
+          placeholder="Search Column name"
+          onChange={this.onSearch}
+        />
+        </div>
+        <div className="split-info-numerical-table">
+          <div className="split-table-header">Numerical Data</div>
+          {this.renderNumericalTable(numericalFields)}
+        </div>
+        <div className="split-info-categorical-table">
+          <div className="split-table-header">Categorical Data</div>
+          {this.renderCategoricalTable(categoricalFields)}
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <div className="split-info-table">
+        <div className="split-info-collapsable-section" onClick={this.toggleCollapse}>
+          {
+            this.state.collapsed ? <IconSVG name="icon-caret-right" /> : <IconSVG name="icon-caret-down" />
+          }
+          <span> Select a row to inspect how Test Data is compared to the Training Data </span>
+        </div>
+        {
+          !this.state.collapsed ?
+            <div className="split-info-table-section">
+              {this.renderTable()}
+            </div>
+          :
+            null
+        }
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/index.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect, Provider} from 'react-redux';
+import createExperimentStore from 'components/Experiments/store/createExperimentStore';
+import {createSplitAndUpdateStatus, setSplitFinalized} from 'components/Experiments/store/ActionCreator';
+import SplitInfo from 'components/Experiments/CreateView/SplitDataStep/SplitInfo';
+import IconSVG from 'components/IconSVG';
+
+require('./SplitDataStep.scss');
+
+const renderSplitBtn = (splitInfo, onClick) => {
+  let isSplitCreated = Object.keys(splitInfo).length;
+  let isSplitComplete = (splitInfo || {}).status === 'Complete';
+  if (!isSplitCreated || (isSplitCreated && isSplitComplete)) {
+    return (
+      <button
+        className="btn btn-primary"
+        onClick={onClick}
+      >
+        Split data Randomly and verify sample
+      </button>
+    );
+  }
+  return (
+    <button
+      className="btn btn-primary"
+      disabled
+    >
+      <div className="btn-inner-container">
+        <IconSVG name="icon-spinner" className="fa-spin" />
+        <span>Splitting data</span>
+      </div>
+    </button>
+  );
+};
+
+function SplitDataStep({splitInfo = {}, createSplitAndUpdateStatus, setSplitFinalized}) {
+  let splitStatus = splitInfo.status || 'Complete';
+  return (
+    <div className="split-data-step">
+      <h3>Split Data </h3>
+      <div>Create Test Dataset for this Model.</div>
+      <br />
+      {renderSplitBtn(splitInfo, createSplitAndUpdateStatus)}
+      {
+        Object.keys(splitInfo).length && splitInfo.status === 'Complete' ? (
+          <div className="action-button-group">
+            <SplitInfo />
+            <button
+              className="btn btn-primary"
+              onClick={setSplitFinalized}
+              disabled={splitStatus !== 'Complete'}
+            >
+              Done
+            </button>
+            <span> Next, Select a machine learning algorithm </span>
+          </div>
+        ) : null
+      }
+    </div>
+  );
+}
+
+SplitDataStep.propTypes = {
+  splitInfo: PropTypes.object,
+  schema: PropTypes.object,
+  createSplitAndUpdateStatus: PropTypes.func,
+  setSplitFinalized: PropTypes.func
+};
+
+const mapStateToSplitDataStepProps = (state) => {
+  let {model_create} = state;
+  let {splitInfo = {}} = model_create;
+  return {
+    splitInfo: splitInfo,
+    schema: splitInfo.schema
+  };
+};
+const mapDispatchToSplitDataStepProps = () => {
+  return {
+    createSplitAndUpdateStatus,
+    setSplitFinalized
+  };
+};
+const ConnectedSplitDataStep = connect(mapStateToSplitDataStepProps, mapDispatchToSplitDataStepProps)(SplitDataStep);
+function ProvidedSplitDataStep() {
+  return (
+    <Provider store={createExperimentStore}>
+      <ConnectedSplitDataStep />
+    </Provider>
+  );
+}
+export default ProvidedSplitDataStep;
+

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
@@ -39,6 +39,13 @@
     .table-scroll {
       height: calc(100% - 25px);
     }
+    a.grid-body-row-container {
+      text-decoration: none;
+      color: inherit;
+      &:hover {
+        text-decoration: none;
+      }
+    }
     .grid-body-row-container {
       width: 100%;
       &.opened {

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
@@ -43,12 +43,12 @@ let tableHeaders = [
   {
     label: 'Model Name',
     property: 'name',
-    width: '20%'
+    width: '15%'
   },
   {
     label: 'Status',
     property: 'status',
-    width: '10%'
+    width: '15%'
   },
   {
     label: 'Algorithm',
@@ -178,13 +178,20 @@ const renderTableBody = (experimentId, outcomeType, models) => {
     <div className="grid-body">
       {
         list.map((model) => {
+          let Component = 'div';
+          let props = {
+            className: classnames("grid-body-row-container", {
+              "opened": model.active
+            }),
+            key: model.id
+          };
+          let inSplitStep = (['SPLITTING', 'DATA_READY', 'EMPTY'].indexOf(model.status) !== -1);
+          if (inSplitStep) {
+            Component = Link;
+            props.to = `/ns/${getCurrentNamespace()}/experiments/create?experimentId=${experimentId}&modelId=${model.id}`;
+          }
           return (
-            <div
-              className={classnames("grid-body-row-container", {
-                "opened": model.active
-              })}
-              key={model.id}
-            >
+            <Component {...props}>
               <div
                 className={classnames("grid-body-row", {
                   "opened": model.active
@@ -195,10 +202,12 @@ const renderTableBody = (experimentId, outcomeType, models) => {
                 {renderItem(newHeaders[1].width, model.name)}
                 {renderItem(newHeaders[2].width, <ModelStatusIndicator status={model.status || '--'} />)}
                 {renderItem(newHeaders[3].width, (
-                  <span className="algorithm-cell">
-                    <IconSVG name="icon-cog" />
-                    <span>{model.algorithm}</span>
-                  </span>
+                  !inSplitStep ? (
+                    <span className="algorithm-cell">
+                      <IconSVG name="icon-cog" />
+                      <span>{model.algorithm}</span>
+                    </span>)
+                  : '--'
                 ))}
                 {renderMetrics(newHeaders, model)}
                 {
@@ -243,7 +252,7 @@ const renderTableBody = (experimentId, outcomeType, models) => {
                 :
                   null
               }
-            </div>
+            </Component>
           );
        })
       }

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ExperimentsListBarChart/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ExperimentsListBarChart/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/cdap/components/Experiments/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,7 +23,7 @@ import SortableStickyTable from 'components/SortableStickyTable';
 import PieChart from 'components/PieChart';
 import PaginationWithTitle from 'components/PaginationWithTitle';
 import d3 from 'd3';
-import ExperimentsListBarChart from 'components/Experiments/ExperimentsListBarChart';
+import ExperimentsListBarChart from 'components/Experiments/ListView/ExperimentsListBarChart';
 import PlusButton from 'components/PlusButton';
 import EmptyMessageContainer from 'components/EmptyMessageContainer';
 import NamespaceStore, {getCurrentNamespace} from 'services/NamespaceStore';

--- a/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,7 +21,9 @@ import {myExperimentsApi} from 'api/experiments';
 import NamespaceStore, {getCurrentNamespace} from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
 import {directiveRequestBodyCreator} from 'components/DataPrep/helper';
-import MLAlgorithmsList from 'components/Experiments/store/MLAlgorithmsList';
+import {CLASSIFIER_ALGORITHMS, REGRESSION_ALGORITHMS} from 'components/Experiments/store/MLAlgorithmsList';
+import { Observable } from 'rxjs/Observable';
+import {NUMBER_TYPES} from 'services/global-constants';
 
 function setExperimentsLoading() {
   experimentsStore.dispatch({
@@ -106,12 +108,23 @@ function setDirectives(directives) {
     payload: {directives}
   });
 }
-
-function setExperimentCreated(value) {
+function setVisiblePopover(popover = 'experiment') {
   createExperimentStore.dispatch({
-    type: CREATEEXPERIMENTACTIONS.SET_NEW_EXPERIMENT_CREATED,
+    type: CREATEEXPERIMENTACTIONS.SET_VISIBLE_POPOVER,
+    payload: {popover}
+  });
+}
+function setExperimentCreated(experimentId) {
+  let url = `${location.pathname}?experimentId=${experimentId}`;
+  history.replaceState(
+    { url },
+    document.title,
+    url
+  );
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_VISIBLE_POPOVER,
     payload: {
-      isExperimentCreated: typeof value === 'boolean' ? value : true
+      popover: 'model'
     }
   });
 }
@@ -139,12 +152,6 @@ function onModelDescriptionChange(e) {
   });
 }
 
-function setModelCreated() {
-  createExperimentStore.dispatch({
-    type: CREATEEXPERIMENTACTIONS.SET_MODEL_CREATED
-  });
-}
-
 function setModelAlgorithm(algorithm) {
   createExperimentStore.dispatch({
     type: CREATEEXPERIMENTACTIONS.SET_MODEL_ML_ALGORITHM,
@@ -159,45 +166,49 @@ function setWorkspace(workspaceId) {
   });
 }
 
-function createExperiment(experiment) {
-  let {selectedNamespace: namespace} = NamespaceStore.getState();
-  return myExperimentsApi.createExperiment({namespace, experimentId: experiment.name}, experiment);
+function updateSchema(fields) {
+  let schema = {
+    name: 'avroSchema',
+    type: 'record',
+    fields
+  };
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_SCHEMA,
+    payload: {schema}
+  });
 }
 
-function createModel(experiment, model) {
-  let {selectedNamespace: namespace} = NamespaceStore.getState();
-  return myExperimentsApi.createModelInExperiment({namespace, experimentId: experiment.name}, model);
+function setSplitDetails(experimentId, splitId) {
+  if (splitId.id) {
+    splitId = splitId.id;
+  }
+  myExperimentsApi
+    .getSplitDetails({
+      namespace: getCurrentNamespace(),
+      experimentId,
+      splitId
+    })
+    .subscribe((splitInfo) => {
+      createExperimentStore.dispatch({
+        type: CREATEEXPERIMENTACTIONS.SET_SPLIT_INFO,
+        payload: {splitInfo}
+      });
+    });
 }
 
-function createExperimentAndModel() {
-  let {experiments_create, model_create} = createExperimentStore.getState();
-  let {selectedNamespace: namespace} = NamespaceStore.getState();
-  let {workspaceId, directives} = model_create;
+function createExperiment() {
+  let {model_create, experiments_create} = createExperimentStore.getState();
+  let {directives} = model_create;
   let requestBody = directiveRequestBodyCreator(directives);
   let experiment = {
-    name: experiments_create.name,
-    description: experiments_create.description,
-    outcome: experiments_create.outcome,
-    srcpath: experiments_create.srcpath,
-    workspaceId: model_create.workspaceId
+    ...experiments_create
   };
-  setExperimentLoading();
-  let fields;
-
-  let model = {
-    name: model_create.name,
-    description: model_create.description,
-    algorithm: model_create.algorithm.name,
-    hyperparameters: {},
-    split: 'random',
-    directives: model_create.directives,
-    features: model_create.columns.filter(column => column !== experiments_create.outcome)
-  };
-
   MyDataPrepApi
-    .getSchema({ namespace, workspaceId}, requestBody)
+    .getSchema({
+      namespace: getCurrentNamespace(),
+      workspaceId: experiments_create.workspaceId
+    }, requestBody)
     .mergeMap((schema) => {
-      fields = schema;
       // The outcome will always be simple type. So ["null", "anything"] should give correct outcomeType at the end.
       let outcomeType = schema
         .find(field => field.name === experiment.outcome)
@@ -205,30 +216,119 @@ function createExperimentAndModel() {
         .filter(t => t !== 'null')
         .pop();
       experiment.outcomeType = outcomeType;
-      return createExperiment(experiment);
+      updateSchema(schema);
+      return myExperimentsApi.createExperiment({
+        namespace: getCurrentNamespace(),
+        experimentId: experiment.name
+      }, experiment);
     })
-    .mergeMap(() => {
-      let tempSchema = {
-        name: 'avroSchema',
-        type: 'record',
-        fields
-      };
-      let splitInfo = {
-        schema: tempSchema,
-        directives,
-        type: 'random',
-        parameters: { percent: "80"},
-        description: `Default Random split created for model: ${model_create.name}`
-      };
-      return myExperimentsApi.createSplit({namespace, experimentId: experiments_create.name}, splitInfo);
+    .subscribe(setExperimentCreated.bind(null, experiments_create.name));
+}
+
+function pollForSplitStatus(experimentId, split) {
+  const getStatusOfSplit = (callback, errorCallback) => {
+    const params = {
+      namespace: getCurrentNamespace(),
+      experimentId,
+      splitId: split.id
+    };
+    let splitStautsPoll = myExperimentsApi
+      .getSplitStatus(params)
+      .subscribe(status => {
+        if (status === 'Splitting') {
+          return;
+        }
+        if (status === 'Complete') {
+          splitStautsPoll.unsubscribe();
+          return callback();
+        }
+        errorCallback();
+      });
+  };
+  return Observable.create((observer) => {
+    const successCallback = () => {
+      observer.next(split);
+    };
+    const failureCallback = () => {
+      observer.error(`Couldn't create split`);
+    };
+    getStatusOfSplit(successCallback, failureCallback);
+  });
+}
+
+function createSplitAndUpdateStatus() {
+  let {model_create, experiments_create} = createExperimentStore.getState();
+  let {directives, schema} = model_create;
+  let splitInfo = {
+    schema,
+    directives,
+    type: 'random',
+    parameters: { percent: "80"},
+    description: `Default Random split created for model: ${model_create.name}`
+  };
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_SPLIT_INFO,
+    payload: {
+      splitInfo: {
+        id: null,
+        status: 'CREATING' // INTERMEDIATE STATE TO SHOW LOADING ANIMATION FOR THE SPLIT BUTTON
+      }
+    }
+  });
+  myExperimentsApi
+    .createSplit({namespace: getCurrentNamespace(), experimentId: experiments_create.name}, splitInfo)
+    .mergeMap(split => {
+      setSplitDetails(experiments_create.name, split.id, true);
+      addSplitToModel(split.id);
+      return pollForSplitStatus(experiments_create.name, split);
     })
-    .mergeMap(({id: split}) => createModel(experiment, {...model, split}))
-    .subscribe(() => {
-      let {selectedNamespace: namespace} = NamespaceStore.getState();
-      window.location.href = `${window.location.origin}/cdap/ns/${namespace}/experiments/${experiment.name}`;
+    .subscribe(setSplitDetails.bind(null, experiments_create.name));
+}
+
+function createModel() {
+  let {experiments_create, model_create} = createExperimentStore.getState();
+  let {split} = model_create;
+  let model = {
+    name: model_create.name,
+    description: model_create.description
+  };
+
+  return myExperimentsApi
+    .createModelInExperiment({namespace: getCurrentNamespace(), experimentId: experiments_create.name}, {...model, split})
+    .subscribe(({id: modelId}) => {
+      createExperimentStore.dispatch({
+        type: CREATEEXPERIMENTACTIONS.SET_MODEL_ID,
+        payload: {modelId}
+      });
+      setExperimentLoading(false);
+      let url = `${location.pathname}${location.search}&modelId=${modelId}`;
+      history.replaceState(
+        { url },
+        document.title,
+        url
+      );
     }, (err) => {
       console.log('ERROR: ', err); // FIXME: We should surface the errors. There will be errors
       setExperimentLoading(false);
+    });
+}
+
+function trainModel() {
+  let {experiments_create, model_create} = createExperimentStore.getState();
+  let {name: experimentId} = experiments_create;
+  let {modelId} = model_create;
+  let postBody = {
+    algorithm: model_create.algorithm.name,
+    hyperParameters: {}
+  };
+  return myExperimentsApi
+    .trainModel({
+      namespace: getCurrentNamespace(),
+      experimentId,
+      modelId
+    }, postBody)
+    .subscribe(() => {
+      window.location.href = `${window.location.origin}/cdap/ns/${getCurrentNamespace()}/experiments/${experimentId}`;
     });
 }
 
@@ -327,7 +427,7 @@ function setActiveModel(activeModelId) {
 }
 
 const getAlgorithmLabel = (algorithm) => {
-  let match = MLAlgorithmsList.find(algo => algo.name === algorithm);
+  let match = [...REGRESSION_ALGORITHMS, ...CLASSIFIER_ALGORITHMS].find(algo => algo.name === algorithm);
   if (match) {
     return match.label;
   }
@@ -335,18 +435,174 @@ const getAlgorithmLabel = (algorithm) => {
 };
 
 const getExperimentForEdit = (experimentId) => {
+  setExperimentLoading();
+  let experiment;
   myExperimentsApi
     .getExperiment({
       namespace: getCurrentNamespace(),
       experimentId
     })
-    .subscribe(experimentDetails => {
+    .mergeMap(exp => {
+      experiment = exp;
+    // Get workspace info for directives
+      return MyDataPrepApi.getWorkspace({
+        namespace: getCurrentNamespace(),
+        workspaceId: exp.workspaceId
+      });
+    })
+    .mergeMap(workspaceInfo => {
+    // Get schema with workspaceId and directives
+      let directives = workspaceInfo.values[0].recipe.directives;
+      setDirectives(directives);
+      let requestBody = directiveRequestBodyCreator(directives);
+      return MyDataPrepApi.getSchema({
+        namespace: getCurrentNamespace(),
+        workspaceId: experiment.workspaceId
+      }, requestBody);
+    })
+    .subscribe(fields => {
+      let schema = {
+        name: 'avroSchema',
+        type: 'record',
+        fields
+      };
       createExperimentStore.dispatch({
         type: CREATEEXPERIMENTACTIONS.SET_EXPERIMENT_METADATA_FOR_EDIT,
-        payload: {experimentDetails}
+        payload: {
+          experimentDetails: experiment,
+          schema
+        }
       });
     });
 };
+
+const getExperimentModelSplitForCreate = (experimentId, modelId) => {
+  setExperimentLoading();
+  let experiment, model;
+  // Get experiment
+  myExperimentsApi
+    .getExperiment({
+      namespace: getCurrentNamespace(),
+      experimentId
+    })
+    .mergeMap(exp => {
+      experiment = exp;
+    // Get workspace info for directives
+      return MyDataPrepApi.getWorkspace({
+        namespace: getCurrentNamespace(),
+        workspaceId: exp.workspaceId
+      });
+    })
+    .mergeMap(workspaceInfo => {
+    // Get schema with workspaceId and directives
+      let directives = workspaceInfo.values[0].recipe.directives;
+      setDirectives(directives);
+      let requestBody = directiveRequestBodyCreator(directives);
+      return MyDataPrepApi.getSchema({
+        namespace: getCurrentNamespace(),
+        workspaceId: experiment.workspaceId
+      }, requestBody);
+    })
+    .mergeMap((schema) => {
+      updateSchema(schema);
+    // Get model details
+      return myExperimentsApi
+        .getModel({
+          namespace: getCurrentNamespace(),
+          experimentId: experiment.name,
+          modelId
+        });
+    })
+    .mergeMap(m => {
+      model = m;
+      // The user refreshed before creating the split. So no split info is present in model.
+      if (!m.split) {
+        return Observable.create((observer) => {
+          observer.next(false);
+        });
+      }
+      // If split already created get the split info to check the status of split.
+      return myExperimentsApi
+        .getSplitDetails({
+          namespace: getCurrentNamespace(),
+          experimentId: experiment.name,
+          splitId: m.split
+        });
+    })
+    .subscribe(
+      splitInfo => {
+        let payload = {
+          experimentDetails: experiment,
+          modelDetails: model
+        };
+        if (splitInfo) {
+          payload.splitInfo = splitInfo;
+        }
+        createExperimentStore.dispatch({
+          type: CREATEEXPERIMENTACTIONS.SET_EXPERIMENT_MODEL_FOR_EDIT,
+          payload
+        });
+        if (typeof splitInfo === 'object' && splitInfo.status !== 'Complete') {
+          pollForSplitStatus(experiment.name, splitInfo)
+            .subscribe(setSplitDetails.bind(null, experiment.name));
+        }
+      },
+      (err) => {
+        console.log('Failed to retrieve experiment and model: ', err);
+      }
+    );
+};
+
+function setAlgorithmList() {
+  let {experiments_create} = createExperimentStore.getState();
+  let outcome = experiments_create.outcome;
+  let {model_create} = createExperimentStore.getState();
+  let {directives} = model_create;
+  let requestBody = directiveRequestBodyCreator(directives);
+  MyDataPrepApi
+    .getSchema({
+      namespace: getCurrentNamespace(),
+      workspaceId: experiments_create.workspaceId
+    }, requestBody)
+    .subscribe(fields => {
+      updateSchema(fields);
+      let outcomeType = fields
+        .find(field => field.name === outcome)
+        .type
+        .filter(t => t !== 'null')
+        .pop();
+      createExperimentStore.dispatch({
+        type: CREATEEXPERIMENTACTIONS.SET_ALGORITHMS_LIST,
+        payload: {
+          algorithmsList: (NUMBER_TYPES.indexOf(outcomeType) !== -1) ? REGRESSION_ALGORITHMS : CLASSIFIER_ALGORITHMS
+        }
+      });
+    });
+}
+
+function addSplitToModel(splitId) {
+  let {experiments_create, model_create} = createExperimentStore.getState();
+  myExperimentsApi
+    .setSplitToModel({
+      namespace: getCurrentNamespace(),
+      experimentId: experiments_create.name,
+      modelId: model_create.modelId
+    }, {id: splitId})
+    .subscribe();
+}
+
+function setSplitFinalized() {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.SET_SPLIT_FINALIZED,
+    payload: {isSplitFinalized: true}
+  });
+}
+
+function resetCreateExperimentsStore() {
+  createExperimentStore.dispatch({
+    type: CREATEEXPERIMENTACTIONS.RESET
+  });
+}
 
 export {
   setExperimentsLoading,
@@ -362,9 +618,10 @@ export {
   setExperimentCreated,
   onModelNameChange,
   onModelDescriptionChange,
-  setModelCreated,
   setModelAlgorithm,
-  createExperimentAndModel,
+  createExperiment,
+  createSplitAndUpdateStatus,
+  createModel,
   setSrcPath,
   getExperimentDetails,
   getModelsInExperiment,
@@ -372,6 +629,13 @@ export {
   deleteExperiment,
   getAlgorithmLabel,
   getModelStatus,
-  getExperimentForEdit
+  getExperimentForEdit,
+  addSplitToModel,
+  getExperimentModelSplitForCreate,
+  setSplitFinalized,
+  trainModel,
+  resetCreateExperimentsStore,
+  setAlgorithmList,
+  setVisiblePopover
 };
 

--- a/cdap-ui/app/cdap/components/Experiments/store/MLAlgorithmsList.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/MLAlgorithmsList.js
@@ -14,7 +14,7 @@
  * the License.
 */
 
-export default [
+const REGRESSION_ALGORITHMS = [
   {
     name: 'linear.regression',
     label: 'Linear Regression'
@@ -36,3 +36,30 @@ export default [
     label: 'Gradient Boosted Tree Regression'
   }
 ];
+const CLASSIFIER_ALGORITHMS = [
+  {
+    name: 'decision.tree.classifier',
+    label: 'Decision Tree Classifier'
+  },
+  {
+    name: 'random.forest.classifier',
+    label: 'Random Forest Classifier'
+  },
+  {
+    name: 'gradient.boosted.tree.classifier',
+    label: 'Gradient Boosted Tree Classifier'
+  },
+  {
+    name: 'multilayer.perceptron.classifier',
+    label: 'Multilayer Perceptron Classifier'
+  },
+  {
+    name: 'logistic.regression',
+    label: 'Logistic Regression'
+  },
+  {
+    name: 'naive.bayes',
+    label: 'Naive Bayes'
+  }
+];
+export {REGRESSION_ALGORITHMS, CLASSIFIER_ALGORITHMS};

--- a/cdap-ui/app/cdap/components/Experiments/store/experimentDetailStore.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/experimentDetailStore.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,8 @@
  * the License.
 */
 
-import {createStore, compose} from 'redux';
+import {createStore} from 'redux';
+import {composeEnhancers} from 'services/helpers';
 import {defaultAction} from 'services/helpers';
 
 const ACTIONS = {
@@ -116,17 +117,12 @@ const experimentDetails = (state = DEFAULT_EXPERIMENT_DETAILS, action = defaultA
       return state;
   }
 };
-const composeEnhancers =
-typeof window === 'object' &&
-window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
-  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-    name: 'ExperimentDetailStore'
-  }) : compose;
+
 
 const experimentDetailsStore = createStore(
   experimentDetails,
   DEFAULT_EXPERIMENT_DETAILS,
-  composeEnhancers()
+  composeEnhancers('ExperimentDetailStore')()
 );
 
 export default experimentDetailsStore;

--- a/cdap-ui/app/cdap/components/GroupedBarChart/index.js
+++ b/cdap-ui/app/cdap/components/GroupedBarChart/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -45,7 +45,7 @@ const chartSpec = {
   }
 };
 
-export default function GroupedBarChart({data, customEncoding = {}, width, heightOffset}) {
+export default function GroupedBarChart({data, customEncoding = {}, width, heightOffset, tooltipOptions}) {
   let newSpec = {
     ...chartSpec,
     "encoding": {
@@ -60,6 +60,7 @@ export default function GroupedBarChart({data, customEncoding = {}, width, heigh
       className="grouped-bar-chart"
       width={width}
       heightOffset={heightOffset}
+      tooltipOptions={tooltipOptions}
     />
   );
 }
@@ -74,5 +75,6 @@ GroupedBarChart.propTypes = {
   })).isRequired,
   customEncoding: PropTypes.object,
   width: PropTypes.oneOfType(PropTypes.number, PropTypes.func),
-  heightOffset: PropTypes.number
+  heightOffset: PropTypes.number,
+  tooltipOptions:  PropTypes.object
 };

--- a/cdap-ui/app/cdap/components/VegaLiteChart/index.js
+++ b/cdap-ui/app/cdap/components/VegaLiteChart/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,7 +30,8 @@ export default class VegaLiteChart extends Component {
     className: PropTypes.string,
     widthOffset: PropTypes.number,
     heightOffset: PropTypes.number,
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+    tooltipOptions: PropTypes.object
   };
   state = {
     data: this.props.data || [],
@@ -40,6 +41,9 @@ export default class VegaLiteChart extends Component {
   componentDidMount() {
     this.renderChart();
     document.body.onresize = debounce(this.renderChart, 1);
+  }
+  componentWillUnmount() {
+    document.body.onresize = null;
   }
   componentWillReceiveProps(nextProps) {
     this.setState({data: nextProps.data || []}, this.renderChart.bind(this, true));
@@ -89,7 +93,11 @@ export default class VegaLiteChart extends Component {
         .initialize(el)
         .renderer('svg')
         .hover();
-      vegaTooltip.vega(this.view);
+        if (this.props.tooltipOptions && Object.keys(this.props.tooltipOptions).length) {
+          vegaTooltip.vega(this.view, this.props.tooltipOptions);
+        } else {
+          vegaTooltip.vega(this.view);
+        }
       this.bindData();
     } catch (err) {
       console.log('ERROR: Failed to compile vega spec ', err);

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,7 +23,7 @@ const pluginLabels = {
   'action': 'Conditions and Actions',
   'erroralert': 'Error Handlers and Alerts'
 };
-export const NUMBER_TYPES = ['integer', 'short', 'long', 'float', 'double'];
+export const NUMBER_TYPES = ['integer', 'int', 'short', 'long', 'float', 'double'];
 const GLOBALS = {
   etlBatch: 'cdap-etl-batch',
   etlRealtime: 'cdap-etl-realtime',

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,7 @@ import moment from 'moment';
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import T from 'i18n-react';
+import {compose} from 'redux';
 
 /*
   Purpose: Query a json object or an array of json objects
@@ -264,6 +265,13 @@ const isBatchPipeline = (pipelineType) => {
   return ['cdap-data-pipeline'].indexOf(pipelineType) !== -1;
 };
 
+const composeEnhancers = (storeTitle) =>
+  typeof window === 'object' &&
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+      name: storeTitle
+    }) : compose;
+
 export {
   objectQuery,
   convertBytesToHumanReadable,
@@ -282,5 +290,6 @@ export {
   difference,
   isPluginSource,
   isPluginSink,
-  isBatchPipeline
+  isBatchPipeline,
+  composeEnhancers
 };


### PR DESCRIPTION
- Moves components around CreateView/ListView/DetailedView in Experiments feature
- Fixes `VegaLiteChart` and `GroupedBarChart` to be a little more generic
- Adds Split Data Step while creating a model.
  The sequence of steps that we have finalized for spliting data and creating/training a model are,
  - User chooses the dataset
  - Clean up using wrangler
  - Create an experiment (if not already exists)
  - Provide name and description to the model
  - Split the data randomly and analyze the results of the split.
  - If the split is not satisfactory repeat above step
  - If satisfied with the split, then choose algorithm
  - Train the model.
- Sets the appropriate algorithms list based on outcome type.

JIRA: https://issues.cask.co/browse/CDAP-12709, https://issues.cask.co/browse/CDAP-13049

#### Todo:
- Need to split ActionCreator for Experiment into respective view/ActionCreators as it is growing too large to be manageable. Will do in a subsequent PR.
- i18n