### PR TITLE
Feature/chef version installers

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -43,7 +43,7 @@ COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
 # Install Chef, setup APT, run Chef cdap::sdk recipe, then clean up
-RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.19.36 && \
+RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.21.31 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -28,7 +28,7 @@ CDAP_TAG=${CDAP_TAG:+v5.0.0}
 # The CDAP package version passed to Chef
 CDAP_VERSION=${CDAP_VERSION:-5.0.0-1}
 # The version of Chef to install
-CHEF_VERSION=${CHEF_VERSION:-12.10.24}
+CHEF_VERSION=${CHEF_VERSION:-12.21.31}
 # cdap-site.xml configuration parameters
 EXPLORE_ENABLED='true'
 # Sleep delay before starting services (in seconds)

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -102,10 +102,10 @@ __create_tmpdir() { mkdir -p ${__tmpdir}; };
 sudo yum install -y git || die "Failed to install git"
 
 # Install chef
-curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v ${CHEF_VERSION} || die "Failed to install chef"
+__create_tmpdir
+curl -L -o ${__tmpdir}/install.sh https://www.chef.io/chef/install.sh && sudo bash ${__tmpdir}/install.sh -v ${CHEF_VERSION} || die "Failed to install chef"
 
 # Clone CDAP repo
-__create_tmpdir
 echo "INFO: Checking out CDAP_BRANCH ${CDAP_BRANCH}"
 git clone --depth 1 --branch ${CDAP_BRANCH} https://github.com/caskdata/cdap.git ${__gitdir}
 

--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -55,10 +55,10 @@ apt-get update --yes || die "Failed to run 'apt-get update'"
 apt-get install --yes git || die "Failed to install git"
 
 # Install chef
-curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v ${CHEF_VERSION} || die "Failed to install chef"
+__create_tmpdir
+curl -L -o ${__tmpdir}/install.sh https://www.chef.io/chef/install.sh && sudo bash ${__tmpdir}/install.sh -v ${CHEF_VERSION} || die "Failed to install chef"
 
 # Clone CDAP repo
-__create_tmpdir
 git clone --depth 1 --branch ${CDAP_BRANCH} https://github.com/caskdata/cdap.git ${__gitdir}
 
 # Check out to specific tag if specified

--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -28,7 +28,7 @@ CDAP_TAG=${CDAP_TAG:+hdi5.0}
 # The CDAP package version passed to Chef
 CDAP_VERSION='5.0.0-1'
 # The version of Chef to install
-CHEF_VERSION='12.10.24'
+CHEF_VERSION='12.21.31'
 # cdap-site.xml configuration parameters
 EXPLORE_ENABLED='true'
 

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -112,7 +112,7 @@
     },
     {
       "type": "chef-solo",
-      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.19.36",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.21.31",
       "remote_cookbook_paths": "/var/chef/cookbooks"
     },
     {


### PR DESCRIPTION
- [x] updated the chef version used in the various distributions to the latest Chef 12.  This was required for EMR, since the yum cookbook requires Chef 12.14 as of [5.0.0](https://github.com/chef-cookbooks/yum/blob/master/CHANGELOG.md).  Updated Docker/VM/HDInsight for consistency.
- [x] modified chef install invocation in EMR/HDInsight to avoid masking chef download failure.  New invocation per https://docs.chef.io/install_omnibus.html