### PR TITLE
CDAP-13088 Introduce MetadataEntity which is compatible with EntityId

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataEntity.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataEntity.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.metadata;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Entity representation for Metadata
+ */
+public class MetadataEntity {
+
+  public static final String NAMESPACE = "namespace";
+  public static final String APPLICATION = "application";
+  public static final String ARTIFACT = "artifact";
+  public static final String VERSION = "version";
+  public static final String DATASET = "dataset";
+  public static final String STREAM = "stream";
+  public static final String VIEW = "view";
+  public static final String TYPE = "type";
+  public static final String PROGRAM = "program";
+
+  private final List<KeyValue> details;
+
+  private MetadataEntity(List<KeyValue> details) {
+    ArrayList<KeyValue> keyValues = new ArrayList<>(details);
+    this.details = Collections.unmodifiableList(keyValues);
+  }
+
+  /**
+   * Creates a {@link MetadataEntity} representing the given datasetName. To create a {@link MetadataEntity} for a
+   * dataset in a specified namespace please use {@link MetadataEntity#ofDataset(String, String)}.
+   *
+   * @param datasetName the name of the dataset
+   * @return {@link MetadataEntity} representing the dataset name
+   */
+  public static MetadataEntity ofDataset(String datasetName) {
+    return new MetadataEntity(Collections.singletonList(new KeyValue(DATASET, datasetName)));
+  }
+
+  /**
+   * Creates a {@link MetadataEntity} representing the given datasetName in the specified namespace.
+   *
+   * @param namespace the name of the namespace
+   * @param datasetName the name of the dataset
+   * @return {@link MetadataEntity} representing the dataset name
+   */
+  public static MetadataEntity ofDataset(String namespace, String datasetName) {
+    return new MetadataEntity(Arrays.asList(new KeyValue(NAMESPACE, namespace),
+                                            new KeyValue(DATASET, datasetName)));
+  }
+
+  /**
+   * Creates a {@link MetadataEntity} representing the given namespace.
+   *
+   * @param ns the name of the namespace
+   * @return {@link MetadataEntity} representing the namespace name
+   */
+  public static MetadataEntity ofNamespace(String ns) {
+    return new MetadataEntity(Collections.singletonList(new KeyValue(NAMESPACE, ns)));
+  }
+
+  /**
+   * Creates a new {@link MetadataEntity} which consists of the given key and values following the key and values of
+   * this {@link MetadataEntity}
+   *
+   * @param key the key to be added
+   * @param value the value to be added
+   * @return a new {@link MetadataEntity} which consists of the given key and values following the key and values of
+   * this {@link MetadataEntity}
+   */
+  public MetadataEntity append(String key, String value) {
+    List<KeyValue> existingParts = new ArrayList<>(getKeyValues());
+    existingParts.add(new KeyValue(key, value));
+    return new MetadataEntity(existingParts);
+  }
+
+  /**
+   * @return A {@link List} of {@link KeyValue} representing the metadata entity
+   */
+  public List<KeyValue> getKeyValues() {
+    return details;
+  }
+
+  /**
+   * {@link MetadataEntity} key-value.
+   */
+  public static class KeyValue {
+    private final String key;
+    private final String value;
+
+    public KeyValue(String key, String value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -252,7 +252,6 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
                                    @PathParam("namespace-id") String namespace,
                                    @PathParam("app-id") String application,
                                    @PathParam("workflow-id") String workflow,
-                                   @QueryParam("format") String format,
                                    @QueryParam("trigger-type") String triggerType,
                                    @QueryParam("schedule-status") String scheduleStatus)
     throws NotFoundException, BadRequestException {
@@ -270,7 +269,6 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
                                    @PathParam("app-id") String application,
                                    @PathParam("app-version") String version,
                                    @PathParam("workflow-id") String workflow,
-                                   @QueryParam("format") String format,
                                    @QueryParam("trigger-type") String triggerType,
                                    @QueryParam("schedule-status") String scheduleStatus)
     throws NotFoundException, BadRequestException {

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -1004,9 +1004,6 @@ To retrieve a schedule in an application, submit an HTTP GET request::
 
 The response will contain the schedule in the same form described in :ref:`http-restful-api-lifecycle-schedule-add`.
 
-Note: The response format has changed in CDAP 4.2.0. To retrieve the schedule in the ``ScheduleSpecification``
-format that was used in previous versions of CDAP, add a URL parameter ``?format=spec`` to the request URL.
-
 List Schedules
 --------------
 To list all of the schedules for an application, use an HTTP GET request::
@@ -1023,9 +1020,6 @@ To list all of the schedules of a workflow of an application, use an HTTP GET re
 
 The response will contain a list of schedules in the same form as described
 in :ref:`http-restful-api-lifecycle-schedule-add`.
-
-Note: The response format has changed in CDAP 4.2.0. To retrieve the schedules in the ``ScheduleSpecification``
-format that was used in previous versions of CDAP, add a URL parameter ``?format=spec`` to the request URL.
 
 .. list-table::
    :widths: 20 80

--- a/cdap-docs/reference-manual/source/http-restful-api/metadata.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metadata.rst
@@ -569,17 +569,12 @@ Entities that match the specified query and entity type are returned in the body
     "results": [
         {
             "entityId": {
-                "id": {
-                    "application": {
-                        "applicationId": "WordCount",
-                        "namespace": {
-                            "id": "default"
-                        }
-                    },
-                    "id": "RetrieveCounts",
-                    "type": "Service"
-                },
-                "type": "program"
+                "application": "WordCount",
+                "entity": "PROGRAM",
+                "namespace": "default",
+                "program": "RetrieveCounts",
+                "type": "Service",
+                "version": "-SNAPSHOT"
             },
             "metadata": {
                 "SYSTEM": {
@@ -598,17 +593,12 @@ Entities that match the specified query and entity type are returned in the body
         },
         {
             "entityId": {
-                "id": {
-                    "application": {
-                        "applicationId": "WordCount",
-                        "namespace": {
-                            "id": "default"
-                        }
-                    },
-                    "id": "WordCounter",
-                    "type": "Flow"
-                },
-                "type": "program"
+                "application": "WordCount",
+                "entity": "PROGRAM",
+                "namespace": "default",
+                "program": "WordCounter",
+                "type": "Flow",
+                "version": "-SNAPSHOT"
             },
             "metadata": {
                 "SYSTEM": {
@@ -802,41 +792,28 @@ Here is an example, pretty-printed::
       "data": {
           "dataset.default.purchases": {
               "entityId": {
-                  "id": {
-                      "instanceId": "purchases",
-                      "namespace": {
-                          "id": "default"
-                      }
-                  },
-                  "type": "datasetinstance"
+                  "dataset": "history",
+                  "entity": "DATASET",
+                  "namespace": "default"
               }
           },
           "stream.default.purchaseStream": {
               "entityId": {
-                  "id": {
-                      "namespace": {
-                          "id": "default"
-                      },
-                      "streamName": "purchaseStream"
-                  },
-                  "type": "stream"
+                  "entity": "STREAM",
+                  "namespace": "default",
+                  "stream": "purchaseStream"
               }
           }
       },
       "programs": {
           "flows.default.PurchaseHistory.PurchaseFlow": {
               "entityId": {
-                  "id": {
-                      "application": {
-                          "applicationId": "PurchaseHistory",
-                          "namespace": {
-                              "id": "default"
-                          }
-                      },
-                      "id": "PurchaseFlow",
-                      "type": "Flow"
-                  },
-                  "type": "program"
+                  "application": "PurchaseHistory",
+                  "entity": "PROGRAM",
+                  "namespace": "default",
+                  "program": "PurchaseFlow",
+                  "type": "Flow",
+                  "version": "-SNAPSHOT"
               }
           }
       }
@@ -1154,45 +1131,31 @@ Consider these relations from the output of a lineage API request::
     "data": {
       "dataset.default.purchases": {
         "entityId": {
-          "id": {
-            "instanceId": "purchases",
-            "namespace": {
-              "id": "default"
-            }
-          },
-          "type": "datasetinstance"
+            "dataset": "purchases",
+            "entity": "DATASET",
+            "namespace": "default"
         }
       },
     },
     "programs": {
       "mapreduce.default.PurchaseHistory.phase-1": {
         "entityId": {
-          "id": {
-            "application": {
-              "applicationId": "PurchaseHistory",
-              "namespace": {
-                "id": "default"
-              }
-            },
-            "id": "phase-1",
-            "type": "Mapreduce"
-          },
-          "type": "program"
+            "application": "PurchaseHistory",
+            "entity": "PROGRAM",
+            "namespace": "default",
+            "program": "phase-1",
+            "type": "Mapreduce",
+            "version": "-SNAPSHOT"
         }
       },
       "mapreduce.default.PurchaseHistory.phase-2": {
         "entityId": {
-          "id": {
-            "application": {
-              "applicationId": "PurchaseHistory",
-              "namespace": {
-                "id": "default"
-              }
-            },
-            "id": "phase-2",
-            "type": "Mapreduce"
-          },
-          "type": "program"
+            "application": "PurchaseHistory",
+            "entity": "PROGRAM",
+            "namespace": "default",
+            "program": "phase-2",
+            "type": "Mapreduce",
+            "version": "-SNAPSHOT"
         }
       }
     },
@@ -1222,30 +1185,21 @@ Rolling up the above using ``rollup=workflow`` would group the programs together
     "data": {
       "dataset.default.purchases": {
         "entityId": {
-          "id": {
-            "instanceId": "purchases",
-            "namespace": {
-                "id": "default"
-            }
-          },
-          "type": "datasetinstance"
+          "dataset": "purchases",
+          "entity": "DATASET",
+          "namespace": "default"
         }
       },
     },
     "programs": {
       "workflows.default.PurchaseHistory.DataPipelineWorkflow": {
         "entityId": {
-          "id": {
-            "application": {
-              "applicationId": "PurchaseHistory",
-              "namespace": {
-                "id": "default"
-              }
-            },
-            "id": "DataPipelineWorkflow",
-            "type": "Workflow"
-          },
-          "type": "program"
+            "application": "PurchaseHistory",
+            "entity": "PROGRAM",
+            "namespace": "default",
+            "program": "DataPipelineWorkflow",
+            "type": "Workflow",
+            "version": "-SNAPSHOT"
         }
       },
     },
@@ -1269,13 +1223,9 @@ with the metadata returned as a JSON string in the return body::
   [
       {
           "entityId": {
-              "id": {
-                  "namespace": {
-                      "id": "default"
-                  },
-                  "streamName": "purchaseStream"
-              },
-              "type": "stream"
+              "entity": "STREAM",
+              "namespace": "default",
+              "stream": "purchaseStream"
           },
           "properties": {},
           "scope": "USER",
@@ -1283,17 +1233,12 @@ with the metadata returned as a JSON string in the return body::
       },
       {
           "entityId": {
-              "id": {
-                  "application": {
-                      "applicationId": "PurchaseHistory",
-                      "namespace": {
-                          "id": "default"
-                      }
-                  },
-                  "id": "PurchaseFlow",
-                  "type": "Flow"
-              },
-              "type": "program"
+              "application": "PurchaseHistory",
+              "entity": "PROGRAM",
+              "namespace": "default",
+              "program": "PurchaseFlow",
+              "type": "Flow",
+              "version": "-SNAPSHOT"
           },
           "properties": {},
           "scope": "USER",
@@ -1303,13 +1248,9 @@ with the metadata returned as a JSON string in the return body::
       },
       {
           "entityId": {
-              "id": {
-                  "instanceId": "purchases",
-                  "namespace": {
-                      "id": "default"
-                  }
-              },
-              "type": "datasetinstance"
+              "dataset": "purchases",
+              "entity": "DATASET",
+              "namespace": "default"
           },
           "properties": {},
           "scope": "USER",
@@ -1317,13 +1258,10 @@ with the metadata returned as a JSON string in the return body::
       },
       {
           "entityId": {
-              "id": {
-                  "applicationId": "PurchaseHistory",
-                  "namespace": {
-                      "id": "default"
-                  }
-              },
-              "type": "application"
+              "application": "PurchaseHistory",
+              "entity": "APPLICATION",
+              "namespace": "default",
+              "version": "-SNAPSHOT"
           },
           "properties": {},
           "scope": "USER",

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -30,6 +30,35 @@ Cask Data Application Platform Release Notes
    :backlinks: none
    :depth: 2
 
+`Release 5.0.0 <http://docs.cask.co/cdap/5.0.0/index.html>`__
+=============================================================
+Deprecated and Removed Features
+-------------------------------
+
+- The Following deprecations have been removed from the `cdap-api` module:
+	- Scheduling workflow using co.cask.cdap.api.schedule.Schedule in AbstractApplication is removed, Use co.cask.cdap.internal.schedule.ScheduleCreationSpec for scheduling workflow.
+	- Adding schedule using co.cask.cdap.api.schedule.Schedule is removed in ApplicationConfigurer, use co.cask.cdap.internal.schedule.ScheduleCreationSpec for adding schedules.
+	- Deprecated methods getStreams, getDatasetModules and getDatasetSpecs have been removed from FlowletDefinition.
+	- beforeSubmit and onFinish methods have been removed from Mapreduce, Spark interface. use ProgramLifecycle#initialize and ProgramLifecycle#destroy instead.
+	- RunConstraints, ScheduleSpecification and Schedule classes in package co.cask.cdap.api.schedule have been removed.
+	- WorkflowAction, WorkflowActionConfigurer, WorkflowActionSpecification, AbstractWorkflowAction have been removed from the package co.cask.cdap.api.workflow. Use CustomAction for workflows instead.
+	- WorkflowConfigurer#addAction(WorkflowAction action) has been removed, use addAction(CustomAction action) instead.
+	- MapReduceTaskContext#getInputName has been removed, use getInputContext instead.
+
+
+- The Following deprecations have been removed from the `cdap-proto` module:
+	- ApplicationDetail#getArtifactVersion has been removed, use ApplicationDetail#getArtifact instead.
+	- getId() method has been removed in ApplicationRecord, DatasetRecord, ProgramLiveInfo and ProgramRecord.
+	- Id class has been removed.
+	- ScheduleUpdateDetail has been removed, use ScheduleDetail instead.
+	- ScheduleType has been removed, use Trigger instead.
+	- Methods for getting ScheduleSpecification toScheduleSpec() and toScheduleSpecs(List<ScheduleDetail> details), have been removed from ScheduleDetail.
+	- Deprecated MetadataRecord class has been removed.
+
+- The Following deprecations have been removed from the `cdap-client` module:
+ 	- Removed Methods which were using the old co.cask.cdap.proto.Id classes in ApplicationClient, ArtifactClient, ClientConfig, DatsetClient, DatasetModuleClient, DatasetTypeClient, LineageClient, MetricsClient, ProgramClient, ScheduleClient, ServiceClient, StreamClient, StreamViewClient and WorkflowClient.
+ 	- Removed methods to add, update schedules using ScheduleInstanceConfiguration in ScheduleClient, use methods taking ScheduleDetail as parameter instead.
+
 
 `Release 4.3.2 <http://docs.cask.co/cdap/4.3.2/index.html>`__
 =============================================================

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto.id;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.element.EntityType;
@@ -61,6 +62,12 @@ public class ApplicationId extends NamespacedEntityId implements ParentedId<Name
   @Override
   public String getEntityName() {
     return getApplication();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() throws UnsupportedOperationException {
+    return MetadataEntity.ofNamespace(namespace).append(MetadataEntity.APPLICATION, application)
+      .append(MetadataEntity.VERSION, version);
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
@@ -17,6 +17,7 @@ package co.cask.cdap.proto.id;
 
 import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
 
@@ -88,6 +89,12 @@ public class ArtifactId extends NamespacedEntityId implements ParentedId<Namespa
   @Override
   public String getEntityName() {
     return getArtifact();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() throws UnsupportedOperationException {
+    return MetadataEntity.ofNamespace(namespace).append(MetadataEntity.ARTIFACT, artifact)
+      .append(MetadataEntity.VERSION, version);
   }
 
   public String getVersion() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto.id;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
 
@@ -50,6 +51,11 @@ public class DatasetId extends NamespacedEntityId implements ParentedId<Namespac
   @Override
   public String getEntityName() {
     return getDataset();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() throws UnsupportedOperationException {
+    return MetadataEntity.ofDataset(namespace, dataset);
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto.id;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
 
@@ -139,6 +140,15 @@ public abstract class EntityId implements IdCompatible {
   public abstract Iterable<String> toIdParts();
 
   public abstract String getEntityName();
+
+  /**
+   * @return The {@link MetadataEntity} which represents this {@link EntityId}. If an Entity supports metadata the
+   * Entityid of the entity must override this method and provide the correct implementation to convert the EntityId
+   * to {@link MetadataEntity}
+   */
+  public MetadataEntity toMetadataEntity() {
+    throw new UnsupportedOperationException("Metadata is not supported");
+  }
 
   public final EntityType getEntityType() {
     return entity;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.proto.id;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
 
@@ -41,6 +42,11 @@ public class NamespaceId extends NamespacedEntityId {
   @Override
   public String getEntityName() {
     return getNamespace();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() throws UnsupportedOperationException {
+    return MetadataEntity.ofNamespace(namespace);
   }
 
   public ArtifactId artifact(String artifact, String version) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto.id;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.element.EntityType;
@@ -76,6 +77,13 @@ public class ProgramId extends NamespacedEntityId implements ParentedId<Applicat
   @Override
   public String getEntityName() {
     return getProgram();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() throws UnsupportedOperationException {
+    return MetadataEntity.ofNamespace(namespace).append(MetadataEntity.APPLICATION, application)
+      .append(MetadataEntity.VERSION, version).append(MetadataEntity.TYPE, type.getPrettyName())
+      .append(MetadataEntity.PROGRAM, program);
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.proto.id;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
 
@@ -48,6 +49,11 @@ public class StreamId extends NamespacedEntityId implements ParentedId<Namespace
   @Override
   public String getEntityName() {
     return getStream();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() throws UnsupportedOperationException {
+    return MetadataEntity.ofNamespace(namespace).append(MetadataEntity.STREAM, stream);
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto.id;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
 
@@ -56,6 +57,12 @@ public class StreamViewId extends NamespacedEntityId implements ParentedId<Strea
   @Override
   public String getEntityName() {
     return getView();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() throws UnsupportedOperationException {
+    return MetadataEntity.ofNamespace(namespace).append(MetadataEntity.STREAM, stream)
+      .append(MetadataEntity.VIEW, view);
   }
 
   @Override


### PR DESCRIPTION
- Part 1 of the PR to support adding metadata to schema fields and custom entities in CDAP.
- metadata-rel50 is the development branch for Metadata 5.0 which we will periodically merge to develop.

Issue: https://issues.cask.co/browse/CDAP-13088
Build: https://builds.cask.co/browse/CDAP-DUT6300-1