### PR TITLE
Exclude an older version (2.2.2) of gson

### DIFF
--- a/cdap-formats/pom.xml
+++ b/cdap-formats/pom.xml
@@ -48,6 +48,12 @@
     <dependency>
       <groupId>io.thekraken</groupId>
       <artifactId>grok</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Exclude an older version (2.2.2) of gson.
Otherwise, there can be errors like the following:

![image](https://user-images.githubusercontent.com/2440977/35127241-115348ca-fc66-11e7-94c3-ec9ce8c479b1.png)

Unit tests: https://builds.cask.co/browse/CDAP-DUT6264