### PR TITLE
CDAP-13068 Support CDH 5.14 (HBase version 1.2.0-cdh5.14.0).

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -100,6 +100,7 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.11.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.12.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.13.0");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.14.0");
 
     // bigtop 1.1.0
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.12-hadoop2");

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -48,6 +48,7 @@ public class HBaseVersion {
   private static final String CDH511_CLASSIFIER = "cdh5.11.";
   private static final String CDH512_CLASSIFIER = "cdh5.12.";
   private static final String CDH513_CLASSIFIER = "cdh5.13.";
+  private static final String CDH514_CLASSIFIER = "cdh5.14.";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -300,13 +301,14 @@ public class HBaseVersion {
   private static Version getHBase12VersionFromVersion(VersionNumber ver) {
     if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
       if (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
-        // CDH 5.7 compat module can be re-used with CDH 5.[8-11].x
+        // CDH 5.7 compat module can be re-used with CDH 5.[8-14].x
         ver.getClassifier().startsWith(CDH58_CLASSIFIER) ||
         ver.getClassifier().startsWith(CDH59_CLASSIFIER) ||
         ver.getClassifier().startsWith(CDH510_CLASSIFIER) ||
         ver.getClassifier().startsWith(CDH511_CLASSIFIER) ||
         ver.getClassifier().startsWith(CDH512_CLASSIFIER) ||
-        ver.getClassifier().startsWith(CDH513_CLASSIFIER)) {
+        ver.getClassifier().startsWith(CDH513_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH514_CLASSIFIER)) {
         return Version.HBASE_12_CDH57;
       }
       return Version.UNKNOWN_CDH;


### PR DESCRIPTION
Our CDH 5.7 compat module works with HBase version 1.2.0-cdh5.14.0, so reuse it for CDH 5.14.

JIRA: https://issues.cask.co/browse/CDAP-13068