### PR TITLE
CDAP-13120 use correct directory for file in PartitionedFileSet

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
@@ -33,7 +33,6 @@ import co.cask.cdap.api.dataset.table.TableProperties;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetServiceTestBase;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.TestObject;
-import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDefinition;
 import co.cask.cdap.data2.metadata.lineage.LineageDataset;
 import co.cask.cdap.data2.registry.UsageDataset;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -58,14 +57,9 @@ public class DatasetsUtilTest extends DatasetServiceTestBase {
             FileSetProperties.builder().setEnableExploreOnCreate(true).setExploreFormat("csv").build());
 
     testFix("timePartitionedFileSet",
-            FileSetProperties.builder()
-              .setBasePath("relative")
-              .add(PartitionedFileSetDefinition.NAME_AS_BASE_PATH_DEFAULT, "true").build());
+            FileSetProperties.builder().setBasePath("relative").build());
     testFix(TimePartitionedFileSet.class.getName(),
-            FileSetProperties.builder()
-              .setBasePath("relative")
-              .add("custom", "value")
-              .add(PartitionedFileSetDefinition.NAME_AS_BASE_PATH_DEFAULT, "true").build());
+            FileSetProperties.builder().setBasePath("relative").add("custom", "value").build());
 
     testFix("objectMappedTable",
             ObjectMappedTableProperties.builder().setType(TestObject.class)

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
@@ -33,6 +33,7 @@ import co.cask.cdap.api.dataset.table.TableProperties;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetServiceTestBase;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.TestObject;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDefinition;
 import co.cask.cdap.data2.metadata.lineage.LineageDataset;
 import co.cask.cdap.data2.registry.UsageDataset;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -57,9 +58,14 @@ public class DatasetsUtilTest extends DatasetServiceTestBase {
             FileSetProperties.builder().setEnableExploreOnCreate(true).setExploreFormat("csv").build());
 
     testFix("timePartitionedFileSet",
-            FileSetProperties.builder().setBasePath("relative").build());
+            FileSetProperties.builder()
+              .setBasePath("relative")
+              .add(PartitionedFileSetDefinition.NAME_AS_BASE_PATH_DEFAULT, "true").build());
     testFix(TimePartitionedFileSet.class.getName(),
-            FileSetProperties.builder().setBasePath("relative").add("custom", "value").build());
+            FileSetProperties.builder()
+              .setBasePath("relative")
+              .add("custom", "value")
+              .add(PartitionedFileSetDefinition.NAME_AS_BASE_PATH_DEFAULT, "true").build());
 
     testFix("objectMappedTable",
             ObjectMappedTableProperties.builder().setType(TestObject.class)

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -19,7 +19,9 @@ package co.cask.cdap.data2.dataset2.lib.partitioned;
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.PartitionNotFoundException;
+import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionAlreadyExistsException;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
@@ -31,6 +33,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.api.dataset.table.TableProperties;
+import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.proto.id.DatasetId;
@@ -222,6 +225,15 @@ public class PartitionedFileSetTest {
     Assert.assertEquals(baseLocation.getName(), id.getDataset());
     Assert.assertTrue(baseLocation.exists());
     Assert.assertTrue(baseLocation.isDirectory());
+
+    DatasetId fid = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testDefaultPathFileSet");
+    dsFrameworkUtil.createInstance("fileSet", fid, FileSetProperties.builder().build());
+    FileSet fs = dsFrameworkUtil.getInstance(fid);
+    Location fsBaseLocation = fs.getBaseLocation();
+
+    Assert.assertEquals(Locations.getParent(baseLocation), Locations.getParent(fsBaseLocation));
+
+    dsFrameworkUtil.deleteInstance(fid);
     dsFrameworkUtil.deleteInstance(id);
     Assert.assertFalse(baseLocation.exists());
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -212,6 +212,21 @@ public class PartitionedFileSetTest {
   }
 
   @Test
+  public void testDefaultBasePath() throws Exception {
+    DatasetId id = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testDefaultPath");
+    dsFrameworkUtil.createInstance("partitionedFileSet", id, PartitionedFileSetProperties.builder()
+      .setPartitioning(PARTITIONING_1)
+      .build());
+    PartitionedFileSet pfs = dsFrameworkUtil.getInstance(id);
+    Location baseLocation = pfs.getEmbeddedFileSet().getBaseLocation();
+    Assert.assertEquals(baseLocation.getName(), id.getDataset());
+    Assert.assertTrue(baseLocation.exists());
+    Assert.assertTrue(baseLocation.isDirectory());
+    dsFrameworkUtil.deleteInstance(id);
+    Assert.assertFalse(baseLocation.exists());
+  }
+
+  @Test
   public void testPartitionConsumer() throws Exception {
     // exercises the edge case of partition consumption, when partitions are being consumed, while another in-progress
     // transaction has added a partition, but it has not yet committed, so the partition is not available for the


### PR DESCRIPTION
If there was no base path set for a PartitionedFileSet, it would
default to a 'files' directory whose parent is a directory named
after the dataset. This means when the dataset is deleted, only
the 'files' directory is deleted, but not the parent directory.
This behavior is especially problematic when using a
PartitionedFileSet as a local fileset in a workflow, as each run
of the workflow would leave a directory per PartitionedFileSet.