### PR TITLE
CDAP-13096 store changes to write cluster state for runs

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -83,8 +83,10 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
   private void setStartAndRunning(final ProgramId id, final String pid, final long startTime,
                                   final Map<String, String> runtimeArgs,
                                   final Map<String, String> systemArgs) {
-    store.setStart(id.run(pid), startTime, null, runtimeArgs, systemArgs,
-                   AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioning(id.run(pid), startTime, runtimeArgs, systemArgs,
+                          AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioned(id.run(pid), 0, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id.run(pid), null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id.run(pid), startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -79,8 +79,10 @@ public class WorkflowTest {
   private int sourceId;
 
   private void setStartAndRunning(Store store, final ProgramId id, final String pid, final long startTime) {
-    store.setStart(id.run(pid), startTime, null, ImmutableMap.of(),
-                   ImmutableMap.of(), AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioning(id.run(pid), startTime, ImmutableMap.of(), ImmutableMap.of(),
+                          AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioned(id.run(pid), 0, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id.run(pid), null, ImmutableMap.of(), AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id.run(pid), startTime + startDelaySecs, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -31,6 +31,7 @@ import co.cask.cdap.common.ProgramNotFoundException;
 import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.internal.app.store.WorkflowDataset;
 import co.cask.cdap.proto.BasicThrowable;
+import co.cask.cdap.proto.ProgramRunClusterStatus;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.WorkflowStatistics;
@@ -51,22 +52,63 @@ import javax.annotation.Nullable;
 
 /**
  * Responsible for managing {@link Program} and {@link Application} metadata.
+ *
+ * TODO: set state methods are only called from unit tests. They should be removed in favor of using AppMetadataStore.
  */
 public interface Store extends RuntimeStore {
 
   /**
-   * Logs initialization of program run and persists program status to {@link ProgramRunStatus#STARTING}.
+   * Logs initialization of program run and persists program cluster status to
+   * {@link ProgramRunClusterStatus#PROVISIONING}.
    *
    * @param id run id of the program
    * @param startTime start timestamp in seconds
-   * @param twillRunId Twill run id
    * @param runtimeArgs the runtime arguments for this program run
    * @param systemArgs the system arguments for this program run
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setStart(ProgramRunId id, long startTime, @Nullable String twillRunId,
-                Map<String, String> runtimeArgs, Map<String, String> systemArgs, byte[] sourceId);
+  void setProvisioning(ProgramRunId id, long startTime, Map<String, String> runtimeArgs,
+                       Map<String, String> systemArgs, byte[] sourceId);
+
+  /**
+   * Persists program run cluster status to {@link ProgramRunClusterStatus#PROVISIONED}.
+   *
+   * @param id run id of the program
+   * @param numNodes number of nodes for the cluster
+   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
+   *                 when the current program run status is reached
+   */
+  void setProvisioned(ProgramRunId id, int numNodes, byte[] sourceId);
+
+  /**
+   * Persists program run cluster status to {@link ProgramRunClusterStatus#DEPROVISIONING}.
+   *
+   * @param id run id of the program
+   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
+   *                 when the current program run status is reached
+   */
+  void setDeprovisioning(ProgramRunId id, byte[] sourceId);
+
+  /**
+   * Persists program run cluster status to {@link ProgramRunClusterStatus#DEPROVISIONED}.
+   *
+   * @param id run id of the program
+   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
+   *                 when the current program run status is reached
+   */
+  void setDeprovisioned(ProgramRunId id, byte[] sourceId);
+
+  /**
+   * Logs initialization of program run and persists program status to {@link ProgramRunStatus#STARTING}.
+   *
+   * @param id run id of the program
+   * @param twillRunId Twill run id
+   * @param systemArgs the system arguments for this program run
+   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
+   *                 when the current program run status is reached
+   */
+  void setStart(ProgramRunId id, @Nullable String twillRunId, Map<String, String> systemArgs, byte[] sourceId);
 
   /**
    * Logs start of program run and persists program status to {@link ProgramRunStatus#RUNNING}.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -482,7 +482,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     ProgramId progId = new ApplicationId(namespaceId, appName, appVersion).program(programType, programName);
     RunRecordMeta runRecordMeta = store.getRun(progId.run(runid));
     if (runRecordMeta != null) {
-      RunRecord runRecord = new RunRecord(runRecordMeta);
+      RunRecord runRecord = RunRecord.builder(runRecordMeta).build();
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(runRecord));
       return;
     }
@@ -1784,7 +1784,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         ProgramRunStatus.valueOf(status.toUpperCase());
 
       List<RunRecord> records = store.getRuns(programId, runStatus, start, end, limit).values().stream()
-        .map(RunRecord::new).collect(Collectors.toList());
+        .map(record -> RunRecord.builder(record).build()).collect(Collectors.toList());
 
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(records));
     } catch (IllegalArgumentException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -176,7 +176,6 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
       }
 
       ProgramRunId programRunId = GSON.fromJson(programRun, ProgramRunId.class);
-      ProgramId programId = programRunId.getParent();
 
       ApplicationMeta meta = appMetadataStore.getApplication(programRunId.getNamespace(),
                                                              programRunId.getApplication(),
@@ -193,7 +192,6 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
       }
 
       LOG.trace("Processing program status notification: {}", notification);
-      String runId = programRunId.getRun();
       String twillRunId = notification.getProperties().get(ProgramOptionConstants.TWILL_RUN_ID);
       long endTimeSecs = getTimeSeconds(notification.getProperties(), ProgramOptionConstants.END_TIME);
 
@@ -215,8 +213,13 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
           }
           Map<String, String> userArguments = GSON.fromJson(userArgumentsString, STRING_STRING_MAP);
           Map<String, String> systemArguments = GSON.fromJson(systemArgumentsString, STRING_STRING_MAP);
-          recordedStatus = appMetadataStore.recordProgramStart(programRunId, startTimeSecs, twillRunId,
-                                                               userArguments, systemArguments, messageIdBytes);
+          // TODO: CDAP-13096 move to provisioner status subscriber
+          // for now, save these states here to follow correct lifecycle
+          appMetadataStore.recordProgramProvisioning(programRunId, startTimeSecs, userArguments, systemArguments,
+                                                     messageIdBytes);
+          appMetadataStore.recordProgramProvisioned(programRunId, 0, messageIdBytes);
+          recordedStatus = appMetadataStore.recordProgramStart(programRunId, twillRunId,
+                                                               systemArguments, messageIdBytes);
           break;
         case RUNNING:
           long logicalStartTimeSecs = getTimeSeconds(notification.getProperties(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -59,8 +59,9 @@ public class ConcurrencyConstraintTest {
   private void setStartAndRunning(Store store, final ProgramRunId id, final long startTime,
                                   final Map<String, String> runtimeArgs,
                                   final Map<String, String> systemArgs) {
-    store.setStart(id, startTime, null, runtimeArgs, systemArgs,
-                   AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioning(id, startTime, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioned(id, 0, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id, null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/constraint/LastRunConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/constraint/LastRunConstraintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -58,8 +58,9 @@ public class LastRunConstraintTest {
   private void setStartAndRunning(Store store, final ProgramRunId id, final long startTime,
                                   final Map<String, String> runtimeArgs,
                                   final Map<String, String> systemArgs) {
-    store.setStart(id, startTime, null, runtimeArgs,
-                   systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioning(id, startTime, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioned(id, 0, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id, null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
   

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -686,8 +686,10 @@ public class LineageAdminTest extends AppFabricTestBase {
   private void setStartAndRunning(Store store, final ProgramId id, final String pid, final long startTime,
                                   final Map<String, String> runtimeArgs,
                                   final Map<String, String> systemArgs) {
-    store.setStart(id.run(pid), startTime, null, runtimeArgs, systemArgs,
-                   AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioning(id.run(pid), startTime, runtimeArgs, systemArgs,
+                          AppFabricTestHelper.createSourceId(++sourceId));
+    store.setProvisioned(id.run(pid), 0, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id.run(pid), null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id.run(pid), startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 
@@ -712,8 +714,10 @@ public class LineageAdminTest extends AppFabricTestBase {
     workflowIDMap.put(ProgramOptionConstants.WORKFLOW_NODE_ID, "workflowNodeId");
     workflowIDMap.put(ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId);
     for (ProgramRunId run : runs) {
-      store.setStart(run, RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS), null,
-                     emptyMap, workflowIDMap, AppFabricTestHelper.createSourceId(++sourceId));
+      store.setProvisioning(run, RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS),
+                            emptyMap, workflowIDMap, AppFabricTestHelper.createSourceId(++sourceId));
+      store.setProvisioned(run, 0, AppFabricTestHelper.createSourceId(++sourceId));
+      store.setStart(run, null, workflowIDMap, AppFabricTestHelper.createSourceId(++sourceId));
       store.setRunning(run, RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS) + 1, null,
                        AppFabricTestHelper.createSourceId(++sourceId));
     }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunCluster.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunCluster.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Information about the cluster used for a program run.
+ */
+public class ProgramRunCluster {
+  private final ProgramRunClusterStatus status;
+  private final Long expiresAt;
+  private final Integer numNodes;
+
+  public ProgramRunCluster(ProgramRunClusterStatus status,
+                           @Nullable Long expiresAt,
+                           @Nullable Integer numNodes) {
+    this.status = status;
+    this.expiresAt = expiresAt;
+    this.numNodes = numNodes;
+  }
+
+  public ProgramRunClusterStatus getStatus() {
+    return status;
+  }
+
+  /**
+   * @return timestamp that the cluster expires at. Only applicable if the cluster is in the waiting state.
+   */
+  @Nullable
+  public Long getExpiresAt() {
+    return expiresAt;
+  }
+
+  /**
+   * @return number of nodes in the cluster. Can be null if the cluster has not been provisioned yet, or if it is on
+   *         the local cluster.
+   */
+  @Nullable
+  public Integer getNumNodes() {
+    return numNodes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ProgramRunCluster that = (ProgramRunCluster) o;
+
+    return Objects.equals(status, that.status) &&
+      Objects.equals(expiresAt, that.expiresAt) &&
+      Objects.equals(numNodes, that.numNodes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, expiresAt, numNodes);
+  }
+
+  @Override
+  public String toString() {
+    return "ProgramRunCluster{" +
+      "status=" + status +
+      ", expiresAt=" + expiresAt +
+      ", numNodes=" + numNodes +
+      '}';
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunClusterStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunClusterStatus.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto;
+
+/**
+ * State of the cluster for a program run
+ */
+public enum ProgramRunClusterStatus {
+  PROVISIONING,
+  PROVISIONED,
+  WAITING,
+  DEPROVISIONING,
+  DEPROVISIONED,
+  ORPHANED
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2017 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -31,6 +31,13 @@ public enum ProgramRunStatus {
   COMPLETED,
   FAILED,
   KILLED;
+
+  /**
+   * @return whether the status is an end status for a program run.
+   */
+  public boolean isEndState() {
+    return this == COMPLETED || this == FAILED || this == KILLED;
+  }
 
   /**
    * Conversion from program run status to Workflow node status.


### PR DESCRIPTION
Adding cluster information to run records. Each run record now
has a 'cluster' field that includes the cluster information. In
addition, adding states for provisioning, provisioned,
deprovisioning, and deprovisioned to the AppMetadataStore.

Also adding builders to RunRecord and RunRecordMeta since there
are a bunch of fields, many of which are nullable. Also because
we commonly create a new record from an existing one and modify
just a couple of fields. This will also make it easier to add
profile to the records once we have them.