### PR TITLE
Fixes plus button to listen to plusbuttonstore invoked from home page

### DIFF
--- a/cdap-ui/app/cdap/components/PlusButton/index.js
+++ b/cdap-ui/app/cdap/components/PlusButton/index.js
@@ -19,6 +19,7 @@ import React, {Component} from 'react';
 import Popover from 'components/Popover';
 import PlusButtonModal from 'components/PlusButtonModal';
 import {Link} from 'react-router-dom';
+import PlusButtonStore from 'services/PlusButtonStore';
 require('./PlusButton.scss');
 
 const PLUSBUTTON_DIMENSION = 58;
@@ -32,6 +33,22 @@ export default class PlusButton extends Component {
     })),
     mode: PropTypes.oneOf(['marketplace', 'resourcecenter'])
   };
+
+  componentDidMount() {
+    this.plusButtonSubscription = PlusButtonStore.subscribe(() => {
+      let modalState = PlusButtonStore.getState().modalState;
+      this.setState({
+        showModal: modalState
+      });
+    });
+  }
+
+  componentWillUnmount() {
+    if (this.plusButtonSubscription) {
+      this.plusButtonSubscription();
+    }
+  }
+
   static defaultProps = {
     contextItems: []
   };


### PR DESCRIPTION
#### Issue:
- Previous implementation of `PlusButton` listens to `PlusButtonStore` for modal state changes
- This is used in the "Add new entities" in the home page when there are no entities in a namespace.
- New `PlusButton` missed that store subscription and so now clicking on "Add new entities" link didn't do anything.

#### Solution:
- Added the same subscription in the new `PlusButton`