### PR TITLE
[MMDS][CDAP-12711] Show feedback after user creates a new model

### DIFF
--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/HyperParamsPopover/HyperParamsPopover.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/HyperParamsPopover/HyperParamsPopover.scss
@@ -29,6 +29,7 @@
 
       thead tr th {
         color: $grey-03;
+        border-top: 0;
         &:first-of-type {
           border-left: 0;
         }

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/HyperParamsPopover/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/HyperParamsPopover/index.js
@@ -25,7 +25,7 @@ require('./HyperParamsPopover.scss');
 export default function HyperParamsPopover({algorithm, hyperparameters}) {
   return (
     <Popover
-      target={() => <IconSVG name="icon-cog" />}
+      target={() => <IconSVG name="icon-cogs" />}
       className="hyperparameters-popover"
       placement="right"
       bubbleEvent={false}

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/index.js
@@ -22,13 +22,15 @@ import {
   getExperimentDetails,
   updatePaginationForModels,
   handleModelsPageChange,
-  resetExperimentDetailStore
+  resetExperimentDetailStore,
+  resetNewlyTrainingModel
 } from 'components/Experiments/store/ActionCreator';
 import ConnectedTopPanel from 'components/Experiments/DetailedView/TopPanel';
 import ModelsTableWrapper from 'components/Experiments/DetailedView/ModelsTable';
 import Mousetrap from 'mousetrap';
 import isNil from 'lodash/isNil';
 import queryString from 'query-string';
+import Alert from 'components/Alert';
 
 require('./DetailedView.scss');
 
@@ -52,6 +54,20 @@ export default class ExperimentDetails extends Component {
     Mousetrap.unbind('right');
     resetExperimentDetailStore();
   }
+
+  showNewlyTrainingModel = () => {
+    let {newlyTrainingModel} = experimentDetailStore.getState();
+    if (newlyTrainingModel) {
+      return (
+        <Alert
+          message={`You have successfully started training the model: ${newlyTrainingModel.name}`}
+          type='success'
+          showAlert={true}
+          onClose={resetNewlyTrainingModel}
+        />
+      );
+    }
+  };
 
   goToNextPage = () => {
     let {modelsOffset, modelsLimit, modelsTotalPages} = experimentDetailStore.getState();
@@ -94,6 +110,7 @@ export default class ExperimentDetails extends Component {
         <div className="experiment-detailed-view">
           <ConnectedTopPanel />
           <ModelsTableWrapper />
+          {this.showNewlyTrainingModel()}
         </div>
       </Provider>
     );

--- a/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
@@ -268,6 +268,12 @@ function resetExperimentDetailStore() {
     type: EXPERIMENTDETAILACTIONS.RESET
   });
 }
+
+function resetNewlyTrainingModel() {
+  experimentDetailsStore.dispatch({
+    type: EXPERIMENTDETAILACTIONS.RESET_NEWLY_TRAINING_MODEL
+  });
+}
 export {
   setExperimentsLoading,
   getExperimentsList,
@@ -285,6 +291,7 @@ export {
   handleModelsPageChange,
   handlePageChange,
   updatePagination,
-  resetExperimentDetailStore
+  resetExperimentDetailStore,
+  resetNewlyTrainingModel
 };
 

--- a/cdap-ui/app/cdap/components/Experiments/store/CreateExperimentActionCreator.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/CreateExperimentActionCreator.js
@@ -15,6 +15,7 @@
 */
 
 import createExperimentStore, {ACTIONS as CREATEEXPERIMENTACTIONS} from 'components/Experiments/store/createExperimentStore';
+import experimentDetailStore, {ACTIONS as EXPERIMENTDETAILACTIONS} from 'components/Experiments/store/experimentDetailStore';
 import {myExperimentsApi} from 'api/experiments';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
@@ -294,7 +295,13 @@ function trainModel() {
       modelId
     }, postBody)
     .subscribe(() => {
-      window.location.href = `${window.location.origin}/cdap/ns/${getCurrentNamespace()}/experiments/${experimentId}`;
+      experimentDetailStore.dispatch({
+        type: EXPERIMENTDETAILACTIONS.SET_NEWLY_TRAINING_MODEL,
+        payload: {model: model_create}
+      });
+      createExperimentStore.dispatch({
+        type: CREATEEXPERIMENTACTIONS.SET_MODEL_TRAINED
+      });
     });
 }
 

--- a/cdap-ui/app/cdap/components/Experiments/store/createExperimentStore.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/createExperimentStore.js
@@ -40,6 +40,7 @@ const ACTIONS = {
   SET_WORKSPACE_ID: 'SET_WORKSPACE_ID',
   SET_SPLIT_FINALIZED: 'SET_SPLIT_FINALIZED',
   UPDATE_HYPER_PARAM: 'UPDATE_HYPER_PARAM',
+  SET_MODEL_TRAINED: 'SET_MODEL_TRAINED',
   RESET: 'RESET'
 };
 
@@ -71,7 +72,8 @@ const DEFAULT_MODEL_CREATE_VALUE = {
   },
 
   validAlgorithmsList: [],
-  algorithmsList: []
+  algorithmsList: [],
+  isModelTrained: false
 };
 
 const experiments_create = (state = DEFAULT_EXPERIMENTS_CREATE_VALUE, action = defaultAction) => {
@@ -127,6 +129,7 @@ const experiments_create = (state = DEFAULT_EXPERIMENTS_CREATE_VALUE, action = d
       return state;
   }
 };
+
 const model_create = (state = DEFAULT_MODEL_CREATE_VALUE, action = defaultAction) => {
   switch (action.type) {
     case ACTIONS.SET_MODEL_ID:
@@ -211,6 +214,11 @@ const model_create = (state = DEFAULT_MODEL_CREATE_VALUE, action = defaultAction
             .map(al => al.name)
             .indexOf(algo.algorithm) !== -1
         )
+      };
+    case ACTIONS.SET_MODEL_TRAINED:
+      return {
+        ...state,
+        isModelTrained: true
       };
     case ACTIONS.RESET:
       return DEFAULT_MODEL_CREATE_VALUE;

--- a/cdap-ui/app/cdap/components/Experiments/store/experimentDetailStore.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/experimentDetailStore.js
@@ -27,6 +27,8 @@ const ACTIONS = {
   SET_SPLITS: 'SET_SPLITS',
   SET_MODEL_STATUS: 'SET_MODEL_STATUS',
   SET_MODEL_PAGINATION: 'SET_MODEL_PAGINATION',
+  SET_NEWLY_TRAINING_MODEL: 'SET_NEWLY_TRAINING_MODEL',
+  RESET_NEWLY_TRAINING_MODEL: 'RESET_NEWLY_TRAINING_MODEL',
   RESET: 'RESET'
 };
 
@@ -40,6 +42,7 @@ export const DEFAULT_EXPERIMENT_DETAILS = {
   algorithms: {},
   statuses: {},
   models: [],
+  newlyTrainingModel: false,
   modelsOffset: 0,
   modelsLimit: 10,
   modelsTotalCount: 0,
@@ -72,14 +75,37 @@ const experimentDetails = (state = DEFAULT_EXPERIMENT_DETAILS, action = defaultA
         statuses
       };
     }
-    case ACTIONS.SET_MODELS:
+    case ACTIONS.SET_NEWLY_TRAINING_MODEL:
       return {
         ...state,
-        models: action.payload.models,
+        newlyTrainingModel: action.payload.model
+      };
+    case ACTIONS.RESET_NEWLY_TRAINING_MODEL:
+      return {
+        ...state,
+        newlyTrainingModel: false
+      };
+    case ACTIONS.SET_MODELS: {
+      let {models} = action.payload;
+      if (state.newlyTrainingModel) {
+        models = models.map(model => {
+          if (model.id === state.newlyTrainingModel.modelId) {
+            return {
+              ...model,
+              active: true
+            };
+          }
+          return model;
+        });
+      }
+      return {
+        ...state,
+        models,
         modelsTotalCount: action.payload.totalCount,
         modelsTotalPages: Math.ceil(action.payload.totalCount / state.modelsLimit),
         loading: false
       };
+    }
     case ACTIONS.SET_MODEL_PAGINATION:
       return {
         ...state,


### PR DESCRIPTION
- Open the newly created model in the experiment list view
- Show success banner indicating the the model has been successfully created.

#### Note:
- Need to confirm on the message with @bdmogal that we show in alert after the user has started training the model.
- If you have a lot of models in an experiment the newly training experiment might not be in the first page when users navigate to after training starts. This will be fixed when we have sorting models from backend when we can sort by newly training models.

JIRA: https://issues.cask.co/browse/CDAP-12711