### PR TITLE
Fix references of node-uuid used for id for DOM elements

### DIFF
--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -111,7 +111,7 @@ export default class DeleteAction extends Component {
   render() {
     const actionLabel = T.translate('features.FastAction.deleteLabel');
     const headerTitle = `${actionLabel} ${this.props.entity.type}`;
-    const tooltipID = `${this.props.entity.uniqueId}-delete`;
+    const tooltipID = `delete-${this.props.entity.uniqueId}`;
 
     return (
       <span className="btn btn-secondary btn-sm">

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
@@ -236,7 +236,7 @@ export default class ExploreModal extends Component {
 
   render() {
     const renderQueryRow = (query) => {
-      let id = uuidV4();
+      let id = `explore-${uuidV4()}`;
       return (
         <tr key={id}>
           <td> {humanReadableDate(query.timestamp, true)} </td>
@@ -261,13 +261,13 @@ export default class ExploreModal extends Component {
                     disabled="disabled"
                     >
                     <i
-                      id={`${id}-download`}
+                      id={`download-${id}`}
                       className="fa fa-download"
                     ></i>
                     {
                       !query.is_active ?
                         <UncontrolledTooltip
-                          target={`${id}-download`}
+                          target={`download-${id}`}
                           placement="left"
                           delay={300}
                         >
@@ -295,13 +295,13 @@ export default class ExploreModal extends Component {
               >
                 <i
                   className="fa fa-eye"
-                  id={`${id}-explore`}
+                  id={`explore-${id}`}
                   delay={300}
                 ></i>
               {
                 !query.is_active?
                   <UncontrolledTooltip
-                      target={`${id}-explore`}
+                      target={`explore-${id}`}
                       placement="top"
                     >
                       <div className="text-xs-left">
@@ -330,7 +330,7 @@ export default class ExploreModal extends Component {
                   <thead>
                     <tr>
                       {
-                        query.schema.map(s => (<th key={uuidV4()}>{s.name}</th>))
+                        query.schema.map(s => (<th key={`A-${uuidV4()}`}>{s.name}</th>))
                       }
                     </tr>
                   </thead>
@@ -340,7 +340,7 @@ export default class ExploreModal extends Component {
                         .preview
                         .map((row) => {
                           return (
-                            <tr key={uuidV4()}>
+                            <tr key={`A-${uuidV4()}`}>
                               {
                                 !row.columns ?
                                   T.translate('features.FastAction.viewEvents.noResults')
@@ -355,7 +355,7 @@ export default class ExploreModal extends Component {
                                     }
 
                                     return (
-                                      <td key={uuidV4()}>
+                                      <td key={`A-${uuidV4()}`}>
                                         {content}
                                       </td>
                                     );
@@ -376,7 +376,7 @@ export default class ExploreModal extends Component {
         );
       };
       return (
-        <tr key={uuidV4()}>
+        <tr key={`A-${uuidV4()}`}>
           <td colSpan="4" className="preview-cell">
             {
               query.schema && !query.preview ?

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
@@ -117,7 +117,7 @@ export default class ExploreAction extends Component {
     }
   }
   render() {
-    let tooltipID = `${this.props.entity.uniqueId}-explore`;
+    let tooltipID = `explore-${this.props.entity.uniqueId}`;
     let showRunningQueriesNotification = this.state.showRunningQueriesDoneLabel && this.state.runningQueries && objectQuery(this.props.argsToAction, 'showQueriesCount');
     return (
       <span className={classnames("btn btn-secondary btn-sm", {'fast-action-with-popover': showRunningQueriesNotification})}>

--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
@@ -57,7 +57,7 @@ export default class SendEventAction extends Component {
   }
 
   render() {
-    let tooltipID = `${this.props.entity.uniqueId}-sendevents`;
+    let tooltipID = `sendevents-${this.props.entity.uniqueId}`;
     return (
       <span className="btn btn-secondary btn-sm">
         <FastActionButton

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
@@ -79,7 +79,7 @@ export default class SetPreferenceAction extends Component {
     let iconClasses = classnames({'fa-lg': this.props.setAtNamespaceLevel}, {'text-success': this.state.preferencesSaved});
     let tooltipID = `${this.namespace}-setpreferences`;
     if (this.props.entity) {
-      tooltipID = `${this.props.entity.uniqueId}-setpreferences`;
+      tooltipID = `setpreferences-${this.props.entity.uniqueId}`;
     }
     return (
       <span className="btn btn-secondary btn-sm">

--- a/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
@@ -104,7 +104,7 @@ export default class TruncateAction extends Component {
   render() {
     const actionLabel = T.translate('features.FastAction.truncateLabel');
     const headerTitle = `${actionLabel} ${this.props.entity.type}`;
-    const tooltipID = `${this.props.entity.uniqueId}-truncate`;
+    const tooltipID = `truncate-${this.props.entity.uniqueId}`;
     let truncateActionClassNames = 'icon-cut';
     return (
       <span className="btn btn-secondary btn-sm">

--- a/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
+++ b/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
@@ -115,7 +115,9 @@ export default class OverviewMetaSection extends Component {
     let description =  objectQuery(this.props, 'entity', 'properties', 'description');
     // have to generate new uniqueId here, because we don't want the fast actions here to
     // trigger the tooltips on the card view
-    let entity = Object.assign({}, this.props.entity, {uniqueId: uuidV4()});
+    let entity = Object.assign({}, this.props.entity, {
+      uniqueId: `meta-${uuidV4()}`
+    });
     return (
       <div className="overview-meta-section">
         <h2 title={this.props.entity.id}>

--- a/cdap-ui/app/cdap/components/ProgramTable/index.js
+++ b/cdap-ui/app/cdap/components/ProgramTable/index.js
@@ -83,7 +83,7 @@ export default class ProgramTable extends Component {
         programType: prog.type,
         type: 'program',
         id: prog.id,
-        uniqueId: uuidV4()
+        uniqueId: `program-${uuidV4()}`
       });
     });
   }

--- a/cdap-ui/app/cdap/components/UncontrolledComponents/Popover.js
+++ b/cdap-ui/app/cdap/components/UncontrolledComponents/Popover.js
@@ -28,7 +28,7 @@ export default class UncontrolledPopover extends Component {
     super(props);
     this.state = {
       dropdownOpen: props.dropdownOpen,
-      id: uuidV4()
+      id: `popover-${uuidV4()}`
     };
     this.togglePopover = this.togglePopover.bind(this);
     this.itemClicked = this.itemClicked.bind(this);

--- a/cdap-ui/app/tracker/directives/jump/jump.less
+++ b/cdap-ui/app/tracker/directives/jump/jump.less
@@ -17,7 +17,6 @@
 
 my-jump-button {
   .btn-jump {
-    color: white;
     padding: 5px 10px;
     transition: background-color 0.1s ease-in-out;
     &:hover,


### PR DESCRIPTION
#### Issue:
- ids for DOM elements has to start with a character. 
- node-uuid is generating unique ids each time but doesn't guarantee to have characters at the start.
- Fixes the color for "Actions" button in dataset detailed view in tracker. Right now since the color of the font is the same as background it looks hidden.


Similar to this PR but for 4.3.4: https://github.com/caskdata/cdap/pull/9946