### PR TITLE
code cleanup around AppMetadataStore

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
@@ -83,9 +83,9 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
   private void setStartAndRunning(final ProgramId id, final String pid, final long startTime,
                                   final Map<String, String> runtimeArgs,
                                   final Map<String, String> systemArgs) {
-    store.setStart(id, pid, startTime, null, runtimeArgs, systemArgs,
+    store.setStart(id.run(pid), startTime, null, runtimeArgs, systemArgs,
                    AppFabricTestHelper.createSourceId(++sourceId));
-    store.setRunning(id, pid, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setRunning(id.run(pid), startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 
   @Test
@@ -123,7 +123,7 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
       setStartAndRunning(mapreduceProgram, mapreduceRunid.getId(), workflowStartTimeSecs,
                          ImmutableMap.<String, String>of(), systemArgs);
 
-      store.setStop(mapreduceProgram, mapreduceRunid.getId(),
+      store.setStop(mapreduceProgram.run(mapreduceRunid),
                     // map-reduce job ran for 17 seconds
                     TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis) + 19,
                     ProgramRunStatus.COMPLETED, AppFabricTestHelper.createSourceId(++sourceId));
@@ -145,7 +145,7 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
           // spark job ran for 100 seconds. 62 seconds greater than avg.
           stopTime = TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis) + 120;
         }
-        store.setStop(sparkProgram, sparkRunid.getId(), stopTime, ProgramRunStatus.COMPLETED,
+        store.setStop(sparkProgram.run(sparkRunid.getId()), stopTime, ProgramRunStatus.COMPLETED,
                       AppFabricTestHelper.createSourceId(++sourceId));
       }
 
@@ -157,7 +157,7 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
         outlierRunId = workflowRunId.getId();
       }
 
-      store.setStop(workflowProgram, workflowRunId.getId(), workflowStopTime, ProgramRunStatus.COMPLETED,
+      store.setStop(workflowProgram.run(workflowRunId.getId()), workflowStopTime, ProgramRunStatus.COMPLETED,
                     AppFabricTestHelper.createSourceId(++sourceId));
     }
 
@@ -334,7 +334,7 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
       workflowStartTimeSecs = RunIds.getTime(mapreduceRunid, TimeUnit.SECONDS);
       setStartAndRunning(mapreduceProgram, mapreduceRunid.getId(), workflowStartTimeSecs,
                          ImmutableMap.<String, String>of(), systemArgs);
-      store.setStop(mapreduceProgram, mapreduceRunid.getId(),
+      store.setStop(mapreduceProgram.run(mapreduceRunid.getId()),
                     // map-reduce job ran for 17 seconds
                     TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis) + 19,
                     ProgramRunStatus.COMPLETED, AppFabricTestHelper.createSourceId(++sourceId));
@@ -363,13 +363,13 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
 
       // spark job runs for 38 seconds
       long stopTime = TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis) + 58;
-      store.setStop(sparkProgram, sparkRunid.getId(), stopTime, ProgramRunStatus.COMPLETED,
+      store.setStop(sparkProgram.run(sparkRunid.getId()), stopTime, ProgramRunStatus.COMPLETED,
                     AppFabricTestHelper.createSourceId(++sourceId));
 
       // workflow ran for 1 minute
       long workflowStopTime = TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis) + 60;
 
-      store.setStop(workflowProgram, workflowRunId.getId(), workflowStopTime, ProgramRunStatus.COMPLETED,
+      store.setStop(workflowProgram.run(workflowRunId.getId()), workflowStopTime, ProgramRunStatus.COMPLETED,
                     AppFabricTestHelper.createSourceId(++sourceId));
     }
     return runIdList;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -39,7 +39,6 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.id.WorkflowId;
-import com.google.common.base.Predicate;
 import org.apache.twill.api.RunId;
 
 import java.io.IOException;
@@ -47,17 +46,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 /**
  * Responsible for managing {@link Program} and {@link Application} metadata.
  */
 public interface Store extends RuntimeStore {
+
   /**
    * Logs initialization of program run and persists program status to {@link ProgramRunStatus#STARTING}.
    *
-   * @param id id of the program
-   * @param pid run id
+   * @param id run id of the program
    * @param startTime start timestamp in seconds
    * @param twillRunId Twill run id
    * @param runtimeArgs the runtime arguments for this program run
@@ -65,66 +65,61 @@ public interface Store extends RuntimeStore {
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setStart(ProgramId id, String pid, long startTime, @Nullable String twillRunId,
+  void setStart(ProgramRunId id, long startTime, @Nullable String twillRunId,
                 Map<String, String> runtimeArgs, Map<String, String> systemArgs, byte[] sourceId);
 
   /**
    * Logs start of program run and persists program status to {@link ProgramRunStatus#RUNNING}.
    *
-   * @param id id of the program
-   * @param pid run id
+   * @param id run id of the program
    * @param twillRunId Twill run id
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setRunning(ProgramId id, String pid, long runTime, @Nullable String twillRunId, byte[] sourceId);
+  void setRunning(ProgramRunId id, long runTime, @Nullable String twillRunId, byte[] sourceId);
 
   /**
    * Logs end of program run and sets the run status to one of: {@link ProgramRunStatus#COMPLETED},
    * or {@link ProgramRunStatus#KILLED}.
    *
-   * @param id id of the program
-   * @param pid run id
+   * @param id run id of the program
    * @param endTime end timestamp in seconds
    * @param runStatus {@link ProgramRunStatus} of program run
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setStop(ProgramId id, String pid, long endTime, ProgramRunStatus runStatus, byte[] sourceId);
+  void setStop(ProgramRunId id, long endTime, ProgramRunStatus runStatus, byte[] sourceId);
 
   /**
    * Logs end of program run and sets the run status to {@link ProgramRunStatus#FAILED} with a failure cause.
    *
-   * @param id id of the program
-   * @param pid run id
+   * @param id run id of the program
    * @param endTime end timestamp in seconds
    * @param runStatus {@link ProgramRunStatus} of program run
    * @param failureCause failure cause if the program failed to execute
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setStop(ProgramId id, String pid, long endTime, ProgramRunStatus runStatus,
+  void setStop(ProgramRunId id, long endTime, ProgramRunStatus runStatus,
                @Nullable BasicThrowable failureCause, byte[] sourceId);
 
   /**
    * Logs suspend of a program run and sets the run status to {@link ProgramRunStatus#SUSPENDED}.
    *
-   * @param id id of the program
-   * @param pid run id
+   * @param id run id of the program
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setSuspend(ProgramId id, String pid, byte[] sourceId);
+  void setSuspend(ProgramRunId id, byte[] sourceId);
 
   /**
    * Logs resume of a program run and sets the run status to {@link ProgramRunStatus#RUNNING}.
    *
-   * @param id id of the program
-   * @param pid run id
+   * @param id run id of the program
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setResume(ProgramId id, String pid, byte[] sourceId);
+  void setResume(ProgramRunId id, byte[] sourceId);
 
   /**
    * Loads a given program.
@@ -217,12 +212,11 @@ public interface Store extends RuntimeStore {
   /**
    * Fetches the run record for particular run of a program.
    *
-   * @param id        id of the program
-   * @param runid     run id of the program
+   * @param id        run id of the program
    * @return          run record for the specified program and runid, null if not found
    */
   @Nullable
-  RunRecordMeta getRun(ProgramId id, String runid);
+  RunRecordMeta getRun(ProgramRunId id);
 
   /**
    * Creates a new stream if it does not exist.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -241,7 +241,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     if (!appSpec.getMapReduce().containsKey(mapreduceId)) {
       throw new NotFoundException(programId);
     }
-    RunRecordMeta runRecordMeta = store.getRun(programId, runId);
+    RunRecordMeta runRecordMeta = store.getRun(run);
     if (runRecordMeta == null) {
       throw new NotFoundException(run);
     }
@@ -480,7 +480,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                                 programType));
     }
     ProgramId progId = new ApplicationId(namespaceId, appName, appVersion).program(programType, programName);
-    RunRecordMeta runRecordMeta = store.getRun(progId, runid);
+    RunRecordMeta runRecordMeta = store.getRun(progId.run(runid));
     if (runRecordMeta != null) {
       RunRecord runRecord = new RunRecord(runRecordMeta);
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(runRecord));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -313,7 +313,7 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
     if (!appSpec.getWorkflows().containsKey(workflow)) {
       throw new NotFoundException(workflowId);
     }
-    if (store.getRun(workflowId, runId) == null) {
+    if (store.getRun(workflowId.run(runId)) == null) {
       throw new NotFoundException(workflowId.run(runId));
     }
     return store.getWorkflowToken(workflowId, runId);
@@ -341,7 +341,7 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
     }
 
     ProgramRunId workflowRunId = workflowProgramId.run(runId);
-    if (store.getRun(workflowProgramId, runId) == null) {
+    if (store.getRun(workflowRunId) == null) {
       throw new NotFoundException(workflowRunId);
     }
 
@@ -431,7 +431,7 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
       throw new ProgramNotFoundException(programId);
     }
 
-    if (store.getRun(programId, runId) == null) {
+    if (store.getRun(programId.run(runId)) == null) {
       throw new NotFoundException(new ProgramRunId(programId.getNamespace(), programId.getApplication(),
                                                    programId.getType(), programId.getProgram(), runId));
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRunExistenceVerifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRunExistenceVerifier.java
@@ -35,7 +35,7 @@ public class ProgramRunExistenceVerifier implements EntityExistenceVerifier<Prog
 
   @Override
   public void ensureExists(ProgramRunId runId) throws NotFoundException {
-    if (store.getRun(runId.getParent(), runId.getRun()) == null) {
+    if (store.getRun(runId) == null) {
       throw new NotFoundException(runId);
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/TriggerInfoContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/trigger/TriggerInfoContext.java
@@ -91,14 +91,12 @@ public class TriggerInfoContext {
    * @return run time arguments as a map for the specified program and runId, null if not found
    */
   public Map<String, String> getProgramRuntimeArguments(ProgramRunId programRunId) {
-    RunRecordMeta runRecordMeta = store.getRun(programRunId.getParent(), programRunId.getRun());
+    RunRecordMeta runRecordMeta = store.getRun(programRunId);
     if (runRecordMeta == null) {
       return Collections.emptyMap();
     }
     Map<String, String> properties = runRecordMeta.getProperties();
     String runtimeArgsJson = properties.get("runtimeArgs");
-    return runtimeArgsJson == null
-      ? Collections.<String, String>emptyMap()
-      : GSON.<Map<String, String>>fromJson(runtimeArgsJson, STRING_STRING_MAP);
+    return runtimeArgsJson == null ? Collections.emptyMap() : GSON.fromJson(runtimeArgsJson, STRING_STRING_MAP);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -398,7 +398,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
         ProgramRunId activeRunId = programId.run(iterator.next());
         RunRecordMeta runRecord = activeRunRecords.get(activeRunId);
         if (runRecord == null) {
-          runRecord = store.getRun(programId, activeRunId.getRun());
+          runRecord = store.getRun(activeRunId);
         }
         // Check if the program is actually started from workflow and the workflow is running
         if (runRecord != null && runRecord.getProperties().containsKey("workflowrunid")
@@ -819,7 +819,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
     if (runId == null) {
       return store.getActiveRuns(programId);
     }
-    RunRecordMeta runRecord = store.getRun(programId, runId);
+    RunRecordMeta runRecord = store.getRun(programId.run(runId));
     EnumSet<ProgramRunStatus> activeStates = EnumSet.of(ProgramRunStatus.STARTING,
                                                         ProgramRunStatus.RUNNING,
                                                         ProgramRunStatus.SUSPENDED);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -215,7 +215,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
           }
           Map<String, String> userArguments = GSON.fromJson(userArgumentsString, STRING_STRING_MAP);
           Map<String, String> systemArguments = GSON.fromJson(systemArgumentsString, STRING_STRING_MAP);
-          recordedStatus = appMetadataStore.recordProgramStart(programId, runId, startTimeSecs, twillRunId,
+          recordedStatus = appMetadataStore.recordProgramStart(programRunId, startTimeSecs, twillRunId,
                                                                userArguments, systemArguments, messageIdBytes);
           break;
         case RUNNING:
@@ -227,13 +227,13 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
             return;
           }
           recordedStatus =
-            appMetadataStore.recordProgramRunning(programId, runId, logicalStartTimeSecs, twillRunId, messageIdBytes);
+            appMetadataStore.recordProgramRunning(programRunId, logicalStartTimeSecs, twillRunId, messageIdBytes);
           break;
         case SUSPENDED:
-          recordedStatus = appMetadataStore.recordProgramSuspend(programId, runId, messageIdBytes);
+          recordedStatus = appMetadataStore.recordProgramSuspend(programRunId, messageIdBytes);
           break;
         case RESUMING:
-          recordedStatus = appMetadataStore.recordProgramResumed(programId, runId, messageIdBytes);
+          recordedStatus = appMetadataStore.recordProgramResumed(programRunId, messageIdBytes);
           break;
         case COMPLETED:
         case KILLED:
@@ -243,7 +243,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
             return;
           }
           recordedStatus =
-            appMetadataStore.recordProgramStop(programId, runId, endTimeSecs, programRunStatus, null, messageIdBytes);
+            appMetadataStore.recordProgramStop(programRunId, endTimeSecs, programRunStatus, null, messageIdBytes);
           break;
         case FAILED:
           if (endTimeSecs == -1) {
@@ -253,7 +253,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
           }
           BasicThrowable cause = decodeBasicThrowable(properties.get(ProgramOptionConstants.PROGRAM_ERROR));
           recordedStatus =
-            appMetadataStore.recordProgramStop(programId, runId, endTimeSecs, programRunStatus, cause, messageIdBytes);
+            appMetadataStore.recordProgramStop(programRunId, endTimeSecs, programRunStatus, cause, messageIdBytes);
           break;
         default:
           // This should not happen

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -24,7 +24,6 @@ import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.id.Id;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
@@ -38,15 +37,11 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.id.ApplicationId;
-import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableMap;
@@ -73,12 +68,28 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
-import static com.google.common.base.Predicates.and;
-
 /**
- * Store for application metadata
+ * Store for application metadata.
+ *
+ * This class is mostly responsible for reading and storing run records. Each program run will have several run
+ * records corresponding to state changes that occur during the program run. The rowkeys are of the form:
+ *
+ * runRecordStarting|namespace|app|version|programtype|program|runid
+ * runRecordStarted|namespace|app|version|programtype|program|runid
+ * runRecordSuspended|namespace|app|version|programtype|program|runid
+ * runRecordCompleted|namespace|app|version|programtype|program|inverted start time|runid
+ *
+ * These rows get deleted whenever state changes, with a new record written on top. In addition, workflow node state
+ * is stored as:
+ *
+ * wns|namespace|app|version|programtype|program|runid|nodeid
+ *
+ * Workflow node state is updated whenever program state is updated
+ * and we notice that the program belongs to a workflow.
  */
 public class AppMetadataStore extends MetadataStoreDataset implements TopicMessageIdStore {
   private static final Logger LOG = LoggerFactory.getLogger(AppMetadataStore.class);
@@ -113,7 +124,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    */
   private static final Map<ProgramRunStatus, Set<ProgramRunStatus>> ALLOWED_STATUSES =
     ImmutableMap.<ProgramRunStatus, Set<ProgramRunStatus>>builder()
-      .put(ProgramRunStatus.STARTING, ImmutableSet.<ProgramRunStatus>of())
+      .put(ProgramRunStatus.STARTING, ImmutableSet.of())
       .put(ProgramRunStatus.RUNNING, ImmutableSet.of(ProgramRunStatus.STARTING))
       .put(ProgramRunStatus.SUSPENDED, ImmutableSet.of(ProgramRunStatus.STARTING, ProgramRunStatus.RUNNING))
       .put(ProgramRunStatus.RESUMING, ImmutableSet.of(ProgramRunStatus.SUSPENDED))
@@ -128,25 +139,17 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    */
   private static final Map<ProgramRunStatus, Set<ProgramRunStatus>> ALLOWED_WITH_LOG_STATUSES =
     ImmutableMap.<ProgramRunStatus, Set<ProgramRunStatus>>builder()
-      .put(ProgramRunStatus.STARTING, ImmutableSet.<ProgramRunStatus>of())
+      .put(ProgramRunStatus.STARTING, ImmutableSet.of())
       .put(ProgramRunStatus.RUNNING, ImmutableSet.of(ProgramRunStatus.SUSPENDED, ProgramRunStatus.RUNNING))
       .put(ProgramRunStatus.SUSPENDED, ImmutableSet.of(ProgramRunStatus.SUSPENDED))
       .put(ProgramRunStatus.RESUMING, ImmutableSet.of(ProgramRunStatus.STARTING, ProgramRunStatus.RUNNING))
-      .put(ProgramRunStatus.COMPLETED, ImmutableSet.<ProgramRunStatus>of())
-      .put(ProgramRunStatus.KILLED, ImmutableSet.<ProgramRunStatus>of())
-      .put(ProgramRunStatus.FAILED, ImmutableSet.<ProgramRunStatus>of())
+      .put(ProgramRunStatus.COMPLETED, ImmutableSet.of())
+      .put(ProgramRunStatus.KILLED, ImmutableSet.of())
+      .put(ProgramRunStatus.FAILED, ImmutableSet.of())
       .build();
 
   private final CConfiguration cConf;
   private final AtomicBoolean upgradeComplete;
-
-  private static final Function<RunRecordMeta, RunId> RUN_RECORD_META_TO_RUN_ID_FUNCTION =
-    new Function<RunRecordMeta, RunId>() {
-      @Override
-      public RunId apply(RunRecordMeta runRecordMeta) {
-        return RunIds.fromString(runRecordMeta.getPid());
-      }
-    };
 
   public AppMetadataStore(Table table, CConfiguration cConf, AtomicBoolean upgradeComplete) {
     super(table);
@@ -273,8 +276,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * Return the {@link List} of {@link WorkflowNodeStateDetail} for a given Workflow run.
    */
   public List<WorkflowNodeStateDetail> getWorkflowNodeStates(ProgramRunId workflowRunId) {
-    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId.getParent())
-      .add(workflowRunId.getRun()).build();
+    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId).build();
 
     List<WorkflowNodeStateDetail> nodeStateDetails = list(key, WorkflowNodeStateDetail.class);
 
@@ -283,8 +285,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     // one specific run-id either in the old format or in the new format.
     if (!upgradeComplete.get() && nodeStateDetails.isEmpty() &&
       workflowRunId.getVersion().equals(ApplicationId.DEFAULT_VERSION)) {
-      key = getVersionLessProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId.getParent())
-        .add(workflowRunId.getRun()).build();
+      key = getVersionLessProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId).build();
       nodeStateDetails = list(key, WorkflowNodeStateDetail.class);
     }
     return nodeStateDetails;
@@ -299,49 +300,45 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
   public void addWorkflowNodeState(ProgramRunId workflowRunId, WorkflowNodeStateDetail nodeStateDetail) {
     // Node states will be stored with following key:
     // workflowNodeState.namespace.app.WORKFLOW.workflowName.workflowRun.workflowNodeId
-    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId.getParent())
-      .add(workflowRunId.getRun()).add(nodeStateDetail.getNodeId()).build();
+    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId).add(nodeStateDetail.getNodeId()).build();
 
     write(key, nodeStateDetail);
   }
 
-  private void addWorkflowNodeState(ProgramId programId, String pid, Map<String, String> systemArgs,
+  private void addWorkflowNodeState(ProgramRunId programRunId, Map<String, String> systemArgs,
                                     ProgramRunStatus status, @Nullable BasicThrowable failureCause, byte[] sourceId) {
     String workflowNodeId = systemArgs.get(ProgramOptionConstants.WORKFLOW_NODE_ID);
     String workflowName = systemArgs.get(ProgramOptionConstants.WORKFLOW_NAME);
     String workflowRun = systemArgs.get(ProgramOptionConstants.WORKFLOW_RUN_ID);
 
-    ApplicationId appId = Ids.namespace(programId.getNamespace()).app(programId.getApplication());
+    ApplicationId appId = programRunId.getParent().getParent();
     ProgramRunId workflowRunId = appId.workflow(workflowName).run(workflowRun);
 
     // Node states will be stored with following key:
     // workflowNodeState.namespace.app.WORKFLOW.workflowName.workflowRun.workflowNodeId
-    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId.getParent())
-      .add(workflowRun).add(workflowNodeId).build();
+    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId).add(workflowNodeId).build();
 
     WorkflowNodeStateDetail nodeStateDetail = new WorkflowNodeStateDetail(workflowNodeId,
                                                                           ProgramRunStatus.toNodeStatus(status),
-                                                                          pid, failureCause);
+                                                                          programRunId.getRun(), failureCause);
 
     write(key, nodeStateDetail);
 
     // Get the run record of the Workflow which started this program
-    key = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, workflowRunId.getParent())
-      .add(workflowRunId.getRun()).build();
+    key = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, workflowRunId).build();
 
     RunRecordMeta record = get(key, RunRecordMeta.class);
     if (record != null) {
       // Update the parent Workflow run record by adding node id and program run id in the properties
       Map<String, String> properties = new HashMap<>(record.getProperties());
-      properties.put(workflowNodeId, pid);
+      properties.put(workflowNodeId, programRunId.getRun());
       write(key, new RunRecordMeta(record, properties, sourceId));
     }
   }
 
   /**
    * Logs initialization of program run and persists program status to {@link ProgramRunStatus#STARTING}.
-   * @param programId id of the program
-   * @param pid run id
+   * @param programRunId run id of the program
    * @param startTs initialization timestamp in seconds
    * @param twillRunId Twill run id
    * @param runtimeArgs the runtime arguments for this program run
@@ -352,11 +349,11 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    *                 program run status will be ignored
    * @return {@link ProgramRunStatus#STARTING} if it is successfully persisted, {@code null} otherwise.
    */
-  public ProgramRunStatus recordProgramStart(ProgramId programId, String pid, long startTs, String twillRunId,
+  public ProgramRunStatus recordProgramStart(ProgramRunId programRunId, long startTs, String twillRunId,
                                              Map<String, String> runtimeArgs, Map<String, String> systemArgs,
                                              byte[] sourceId) {
-    MDSKey.Builder keyBuilder = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTING, programId);
-    boolean isValid = validateExistingRecords(getRuns(programId, pid), programId, pid, sourceId,
+    MDSKey.Builder keyBuilder = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTING, programRunId.getParent());
+    boolean isValid = validateExistingRecords(getRunRecord(programRunId), programRunId, sourceId,
                                               "start", ProgramRunStatus.STARTING);
     if (!isValid) {
       // Skip recording start if the existing records are not valid
@@ -365,7 +362,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     String workflowRunId = null;
     if (systemArgs != null && systemArgs.containsKey(ProgramOptionConstants.WORKFLOW_NAME)) {
       // Program is started by Workflow. Add row corresponding to its node state.
-      addWorkflowNodeState(programId, pid, systemArgs, ProgramRunStatus.STARTING, null, sourceId);
+      addWorkflowNodeState(programRunId, systemArgs, ProgramRunStatus.STARTING, null, sourceId);
       workflowRunId = systemArgs.get(ProgramOptionConstants.WORKFLOW_RUN_ID);
     }
 
@@ -375,8 +372,8 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
       builder.put("workflowrunid", workflowRunId);
     }
 
-    MDSKey key = keyBuilder.add(pid).build();
-    RunRecordMeta meta = new RunRecordMeta(programId.run(pid), startTs, null, null, ProgramRunStatus.STARTING,
+    MDSKey key = keyBuilder.add(programRunId.getRun()).build();
+    RunRecordMeta meta = new RunRecordMeta(programRunId, startTs, null, null, ProgramRunStatus.STARTING,
                                            builder.build(), systemArgs, twillRunId, sourceId);
     write(key, meta);
     return ProgramRunStatus.STARTING;
@@ -384,8 +381,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
 
   /**
    * Logs start of program run and persists program status to {@link ProgramRunStatus#RUNNING}.
-   * @param programId id of the program
-   * @param pid run id
+   * @param programRunId run id of the program
    * @param stateChangeTime start timestamp in seconds
    * @param twillRunId Twill run id
    * @param sourceId unique id representing the source of program run status, such as the message id of the program
@@ -394,48 +390,44 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    *                 program run status will be ignored
    * @return {@link ProgramRunStatus#RUNNING} if it is successfully persisted, {@code null} otherwise.
    */
-  public ProgramRunStatus recordProgramRunning(ProgramId programId, String pid, long stateChangeTime, String twillRunId,
-                                   byte[] sourceId) {
-    MDSKey.Builder builder = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, programId);
-    return recordProgramRunning(programId, pid, stateChangeTime, twillRunId, builder, sourceId);
+  public ProgramRunStatus recordProgramRunning(ProgramRunId programRunId, long stateChangeTime, String twillRunId,
+                                               byte[] sourceId) {
+    MDSKey key = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, programRunId).build();
+    return recordProgramRunning(programRunId, stateChangeTime, twillRunId, key, sourceId);
   }
 
   /**
    * Logs start of program run and persists program status to {@link ProgramRunStatus#STARTING} with version-less key.
-   * See {@link #recordProgramRunning(ProgramId, String, long, String, byte[])}
+   * See {@link #recordProgramRunning(ProgramRunId, long, String, byte[])}
    */
   @VisibleForTesting
-  void recordProgramRunningOldFormat(ProgramId programId, String pid, long stateChangeTime, String twillRunId,
+  void recordProgramRunningOldFormat(ProgramRunId programRunId, long stateChangeTime, String twillRunId,
                                      byte[] sourceId) {
-    MDSKey.Builder builder = getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, programId);
-    recordProgramRunning(programId, pid, stateChangeTime, twillRunId, builder, sourceId);
+    MDSKey key = getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, programRunId).build();
+    recordProgramRunning(programRunId, stateChangeTime, twillRunId, key, sourceId);
   }
 
-  private ProgramRunStatus recordProgramRunning(ProgramId programId, String pid, long runTs, String twillRunId,
-                                                MDSKey.Builder keyBuilder, byte[] sourceId) {
-    List<RunRecordMeta> existingRecords = getRuns(programId, pid);
-    boolean isValid = validateExistingRecords(existingRecords, programId, pid, sourceId,
+  private ProgramRunStatus recordProgramRunning(ProgramRunId programRunId, long runTs, String twillRunId,
+                                                MDSKey key, byte[] sourceId) {
+    RunRecordMeta existing = getRunRecord(programRunId);
+    boolean isValid = validateExistingRecords(existing, programRunId, sourceId,
                                               "running", ProgramRunStatus.RUNNING);
     if (!isValid) {
       // Skip recording running if the existing records are not valid
       return null;
     }
-    // Only one record in the valid existing records
-    RunRecordMeta existing = existingRecords.get(0);
     Map<String, String> systemArgs = existing.getSystemArgs();
     if (systemArgs != null && systemArgs.containsKey(ProgramOptionConstants.WORKFLOW_NAME)) {
       // Program was started by Workflow. Add row corresponding to its node state.
-      addWorkflowNodeState(programId, pid, systemArgs, ProgramRunStatus.RUNNING, null, sourceId);
+      addWorkflowNodeState(programRunId, systemArgs, ProgramRunStatus.RUNNING, null, sourceId);
     }
 
     // Delete the old run record
-    MDSKey key = getProgramKeyBuilder(STATUS_TYPE_MAP.get(existing.getStatus()), programId).add(pid).build();
-    deleteAll(key);
+    MDSKey oldKey = getProgramKeyBuilder(STATUS_TYPE_MAP.get(existing.getStatus()), programRunId).build();
+    deleteAll(oldKey);
 
-    // Build the key for TYPE_RUN_RECORD_STARTED
-    key = keyBuilder.add(pid).build();
     // The existing record's properties already contains the workflowRunId
-    RunRecordMeta meta = new RunRecordMeta(programId.run(pid), existing.getStartTs(), runTs, null,
+    RunRecordMeta meta = new RunRecordMeta(programRunId, existing.getStartTs(), runTs, null,
                                            ProgramRunStatus.RUNNING, existing.getProperties(),
                                            systemArgs, twillRunId, sourceId);
     write(key, meta);
@@ -444,8 +436,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
 
   /**
    * Logs suspend of a program run and sets the run status to {@link ProgramRunStatus#SUSPENDED}.
-   * @param programId id of the program
-   * @param pid run id
+   * @param programRunId run id of the program
    * @param sourceId unique id representing the source of program run status, such as the message id of the program
    *                 run status notification in TMS. The source id must increase as the recording time of the program
    *                 run status increases, so that the attempt to persist program run status older than the existing
@@ -453,24 +444,21 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * @return {@link ProgramRunStatus#SUSPENDED} if it is successfully persisted, {@code null} otherwise.
    */
   @Nullable
-  public ProgramRunStatus recordProgramSuspend(ProgramId programId, String pid, byte[] sourceId) {
-    List<RunRecordMeta> existingRecords = getRuns(programId, pid);
-    boolean isValid = validateExistingRecords(existingRecords, programId, pid, sourceId,
+  public ProgramRunStatus recordProgramSuspend(ProgramRunId programRunId, byte[] sourceId) {
+    RunRecordMeta existing = getRunRecord(programRunId);
+    boolean isValid = validateExistingRecords(existing, programRunId, sourceId,
                                               "suspend", ProgramRunStatus.SUSPENDED);
     if (!isValid) {
-      // Skip recording suspend if the existing records are not valid
+      // Skip recording suspend if the existing record is not valid
       return null;
     }
-    // Only one record in the valid existing records
-    RunRecordMeta existing = existingRecords.get(0);
-    recordProgramSuspendResume(programId, pid, sourceId, existing, "suspend");
+    recordProgramSuspendResume(programRunId, sourceId, existing, "suspend");
     return ProgramRunStatus.SUSPENDED;
   }
 
   /**
    * Logs resume of a program run and sets the run status to {@link ProgramRunStatus#RUNNING}.
-   * @param programId id of the program
-   * @param pid run id
+   * @param programRunId run id of the program
    * @param sourceId unique id representing the source of program run status, such as the message id of the program
    *                 run status notification in TMS. The source id must increase as the recording time of the program
    *                 run status increases, so that the attempt to persist program run status older than the existing
@@ -478,41 +466,37 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * @return {@link ProgramRunStatus#RUNNING} if it is successfully persisted, {@code null} otherwise.
    */
   @Nullable
-  public ProgramRunStatus recordProgramResumed(ProgramId programId, String pid, byte[] sourceId) {
-    List<RunRecordMeta> existingRecords = getRuns(programId, pid);
+  public ProgramRunStatus recordProgramResumed(ProgramRunId programRunId, byte[] sourceId) {
+    RunRecordMeta existing = getRunRecord(programRunId);
     // ProgramRunStatus.RUNNING will actually be persisted but ProgramRunStatus.RESUMING is used here to distinguish
     // recordProgramResumed from recordProgramRunning, since the two methods have different sets of allowed statuses
     // of the existing records
-    boolean isValid = validateExistingRecords(existingRecords, programId, pid, sourceId,
+    boolean isValid = validateExistingRecords(existing, programRunId, sourceId,
                                               "resume", ProgramRunStatus.RESUMING);
-    if (!isValid && !existingRecords.isEmpty()) {
+    if (!isValid && existing != null) {
       // Skip recording resumed if the existing records are not valid
       return null;
     }
-    RunRecordMeta existing = null;
     // Only if existingRecords is empty & upgrade is not complete & the version is default version,
     // also try to get the record without the version string
-    if (existingRecords.isEmpty()) {
-      if (!upgradeComplete.get() && programId.getVersion().equals(ApplicationId.DEFAULT_VERSION)) {
-        MDSKey key = getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_SUSPENDED, programId)
-          .add(pid)
+    if (existing == null) {
+      if (!upgradeComplete.get() && programRunId.getVersion().equals(ApplicationId.DEFAULT_VERSION)) {
+        MDSKey key = getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_SUSPENDED, programRunId.getParent())
+          .add(programRunId.getRun())
           .build();
         existing = get(key, RunRecordMeta.class);
       }
       if (existing == null) {
         LOG.error("No run record meta for program '{}' pid '{}' exists. Skip recording program suspend.",
-                  programId, pid);
+                  programRunId.getParent(), programRunId.getRun());
         return null;
       }
-    } else {
-      // Only one record in the valid existing records
-      existing = existingRecords.get(0);
     }
-    recordProgramSuspendResume(programId, pid, sourceId, existing, "resume");
+    recordProgramSuspendResume(programRunId, sourceId, existing, "resume");
     return ProgramRunStatus.RUNNING;
   }
 
-  private void recordProgramSuspendResume(ProgramId programId, String pid, byte[] sourceId,
+  private void recordProgramSuspendResume(ProgramRunId programRunId, byte[] sourceId,
                                           RunRecordMeta existing, String action) {
     String toType = TYPE_RUN_RECORD_SUSPENDED;
     ProgramRunStatus toStatus = ProgramRunStatus.SUSPENDED;
@@ -522,18 +506,15 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
       toStatus = ProgramRunStatus.RUNNING;
     }
     // Delete the old run record
-    MDSKey key = getProgramKeyBuilder(STATUS_TYPE_MAP.get(existing.getStatus()), programId).add(pid).build();
+    MDSKey key = getProgramKeyBuilder(STATUS_TYPE_MAP.get(existing.getStatus()), programRunId).build();
     deleteAll(key);
-    key = getProgramKeyBuilder(toType, programId)
-      .add(pid)
-      .build();
+    key = getProgramKeyBuilder(toType, programRunId).build();
     write(key, new RunRecordMeta(existing, null, toStatus, sourceId));
   }
 
   /**
    * Logs end of program run and sets the run status to the given run status with a failure cause.
-   * @param programId id of the program
-   * @param pid run id
+   * @param programRunId run id of the program
    * @param stopTs stop timestamp in seconds
    * @param runStatus {@link ProgramRunStatus} of program run
    * @param failureCause failure cause if the program failed to execute
@@ -543,68 +524,86 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    *                 program run status will be ignored
    * @return the program run status that is successfully persisted, {@code null} otherwise.
    */
-  public ProgramRunStatus recordProgramStop(ProgramId programId, String pid, long stopTs, ProgramRunStatus runStatus,
+  public ProgramRunStatus recordProgramStop(ProgramRunId programRunId, long stopTs, ProgramRunStatus runStatus,
                                             @Nullable BasicThrowable failureCause, byte[] sourceId) {
-    MDSKey.Builder builder = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programId);
-    return recordProgramStop(programId, pid, stopTs, runStatus, failureCause, builder, sourceId);
+    MDSKey.Builder builder = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent());
+    return recordProgramStop(programRunId, stopTs, runStatus, failureCause, builder, sourceId);
   }
 
   @VisibleForTesting
-  void recordProgramStopOldFormat(ProgramId programId, String pid, long stopTs, ProgramRunStatus runStatus,
+  void recordProgramStopOldFormat(ProgramRunId programRunId, long stopTs, ProgramRunStatus runStatus,
                                   @Nullable BasicThrowable failureCause, byte[] sourceId) {
-    MDSKey.Builder builder = getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programId);
-    recordProgramStop(programId, pid, stopTs, runStatus, failureCause, builder, sourceId);
+    MDSKey.Builder builder = getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent());
+    recordProgramStop(programRunId, stopTs, runStatus, failureCause, builder, sourceId);
   }
 
-  private ProgramRunStatus recordProgramStop(ProgramId programId, String pid, long stopTs, ProgramRunStatus runStatus,
+  private ProgramRunStatus recordProgramStop(ProgramRunId programRunId, long stopTs, ProgramRunStatus runStatus,
                                              @Nullable BasicThrowable failureCause, MDSKey.Builder builder,
                                              byte[] sourceId) {
-    List<RunRecordMeta> existingRecords = getRuns(programId, pid);
-    boolean isValid = validateExistingRecords(existingRecords, programId, pid, sourceId,
+    RunRecordMeta existing = getRunRecord(programRunId);
+    boolean isValid = validateExistingRecords(existing, programRunId, sourceId,
                                               runStatus.name().toLowerCase(), runStatus);
-    if (!isValid) {
+    if (!isValid || existing == null) {
       // Skip recording stop if the existing records are not valid
       return null;
     }
-    // Only one record in the valid existing records
-    RunRecordMeta existing = existingRecords.get(0);
     // Delete the old run record
-    MDSKey key = getProgramKeyBuilder(STATUS_TYPE_MAP.get(existing.getStatus()), programId).add(pid).build();
+    MDSKey key = getProgramKeyBuilder(STATUS_TYPE_MAP.get(existing.getStatus()), programRunId.getParent())
+      .add(programRunId.getRun()).build();
     deleteAll(key);
 
     // Record in the workflow
     Map<String, String> systemArgs = existing.getSystemArgs();
     if (systemArgs != null && systemArgs.containsKey(ProgramOptionConstants.WORKFLOW_NAME)) {
-      addWorkflowNodeState(programId, pid, systemArgs, runStatus, failureCause, sourceId);
+      addWorkflowNodeState(programRunId, systemArgs, runStatus, failureCause, sourceId);
     }
 
-    key = builder.add(getInvertedTsKeyPart(existing.getStartTs())).add(pid).build();
+    key = builder.add(getInvertedTsKeyPart(existing.getStartTs())).add(programRunId.getRun()).build();
     write(key, new RunRecordMeta(existing, stopTs, runStatus, sourceId));
     return runStatus;
   }
 
-  private List<RunRecordMeta> getRuns(ProgramId programId, String pid) {
+  /**
+   * Returns all run records for the given program run. It should only ever return a single run record, but
+   * this is not enforced in the underlying table due to how the row keys are built.
+   *
+   * @param programRunId the run id to fetch metadata for
+   * @return metadata for the given run id
+   */
+  @Nullable
+  private RunRecordMeta getRunRecord(ProgramRunId programRunId) {
     ImmutableSet.Builder<MDSKey> keySet = ImmutableSet.<MDSKey>builder().add(
-      getProgramKeyBuilder(TYPE_RUN_RECORD_STARTING, programId).add(pid).build(),
-      getProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, programId).add(pid).build(),
-      getProgramKeyBuilder(TYPE_RUN_RECORD_SUSPENDED, programId).add(pid).build(),
-      getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programId).add(pid).build());
+      getProgramKeyBuilder(TYPE_RUN_RECORD_STARTING, programRunId).build(),
+      getProgramKeyBuilder(TYPE_RUN_RECORD_STARTED, programRunId).build(),
+      getProgramKeyBuilder(TYPE_RUN_RECORD_SUSPENDED, programRunId).build(),
+      getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId).build());
     // Get version-less record of type TYPE_RUN_RECORD_COMPLETED only if upgrade is not complete and
     // programId has default version. Because upgrade is only done for record type TYPE_RUN_RECORD_COMPLETED in
     // one transaction, there won't be duplicated records for the same program run
-    if (!upgradeComplete.get() && ApplicationId.DEFAULT_VERSION.equals(programId.getVersion())) {
-      keySet.add(getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programId).add(pid).build());
+    if (!upgradeComplete.get() && ApplicationId.DEFAULT_VERSION.equals(programRunId.getVersion())) {
+      keySet.add(getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId).build());
     }
-    return get(keySet.build(), RunRecordMeta.class);
+    List<RunRecordMeta> existingRecords = get(keySet.build(), RunRecordMeta.class);
+    if (existingRecords.size() > 1) {
+      // This should never happen because existing run records are deleted before a new one is written.
+      // Ideally it shouldn't even be possible in the underlying storage, but that cannot be done
+      // unless the rowkeys are modified
+      throw new IllegalStateException(String.format(
+        "Found more than 1 existing run record for program run '%s'. ", programRunId));
+    }
+    return existingRecords.isEmpty() ? null : existingRecords.iterator().next();
   }
 
   /**
    * Checks whether the existing run record metas of a given program run are in a state for
    * the program run to transition into the given run status.
+   * This is required because program states are not guaranteed to be written in order.
+   * For example, starting can be written from a twill AM, while running may be written from a twill runnable.
+   * If the running state is written before the starting state, we don't want to record the state as starting
+   * once it is already running.
    *
-   * @param existingRecords the existing run record metas of the given program run
-   * @param programId id of the program
-   * @param pid run id
+   * @param existing the existing run record meta of the given program run
+   * @param programRunId run id of the program
    * @param sourceId unique id representing the source of program run status, such as the message id of the program
    *                 run status notification in TMS. The source id must increase as the recording time of the program
    *                 run status increases, so that the attempt to persist program run status older than the existing
@@ -613,14 +612,10 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    * @param status the status that the program run is transitioning into
    * @return {@code true} if the program run is allowed to persist the given status, {@code false} otherwise
    */
-  private boolean validateExistingRecords(List<RunRecordMeta> existingRecords, ProgramId programId, String pid,
+  private boolean validateExistingRecords(@Nullable RunRecordMeta existing, ProgramRunId programRunId,
                                           byte[] sourceId, String recordType, ProgramRunStatus status) {
-    if (existingRecords.size() > 1) {
-      // This should never happen
-      LOG.warn("Found more than 1 existing run record meta '{}' for program '{}' run id '{}'. " +
-                 "Skip recording program {}.", existingRecords, programId, pid, recordType);
-      return false;
-    }
+    ProgramId programId = programRunId.getParent();
+    String pid = programRunId.getRun();
     Set<ProgramRunStatus> allowedStatuses = ALLOWED_STATUSES.get(status);
     Set<ProgramRunStatus> allowedWithLogStatuses = ALLOWED_WITH_LOG_STATUSES.get(status);
     if (allowedStatuses == null || allowedWithLogStatuses == null) {
@@ -630,25 +625,24 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     }
     // If existing record is not allowed, only empty existing records is valid
     if (allowedStatuses.isEmpty() && allowedWithLogStatuses.isEmpty()) {
-      if (existingRecords.isEmpty()) {
+      if (existing == null) {
         return true;
       }
       LOG.error("No existing run record meta should exist for program '{}' run id '{}' but found '{}'.",
-                programId, pid, existingRecords);
+                programId, pid, existing);
       return false;
     }
-    if (existingRecords.isEmpty()) {
+    if (existing == null) {
       LOG.error("No run record meta for program '{}' pid '{}' exists. Skip recording program {}.",
                 programId, pid, recordType);
       return false;
     }
-    // There is only one existing record
-    RunRecordMeta existing = existingRecords.get(0);
+
     byte[] existingSourceId = existing.getSourceId();
     if (existingSourceId != null && Bytes.compareTo(sourceId, existingSourceId) <= 0) {
       LOG.debug("Current source id '{}' is not larger than the existing source id '{}' in the existing " +
                   "run record meta '{}'. Skip recording program {} for program '{}' with run id '{}'.",
-                Bytes.toHexString(sourceId), Bytes.toHexString(existingSourceId), existingRecords.get(0),
+                Bytes.toHexString(sourceId), Bytes.toHexString(existingSourceId), existing,
                 recordType, programId, pid);
       return false;
     }
@@ -747,57 +741,58 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
   // TODO: getRun is duplicated in cdap-watchdog AppMetadataStore class.
   // Any changes made here will have to be made over there too.
   // JIRA https://issues.cask.co/browse/CDAP-2172
-  public RunRecordMeta getRun(ProgramId program, final String runid) {
+  public RunRecordMeta getRun(ProgramRunId programRun) {
     // Query active run record first
-    RunRecordMeta running = getUnfinishedRun(program, TYPE_RUN_RECORD_STARTED, runid);
+    RunRecordMeta running = getUnfinishedRun(programRun, TYPE_RUN_RECORD_STARTED);
     // If program is running, this will be non-null
     if (running != null) {
       return running;
     }
 
     // Then query for started run record
-    RunRecordMeta starting = getUnfinishedRun(program, TYPE_RUN_RECORD_STARTING, runid);
+    RunRecordMeta starting = getUnfinishedRun(programRun, TYPE_RUN_RECORD_STARTING);
     if (starting != null) {
       return starting;
     }
 
     // If program is not running, query completed run records
-    RunRecordMeta complete = getCompletedRun(program, runid);
+    RunRecordMeta complete = getCompletedRun(programRun);
     if (complete != null) {
       return complete;
     }
 
     // Else query suspended run records
-    return getUnfinishedRun(program, TYPE_RUN_RECORD_SUSPENDED, runid);
+    return getUnfinishedRun(programRun, TYPE_RUN_RECORD_SUSPENDED);
   }
 
   /**
    * @return run records for runs that do not have start time in mds key for the run record.
    */
-  private RunRecordMeta getUnfinishedRun(ProgramId programId, String recordType, String runid) {
-    MDSKey runningKey = getProgramKeyBuilder(recordType, programId)
-      .add(runid)
+  private RunRecordMeta getUnfinishedRun(ProgramRunId programRunId, String recordType) {
+    MDSKey runningKey = getProgramKeyBuilder(recordType, programRunId.getParent())
+      .add(programRunId.getRun())
       .build();
 
     RunRecordMeta runRecordMeta = get(runningKey, RunRecordMeta.class);
 
     if (!upgradeComplete.get() && runRecordMeta == null &&
-      programId.getVersion().equals(ApplicationId.DEFAULT_VERSION)) {
-      runningKey = getVersionLessProgramKeyBuilder(recordType, programId).add(runid).build();
+      programRunId.getVersion().equals(ApplicationId.DEFAULT_VERSION)) {
+      runningKey = getVersionLessProgramKeyBuilder(recordType, programRunId.getParent())
+        .add(programRunId.getRun()).build();
       return get(runningKey, RunRecordMeta.class);
     }
 
     return runRecordMeta;
   }
 
-  private RunRecordMeta getCompletedRun(ProgramId programId, final String runid) {
-    MDSKey completedKey = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programId).build();
-    RunRecordMeta runRecordMeta = getCompletedRun(completedKey, runid);
+  private RunRecordMeta getCompletedRun(ProgramRunId programRunId) {
+    MDSKey completedKey = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent()).build();
+    RunRecordMeta runRecordMeta = getCompletedRun(completedKey, programRunId.getRun());
 
     if (!upgradeComplete.get() && runRecordMeta == null &&
-      programId.getVersion().equals(ApplicationId.DEFAULT_VERSION)) {
-      completedKey = getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programId).build();
-      return getCompletedRun(completedKey, runid);
+      programRunId.getVersion().equals(ApplicationId.DEFAULT_VERSION)) {
+      completedKey = getVersionLessProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent()).build();
+      return getCompletedRun(completedKey, programRunId.getRun());
     }
 
     return runRecordMeta;
@@ -820,12 +815,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
       MDSKey stopKey = new MDSKey.Builder(completedKey).add(getInvertedTsScanKeyPart(0)).build();
       List<RunRecordMeta> runRecords =
         list(startKey, stopKey, RunRecordMeta.class, 1,  // Should have only one record for this runid
-             new Predicate<RunRecordMeta>() {
-               @Override
-               public boolean apply(RunRecordMeta input) {
-                 return input.getPid().equals(runid);
-               }
-             });
+             (input) -> input.getPid().equals(runid));
       return Iterables.getFirst(runRecords, null);
     }
   }
@@ -860,20 +850,17 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     Set<MDSKey> keySet = new HashSet<>();
     boolean includeVersionLessKeys = !upgradeComplete.get();
     for (ProgramRunId programRunId : runIds) {
-      keySet.add(getProgramKeyBuilder(recordType, programRunId).build());
+      keySet.add(getProgramKeyBuilder(recordType, programRunId.getParent()).build());
       if (includeVersionLessKeys && programRunId.getVersion().equals(ApplicationId.DEFAULT_VERSION)) {
-        keySet.add(getVersionLessProgramKeyBuilder(recordType, programRunId).build());
+        keySet.add(getVersionLessProgramKeyBuilder(recordType, programRunId.getParent()).build());
       }
     }
 
-    Predicate<KeyValue<RunRecordMeta>> combinedFilter = new Predicate<KeyValue<RunRecordMeta>>() {
-      @Override
-      public boolean apply(KeyValue<RunRecordMeta> input) {
-        ProgramId programId = getProgramID(input.getKey());
-        RunRecordMeta meta = input.getValue();
-        ProgramRunId programRunId = programId.run(meta.getPid());
-        return runIds.contains(programRunId);
-      }
+    Predicate<KeyValue<RunRecordMeta>> combinedFilter = input -> {
+      ProgramId programId = getProgramID(input.getKey());
+      RunRecordMeta meta = input.getValue();
+      ProgramRunId programRunId = programId.run(meta.getPid());
+      return runIds.contains(programRunId);
     };
 
     Map<MDSKey, RunRecordMeta> returnMap = listKV(keySet, RunRecordMeta.class, limit, combinedFilter);
@@ -929,7 +916,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     if (status.equals(ProgramRunStatus.ALL)) {
       //return all records (successful and failed)
       return getProgramRunIdMap(listKV(start, stop, RunRecordMeta.class, limit, keyFiter,
-                                       valueFilter == null ? Predicates.<RunRecordMeta>alwaysTrue() : valueFilter));
+                                       valueFilter == null ? x -> true : valueFilter));
     }
 
     if (status.equals(ProgramRunStatus.COMPLETED)) {
@@ -945,27 +932,17 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
   }
 
   private Predicate<RunRecordMeta> getPredicate(final ProgramController.State state) {
-    return new Predicate<RunRecordMeta>() {
-      @Override
-      public boolean apply(RunRecordMeta record) {
-        return record.getStatus().equals(state.getRunStatus());
-      }
-    };
+    return (record) -> record.getStatus().equals(state.getRunStatus());
   }
 
   private Predicate<RunRecordMeta> getTimeRangePredicate(final long startTime, final long endTime) {
-    return new Predicate<RunRecordMeta>() {
-      @Override
-      public boolean apply(RunRecordMeta record) {
-        return record.getStartTs() >= startTime && record.getStartTs() < endTime;
-      }
-    };
+    return (record) -> record.getStartTs() >= startTime && record.getStartTs() < endTime;
   }
 
   private Predicate<RunRecordMeta> andPredicate(Predicate<RunRecordMeta> first,
                                                 @Nullable Predicate<RunRecordMeta> second) {
     if (second != null) {
-      return and(first, second);
+      return first.and(second);
     }
     return first;
   }
@@ -1000,10 +977,6 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     deleteAll(new MDSKey.Builder().add(TYPE_STREAM, namespaceId).build());
   }
 
-  public void deleteStream(String namespaceId, String name) {
-    deleteAll(new MDSKey.Builder().add(TYPE_STREAM, namespaceId, name).build());
-  }
-
   public void deleteProgramHistory(String namespaceId, String appId, String versionId) {
     if (!upgradeComplete.get() && versionId.equals(ApplicationId.DEFAULT_VERSION)) {
       Predicate<MDSKey> keyPredicate = new AppVersionPredicate(ApplicationId.DEFAULT_VERSION);
@@ -1030,18 +1003,6 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     write(getNamespaceKey(metadata.getName()), metadata);
   }
 
-  public NamespaceMeta getNamespace(Id.Namespace id) {
-    return getFirst(getNamespaceKey(id.getId()), NamespaceMeta.class);
-  }
-
-  public void deleteNamespace(Id.Namespace id) {
-    deleteAll(getNamespaceKey(id.getId()));
-  }
-
-  public List<NamespaceMeta> listNamespaces() {
-    return list(getNamespaceKey(null), NamespaceMeta.class);
-  }
-
   private MDSKey getNamespaceKey(@Nullable String name) {
     MDSKey.Builder builder = new MDSKey.Builder().add(TYPE_NAMESPACE);
     if (null != name) {
@@ -1053,8 +1014,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
   public void updateWorkflowToken(ProgramRunId workflowRunId, WorkflowToken workflowToken) {
     // Workflow token will be stored with following key:
     // [wft][namespace][app][WORKFLOW][workflowName][workflowRun]
-    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_TOKEN, workflowRunId.getParent())
-      .add(workflowRunId.getRun()).build();
+    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_TOKEN, workflowRunId).build();
 
     write(key, workflowToken);
   }
@@ -1063,7 +1023,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     Preconditions.checkArgument(ProgramType.WORKFLOW == workflowId.getType());
     // Workflow token is stored with following key:
     // [wft][namespace][app][version][WORKFLOW][workflowName][workflowRun]
-    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_TOKEN, workflowId).add(workflowRunId).build();
+    MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_TOKEN, workflowId.run(workflowRunId)).build();
 
     BasicWorkflowToken workflowToken = get(key, BasicWorkflowToken.class);
 
@@ -1153,15 +1113,9 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
   List<Iterable<RunId>> getRunningInRangeForStatus(String statusKey, final long startTimeInSecs,
                                                    final long endTimeInSecs, long maxScanTimeMillis, Ticker ticker) {
     // Create time filter to get running programs between start and end time
-    Predicate<RunRecordMeta> timeFilter = new Predicate<RunRecordMeta>() {
-      @Override
-      public boolean apply(RunRecordMeta runRecordMeta) {
-        // Program is running in range [startTime, endTime) if the program started before endTime
-        // or program's stop time was after startTime
-        return runRecordMeta.getStartTs() < endTimeInSecs &&
-          (runRecordMeta.getStopTs() == null || runRecordMeta.getStopTs() >= startTimeInSecs);
-      }
-    };
+    Predicate<RunRecordMeta> timeFilter = (runRecordMeta) ->
+      runRecordMeta.getStartTs() < endTimeInSecs &&
+        (runRecordMeta.getStopTs() == null || runRecordMeta.getStopTs() >= startTimeInSecs);
 
     // Break up scans into smaller batches to prevent transaction timeout
     List<Iterable<RunId>> batches = new ArrayList<>();
@@ -1175,7 +1129,8 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
       if (scanFunction.getNumProcessed() == 0) {
         break;
       }
-      batches.add(Iterables.transform(scanFunction.getValues(), RUN_RECORD_META_TO_RUN_ID_FUNCTION));
+      batches.add(Iterables.transform(scanFunction.getValues(),
+                                      runRecordMeta -> RunIds.fromString(runRecordMeta.getPid())));
       // key for next scan is the last key + 1 from the previous scan
       startKey = new MDSKey(Bytes.stopKeyForPrefix(scanFunction.getLastKey().getKey()));
     }
@@ -1211,7 +1166,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
 
     for (Map.Entry<MDSKey, T> oldEntry : oldMap.entrySet()) {
       MDSKey oldKey = oldEntry.getKey();
-      MDSKey newKey = appendDefaultVersion(recordType, typeOfT, oldKey);
+      MDSKey newKey = appendDefaultVersion(recordType, oldKey);
       // If the key has been modified, only then add it to the map.
       if (!newKey.equals(oldKey)) {
         deleteKeys.add(oldKey);
@@ -1351,7 +1306,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
   }
 
   // Append version only if it doesn't have version in the key
-  private static MDSKey appendDefaultVersion(String recordType, Type typeOfT, MDSKey originalKey) {
+  private static MDSKey appendDefaultVersion(String recordType, MDSKey originalKey) {
     switch (recordType) {
       case TYPE_APP_META:
         return getUpgradedAppMetaKey(originalKey);
@@ -1419,7 +1374,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
     }
 
     @Override
-    public boolean apply(MDSKey input) {
+    public boolean test(MDSKey input) {
       ProgramId programId = getProgramID(input);
       return programId.getVersion().equals(version);
     }
@@ -1464,7 +1419,7 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
 
       ++numProcessed;
       lastKey = input.getKey();
-      if (filter.apply(input.getValue())) {
+      if (filter.test(input.getValue())) {
         values.add(input.getValue());
       }
       return true;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageAdmin.java
@@ -283,12 +283,7 @@ public class LineageAdmin {
     // TODO: These scans could be expensive. CDAP-7571.
     Map<ProgramRunId, RunRecordMeta> workflowRunRecordMap =
       store.getRuns(ProgramRunStatus.ALL,
-                    new Predicate<RunRecordMeta>() {
-                      @Override
-                      public boolean apply(RunRecordMeta input) {
-                        return workflowIDs.contains(input.getPid());
-                      }
-                    });
+                    input ->  workflowIDs.contains(input.getPid()));
 
     // Create a map from RunId to ProgramId for all workflows
     Map<String, ProgramRunId> workflowIdMap = new HashMap<>();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -679,18 +679,16 @@ public class LineageAdminTest extends AppFabricTestBase {
   }
 
   private void setStartAndRunning(Store store, final ProgramId id, final String pid, final long startTime) {
-    setStartAndRunning(store, id, pid, startTime, ImmutableMap.<String, String>of(),
-                       ImmutableMap.<String, String>of());
-
+    setStartAndRunning(store, id, pid, startTime, ImmutableMap.of(), ImmutableMap.of());
   }
 
 
   private void setStartAndRunning(Store store, final ProgramId id, final String pid, final long startTime,
                                   final Map<String, String> runtimeArgs,
                                   final Map<String, String> systemArgs) {
-    store.setStart(id, pid, startTime, null, runtimeArgs, systemArgs,
+    store.setStart(id.run(pid), startTime, null, runtimeArgs, systemArgs,
                    AppFabricTestHelper.createSourceId(++sourceId));
-    store.setRunning(id, pid, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setRunning(id.run(pid), startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 
   private void addRuns(Store store, ProgramRunId... runs) {
@@ -714,11 +712,9 @@ public class LineageAdminTest extends AppFabricTestBase {
     workflowIDMap.put(ProgramOptionConstants.WORKFLOW_NODE_ID, "workflowNodeId");
     workflowIDMap.put(ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId);
     for (ProgramRunId run : runs) {
-      store.setStart(run.getParent(), run.getEntityName(), RunIds.getTime(
-                     RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS), null,
+      store.setStart(run, RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS), null,
                      emptyMap, workflowIDMap, AppFabricTestHelper.createSourceId(++sourceId));
-      store.setRunning(run.getParent(), run.getEntityName(), RunIds.getTime(
-                       RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS) + 1, null,
+      store.setRunning(run, RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS) + 1, null,
                        AppFabricTestHelper.createSourceId(++sourceId));
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetInstanceMDS.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetInstanceMDS.java
@@ -24,7 +24,6 @@ import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -32,6 +31,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 /**
@@ -68,23 +68,14 @@ public final class DatasetInstanceMDS extends MetadataStoreDataset {
   }
 
   public Collection<DatasetSpecification> getAll(NamespaceId namespaceId) {
-    Predicate<DatasetSpecification> localDatasetFilter = new Predicate<DatasetSpecification>() {
-      @Override
-      public boolean apply(@Nullable DatasetSpecification input) {
-        return input != null
-          && !Boolean.parseBoolean(input.getProperty(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY));
-      }
-    };
+    Predicate<DatasetSpecification> localDatasetFilter = input -> input != null
+      && !Boolean.parseBoolean(input.getProperty(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY));
     return getAll(namespaceId, localDatasetFilter);
   }
 
   public Collection<DatasetSpecification> get(NamespaceId namespaceId, final Map<String, String> properties) {
-    Predicate<DatasetSpecification> propertyFilter = new Predicate<DatasetSpecification>() {
-      @Override
-      public boolean apply(@Nullable DatasetSpecification input) {
-        return input != null && Maps.difference(properties, input.getProperties()).entriesOnlyOnLeft().isEmpty();
-      }
-    };
+    Predicate<DatasetSpecification> propertyFilter = input -> input != null
+      && Maps.difference(properties, input.getProperties()).entriesOnlyOnLeft().isEmpty();
 
     return getAll(namespaceId, propertyFilter);
   }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
@@ -43,6 +43,7 @@ import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
@@ -85,19 +86,16 @@ public class MockLogReader implements LogReader {
     this.store = store;
   }
 
-  private void setStartAndRunning(final ProgramId id, final String pid, final long startTime) {
-    setStartAndRunning(id, pid, startTime, ImmutableMap.<String, String>of(),
-                       ImmutableMap.<String, String>of());
-
+  private void setStartAndRunning(final ProgramRunId id, final long startTime) {
+    setStartAndRunning(id, startTime, ImmutableMap.of(), ImmutableMap.of());
   }
 
-
-  private void setStartAndRunning(final ProgramId id, final String pid, final long startTime,
+  private void setStartAndRunning(final ProgramRunId id, final long startTime,
                                   final Map<String, String> runtimeArgs,
                                   final Map<String, String> systemArgs) {
-    store.setStart(id, pid, startTime, null, runtimeArgs, systemArgs,
+    store.setStart(id, startTime, null, runtimeArgs, systemArgs,
                    AppFabricTestHelper.createSourceId(++sourceId));
-    store.setRunning(id, pid, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setRunning(id, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 
   public void generateLogs() throws InterruptedException {
@@ -158,8 +156,8 @@ public class MockLogReader implements LogReader {
     ProgramId workflowId = SOME_WORKFLOW_APP.workflow(SOME_WORKFLOW);
     long currentTime = TimeUnit.SECONDS.toMillis(10);
     RunId workflowRunId = RunIds.generate();
-    setStartAndRunning(workflowId, workflowRunId.getId(), currentTime);
-    runRecordMap.put(workflowId, store.getRun(workflowId, workflowRunId.getId()));
+    setStartAndRunning(workflowId.run(workflowRunId.getId()), currentTime);
+    runRecordMap.put(workflowId, store.getRun(workflowId.run(workflowRunId.getId())));
     WorkflowLoggingContext wfLoggingContext = new WorkflowLoggingContext(workflowId.getNamespace(),
                                                                          workflowId.getApplication(),
                                                                          workflowId.getProgram(),
@@ -174,10 +172,10 @@ public class MockLogReader implements LogReader {
                                                      ProgramOptionConstants.WORKFLOW_NAME, SOME_WORKFLOW,
                                                      ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId.getId());
 
-    setStartAndRunning(mapReduceId, mapReduceRunId.getId(), currentTime,
-                       new HashMap<String, String>(), systemArgs);
+    setStartAndRunning(mapReduceId.run(mapReduceRunId.getId()), currentTime,
+                       new HashMap<>(), systemArgs);
 
-    runRecordMap.put(mapReduceId, store.getRun(mapReduceId, mapReduceRunId.getId()));
+    runRecordMap.put(mapReduceId, store.getRun(mapReduceId.run(mapReduceRunId.getId())));
     WorkflowProgramLoggingContext context = new WorkflowProgramLoggingContext(workflowId.getNamespace(),
                                                                               workflowId.getApplication(),
                                                                               workflowId.getProgram(),
@@ -194,9 +192,9 @@ public class MockLogReader implements LogReader {
                                  ProgramOptionConstants.WORKFLOW_NAME, SOME_WORKFLOW,
                                  ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId.getId());
 
-    setStartAndRunning(sparkId, sparkRunId.getId(), currentTime,
-                       new HashMap<String, String>(), systemArgs);
-    runRecordMap.put(sparkId, store.getRun(sparkId, sparkRunId.getId()));
+    setStartAndRunning(sparkId.run(sparkRunId.getId()), currentTime,
+                       new HashMap<>(), systemArgs);
+    runRecordMap.put(sparkId, store.getRun(sparkId.run(sparkRunId.getId())));
     context = new WorkflowProgramLoggingContext(workflowId.getNamespace(), workflowId.getApplication(),
                                                 workflowId.getProgram(), workflowRunId.getId(), ProgramType.SPARK,
                                                 SOME_SPARK, sparkRunId.getId());
@@ -419,9 +417,9 @@ public class MockLogReader implements LogReader {
     if (programId != null) {
       //noinspection ConstantConditions
       runRecordMap.put(programId, new RunRecord(runId.getId(), startTs, startTs + 1, stopTs, runStatus, null));
-      setStartAndRunning(programId, runId.getId(), startTs);
+      setStartAndRunning(programId.run(runId.getId()), startTs);
       if (stopTs != null) {
-        store.setStop(programId, runId.getId(), stopTs, runStatus,
+        store.setStop(programId.run(runId.getId()), stopTs, runStatus,
                       AppFabricTestHelper.createSourceId(++sourceId));
       }
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/store/AppMetadataStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/store/AppMetadataStore.java
@@ -23,7 +23,6 @@ import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
 import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ProgramId;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
 import java.util.List;
@@ -117,12 +116,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
       MDSKey stopKey = new MDSKey.Builder(completedKey).add(getInvertedTsScanKeyPart(0)).build();
       List<RunRecordMeta> runRecords =
         list(startKey, stopKey, RunRecordMeta.class, 1,  // Should have only one record for this runid
-             new Predicate<RunRecordMeta>() {
-               @Override
-               public boolean apply(RunRecordMeta input) {
-                 return input.getPid().equals(runid);
-               }
-             });
+             input -> input.getPid().equals(runid));
       return Iterables.getFirst(runRecords, null);
     }
   }


### PR DESCRIPTION
Cleaning up code that touches AppMetadataStore.
This started out as changing methods that take a ProgramId and
a run id as separate arguments and combining them into a single
ProgramRunId argument.

Along the way, also fixed style warnings. Removed guava
Predicate and Function in favor of Java8's version of Predicate
and Function. Used lambda functions where possible, removed
explicit casts that are no longer needed, and removed usages
of deprecated Id classes when encountered.