### PR TITLE
[CDAP-13022] Adds radio-group widget to be able to use radio buttons in plugin configuration

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -253,6 +253,13 @@ angular.module(PKG.name + '.commons')
           'ng-model': 'model',
           'config': 'myconfig'
         }
+      },
+      'radio-group': {
+        element: '<my-radio-group></my-radio-group>',
+        attributes: {
+          'ng-model': 'model',
+          'config': 'myconfig'
+        }
       }
     };
     this.registry['__default__'] = this.registry['textbox'];

--- a/cdap-ui/app/directives/widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.js
+++ b/cdap-ui/app/directives/widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.js
@@ -20,8 +20,7 @@ angular.module(PKG.name + '.commons')
       restrict: 'E',
       scope: {
         model: '=ngModel',
-        config: '=',
-        radioBtnMode: '='
+        config: '='
       },
       templateUrl: 'widget-container/widget-multi-select-dropdown/widget-multi-select-dropdown.html',
       controller: function($scope, myHelpers) {

--- a/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.html
+++ b/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.html
@@ -1,0 +1,57 @@
+<!--
+  Copyright © 2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<div
+  ng-class="{
+    'widget-radio-group': true,
+    'widget-radio-group-inline': layout === 'inline'
+  }"
+>
+  <div ng-if="error">
+    <div class="text-danger">
+      {{error}}
+      <div ng-if="model">
+          <label>
+            <input
+              type="radio"
+              id="{{model}}"
+              value="{{model}}"
+              name="{{groupName}}"
+              ng-model="model"
+            />
+            {{model}}
+          </label>
+      </div>
+    </div>
+  </div>
+  <div
+    ng-class="{
+      radio: layout === 'block',
+      'radio-inline': layout === 'inline'
+    }"
+    ng-repeat="option in options"
+  >
+    <label>
+      <input
+        type="radio"
+        id="{{option.id}}"
+        value="{{option.id}}"
+        name="{{groupName}}"
+        ng-model="$parent.model"
+      />
+      {{option.label}}
+    </label>
+  </div>
+</div>

--- a/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.js
+++ b/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+angular.module(PKG.name + '.commons')
+  .directive('myRadioGroup', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        model: '=ngModel',
+        config: '='
+      },
+      templateUrl: 'widget-container/widget-radio-group/widget-radio-group.html',
+      controller: function(myHelpers, $scope, uuid) {
+        $scope.groupName = 'radio-group-'+ uuid.v4();
+        $scope.options = myHelpers.objectQuery($scope.config, 'widget-attributes', 'options') || [];
+        if (!Array.isArray($scope.options) || (Array.isArray($scope.options) && !$scope.options.length)) {
+          $scope.error = 'Missing options for ' + myHelpers.objectQuery($scope.config, 'name');
+        }
+        let defaultValue = myHelpers.objectQuery($scope.config, 'widget-attributes', 'default') || '';
+        $scope.layout = myHelpers.objectQuery($scope.config, 'widget-attributes', 'layout') || 'block';
+        $scope.model = $scope.model || defaultValue;
+        let isModelValid = $scope.options.find(option => option.id === $scope.model);
+        if (!isModelValid) {
+          $scope.error = 'Unknown value for ' + myHelpers.objectQuery($scope.config, 'name') + ' specified.';
+        }
+        $scope.$watch('model', () => {
+          let isModelValid = $scope.options.find(option => option.id === $scope.model);
+          if (isModelValid) {
+            $scope.error = null;
+          }
+        });
+        $scope.options = $scope.options.map(option => ({
+          id: option.id,
+          label: option.label || option.id
+        }));
+      }
+    };
+  });

--- a/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.less
+++ b/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.less
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+.widget-radio-group {
+  &.widget-radio-group-inline {
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    .radio-inline {
+      margin: 0 5px;
+      font-weight: normal;
+      > label {
+        font-weight: normal;
+        margin-bottom: 0;
+        > input[type="radio"] {
+          margin-top: 2px;
+        }
+      }
+    }
+  }
+  .radio {
+    > label {
+      > input[type="radio"] {
+        margin-top: 2px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Adds `radio-group` widget to be used in plugin configuration modal.
- widget json structure:

  ```
  {
    "widget-type": "radio-group",
    "label": "Formats",
    "name": "format",
    "widget-attributes": {
      "layout": "inline", // or "block" or nothing to render one radio option below other
      "options": [
          {
            "id": "DELIMITED",
            "label": "Delimited"
          },
          {
            "id": "EXCEL",
            "label": "Excel"
          },
          {
            "id": "MYSQL",
            "label": "MySql"
          },
          {
            "id": "RFC4180",
            "label": "RFC 4180"
          },
          {
            "id": "TDF",
            "label": "Trusted Data Format"
          }
      ],
      "default": "DELIMITED"
    }
  },
  ```
  
JIRA: https://issues.cask.co/browse/CDAP-13022