### PR TITLE
[CDAP-13146] Fixes height of cask market body to be the same as parent for auto scrolling

### DIFF
--- a/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.scss
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.scss
@@ -22,6 +22,12 @@
 
   &.cask-market {
     height: 75vh;
+    .modal-body {
+      height: calc(100% - 51px);
+      > div {
+        height: 100%;
+      }
+    }
   }
 
   &.add-entity-modal {


### PR DESCRIPTION
- Enable scrolling in cask market.
- Caused by regression from here: [Incorrect Change](https://github.com/caskdata/cdap/pull/9926/files#diff-4cdd98e40594d501f04c503de183eff4L45)


JIRA: https://issues.cask.co/browse/CDAP-13146
