### PR TITLE
Fix a connection close issue in the router

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/http/AuthenticationChannelHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/AuthenticationChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +65,8 @@ public class AuthenticationChannelHandler extends ChannelInboundHandlerAdapter {
     LOG.error("Got exception: {}", cause.getMessage(), cause);
     // TODO: add WWW-Authenticate header for 401 response -  REACTOR-900
     HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED);
+    HttpUtil.setContentLength(response, 0);
+    HttpUtil.setKeepAlive(response, false);
     ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
   }
 }

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/AuthenticationHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/AuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -136,6 +136,7 @@ public class AuthenticationHandler extends ChannelInboundHandlerAdapter {
       HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                                                           HttpResponseStatus.UNAUTHORIZED, content);
       HttpUtil.setContentLength(response, content.readableBytes());
+      HttpUtil.setKeepAlive(response, false);
       response.headers().setAll(headers);
       response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8");
 

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -164,6 +164,7 @@ public class HttpRequestRouter extends ChannelDuplexHandler {
     HttpResponse response = cause instanceof HandlerException
       ? ((HandlerException) cause).createFailureResponse()
       : createErrorResponse(cause);
+    HttpUtil.setKeepAlive(response, false);
     ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
   }
 
@@ -186,7 +187,9 @@ public class HttpRequestRouter extends ChannelDuplexHandler {
         @Override
         public void operationComplete(ChannelFuture future) throws Exception {
           if (!future.isSuccess()) {
-            inboundChannel.writeAndFlush(createErrorResponse(future.cause())).addListener(ChannelFutureListener.CLOSE);
+            HttpResponse response = createErrorResponse(future.cause());
+            HttpUtil.setKeepAlive(response, false);
+            inboundChannel.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
           }
         }
       };

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpStatusRequestHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpStatusRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -54,6 +54,7 @@ public class HttpStatusRequestHandler extends ChannelInboundHandlerAdapter {
 
         HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, content);
         HttpUtil.setContentLength(response, content.readableBytes());
+        HttpUtil.setKeepAlive(response, false);
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8");
 
         ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);


### PR DESCRIPTION
- When a inbound connection (client->router) is reused, hence shared among different backend service, connection close events that is raised from non-request related event, it shouldn't affect the inbound connection