### PR TITLE
[RulesEngine] Fix error message during the start of Rules engine

### DIFF
--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/index.js
@@ -56,9 +56,9 @@ export default class ExperimentsServiceControl extends Component {
       i18nPrefix: ''
     }).subscribe(
       this.props.onServiceStart,
-      (err) => {
+      () => {
         this.setState({
-          error: typeof err === 'object' ? err.error : err,
+          error: T.translate(`${PREFIX}.errorMessage`),
           loading: false
         });
       }

--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -111,7 +111,7 @@ export default class DeleteAction extends Component {
   render() {
     const actionLabel = T.translate('features.FastAction.deleteLabel');
     const headerTitle = `${actionLabel} ${this.props.entity.type}`;
-    const tooltipID = `${this.props.entity.uniqueId}-delete`;
+    const tooltipID = `delete-${this.props.entity.uniqueId}`;
 
     return (
       <span className="btn btn-secondary btn-sm">

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
@@ -236,7 +236,7 @@ export default class ExploreModal extends Component {
 
   render() {
     const renderQueryRow = (query) => {
-      let id = uuidV4();
+      let id = `explore-${uuidV4()}`;
       return (
         <tr key={id}>
           <td> {humanReadableDate(query.timestamp, true)} </td>
@@ -261,13 +261,13 @@ export default class ExploreModal extends Component {
                     disabled="disabled"
                     >
                     <i
-                      id={`${id}-download`}
+                      id={`download-${id}`}
                       className="fa fa-download"
                     ></i>
                     {
                       !query.is_active ?
                         <UncontrolledTooltip
-                          target={`${id}-download`}
+                          target={`download-${id}`}
                           placement="left"
                           delay={300}
                         >
@@ -295,13 +295,13 @@ export default class ExploreModal extends Component {
               >
                 <i
                   className="fa fa-eye"
-                  id={`${id}-explore`}
+                  id={`explore-${id}`}
                   delay={300}
                 ></i>
               {
                 !query.is_active?
                   <UncontrolledTooltip
-                      target={`${id}-explore`}
+                      target={`explore-${id}`}
                       placement="top"
                     >
                       <div className="text-xs-left">
@@ -330,7 +330,7 @@ export default class ExploreModal extends Component {
                   <thead>
                     <tr>
                       {
-                        query.schema.map(s => (<th key={uuidV4()}>{s.name}</th>))
+                        query.schema.map(s => (<th key={`A-${uuidV4()}`}>{s.name}</th>))
                       }
                     </tr>
                   </thead>
@@ -340,7 +340,7 @@ export default class ExploreModal extends Component {
                         .preview
                         .map((row) => {
                           return (
-                            <tr key={uuidV4()}>
+                            <tr key={`A-${uuidV4()}`}>
                               {
                                 !row.columns ?
                                   T.translate('features.FastAction.viewEvents.noResults')
@@ -355,7 +355,7 @@ export default class ExploreModal extends Component {
                                     }
 
                                     return (
-                                      <td key={uuidV4()}>
+                                      <td key={`A-${uuidV4()}`}>
                                         {content}
                                       </td>
                                     );
@@ -376,7 +376,7 @@ export default class ExploreModal extends Component {
         );
       };
       return (
-        <tr key={uuidV4()}>
+        <tr key={`A-${uuidV4()}`}>
           <td colSpan="4" className="preview-cell">
             {
               query.schema && !query.preview ?

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
@@ -117,7 +117,7 @@ export default class ExploreAction extends Component {
     }
   }
   render() {
-    let tooltipID = `${this.props.entity.uniqueId}-explore`;
+    let tooltipID = `explore-${this.props.entity.uniqueId}`;
     let showRunningQueriesNotification = this.state.showRunningQueriesDoneLabel && this.state.runningQueries && objectQuery(this.props.argsToAction, 'showQueriesCount');
     return (
       <span className={classnames("btn btn-secondary btn-sm", {'fast-action-with-popover': showRunningQueriesNotification})}>

--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
@@ -57,7 +57,7 @@ export default class SendEventAction extends Component {
   }
 
   render() {
-    let tooltipID = `${this.props.entity.uniqueId}-sendevents`;
+    let tooltipID = `sendevents-${this.props.entity.uniqueId}`;
     return (
       <span className="btn btn-secondary btn-sm">
         <FastActionButton

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
@@ -79,7 +79,7 @@ export default class SetPreferenceAction extends Component {
     let iconClasses = classnames({'fa-lg': this.props.setAtNamespaceLevel}, {'text-success': this.state.preferencesSaved});
     let tooltipID = `${this.namespace}-setpreferences`;
     if (this.props.entity) {
-      tooltipID = `${this.props.entity.uniqueId}-setpreferences`;
+      tooltipID = `setpreferences-${this.props.entity.uniqueId}`;
     }
     return (
       <span className="btn btn-secondary btn-sm">

--- a/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
@@ -106,7 +106,7 @@ export default class TruncateAction extends Component {
     const actionLabel = T.translate('features.FastAction.truncateLabel');
     const type = getType(this.props.entity);
     const headerTitle = `${actionLabel} ${type}`;
-    const tooltipID = `${this.props.entity.uniqueId}-truncate`;
+    const tooltipID = `truncate-${this.props.entity.uniqueId}`;
     let truncateActionClassNames = 'icon-cut';
     return (
       <span className="btn btn-secondary btn-sm">

--- a/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
+++ b/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
@@ -115,7 +115,9 @@ export default class OverviewMetaSection extends Component {
     let description =  objectQuery(this.props, 'entity', 'properties', 'description');
     // have to generate new uniqueId here, because we don't want the fast actions here to
     // trigger the tooltips on the card view
-    let entity = Object.assign({}, this.props.entity, {uniqueId: uuidV4()});
+    let entity = Object.assign({}, this.props.entity, {
+      uniqueId: `meta-${uuidV4()}`
+    });
     return (
       <div className="overview-meta-section">
         <h2 title={this.props.entity.id}>

--- a/cdap-ui/app/cdap/components/ProgramTable/index.js
+++ b/cdap-ui/app/cdap/components/ProgramTable/index.js
@@ -84,7 +84,7 @@ export default class ProgramTable extends Component {
         programType: prog.type,
         type: 'program',
         id: prog.name,
-        uniqueId: uuidV4()
+        uniqueId: `program-${uuidV4()}`
       });
     });
   }

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
@@ -57,9 +57,9 @@ export default class RulesEngineServiceControl extends Component {
     })
       .subscribe(
         this.props.onServiceStart,
-        (err) => {
+        () => {
           this.setState({
-            error: typeof err === 'object' ? err.error : err,
+            error: T.translate(`${PREFIX}.errorMessage`),
             loading: false
           });
         }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1125,6 +1125,7 @@ features:
       description: "Data Scientists typically build custom tooling for managing their machine learning models and deploying them. Model Management and Distribution Service (MMDS) provides a seamless, automated interface to help users develop, train, test, evaluate and deploy their machine learning models using CDAP."
       enableBtnLabel: Enable MMDS
       errorTitle: Enabling MMDS Failed
+      errorMessage: Please check logs for more information
       title: Welcome to Model Management and Distribution Service
 
   FileBrowser:
@@ -1678,6 +1679,7 @@ features:
                   The intuitive UI allows business analysts to set up business rules and use them within a data pipeline.
       enableBtnLabel: Enable Rules Engine
       errorTitle: Enabling Rules Engine Failed
+      errorMessage: Please check logs for more information
       title: Welcome to Rules Engine Management
     RulesList:
       dropContainerText: Add a rule by dragging and dropping from the Rules tab


### PR DESCRIPTION
### Issue:
- Original issue is we started sharing service control code between dataprep and rules engine as we pretty much did exactly the same.
- But when things fail we were still referencing to the message thrown when we start dataprep (even though the context was rules engine).
- Have also fixed more node-uuid transitions being used as ids for DOM elements.

### Fix:
- Fixed the error message to be based on context. 
- Have not changed the common dataprep service control to isolate the change to Rules engine and not dataprep
