### PR TITLE
[CDAP-13054] Fix z-index for the generic PlusButton component

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrep.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrep.scss
@@ -57,6 +57,9 @@ $toggle-btn-disabled-bg-color: #cccccc;
         width: 100%;
         height: 100%;
         color: white;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
 
       &:hover {

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/GCSBrowser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/GCSBrowser.scss
@@ -27,43 +27,6 @@ $gcs_file_icon_color: $orange-03;
 .gcs-browser {
   height: 100%;
 
-  .sub-panel {
-
-    &.routing-disabled {
-      display: block;
-      > div {
-        display: block;
-        &:first-child {
-          margin-top: 10px;
-        }
-        &:last-child {
-          display: flex;
-          justify-content: space-between;
-        }
-      }
-    }
-    padding: 0 15px;
-    display: flex;
-    justify-content: space-between;
-    > div {
-      flex: 0.5;
-      display: flex;
-      align-items: center;
-      &:last-child {
-        justify-content: flex-end;
-      }
-    }
-    .info {
-      line-height: 46px;
-      font-size: 12px;
-      color: #999999;
-    }
-    .search-container {
-      width: 200px;
-      padding-left: 15px;
-      display: inline-block;
-    }
-  }
   .gcs-content {
     height: calc(100% - 56px - 46px);
     > div {

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/index.js
@@ -119,13 +119,13 @@ export default class GCSBrowser extends Component {
             </div>
           </div>
           <div className={classnames("sub-panel", {'routing-disabled': !this.props.enableRouting})}>
-            <div>
+            <div className="path-container">
               <GCSPath
                 baseStatePath={this.props.match.url}
                 enableRouting={this.props.enableRouting}
               />
             </div>
-            <div>
+            <div className="info-container">
               <span className="info">
                 <ListingInfo />
               </span>

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/S3Browser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/S3Browser.scss
@@ -27,43 +27,6 @@ $s3_file_icon_color: $orange-03;
 .s3-browser {
   height: 100%;
 
-  .sub-panel {
-
-    &.routing-disabled {
-      display: block;
-      > div {
-        display: block;
-        &:first-child {
-          margin-top: 10px;
-        }
-        &:last-child {
-          display: flex;
-          justify-content: space-between;
-        }
-      }
-    }
-    padding: 0 15px;
-    display: flex;
-    justify-content: space-between;
-    > div {
-      flex: 0.5;
-      display: flex;
-      align-items: center;
-      &:last-child {
-        justify-content: flex-end;
-      }
-    }
-    .info {
-      line-height: 46px;
-      font-size: 12px;
-      color: #999999;
-    }
-    .search-container {
-      width: 200px;
-      padding-left: 15px;
-      display: inline-block;
-    }
-  }
   .s3-content {
     height: calc(100% - 56px - 46px);
     > div {

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
@@ -118,13 +118,13 @@ export default class S3Browser extends Component {
             </div>
           </div>
           <div className={classnames("sub-panel", {'routing-disabled': !this.props.enableRouting})}>
-            <div>
+            <div className="path-container">
               <S3Path
                 baseStatePath={this.props.match.url}
                 enableRouting={this.props.enableRouting}
               />
             </div>
-            <div>
+            <div className="info-container">
               <span className="info">
                 <ListingInfo />
               </span>

--- a/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTabs.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTabs.scss
@@ -47,8 +47,14 @@ $workspace-link-active-color: #ff6600;
   width: 250px;
   border-radius: 0;
 
-  &.bs-tether-element-attached-right { margin-left: 0; }
-  &.bs-tether-element-attached-top { margin-top: 2px; }
+  &.bs-tether-element-attached-right {
+    margin-left: 0;
+    z-index: 999;
+  }
+  &.bs-tether-element-attached-top {
+    margin-top: 2px;
+    z-index: 999;
+  }
 
   .workspace-list-dropdown-item {
     display: block;

--- a/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/index.js
@@ -130,7 +130,7 @@ export default class WorkspaceTabs extends Component {
     let containerElem = document.getElementsByClassName('workspace-tabs')[0];
     let boundingBox = containerElem.getBoundingClientRect();
 
-    let maxTabs = Math.floor((boundingBox.width - 100) / WORKSPACE_WIDTH);
+    let maxTabs = Math.floor((boundingBox.width - 200) / WORKSPACE_WIDTH);
 
     let {displayTabs, dropdownTabs} = this.splitTabs(this.state.workspaceList, maxTabs);
 

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DataPrepConnections.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DataPrepConnections.scss
@@ -19,8 +19,9 @@ $connections-panel-border-color: #cccccc;
 $connections-menu-active-color: #ff6600;
 $connections-menu-item-color: #333333;
 $top-panel-bg-color: #efefef;
+$info-font-color: #999999;
 $border-color: #cccccc;
-$top-panel-height: 56px;
+$top-panel-height: 50px;
 $gutter-width: 15px;
 
 .dataprep-connections-container {
@@ -142,6 +143,55 @@ $gutter-width: 15px;
   .connections-content {
     width: calc(100% - 250px);
 
+    .sub-panel {
+      padding: 10px;
+      display: flex;
+      .path-container,
+      .info-container {
+        width: 50%;
+      }
+      .path-container {
+        padding-right: 10px;
+        .file-path-container {
+          height: 100%;
+          .paths {
+            display: inline-flex;
+            align-items: center;
+            height: inherit;
+            width: 100%;
+            overflow: hidden;
+
+            a.active-directory {
+              width: 100%;
+              overflow: hidden;
+              text-overflow: ellipsis;
+            }
+          }
+          .collapsed-paths {
+            display: flex;
+            height: 100%;
+            align-items: center;
+          }
+        }
+      }
+      .info-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding-left: 10px;
+        justify-content: flex-end;
+        .info {
+          flex: 0.7;
+          font-size: 12px;
+          color: $info-font-color;
+          text-align: right;
+          padding-right: 5px;
+        }
+        .search-container {
+          flex: 0.3;
+        }
+      }
+    }
     &.expanded { width: 100%; }
   }
 }

--- a/cdap-ui/app/cdap/components/EntityListView/EntityListHeader/EntityListHeader.scss
+++ b/cdap-ui/app/cdap/components/EntityListView/EntityListHeader/EntityListHeader.scss
@@ -33,7 +33,6 @@ $margin-to-border: 0.5rem;
 
   .plus-button {
     margin: 20px 20px 0;
-    z-index: 1061;
     .popper {
       display: none;
     }

--- a/cdap-ui/app/cdap/components/FileBrowser/FileBrowser.scss
+++ b/cdap-ui/app/cdap/components/FileBrowser/FileBrowser.scss
@@ -22,10 +22,8 @@ $table-row-hover-color: #eeeeee;
 $folder-icon-color: $blue-02;
 $file-icon-color: $orange-03;
 $table-font-color: #333333;
-$info-font-color: #999999;
 $row-disabled-color: #aaaaaa;
 $subpanel-height: 46px;
-$gutter-width: 15px;
 $divider-color: #999999;
 $empty-message-link-color: $cdap-orange;
 
@@ -34,34 +32,9 @@ $empty-message-link-color: $cdap-orange;
   // overwrite this height styling
   height: calc(100vh - 50px - 54px);
 
-  .sub-panel {
-    padding: 0 $gutter-width;
-
-    .path-container {
-      line-height: $subpanel-height;
-    }
-
-    .search-container,
-    .info {
-      float: left;
-      width: 200px;
-      padding-left: $gutter-width;
-    }
-
-    .info {
-      line-height: $subpanel-height;
-      font-size: 12px;
-      color: $info-font-color;
-    }
-
-    .search-container .form-control {
-      margin-top: ($subpanel-height - 32px) / 2;
-    }
-  }
-
   .directory-content-table {
-    padding: 0 $gutter-width;
-    height: calc(100% - 56px - 46px);
+    padding: 0;
+    height: calc(100% - 50px - 51px);
 
     .row { margin: 0; }
 

--- a/cdap-ui/app/cdap/components/FileBrowser/FilePath/FilePath.scss
+++ b/cdap-ui/app/cdap/components/FileBrowser/FilePath/FilePath.scss
@@ -23,6 +23,12 @@ $dropdown-item-height: 35px;
 
   a {
     color: $path-color;
+    > span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 100px;
+    }
 
     &:hover {
       text-decoration: none;

--- a/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
@@ -162,7 +162,7 @@ export default class FilePath extends Component {
                 onClick={this.handlePropagation.bind(this, path.link)}
                 enableRouting={this.props.enableRouting}
               >
-                {path.name}
+                <span>{path.name}</span>
                 {
                   index !== links.length - 1 ? <span className="path-divider">/</span> : null
                 }

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -504,8 +504,8 @@ export default class FileBrowser extends Component {
           </div>
         </div>
 
-        <div className="sub-panel clearfix">
-          <div className="path-container float-xs-left">
+        <div className="sub-panel">
+          <div className="path-container">
             <FilePath
               baseStatePath={this.state.statePath}
               fullpath={this.state.path}
@@ -514,7 +514,7 @@ export default class FileBrowser extends Component {
             />
           </div>
 
-          <div className="float-xs-right">
+          <div className="info-container">
             <div className="info">
               <span>
                 {T.translate(`${PREFIX}.TopPanel.directoryMetrics`, {count: this.state.contents.length})}

--- a/cdap-ui/app/cdap/components/PlusButton/PlusButton.scss
+++ b/cdap-ui/app/cdap/components/PlusButton/PlusButton.scss
@@ -19,6 +19,7 @@
 .plus-button {
   margin-top: 48px;
   display: inline-block;
+  z-index: 999;
   cursor: pointer;
   .popper {
     width: auto;


### PR DESCRIPTION
- Fixes the z-index for the generic plus button component to be `999` so that it goes underneath any modal or popovers
- Fixes the layout for sub-panel for each connections in dataprep while browsing the connection (S3 or GCS or HDFS). The reason this had to be fixed is,
  - When opened the connection while in dataprep and open the connection drawer the breadcrumbs and the info section now occupies two lines. This automatically adds scrolling on the entire page. Something like in this gif,
  ![connections](https://user-images.githubusercontent.com/1452845/34897168-986851d0-f7a1-11e7-966a-63fd6389c034.gif)
  - The solution I have added for this is to place them side by side and show ellipsis if the path goes too long. There is a corner case where this would not be correct. If the parent folder name is bigger and the current active directory's name is a small one. Like this,
![screen shot 2018-01-12 at 2 08 00 pm](https://user-images.githubusercontent.com/1452845/34897273-0ce12cbc-f7a2-11e7-83e3-46e07943809c.png)
  - A easier manageable solution for this would be to render the entire path as text and have browser add ellipsis as and when width is not enough ( and we can show the name in tooltip). I will work on this solution if we finalize on this.
  