### PR TITLE
CDAP-13122 use combine input format for connectors

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/connector/ConnectorSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/connector/ConnectorSource.java
@@ -28,7 +28,7 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 
 import java.util.HashMap;
@@ -64,7 +64,7 @@ public class ConnectorSource<T> extends BatchSource<LongWritable, Text, T> {
     workflowConfigurer.createLocalDataset(datasetName, PartitionedFileSet.class,
                                           PartitionedFileSetProperties.builder()
                                             .setPartitioning(partitioning)
-                                            .setInputFormat(TextInputFormat.class)
+                                            .setInputFormat(CombineTextInputFormat.class)
                                             .setOutputFormat(TextOutputFormat.class)
                                             .build());
   }


### PR DESCRIPTION
This is a small optimization in case connector output is small
but in multiple files. In that scenario, this change will use
fewer mappers, lowering the overhead and resource usage of the
pipeline.