### PR TITLE
[CDAP-13117] Adds sorting to experiments list and models list view in MMDS

### DIFF
--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ExperimentMetricsDropdown/AlgorithmDistribution.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ExperimentMetricsDropdown/AlgorithmDistribution.js
@@ -16,13 +16,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import d3 from 'd3';
+import * as d3Lib from 'd3';
 import PieChartWithLegends from 'components/PieChartWithLegend';
 import {getAlgorithmLabel} from 'components/Experiments/store/ActionCreator';
 import EmptyMetricMessage from 'components/Experiments/DetailedView/ExperimentMetricsDropdown/EmptyMetricMessage';
 
 const HEIGHT_OF_PIE_CHART = 190;
-const colorScale = d3.scale.category20();
+const colorScale = d3Lib.scaleOrdinal(d3Lib.schemeCategory20);
 const AlgorithmDistribution = ({algorithms}) => {
   if (!algorithms.length) {
     return (

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ExperimentMetricsDropdown/ModelStatusesDistribution.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ExperimentMetricsDropdown/ModelStatusesDistribution.js
@@ -16,12 +16,12 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import d3 from 'd3';
+import * as d3Lib from 'd3';
 import PieChartWithLegends from 'components/PieChartWithLegend';
 import EmptyMetricMessage from 'components/Experiments/DetailedView/ExperimentMetricsDropdown/EmptyMetricMessage';
 
 const HEIGHT_OF_PIE_CHART = 190;
-const colorScale = d3.scale.category20();
+const colorScale = d3Lib.scaleOrdinal(d3Lib.schemeCategory20);
 const ModelStatusesDistribution = ({modelStatuses}) => {
   if (!modelStatuses.length) {
     return (

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
@@ -41,10 +41,24 @@
   .grid.grid-container {
     max-height: calc(100% - 32px);
     height: 100%;
+    .grid-header {
+      .sortable-header {
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        &:hover {
+          text-decoration: underline;
+        }
+        .icon-svg {
+          font-size: 1.3rem;
+        }
+      }
+    }
     .grid-header,
     .grid-body {
       .grid-item {
         grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 1fr 20px;
+        padding: 7px;
         &:hover {
           [class*="icon-"] {
             color: $blue-03;
@@ -54,7 +68,6 @@
     }
     .grid-body {
       .grid-item {
-        padding: 7px 7px;
         &.opened {
           grid-template-columns: 20px 1fr 1fr 1fr 1fr 20px;
           background: $grey-08;

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
@@ -19,7 +19,12 @@ import React from 'react';
 import PaginationWithTitle from 'components/PaginationWithTitle';
 import IconSVG from 'components/IconSVG';
 import {connect} from 'react-redux';
-import {handleModelsPageChange, getAlgorithmLabel, setActiveModel} from 'components/Experiments/store/ActionCreator';
+import {
+  handleModelsPageChange,
+  handleModelsSorting,
+  getAlgorithmLabel,
+  setActiveModel
+} from 'components/Experiments/store/ActionCreator';
 import {humanReadableDate} from 'services/helpers';
 import {NUMBER_TYPES} from 'services/global-constants';
 import classnames from 'classnames';
@@ -335,8 +340,10 @@ function renderGridBody(models, outcomeType, experimentId, newlyTrainingModel) {
  });
 }
 
-function renderGrid(models, outcomeType, experimentId, newlyTrainingModel) {
+function renderGrid(models, outcomeType, experimentId, newlyTrainingModel, modelsSortColumn, modelsSortMethod) {
   let newHeaders = getNewHeadersBasedOnOutcome(outcomeType);
+  const renderSortIcon = (sortMethod) =>
+    sortMethod === 'asc' ? <IconSVG name="icon-caret-down" /> : <IconSVG name="icon-caret-up" />;
   return (
     <div className={classnames("grid grid-container", {
       "classification": NUMBER_TYPES.indexOf(outcomeType) === -1
@@ -346,9 +353,20 @@ function renderGrid(models, outcomeType, experimentId, newlyTrainingModel) {
           <strong></strong>
           {
             newHeaders.map(header => {
+              if (modelsSortColumn === header.property) {
+                return (
+                  <strong
+                    onClick={handleModelsSorting.bind(null, header.property)}
+                    className='sortable-header'
+                  >
+                    <span>{header.label}</span>
+                    { renderSortIcon(modelsSortMethod) }
+                  </strong>
+                );
+              }
               return (
                 <strong>
-                  {header.label}
+                  <span>{header.label}</span>
                 </strong>
               );
             })
@@ -363,7 +381,18 @@ function renderGrid(models, outcomeType, experimentId, newlyTrainingModel) {
   );
 }
 
-function ModelsTable({experimentId, modelsList, loading, outcomeType, modelsTotalPages, modelsCurrentPage, modelsTotalCount, newlyTrainingModel}) {
+function ModelsTable({
+  experimentId,
+  modelsList,
+  loading,
+  outcomeType,
+  modelsTotalPages,
+  modelsCurrentPage,
+  modelsTotalCount,
+  newlyTrainingModel,
+  modelsSortColumn,
+  modelsSortMethod
+}) {
   if (loading || isEmpty(experimentId)) {
     return (
       <LoadingSVGCentered />
@@ -389,7 +418,7 @@ function ModelsTable({experimentId, modelsList, loading, outcomeType, modelsTota
           numberOfEntities={modelsTotalCount}
         />
       </div>
-      {renderGrid(modelsList, outcomeType, experimentId, newlyTrainingModel)}
+      {renderGrid(modelsList, outcomeType, experimentId, newlyTrainingModel, modelsSortColumn, modelsSortMethod)}
     </div>
   );
 }
@@ -402,6 +431,8 @@ ModelsTable.propTypes = {
   modelsTotalPages: PropTypes.number,
   modelsCurrentPage: PropTypes.number,
   modelsTotalCount: PropTypes.number,
+  modelsSortMethod: PropTypes.string,
+  modelsSortColumn: PropTypes.string,
   newlyTrainingModel: PropTypes.bool
 };
 
@@ -414,7 +445,9 @@ const mapStateToProps = (state) => {
     modelsTotalPages: state.modelsTotalPages,
     modelsCurrentPage: state.modelsOffset === 0 ? 1 : Math.ceil((state.modelsOffset + 1) / state.modelsLimit),
     modelsTotalCount: state.modelsTotalCount,
-    newlyTrainingModel: state.newlyTrainingModel
+    newlyTrainingModel: state.newlyTrainingModel,
+    modelsSortMethod: state.modelsSortMethod,
+    modelsSortColumn: state.modelsSortColumn
   };
 };
 

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
@@ -15,7 +15,12 @@
 */
 
 @import "../../../styles/variables.scss";
+@import "../../../styles/mixins.scss";
 @import "../ExperimentsVariables.scss";
+
+.experiments-list-container {
+  height: 100%;
+}
 
 .experiments-listview {
   padding: 0 $listview-padding;
@@ -40,7 +45,6 @@
   }
   > .clearfix {
     margin-top: 20px;
-    height: calc(100% - 380px); // 50px (top panel) + 307 for chart + 20px margin top in this element
     .pagination-with-title {
       margin-right: 0;
     }
@@ -50,6 +54,44 @@
     .table-scroll {
       height: calc(100% - 70px); // 70px for pagination + table header. .table-scroll is the table body
       overflow-y: auto;
+    }
+  }
+
+  @include grid();
+
+  .grid.grid-container {
+    // 50px (top panel) + 310 for chart + 51px for pagination
+    max-height: calc(100% - 411px);
+
+    .grid-header {
+      .grid-item {
+        grid-template-rows: auto;
+      }
+      .sortable-header {
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        &:hover {
+          text-decoration: underline;
+        }
+        .icon-svg {
+          font-size: 1.3rem;
+        }
+      }
+    }
+
+    .grid-item {
+      grid-template-columns: repeat(5, 1fr);
+      grid-template-rows: 50px;
+      > div {
+        padding: 0;
+      }
+      small {
+        color: $cdap-lightgray;
+      }
+    }
+    a.grid-item {
+      color: inherit;
     }
   }
   .table {

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListViewWrapper.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListViewWrapper.js
@@ -19,18 +19,17 @@ import React from 'react';
 import {connect} from 'react-redux';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import TopPanel from 'components/Experiments/TopPanel';
-import SortableStickyTable from 'components/SortableStickyTable';
 import PieChart from 'components/PieChart';
 import PaginationWithTitle from 'components/PaginationWithTitle';
-import d3 from 'd3';
+import * as d3Lib from 'd3';
 import ExperimentsListBarChart from 'components/Experiments/ListView/ExperimentsListBarChart';
 import PlusButton from 'components/PlusButton';
 import InvalidPageView from 'components/Experiments/ListView/InvalidPageView';
 import EmptyListView from 'components/Experiments/ListView/EmptyListView';
 import NamespaceStore, { getCurrentNamespace } from 'services/NamespaceStore';
 import { Link } from 'react-router-dom';
-import {handlePageChange} from 'components/Experiments/store/ActionCreator';
-
+import {handlePageChange, handleExperimentsSort} from 'components/Experiments/store/ActionCreator';
+import IconSVG from 'components/IconSVG';
 
 require('./ListView.scss');
 
@@ -57,7 +56,7 @@ const tableHeaders = [
   }
 ];
 
-const colorScale = d3.scale.category20();
+const colorScale = d3Lib.scaleOrdinal(d3Lib.schemeCategory20);
 const PLUSBUTTONCONTEXTMENUITEMS = [
   {
     label: 'Create a new Experiment',
@@ -67,11 +66,14 @@ const PLUSBUTTONCONTEXTMENUITEMS = [
 
 const getAlgoDistribution = (models) => {
   if (!models.length) {
-    return null;
+    return [];
   }
   let modelsMap = {};
   models.forEach(model => {
     let algo = model.algorithm;
+    if (!algo) {
+      return;
+    }
     if (!modelsMap[algo]) {
       modelsMap = {
         ...modelsMap,
@@ -94,8 +96,8 @@ const getAlgoDistribution = (models) => {
   return Object.keys(modelsMap).map(m => modelsMap[m]);
 };
 
-const renderTableBody = (entities) => {
-  let list = entities.map(entity => {
+const renderGrid = (experiments, sortMethod, sortColumn) => {
+  let list = experiments.map(entity => {
     let models = entity.models || [];
     let modelsCount = entity.modelsCount;
     return {
@@ -107,32 +109,60 @@ const renderTableBody = (entities) => {
       algorithmTypes: getAlgoDistribution(models)
     };
   });
-  let {selectedNamespace: namespace} = NamespaceStore.getState();
+  const renderSortIcon = (sortMethod) =>
+    sortMethod === 'asc' ? <IconSVG name="icon-caret-down" /> : <IconSVG name="icon-caret-up" />;
+
   return (
-    <table className="table">
-      <tbody>
+    <div className="grid grid-container">
+      <div className="grid-header">
+        <div className="grid-item">
+          {
+            tableHeaders.map((header, i) => {
+              if (sortColumn === header.property) {
+                return (
+                  <strong
+                    className="sortable-header"
+                    key={i}
+                    onClick={handleExperimentsSort.bind(null, header.property)}
+                  >
+                    <span>{header.label}</span>
+                    {renderSortIcon(sortMethod)}
+                  </strong>
+                );
+              }
+              return (
+                <strong >
+                  {header.label}
+                </strong>
+              );
+            })
+          }
+        </div>
+      </div>
+      <div className="grid-body">
         {
-          list.map(entity => {
+          list.map(experiment => {
             return (
-              <tr>
-                <Link to={`/ns/${namespace}/experiments/${entity.name}`}>
-                  <td>
-                    <h5>
-                      <div>{entity.name}</div>
-                      <small>{entity.description}</small>
-                    </h5>
-                  </td>
-                  <td>{entity.numOfModels}</td>
-                  <td>{entity.numOfDeployedModels}</td>
-                  <td>{!entity.algorithmTypes ? null : <PieChart data={entity.algorithmTypes} />}</td>
-                  <td>{entity.testData}</td>
-                </Link>
-              </tr>
+              <Link
+                to={`/ns/${getCurrentNamespace()}/experiments/${experiment.name}`}
+                className="grid-item"
+              >
+                <div>
+                  <h5>
+                    <div>{experiment.name}</div>
+                    <small>{experiment.description}</small>
+                  </h5>
+                </div>
+                <div>{experiment.numOfModels}</div>
+                <div>{experiment.numOfDeployedModels}</div>
+                <div>{!experiment.algorithmTypes.length ? '--' : <PieChart data={experiment.algorithmTypes} />}</div>
+                <div>{experiment.testData}</div>
+              </Link>
             );
           })
         }
-      </tbody>
-    </table>
+      </div>
+    </div>
   );
 };
 
@@ -158,7 +188,15 @@ const getDataForGroupedChart = (experiments) => {
   return data;
 };
 
-function ExperimentsListView({ loading, list, totalPages, currentPage, totalCount }) {
+function ExperimentsListView({
+  loading,
+  list,
+  totalPages,
+  currentPage,
+  totalCount,
+  sortMethod,
+  sortColumn
+}) {
   if (loading) {
     return <LoadingSVGCentered />;
   }
@@ -200,12 +238,8 @@ function ExperimentsListView({ loading, list, totalPages, currentPage, totalCoun
           title={totalCount > 1 ? "Experiments" : "Experiment"}
           numberOfEntities={totalCount}
         />
-        <SortableStickyTable
-          entities={list}
-          tableHeaders={tableHeaders}
-          renderTableBody={renderTableBody}
-        />
       </div>
+      { renderGrid(list, sortMethod, sortColumn) }
     </div>
   );
 }
@@ -215,7 +249,9 @@ ExperimentsListView.propTypes = {
   list: PropTypes.arrayOf(PropTypes.object),
   totalPages: PropTypes.number,
   currentPage: PropTypes.number,
-  totalCount: PropTypes.number
+  totalCount: PropTypes.number,
+  sortMethod: PropTypes.string,
+  sortColumn: PropTypes.string
 };
 
 const mapStateToProps = (state) => {
@@ -224,7 +260,9 @@ const mapStateToProps = (state) => {
     list: state.experiments.list,
     totalPages: state.experiments.totalPages,
     currentPage: state.experiments.offset === 0 ? 1 : Math.ceil((state.experiments.offset + 1) / state.experiments.limit),
-    totalCount: state.experiments.totalCount
+    totalCount: state.experiments.totalCount,
+    sortMethod: state.experiments.sortMethod,
+    sortColumn: state.experiments.sortColumn
   };
 };
 

--- a/cdap-ui/app/cdap/components/Experiments/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/index.js
@@ -18,8 +18,8 @@ import React, { Component } from 'react';
 import Helmet from 'react-helmet';
 import ExperimentsListViewWrapper from 'components/Experiments/ListView/ListViewWrapper';
 import { Provider } from 'react-redux';
-import experimentsStore, { DEFAULT_EXPERIMENTS } from 'components/Experiments/store';
-import { getExperimentsList, setAlgorithmsList, updatePagination, handlePageChange } from 'components/Experiments/store/ActionCreator';
+import experimentsStore, { DEFAULT_EXPERIMENTS, MMDS_SORT_METHODS, MMDS_SORT_COLUMN } from 'components/Experiments/store';
+import { getExperimentsList, setAlgorithmsList, updateQueryParameters, handlePageChange } from 'components/Experiments/store/ActionCreator';
 import queryString from 'query-string';
 import isNil from 'lodash/isNil';
 import Mousetrap from 'mousetrap';
@@ -61,8 +61,8 @@ export default class ExperimentsList extends Component {
 
   parseUrlAndUpdateStore = (nextProps) => {
     let props = nextProps || this.props;
-    let { offset, limit } = this.getQueryObject(queryString.parse(props.location.search));
-    updatePagination({ offset, limit });
+    let { offset, limit, sortMethod, sortColumn } = this.getQueryObject(queryString.parse(props.location.search));
+    updateQueryParameters({ offset, limit, sortMethod, sortColumn });
   };
 
   getQueryObject = (query) => {
@@ -71,8 +71,10 @@ export default class ExperimentsList extends Component {
     }
     let {
       offset = DEFAULT_EXPERIMENTS.offset,
-      limit = DEFAULT_EXPERIMENTS.limit
+      limit = DEFAULT_EXPERIMENTS.limit,
+      sort
     } = query;
+    let sortMethod, sortColumn;
     offset = parseInt(offset, 10);
     limit = parseInt(limit, 10);
     if (isNaN(offset)) {
@@ -81,13 +83,21 @@ export default class ExperimentsList extends Component {
     if (isNaN(limit)) {
       limit = DEFAULT_EXPERIMENTS.limit;
     }
-    return { offset, limit };
+    if (!sort) {
+      sortMethod = MMDS_SORT_METHODS.ASC;
+      sortColumn = MMDS_SORT_COLUMN;
+    } else {
+      let sortSplit = sort.split(' ');
+      sortColumn = sortSplit[0] || MMDS_SORT_COLUMN;
+      sortMethod = sortSplit[1] || MMDS_SORT_METHODS.ASC;
+    }
+    return { offset, limit, sortMethod, sortColumn };
   };
 
   render() {
     return (
       <Provider store={experimentsStore}>
-        <div>
+        <div className="experiments-list-container">
           <Helmet title="CDAP | All Experiments" />
           <ExperimentsListViewWrapper />
         </div>

--- a/cdap-ui/app/cdap/components/Experiments/store/experimentDetailStore.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/experimentDetailStore.js
@@ -17,6 +17,7 @@
 import {createStore} from 'redux';
 import {composeEnhancers} from 'services/helpers';
 import {defaultAction} from 'services/helpers';
+import {MMDS_SORT_METHODS, MMDS_SORT_COLUMN} from 'components/Experiments/store';
 
 const ACTIONS = {
   SET_EXPERIMENT_DETAILS: 'SET_EXPERIMENT_DETAILS',
@@ -27,8 +28,10 @@ const ACTIONS = {
   SET_SPLITS: 'SET_SPLITS',
   SET_MODEL_STATUS: 'SET_MODEL_STATUS',
   SET_MODEL_PAGINATION: 'SET_MODEL_PAGINATION',
+  SET_MODELS_QUERY_PARAMS: 'SET_MODELS_QUERY_PARAMS',
   SET_NEWLY_TRAINING_MODEL: 'SET_NEWLY_TRAINING_MODEL',
   RESET_NEWLY_TRAINING_MODEL: 'RESET_NEWLY_TRAINING_MODEL',
+  SET_MODELS_SORT: 'SET_MODELS_SORT',
   RESET: 'RESET'
 };
 
@@ -47,6 +50,8 @@ export const DEFAULT_EXPERIMENT_DETAILS = {
   modelsLimit: 10,
   modelsTotalCount: 0,
   modelsTotalPages: 0,
+  modelsSortMethod: MMDS_SORT_METHODS.ASC,
+  modelsSortColumn: MMDS_SORT_COLUMN,
   loading: false
 };
 
@@ -112,6 +117,14 @@ const experimentDetails = (state = DEFAULT_EXPERIMENT_DETAILS, action = defaultA
         modelsOffset: action.payload.modelsOffset,
         modelsLimit: action.payload.modelsLimit || state.modelsLimit
       };
+    case ACTIONS.SET_MODELS_QUERY_PARAMS:
+      return {
+        ...state,
+        modelsOffset: action.payload.modelsOffset,
+        modelsLimit: action.payload.modelsLimit || state.modelsLimit,
+        modelsSortMethod: action.payload.modelsSortMethod,
+        modelsSortColumn: action.payload.modelsSortColumn
+      };
     case ACTIONS.SET_ACTIVE_MODEL:
       return {
         ...state,
@@ -153,6 +166,12 @@ const experimentDetails = (state = DEFAULT_EXPERIMENT_DETAILS, action = defaultA
           return model;
         })
       };
+      case ACTIONS.SET_MODELS_SORT:
+        return {
+          ...state,
+          modelsSortMethod: action.payload.modelsSortMethod,
+          modelsSortColumn: action.payload.modelsSortColumn
+        };
     default:
       return state;
   }

--- a/cdap-ui/app/cdap/components/Experiments/store/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/index.js
@@ -21,12 +21,23 @@ const ACTIONS = {
   SET_EXPERIMENTS_LIST: 'SET_EXPERIMENTS_LIST',
   SET_EXPERIMENTS_LOADING: 'SET_EXPERIMENTS_LOADING',
   SET_MODELS_IN_EXPERIMENT: 'SET_MODELS_IN_EXPERIMENT',
+  SET_EXPERIMENTS_SORT: 'SET_EXPERIMENTS_SORT',
+  SET_QUERY_PARAMS: 'SET_QUERY_PARAMS',
   SET_PAGINATION: 'SET_PAGINATION'
 };
+
+export const MMDS_SORT_METHODS = {
+  ASC: 'asc',
+  DESC: 'desc'
+};
+
+export const MMDS_SORT_COLUMN = 'name';
 
 export const DEFAULT_EXPERIMENTS = {
   list: [],
   offset: 0,
+  sortMethod: MMDS_SORT_METHODS.ASC,
+  sortColumn: MMDS_SORT_COLUMN,
   totalPages: 0,
   totalCount: 0,
   limit: 10,
@@ -67,6 +78,19 @@ const experiments = (state = DEFAULT_EXPERIMENTS, action = defaultAction) => {
           }
           return experiment;
         })
+      };
+    case ACTIONS.SET_EXPERIMENTS_SORT:
+      return {
+        ...state,
+        sortMethod: action.payload.sortMethod,
+        sortColumn: action.payload.sortColumn
+      };
+    case ACTIONS.SET_QUERY_PARAMS:
+      return {
+        ...state,
+        sortMethod: action.payload.sortMethod,
+        sortColumn: action.payload.sortColumn,
+        offset: action.payload.offset
       };
     default:
       return state;

--- a/cdap-ui/app/cdap/components/PieChart/index.js
+++ b/cdap-ui/app/cdap/components/PieChart/index.js
@@ -16,7 +16,7 @@
 
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import d3 from 'd3';
+import * as d3Lib from 'd3';
 import uuidV4 from 'uuid/v4';
 import isNil from 'lodash/isNil';
 
@@ -43,17 +43,17 @@ export default class PieChart extends Component {
     if (isNil(this.state.data) || (Array.isArray(this.state.data) && !this.state.data.length)) {
       return;
     }
-    var svg = d3.select(`#${this.state.id} svg`),
+    var svg = d3Lib.select(`#${this.state.id} svg`),
         width = +svg.attr("width"),
         height = +svg.attr("height"),
         radius = Math.min(width, height) / 2,
         g = svg.append("g").attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
 
-    var pie = d3.layout.pie()
+    var pie = d3Lib.layout.pie()
         .sort(null)
         .value(function(d) { return d.count; });
 
-    var path = d3.svg.arc()
+    var path = d3Lib.svg.arc()
         .outerRadius(radius - 10)
         .innerRadius(0);
 


### PR DESCRIPTION
- Adds sorting to experiments and models list view MMDS
   - Updates store to store the changes
   - Parses url to sync store on refresh.
- Modifies experiments list view to use css grid we use for models list view for consistency.
- Fixes D3 library APIs to match the new v4. (This could be wrong. I am not sure why this keeps changing back and forth. Could be again my local yarn cache doing this. Will confirm before PR is about to be merged.).
- Fixes more uuid references used as `id` for DOM elements.

### Note:
- Right now MMDS is not end-to-end working. MMDS app has been updated based on the new flow but the UI hasn't integrated with the backend

JIRA: https://issues.cask.co/browse/CDAP-13117