### PR TITLE
[CDAP-12554] Adds labels to stage properties name while selecting the payload

### DIFF
--- a/cdap-ui/app/cdap/api/pipeline.js
+++ b/cdap-ui/app/cdap/api/pipeline.js
@@ -19,10 +19,12 @@ import {apiCreator} from 'services/resource-helper';
 
 let dataSrc = DataSourceConfigurer.getInstance();
 let basepath = '/namespaces/:namespace/apps/:appId';
+let artifactBasePath = `/namespaces/:namespace/artifacts/:artifactName/versions/:artifactVersion/properties`;
 let statsPath = `${basepath}/workflows/:workflowId/statistics?start=0`;
 
 export const MyPipelineApi = {
   publish: apiCreator(dataSrc, 'PUT', 'REQUEST', basepath),
   pollStatistics: apiCreator(dataSrc, 'GET', 'REQUEST', statsPath),
   fetchMacros: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/plugins`),
+  fetchWidgetJson: apiCreator(dataSrc, 'GET', 'REQUEST', artifactBasePath)
 };

--- a/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsStore.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsStore.js
@@ -28,6 +28,7 @@ const SCHEDULERUNTIMEARGSACTIONS = {
   SETARGSVALUE: 'SETARGSVALUE',
   BULKSETARGSVALUE: 'BULKSETARGSVALUE',
   SETDISABLED: 'SETDISABLED',
+  SETSTAGEWIDGETJSON: 'SETSTAGEWIDGETJSON',
   RESET: 'RESET'
 };
 
@@ -56,6 +57,7 @@ const DEFAULTARGS = {
     id: null
   },
   argsMapping: DEFAULTARGSMAPPING,
+  stageWidgetJsonMap: {},
   disabled: false
 };
 
@@ -157,6 +159,14 @@ const args = (state = DEFAULTARGS, action = defaultAction) => {
       });
     case SCHEDULERUNTIMEARGSACTIONS.RESET:
       return DEFAULTARGS;
+    case SCHEDULERUNTIMEARGSACTIONS.SETSTAGEWIDGETJSON:
+      return {
+        ...state,
+        stageWidgetJsonMap: {
+          ...state.stageWidgetJsonMap,
+          [action.payload.stageid]: action.payload.stageWidgetJson || {}
+        }
+      };
     default:
       return state;
   }

--- a/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/StagePropertiesTab/StagePropertiesRow.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/StagePropertiesTab/StagePropertiesRow.js
@@ -74,18 +74,25 @@ export default class StagePropertiesRow extends Component {
     setArgMapping(constructedKey, this.state.triggeredPipelineMacro, 'properties', oldValue);
   };
 
-  getDisplaForPropertyName = () => {
-    if (!this.state.property) {
-      return [DEFAULTPROPERTYMESSAGE];
-    }
-    return [this.state.property, DEFAULTPROPERTYMESSAGE];
-  };
-
   getDisplayForTriggeredPipelineMacro = () => {
     if (!this.state.triggeredPipelineMacro) {
       return [DEFAULTTRIGGEREDMACROMESSAGE];
     }
     return [this.state.triggeredPipelineMacro, DEFAULTTRIGGEREDMACROMESSAGE];
+  };
+
+  getPropertyLabel = (property) => {
+    if (property === DEFAULTPROPERTYMESSAGE) {
+      return DEFAULTPROPERTYMESSAGE;
+    }
+    let {args} = ScheduleRuntimeArgsStore.getState();
+    let {stageWidgetJsonMap} = args;
+    let properties = [];
+    stageWidgetJsonMap[this.state.stage]['configuration-groups'].map(group => {
+      properties = properties.concat(group.properties);
+    });
+    let matchProperty = properties.filter(prop => prop.name === property);
+    return !matchProperty.length ? property : matchProperty[0].label;
   };
 
   render() {
@@ -95,6 +102,13 @@ export default class StagePropertiesRow extends Component {
     if (stage) {
       properties = stage.properties;
     }
+    properties = [DEFAULTPROPERTYMESSAGE].concat(properties);
+    properties = properties.map(prop => {
+      return {
+        id: prop,
+        label: this.getPropertyLabel(prop)
+      };
+    });
     return (
       <Row>
         <Col xs={3}>
@@ -123,15 +137,19 @@ export default class StagePropertiesRow extends Component {
         <Col xs={4}>
           <div className="select-dropdown">
             <select
-              value={this.state.property}
               onChange={this.onPropertyChange}
+              value={this.state.property}
             >
               {
-                this.getDisplaForPropertyName()
-                .concat(properties)
-                .map((prop, i) => {
+                properties.map((prop, i) => {
                   return (
-                    <option key={i}>{prop}</option>
+                    <option
+                      key={i}
+                      value={prop.id}
+                      selected={prop.id === this.state.property}
+                    >
+                      {prop.label}
+                    </option>
                   );
                 })
               }


### PR DESCRIPTION
#### Issue:
- While configuring payload when setting up a trigger we show the plugin(stage) names as proper labels. However when user chooses the property we show the property names defined in the plugin and not in the widget jsons.

#### Fix:
- Show proper labels while choosing property to be consistent with node configuration modals.


JIRA: https://issues.cask.co/browse/CDAP-12554
