### PR TITLE
[MMDS]Converts ModelsTable to be a css grid

### DIFF
--- a/cdap-ui/app/cdap/components/Alert/index.js
+++ b/cdap-ui/app/cdap/components/Alert/index.js
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import {Modal} from 'reactstrap';
 require('./Alert.scss');
+const SUCCESS_CLOSE_TIMEOUT = 3000;
 
 export default class Alert extends Component {
   constructor(props) {
@@ -29,6 +30,7 @@ export default class Alert extends Component {
       type: props.type
     };
   }
+  successTimeout = null;
   componentWillReceiveProps(nextProps) {
     let {showAlert, type, message} = nextProps;
     if (
@@ -41,6 +43,10 @@ export default class Alert extends Component {
         type,
         message
       });
+    }
+    if (type === 'success') {
+      clearTimeout(this.successTimeout);
+      this.successTimeout = setTimeout(this.onClose, SUCCESS_CLOSE_TIMEOUT);
     }
   }
   onClose = () => {

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/HyperParamsPopover/HyperParamsPopover.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/HyperParamsPopover/HyperParamsPopover.scss
@@ -19,6 +19,7 @@
 .hyperparameters-popover {
   cursor: pointer;
   display: inline-block;
+  margin-right: 5px;
   .popper {
     width: auto;
     padding: 10px;
@@ -26,6 +27,7 @@
 
     .table.table-bordered {
       border: 0;
+      margin: 0;
 
       thead tr th {
         color: $grey-03;

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
@@ -16,6 +16,7 @@
 
 @import "../../ExperimentsVariables.scss";
 @import "../../../../styles/variables.scss";
+@import "../../../../styles/mixins.scss";
 
 .experiment-models-table {
   padding: $padding-top-bottom $padding-left-right;
@@ -34,60 +35,52 @@
       margin: 0;
     }
   }
-  .sortable-sticky-grid {
-    height: calc(100% - 45px);
-    .table-scroll {
-      height: calc(100% - 25px);
-    }
-    a.grid-body-row-container {
-      text-decoration: none;
-      color: inherit;
-      &:hover {
-        text-decoration: none;
-      }
-    }
-    .grid-body-row-container {
-      width: 100%;
-      &.opened {
-        border-top: 3px solid $grey-04;
-        border-bottom: 3px solid $grey-04;
-      }
-    }
-    .grid-header {
-      .grid-header-item {
-        padding: 0;
-      }
-    }
-    .grid-body-row {
-      cursor: pointer;
-      &.opened {
-        background-color: $grey-08;
-        border: 0;
-      }
-      .grid-body-item {
-        padding: 0.7rem 0 0.7rem 0;
-        [class*="icon-caret-"] {
-          font-size: 1.2rem; // FIXME: We should have this as a variable and should be standard in variables.scss
-        }
-        .algorithm-cell {
-          > span {
-            margin-left: 3px;
+
+  @include grid();
+
+  .grid.grid-container {
+    max-height: calc(100% - 32px);
+    .grid-header,
+    .grid-body {
+      .grid-item {
+        grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 1fr 20px;
+        &.opened {
+          grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 1fr 20px;
+          background: $grey-08;
+          border-bottom: 3px solid $grey-04;
+          border-top: 0;
+          align-items: start;
+          div {
+            word-break: break-word;
           }
         }
-      }
-      &:not(.opened):hover {
-        background-color: $grey-08;
+        &.active {
+          border-bottom: 0;
+          border-top: 2px solid $grey-04; // ALERT: HACK - 1px from the row on top.
+          background: $grey-08;
+        }
+        &.highlight {
+          border-color: $green-02;
+        }
       }
     }
-    .grid-body-row-details {
-      display: flex;
-      word-break: break-word;
-      background-color: $grey-08;
-      padding: 0 0 10px 0;
-      > div {
-        padding: 0 10px 0 0;
-        > div {
-          margin-top: 10px;
+    .grid-body {
+      .algorithm-cell,
+      > div > span {
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+    &.classification {
+      .grid-header,
+      .grid-body {
+        .grid-item {
+          grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 20px;
+        }
+        &.opened {
+          grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 20px;
         }
       }
     }

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/index.js
@@ -23,7 +23,8 @@ import {
   updatePaginationForModels,
   handleModelsPageChange,
   resetExperimentDetailStore,
-  resetNewlyTrainingModel
+  resetNewlyTrainingModel,
+  setAlgorithmsList
 } from 'components/Experiments/store/ActionCreator';
 import ConnectedTopPanel from 'components/Experiments/DetailedView/TopPanel';
 import ModelsTableWrapper from 'components/Experiments/DetailedView/ModelsTable';
@@ -43,6 +44,7 @@ export default class ExperimentDetails extends Component {
   componentWillMount() {
     Mousetrap.bind('right', this.goToNextPage);
     Mousetrap.bind('left', this.goToPreviousPage);
+    setAlgorithmsList();
     let { experimentId } = this.props.match.params;
     let { offset: modelsOffset, limit: modelsLimit } = this.getQueryObject(queryString.parse(this.props.location.search));
     updatePaginationForModels({modelsOffset, modelsLimit});

--- a/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/ActionCreator.js
@@ -128,7 +128,7 @@ function handleModelsPageChange({ selected }) {
     }
   });
   updateQueryStringWithModelsOffset();
-  getModelsInExperiment(experimentId);
+  getExperimentDetails(experimentId);
 }
 
 function updatePaginationForModels({ modelsLimit, modelsOffset }) {

--- a/cdap-ui/app/cdap/components/Experiments/store/experimentDetailStore.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/experimentDetailStore.js
@@ -42,7 +42,7 @@ export const DEFAULT_EXPERIMENT_DETAILS = {
   algorithms: {},
   statuses: {},
   models: [],
-  newlyTrainingModel: false,
+  newlyTrainingModel: null,
   modelsOffset: 0,
   modelsLimit: 10,
   modelsTotalCount: 0,
@@ -83,7 +83,7 @@ const experimentDetails = (state = DEFAULT_EXPERIMENT_DETAILS, action = defaultA
     case ACTIONS.RESET_NEWLY_TRAINING_MODEL:
       return {
         ...state,
-        newlyTrainingModel: false
+        newlyTrainingModel: null
       };
     case ACTIONS.SET_MODELS: {
       let {models} = action.payload;

--- a/cdap-ui/app/cdap/styles/mixins.scss
+++ b/cdap-ui/app/cdap/styles/mixins.scss
@@ -14,6 +14,7 @@
  * the License.
  */
 
+@import "./variables.scss";
 
 @mixin placeholder-color($color: white, $font-weight: 500) {
     color: $color;
@@ -26,5 +27,57 @@
   -o-appearance: $value;
   ::-ms-expand {
     display: none;  // Need this to hide default select in IE10
+  }
+}
+
+@mixin grid($maxGridHeight: 200px, $minGridWidth: 10px, $maxGridWidth: 1fr, $headerBgColor: white, $borderColor: $grey-04) {
+  .grid{
+    &.grid-container {
+      max-height: $maxGridHeight;
+      overflow-y: auto;
+      .grid-item {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax($minGridWidth, $maxGridWidth));
+
+        > strong,
+        > div {
+          border-left: 0;
+          border-bottom: 0;
+          padding: 5px;
+          max-width: 100%;
+          overflow: hidden;
+          word-break: inherit;
+          text-overflow: ellipsis;
+        }
+      }
+      .grid-header {
+        position: sticky;
+        top: 0;
+        background: $headerBgColor;
+        > .grid-item {
+          border-bottom: 1px solid $grey-04;
+          padding: 10px 0;
+          border-left: 0;
+          border-right: 0;
+          border-top: 0;
+        }
+      }
+      .grid-body {
+        .grid-item {
+          padding: 7px 0;
+          cursor: pointer;
+          align-content: center;
+          align-items: center;
+          border-bottom: 1px solid $grey-04;
+          &:hover {
+            background: $grey-08;
+          }
+        }
+        a {
+          text-decoration: none;
+          color: inherit;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- Makes rendering a grid slightly better
- Re-writes `ModelsTable` to be a css grid
- Adds a generic grid mixin to be re-used across everywhere.

#### Usage:
```
<div className="grid grid-container">
  <div className="grid-header">
    <div className="grid-item">
        <strong> Header 1 </strong>
        <strong> Header 2 </strong>
        ...
    </div>
  </div>
  <div className="grid-body">
    <div className="grid-item">
      <div></div>
      <div></div>
      ...
    </div>
  </div>
</div>
```
the `grid-item` defines the columns and their sizes. 

Since the table most likely will have a static number(except dataprep) of columns we can fix the size of individual columns in the css in one place and leave the rest of the styles from the mixin to take care.

