### PR TITLE
CDAP-13217 remove app spec check when recording run state

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -16,31 +16,23 @@
 
 package co.cask.cdap.internal.app.services;
 
-import co.cask.cdap.api.ProgramSpecification;
-import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.retry.RetryableException;
-import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.logging.LogSamplers;
-import co.cask.cdap.common.logging.Loggers;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.store.AppMetadataStore;
-import co.cask.cdap.internal.app.store.ApplicationMeta;
 import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Notification;
 import co.cask.cdap.proto.ProgramRunStatus;
-import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
@@ -182,20 +174,6 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
       ProgramRunId programRunId = GSON.fromJson(programRun, ProgramRunId.class);
       ProgramId programId = programRunId.getParent();
 
-      ApplicationMeta meta = appMetadataStore.getApplication(programRunId.getNamespace(),
-                                                             programRunId.getApplication(),
-                                                             programRunId.getVersion());
-      // Check if the application exists
-      if (meta == null) {
-        LOG.warn("Ignore notification for application {} that doesn't exist, {}", programRunId, notification);
-        return;
-      }
-      // Check if the program exists
-      if (getProgramSpecFromApp(meta.getSpec(), programRunId) == null) {
-        LOG.warn("Ignore notification for program {} that doesn't exist, {}", programRunId, notification);
-        return;
-      }
-
       LOG.trace("Processing program status notification: {}", notification);
       String runId = programRunId.getRun();
       String twillRunId = notification.getProperties().get(ProgramOptionConstants.TWILL_RUN_ID);
@@ -278,31 +256,6 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
       getMessagingContext().getMessagePublisher().publish(NamespaceId.SYSTEM.getNamespace(),
                                                           recordedProgramStatusPublishTopic,
                                                           GSON.toJson(programStatusNotification));
-    }
-
-    @Nullable
-    private ProgramSpecification getProgramSpecFromApp(ApplicationSpecification appSpec, ProgramRunId programRunId) {
-      String programName = programRunId.getProgram();
-      ProgramType type = programRunId.getType();
-      if (type == ProgramType.FLOW && appSpec.getFlows().containsKey(programName)) {
-        return appSpec.getFlows().get(programName);
-      }
-      if (type == ProgramType.MAPREDUCE && appSpec.getMapReduce().containsKey(programName)) {
-        return appSpec.getMapReduce().get(programName);
-      }
-      if (type == ProgramType.SPARK && appSpec.getSpark().containsKey(programName)) {
-        return appSpec.getSpark().get(programName);
-      }
-      if (type == ProgramType.WORKFLOW && appSpec.getWorkflows().containsKey(programName)) {
-        return appSpec.getWorkflows().get(programName);
-      }
-      if (type == ProgramType.SERVICE && appSpec.getServices().containsKey(programName)) {
-        return appSpec.getServices().get(programName);
-      }
-      if (type == ProgramType.WORKER && appSpec.getWorkers().containsKey(programName)) {
-        return appSpec.getWorkers().get(programName);
-      }
-      return null;
     }
 
     /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
@@ -139,9 +139,9 @@ public abstract class RunRecordCorrectorService extends AbstractIdleService {
     }
 
     if (fixedPrograms.isEmpty()) {
-      LOG.trace("No RunRecord found with status in {} and the program not actually running", NOT_STOPPED_STATUSES);
+      LOG.trace("No RunRecord found with status in {}, but the program are not actually running", NOT_STOPPED_STATUSES);
     } else {
-      LOG.warn("Fixed {} RunRecords with status in {} and the program not actually running",
+      LOG.warn("Fixed {} RunRecords with status in {}, but the programs are not actually running",
                fixedPrograms.size(), NOT_STOPPED_STATUSES);
     }
     return fixedPrograms;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.app.runtime.ProgramStateWriter;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.internal.app.store.AppMetadataStore;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import org.apache.tephra.TransactionAware;
+import org.apache.tephra.TransactionExecutor;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Tests program run state persistence.
+ */
+public class ProgramNotificationSubscriberServiceTest {
+
+  @Test
+  public void testAppSpecNotRequiredToWriteState() throws Exception {
+    Injector injector = AppFabricTestHelper.getInjector();
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+
+    ProgramNotificationSubscriberService programNotificationSubscriberService =
+      injector.getInstance(ProgramNotificationSubscriberService.class);
+    programNotificationSubscriberService.startAndWait();
+    DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
+    TransactionExecutorFactory txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
+
+    DatasetId storeTable = NamespaceId.SYSTEM.dataset(Constants.AppMetaStore.TABLE);
+    datasetFramework.addInstance(Table.class.getName(), storeTable, DatasetProperties.EMPTY);
+    Table table = datasetFramework.getDataset(storeTable, ImmutableMap.<String, String>of(), null);
+    final AppMetadataStore metadataStoreDataset = new AppMetadataStore(table, cConf, new AtomicBoolean(false));
+    final TransactionExecutor txnl = txExecutorFactory.createExecutor(
+      Collections.singleton((TransactionAware) metadataStoreDataset));
+
+    ProgramStateWriter programStateWriter = injector.getInstance(ProgramStateWriter.class);
+
+    ProgramId programId = NamespaceId.DEFAULT.app("someapp").program(ProgramType.SERVICE, "s");
+    ProgramOptions programOptions = new SimpleProgramOptions(programId);
+    final ProgramRunId runId = programId.run(RunIds.generate());
+    programStateWriter.start(runId, programOptions, null);
+
+    Tasks.waitFor(ProgramRunStatus.STARTING, new Callable<ProgramRunStatus>() {
+                    @Override
+                    public ProgramRunStatus call() throws Exception {
+                      return txnl.execute(new Callable<ProgramRunStatus>() {
+                        @Override
+                        public ProgramRunStatus call() throws Exception {
+                          RunRecordMeta meta = metadataStoreDataset.getRun(runId.getParent(), runId.getRun());
+                          return meta == null ? null : meta.getStatus();
+                        }
+                      });
+                    }
+                  },
+                  10, TimeUnit.SECONDS);
+
+    programStateWriter.running(runId, UUID.randomUUID().toString());
+    Tasks.waitFor(ProgramRunStatus.RUNNING, new Callable<ProgramRunStatus>() {
+                    @Override
+                    public ProgramRunStatus call() throws Exception {
+                      return txnl.execute(new Callable<ProgramRunStatus>() {
+                        @Override
+                        public ProgramRunStatus call() throws Exception {
+                          RunRecordMeta meta = metadataStoreDataset.getRun(runId.getParent(), runId.getRun());
+                          return meta == null ? null : meta.getStatus();
+                        }
+                      });
+                    }
+                  },
+                  10, TimeUnit.SECONDS);
+
+    programStateWriter.killed(runId);
+    Tasks.waitFor(ProgramRunStatus.KILLED, new Callable<ProgramRunStatus>() {
+                    @Override
+                    public ProgramRunStatus call() throws Exception {
+                      return txnl.execute(new Callable<ProgramRunStatus>() {
+                        @Override
+                        public ProgramRunStatus call() throws Exception {
+                          RunRecordMeta meta = metadataStoreDataset.getRun(runId.getParent(), runId.getRun());
+                          return meta == null ? null : meta.getStatus();
+                        }
+                      });
+                    }
+                  },
+                  10, TimeUnit.SECONDS);
+  }
+}


### PR DESCRIPTION
When we are recording run record state, we should not check for
existence of the application or program. Otherwise, there can
be a situation where an app is modified to remove a running
program. If that program is killed on the cluster, then the run
record will be in the 'running' state, which will eventually
be fixed by the run record corrector. However, when it is time
to save the run state, the program will not be found and the
state update will be ignored. This will loop infinitely.