### PR TITLE
[CDAP-13211] Ops Dashboard Report Generation App

### DIFF
--- a/cdap-app-templates/cdap-program-report/pom.xml
+++ b/cdap-app-templates/cdap-program-report/pom.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap-app-templates</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-program-report</artifactId>
+  <name>CDAP Program Run Report Artifact</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <app.main.class>co.cask.cdap.report.ReportGenerationApp</app.main.class>
+    <scala.version>2.11.8</scala.version>
+    <spark.version>2.1.0</spark.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>scala-tools.org</id>
+      <name>Scala-tools Maven2 Repository</name>
+      <url>http://scala-tools.org/repo-releases</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api-spark2_2.11</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.11</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-unit-test-spark2_2.11</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-exec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.7.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-mapred</artifactId>
+      <version>1.7.7</version>
+      <classifier>hadoop2</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.databricks</groupId>
+      <artifactId>spark-avro_2.11</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    <!-- Hadoop Dependencies -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-core</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-json</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-server</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>servlet-api</artifactId>
+          <groupId>javax.servlet</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jasper-compiler</artifactId>
+          <groupId>tomcat</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jasper-runtime</artifactId>
+          <groupId>tomcat</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jsp-api</artifactId>
+          <groupId>javax.servlet.jsp</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-api</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.3.0</version>
+          <extensions>true</extensions>
+          <configuration>
+            <archive>
+              <manifest>
+                <mainClass>${app.main.class}</mainClass>
+              </manifest>
+            </archive>
+            <instructions>
+              <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+              <Embed-Transitive>true</Embed-Transitive>
+              <Embed-Directory>lib</Embed-Directory>
+            </instructions>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>bundle</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.3.0</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/ReportGenerationApp.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/ReportGenerationApp.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+
+/**
+ * An application that accepts request to generate reports from program runs.
+ */
+public class ReportGenerationApp extends AbstractApplication {
+  public static final String NAME = "ReportGenerationApp";
+  public static final String RUN_META_FILESET = "RunMetaFileset";
+  public static final String REPORT_FILESET = "ReportFileset";
+
+  @Override
+  public void configure() {
+    setName(NAME);
+    addSpark(new ReportGenerationSpark());
+    createDataset(REPORT_FILESET, FileSet.class, FileSetProperties.builder()
+      .setEnableExploreOnCreate(false)
+      .setDescription("fileSet")
+      .build());
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/ReportGenerationSpark.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/ReportGenerationSpark.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report;
+
+import co.cask.cdap.api.Transactionals;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import co.cask.cdap.api.spark.AbstractExtendedSpark;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.spark.JavaSparkMain;
+import co.cask.cdap.api.spark.service.AbstractSparkHttpServiceHandler;
+import co.cask.cdap.api.spark.service.SparkHttpServiceContext;
+import co.cask.cdap.api.spark.service.SparkHttpServiceHandler;
+import co.cask.cdap.report.proto.Filter;
+import co.cask.cdap.report.proto.FilterDeserializer;
+import co.cask.cdap.report.proto.ReportContent;
+import co.cask.cdap.report.proto.ReportGenerationInfo;
+import co.cask.cdap.report.proto.ReportGenerationRequest;
+import co.cask.cdap.report.proto.ReportList;
+import co.cask.cdap.report.proto.ReportStatus;
+import co.cask.cdap.report.proto.ReportStatusInfo;
+import co.cask.cdap.report.proto.ValueFilter;
+import co.cask.cdap.report.util.Constants;
+import co.cask.cdap.report.util.ReportField;
+import co.cask.cdap.report.util.ReportIds;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.twill.common.Threads;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * A Spark program for generating reports, querying for report statuses, and reading reports.
+ */
+public class ReportGenerationSpark extends AbstractExtendedSpark implements JavaSparkMain {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Filter.class, new FilterDeserializer())
+    .create();
+  private static final ExecutorService REPORT_EXECUTOR =
+    new ThreadPoolExecutor(0, 3, 60L, TimeUnit.SECONDS,
+                           new SynchronousQueue<>(), Threads.createDaemonThreadFactory("report-generation-%d"));
+
+  @Override
+  protected void configure() {
+    setMainClass(ReportGenerationSpark.class);
+    addHandlers(new ReportSparkHandler());
+  }
+
+  @Override
+  public void run(JavaSparkExecutionContext sec) throws Exception {
+    JavaSparkContext jsc = new JavaSparkContext();
+  }
+
+  /**
+   * A {@link SparkHttpServiceHandler} generating reports, querying for report statuses, and reading reports.
+   */
+  public static final class ReportSparkHandler extends AbstractSparkHttpServiceHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReportSparkHandler.class);
+    private static final Type REPORT_GENERATION_REQUEST_TYPE = new TypeToken<ReportGenerationRequest>() { }.getType();
+    private static final String DEFAULT_LIMIT = "10000";
+    private static final String READ_LIMIT = "readLimit";
+    private static final String START_FILE = "_START";
+    private static final String FAILURE_FILE = "_FAILURE";
+
+    private int readLimit;
+    private SparkSession sparkSession;
+
+    @Override
+    public void initialize(SparkHttpServiceContext context) throws Exception {
+      super.initialize(context);
+      sparkSession = new SQLContext(getContext().getSparkContext()).sparkSession();
+      String readLimitString = context.getRuntimeArguments().get(READ_LIMIT);
+      readLimit = readLimitString == null ? 10000 : Integer.valueOf(readLimitString);
+    }
+
+    @GET
+    @Path("/reports")
+    public void getReports(HttpServiceRequest request, HttpServiceResponder responder,
+                           @QueryParam("offset") @DefaultValue("0") int offset,
+                           @QueryParam("limit")  @DefaultValue(DEFAULT_LIMIT) int limit)
+      throws IOException {
+      Location reportFilesetLocation = getDatasetBaseLocation(ReportGenerationApp.REPORT_FILESET);
+      List<ReportStatusInfo> reportStatuses = new ArrayList<>();
+      // The index of the report directory to start reading from, initialized to the given offset
+      int idx = offset;
+      // TODO: [CDAP-13292] use cache store reportIdDirs
+      List<Location> reportIdDirs = new ArrayList<>(reportFilesetLocation.list());
+      // sort reportIdDirs directories by the creation time of report ID
+      reportIdDirs.sort((loc1, loc2) -> Long.compare(ReportIds.getTime(loc1.getName(), TimeUnit.SECONDS),
+                                                     ReportIds.getTime(loc2.getName(), TimeUnit.SECONDS)));
+
+      // Keep adding report status information to the list until the index is no longer smaller than
+      // the number of report directories or the list is reaching the given limit
+      while (idx < reportIdDirs.size() && reportStatuses.size() < limit) {
+        Location reportIdDir = reportIdDirs.get(idx++);
+        String reportId = reportIdDir.getName();
+        // Report ID is time based UUID. Get the creation time from the report ID.
+        long creationTime = ReportIds.getTime(reportId, TimeUnit.SECONDS);
+        reportStatuses.add(new ReportStatusInfo(reportId, creationTime, getReportStatus(reportIdDir)));
+      }
+      responder.sendJson(200, new ReportList(offset, limit, reportIdDirs.size(), reportStatuses));
+    }
+
+    @GET
+    @Path("/reports/{report-id}")
+    public void getReportStatus(HttpServiceRequest request, HttpServiceResponder responder,
+                                @PathParam("report-id") String reportId,
+                                @QueryParam("share-id") String shareId)
+      throws IOException {
+      Location reportIdDir = getDatasetBaseLocation(ReportGenerationApp.REPORT_FILESET).append(reportId);
+      if (!reportIdDir.exists()) {
+        responder.sendError(404, String.format("Report with id %s does not exist.", reportId));
+        return;
+      }
+      long creationTime = ReportIds.getTime(reportId, TimeUnit.SECONDS);
+      // Read the report request from _START file, which was written at the beginning of report generation
+      String reportRequest =
+        new String(ByteStreams.toByteArray(reportIdDir.append(START_FILE).getInputStream()), StandardCharsets.UTF_8);
+      responder.sendJson(new ReportGenerationInfo(creationTime, getReportStatus(reportIdDir), reportRequest));
+    }
+
+    @GET
+    @Path("reports/{report-id}/details")
+    public void getReportDetails(HttpServiceRequest request, HttpServiceResponder responder,
+                                 @PathParam("report-id") String reportId,
+                                 @QueryParam("offset") @DefaultValue("0") long offset,
+                                 @QueryParam("limit") @DefaultValue(DEFAULT_LIMIT) int limit,
+                                 @QueryParam("share-id") String shareId) throws IOException {
+      if (offset < 0) {
+        responder.sendError(400, "offset cannot be negative");
+        return;
+      }
+      if (limit <= 0) {
+        responder.sendError(400, "limit must be a positive integer");
+        return;
+      }
+      if (limit > readLimit) {
+        responder.sendError(400, "limit must cannot be larger than " + readLimit);
+        return;
+      }
+      Location reportIdDir = getDatasetBaseLocation(ReportGenerationApp.REPORT_FILESET).append(reportId);
+      if (!reportIdDir.exists()) {
+        responder.sendError(404, String.format("Report with id %s does not exist.", reportId));
+        return;
+      }
+      // Get the status of the report and only COMPLETED report can be read
+      ReportStatus status = getReportStatus(reportIdDir);
+      switch (status) {
+        case RUNNING:
+          responder.sendError(202, String.format("Report %s is still being generated, please retry later.", reportId));
+          return;
+        case FAILED:
+          responder.sendError(400, String.format("Reading details of the report %s with failed status is not allowed.",
+                                                 reportId));
+          return;
+        case COMPLETED:
+          break;
+        default: // this should never happen
+          responder.sendError(500, String.format("Unable to read report %s with unknown status %s.", reportId, status));
+          return;
+      }
+      List<String> reportRecords = new ArrayList<>();
+      long lineCount = 0;
+      Location reportDir = reportIdDir.append(Constants.LocationName.REPORT_DIR);
+      // TODO: [CDAP-13290] reports should be in avro format instead of json text;
+      // TODO: [CDAP-13291] need to support reading multiple report files
+      Optional<Location> reportFile = reportDir.list().stream().filter(l -> l.getName().endsWith(".json")).findFirst();
+      // TODO: [CDAP-13292] use cache to store content of the reports
+      // Read the report file and add lines starting from the position of offset to the result until the result reaches
+      // the limit
+      if (reportFile.isPresent()) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(reportFile.get().getInputStream(),
+                                                                          StandardCharsets.UTF_8))) {
+          String line;
+          while ((line = br.readLine()) != null) {
+            // skip lines before the offset
+            if (lineCount++ < offset) {
+              continue;
+            }
+            if (reportRecords.size() == limit) {
+              break;
+            }
+            reportRecords.add(line);
+          }
+        }
+      }
+      // Get the total number of records from the COUNT file
+      String total =
+        new String(ByteStreams.toByteArray(reportIdDir.append(Constants.LocationName.COUNT_FILE).getInputStream()),
+                   StandardCharsets.UTF_8);
+      responder.sendJson(200, new ReportContent(offset, limit, Integer.parseInt(total), reportRecords));
+    }
+
+    @POST
+    @Path("/reports")
+    public void executeReportGeneration(HttpServiceRequest request, HttpServiceResponder responder)
+      throws IOException {
+      String requestJson = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      LOG.debug("Received report generation request {}", requestJson);
+      ReportGenerationRequest reportRequest;
+      try {
+        reportRequest = decodeRequestBody(requestJson, REPORT_GENERATION_REQUEST_TYPE);
+        reportRequest.validate();
+      } catch (IllegalArgumentException e) {
+        responder.sendError(400, e.getMessage());
+        return;
+      }
+
+      String reportId = ReportIds.generate().toString();
+      Location reportIdDir = getDatasetBaseLocation(ReportGenerationApp.REPORT_FILESET).append(reportId);
+      if (!reportIdDir.mkdirs()) {
+        responder.sendError(500, "Failed to create a new directory for report " + reportId);
+        return;
+      }
+      LOG.debug("Created report base directory {} for report {}", reportIdDir, reportId);
+      // Create a _START file to indicate the start of report generation
+      Location startFile = reportIdDir.append(START_FILE);
+      if (!startFile.createNew()) {
+        reportIdDir.delete();
+        responder.sendError(500, "Failed to create a _START file for report " + reportId);
+        return;
+      }
+      // Save the report generation request in the _START file
+      try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(startFile.getOutputStream(),
+                                                                       StandardCharsets.UTF_8), true)) {
+        writer.write(requestJson);
+      }
+      LOG.debug("Wrote to startFile {}", startFile.toURI());
+      // Generate the report asynchronously
+      REPORT_EXECUTOR.execute(() -> {
+        tryGenerateReport(reportRequest, reportIdDir, reportId);
+      });
+      responder.sendJson(200, ImmutableMap.of("id", reportId));
+    }
+
+    /**
+     * Delegates report generation to {@link #generateReport(ReportGenerationRequest, Location)} and writes
+     * errors caught during report generation to a _FAILURE file.
+     *
+     * @param reportRequest the request to generate report
+     * @param reportIdDir the location of the directory which will be the parent directory of _FAILURE file
+     *                    and will be passed to {@link #generateReport(ReportGenerationRequest, Location)}
+     * @param reportId the ID of the report being generated
+     */
+    private void tryGenerateReport(ReportGenerationRequest reportRequest, Location reportIdDir, String reportId) {
+      try {
+        generateReport(reportRequest, reportIdDir);
+      } catch (Throwable t) {
+        LOG.error("Failed to generate report {}", reportId, t);
+        try {
+          // Write to the failure file in case of any exception occurs during report generation
+          Location failureFile = reportIdDir.append(FAILURE_FILE);
+          if (!failureFile.createNew()) {
+            // delete the reportIdDir in case of failing to create failure file, otherwise the report generation job
+            // will be seen as still running
+            reportIdDir.delete();
+            LOG.error("Failed to create a _FAILURE file for report {}", reportId);
+            return;
+          }
+          try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(failureFile.getOutputStream(),
+                                                                           StandardCharsets.UTF_8), true)) {
+            writer.println(t.toString());
+            t.printStackTrace(writer);
+          }
+        } catch (Throwable t2) {
+          LOG.error("Failed to write cause of failure to file for report {}", reportId, t2);
+        }
+      }
+    }
+
+    /**
+     * Generates report files according to the given request and write them to the given location.
+     * Program run meta files are first filtered to exclude unnecessary files for report generation,
+     * and send the paths of qualified run meta files to {@link ReportGenerationHelper#generateReport}
+     * that actually launches a Spark job to generate reports.
+     *
+     * @param reportRequest the request to generate report
+     * @param reportIdDir the location of the directory where the report files directory, COUNT file,
+     *                    and _SUCCESS file will be created.
+     */
+    private void generateReport(ReportGenerationRequest reportRequest, Location reportIdDir) throws IOException {
+      Location baseLocation = getDatasetBaseLocation(ReportGenerationApp.RUN_META_FILESET);
+      // Get a list of directories of all namespaces under RunMetaFileset base location
+      List<Location> nsLocations;
+      nsLocations = baseLocation.list();
+      // Get the namespace filter from the request if it exists
+      final ValueFilter<String> nsFilter = getNamespaceFilterIfExists(reportRequest);
+      Stream<Location> filteredNsLocations = nsLocations.stream();
+      // If the namespace filter exists, apply the filter to get filtered namespace directories
+      if (nsFilter != null) {
+        filteredNsLocations = nsLocations.stream().filter(nsLocation -> nsFilter.apply(nsLocation.getName()));
+      }
+      // Iterate through all qualified namespaces directories to get program run meta files
+      Stream<Location> metaFiles = filteredNsLocations.flatMap(nsLocation -> {
+        try {
+          List<Location> metaFileLocations = nsLocation.list();
+          LOG.debug("Files under namespace {}: {}", nsLocation.getName(), metaFileLocations);
+          return metaFileLocations.stream();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+      // Program run meta files are in avro format. Each file is named by the earliest program run meta record
+      // in the file, so exclude the files with no record earlier than the end of query time range.
+      List<String> metaFilePaths = metaFiles.filter(metaFile -> {
+        String fileName = metaFile.getName();
+        return fileName.endsWith(".avro")
+          && Long.parseLong(fileName.substring(0, fileName.indexOf(".avro"))) < reportRequest.getEnd();
+      }).map(location -> location.toURI().toString()).collect(Collectors.toList());
+      LOG.debug("Filtered meta files {}", metaFiles);
+      // Generate the report with the request and program run meta files
+      ReportGenerationHelper.generateReport(sparkSession, reportRequest, metaFilePaths, reportIdDir);
+    }
+
+    /**
+     * Get the value filter on namespace from the report generation request
+     *
+     * @param request the request to get the namespace filter from
+     * @return the namespace filter found or {@code null}
+     */
+    @Nullable
+    private static ValueFilter<String> getNamespaceFilterIfExists(ReportGenerationRequest request) {
+      if (request.getFilters() != null) {
+        for (Filter filter : request.getFilters()) {
+          if (ReportField.NAMESPACE.getFieldName().equals(filter.getFieldName())) {
+            // ReportGenerationRequest is validated to contain only one filter for namespace field
+            LOG.debug("Found namespace filter {}", filter);
+            return (ValueFilter<String>) filter;
+          }
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Returns the status of the report generation by checking the presence of the success file or the failure file.
+     * If neither of these files exists, the report generation is still running.
+     *
+     * TODO: [CDAP-13215] failure file may not be written if the Spark program is killed. Status of killed
+     * report generation job might be returned as RUNNING
+     *
+     * @param reportIdDir the base directory with report ID as directory name
+     * @return status of the report generation
+     */
+    private static ReportStatus getReportStatus(Location reportIdDir) throws IOException {
+      if (reportIdDir.append(Constants.LocationName.SUCCESS_FILE).exists()) {
+        return ReportStatus.COMPLETED;
+      }
+      if (reportIdDir.append(FAILURE_FILE).exists()) {
+        return ReportStatus.FAILED;
+      }
+      return ReportStatus.RUNNING;
+    }
+
+    private Location getDatasetBaseLocation(String datasetName) {
+      return Transactionals.execute(getContext(), context -> {
+        return context.<FileSet>getDataset(datasetName).getBaseLocation();
+      });
+    }
+
+    private <T> T decodeRequestBody(String request, Type type) {
+      T decodedRequestBody;
+      try {
+        decodedRequestBody = GSON.fromJson(request, type);
+        if (decodedRequestBody == null) {
+          throw new IllegalArgumentException("Request body cannot be empty.");
+        }
+      } catch (JsonSyntaxException e) {
+        throw new IllegalArgumentException("Request body is invalid json: " + e.getMessage());
+      }
+      return decodedRequestBody;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/package-info.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * Package for Report Generation Application.
+ */
+package co.cask.cdap.report;

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/Filter.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/Filter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+import co.cask.cdap.report.util.ReportField;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a filter that checks whether the value of a field is allowed to be included in the report.
+ *
+ * @param <T> type of the values
+ */
+public abstract class Filter<T> extends ReportGenerationRequest.Field {
+  public Filter(String fieldName) {
+    super(fieldName);
+  }
+
+  /**
+   * Checks whether the given value of the field is allowed to be included in the report.
+   *
+   * @param value value of the field
+   * @return {@code true} if the value is allowed, {@code false} otherwise.
+   */
+  public abstract boolean apply(T value);
+
+  /**
+   * Gets errors in the filter of a given filter type that are not allowed in a report generation request.
+   *
+   * @param filterType type of the filter
+   * @return list of errors in the filter
+   */
+  protected List<String> getFilterTypeErrors(ReportField.FilterType filterType) {
+    List<String> errors = new ArrayList<>();
+    ReportField valueFilterField = ReportField.valueOfFieldName(getFieldName());
+    if (valueFilterField != null && !valueFilterField.getApplicableFilters().contains(filterType)) {
+      errors.add(String.format("Field '%s' cannot be filtered by %s. It can only be filtered by: [%s]",
+                               getFieldName(), filterType.getPrettyName(),
+                               valueFilterField.getApplicableFilters().stream()
+                                 .map(ReportField.FilterType::getPrettyName).collect(Collectors.joining(","))));
+    }
+    return errors;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/FilterDeserializer.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/FilterDeserializer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.report.proto;
+
+import co.cask.cdap.internal.guava.reflect.TypeToken;
+import co.cask.cdap.report.util.ReportField;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * JSON deserializer for {@link Filter}
+ */
+public class FilterDeserializer implements JsonDeserializer<Filter> {
+  private static final Type INT_RANGE_FILTER_TYPE =
+    new TypeToken<RangeFilter<Integer>>() { }.getType();
+  private static final Type LONG_RANGE_FILTER_TYPE =
+    new TypeToken<RangeFilter<Long>>() { }.getType();
+  private static final Type STRING_VALUE_FILTER_TYPE =
+    new TypeToken<ValueFilter<String>>() { }.getType();
+
+  /**
+   * Deserializes a JSON String as {@link Filter}. Determines the class and data type of
+   * the filter according to the field name that the filter contains.
+   */
+  @Nullable
+  @Override
+  public Filter deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    throws JsonParseException {
+    if (json == null) {
+      return null;
+    }
+    if (!(json instanceof JsonObject)) {
+      throw new JsonParseException("Expected a JsonObject but found a " + json.getClass().getName());
+    }
+
+    JsonObject object = (JsonObject) json;
+    JsonElement fieldName = object.get("fieldName");
+    if (fieldName == null) {
+      throw new JsonParseException("Field name must be specified for filters");
+    }
+    ReportField field = ReportField.valueOfFieldName(fieldName.getAsString());
+    if (field == null) {
+      throw new JsonParseException(String.format("Invalid field name '%s'. Field name must be one of: [%s]", fieldName,
+                                                 String.join(", ", ReportField.FIELD_NAME_MAP.keySet())));
+    }
+    Filter filter = null;
+    // if the object contains "range" field, try to deserialize it as a range filter
+    if (object.get("range") != null) {
+      // Use the type token that matches the class of this field's value to deserialize the JSON
+      if (field.getValueClass().equals(Integer.class)) {
+        filter = context.deserialize(json, INT_RANGE_FILTER_TYPE);
+      } else if (field.getValueClass().equals(Long.class)) {
+        filter = context.deserialize(json, LONG_RANGE_FILTER_TYPE);
+      }
+      // otherwise, try to deserialize it as a value filter
+    } else if (field.getValueClass().equals(String.class)) {
+      // Use the type token that matches the class of this field's value to deserialize the JSON
+      filter = context.deserialize(json, STRING_VALUE_FILTER_TYPE);
+    }
+    if (filter == null) {
+      // this should never happen. If the field's applicable filters contains value filter,
+      // there must be a know class matches the class of its value
+      throw new JsonParseException(String.format("No applicable filter found for field %s with value type %s.",
+                                                 fieldName, field.getValueClass().getName()));
+    }
+    return filter;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/RangeFilter.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/RangeFilter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+import co.cask.cdap.report.util.ReportField;
+
+import java.util.ArrayList;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a filter that checks whether a given value of a field is within the allowed range.
+ *
+ * @param <T> type of the values
+ */
+public class RangeFilter<T extends Comparable<T>> extends Filter<T> {
+  private final Range<T> range;
+
+  public RangeFilter(String fieldName, Range<T> range) {
+    super(fieldName);
+    this.range = range;
+  }
+
+  /**
+   * @return the allowed range of values of this field
+   */
+  public Range getRange() {
+    return range;
+  }
+
+  /**
+   * @return {@code true} if the given value is larger or equal to min if min is not {@code null}
+   *         and smaller than max if max is not {@code null}, {@code false} otherwise
+   */
+  @Override
+  public boolean apply(T value) {
+    return (range.getMin() == null || range.getMin().compareTo(value) <= 0)
+      && (range.getMax() == null || range.getMax().compareTo(value) > 0);
+  }
+
+  @Override
+  @Nullable
+  public String getError() {
+    ArrayList<String> errors = new ArrayList<>();
+    String fieldError = super.getError();
+    if (fieldError != null) {
+      errors.add(fieldError);
+    }
+    errors.addAll(getFilterTypeErrors(ReportField.FilterType.RANGE));
+    if (range == null) {
+      errors.add("'range' cannot be null");
+    } else {
+      if (range.getMin() == null && range.getMax() == null) {
+        errors.add("'min' and 'max' cannot both be null'");
+      } else if (range.getMin() != null && range.getMax() != null && range.getMin().compareTo(range.getMax()) >= 0) {
+        errors.add("'min' must be smaller than 'max'");
+      }
+    }
+    return errors.isEmpty() ? null :
+      String.format("Filter %s contains these errors: %s", getFieldName(), String.join("; ", errors));
+  }
+
+  @Override
+  public String toString() {
+    return "RangeFilter{" +
+      "fieldName=" + getFieldName() +
+      ", range=" + range +
+      '}';
+  }
+
+  /**
+   * Range of allowed values of a field represented as [min, max) where min is the inclusive minimum value
+   * and max is the exclusive maximum value.
+   *
+   * @param <T> the value type of the field
+   */
+  public static class Range<T> {
+    @Nullable
+    private final T min;
+    @Nullable
+    private final T max;
+
+    public Range(T min, T max) {
+      this.min = min;
+      this.max = max;
+    }
+
+    /**
+     * @return the inclusive minimum value of this range
+     */
+    @Nullable
+    public T getMin() {
+      return min;
+    }
+
+    /**
+     * @return the exclusive maximum value of this range
+     */
+    @Nullable
+    public T getMax() {
+      return max;
+    }
+
+    @Override
+    public String toString() {
+      return "Range{" +
+        "min=" + min +
+        ", max=" + max +
+        '}';
+    }
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportContent.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportContent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+import java.util.List;
+
+/**
+ * Represents report content details in an HTTP response.
+ */
+public class ReportContent {
+  private final long offset;
+  private final int limit;
+  private final long total;
+  private final List<String> runs;
+
+  public ReportContent(long offset, int limit, long total, List<String> reports) {
+    this.offset = offset;
+    this.limit = limit;
+    this.total = total;
+    this.runs = reports;
+  }
+
+  /**
+   * @return the offset in the whole report from which the report records are added to this {@link ReportContent}
+   */
+  public long getOffset() {
+    return offset;
+  }
+
+  /**
+   * @return the max limit of number of report records contained in this {@link ReportContent}
+   */
+  public int getLimit() {
+    return limit;
+  }
+
+  /**
+   * @return the total number of report records in the whole report
+   */
+  public long getTotal() {
+    return total;
+  }
+
+  /**
+   * @return the records of program runs in the report
+   */
+  public List<String> getRuns() {
+    return runs;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportGenerationInfo.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportGenerationInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+/**
+ * Represents the information of a report generation in an HTTP response.
+ */
+public class ReportGenerationInfo {
+  private final long created;
+  private final ReportStatus status;
+  private final String request;
+
+  public ReportGenerationInfo(long created, ReportStatus status, String request) {
+    this.created = created;
+    this.status = status;
+    this.request = request;
+  }
+
+  /**
+   * @return the creation time of this report in seconds
+   */
+  public long getCreated() {
+    return created;
+  }
+
+  /**
+   * @return the report generation status
+   */
+  public ReportStatus getStatus() {
+    return status;
+  }
+
+  /**
+   * @return the request for generating this report
+   */
+  public String getRequest() {
+    return request;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportGenerationRequest.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportGenerationRequest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+import co.cask.cdap.report.util.ReportField;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a request to generate a program run report in an HTTP request.
+ */
+public class ReportGenerationRequest {
+  private final Long start;
+  private final Long end;
+  private final List<String> fields;
+  @Nullable
+  private final List<Sort> sort;
+  @Nullable
+  private final List<Filter> filters;
+
+  public ReportGenerationRequest(Long start, Long end, List<String> fields, @Nullable List<Sort> sort,
+                                 @Nullable List<Filter> filters) {
+    this.start = start;
+    this.end = end;
+    this.fields = fields;
+    this.sort = sort;
+    this.filters = filters;
+    this.validate();
+  }
+
+  /**
+   * @return the start of the time range within which the report is generated. All program runs in the report must be
+   *         still running at {@code start}, or with end time not earlier than {@code start}.
+   */
+  public Long getStart() {
+    return start;
+  }
+
+  /**
+   * @return the end of the time range within which the report is generated. All program runs in the report must
+   *         start before {@code end}.
+   */
+  public Long getEnd() {
+    return end;
+  }
+
+  /**
+   * @return names of the fields to be included in the final report. Must be valid fields from {@link ReportField}.
+   */
+  public List<String> getFields() {
+    return fields;
+  }
+
+  /**
+   * @return the field to sort the report by. Currently only support a single field.
+   */
+  @Nullable
+  public List<Sort> getSort() {
+    return sort;
+  }
+
+  /**
+   * @return the filters that must be satisfied for every record in the report.
+   */
+  @Nullable
+  public List<Filter> getFilters() {
+    return filters;
+  }
+
+  /**
+   * Validates this {@link ReportGenerationRequest}
+   *
+   * @throws IllegalArgumentException if this request is not valid.
+   */
+  public void validate() {
+    List<String> errors = new ArrayList<>();
+    if (start == null) {
+      errors.add("'start' must be specified.");
+    }
+    if (end == null) {
+      errors.add("'end' must be specified.");
+    }
+    if (start >= end) {
+      errors.add("'start' must be smaller than 'end'.");
+    }
+    if (fields == null || fields.isEmpty()) {
+      errors.add("'fields' must be specified.");
+    } else {
+      errors.addAll(fields.stream().map(f -> new ReportGenerationRequest.Field(f).getError())
+                      .filter(e -> e != null).collect(Collectors.toList()));
+    }
+    if (filters != null) {
+      errors.addAll(filters.stream().map(Filter::getError).filter(e -> e != null).collect(Collectors.toList()));
+    }
+    if (sort != null) {
+      if (sort.size() > 1) {
+        errors.add("Currently only one field is supported in sort.");
+      }
+      errors.addAll(sort.stream().map(Sort::getError).filter(e -> e != null).collect(Collectors.toList()));
+    }
+    if (errors.size() > 0) {
+      throw new IllegalArgumentException("Please fix the following errors in the report generation request: "
+                                           + String.join("; ", errors));
+    }
+  }
+
+  /**
+   * Represents a flied in the report generation request.
+   */
+  public static class Field {
+    private final String fieldName;
+
+    public Field(String fieldName) {
+      this.fieldName = fieldName;
+    }
+
+    public String getFieldName() {
+      return fieldName;
+    }
+
+    /**
+     * @return the error of this field that are not allowed in a valid report generation request, or {@code null} if
+     *         no such error exists.
+     */
+    @Nullable
+    public String getError() {
+      if (ReportField.isValidField(fieldName)) {
+        return null;
+      }
+      return String.format("Invalid field name '%s' in fields. Field name must be one of: [%s]",
+                           fieldName, String.join(", ", ReportField.FIELD_NAME_MAP.keySet()));
+    }
+  }
+
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportList.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportList.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+import java.util.List;
+
+/**
+ * Represents a list of information about the reports owned by a user in an HTTP response.
+ */
+public class ReportList {
+  private final int offset;
+  private final int limit;
+  private final int total;
+  private final List<ReportStatusInfo> reports;
+
+  public ReportList(int offset, int limit, int total, List<ReportStatusInfo> reports) {
+    this.offset = offset;
+    this.limit = limit;
+    this.total = total;
+    this.reports = reports;
+  }
+
+  /**
+   * @return the offset in the whole list of reports where the report information's
+   *         start to be added to this {@link ReportList}
+   */
+  public int getOffset() {
+    return offset;
+  }
+
+  /**
+   * @return the max number of report information's contained in this {@link ReportList}
+   */
+  public int getLimit() {
+    return limit;
+  }
+
+  /**
+   * @return the total number of reports owned by a user
+   */
+  public int getTotal() {
+    return total;
+  }
+
+  /**
+   * @return the list of report information's
+   */
+  public List<ReportStatusInfo> getReports() {
+    return reports;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportStatus.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+/**
+ * Represents the status of a report generation job.
+ */
+public enum ReportStatus {
+  RUNNING,
+  COMPLETED,
+  FAILED
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportStatusInfo.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ReportStatusInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+/**
+ * Represents the status information of a report.
+ */
+public class ReportStatusInfo {
+  private final String id;
+  private final long created;
+  private final ReportStatus status;
+
+  public ReportStatusInfo(String id, long created, ReportStatus status) {
+    this.id = id;
+    this.created = created;
+    this.status = status;
+  }
+
+  /**
+   * @return report ID
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * @return the creation time of this report in seconds
+   */
+  public long getCreated() {
+    return created;
+  }
+
+  /**
+   * @return the report generation status
+   */
+  public ReportStatus getStatus() {
+    return status;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/Sort.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/Sort.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+import co.cask.cdap.report.util.ReportField;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * A class represents the field to sort the report by and the order of sorting by this field.
+ */
+public class Sort extends ReportGenerationRequest.Field {
+  private final Order order;
+
+  public Sort(String fieldName, Order order) {
+    super(fieldName);
+    this.order = order;
+  }
+
+  /**
+   * @return the sorting order with this field
+   */
+  public Order getOrder() {
+    return order;
+  }
+
+  @Override
+  @Nullable
+  public String getError() {
+    List<String> errors = new ArrayList<>();
+    String fieldError = super.getError();
+    if (fieldError != null) {
+      errors.add(fieldError);
+    }
+    ReportField sortField = ReportField.valueOfFieldName(getFieldName());
+    if (sortField != null && !sortField.isSortable()) {
+      errors.add(String.format("Field '%s' in sort is not sortable. Only fields: [%s] are sortable",
+                               getFieldName(), String.join(", ", ReportField.SORTABLE_FIELDS)));
+    }
+    if (order == null) {
+      errors.add("'order' cannot be null, it can only be ASCENDING or DESCENDING");
+    }
+    return errors.isEmpty() ? null :
+      String.format("Sort %s contains these errors: %s", getFieldName(), String.join("; ", errors));
+  }
+
+  @Override
+  public String toString() {
+    return "Sort{" +
+      "fieldName=" + getFieldName() +
+      ", order=" + order +
+      '}';
+  }
+
+  /**
+   * The order to sort a field by.
+   */
+  public enum Order {
+    ASCENDING,
+    DESCENDING
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ValueFilter.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/proto/ValueFilter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+import co.cask.cdap.report.util.ReportField;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a filter that checks whether a given value of a field is one of the allowed values and is not one of
+ * the disallowed values.
+ *
+ * @param <T> type of the values
+ */
+public class ValueFilter<T> extends Filter<T> {
+  @Nullable
+  private final Set<T> whitelist;
+  @Nullable
+  private final Set<T> blacklist;
+
+  public ValueFilter(String fieldName, @Nullable Set<T> whitelist, @Nullable Set<T> blacklist) {
+    super(fieldName);
+    this.whitelist = whitelist;
+    this.blacklist = blacklist;
+  }
+
+  /**
+   * @return the allowed values for this field, or an empty set if there's no such limit
+   */
+  public Set<T> getWhitelist() {
+    return whitelist == null ? Collections.emptySet() : whitelist;
+  }
+
+  /**
+   * @return the disallowed values for this field, or an empty set if there's no such limit
+   */
+  public Set<T> getBlacklist() {
+    return blacklist == null ? Collections.emptySet() : blacklist;
+  }
+
+  @Override
+  @Nullable
+  public String getError() {
+    List<String> errors = new ArrayList<>();
+    String fieldError = super.getError();
+    if (fieldError != null) {
+      errors.add(fieldError);
+    }
+    errors.addAll(getFilterTypeErrors(ReportField.FilterType.VALUE));
+    if (getWhitelist().isEmpty() && getBlacklist().isEmpty()) {
+      errors.add("'whitelist' and 'blacklist' cannot both be empty");
+    } else if (!getWhitelist().isEmpty() && !getBlacklist().isEmpty()) {
+      errors.add("Only one of 'whitelist' and 'blacklist' can be non-empty");
+    }
+    return errors.isEmpty() ? null :
+      String.format("Filter %s contains these errors: %s", getFieldName(), String.join("; ", errors));
+  }
+
+  @Override
+  public boolean apply(T value) {
+    return (getWhitelist().isEmpty() || getWhitelist().contains(value))
+      && (getBlacklist().isEmpty() || !getBlacklist().contains(value));
+  }
+
+  @Override
+  public String toString() {
+    return "ValueFilter{" +
+      "fieldName=" + getFieldName() +
+      ", whitelist=" + whitelist +
+      ", blacklist=" + blacklist +
+      '}';
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/util/Constants.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/util/Constants.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0  = the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.util;
+
+/**
+ * Constants used by the report generation app and file schema.
+ */
+public final class Constants {
+  public static final String NAMESPACE = "namespace";
+  public static final String ARTIFACT_SCOPE = "artifact.scope";
+  public static final String ARTIFACT_NAME = "artifact.name";
+  public static final String ARTIFACT_VERSION = "artifact.version";
+  public static final String APPLICATION_NAME = "application.name";
+  public static final String APPLICATION_VERSION = "application.version";
+  public static final String PROGRAM = "program";
+  public static final String RUN = "run";
+  public static final String STATUS = "status";
+  public static final String START = "start";
+  public static final String RUNNING = "running";
+  public static final String END = "end";
+  public static final String DURATION = "duration";
+  public static final String USER = "user";
+  public static final String START_METHOD = "startMethod";
+  public static final String RUNTIME_ARGUMENTS = "runtimeArguments";
+  public static final String NUM_LOG_WARNINGS = "numLogWarnings";
+  public static final String NUM_LOG_ERRORS = "numLogErrors";
+  public static final String NUM_RECORDS_OUT = "numRecordsOut";
+  public static final String TIME = "time";
+  public static final String START_INFO = "startInfo";
+
+  /**
+   * Constants used as location names for report generation app.
+   */
+  public static final class LocationName {
+    public static final String REPORT_DIR = "reports";
+    public static final String COUNT_FILE = "COUNT";
+    public static final String SUCCESS_FILE = "_SUCCESS";
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/util/ProgramRunMetaFileUtil.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/util/ProgramRunMetaFileUtil.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.util;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.report.StartInfo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumWriter;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Utility class for reading and writing program run meta files.
+ */
+public final class ProgramRunMetaFileUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(ProgramRunMetaFileUtil.class);
+
+  // TODO: [CDAP-13215] add omitted fields when the actual program meta files are generated
+  private static final Schema STARTING_INFO = Schema.recordOf(
+    "ProgramStartingInfo",
+    Schema.Field.of(Constants.USER, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(Constants.RUNTIME_ARGUMENTS, Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                              Schema.of(Schema.Type.STRING)))
+    );
+
+  // TODO: [CDAP-13215] add omitted fields when the actual program meta files are generated
+  private static final String SCHEMA_STRING = Schema.recordOf(
+    "ReportRecord",
+    Schema.Field.of(Constants.NAMESPACE, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(Constants.PROGRAM, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(Constants.RUN, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(Constants.STATUS, Schema.of(Schema.Type.STRING)),
+    Schema.Field.of(Constants.TIME, Schema.of(Schema.Type.LONG)),
+    Schema.Field.of(Constants.START_INFO,  Schema.nullableOf(STARTING_INFO))
+  ).toString();
+
+  public static final org.apache.avro.Schema STARTING_INFO_SCHEMA =
+    new org.apache.avro.Schema.Parser().parse(STARTING_INFO.toString());
+  public static final org.apache.avro.Schema SCHEMA = new org.apache.avro.Schema.Parser().parse(SCHEMA_STRING);
+
+  private ProgramRunMetaFileUtil() {
+    // no-op
+  }
+
+  /**
+   * Creates a mock report record with the given information
+   *
+   * @return a report record containing the given information
+   */
+  public static GenericData.Record createRecord(String namespace, String program, String run, String status, long time,
+                                                @Nullable StartInfo startInfo) {
+    GenericData.Record startInfoRecord = null;
+    if (startInfo != null) {
+      startInfoRecord = new GenericData.Record(STARTING_INFO_SCHEMA);
+      startInfoRecord.put(Constants.USER, startInfo.user());
+      startInfoRecord.put(Constants.RUNTIME_ARGUMENTS, startInfo.getRuntimeArgsAsJavaMap());
+    }
+    GenericData.Record record = new GenericData.Record(SCHEMA);
+    record.put(Constants.NAMESPACE, namespace);
+    record.put(Constants.PROGRAM, program);
+    record.put(Constants.RUN, run);
+    record.put(Constants.STATUS, status);
+    record.put(Constants.TIME, time);
+    record.put(Constants.START_INFO, startInfoRecord);
+    return record;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/util/ReportField.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/util/ReportField.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.report.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import static co.cask.cdap.report.util.ReportField.FilterType.RANGE;
+import static co.cask.cdap.report.util.ReportField.FilterType.VALUE;
+
+/**
+ * Represents the types of fields in a report.
+ */
+public enum ReportField {
+  NAMESPACE(Constants.NAMESPACE, String.class, Collections.singletonList(VALUE), false),
+  ARTIFACT_SCOPE(Constants.ARTIFACT_SCOPE, String.class, Collections.singletonList(VALUE), false),
+  ARTIFACT_NAME(Constants.ARTIFACT_NAME, String.class, Collections.singletonList(VALUE), false),
+  ARTIFACT_VERSION(Constants.ARTIFACT_VERSION, String.class, Collections.singletonList(VALUE), false),
+  APPLICATION_NAME(Constants.APPLICATION_NAME, String.class, Collections.singletonList(VALUE), false),
+  APPLICATION_VERSION(Constants.ARTIFACT_VERSION, String.class, Collections.singletonList(VALUE), false),
+  PROGRAM(Constants.PROGRAM, String.class, Collections.singletonList(VALUE), false),
+  RUN(Constants.RUN, String.class, Collections.singletonList(VALUE), false),
+  STATUS(Constants.STATUS, String.class, Collections.singletonList(VALUE), false),
+  START(Constants.START, Long.class, Collections.singletonList(RANGE), true),
+  RUNNING(Constants.RUNNING, Long.class, Collections.singletonList(RANGE), true),
+  END(Constants.END, Long.class, Collections.singletonList(RANGE), true),
+  DURATION(Constants.DURATION, Long.class, Collections.singletonList(RANGE), true),
+  USER(Constants.USER, String.class, Collections.singletonList(VALUE), false),
+  START_METHOD(Constants.START_METHOD, String.class, Collections.singletonList(VALUE), false),
+  RUNTIME_ARGUMENTS(Constants.RUNTIME_ARGUMENTS, String.class, Collections.emptyList(), false),
+  NUM_LOG_WARNINGS(Constants.NUM_LOG_WARNINGS, Integer.class, Collections.singletonList(RANGE), true),
+  NUM_LOG_ERRORS(Constants.NUM_LOG_ERRORS, Integer.class, Collections.singletonList(RANGE), true),
+  NUM_RECORDS_OUT(Constants.NUM_RECORDS_OUT, Integer.class, Collections.singletonList(RANGE), true);
+
+  private final String fieldName;
+  private final Class valueClass;
+  private final List<FilterType> applicableFilters;
+  private final boolean sortable;
+
+  /**
+   * A map with all valid field names as keys and the corresponding {@link ReportField} as values
+   */
+  public static final Map<String, ReportField> FIELD_NAME_MAP;
+  /**
+   * A list of the names of all fields that can be used to sort a report
+   */
+  public static final List<String> SORTABLE_FIELDS;
+
+  static {
+    FIELD_NAME_MAP = new HashMap<>();
+    SORTABLE_FIELDS = new ArrayList<>();
+    for (ReportField field : ReportField.values()) {
+      FIELD_NAME_MAP.put(field.getFieldName(), field);
+      if (field.isSortable()) {
+        SORTABLE_FIELDS.add(field.getFieldName());
+      }
+    }
+  }
+
+  ReportField(String fieldName, Class valueClass, List<FilterType> applicableFilters, boolean sortable) {
+    this.fieldName = fieldName;
+    this.valueClass = valueClass;
+    this.applicableFilters = applicableFilters;
+    this.sortable = sortable;
+  }
+
+  /**
+   * @return the name of this field
+   */
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  /**
+   * @return the class of this field's value
+   */
+  public Class getValueClass() {
+    return valueClass;
+  }
+
+  /**
+   * @return the {@link FilterType}'s that are applicable to this field
+   */
+  public List<FilterType> getApplicableFilters() {
+    return applicableFilters;
+  }
+
+  /**
+   * @return {@code true} if this field can be used to sort a report, {@code false} otherwise.
+   */
+  public boolean isSortable() {
+    return sortable;
+  }
+
+  /**
+   * Returns the corresponding report field given a field's name.
+   *
+   * @param fieldName the name of the field
+   * @return the corresponding report field or {@code null} if no field with the given name exists
+   */
+  @Nullable
+  public static ReportField valueOfFieldName(String fieldName) {
+    return FIELD_NAME_MAP.get(fieldName);
+  }
+
+  /**
+   * Returns whether there exists a field with the given name.
+   *
+   * @param fieldName the field name to be checked
+   * @return {@code true} if there exists a field with the given name, {@code false} otherwise.
+   */
+  public static boolean isValidField(String fieldName) {
+    return FIELD_NAME_MAP.containsKey(fieldName);
+  }
+
+  /**
+   * Represents the type of a filter.
+   */
+  public enum FilterType {
+    VALUE("value"),
+    RANGE("range");
+
+    private final String prettyName;
+
+    FilterType(String prettyName) {
+      this.prettyName = prettyName;
+    }
+
+    /**
+     * @return the name of the filter type used in HTTP request/response
+     */
+    public String getPrettyName() {
+      return prettyName;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/util/ReportIds.java
+++ b/cdap-app-templates/cdap-program-report/src/main/java/co/cask/cdap/report/util/ReportIds.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.util;
+
+import com.google.common.primitives.Longs;
+
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+// TODO: Most of this class is copied from {@link co.cask.cdap.common.app.RunIds}. Need to reduce code duplication.
+/**
+ * Generates an unique ID for a report using type 1 and variant 2 time-based {@link UUID}.
+ * This implements time-based UUID generation algorithm described in
+ * <a href="http://www.ietf.org/rfc/rfc4122.txt">A Universally Unique IDentifier (UUID) URN Namespace</a>
+ * with the following modifications:
+ * <ul>
+ *   <li>It does not share state with other instances of time-based UUID generators on a given machine. So it is
+ *   recommended not to run more than one instance of this on a machine to guarantee uniqueness of UUIDs generated.</li>
+ *   <li>The timestamp embedded in the UUID is only valid up to millisecond precision. This is because this
+ *   implementation uses a counter value in the remaining bits to ensure unique UUIDs are generated when invoked
+ *   multiple times at the same millisecond (up to 10000 times).</li>
+ * </ul>
+ */
+public final class ReportIds {
+  private static final Random RANDOM = new Random();
+
+  // Number of 100ns intervals since 15 October 1582 00:00:000000000 until UNIX epoch
+  private static final long NUM_100NS_INTERVALS_SINCE_UUID_EPOCH = 0x01b21dd213814000L;
+  // Multiplier to convert millisecond into 100ns
+  private static final long HUNDRED_NANO_MULTIPLIER = 10000;
+
+  private static final AtomicLong COUNTER = new AtomicLong();
+
+
+  /**
+   * @return UUID based on current time. If called repeatedly within the same millisecond, this is
+   * guaranteed to generate at least 10000 unique UUIDs for the millisecond.
+   */
+  public static UUID generate() {
+    return (generateUUIDForTime(System.currentTimeMillis()));
+  }
+
+  /**
+   * Converts string representation of run id into {@link UUID}l
+   */
+  public static UUID fromString(String id) {
+    return UUID.fromString(id);
+  }
+
+  /**
+   * @return time from the UUID if it is a time-based UUID, -1 otherwise.
+   */
+  public static long getTime(String reportId, TimeUnit timeUnit) {
+    UUID uuid = UUID.fromString(reportId);
+    if (uuid.version() == 1 && uuid.variant() == 2) {
+      long timeInMilliseconds = (uuid.timestamp() - NUM_100NS_INTERVALS_SINCE_UUID_EPOCH) / HUNDRED_NANO_MULTIPLIER;
+      return timeUnit.convert(timeInMilliseconds, TimeUnit.MILLISECONDS);
+    }
+    return -1;
+  }
+
+  private static UUID generateUUIDForTime(long timeInMillis) {
+    // Use system time in milliseconds to generate time in 100ns.
+    // Use COUNTER to ensure unique time gets generated for the same millisecond (up to HUNDRED_NANO_MULTIPLIER)
+    // Hence the time is valid only for millisecond precision, event though it represents 100ns precision.
+    long ts = timeInMillis * HUNDRED_NANO_MULTIPLIER + COUNTER.incrementAndGet() % HUNDRED_NANO_MULTIPLIER;
+    long time = ts + NUM_100NS_INTERVALS_SINCE_UUID_EPOCH;
+
+    long timeLow = time &       0xffffffffL;
+    long timeMid = time &   0xffff00000000L;
+    long timeHi = time & 0xfff000000000000L;
+    long upperLong = (timeLow << 32) | (timeMid >> 16) | (1 << 12) | (timeHi >> 48);
+
+    // Random clock ID
+    int clockId = RANDOM.nextInt() & 0x3FFF;
+    long nodeId;
+
+    try {
+      Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+      NetworkInterface networkInterface = null;
+      while (interfaces.hasMoreElements()) {
+        networkInterface = interfaces.nextElement();
+        if (!networkInterface.isLoopback()) {
+          break;
+        }
+      }
+      byte[] mac = networkInterface == null ? null : networkInterface.getHardwareAddress();
+      if (mac == null) {
+        nodeId = (RANDOM.nextLong() & 0xFFFFFFL) | 0x100000L;
+      } else {
+        nodeId = Longs.fromBytes((byte) 0, (byte) 0, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+      }
+
+    } catch (SocketException e) {
+      // Generate random node ID
+      nodeId = RANDOM.nextLong() & 0xFFFFFFL | 0x100000L;
+    }
+
+    long lowerLong = ((long) clockId | 0x8000) << 48 | nodeId;
+
+    return new java.util.UUID(upperLong, lowerLong);
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/main/scala/co/cask/cdap/report/Record.scala
+++ b/cdap-app-templates/cdap-program-report/src/main/scala/co/cask/cdap/report/Record.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.report
+
+/**
+  * Represents the full content of a report record.
+  * TODO: [CDAP-13294] add artifact and app information
+  */
+case class Record(namespace: String, program: String, run: String, start: Option[Long], running: Option[Long],
+                  end: Option[Long], duration: Option[Long], user: Option[String],
+                  // use scala.collection.Map[String,String]] instead of Map[String, String] to avoid compilation error
+                  // in Janino generated code
+                  runtimeArguments: Option[scala.collection.Map[String, String]])

--- a/cdap-app-templates/cdap-program-report/src/main/scala/co/cask/cdap/report/RecordAggregator.scala
+++ b/cdap-app-templates/cdap-program-report/src/main/scala/co/cask/cdap/report/RecordAggregator.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.report
+
+import co.cask.cdap.report.util.Constants
+import org.apache.spark.sql.{Encoder, Encoders, Row}
+import org.apache.spark.sql.expressions.Aggregator
+
+/**
+  * An aggregator that aggregates [[Row]]'s with the same program run ID into intermediate [[RecordBuilder]]'s
+  * and finally merge the [[RecordBuilder]]'s to build a single [[Record]]
+  */
+class RecordAggregator extends Aggregator[Row, RecordBuilder, Record] {
+
+  def zero: RecordBuilder = RecordBuilder("", "", "", Vector.empty, None)
+  def reduce(builder: RecordBuilder, row: Row): RecordBuilder = {
+    // Get the StartInfo from the builder if it exists or construct a new StartInfo from the row
+    val startInfo = builder.startInfo.orElse(Option(row.getAs[Row](Constants.START_INFO)).map(rowToStartInfo))
+
+    // Merge statusTimes from the builder with the new status and time tuple from the row. Combined with
+    // the information from the row and the startInfo to create a new RecordBuilder
+    RecordBuilder(row.getAs(Constants.NAMESPACE), row.getAs(Constants.PROGRAM), row.getAs(Constants.RUN),
+      builder.statusTimes :+ (row.getAs[String](Constants.STATUS), row.getAs[Long](Constants.TIME)), startInfo)
+  }
+  def merge(b1: RecordBuilder, b2: RecordBuilder): RecordBuilder = {
+    b1.merge(b2)
+  }
+  def finish(b: RecordBuilder): Record = {
+    b.build()
+  }
+  def bufferEncoder(): Encoder[RecordBuilder] = Encoders.product[RecordBuilder]
+  def outputEncoder(): Encoder[Record] = Encoders.product[Record]
+
+  private def rowToStartInfo(row: Row): StartInfo =
+    StartInfo(row.getAs(Constants.USER), row.getAs(Constants.RUNTIME_ARGUMENTS))
+}

--- a/cdap-app-templates/cdap-program-report/src/main/scala/co/cask/cdap/report/RecordBuilder.scala
+++ b/cdap-app-templates/cdap-program-report/src/main/scala/co/cask/cdap/report/RecordBuilder.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.report
+
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConversions._
+
+/**
+  * Builder for creating a [[Record]].
+  *
+  * @param namespace namespace of the program run
+  * @param program program name
+  * @param run run ID
+  * @param statusTimes status and time tuples indicating the time when each status of the program is reached
+  * @param startInfo the information obtained when a program run starts
+  */
+case class RecordBuilder(namespace: String, program: String, run: String,
+                         statusTimes: Seq[(String, Long)], startInfo: Option[StartInfo]) {
+  import RecordBuilder._
+  /**
+    * Merges the contents of this with the other [[RecordBuilder]] by replacing empty values in this with
+    * values from the other.
+    *
+    * @param other the [[RecordBuilder]] to combine this with
+    * @return a new [[RecordBuilder]] combining this and other
+    */
+  def merge(other: RecordBuilder): RecordBuilder = {
+    val namespace = if (this.namespace.isEmpty) other.namespace else this.namespace
+    val program = if (this.program.isEmpty) other.program else this.program
+    val run = if (this.run.isEmpty) other.run else this.run
+    val statusTimes = this.statusTimes ++ other.statusTimes
+    val startInfo = if (this.startInfo.isEmpty) other.startInfo else this.startInfo
+    val r = RecordBuilder(namespace, program, run, statusTimes, startInfo)
+    LOG.trace("Merged this {} with other {} to get a new {}", this, other, r)
+    r
+  }
+
+  /**
+    * @return a [[Record]] built from the information in this [[RecordBuilder]]
+    */
+  def build(): Record = {
+    import ReportGenerationHelper._
+    // Construct a status to time map from the list of status time tuples, by keeping the earliest time of a status
+    // if there exists multiple times for the same status
+    val statusTimeMap = statusTimes.groupBy(_._1).map(v => (v._1, v._2.map(_._2).min))
+    val start = statusTimeMap.get("STARTING")
+    val running = statusTimeMap.get("RUNNING")
+    // Get the earliest status with one of the ending statuses
+    val end = statusTimeMap.filterKeys(END_STATUSES.contains).values
+      .reduceOption(Math.min(_, _)) // avoid compilation error with Math.min(_, _) instead of Math.min
+    val duration = end.flatMap(e => start.map(e - _))
+    val user = startInfo.map(_.user)
+    val runtimeArgs = startInfo.map(_.runtimeArgs)
+    val r = Record(namespace, program, run, start, running, end, duration, user, runtimeArgs)
+    LOG.trace("RecordBuilder = {}", this)
+    LOG.trace("Record = {}", r)
+    r
+  }
+}
+
+/**
+  * Represents the information obtained when a program run starts.
+  *
+  * @param user the user who starts the program run
+  * @param runtimeArgs runtime arguments of the program run
+  */
+
+case class StartInfo(user: String,
+                     // Use scala.collection.Map to avoid compilation error in Janino generated code
+                     runtimeArgs: scala.collection.Map[String, String]) {
+  def this(user: String, runtimeArgs: java.util.Map[String, String]) = this(user, mapAsScalaMap(runtimeArgs).toMap)
+  def getRuntimeArgsAsJavaMap(): java.util.Map[String, String] = runtimeArgs
+}
+
+object RecordBuilder {
+  val LOG = LoggerFactory.getLogger(RecordBuilder.getClass)
+  val END_STATUSES = Set("COMPLETED", "KILLED", "FAILED")
+}

--- a/cdap-app-templates/cdap-program-report/src/main/scala/co/cask/cdap/report/ReportGenerationHelper.scala
+++ b/cdap-app-templates/cdap-program-report/src/main/scala/co/cask/cdap/report/ReportGenerationHelper.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.report
+
+import java.io.{IOException, PrintWriter}
+import java.util.stream.Collectors
+
+import co.cask.cdap.report.proto.Sort.Order
+import co.cask.cdap.report.proto.{Sort, _}
+import co.cask.cdap.report.util.Constants
+import com.databricks.spark._
+import com.google.gson._
+import org.apache.avro.mapred._
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
+import org.apache.twill.filesystem.Location
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConversions._
+
+/**
+  * A helper class for report generation.
+  */
+object ReportGenerationHelper {
+
+  val GSON = new Gson()
+  val LOG = LoggerFactory.getLogger(ReportGenerationHelper.getClass)
+  val RECORD_COL = "record"
+  val REQUIRED_FIELDS = Set(Constants.PROGRAM)
+  val REQUIRED_FILTER_FIELDS = Set(Constants.START, Constants.END)
+  val AVRO_READER = avro.AvroDataFrameReader(_)
+  val FS_INPUT = classOf[FsInput]
+
+  /**
+    * Generates a report file according to the given request from the given program run meta files.
+    * The given program run meta files are first read into a single [[org.apache.spark.sql.DataFrame]].
+    * The [[org.apache.spark.sql.DataFrame]] is then grouped by program run ID and aggregated to form
+    * a new aggregated [[org.apache.spark.sql.DataFrame]] with a column "run" containing program run ID and a column
+    * "record" containing [[Record]] objects as shown below:
+    * +---------+----------+
+    * |   run   |  record  |
+    * +---------+----------+
+    * The request is then used to obtain names of the fields in [[Record]] to be included
+    * in the final report and the fields that are used for filtering or sorting. New columns containing
+    * those fields will be added to the aggregated [[org.apache.spark.sql.DataFrame]] as shown below:
+    * +---------+----------+-----------------------------------------------------
+    * |   run   |  record  |  required columns, filter columns, sort columns ...
+    * +---------+----------+-----------------------------------------------------
+    * For instance, if the required columns, filter columns and sort columns combined only contain three columns
+    * "namespace", "program", and "duration", the aggregated [[org.apache.spark.sql.DataFrame]]
+    * will contain columns as shown below:
+    * +---------+----------+---------------+-----------+------------+
+    * |   run   |  record  |   namespace   |  program  |  duration  |
+    * +---------+----------+---------------+-----------+------------+
+    * After filtering and sorting are done on the [[org.apache.spark.sql.DataFrame]],
+    * only the columns required in the report will be kept in the [[org.apache.spark.sql.DataFrame]] as shown below:
+    * +---------------------+--------------------+----------------------
+    * |  required column 1  | required column 2  | required columns ...
+    * +---------------------+--------------------+----------------------
+    * For instance, if the required columns only contain three columns "namespace", "program", and "run",
+    * the final [[org.apache.spark.sql.DataFrame]] will contain columns as shown below:
+    * +---------+---------------+-----------+
+    * |   run   |   namespace   |  program  |
+    * +---------+---------------+-----------+
+    * The final [[org.apache.spark.sql.DataFrame]] will be written to a JSON file at the given output location,
+    * accompanied by an empty _SUCCESS file indicating success.
+    *
+    * @param spark the spark session to run report generation with
+    * @param request the report generation request
+    * @param inputURIs URIs of the avro files containing program run meta records
+    * @param reportIdDir location of the directory where the report files directory, COUNT file,
+    *                      and _SUCCESS file will be created.
+    * @throws java.io.IOException when fails to write to the COUNT or _SUCCESS file
+    */
+  @throws(classOf[IOException])
+  def generateReport(spark: SparkSession, request: ReportGenerationRequest, inputURIs: java.util.List[String],
+                     reportIdDir: Location): Unit = {
+    import spark.implicits._
+    val df = spark.read.format("com.databricks.spark.avro").load(inputURIs: _*)
+    // Get the fields to be included in the final report and additional fields required for filtering and sorting
+    val (reportFields: Set[String], additionalFields: Set[String]) = getReportAndAdditionalFields(request)
+    // Create an aggregator that aggregates grouped data into a column with data type Record.
+    val aggCol = new RecordAggregator().toColumn.alias(RECORD_COL).as[Record]
+    // TODO: configure partitions. The default number of partitions is 200
+    // Group the program run meta records by program run Id's and aggregate the grouped data with aggCol.
+    // The initial aggregated DataFrame will have two columns:
+    // With every unique field in reportFields and additionalFields, construct and add new columns from record column
+    // in aggregated DataFrame, in addition to the two initial columns "run" and "record"
+    val aggDf = (reportFields ++ additionalFields).foldLeft(df.groupBy(Constants.RUN).agg(aggCol))((df, fieldName) =>
+      df.withColumn(fieldName, df(RECORD_COL).getField(fieldName)))
+    // Filter the aggregated DataFrame
+    var resultDf = aggDf.filter(getFilter(request, aggDf))
+    // If sort is specified in the request, apply sorting to the result DataFrame
+    Option(request.getSort).foreach(_.foreach(sort => {
+      val sortField = aggDf(sort.getFieldName)
+      sort.getOrder match {
+        case Order.ASCENDING => {
+          resultDf = resultDf.sort(sortField.asc)
+          LOG.debug("Sort by {} in ascending order", sortField)
+        }
+        case Sort.Order.DESCENDING => {
+          resultDf = resultDf.sort(sortField.desc)
+          LOG.debug("Sort by {} in descending order", sortField)
+        }
+      }
+    }))
+    // drop the columns which should not be included in the report
+    resultDf.columns.foreach(col => if (!reportFields.contains(col)) resultDf = resultDf.drop(col))
+    resultDf.persist()
+    // Writing the DataFrame to JSON files requires a non-existing directory to write report files.
+    // Create a non-existing directory location with name ReportSparkHandler.REPORT_DIR
+    val reportDir = reportIdDir.append(Constants.LocationName.REPORT_DIR).toURI.toString
+    // TODO: [CDAP-13290] output reports as avro instead of json text files
+    // TODO: [CDAP-13291] improve how the number of partitions is configured
+    resultDf.coalesce(1).write.option("timestampFormat", "yyyy/MM/dd HH:mm:ss ZZ").json(reportDir)
+    val count = resultDf.count
+    // Write the total number of records in _SUCCESS file generated after successful report generation
+    var writer: Option[PrintWriter] = None
+    try {
+      val countFile = reportIdDir.append(Constants.LocationName.COUNT_FILE)
+      countFile.createNew
+      writer = Some(new PrintWriter(countFile.getOutputStream))
+      writer.get.write(count.toString)
+    } catch {
+      case e: IOException => {
+        LOG.error("Failed to write to {} in {}", Constants.LocationName.COUNT_FILE, reportIdDir.toURI.toString, e)
+        throw e
+      }
+    } finally if (writer.isDefined) writer.get.close()
+    reportIdDir.append(Constants.LocationName.SUCCESS_FILE).createNew()
+  }
+
+  /**
+    * Gets the fields to be included in the final report and additional fields required for filtering and sorting
+    *
+    * @param request the report generation request
+    * @return a tuple containing the set of fields to be included in the final report and
+    *         the set of additional fields for filtering and sorting
+    */
+  def getReportAndAdditionalFields(request: ReportGenerationRequest): (Set[String], Set[String]) = {
+    // Construct a set of fields to be included in the final report with required fields and fields from the request
+    val reportFields: Set[String] = REQUIRED_FIELDS ++ Option(request.getFields).map(_.toSet).getOrElse(Nil)
+    LOG.debug("Fields to be included in the report: {}", reportFields)
+    // Initialize the set with "start" and "end" for filtering records according to the time range [start, end)
+    // specified in the request.
+    val additionalFields: Set[String] = REQUIRED_FILTER_FIELDS ++
+      // Add field names for filtering
+      Option(request.getFilters).map(_.toSet[Filter[_]].map(_.getFieldName)).getOrElse(Nil) ++
+      // Add field names for sorting
+      Option(request.getSort).map(_.toSet[Sort].map(_.getFieldName)).getOrElse(Nil)
+    LOG.debug("Additional fields for filtering and sorting: {}", additionalFields)
+    (reportFields, additionalFields)
+  }
+
+  /**
+    * Gets a filter constructed from the report time range and filters in the report generation request.
+    *
+    * @param request the report generation request
+    * @param df the DateFrame to apply filter on
+    * @return the filter
+    */
+  def getFilter(request: ReportGenerationRequest, df: DataFrame): Column = {
+    // Construct the filter column starting with condition:
+    // aggDf("start") not null AND aggDf("start") < request.getEnd
+    //   AND (aggDf("end") is null OR aggDf("end") >= request.getStart)
+    // Then combine additional filters from the request with AND
+    val filterCol = Option(request.getFilters).map(_.toList).getOrElse(Nil).foldLeft(
+      df(Constants.START).isNotNull && df(Constants.START) < request.getEnd &&
+        (df(Constants.END).isNull || df(Constants.END) >= request.getStart))(
+      (fCol: Column, filter: Filter[_]) => {
+        val fieldCol = df(filter.getFieldName)
+        // the filed to be filtered must contain non-null value
+        var newFilterCol = fieldCol.isNotNull
+        // the filter is either a RangeFilter or ValueFilter. Construct the filter according to the filter type
+        filter match {
+          case rangeFilter: RangeFilter[_] => {
+            val min = rangeFilter.getRange.getMin
+            if (Option(min).isDefined) {
+              newFilterCol &&= fieldCol >= min
+            }
+            val max = rangeFilter.getRange.getMax
+            if (Option(max).isDefined) {
+              newFilterCol &&= fieldCol < max
+            }
+            // cast filter.getFieldName to Any to avoid ambiguous method reference error
+            LOG.debug("Added RangeFilter {} for field {}", rangeFilter, filter.getFieldName: Any)
+          }
+          case valueFilter: ValueFilter[_] => {
+            val whitelist = valueFilter.getWhitelist
+            newFilterCol &&= fieldCol.isin(whitelist.stream().collect(Collectors.toList()): _*)
+            val blacklist = valueFilter.getBlacklist
+            newFilterCol &&= !fieldCol.isin(blacklist.stream().collect(Collectors.toList()): _*)
+            // cast filter.getFieldName to Any to avoid ambiguous method reference error
+            LOG.debug("Added ValueFilter {} for field {}", valueFilter, filter.getFieldName: Any)
+          }
+        }
+        fCol && newFilterCol
+      })
+    LOG.debug("Final filter column: {}", filterCol)
+    filterCol
+  }
+}

--- a/cdap-app-templates/cdap-program-report/src/test/java/co/cask/cdap/report/ReportGenerationAppTest.java
+++ b/cdap-app-templates/cdap-program-report/src/test/java/co/cask/cdap/report/ReportGenerationAppTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.report.proto.Filter;
+import co.cask.cdap.report.proto.RangeFilter;
+import co.cask.cdap.report.proto.ReportContent;
+import co.cask.cdap.report.proto.ReportGenerationInfo;
+import co.cask.cdap.report.proto.ReportGenerationRequest;
+import co.cask.cdap.report.proto.ReportStatus;
+import co.cask.cdap.report.proto.Sort;
+import co.cask.cdap.report.proto.ValueFilter;
+import co.cask.cdap.report.util.ProgramRunMetaFileUtil;
+import co.cask.cdap.report.util.ReportIds;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.SparkManager;
+import co.cask.cdap.test.TestBaseWithSpark2;
+import co.cask.cdap.test.TestConfiguration;
+import com.databricks.spark.avro.DefaultSource;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.ByteStreams;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumWriter;
+import org.apache.twill.api.ClassAcceptor;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.internal.ApplicationBundler;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests {@link ReportGenerationApp}.
+ */
+public class ReportGenerationAppTest extends TestBaseWithSpark2 {
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  @ClassRule
+  public static final TestConfiguration CONF = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, "false");
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReportGenerationAppTest.class);
+  private static final Gson GSON = new Gson();
+  private static final Type STRING_STRING_MAP = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Type REPORT_GEN_INFO_TYPE = new TypeToken<ReportGenerationInfo>() { }.getType();
+  private static final Type REPORT_CONTENT_TYPE = new TypeToken<ReportContent>() { }.getType();
+
+  @Test
+  public void testGenerateReport() throws Exception {
+    DatasetId metaFileset = NamespaceId.DEFAULT.dataset(ReportGenerationApp.RUN_META_FILESET);
+    addDatasetInstance(metaFileset, FileSet.class.getName());
+    // TODO: [CDAP-13216] temporarily create the run meta fileset and generate mock program run meta files here.
+    // Will remove once the TMS subscriber writing to the run meta fileset is implemented.
+    DataSetManager<FileSet> fileSet = getDataset(metaFileset);
+    populateMetaFiles(fileSet.get().getBaseLocation());
+
+    // Trace the dependencies for the spark avro
+    ApplicationBundler bundler = new ApplicationBundler(new ClassAcceptor() {
+      @Override
+      public boolean accept(String className, URL classUrl, URL classPathUrl) {
+        if (className.startsWith("org.apache.spark.")) {
+          return false;
+        }
+        if (className.startsWith("scala.")) {
+          return false;
+        }
+        if (className.startsWith("org.apache.hadoop.")) {
+          return false;
+        }
+        if (className.startsWith("org.codehaus.janino.")) {
+          return false;
+        }
+        return true;
+      }
+    });
+
+    Location avroSparkBundle = Locations.toLocation(TEMP_FOLDER.newFile());
+    // Since spark-avro and its dependencies need to be included into the application jar,
+    // but spark-avro is not used directly in the application code, explicitly add a class DefaultSource
+    // from spark-avro so that spark-avro and its dependencies will be included.
+    bundler.createBundle(avroSparkBundle, DefaultSource.class);
+    File unJarDir = BundleJarUtil.unJar(avroSparkBundle, TEMP_FOLDER.newFolder());
+
+    ApplicationManager app = deployApplication(ReportGenerationApp.class, new File(unJarDir, "lib").listFiles());
+    SparkManager sparkManager = app.getSparkManager(ReportGenerationSpark.class.getSimpleName()).start();
+    URL url = sparkManager.getServiceURL(1, TimeUnit.MINUTES);
+    Assert.assertNotNull(url);
+    URL reportURL = url.toURI().resolve("reports/").toURL();
+    List<Filter> filters =
+      ImmutableList.of(
+        new ValueFilter<>("namespace", ImmutableSet.of("ns1", "ns2"), null),
+        new RangeFilter<>("duration", new RangeFilter.Range<>(500L, null)));
+    ReportGenerationRequest request =
+      new ReportGenerationRequest(1520808000L, 1520808301L, ImmutableList.of("namespace", "duration"),
+                                  ImmutableList.of(
+                                    new Sort("duration",
+                                             Sort.Order.DESCENDING)),
+                                  filters);
+    HttpURLConnection urlConn = (HttpURLConnection) reportURL.openConnection();
+    urlConn.setDoOutput(true);
+    urlConn.setRequestMethod("POST");
+    urlConn.getOutputStream().write(GSON.toJson(request).getBytes(StandardCharsets.UTF_8));
+    if (urlConn.getErrorStream() != null) {
+      Assert.fail(Bytes.toString(ByteStreams.toByteArray(urlConn.getErrorStream())));
+    }
+    Assert.assertEquals(200, urlConn.getResponseCode());
+    Map<String, String> reportIdMap = getResponseObject(urlConn, STRING_STRING_MAP);
+    String reportId = reportIdMap.get("id");
+    Assert.assertNotNull(reportId);
+    URL reportStatusURL = reportURL.toURI().resolve(reportId + "/").toURL();
+    Tasks.waitFor(ReportStatus.COMPLETED, () -> {
+      ReportGenerationInfo reportGenerationInfo = getResponseObject(reportStatusURL.openConnection(),
+                                                                    REPORT_GEN_INFO_TYPE);
+      if (ReportStatus.FAILED.equals(reportGenerationInfo.getStatus())) {
+        Assert.fail("Report generation failed");
+      }
+      return reportGenerationInfo.getStatus();
+    }, 5, TimeUnit.MINUTES, 2, TimeUnit.SECONDS);
+    URL reportRunsURL = reportStatusURL.toURI().resolve("details").toURL();
+    ReportContent reportContent = getResponseObject(reportRunsURL.openConnection(), REPORT_CONTENT_TYPE);
+    Assert.assertEquals(2, reportContent.getTotal());
+  }
+
+  private static <T> T getResponseObject(URLConnection urlConnection, Type typeOfT) throws IOException {
+    String response;
+    try {
+      response = new String(ByteStreams.toByteArray(urlConnection.getInputStream()), Charsets.UTF_8);
+    } finally {
+      ((HttpURLConnection) urlConnection).disconnect();
+    }
+    LOG.info(response);
+    return GSON.fromJson(response, typeOfT);
+  }
+
+  /**
+   * Adds mock program run meta files to the given location.
+   * TODO: [CDAP-13216] this method should be marked as @VisibleForTesting. Temporarily calling this method
+   * when initializing report generation Spark program to add mock data
+   *
+   * @param metaBaseLocation the location to add files
+   */
+  private static void populateMetaFiles(Location metaBaseLocation) throws Exception {
+    DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(ProgramRunMetaFileUtil.SCHEMA);
+    DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter);
+    for (String namespace : ImmutableList.of("default", "ns1", "ns2")) {
+      Location nsLocation = metaBaseLocation.append(namespace);
+      nsLocation.mkdirs();
+      for (int i = 0; i < 5; i++) {
+        long time = 1520808000L + 1000 * i;
+        Location reportLocation = nsLocation.append(String.format("%d.avro", time));
+        reportLocation.createNew();
+        dataFileWriter.create(ProgramRunMetaFileUtil.SCHEMA, reportLocation.getOutputStream());
+        String program = "SmartWorkflow";
+        String run1 = ReportIds.generate().toString();
+        String run2 = ReportIds.generate().toString();
+        long delay = TimeUnit.MINUTES.toSeconds(5);
+        dataFileWriter.append(ProgramRunMetaFileUtil.createRecord(namespace, program, run1, "STARTING",
+                                                                  time, new StartInfo("user",
+                                                                                      ImmutableMap.of("k1", "v1",
+                                                                                                      "k2", "v2"))));
+        dataFileWriter.append(ProgramRunMetaFileUtil.createRecord(namespace, program, run1,
+                                                                  "FAILED", time + delay, null));
+        dataFileWriter.append(ProgramRunMetaFileUtil.createRecord(namespace, program + "_1", run2,
+                                                                  "STARTING", time + delay, null));
+        dataFileWriter.append(ProgramRunMetaFileUtil.createRecord(namespace, program + "_1", run2,
+                                                                  "RUNNING", time + 2 * delay, null));
+        dataFileWriter.append(ProgramRunMetaFileUtil.createRecord(namespace, program + "_1", run2,
+                                                                  "COMPLETED", time + 4 * delay, null));
+        dataFileWriter.close();
+      }
+      LOG.debug("nsLocation.list() = {}", nsLocation.list());
+    }
+  }
+}

--- a/cdap-app-templates/pom.xml
+++ b/cdap-app-templates/pom.xml
@@ -33,6 +33,7 @@
   <modules>
     <module>cdap-etl</module>
     <module>cdap-data-quality</module>
+    <module>cdap-program-report</module>
   </modules>
 
 </project>

--- a/cdap-explore/pom.xml
+++ b/cdap-explore/pom.xml
@@ -104,6 +104,16 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.janino</groupId>
+          <artifactId>janino</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.janino</groupId>
+          <artifactId>commons-compiler</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -237,14 +237,16 @@ public class IntegrationTestManager extends AbstractTestManager {
   @Override
   public ArtifactManager addAppArtifact(ArtifactId artifactId, Class<?> appClass,
                                         Manifest manifest) throws Exception {
-    final Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass, manifest, CLASS_ACCEPTOR);
+    return addAppArtifact(artifactId, appClass, manifest, new File[0]);
+  }
 
-    artifactClient.add(artifactId, null, new InputSupplier<InputStream>() {
-      @Override
-      public InputStream getInput() throws IOException {
-        return appJar.getInputStream();
-      }
-    });
+  @Override
+  public ArtifactManager addAppArtifact(ArtifactId artifactId, Class<?> appClass,
+                                        Manifest manifest, File... bundleEmbeddedJars) throws Exception {
+    final Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass, manifest, CLASS_ACCEPTOR,
+                                                             bundleEmbeddedJars);
+
+    artifactClient.add(artifactId, null, appJar::getInputStream);
     appJar.delete();
     return new RemoteArtifactManager(clientConfig, restClient, artifactId);
   }

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -131,6 +131,18 @@ public interface TestManager {
                                  Manifest manifest) throws Exception;
 
   /**
+   * Builds an application artifact from the specified class and then adds it.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param appClass the application class to build the artifact from
+   * @param manifest the manifest to use when building the jar
+   * @param bundleEmbeddedJars a list of jars that will be included in the application bundle.
+   * @return an {@link ArtifactManager} to manage the added app artifact
+   */
+  ArtifactManager addAppArtifact(ArtifactId artifactId, Class<?> appClass,
+                                 Manifest manifest, File...bundleEmbeddedJars) throws Exception;
+
+  /**
    * Builds an artifact from the specified plugin classes and then adds it. The
    * jar created will include all classes in the same package as the give classes, plus any dependencies of the
    * given classes. If another plugin in the same package as the given plugin requires a different set of dependent

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -111,6 +111,7 @@ public class UnitTestManager extends AbstractTestManager {
       if (resourceName.startsWith("scala/")) {
         return true;
       }
+
       try {
         // allow developers to exclude spark-core module from their unit tests (it'll work if they don't use spark)
         getClass().getClassLoader().loadClass("co.cask.cdap.app.runtime.spark.SparkRuntimeUtils");
@@ -175,7 +176,7 @@ public class UnitTestManager extends AbstractTestManager {
 
     try {
       ArtifactId artifactId = new ArtifactId(namespace.getNamespace(), applicationClz.getSimpleName(), "1.0-SNAPSHOT");
-      addAppArtifact(artifactId, applicationClz);
+      addAppArtifact(artifactId, applicationClz, new Manifest(), bundleEmbeddedJars);
 
       if (configObject == null) {
         configObject = (Config) TypeToken.of(configType).getRawType().newInstance();
@@ -229,7 +230,14 @@ public class UnitTestManager extends AbstractTestManager {
   @Override
   public ArtifactManager addAppArtifact(ArtifactId artifactId, Class<?> appClass,
                                         Manifest manifest) throws Exception {
-    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass, manifest, CLASS_ACCEPTOR);
+    return addAppArtifact(artifactId, appClass, manifest, new File[0]);
+  }
+
+  @Override
+  public ArtifactManager addAppArtifact(ArtifactId artifactId, Class<?> appClass,
+                                        Manifest manifest, File... bundleEmbeddedJars) throws Exception {
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass,
+                                                       manifest, CLASS_ACCEPTOR, bundleEmbeddedJars);
     addArtifact(artifactId, appJar);
     return artifactManagerFactory.create(artifactId);
   }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-13211
https://builds.cask.co/browse/CDAP-DUT6305-JOB1-36

Unit test still having problem with running, ignore for now. Tested on Sandbox and cluster.
Report records not including some of the fields, will add them while implementing the TMS subscriber that actually writes the real program run meta files.

The PR is organized in 4 commits as described in the commit messages:
1. pom, package info, and the ReportGenerationApp definition with no actual implementation
2. Utility classes for report generation app
3. classes representing data in HTTP request/response and data used in Spark SQL calculation
4. Classes containing the actual report generation logic and REST API's, such as ReportGenerationSpark and scala helper classes, and an ignored test to be fixed