### PR TITLE
CDAP-13096 refactor program lifecycle to trigger off TMS

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
@@ -86,7 +86,8 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
     store.setProvisioning(id.run(pid), startTime, runtimeArgs, systemArgs,
                           AppFabricTestHelper.createSourceId(++sourceId));
     store.setProvisioned(id.run(pid), 0, AppFabricTestHelper.createSourceId(++sourceId));
-    store.setStart(id.run(pid), null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id.run(pid), startTime, null, runtimeArgs, systemArgs,
+                   AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id.run(pid), startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
@@ -82,7 +82,8 @@ public class WorkflowTest {
     store.setProvisioning(id.run(pid), startTime, ImmutableMap.of(), ImmutableMap.of(),
                           AppFabricTestHelper.createSourceId(++sourceId));
     store.setProvisioned(id.run(pid), 0, AppFabricTestHelper.createSourceId(++sourceId));
-    store.setStart(id.run(pid), null, ImmutableMap.of(), AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id.run(pid), startTime, null, ImmutableMap.of(), ImmutableMap.of(),
+                   AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id.run(pid), startTime + startDelaySecs, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -105,9 +105,8 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
   }
 
   @Override
-  public final RuntimeInfo run(ProgramDescriptor programDescriptor, ProgramOptions options) {
+  public final RuntimeInfo run(ProgramDescriptor programDescriptor, ProgramOptions options, RunId runId) {
     ProgramId programId = programDescriptor.getProgramId();
-    RunId runId = RunIds.generate();
 
     // Publish the program's starting state. We don't know the Twill RunId yet, hence always passing in null.
     programStateWriter.start(programId.run(runId), options, null);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRuntimeService.java
@@ -51,9 +51,10 @@ public interface ProgramRuntimeService extends Service {
    *
    * @param programDescriptor describing the program to run
    * @param options {@link ProgramOptions} that are needed by the program.
+   * @param runId {@link RunId} for the program run
    * @return A {@link ProgramController} for the running program.
    */
-  RuntimeInfo run(ProgramDescriptor programDescriptor, ProgramOptions options);
+  RuntimeInfo run(ProgramDescriptor programDescriptor, ProgramOptions options, RunId runId);
 
   /**
    * Find the {@link RuntimeInfo} for a running program with the given {@link RunId}.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -103,12 +103,15 @@ public interface Store extends RuntimeStore {
    * Logs initialization of program run and persists program status to {@link ProgramRunStatus#STARTING}.
    *
    * @param id run id of the program
+   * @param startTime start timestamp in seconds
    * @param twillRunId Twill run id
+   * @param runtimeArgs the runtime arguments for this program run
    * @param systemArgs the system arguments for this program run
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setStart(ProgramRunId id, @Nullable String twillRunId, Map<String, String> systemArgs, byte[] sourceId);
+  void setStart(ProgramRunId id, long startTime, @Nullable String twillRunId,
+                Map<String, String> runtimeArgs, Map<String, String> systemArgs, byte[] sourceId);
 
   /**
    * Logs start of program run and persists program status to {@link ProgramRunStatus#RUNNING}.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -379,14 +379,14 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     // we have already validated that the action is valid
     switch (action.toLowerCase()) {
       case "start":
-        lifecycleService.start(program, args, false);
+        lifecycleService.run(program, args, false);
         break;
       case "debug":
         if (!isDebugAllowed(programType)) {
           throw new NotImplementedException(String.format("debug action is not implemented for program type %s",
                                                           programType));
         }
-        lifecycleService.start(program, args, true);
+        lifecycleService.run(program, args, true);
         break;
       case "stop":
         lifecycleService.stop(program);
@@ -1186,9 +1186,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       ProgramId programId = new ProgramId(namespaceId, program.getAppId(), program.getProgramType(),
                                           program.getProgramId());
       try {
-        ProgramController programController = lifecycleService.start(programId, program.getRuntimeargs(), false);
-        output.add(new BatchProgramResult(program, HttpResponseStatus.OK.code(), null,
-                                          programController.getRunId().getId()));
+        String runId = lifecycleService.run(programId, program.getRuntimeargs(), false).getId();
+        output.add(new BatchProgramResult(program, HttpResponseStatus.OK.code(), null, runId));
       } catch (NotFoundException e) {
         output.add(new BatchProgramResult(program, HttpResponseStatus.NOT_FOUND.code(), e.getMessage()));
       } catch (BadRequestException e) {
@@ -1554,7 +1553,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     FlowId flow = new FlowId(namespaceId, appId, flowId);
     try {
       ProgramStatus status = lifecycleService.getProgramStatus(flow);
-      if (ProgramStatus.RUNNING == status) {
+      if (ProgramStatus.STOPPED != status) {
         responder.sendString(HttpResponseStatus.FORBIDDEN, "Flow is running, please stop it first.");
       } else {
         queueAdmin.dropAllForFlow(flow);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -25,6 +25,12 @@ public final class ProgramOptionConstants {
 
   public static final String TWILL_RUN_ID = "twillRunId";
 
+  public static final String CLUSTER_STATUS = "clusterStatus";
+
+  public static final String CLUSTER_SIZE = "clusterSize";
+
+  public static final String DEBUG_ENABLED = "debugEnabled";
+
   public static final String PROGRAM_STATUS = "programStatus";
 
   public static final String PROGRAM_RUN_ID = "programRunId";
@@ -40,6 +46,8 @@ public final class ProgramOptionConstants {
   public static final String START_TIME = "startTime";
 
   public static final String END_TIME = "endTime";
+
+  public static final String PROGRAM_DESCRIPTOR = "programDescriptor";
 
   public static final String PROGRAM_NAME_IN_WORKFLOW = "programNameInWorkflow";
 
@@ -74,6 +82,10 @@ public final class ProgramOptionConstants {
   public static final String TRIGGERING_SCHEDULE_INFO = "triggeringScheduleInfo";
 
   public static final String PROGRAM_ERROR = "programError";
+
+  public static final String USER_ID = "userId";
+
+  public static final String SKIP_PROVISIONING = "skipProvisioning";
 
   /**
    * Option to a local file path of a directory containing plugins artifacts.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
@@ -18,8 +18,7 @@ package co.cask.cdap.internal.app.runtime.schedule;
 
 import co.cask.cdap.api.schedule.TriggerInfo;
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo;
-import co.cask.cdap.app.runtime.ProgramController;
-import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
@@ -28,8 +27,9 @@ import co.cask.cdap.common.id.Id;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.internal.UserErrors;
 import co.cask.cdap.internal.UserMessages;
-import co.cask.cdap.internal.app.runtime.AbstractListener;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.internal.app.runtime.schedule.queue.Job;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.TriggerInfoContext;
@@ -39,20 +39,14 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.impersonation.SecurityUtil;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.hadoop.security.authentication.util.KerberosName;
-import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import javax.annotation.Nullable;
 
 /**
  * Task runner that runs a schedule.
@@ -66,17 +60,15 @@ public final class ScheduleTaskRunner {
   private final Store store;
   private final ProgramLifecycleService lifecycleService;
   private final PropertiesResolver propertiesResolver;
-  private final ListeningExecutorService executorService;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final CConfiguration cConf;
 
   public ScheduleTaskRunner(Store store, ProgramLifecycleService lifecycleService,
-                            PropertiesResolver propertiesResolver, ListeningExecutorService taskExecutor,
+                            PropertiesResolver propertiesResolver,
                             NamespaceQueryAdmin namespaceQueryAdmin, CConfiguration cConf) {
     this.store = store;
     this.lifecycleService = lifecycleService;
     this.propertiesResolver = propertiesResolver;
-    this.executorService = taskExecutor;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.cConf = cConf;
   }
@@ -116,12 +108,8 @@ public final class ScheduleTaskRunner {
 
   /**
    * Executes a program without blocking until its completion.
-   *
-   * @return a {@link ListenableFuture} object that completes when the program completes
    */
-  public ListenableFuture<?> execute(final ProgramId id, Map<String, String> sysArgs,
-                                     Map<String, String> userArgs) throws Exception {
-    ProgramRuntimeService.RuntimeInfo runtimeInfo;
+  public void execute(final ProgramId id, Map<String, String> sysArgs, Map<String, String> userArgs) throws Exception {
     String originalUserId = SecurityRequestContext.getUserId();
     try {
       // if the program has a namespace user configured then set that user in the security request context.
@@ -130,50 +118,14 @@ public final class ScheduleTaskRunner {
       if (nsPrincipal != null && SecurityUtil.isKerberosEnabled(cConf)) {
         SecurityRequestContext.setUserId(new KerberosName(nsPrincipal).getServiceName());
       }
-      runtimeInfo = lifecycleService.startInternal(id, sysArgs, userArgs, false);
+      ProgramOptions programOptions = new SimpleProgramOptions(id, new BasicArguments(sysArgs),
+                                                               new BasicArguments(userArgs), false);
+      lifecycleService.runInternal(id, programOptions);
     } catch (ProgramNotFoundException | ApplicationNotFoundException e) {
       throw new TaskExecutionException(String.format(UserMessages.getMessage(UserErrors.PROGRAM_NOT_FOUND), id),
                                        e, false);
     } finally {
       SecurityRequestContext.setUserId(originalUserId);
     }
-
-    final ProgramController controller = runtimeInfo.getController();
-    final CountDownLatch latch = new CountDownLatch(1);
-
-    controller.addListener(new AbstractListener() {
-      @Override
-      public void init(ProgramController.State state, @Nullable Throwable cause) {
-        if (state == ProgramController.State.COMPLETED) {
-          completed();
-        }
-        if (state == ProgramController.State.ERROR) {
-          error(controller.getFailureCause());
-        }
-      }
-
-      @Override
-      public void killed() {
-        latch.countDown();
-      }
-
-      @Override
-      public void completed() {
-        latch.countDown();
-      }
-
-      @Override
-      public void error(Throwable cause) {
-        latch.countDown();
-      }
-    }, Threads.SAME_THREAD_EXECUTOR);
-
-    return executorService.submit(new Callable<Void>() {
-      @Override
-      public Void call() throws Exception {
-        latch.await();
-        return null;
-      }
-    });
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractNotificationSubscriberService.java
@@ -171,8 +171,9 @@ public abstract class AbstractNotificationSubscriberService extends AbstractIdle
      *
      * @param context the dataset context
      * @param lastFetchedMessageId the message id to persist
+     * @throws Exception if there was an error persisting the message
      */
-    protected abstract void persistMessageId(DatasetContext context, String lastFetchedMessageId);
+    protected abstract void persistMessageId(DatasetContext context, String lastFetchedMessageId) throws Exception;
 
     @Override
     public void run() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -32,6 +32,7 @@ import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceEnsurer;
 import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.runtime.plugin.PluginService;
+import co.cask.cdap.internal.provision.ProvisionerNotificationSubscriberService;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.route.store.RouteStore;
@@ -78,6 +79,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final Set<String> handlerHookNames;
   private final StreamCoordinatorClient streamCoordinatorClient;
   private final ProgramNotificationSubscriberService programNotificationSubscriberService;
+  private final ProvisionerNotificationSubscriberService provisionerNotificationSubscriberService;
   private final ProgramLifecycleService programLifecycleService;
   private final RunRecordCorrectorService runRecordCorrectorService;
   private final SystemArtifactLoader systemArtifactLoader;
@@ -107,6 +109,7 @@ public class AppFabricServer extends AbstractIdleService {
                          ProgramRuntimeService programRuntimeService,
                          RunRecordCorrectorService runRecordCorrectorService,
                          ApplicationLifecycleService applicationLifecycleService,
+                         ProvisionerNotificationSubscriberService provisionerNotificationSubscriberService,
                          ProgramNotificationSubscriberService programNotificationSubscriberService,
                          ProgramLifecycleService programLifecycleService,
                          StreamCoordinatorClient streamCoordinatorClient,
@@ -130,6 +133,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.handlerHookNames = handlerHookNames;
     this.applicationLifecycleService = applicationLifecycleService;
     this.streamCoordinatorClient = streamCoordinatorClient;
+    this.provisionerNotificationSubscriberService = provisionerNotificationSubscriberService;
     this.programNotificationSubscriberService = programNotificationSubscriberService;
     this.programLifecycleService = programLifecycleService;
     this.runRecordCorrectorService = runRecordCorrectorService;
@@ -157,6 +161,7 @@ public class AppFabricServer extends AbstractIdleService {
         systemArtifactLoader.start(),
         programRuntimeService.start(),
         streamCoordinatorClient.start(),
+        provisionerNotificationSubscriberService.start(),
         programNotificationSubscriberService.start(),
         programLifecycleService.start(),
         runRecordCorrectorService.start(),
@@ -216,6 +221,7 @@ public class AppFabricServer extends AbstractIdleService {
     notificationService.stopAndWait();
     programNotificationSubscriberService.stopAndWait();
     programLifecycleService.stopAndWait();
+    provisionerNotificationSubscriberService.stopAndWait();
     runRecordCorrectorService.stopAndWait();
     pluginService.stopAndWait();
     if (appVersionUpgradeService != null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
@@ -52,7 +52,8 @@ import java.util.function.Predicate;
 public abstract class RunRecordCorrectorService extends AbstractIdleService {
 
   private static final Logger LOG = LoggerFactory.getLogger(RunRecordCorrectorService.class);
-  private static final Set<ProgramRunStatus> NOT_STOPPED_STATUSES = EnumSet.of(ProgramRunStatus.STARTING,
+  private static final Set<ProgramRunStatus> NOT_STOPPED_STATUSES = EnumSet.of(ProgramRunStatus.PENDING,
+                                                                               ProgramRunStatus.STARTING,
                                                                                ProgramRunStatus.RUNNING,
                                                                                ProgramRunStatus.SUSPENDED);
   private final Store store;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -27,6 +27,7 @@ import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.plugin.PluginService;
+import co.cask.cdap.internal.provision.ProvisionerNotificationSubscriberService;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.route.store.RouteStore;
 import co.cask.cdap.scheduler.CoreSchedulerService;
@@ -59,6 +60,7 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    @Nullable MetricsCollectionService metricsCollectionService,
                                    ProgramRuntimeService programRuntimeService,
                                    ApplicationLifecycleService applicationLifecycleService,
+                                   ProvisionerNotificationSubscriberService provisionerNotificationSubscriberService,
                                    ProgramNotificationSubscriberService programNotificationSubscriberService,
                                    ProgramLifecycleService programLifecycleService,
                                    RunRecordCorrectorService runRecordCorrectorService,
@@ -73,9 +75,9 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    CoreSchedulerService coreSchedulerService) {
     super(cConf, sConf, discoveryService, notificationService, hostname, handlers,
           metricsCollectionService, programRuntimeService, runRecordCorrectorService, applicationLifecycleService,
-          programNotificationSubscriberService, programLifecycleService, streamCoordinatorClient, servicesNames,
-          handlerHookNames, namespaceAdmin, systemArtifactLoader, pluginService, null, routeStore,
-          coreSchedulerService);
+          provisionerNotificationSubscriberService, programNotificationSubscriberService, programLifecycleService,
+          streamCoordinatorClient, servicesNames, handlerHookNames, namespaceAdmin, systemArtifactLoader,
+          pluginService, null, routeStore, coreSchedulerService);
     this.metricStore = metricStore;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -205,7 +205,6 @@ public class DefaultStore implements Store {
     Transactionals.execute(transactional, context -> {
       getAppMetadataStore(context).recordProgramDeprovisioning(id, sourceId);
     });
-
   }
 
   @Override
@@ -213,13 +212,13 @@ public class DefaultStore implements Store {
     Transactionals.execute(transactional, context -> {
       getAppMetadataStore(context).recordProgramDeprovisioned(id, sourceId);
     });
-
   }
 
   @Override
-  public void setStart(ProgramRunId id, String twillRunId, Map<String, String> systemArgs, byte[] sourceId) {
+  public void setStart(ProgramRunId id, long startTime, @Nullable String twillRunId,
+                       Map<String, String> runtimeArgs, Map<String, String> systemArgs, byte[] sourceId) {
     Transactionals.execute(transactional, context -> {
-      getAppMetadataStore(context).recordProgramStart(id, twillRunId, systemArgs, sourceId);
+      getAppMetadataStore(context).recordProgramStart(id, startTime, twillRunId, runtimeArgs, systemArgs, sourceId);
     });
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerModule.java
@@ -27,6 +27,7 @@ public class ProvisionerModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(ProvisioningService.class).in(Scopes.SINGLETON);
+    bind(ProvisionerNotificationSubscriberService.class).in(Scopes.SINGLETON);
   }
 
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerNotificationSubscriberService.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.provision;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.retry.RetryableException;
+import co.cask.cdap.app.program.ProgramDescriptor;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.internal.app.services.AbstractNotificationSubscriberService;
+import co.cask.cdap.internal.app.services.ProgramNotificationSubscriberService;
+import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.proto.Notification;
+import co.cask.cdap.proto.ProgramRunClusterStatus;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.runtime.spi.provisioner.Cluster;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
+import org.apache.tephra.TransactionSystemClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Subscribes to TMS for program run status changes, calling the ProvisioningService when necessary.
+ */
+public class ProvisionerNotificationSubscriberService extends AbstractNotificationSubscriberService {
+  private static final Logger LOG = LoggerFactory.getLogger(ProgramNotificationSubscriberService.class);
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
+  private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private final String programStatusTopic;
+  private final int fetchSize;
+  private final long pollDelayMillis;
+  private final ExecutorService taskExecutorService;
+  private final ProvisioningService provisioningService;
+  private final ProvisionerNotifier provisionerNotifier;
+  private final DatasetFramework datasetFramework;
+
+  @Inject
+  private ProvisionerNotificationSubscriberService(MessagingService messagingService, CConfiguration cConf,
+                                                   DatasetFramework datasetFramework, TransactionSystemClient txClient,
+                                                   MetricsCollectionService metricsCollectionService,
+                                                   ProvisioningService provisioningService,
+                                                   ProvisionerNotifier provisionerNotifier) {
+    super(messagingService, cConf, datasetFramework, txClient, metricsCollectionService);
+    this.programStatusTopic = cConf.get(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC);
+    this.pollDelayMillis = cConf.getLong(Constants.AppFabric.STATUS_EVENT_POLL_DELAY_MILLIS);
+    this.fetchSize = cConf.getInt(Constants.AppFabric.STATUS_EVENT_FETCH_SIZE);
+    this.taskExecutorService = Executors.newSingleThreadExecutor(
+      new ThreadFactoryBuilder().setNameFormat("provisioner-status-subscriber").build());
+    this.provisioningService = provisioningService;
+    this.provisionerNotifier = provisionerNotifier;
+    this.datasetFramework = datasetFramework;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting {}", getClass().getSimpleName());
+    taskExecutorService.submit(new ProvisioningSubscriberRunnable(programStatusTopic, pollDelayMillis, fetchSize));
+  }
+
+  @Override
+  protected void shutDown() {
+    super.shutDown();
+    try {
+      // Shutdown the executor, which will issue an interrupt to the running thread.
+      taskExecutorService.shutdownNow();
+      taskExecutorService.awaitTermination(5, TimeUnit.SECONDS);
+    } catch (InterruptedException ie) {
+      // Ignore it.
+    } finally {
+      if (!taskExecutorService.isTerminated()) {
+        taskExecutorService.shutdownNow();
+      }
+    }
+    LOG.info("Stopped {}", getClass().getSimpleName());
+  }
+
+  /**
+   * Thread that receives TMS notifications on program status and provisions/deprovisions clusters.
+   */
+  private class ProvisioningSubscriberRunnable extends AbstractSubscriberRunnable {
+    private static final String NAME = "provisioner.status.subscriber";
+
+    ProvisioningSubscriberRunnable(String topic, long pollDelayMillis, int fetchSize) {
+      // Fetching of program status events are non-transactional
+      super(NAME, topic, pollDelayMillis, fetchSize, false);
+    }
+
+    @Nullable
+    @Override
+    protected String initialize(DatasetContext context) {
+      try {
+        ProvisionerStore.createIfNotExists(datasetFramework);
+        ProvisionerStore store = ProvisionerStore.get(context);
+        return store.getSubscriberState(NAME);
+      } catch (Exception e) {
+        throw new RetryableException(e);
+      }
+    }
+
+    @Override
+    public void persistMessageId(DatasetContext context, String lastFetchedMessageId) throws Exception {
+      ProvisionerStore store = ProvisionerStore.get(context);
+      store.persistSubscriberState(NAME, lastFetchedMessageId);
+    }
+
+    @Override
+    protected void processNotifications(DatasetContext context,
+                                        AbstractNotificationSubscriberService.NotificationIterator notifications)
+      throws Exception {
+      while (notifications.hasNext()) {
+        processNotification(notifications.next());
+      }
+    }
+
+    private void processNotification(Notification notification) throws Exception {
+      Map<String, String> properties = notification.getProperties();
+
+      // Required parameters
+      String programRun = properties.get(ProgramOptionConstants.PROGRAM_RUN_ID);
+      String clusterStatusStr = properties.get(ProgramOptionConstants.CLUSTER_STATUS);
+
+      // Ignore notifications about other state transitions
+      if (programRun == null || clusterStatusStr == null) {
+        return;
+      }
+
+      ProgramRunClusterStatus clusterStatus = ProgramRunClusterStatus.valueOf(clusterStatusStr);
+      ProgramRunId programRunId = GSON.fromJson(programRun, ProgramRunId.class);
+      ProgramId programId = programRunId.getParent();
+
+      switch (clusterStatus) {
+        case PROVISIONING:
+          ProgramOptions programOptions = getProgramOptions(programId, properties);
+          ProgramDescriptor programDescriptor =
+            GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_DESCRIPTOR), ProgramDescriptor.class);
+          Cluster cluster = provisioningService.provision(programRunId, getProgramOptions(programId, properties));
+          String userId = properties.get(ProgramOptionConstants.USER_ID);
+          provisionerNotifier.provisioned(programRunId, programOptions, programDescriptor, userId, cluster);
+          break;
+        case DEPROVISIONING:
+          provisioningService.deprovision(programRunId);
+          provisionerNotifier.deprovisioned(programRunId);
+          break;
+      }
+    }
+
+    private ProgramOptions getProgramOptions(ProgramId programId, Map<String, String> properties) {
+      String userArgumentsString = properties.get(ProgramOptionConstants.USER_OVERRIDES);
+      String systemArgumentsString = properties.get(ProgramOptionConstants.SYSTEM_OVERRIDES);
+      String debugString = properties.get(ProgramOptionConstants.DEBUG_ENABLED);
+
+      Boolean debug = Boolean.valueOf(debugString);
+      Map<String, String> userArguments = GSON.fromJson(userArgumentsString, MAP_TYPE);
+      Map<String, String> systemArguments = GSON.fromJson(systemArgumentsString, MAP_TYPE);
+
+      return new SimpleProgramOptions(programId, new BasicArguments(systemArguments),
+                                      new BasicArguments(userArguments), debug);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerNotifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerNotifier.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.provision;
+
+import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.api.retry.RetryableException;
+import co.cask.cdap.app.program.ProgramDescriptor;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.service.Retries;
+import co.cask.cdap.common.service.RetryStrategies;
+import co.cask.cdap.common.service.RetryStrategy;
+import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.messaging.StoreRequest;
+import co.cask.cdap.messaging.client.StoreRequestBuilder;
+import co.cask.cdap.proto.Notification;
+import co.cask.cdap.proto.ProgramRunClusterStatus;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.TopicId;
+import co.cask.cdap.runtime.spi.provisioner.Cluster;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+
+/**
+ * Sends notifications about program run provisioner operations.
+ */
+public class ProvisionerNotifier {
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
+  private final TopicId topic;
+  private final RetryStrategy retryStrategy;
+  private final MessagingService messagingService;
+
+  @Inject
+  ProvisionerNotifier(CConfiguration cConf, MessagingService messagingService) {
+    this.topic = NamespaceId.SYSTEM.topic(cConf.get(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC));
+    this.retryStrategy = RetryStrategies.fromConfiguration(cConf, "system.program.state.");
+    this.messagingService = messagingService;
+  }
+
+  public void provisioning(ProgramRunId programRunId, ProgramOptions programOptions,
+                           ProgramDescriptor programDescriptor) {
+    long startTime = RunIds.getTime(RunIds.fromString(programRunId.getRun()), TimeUnit.MILLISECONDS);
+    if (startTime == -1) {
+      // If RunId is not time-based, use current time as start time
+      startTime = System.currentTimeMillis();
+    }
+    String userId = SecurityRequestContext.getUserId();
+    userId = userId == null ? "" : userId;
+    publish(ImmutableMap.<String, String>builder()
+              .put(ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId))
+              .put(ProgramOptionConstants.PROGRAM_DESCRIPTOR, GSON.toJson(programDescriptor))
+              .put(ProgramOptionConstants.USER_ID, userId)
+              .put(ProgramOptionConstants.START_TIME, String.valueOf(startTime))
+              .put(ProgramOptionConstants.CLUSTER_STATUS, ProgramRunClusterStatus.PROVISIONING.name())
+              .put(ProgramOptionConstants.DEBUG_ENABLED, String.valueOf(programOptions.isDebug()))
+              .put(ProgramOptionConstants.USER_OVERRIDES, GSON.toJson(programOptions.getUserArguments().asMap()))
+              .put(ProgramOptionConstants.SYSTEM_OVERRIDES, GSON.toJson(programOptions.getArguments().asMap()))
+              .build());
+  }
+
+  public void provisioned(ProgramRunId programRunId, ProgramOptions programOptions, ProgramDescriptor programDescriptor,
+                          String userId, Cluster cluster) {
+    publish(ImmutableMap.<String, String>builder()
+              .put(ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId))
+              .put(ProgramOptionConstants.PROGRAM_DESCRIPTOR, GSON.toJson(programDescriptor))
+              .put(ProgramOptionConstants.USER_ID, userId)
+              .put(ProgramOptionConstants.CLUSTER_STATUS, ProgramRunClusterStatus.PROVISIONED.name())
+              .put(ProgramOptionConstants.CLUSTER_SIZE, String.valueOf(cluster.getNodes().size()))
+              .put(ProgramOptionConstants.DEBUG_ENABLED, String.valueOf(programOptions.isDebug()))
+              .put(ProgramOptionConstants.USER_OVERRIDES, GSON.toJson(programOptions.getUserArguments().asMap()))
+              .put(ProgramOptionConstants.SYSTEM_OVERRIDES, GSON.toJson(programOptions.getArguments().asMap()))
+              .build());
+  }
+
+  public void deprovisioning(ProgramRunId programRunId) {
+    publish(ImmutableMap.<String, String>builder()
+              .put(ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId))
+              .put(ProgramOptionConstants.CLUSTER_STATUS, ProgramRunClusterStatus.DEPROVISIONING.name())
+              .build());
+  }
+
+  public void deprovisioned(ProgramRunId programRunId) {
+    publish(ImmutableMap.<String, String>builder()
+              .put(ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId))
+              .put(ProgramOptionConstants.CLUSTER_STATUS, ProgramRunClusterStatus.DEPROVISIONED.name()).build());
+  }
+
+
+  private void publish(Map<String, String> properties) {
+    final StoreRequest storeRequest = StoreRequestBuilder.of(topic)
+      .addPayloads(GSON.toJson(new Notification(Notification.Type.PROGRAM_STATUS, properties)))
+      .build();
+    Retries.supplyWithRetries(
+      () -> {
+        try {
+          messagingService.publish(storeRequest);
+        } catch (TopicNotFoundException e) {
+          throw new RetryableException(e);
+        } catch (IOException e) {
+          throw Throwables.propagate(e);
+        }
+        return null;
+      },
+      retryStrategy);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerStore.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.provision;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Stores information used for provisioning.
+ *
+ * Stores subscriber offset information for TMS, cluster information for program runs, and state information for
+ * each provision and deprovision operation.
+ *
+ * Subscriber information is stored as:
+ *
+ * rowkey           column
+ * s:[client-id]    m -> [last fetched message id]
+ *
+ * This store does not wrap it's operations in a transaction. It is up to the caller to decide what operations
+ * belong in a transaction.
+ */
+public class ProvisionerStore {
+  private static final DatasetId TABLE_ID = NamespaceId.SYSTEM.dataset("provisioner.meta");
+  private static final byte[] subscriberPrefix = Bytes.toBytes("s:");
+  private static final byte[] subscriberMessageCol = Bytes.toBytes("m");
+  private final Table table;
+
+  private ProvisionerStore(Table table) {
+    this.table = table;
+  }
+
+  @Nullable
+  public String getSubscriberState(String clientId) throws Exception {
+    byte[] val = table.get(getSubscriberRowKey(clientId), subscriberMessageCol);
+    return val == null ? null : Bytes.toString(val);
+  }
+
+  public void persistSubscriberState(String clientId, String lastFetchedId) throws Exception {
+    table.put(getSubscriberRowKey(clientId), subscriberMessageCol, Bytes.toBytes(lastFetchedId));
+  }
+
+  private byte[] getSubscriberRowKey(String clientId) {
+    return Bytes.concat(subscriberPrefix, Bytes.toBytes(clientId));
+  }
+
+  public static ProvisionerStore get(DatasetContext datasetContext) {
+    Table table = datasetContext.getDataset(TABLE_ID.getNamespace(), TABLE_ID.getDataset());
+    return new ProvisionerStore(table);
+  }
+
+  public static void createIfNotExists(DatasetFramework datasetFramework)
+    throws IOException, DatasetManagementException {
+    DatasetsUtil.getOrCreateDataset(datasetFramework, TABLE_ID, Table.class.getName(),
+                                    DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
@@ -16,9 +16,13 @@
 
 package co.cask.cdap.internal.provision;
 
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.runtime.spi.provisioner.Cluster;
+import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 import com.google.inject.Inject;
@@ -45,6 +49,15 @@ public class ProvisioningService {
     provisionerExtensionLoader = new ProvisionerExtensionLoader(cConf.get(Constants.Provisioner.EXTENSIONS_DIR));
     provisionerInfo = new AtomicReference<>(new ProvisionerInfo(new HashMap<>(), new HashMap<>()));
     reloadProvisioners();
+  }
+
+  public Cluster provision(ProgramRunId programRunId, ProgramOptions programOptions) {
+    // TODO: implement
+    return new Cluster("name", ClusterStatus.RUNNING, Collections.emptyList(), Collections.emptyMap());
+  }
+
+  public void deprovision(ProgramRunId programRunId) {
+    // TODO: implement
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ConstraintCheckerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ConstraintCheckerService.java
@@ -71,7 +71,7 @@ class ConstraintCheckerService extends AbstractIdleService {
   private final DatasetFramework datasetFramework;
   private final MultiThreadDatasetCache multiThreadDatasetCache;
   private final Store store;
-  private final ProgramLifecycleService lifecycleService;
+  private final ProgramLifecycleService programLifecycleService;
   private final PropertiesResolver propertiesResolver;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final CConfiguration cConf;
@@ -81,13 +81,13 @@ class ConstraintCheckerService extends AbstractIdleService {
 
   @Inject
   ConstraintCheckerService(Store store,
-                           ProgramLifecycleService lifecycleService, PropertiesResolver propertiesResolver,
+                           ProgramLifecycleService programLifecycleService, PropertiesResolver propertiesResolver,
                            NamespaceQueryAdmin namespaceQueryAdmin,
                            CConfiguration cConf,
                            DatasetFramework datasetFramework,
                            TransactionSystemClient txClient) {
     this.store = store;
-    this.lifecycleService = lifecycleService;
+    this.programLifecycleService = programLifecycleService;
     this.propertiesResolver = propertiesResolver;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.cConf = cConf;
@@ -106,8 +106,7 @@ class ConstraintCheckerService extends AbstractIdleService {
     LOG.info("Starting ConstraintCheckerService.");
     taskExecutorService = MoreExecutors.listeningDecorator(
       Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("constraint-checker-task").build()));
-    taskRunner = new ScheduleTaskRunner(store, lifecycleService, propertiesResolver,
-                                        taskExecutorService, namespaceQueryAdmin, cConf);
+    taskRunner = new ScheduleTaskRunner(store, programLifecycleService, propertiesResolver, namespaceQueryAdmin, cConf);
 
     int numPartitions = Schedulers.getJobQueue(multiThreadDatasetCache, datasetFramework).getNumPartitions();
     for (int partition = 0; partition < numPartitions; partition++) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -56,6 +56,7 @@ import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.Artifacts;
 import co.cask.cdap.internal.app.services.ProgramNotificationSubscriberService;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
+import co.cask.cdap.internal.provision.ProvisionerNotificationSubscriberService;
 import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.messaging.data.MessageId;
 import co.cask.cdap.notifications.service.NotificationService;
@@ -140,6 +141,7 @@ public class AppFabricTestHelper {
       injector.getInstance(NotificationService.class).startAndWait();
       injector.getInstance(MetricsCollectionService.class).startAndWait();
       injector.getInstance(ProgramNotificationSubscriberService.class).startAndWait();
+      injector.getInstance(ProvisionerNotificationSubscriberService.class).startAndWait();
       Scheduler programScheduler = injector.getInstance(Scheduler.class);
       if (programScheduler instanceof Service) {
         ((Service) programScheduler).startAndWait();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraintTest.java
@@ -61,7 +61,7 @@ public class ConcurrencyConstraintTest {
                                   final Map<String, String> systemArgs) {
     store.setProvisioning(id, startTime, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setProvisioned(id, 0, AppFabricTestHelper.createSourceId(++sourceId));
-    store.setStart(id, null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id, startTime, null, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/constraint/LastRunConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/constraint/LastRunConstraintTest.java
@@ -60,7 +60,7 @@ public class LastRunConstraintTest {
                                   final Map<String, String> systemArgs) {
     store.setProvisioning(id, startTime, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setProvisioned(id, 0, AppFabricTestHelper.createSourceId(++sourceId));
-    store.setStart(id, null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id, startTime, null, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
   

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
@@ -16,8 +16,13 @@
 
 package co.cask.cdap.internal.app.services;
 
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramStateWriter;
 import co.cask.cdap.common.app.RunIds;
@@ -28,17 +33,20 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
 import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.internal.app.DefaultApplicationSpecification;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.internal.app.store.AppMetadataStore;
 import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.internal.provision.ProvisionerNotifier;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.runtime.spi.provisioner.Cluster;
+import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import com.google.inject.Injector;
-import org.apache.tephra.TransactionAware;
 import org.apache.tephra.TransactionExecutor;
 import org.junit.Test;
 
@@ -65,16 +73,27 @@ public class ProgramNotificationSubscriberServiceTest {
 
     DatasetId storeTable = NamespaceId.SYSTEM.dataset(Constants.AppMetaStore.TABLE);
     Table table = DatasetsUtil.getOrCreateDataset(datasetFramework, storeTable, Table.class.getName(),
-                                                  DatasetProperties.EMPTY, Collections.<String, String>emptyMap());
-    final AppMetadataStore metadataStoreDataset = new AppMetadataStore(table, cConf, new AtomicBoolean(false));
-    final TransactionExecutor txnl = txExecutorFactory.createExecutor(
-      Collections.singleton((TransactionAware) metadataStoreDataset));
+                                                  DatasetProperties.EMPTY, Collections.emptyMap());
+    AppMetadataStore metadataStoreDataset = new AppMetadataStore(table, cConf, new AtomicBoolean(false));
+    TransactionExecutor txnl = txExecutorFactory.createExecutor(Collections.singleton(metadataStoreDataset));
 
+    ProvisionerNotifier provisionerNotifier = injector.getInstance(ProvisionerNotifier.class);
     ProgramStateWriter programStateWriter = injector.getInstance(ProgramStateWriter.class);
 
     ProgramId programId = NamespaceId.DEFAULT.app("someapp").program(ProgramType.SERVICE, "s");
     ProgramOptions programOptions = new SimpleProgramOptions(programId);
-    final ProgramRunId runId = programId.run(RunIds.generate());
+    ProgramRunId runId = programId.run(RunIds.generate());
+
+    Cluster cluster = new Cluster("name", ClusterStatus.RUNNING, Collections.emptyList(), Collections.emptyMap());
+    ApplicationSpecification appSpec = new DefaultApplicationSpecification(
+      "name", "1.0.0", "desc", null, new ArtifactId("r", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM),
+      Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+      Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+      Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    ProgramDescriptor programDescriptor = new ProgramDescriptor(programId, appSpec);
+    provisionerNotifier.provisioning(runId, programOptions, programDescriptor);
+    provisionerNotifier.provisioned(runId, programOptions, programDescriptor, "Bob", cluster);
+
     programStateWriter.start(runId, programOptions, null);
 
     Tasks.waitFor(ProgramRunStatus.STARTING, () -> txnl.execute(() -> {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -78,12 +78,14 @@ public class AppMetadataStoreTest {
   }
 
   private void recordProvisionAndStart(ProgramRunId programRunId, AppMetadataStore metadataStoreDataset) {
-    metadataStoreDataset.recordProgramProvisioning(programRunId,
-                                                   RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS), null, null,
+    long startTime = RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS);
+    metadataStoreDataset.recordProgramProvisioning(programRunId, startTime,
+                                                   Collections.emptyMap(), Collections.emptyMap(),
                                                    AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
     metadataStoreDataset.recordProgramProvisioned(programRunId, 0,
                                                   AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
-    metadataStoreDataset.recordProgramStart(programRunId, null, null,
+    metadataStoreDataset.recordProgramStart(programRunId, startTime, null,
+                                            Collections.emptyMap(), Collections.emptyMap(),
                                             AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
   }
 
@@ -242,7 +244,8 @@ public class AppMetadataStoreTest {
       recordProvisionAndStart(programRunId6, metadataStoreDataset);
       metadataStoreDataset.recordProgramSuspend(programRunId6,
                                                 AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
-      metadataStoreDataset.recordProgramStart(programRunId6, null, ImmutableMap.of(),
+      metadataStoreDataset.recordProgramStart(programRunId6, RunIds.getTime(runId5, TimeUnit.SECONDS), null,
+                                              Collections.emptyMap(), Collections.emptyMap(),
                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
       RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(programRunId6);
       // STARTING status is ignored since there's an existing SUSPENDED record
@@ -251,11 +254,12 @@ public class AppMetadataStoreTest {
     final RunId runId7 = RunIds.generate(runIdTime.incrementAndGet());
     final ProgramRunId programRunId7 = program.run(runId7);
     txnl.execute(() -> {
+      long startTime = RunIds.getTime(runId7, TimeUnit.SECONDS);
       recordProvisionAndStart(programRunId7, metadataStoreDataset);
-      metadataStoreDataset.recordProgramRunning(programRunId7, RunIds.getTime(runId7, TimeUnit.SECONDS),
-                                                null,
+      metadataStoreDataset.recordProgramRunning(programRunId7, startTime, null,
                                                 AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
-      metadataStoreDataset.recordProgramStart(programRunId7, null, ImmutableMap.of(),
+      metadataStoreDataset.recordProgramStart(programRunId7, startTime, null,
+                                              Collections.emptyMap(), Collections.emptyMap(),
                                               AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
       RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(programRunId7);
       // STARTING status is ignored since there's an existing RUNNING record
@@ -274,13 +278,14 @@ public class AppMetadataStoreTest {
     final RunId runId = RunIds.generate(runIdTime.incrementAndGet());
     final ProgramRunId programRunId = program.run(runId);
     txnl.execute(() -> {
-      metadataStoreDataset.recordProgramProvisioning(programRunId,
-                                                     RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS),
-                                                     null, null,
+      long startTime = RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS);
+      metadataStoreDataset.recordProgramProvisioning(programRunId, startTime,
+                                                     Collections.emptyMap(), Collections.emptyMap(),
                                                      AppFabricTestHelper.createSourceId(startSourceId));
       metadataStoreDataset.recordProgramProvisioned(programRunId, 0,
                                                     AppFabricTestHelper.createSourceId(startSourceId + 1));
-      metadataStoreDataset.recordProgramStart(programRunId, null, null,
+      metadataStoreDataset.recordProgramStart(programRunId, startTime, null,
+                                              Collections.emptyMap(), Collections.emptyMap(),
                                               AppFabricTestHelper.createSourceId(startSourceId + 2));
       metadataStoreDataset.recordProgramRunning(programRunId, RunIds.getTime(runId, TimeUnit.SECONDS),
                                                 null, AppFabricTestHelper.createSourceId(runningSourceId));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -77,6 +77,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,7 +131,7 @@ public class DefaultStoreTest {
                         final Map<String, String> systemArgs) {
     store.setProvisioning(id, startTime, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setProvisioned(id, 0, AppFabricTestHelper.createSourceId(++sourceId));
-    store.setStart(id, null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id, startTime, null, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
   }
 
   @Test
@@ -781,11 +782,11 @@ public class DefaultStoreTest {
 
     long nowSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
     setStartAndRunning(flowProgramId.run(flowRunId), nowSecs,
-                       ImmutableMap.of("model", "click"), null);
+                       ImmutableMap.of("model", "click"), Collections.emptyMap());
     setStartAndRunning(mapreduceProgramId.run(mapreduceRunId), nowSecs,
-                       ImmutableMap.of("path", "/data"), null);
+                       ImmutableMap.of("path", "/data"), Collections.emptyMap());
     setStartAndRunning(workflowProgramId.run(workflowRunId), nowSecs,
-                       ImmutableMap.of("whitelist", "cask"), null);
+                       ImmutableMap.of("whitelist", "cask"), Collections.emptyMap());
 
     Map<String, String> args = store.getRuntimeArguments(flowProgramRunId);
     Assert.assertEquals(1, args.size());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -37,6 +37,7 @@ import co.cask.cdap.data.stream.service.StreamServiceRuntimeModule;
 import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
+import co.cask.cdap.internal.provision.ProvisionerModule;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
@@ -113,5 +114,6 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreModules().getInMemoryModules());
     install(new MessagingServerRuntimeModule().getInMemoryModules());
+    install(new ProvisionerModule());
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -689,7 +689,8 @@ public class LineageAdminTest extends AppFabricTestBase {
     store.setProvisioning(id.run(pid), startTime, runtimeArgs, systemArgs,
                           AppFabricTestHelper.createSourceId(++sourceId));
     store.setProvisioned(id.run(pid), 0, AppFabricTestHelper.createSourceId(++sourceId));
-    store.setStart(id.run(pid), null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id.run(pid), startTime, null, runtimeArgs, systemArgs,
+                   AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id.run(pid), startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 
@@ -714,10 +715,10 @@ public class LineageAdminTest extends AppFabricTestBase {
     workflowIDMap.put(ProgramOptionConstants.WORKFLOW_NODE_ID, "workflowNodeId");
     workflowIDMap.put(ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId);
     for (ProgramRunId run : runs) {
-      store.setProvisioning(run, RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS),
-                            emptyMap, workflowIDMap, AppFabricTestHelper.createSourceId(++sourceId));
+      long startTime = RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS);
+      store.setProvisioning(run, startTime, emptyMap, workflowIDMap, AppFabricTestHelper.createSourceId(++sourceId));
       store.setProvisioned(run, 0, AppFabricTestHelper.createSourceId(++sourceId));
-      store.setStart(run, null, workflowIDMap, AppFabricTestHelper.createSourceId(++sourceId));
+      store.setStart(run, startTime, null, emptyMap, workflowIDMap, AppFabricTestHelper.createSourceId(++sourceId));
       store.setRunning(run, RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS) + 1, null,
                        AppFabricTestHelper.createSourceId(++sourceId));
     }

--- a/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/test/DataQualityAppTest.java
+++ b/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/test/DataQualityAppTest.java
@@ -203,7 +203,7 @@ public class DataQualityAppTest extends TestBase {
 
     ServiceManager serviceManager = applicationManager.getServiceManager
       (DataQualityService.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     /* Test for aggregationsGetter handler */
 
@@ -248,7 +248,7 @@ public class DataQualityAppTest extends TestBase {
 
     ServiceManager serviceManager = applicationManager.getServiceManager
       (DataQualityService.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL url = new URL(serviceManager.getServiceURL(),
                       "v1/sources/logStream/fields/content_length/aggregations/DiscreteValuesHistogram/totals");
     HttpResponse httpResponse = HttpRequests.execute(HttpRequest.get(url).build());

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -2895,7 +2895,7 @@ public class DataPipelineTest extends HydratorTestBase {
     ServiceManager serviceManager = appManager.getServiceManager(ServiceApp.Name.SERVICE_NAME).start();
 
     // Wait service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     URL url = new URL(serviceManager.getServiceURL(), "name");
     HttpRequest httpRequest = HttpRequest.post(url).withBody("bob").build();

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/LineageTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/LineageTestRun.java
@@ -39,7 +39,6 @@ import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
 import co.cask.cdap.test.SlowTests;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -53,9 +52,9 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -350,7 +349,7 @@ public class LineageTestRun extends MetadataTestBase {
   }
 
   private void waitForStop(ProgramId program, boolean needsStop) throws Exception {
-    if (needsStop && programClient.getStatus(program).equals(ProgramRunStatus.RUNNING.toString())) {
+    if (needsStop && !programClient.getStatus(program).equals(ProgramStatus.STOPPED.toString())) {
       LOG.info("Stopping program {}", program);
       programClient.stop(program);
     }
@@ -363,20 +362,15 @@ public class LineageTestRun extends MetadataTestBase {
   }
 
   private RunId getRunId(final ProgramId program, @Nullable final RunId exclude) throws Exception {
-    final AtomicReference<Iterable<RunRecord>> runRecords = new AtomicReference<>();
-    Tasks.waitFor(1, new Callable<Integer>() {
-      @Override
-      public Integer call() throws Exception {
-        runRecords.set(Iterables.filter(
-          programClient.getProgramRuns(program, ProgramRunStatus.ALL.name(), 0, Long.MAX_VALUE, Integer.MAX_VALUE),
-          new Predicate<RunRecord>() {
-            @Override
-            public boolean apply(RunRecord input) {
-              return exclude == null || !input.getPid().equals(exclude.getId());
-            }
-          }));
-        return Iterables.size(runRecords.get());
-      }
+    AtomicReference<Iterable<RunRecord>> runRecords = new AtomicReference<>();
+    Tasks.waitFor(1, () -> {
+      runRecords.set(
+        programClient.getProgramRuns(program, ProgramRunStatus.ALL.name(), 0, Long.MAX_VALUE, Integer.MAX_VALUE)
+          .stream()
+          .filter(record -> (exclude == null || !record.getPid().equals(exclude.getId())) &&
+            record.getStatus() != ProgramRunStatus.PENDING)
+          .collect(Collectors.toList()));
+      return Iterables.size(runRecords.get());
     }, 60, TimeUnit.SECONDS, 10, TimeUnit.MILLISECONDS);
     Assert.assertEquals(1, Iterables.size(runRecords.get()));
     return RunIds.fromString(Iterables.getFirst(runRecords.get(), null).getPid());

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1330,7 +1330,7 @@ public final class Constants {
    * Constants for provisioners
    */
   public static final class Provisioner {
-    public static final String EXTENSIONS_DIR = "provisioner.extensions.dir";
+    public static final String EXTENSIONS_DIR = "runtime.extensions.dir";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/internal/app/store/RunRecordMeta.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/app/store/RunRecordMeta.java
@@ -60,7 +60,6 @@ public final class RunRecordMeta extends RunRecord {
     this.twillRunId = twillRunId;
     this.sourceId = sourceId;
   }
-
   @Nullable
   public String getTwillRunId() {
     return twillRunId;

--- a/cdap-examples/DataCleansing/src/test/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduceTest.java
+++ b/cdap-examples/DataCleansing/src/test/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduceTest.java
@@ -88,7 +88,7 @@ public class DataCleansingMapReduceTest extends TestBase {
     ApplicationManager applicationManager = deployApplication(DataCleansing.class);
 
     ServiceManager serviceManager = applicationManager.getServiceManager(DataCleansingService.NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL();
 
     // write a set of records to one partition and run the DataCleansingMapReduce job on that one partition

--- a/cdap-examples/FileSetExample/src/test/java/co/cask/cdap/examples/fileset/FileSetWordCountTest.java
+++ b/cdap-examples/FileSetExample/src/test/java/co/cask/cdap/examples/fileset/FileSetWordCountTest.java
@@ -66,7 +66,7 @@ public class FileSetWordCountTest extends TestBase {
 
     // discover the file set service
     ServiceManager serviceManager = applicationManager.getServiceManager("FileSetService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL();
 
     // write a file to the file set using the service

--- a/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
+++ b/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.examples.helloworld;
 
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.ServiceManager;
@@ -49,7 +50,7 @@ public class HelloWorldTest extends TestBase {
 
     // Start WhoFlow
     FlowManager flowManager = appManager.getFlowManager("WhoFlow").start();
-    flowManager.waitForStatus(true);
+    flowManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Send stream events to the "who" Stream
     StreamManager streamManager = getStreamManager("who");
@@ -72,7 +73,7 @@ public class HelloWorldTest extends TestBase {
     ServiceManager serviceManager = appManager.getServiceManager(HelloWorld.Greeting.SERVICE_NAME).start();
 
     // Wait service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     URL url = new URL(serviceManager.getServiceURL(), "greet");
     HttpURLConnection connection = (HttpURLConnection) url.openConnection();

--- a/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
+++ b/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
@@ -39,7 +39,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Unit test for {@link LogAnalysisApp}
@@ -131,13 +133,13 @@ public class LogAnalysisAppTest extends TestBase {
   }
 
   private ServiceManager getServiceManager(ApplicationManager appManager, String serviceName)
-    throws InterruptedException {
+    throws InterruptedException, TimeoutException, ExecutionException {
     // Start the service
     ServiceManager serviceManager =
       appManager.getServiceManager(serviceName).start();
 
     // Wait for service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     return serviceManager;
   }
 }

--- a/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
+++ b/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
@@ -35,7 +35,9 @@ import org.junit.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Test for {@link PurchaseApp}.
@@ -114,7 +116,7 @@ public class PurchaseAppTest extends TestBase {
       appManager.getServiceManager(PurchaseHistoryService.SERVICE_NAME).start();
 
     // Wait for service startup
-    purchaseHistoryServiceManager.waitForStatus(true);
+    purchaseHistoryServiceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Test service to retrieve a customer's purchase history
     URL url = new URL(purchaseHistoryServiceManager.getServiceURL(15, TimeUnit.SECONDS), "history/joe");
@@ -135,13 +137,14 @@ public class PurchaseAppTest extends TestBase {
     Assert.assertEquals(profileFromPurchaseHistory.getLastName(), "bernard");
   }
 
-  private ServiceManager getUserProfileServiceManager(ApplicationManager appManager) throws InterruptedException {
+  private ServiceManager getUserProfileServiceManager(ApplicationManager appManager)
+    throws InterruptedException, TimeoutException, ExecutionException {
     // Start UserProfileService
     ServiceManager userProfileServiceManager =
       appManager.getServiceManager(UserProfileServiceHandler.SERVICE_NAME).start();
 
     // Wait for service startup
-    userProfileServiceManager.waitForStatus(true);
+    userProfileServiceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     return userProfileServiceManager;
   }
 }

--- a/cdap-examples/SpamClassifier/src/test/java/co/cask/cdap/examples/sparkstreaming/SpamClassifierTest.java
+++ b/cdap-examples/SpamClassifier/src/test/java/co/cask/cdap/examples/sparkstreaming/SpamClassifierTest.java
@@ -119,7 +119,7 @@ public class SpamClassifierTest extends TestBase {
 
     // Start and wait for service to start
     final ServiceManager serviceManager = appManager.getServiceManager(SpamClassifier.SERVICE_HANDLER).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // wait for spark streaming program to write to dataset
     Tasks.waitFor(true, new Callable<Boolean>() {

--- a/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
+++ b/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
@@ -75,7 +75,7 @@ public class SparkKMeansAppTest extends TestBase {
     ServiceManager serviceManager = appManager.getServiceManager(SparkKMeansApp.CentersService.SERVICE_NAME).start();
 
     // Wait service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Request data and verify it
     String response = requestService(new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "centers/0"));

--- a/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
+++ b/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
@@ -66,7 +66,7 @@ public class SparkPageRankAppTest extends TestBase {
       .start();
 
     // Wait for service to start since the Spark program needs it
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Start the SparkPageRankProgram
     SparkManager sparkManager = appManager.getSparkManager(SparkPageRankApp.PageRankSpark.class.getSimpleName())

--- a/cdap-examples/SportResults/src/test/java/co/cask/cdap/examples/sportresults/SportResultsTest.java
+++ b/cdap-examples/SportResults/src/test/java/co/cask/cdap/examples/sportresults/SportResultsTest.java
@@ -61,7 +61,7 @@ public class SportResultsTest extends TestBase {
     // deploy the application and start the upload service
     ApplicationManager appManager = deployApplication(SportResults.class);
     ServiceManager serviceManager = appManager.getServiceManager("UploadService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // upload a few dummy results
     URL url = serviceManager.getServiceURL();

--- a/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
+++ b/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
@@ -57,7 +58,7 @@ public class UserProfilesTest extends TestBase {
     FlowManager flowManager = applicationManager.getFlowManager("ActivityFlow").start();
 
     ServiceManager serviceManager = applicationManager.getServiceManager("UserProfileService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL();
 
     // create a user through the service

--- a/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
+++ b/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
@@ -86,7 +87,7 @@ public class WordCountTest extends TestBase {
     ServiceManager serviceManager = appManager.getServiceManager(RetrieveCounts.SERVICE_NAME).start();
 
     // Wait service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // First verify global statistics
     String response = requestService(new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "stats"));

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
@@ -97,7 +97,7 @@ public class MockLogReader implements LogReader {
                                   final Map<String, String> systemArgs) {
     store.setProvisioning(id, startTime, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setProvisioned(id, 0, AppFabricTestHelper.createSourceId(++sourceId));
-    store.setStart(id, null, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
+    store.setStart(id, startTime, null, runtimeArgs, systemArgs, AppFabricTestHelper.createSourceId(++sourceId));
     store.setRunning(id, startTime + 1, null, AppFabricTestHelper.createSourceId(++sourceId));
   }
 

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -25,6 +25,7 @@ import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ScheduleDetail;
 import co.cask.cdap.proto.artifact.AppRequest;
@@ -146,7 +147,7 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   public boolean isRunning(ProgramId programId) {
     try {
       String status = programClient.getStatus(programId);
-      return "RUNNING".equals(status);
+      return !ProgramStatus.STOPPED.name().equals(status);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
@@ -98,7 +98,7 @@ public class IntegrationTestBaseTest extends IntegrationTestBase {
 
     ApplicationManager appManager = deployApplication(NamespaceId.DEFAULT, AppUsingCustomModule.class);
     ServiceManager serviceManager = appManager.getServiceManager("MyService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     put(serviceManager, "a", "1");
     put(serviceManager, "b", "2");

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Test for {@link IntegrationTestBase}.
@@ -53,7 +55,7 @@ public class IntegrationTestBaseTest extends IntegrationTestBase {
   public void testFlowManager() throws Exception {
     ApplicationManager applicationManager = deployApplication(TestApplication.class);
     FlowManager flowManager = applicationManager.getFlowManager(TestFlow.NAME).start();
-    flowManager.waitForStatus(true);
+    flowManager.waitForRun(ProgramRunStatus.RUNNING, 20, TimeUnit.SECONDS);
     flowManager.stop();
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.workflow.NodeStatus;
  */
 public enum ProgramRunStatus {
   ALL,
+  PENDING,
   STARTING,
   RUNNING,
   SUSPENDED,
@@ -64,6 +65,7 @@ public enum ProgramRunStatus {
 
   public static ProgramStatus toProgramStatus(ProgramRunStatus status) {
     switch(status) {
+      case PENDING:
       case STARTING:
         return ProgramStatus.INITIALIZING;
       case RUNNING:

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramStatus.java
@@ -20,6 +20,7 @@ package co.cask.cdap.proto;
  * Program level status types.
  */
 public enum ProgramStatus {
+  STARTING,
   RUNNING,
   STOPPED
 }

--- a/cdap-standalone/src/main/java/co/cask/cdap/AbstractAppCreationService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/AbstractAppCreationService.java
@@ -152,7 +152,7 @@ class AbstractAppCreationService extends AbstractExecutionThreadService {
 
     for (Map.Entry<ProgramId, Map<String, String>> programEntry : programIdMap.entrySet()) {
       try {
-        programLifecycleService.start(programEntry.getKey(), programEntry.getValue(), false);
+        programLifecycleService.run(programEntry.getKey(), programEntry.getValue(), false);
       } catch (IOException ex) {
         // Might happen if the program is being started in parallel through UI
         LOG.debug("Tried to start {} program but had a conflict. {}", programEntry.getKey(), ex.getMessage());

--- a/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
@@ -57,7 +57,11 @@ public interface ProgramManager<T extends ProgramManager> {
   boolean isRunning();
 
   /**
-   * Wait for the status of the program with 5 seconds timeout.
+   * Wait for the status of the program with 5 seconds timeout. A started program does not mean all functionality
+   * is available. For example, a started service may not yet have registered its url. In most cases, this should only
+   * be used to wait for the program to stop, with {@link #waitForRun(ProgramRunStatus, long, TimeUnit)} used
+   * with {@link ProgramRunStatus#RUNNING} to wait for a program to actually be running.
+   *
    * @param status true if waiting for started, false if waiting for stopped.
    * @throws InterruptedException if the method is interrupted while waiting for the status.
    */

--- a/cdap-unit-test-spark2_2.11/src/test/java/co/cask/cdap/spark/Spark2Test.java
+++ b/cdap-unit-test-spark2_2.11/src/test/java/co/cask/cdap/spark/Spark2Test.java
@@ -121,7 +121,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
     prepareInputData(keysManager);
 
     SparkManager sparkManager = applicationManager.getSparkManager(CharCountProgram.class.getSimpleName()).start();
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStatus(false, 6, 10);
 
     DataSetManager<KeyValueTable> countManager = getDataset("count");
     checkOutputData(countManager);
@@ -162,7 +163,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
     prepareInputData(keysManager);
 
     SparkManager sparkManager = applicationManager.getSparkManager(ScalaCharCountProgram.class.getSimpleName()).start();
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStatus(false, 6, 10);
 
     DataSetManager<KeyValueTable> countManager = getDataset("count");
     checkOutputData(countManager);
@@ -196,7 +198,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
                                                ScalaCrossNSProgram.DATASET_NAME(), "count");
     SparkManager sparkManager =
       applicationManager.getSparkManager(ScalaCrossNSProgram.class.getSimpleName()).start(args);
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStatus(false, 6, 10);
 
     // get the dataset from the other namespace where we expect it to exist and compare the data
     DataSetManager<KeyValueTable> countManager = getDataset(crossNSDatasetMeta.getNamespaceId().dataset("count"));
@@ -223,7 +226,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
     ApplicationManager applicationManager = deploy(NamespaceId.DEFAULT, SparkAppUsingObjectStore.class);
     SparkManager sparkManager =
       applicationManager.getSparkManager(ScalaCharCountProgram.class.getSimpleName()).start(args);
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStatus(false, 6, 10);
 
     DataSetManager<KeyValueTable> countManager = getDataset("count");
     checkOutputData(countManager);
@@ -281,7 +285,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
 
     SparkManager sparkManager = applicationManager.getSparkManager(sparkProgram)
       .start(Collections.singletonMap(SparkAppUsingLocalFiles.LOCAL_FILE_RUNTIME_ARG, localFile.toString()));
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStatus(false, 12, 10);
 
     DataSetManager<KeyValueTable> kvTableManager = getDataset(SparkAppUsingLocalFiles.OUTPUT_DATASET_NAME);
     KeyValueTable kvTable = kvTableManager.get();

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -79,6 +79,8 @@ import co.cask.cdap.internal.app.runtime.messaging.BasicMessagingAdmin;
 import co.cask.cdap.internal.app.runtime.messaging.MultiThreadMessagingContext;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.ProgramNotificationSubscriberService;
+import co.cask.cdap.internal.provision.ProvisionerModule;
+import co.cask.cdap.internal.provision.ProvisionerNotificationSubscriberService;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.MessagingService;
@@ -186,6 +188,7 @@ public class TestBase {
   private static boolean firstInit = true;
   private static MetricsQueryService metricsQueryService;
   private static MetricsCollectionService metricsCollectionService;
+  private static ProvisionerNotificationSubscriberService provisionerNotificationSubscriberService;
   private static ProgramNotificationSubscriberService programNotificationSubscriberService;
   private static Scheduler scheduler;
   private static ExploreExecutorService exploreExecutorService;
@@ -275,6 +278,7 @@ public class TestBase {
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new ProvisionerModule(),
       new PreviewHttpModule(),
       new AbstractModule() {
         @Override
@@ -311,6 +315,10 @@ public class TestBase {
     programLifecycleService.startAndWait();
     programNotificationSubscriberService = injector.getInstance(ProgramNotificationSubscriberService.class);
     programNotificationSubscriberService.startAndWait();
+    provisionerNotificationSubscriberService = injector.getInstance(ProvisionerNotificationSubscriberService.class);
+    provisionerNotificationSubscriberService.startAndWait();
+    programLifecycleService = injector.getInstance(ProgramLifecycleService.class);
+    programLifecycleService.startAndWait();
     scheduler = injector.getInstance(Scheduler.class);
     if (scheduler instanceof Service) {
       ((Service) scheduler).startAndWait();
@@ -498,6 +506,8 @@ public class TestBase {
     streamCoordinatorClient.stopAndWait();
     metricsQueryService.stopAndWait();
     metricsCollectionService.stopAndWait();
+    programLifecycleService.stopAndWait();
+    provisionerNotificationSubscriberService.stopAndWait();
     programNotificationSubscriberService.stopAndWait();
     if (scheduler instanceof Service) {
       ((Service) scheduler).stopAndWait();

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -24,6 +24,7 @@ import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ScheduleDetail;
@@ -164,7 +165,7 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
     try {
       String status = appFabricClient.getStatus(application.getNamespace(), programId.getApplication(),
                                                 programId.getVersion(), programId.getProgram(), programId.getType());
-      return "RUNNING".equals(status);
+      return !ProgramStatus.STOPPED.name().equals(status);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/MapReduceServiceIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/MapReduceServiceIntegrationTestRun.java
@@ -35,7 +35,7 @@ public class MapReduceServiceIntegrationTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(TestMapReduceServiceIntegrationApp.class);
     ServiceManager serviceManager =
       applicationManager.getServiceManager(TestMapReduceServiceIntegrationApp.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     DataSetManager<MyKeyValueTableDefinition.KeyValueTable> inDataSet =
       getDataset(TestMapReduceServiceIntegrationApp.INPUT_DATASET);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionConsumingTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionConsumingTestRun.java
@@ -87,7 +87,7 @@ public class PartitionConsumingTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(AppWithPartitionConsumers.class);
 
     ServiceManager serviceManager = applicationManager.getServiceManager("DatasetService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL();
 
     // write a file to the file set using the service and run the WordCount MapReduce job on that one partition

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -1649,20 +1649,22 @@ public class AuthorizationTest extends TestBase {
   private <T extends ProgramManager> void assertProgramFailure(
     Map<String, String> programArgs, final ProgramManager<T> programManager)
     throws TimeoutException, InterruptedException, ExecutionException {
+    final int prevNumFailures = programManager.getHistory(ProgramRunStatus.FAILED).size();
+
     programManager.start(programArgs);
 
-    Tasks.waitFor(true, new Callable<Boolean>() {
-      @Override
-      public Boolean call() throws Exception {
-        // verify program history just have failures
-        List<RunRecord> history = programManager.getHistory();
-        for (final RunRecord runRecord : history) {
-          if (runRecord.getStatus() != ProgramRunStatus.FAILED) {
-            return false;
-          }
+    // need to check that every run has failed as well as the number of failures
+    // otherwise there is a race where start() returns before any run record is written
+    // and this check passes because there are existing failed runs, but the new run has not failed.
+    Tasks.waitFor(true, () -> {
+      // verify program history just have failures, and there is one more failure than before program start
+      List<RunRecord> history = programManager.getHistory();
+      for (final RunRecord runRecord : history) {
+        if (runRecord.getStatus() != ProgramRunStatus.FAILED) {
+          return false;
         }
-        return !history.isEmpty();
       }
+      return history.size() == prevNumFailures + 1;
     }, 5, TimeUnit.MINUTES, "Not all program runs have failed status. Expected all run status to be failed");
 
     programManager.waitForStatus(false);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/SparkServiceIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/SparkServiceIntegrationTestRun.java
@@ -33,7 +33,9 @@ import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Test Spark program integration with Service
@@ -63,11 +65,11 @@ public class SparkServiceIntegrationTestRun extends TestFrameworkTestBase {
   /**
    * Starts a Service
    */
-  private void startService(ApplicationManager applicationManager) {
+  private void startService(ApplicationManager applicationManager) throws TimeoutException, ExecutionException {
     ServiceManager serviceManager =
       applicationManager.getServiceManager(TestSparkServiceIntegrationApp.SERVICE_NAME).start();
     try {
-      serviceManager.waitForStatus(true);
+      serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       LOG.error("Failed to start {} service", TestSparkServiceIntegrationApp.SERVICE_NAME, e);
       throw Throwables.propagate(e);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.lib.cube.MeasureType;
 import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SlowTests;
@@ -68,7 +69,7 @@ public class TestAppWithCube extends TestBase {
 
     ServiceManager serviceManager = appManager.getServiceManager(AppWithCube.SERVICE_NAME).start();
     try {
-      serviceManager.waitForStatus(true);
+      serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
       URL url = serviceManager.getServiceURL();
 
       long tsInSec = System.currentTimeMillis() / 1000;

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -254,7 +254,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     Assert.assertEquals(0, history.size());
 
     countService.start();
-    countService.waitForStatus(true);
+    countService.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     Assert.assertEquals(2, countService.getProvisionedInstances());
 
     // requesting with ProgramRunStatus.KILLED returns empty list
@@ -2149,6 +2149,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     } catch (Exception e) {
       Assert.assertTrue(Throwables.getRootCause(e) instanceof ConflictException);
     }
+    workerManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     workerManager.stop();
 
     // Start the workflow

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -412,7 +412,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager appManager = deployApplication(appId, createRequest);
     ServiceManager serviceManager = appManager.getServiceManager(ConfigTestApp.SERVICE_NAME);
     serviceManager.start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     URL serviceURL = serviceManager.getServiceURL();
     Gson gson = new Gson();
@@ -427,7 +427,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     appManager = deployApplication(appId, createRequest);
     serviceManager = appManager.getServiceManager(ConfigTestApp.SERVICE_NAME);
     serviceManager.start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     serviceURL = serviceManager.getServiceURL();
     Assert.assertEquals("tV2", gson.fromJson(callServiceGet(serviceURL, "ping"), String.class));
@@ -651,7 +651,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     ApplicationManager appManager = deployApplication(DatasetWithCustomActionApp.class);
     ServiceManager serviceManager = appManager.getServiceManager(DatasetWithCustomActionApp.CUSTOM_SERVICE).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(DatasetWithCustomActionApp.CUSTOM_WORKFLOW).start();
     workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
@@ -1094,13 +1094,13 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(AppUsingGetServiceURL.class);
     ServiceManager centralServiceManager =
       applicationManager.getServiceManager(AppUsingGetServiceURL.CENTRAL_SERVICE).start();
-    centralServiceManager.waitForStatus(true);
+    centralServiceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     WorkerManager pingingWorker = applicationManager.getWorkerManager(AppUsingGetServiceURL.PINGING_WORKER).start();
 
     // Test service's getServiceURL
     ServiceManager serviceManager = applicationManager.getServiceManager(AppUsingGetServiceURL.FORWARDING).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     String result = callServiceGet(serviceManager.getServiceURL(), "ping");
     String decodedResult = new Gson().fromJson(result, String.class);
     // Verify that the service was able to hit the CentralService and retrieve the answer.
@@ -1166,7 +1166,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   public void testWorkerInstances() throws Exception {
     ApplicationManager applicationManager = deployApplication(testSpace, AppUsingGetServiceURL.class);
     WorkerManager workerManager = applicationManager.getWorkerManager(AppUsingGetServiceURL.PINGING_WORKER).start();
-    workerManager.waitForStatus(true);
+    workerManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Should be 5 instances when first started.
     workerInstancesCheck(workerManager, 5);
@@ -1185,7 +1185,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     WorkerManager lifecycleWorkerManager = applicationManager.getWorkerManager(AppUsingGetServiceURL.LIFECYCLE_WORKER);
     lifecycleWorkerManager.setInstances(3);
-    lifecycleWorkerManager.start().waitForStatus(true);
+    lifecycleWorkerManager.start().waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     workerInstancesCheck(lifecycleWorkerManager, 3);
     for (int i = 0; i < 3; i++) {
@@ -1339,7 +1339,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       flowManager.stop();
       flowManager.waitForStatus(false);
 
-      serviceManager.waitForStatus(true);
+      serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
       callServicePut(serviceManager.getServiceURL(), "tx", "hello");
       callServicePut(serviceManager.getServiceURL(), "tx", AppWithCustomTx.FAIL_PRODUCER, 200);
       callServicePut(serviceManager.getServiceURL(), "tx", AppWithCustomTx.FAIL_CONSUMER, 500);
@@ -1586,7 +1586,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(AppWithServices.class);
     LOG.info("Deployed.");
     ServiceManager serviceManager = applicationManager.getServiceManager(AppWithServices.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     LOG.info("Service Started");
 
@@ -1639,7 +1639,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       .getServiceManager(AppWithServices.DATASET_WORKER_SERVICE_NAME).start(args);
     WorkerManager datasetWorker =
       applicationManager.getWorkerManager(AppWithServices.DATASET_UPDATE_WORKER).start(args);
-    datasetWorkerServiceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     ServiceManager noopManager = applicationManager.getServiceManager("NoOpService").start();
     serviceManager.waitForStatus(true, 2, 1);
@@ -1689,7 +1689,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     ServiceManager serviceManager =
       applicationManager.getServiceManager(AppWithServices.TRANSACTIONS_SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     LOG.info("Service Started");
 
     final URL baseUrl = serviceManager.getServiceURL(15, TimeUnit.SECONDS);


### PR DESCRIPTION
Refactoring so that program execution will be triggered off events
on TMS in preparation for additional cluster lifecycle states.
Refactoring the ProgramLifecycleService to remove usage of
ProgramController when possible, as starting a run will first need
to provision the runtime before the ProgramController can be
used.

Added a 'pending' program run status to indicate the actual
program has not been started. This corresponds to the provisioning
cluster state. Also adding a 'starting' program state to the
status rest endpoint, as a 'running' status when a cluster is
being provisioned is quite misleading, and breaks a bunch of
unit tests that assume a 'running' program status means everything,
like service instances, are actually up and running.
Along with this change, fixing unit tests to define isRunning
as anything that is not stopped.