### PR TITLE
[CDAP-13061] Shows correct records in for Alerts Publisher nodes in preview

### DIFF
--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/preview-tab.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/preview-tab.html
@@ -48,14 +48,14 @@
         <!-- INPUT RECORDS -->
         <table class="table table-bordered">
           <thead>
-            <th ng-repeat="field in ::value.schema">
+            <th ng-repeat="field in ::value.schemaFields">
               {{ ::field }}
             </th>
           </thead>
 
           <tbody>
             <tr ng-repeat="row in ::value.records">
-              <td ng-repeat="field in ::value.schema">
+              <td ng-repeat="field in ::value.schemaFields">
                 {{ ::row[field] }}
               </td>
             </tr>
@@ -118,14 +118,14 @@
         <!-- OUTPUT RECORDS -->
         <table class="table table-bordered">
           <thead>
-            <th ng-repeat="field in ::value.schema">
+            <th ng-repeat="field in ::value.schemaFields">
               {{ ::field }}
             </th>
           </thead>
 
           <tbody>
             <tr ng-repeat="row in ::value.records">
-              <td ng-repeat="field in ::value.schema">
+              <td ng-repeat="field in ::value.schemaFields">
                 {{ ::row[field] }}
               </td>
             </tr>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13061

Before this change, when we click on the Preview tab of an Alerts Publisher node after running preview, we won't see any records, even though the backend returns them correctly. The main reason was because: to set the `recordsIn` of the alert node, we were looking for the `records.out` of the previous node, instead of `records.alert`.

Also, I had to change the `formatMultipleRecords` function, which is a function that helps format data returned from backend to be displayed in the UI. Unlike for other records, `records.alert` objects don't always have `schema` and `fields` fields, so this formatting function had to be tweaked a little bit.