### PR TITLE
CDAP-13096 move scheduler out of program lifecycle service

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/schedule/Trigger.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/schedule/Trigger.java
@@ -64,7 +64,8 @@ public interface Trigger {
     public static Type valueOfCategoryName(String categoryName) {
       Type type = CATEGORY_MAP.get(categoryName);
       if (type == null) {
-        throw new IllegalArgumentException("Unknown category name " + categoryName);
+        throw new IllegalArgumentException(String.format("Unknown category name '%s'. Must be one of %s",
+                                                         categoryName, String.join(",", CATEGORY_MAP.keySet())));
       }
       return type;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -48,7 +48,6 @@ import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
-import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.ConstraintCodec;
 import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
@@ -83,18 +82,14 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.id.ScheduleId;
 import co.cask.cdap.proto.id.WorkflowId;
-import co.cask.cdap.proto.security.Action;
-import co.cask.cdap.scheduler.Scheduler;
-import co.cask.cdap.security.spi.authentication.AuthenticationContext;
-import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import co.cask.cdap.scheduler.ProgramScheduleService;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -125,11 +120,11 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
@@ -178,15 +173,13 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     .registerTypeAdapter(Constraint.class, new ConstraintCodec())
     .create();
 
+  private final ProgramScheduleService programScheduleService;
   private final ProgramLifecycleService lifecycleService;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final QueueAdmin queueAdmin;
   private final MetricStore metricStore;
   private final MRJobInfoFetcher mrJobInfoFetcher;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
-  private final Scheduler programScheduler;
-  private final AuthenticationContext authenticationContext;
-  private final AuthorizationEnforcer authorizationEnforcer;
 
   /**
    * Store manages non-runtime lifecycle.
@@ -205,9 +198,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                               QueueAdmin queueAdmin,
                               MRJobInfoFetcher mrJobInfoFetcher,
                               MetricStore metricStore,
-                              NamespaceQueryAdmin namespaceQueryAdmin, Scheduler programScheduler,
-                              AuthenticationContext authenticationContext,
-                              AuthorizationEnforcer authorizationEnforcer) {
+                              NamespaceQueryAdmin namespaceQueryAdmin,
+                              ProgramScheduleService programScheduleService) {
     this.store = store;
     this.runtimeService = runtimeService;
     this.discoveryServiceClient = discoveryServiceClient;
@@ -216,9 +208,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     this.queueAdmin = queueAdmin;
     this.mrJobInfoFetcher = mrJobInfoFetcher;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
-    this.programScheduler = programScheduler;
-    this.authenticationContext = authenticationContext;
-    this.authorizationEnforcer = authorizationEnforcer;
+    this.programScheduleService = programScheduleService;
   }
 
   /**
@@ -290,7 +280,11 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     if (SCHEDULES.equals(type)) {
       JsonObject json = new JsonObject();
       ScheduleId scheduleId = applicationId.schedule(programId);
-      json.addProperty("status", lifecycleService.getScheduleStatus(scheduleId).toString());
+      ApplicationSpecification appSpec = store.getApplication(applicationId);
+      if (appSpec == null) {
+        throw new NotFoundException(applicationId);
+      }
+      json.addProperty("status", programScheduleService.getStatus(scheduleId).toString());
       responder.sendJson(HttpResponseStatus.OK, json.toString());
       return;
     }
@@ -360,7 +354,14 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     ApplicationId applicationId = new ApplicationId(namespaceId, appId, appVersion);
     if (SCHEDULES.equals(type)) {
       ScheduleId scheduleId = applicationId.schedule(programId);
-      lifecycleService.suspendResumeSchedule(scheduleId, action);
+      if (action.equals("disable") || action.equals("suspend")) {
+        programScheduleService.suspend(scheduleId);
+      } else if (action.equals("enable") || action.equals("resume")) {
+        programScheduleService.resume(scheduleId);
+      } else {
+        throw new BadRequestException(
+          "Action for schedules may only be 'enable', 'disable', 'suspend', or 'resume' but is'" + action + "'");
+      }
       responder.sendJson(HttpResponseStatus.OK, "OK");
       return;
     }
@@ -612,36 +613,58 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    * @param triggerProgramType program type of the triggering program in {@link ProgramStatusTrigger}
    * @param triggerProgramName program name of the triggering program in {@link ProgramStatusTrigger}
    * @param triggerProgramStatuses comma separated {@link ProgramStatus} in {@link ProgramStatusTrigger}.
-*                               Schedules with {@link ProgramStatusTrigger} triggered by none of the
-*                               {@link ProgramStatus} in triggerProgramStatuses will be filtered out.
-*                               If not specified, schedules will be returned regardless of triggering program status.
+   *                               Schedules with {@link ProgramStatusTrigger} triggered by none of the
+   *                               {@link ProgramStatus} in triggerProgramStatuses will be filtered out.
+   *                               If not specified, schedules will be returned regardless of triggering program status.
    * @param scheduleStatus status of the schedule. Can only be one of "SCHEDULED" or "SUSPENDED".
-*                       If specified, only schedules with matching status will be returned.
+   *                       If specified, only schedules with matching status will be returned.
    */
   @GET
   @Path("schedules/trigger-type/program-status")
   public void getProgramStatusSchedules(HttpRequest request, HttpResponder responder,
                                         @QueryParam("trigger-namespace-id") String triggerNamespaceId,
                                         @QueryParam("trigger-app-name") String triggerAppName,
-                                        @QueryParam("trigger-app-version") String triggerAppVersion,
+                                        @QueryParam("trigger-app-version") @DefaultValue(ApplicationId.DEFAULT_VERSION)
+                                            String triggerAppVersion,
                                         @QueryParam("trigger-program-type") String triggerProgramType,
                                         @QueryParam("trigger-program-name") String triggerProgramName,
                                         @QueryParam("trigger-program-statuses") String triggerProgramStatuses,
-                                        @QueryParam("schedule-status") String scheduleStatus)
-    throws BadRequestException {
-    if (triggerNamespaceId == null && triggerAppName == null && triggerAppVersion == null
-      && triggerProgramType == null && triggerProgramName == null) {
-      throw new BadRequestException("Must specify the triggering program to find schedules " +
-                                      "triggered by program statuses");
+                                        @QueryParam("schedule-status") String scheduleStatus) throws Exception {
+    if (triggerNamespaceId == null) {
+      throw new BadRequestException("Must specify trigger-namespace-id as a query param");
     }
-    // Filter by triggering programId and in program status trigger
-    ApplicationId appId = triggerAppVersion == null ? new ApplicationId(triggerNamespaceId, triggerAppName)
-      : new ApplicationId(triggerNamespaceId, triggerAppName, triggerAppVersion);
-    final ProgramId triggerProgramId = appId.program(ProgramType.valueOfCategoryName(triggerProgramType),
-                                                     triggerProgramName);
-    programScheduler.findSchedules(triggerProgramId.toString());
-    Set<ProgramScheduleRecord> schedules = new HashSet<>();
-    final Set<co.cask.cdap.api.ProgramStatus> queryProgramStatuses = new HashSet<>();
+    if (triggerAppName == null) {
+      throw new BadRequestException("Must specify trigger-app-name as a query param");
+    }
+    if (triggerProgramType == null) {
+      throw new BadRequestException("Must specify trigger-program-type as a query param");
+    }
+    if (triggerProgramName == null) {
+      throw new BadRequestException("Must specify trigger-program-name as a query param");
+    }
+
+    ProgramType programType;
+    try {
+      programType = ProgramType.valueOfCategoryName(triggerProgramType);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+
+
+    ProgramScheduleStatus programScheduleStatus;
+    try {
+      programScheduleStatus = scheduleStatus == null ? null : ProgramScheduleStatus.valueOf(scheduleStatus);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(String.format("Invalid schedule status '%s'. Must be one of %s.",
+                                                  scheduleStatus, Joiner.on(',').join(ProgramScheduleStatus.values())),
+                                    e);
+    }
+
+    ProgramId triggerProgramId = new NamespaceId(triggerNamespaceId)
+      .app(triggerAppName, triggerAppVersion)
+      .program(programType, triggerProgramName);
+
+    Set<co.cask.cdap.api.ProgramStatus> queryProgramStatuses = new HashSet<>();
     if (triggerProgramStatuses != null) {
       try {
         for (String status : triggerProgramStatuses.split(",")) {
@@ -654,14 +677,14 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       }
     } else {
       // Query for schedules with all the statuses if no query status is specified
-      for (co.cask.cdap.api.ProgramStatus status: co.cask.cdap.api.ProgramStatus.values()) {
-        queryProgramStatuses.add(status);
-      }
+      Collections.addAll(queryProgramStatuses, co.cask.cdap.api.ProgramStatus.values());
     }
-    for (String triggerKey : Schedulers.triggerKeysForProgramStatuses(triggerProgramId, queryProgramStatuses)) {
-      schedules.addAll(programScheduler.findSchedules(triggerKey));
-    }
-    List<ScheduleDetail> details = Schedulers.toScheduleDetails(filterSchedulesByStatus(schedules, scheduleStatus));
+
+    List<ScheduleDetail> details = programScheduleService.findTriggeredBy(triggerProgramId, queryProgramStatuses)
+      .stream()
+      .filter(record -> programScheduleStatus == null || record.getMeta().getStatus().equals(programScheduleStatus))
+      .map(ProgramScheduleRecord::toScheduleDetail)
+      .collect(Collectors.toList());
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(details, Schedulers.SCHEDULE_DETAILS_TYPE));
   }
 
@@ -670,8 +693,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void getSchedule(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId,
                           @PathParam("app-name") String appName,
-                          @PathParam("schedule-name") String scheduleName)
-    throws NotFoundException, SchedulerException, BadRequestException {
+                          @PathParam("schedule-name") String scheduleName) throws Exception {
     doGetSchedule(responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, scheduleName);
   }
 
@@ -681,23 +703,20 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                           @PathParam("namespace-id") String namespaceId,
                           @PathParam("app-name") String appName,
                           @PathParam("app-version") String appVersion,
-                          @PathParam("schedule-name") String scheduleName)
-    throws NotFoundException, SchedulerException, BadRequestException {
+                          @PathParam("schedule-name") String scheduleName) throws Exception {
     doGetSchedule(responder, namespaceId, appName, appVersion, scheduleName);
   }
 
   private void doGetSchedule(HttpResponder responder, String namespace,
-                             String app, String version, String scheduleName)
-    throws NotFoundException, BadRequestException {
-
+                             String app, String version, String scheduleName) throws Exception {
     ScheduleId scheduleId = new ApplicationId(namespace, app, version).schedule(scheduleName);
-    ProgramSchedule schedule = programScheduler.getSchedule(scheduleId);
+    ProgramSchedule schedule = programScheduleService.get(scheduleId);
     ScheduleDetail detail = schedule.toScheduleDetail();
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(detail, ScheduleDetail.class));
   }
 
   /**
-   * See {@link #getAllSchedules(HttpRequest, HttpResponder, String, String, String, String)}
+   * See {@link #getAllSchedules(HttpRequest, HttpResponder, String, String, String, String, String)}
    */
   @GET
   @Path("apps/{app-name}/schedules")
@@ -705,10 +724,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("app-name") String appName,
                               @QueryParam("trigger-type") String triggerType,
-                              @QueryParam("schedule-status") String scheduleStatus)
-    throws NotFoundException, BadRequestException {
-    doGetSchedules(responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, null, triggerType,
-                   scheduleStatus);
+                              @QueryParam("schedule-status") String scheduleStatus) throws Exception {
+    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName, ApplicationId.DEFAULT_VERSION),
+                   null, triggerType, scheduleStatus);
   }
 
   /**
@@ -728,60 +746,55 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                               @PathParam("app-name") String appName,
                               @PathParam("app-version") String appVersion,
                               @QueryParam("trigger-type") String triggerType,
-                              @QueryParam("schedule-status") String scheduleStatus)
-    throws NotFoundException, BadRequestException {
-    doGetSchedules(responder, namespaceId, appName, appVersion, null, triggerType, scheduleStatus);
+                              @QueryParam("schedule-status") String scheduleStatus) throws Exception {
+    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName, appVersion), null, triggerType, scheduleStatus);
   }
 
-  protected void doGetSchedules(HttpResponder responder, String namespace, String app, String version,
-                                @Nullable String workflow, @Nullable String triggerType,
-                                String scheduleStatus)
-    throws NotFoundException, BadRequestException {
-    ApplicationId applicationId = new ApplicationId(namespace, app, version);
+  protected void doGetSchedules(HttpResponder responder, ApplicationId applicationId,
+                                @Nullable String workflow, @Nullable String triggerTypeStr,
+                                @Nullable String statusStr) throws Exception {
     ApplicationSpecification appSpec = store.getApplication(applicationId);
     if (appSpec == null) {
       throw new NotFoundException(applicationId);
     }
+    ProgramScheduleStatus status;
+    try {
+      status = statusStr == null ? null : ProgramScheduleStatus.valueOf(statusStr);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(String.format("Invalid schedule status '%s'. Must be one of %s.",
+                                                  statusStr, Joiner.on(',').join(ProgramScheduleStatus.values())), e);
+    }
+
+    ProtoTrigger.Type triggerType;
+    try {
+      triggerType = triggerTypeStr == null ? null : ProtoTrigger.Type.valueOfCategoryName(triggerTypeStr);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+
+    Predicate<ProgramScheduleRecord> predicate = record -> true;
+    if (status != null) {
+      predicate = predicate.and(record -> record.getMeta().getStatus().equals(status));
+    }
+    if (triggerType != null) {
+      predicate = predicate.and(record -> record.getSchedule().getTrigger().getType().equals(triggerType));
+    }
+
     Collection<ProgramScheduleRecord> schedules;
     if (workflow != null) {
       WorkflowId workflowId = applicationId.workflow(workflow);
       if (appSpec.getWorkflows().get(workflow) == null) {
         throw new NotFoundException(workflowId);
       }
-      schedules = programScheduler.listScheduleRecords(workflowId);
+      schedules = programScheduleService.list(workflowId, predicate);
     } else {
-      schedules = programScheduler.listScheduleRecords(applicationId);
+      schedules = programScheduleService.list(applicationId, predicate);
     }
 
-    if (triggerType != null) {
-      final ProtoTrigger.Type type = ProtoTrigger.Type.valueOfCategoryName(triggerType);
-      // Filter schedules by trigger type
-      Iterator<ProgramScheduleRecord> iterator = schedules.iterator();
-      while (iterator.hasNext()) {
-        // Remove the schedule if its trigger type does not match the given type
-        if (!iterator.next().getSchedule().getTrigger().getType().equals(type)) {
-          iterator.remove();
-        }
-      }
-    }
-    schedules = filterSchedulesByStatus(schedules, scheduleStatus);
-    List<ScheduleDetail> details = Schedulers.toScheduleDetails(schedules);
+    List<ScheduleDetail> details = schedules.stream()
+      .map(ProgramScheduleRecord::toScheduleDetail)
+      .collect(Collectors.toList());
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(details, Schedulers.SCHEDULE_DETAILS_TYPE));
-  }
-
-  private Collection<ProgramScheduleRecord> filterSchedulesByStatus(Collection<ProgramScheduleRecord> scheduleRecords,
-                                                                    @Nullable String scheduleStatus) {
-    // No need to filter by status if scheduleStatus is null, directly return the original records
-    if (scheduleStatus == null) {
-      return scheduleRecords;
-    }
-    final ProgramScheduleStatus status = ProgramScheduleStatus.valueOf(scheduleStatus);
-    return Collections2.filter(scheduleRecords, new Predicate<ProgramScheduleRecord>() {
-      @Override
-      public boolean apply(ProgramScheduleRecord record) {
-        return record.getMeta().getStatus().equals(status);
-      }
-    });
   }
 
   @PUT
@@ -811,7 +824,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              String appVersion, String scheduleName) throws Exception {
 
     final ApplicationId applicationId = new ApplicationId(namespace, appName, appVersion);
-    authorizationEnforcer.enforce(applicationId, authenticationContext.getPrincipal(), Action.ADMIN);
     ScheduleDetail scheduleFromRequest = readScheduleDetailBody(request, scheduleName);
 
     if (scheduleFromRequest.getProgram() == null) {
@@ -841,7 +853,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       Objects.firstNonNull(scheduleFromRequest.getTimeoutMillis(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS);
     ProgramSchedule schedule = new ProgramSchedule(scheduleName, description, programId, properties,
                                                    scheduleFromRequest.getTrigger(), constraints, timeoutMillis);
-    programScheduler.addSchedule(schedule);
+    programScheduleService.add(schedule);
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
@@ -870,11 +882,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                 String appVersion, String scheduleName) throws Exception {
 
     ScheduleId scheduleId = new ApplicationId(namespaceId, appId, appVersion).schedule(scheduleName);
-    authorizationEnforcer.enforce(scheduleId.getParent(), authenticationContext.getPrincipal(), Action.ADMIN);
-    final ProgramSchedule existingSchedule = programScheduler.getSchedule(scheduleId);
     ScheduleDetail scheduleDetail = readScheduleDetailBody(request, scheduleName);
-    ProgramSchedule updatedSchedule = combineForUpdate(scheduleDetail, existingSchedule);
-    programScheduler.updateSchedule(updatedSchedule);
+
+    programScheduleService.update(scheduleId, scheduleDetail);
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
@@ -909,29 +919,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     return scheduleDetail;
   }
 
-  private ProgramSchedule combineForUpdate(ScheduleDetail scheduleDetail, ProgramSchedule existing)
-    throws BadRequestException {
-    String description = Objects.firstNonNull(scheduleDetail.getDescription(), existing.getDescription());
-    ProgramId programId = scheduleDetail.getProgram() == null ? existing.getProgramId()
-      : existing.getProgramId().getParent().program(
-        scheduleDetail.getProgram().getProgramType() == null ? existing.getProgramId().getType()
-        : ProgramType.valueOfSchedulableType(scheduleDetail.getProgram().getProgramType()),
-      Objects.firstNonNull(scheduleDetail.getProgram().getProgramName(), existing.getProgramId().getProgram()));
-    if (!programId.equals(existing.getProgramId())) {
-      throw new BadRequestException(
-        String.format("Must update the schedule '%s' with the same program as '%s'. "
-                        + "To change the program in a schedule, please delete the schedule and create a new one.",
-                      existing.getName(), existing.getProgramId().toString()));
-    }
-    Map<String, String> properties = Objects.firstNonNull(scheduleDetail.getProperties(), existing.getProperties());
-    Trigger trigger = Objects.firstNonNull(scheduleDetail.getTrigger(), existing.getTrigger());
-    List<? extends Constraint> constraints =
-      Objects.firstNonNull(scheduleDetail.getConstraints(), existing.getConstraints());
-    Long timeoutMillis = Objects.firstNonNull(scheduleDetail.getTimeoutMillis(), existing.getTimeoutMillis());
-    return new ProgramSchedule(existing.getName(), description, programId, properties, trigger, constraints,
-                               timeoutMillis);
-  }
-
   @DELETE
   @Path("apps/{app-name}/schedules/{schedule-name}")
   public void deleteSchedule(HttpRequest request, HttpResponder responder,
@@ -954,8 +941,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private void doDeleteSchedule(HttpResponder responder, String namespaceId, String appName,
                                 String appVersion, String scheduleName) throws Exception {
     ScheduleId scheduleId = new ApplicationId(namespaceId, appName, appVersion).schedule(scheduleName);
-    authorizationEnforcer.enforce(scheduleId.getParent(), authenticationContext.getPrincipal(), Action.ADMIN);
-    programScheduler.deleteSchedule(scheduleId);
+    programScheduleService.delete(scheduleId);
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
@@ -1895,7 +1881,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       Set<String> loggerNames = parseBody(request, SET_STRING_TYPE);
       lifecycleService.resetProgramLogLevels(
         new ApplicationId(namespace, appName, appVersion).program(programType, programName),
-        loggerNames == null ? Collections.<String>emptySet() : loggerNames, component, runId);
+        loggerNames == null ? Collections.emptySet() : loggerNames, component, runId);
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (JsonSyntaxException e) {
       throw new BadRequestException("Invalid JSON in body");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/Schedulers.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/Schedulers.java
@@ -97,20 +97,6 @@ public class Schedulers {
     }
   }
 
-  /**
-   * Convert a list of program schedules into a list of schedule details.
-   */
-  public static List<ScheduleDetail> toScheduleDetails(Collection<ProgramScheduleRecord> schedules) {
-    List<ProgramScheduleRecord> scheduleList = new ArrayList<>(schedules);
-    return Lists.transform(scheduleList, new Function<ProgramScheduleRecord, ScheduleDetail>() {
-      @Nullable
-      @Override
-      public ScheduleDetail apply(@Nullable ProgramScheduleRecord input) {
-        return input == null ? null : input.toScheduleDetail();
-      }
-    });
-  }
-
   public static void validateCronExpression(String cronExpression) {
     String quartzCron = getQuartzCronExpression(cronExpression);
     try {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ProgramScheduleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ProgramScheduleService.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.scheduler;
+
+import co.cask.cdap.api.ProgramStatus;
+import co.cask.cdap.api.schedule.Trigger;
+import co.cask.cdap.common.AlreadyExistsException;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.internal.app.runtime.schedule.ProgramSchedule;
+import co.cask.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
+import co.cask.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
+import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
+import co.cask.cdap.internal.schedule.constraint.Constraint;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.ScheduleDetail;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ScheduleId;
+import co.cask.cdap.proto.id.WorkflowId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.security.authorization.AuthorizationUtil;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Used to interact with the Scheduler. Performs authorization checks and other wrapper like functionality.
+ *
+ * TODO: push predicates down to the lowest level to make things more efficient
+ */
+public class ProgramScheduleService {
+  private final AuthorizationEnforcer authorizationEnforcer;
+  private final AuthenticationContext authenticationContext;
+  private final Scheduler scheduler;
+
+  @Inject
+  ProgramScheduleService(AuthorizationEnforcer authorizationEnforcer,
+                         AuthenticationContext authenticationContext, Scheduler scheduler) {
+    this.authorizationEnforcer = authorizationEnforcer;
+    this.authenticationContext = authenticationContext;
+    this.scheduler = scheduler;
+  }
+
+  /**
+   * Add the given schedule
+   *
+   * @param schedule the schedule to add
+   * @throws AlreadyExistsException if the schedule already exists
+   * @throws BadRequestException if the schedule is invalid
+   * @throws UnauthorizedException if the principal is not authorized as an admin operations on the schedule app
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public void add(ProgramSchedule schedule) throws Exception {
+    authorizationEnforcer.enforce(schedule.getProgramId().getParent(),
+                                  authenticationContext.getPrincipal(), Action.ADMIN);
+    scheduler.addSchedule(schedule);
+  }
+
+  /**
+   * Update the given schedule
+   *
+   * @param scheduleId the schedule to update
+   * @param scheduleDetail the schedule to update it to
+   * @throws NotFoundException if the schedule could not be found
+   * @throws BadRequestException if the update is invalid
+   * @throws UnauthorizedException if the principal is not authorized as an admin operations on the schedule program
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public void update(ScheduleId scheduleId, ScheduleDetail scheduleDetail) throws Exception {
+    authorizationEnforcer.enforce(scheduleId.getParent(), authenticationContext.getPrincipal(), Action.ADMIN);
+    ProgramSchedule existing = scheduler.getSchedule(scheduleId);
+
+    String description = Objects.firstNonNull(scheduleDetail.getDescription(), existing.getDescription());
+    ProgramId programId = scheduleDetail.getProgram() == null ? existing.getProgramId()
+      : existing.getProgramId().getParent().program(
+      scheduleDetail.getProgram().getProgramType() == null ? existing.getProgramId().getType()
+        : ProgramType.valueOfSchedulableType(scheduleDetail.getProgram().getProgramType()),
+      Objects.firstNonNull(scheduleDetail.getProgram().getProgramName(), existing.getProgramId().getProgram()));
+    if (!programId.equals(existing.getProgramId())) {
+      throw new BadRequestException(
+        String.format("Must update the schedule '%s' with the same program as '%s'. "
+                        + "To change the program in a schedule, please delete the schedule and create a new one.",
+                      existing.getName(), existing.getProgramId().toString()));
+    }
+    Map<String, String> properties = Objects.firstNonNull(scheduleDetail.getProperties(), existing.getProperties());
+    Trigger trigger = Objects.firstNonNull(scheduleDetail.getTrigger(), existing.getTrigger());
+    List<? extends Constraint> constraints =
+      Objects.firstNonNull(scheduleDetail.getConstraints(), existing.getConstraints());
+    Long timeoutMillis = Objects.firstNonNull(scheduleDetail.getTimeoutMillis(), existing.getTimeoutMillis());
+    ProgramSchedule updatedSchedule = new ProgramSchedule(existing.getName(), description, programId, properties,
+                                                          trigger, constraints, timeoutMillis);
+    scheduler.updateSchedule(updatedSchedule);
+  }
+
+  /**
+   * Get the given schedule
+   *
+   * @return the schedule
+   * @throws NotFoundException if the schedule could not be found
+   * @throws UnauthorizedException if the principal is not authorized to access the schedule program
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public ProgramSchedule get(ScheduleId scheduleId) throws Exception {
+    ProgramSchedule schedule = scheduler.getSchedule(scheduleId);
+    AuthorizationUtil.ensureAccess(schedule.getProgramId(), authorizationEnforcer,
+                                   authenticationContext.getPrincipal());
+    return schedule;
+  }
+
+  /**
+   * Get the state of the given schedule
+   *
+   * @return the status of the given schedule
+   * @throws NotFoundException if the schedule could not be found
+   * @throws UnauthorizedException if the principal is not authorized to access the schedule program
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public ProgramScheduleStatus getStatus(ScheduleId scheduleId) throws Exception {
+    ProgramSchedule schedule = scheduler.getSchedule(scheduleId);
+    AuthorizationUtil.ensureAccess(schedule.getProgramId(), authorizationEnforcer,
+                                   authenticationContext.getPrincipal());
+    return scheduler.getScheduleStatus(scheduleId);
+  }
+
+  /**
+   * List the schedules for the given app that match the given predicate
+   *
+   * @param applicationId the application to get schedules for
+   * @param predicate return schedules that match this predicate
+   * @return schedules for the given app that match the given predicate
+   * @throws NotFoundException if the application could not be found
+   * @throws UnauthorizedException if the principal is not authorized to access the application
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public Collection<ProgramScheduleRecord> list(ApplicationId applicationId,
+                                                Predicate<ProgramScheduleRecord> predicate) throws Exception {
+    AuthorizationUtil.ensureAccess(applicationId, authorizationEnforcer, authenticationContext.getPrincipal());
+    return scheduler.listScheduleRecords(applicationId).stream().filter(predicate).collect(Collectors.toList());
+  }
+
+  /**
+   * List the schedules for the given workflow that match the given predicate
+   *
+   * @param workflowId the workflow to get schedules for
+   * @param predicate return schedules that match this predicate
+   * @return schedules for the given program that match the given predicate
+   * @throws UnauthorizedException if the principal is not authorized to access the application
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public Collection<ProgramScheduleRecord> list(WorkflowId workflowId,
+                                                Predicate<ProgramScheduleRecord> predicate) throws Exception {
+    AuthorizationUtil.ensureAccess(workflowId, authorizationEnforcer, authenticationContext.getPrincipal());
+    return scheduler.listScheduleRecords(workflowId).stream().filter(predicate).collect(Collectors.toList());
+  }
+
+  /**
+   * Get schedules that are triggered by the given program statuses.
+   *
+   * @param programId the program that is in the trigger
+   * @param statusSet statuses that are involved in the trigger
+   * @return schedules triggered by the given program statuses
+   * @throws UnauthorizedException if the principal is not authorized to access the application
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public Collection<ProgramScheduleRecord> findTriggeredBy(ProgramId programId,
+                                                           Set<ProgramStatus> statusSet) throws Exception {
+    AuthorizationUtil.ensureAccess(programId, authorizationEnforcer, authenticationContext.getPrincipal());
+
+    Set<ProgramScheduleRecord> schedules = new HashSet<>();
+    scheduler.findSchedules(programId.toString());
+    for (String triggerKey : Schedulers.triggerKeysForProgramStatuses(programId, statusSet)) {
+      schedules.addAll(scheduler.findSchedules(triggerKey));
+    }
+    return schedules;
+  }
+
+  /**
+   * Suspend the given schedule
+   *
+   * @param scheduleId the schedule to suspend
+   * @throws NotFoundException if the schedule could not be found
+   * @throws UnauthorizedException if the principal is not authorized to suspend the schedule
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public void suspend(ScheduleId scheduleId) throws Exception {
+    ProgramSchedule schedule = scheduler.getSchedule(scheduleId);
+    authorizationEnforcer.enforce(schedule.getProgramId(), authenticationContext.getPrincipal(), Action.EXECUTE);
+    scheduler.disableSchedule(scheduleId);
+  }
+
+  /**
+   * Resume the given schedule
+   *
+   * @param scheduleId the schedule to suspend
+   * @throws NotFoundException if the schedule could not be found
+   * @throws UnauthorizedException if the principal is not authorized to suspend the schedule
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public void resume(ScheduleId scheduleId) throws Exception {
+    ProgramSchedule schedule = scheduler.getSchedule(scheduleId);
+    authorizationEnforcer.enforce(schedule.getProgramId(), authenticationContext.getPrincipal(), Action.EXECUTE);
+    scheduler.enableSchedule(scheduleId);
+  }
+
+  /**
+   * Delete the given schedule
+   *
+   * @param scheduleId the schedule to delete
+   * @throws NotFoundException if the schedule could not be found
+   * @throws UnauthorizedException if the principal is not authorized to delete the schedule
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  public void delete(ScheduleId scheduleId) throws Exception {
+    authorizationEnforcer.enforce(scheduleId.getParent(), authenticationContext.getPrincipal(), Action.ADMIN);
+    scheduler.deleteSchedule(scheduleId);
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -313,7 +313,7 @@ public class AppFabricClient {
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     try {
       workflowHttpHandler.getWorkflowSchedules(request, responder, namespace, app, workflow, null, null, null);
-    } catch (BadRequestException e) {
+    } catch (Exception e) {
       // cannot happen
       throw Throwables.propagate(e);
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1470,8 +1470,12 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.getStatusLine().getStatusCode());
 
     // trying to update a non-existing schedule should fail
+    ScheduleDetail nonExistingSchedule = new ScheduleDetail("NonExistingSchedule", "updatedDescription", null,
+                                                            ImmutableMap.of("twoKey", "twoValue"),
+                                                            new TimeTrigger("0 4 * * *"),
+                                                            ImmutableList.of(new ConcurrencyConstraint(5)), null);
     response = updateSchedule(TEST_NAMESPACE1, AppWithSchedule.NAME, null,
-                              "NonExistingSchedule", updateDetail);
+                              "NonExistingSchedule", nonExistingSchedule);
     Assert.assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.getStatusLine().getStatusCode());
 
     // should be able to update an existing schedule with a valid new time schedule

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
@@ -149,7 +149,8 @@ public enum ProgramType {
   public static ProgramType valueOfCategoryName(String categoryName) {
     ProgramType type = CATEGORY_MAP.get(categoryName);
     if (type == null) {
-      throw new IllegalArgumentException("Unknown category name " + categoryName);
+      throw new IllegalArgumentException(String.format("Unknown category name '%s'. Must be one of %s",
+                                                       categoryName, String.join(",", CATEGORY_MAP.keySet())));
     }
     return type;
   }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -77,6 +77,7 @@ import co.cask.cdap.explore.guice.ExploreRuntimeModule;
 import co.cask.cdap.gateway.handlers.AuthorizationHandler;
 import co.cask.cdap.internal.app.runtime.messaging.BasicMessagingAdmin;
 import co.cask.cdap.internal.app.runtime.messaging.MultiThreadMessagingContext;
+import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.ProgramNotificationSubscriberService;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
@@ -203,6 +204,7 @@ public class TestBase {
   private static Scheduler programScheduler;
   private static MessagingContext messagingContext;
   private static PreviewManager previewManager;
+  private static ProgramLifecycleService programLifecycleService;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -305,6 +307,8 @@ public class TestBase {
     metricsQueryService.startAndWait();
     metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
     metricsCollectionService.startAndWait();
+    programLifecycleService = injector.getInstance(ProgramLifecycleService.class);
+    programLifecycleService.startAndWait();
     programNotificationSubscriberService = injector.getInstance(ProgramNotificationSubscriberService.class);
     programNotificationSubscriberService.startAndWait();
     scheduler = injector.getInstance(Scheduler.class);
@@ -475,6 +479,7 @@ public class TestBase {
       return;
     }
 
+
     if (cConf.getBoolean(Constants.Security.Authorization.ENABLED)) {
       InstanceId instance = new InstanceId(cConf.get(Constants.INSTANCE_NAME));
       Principal principal = new Principal(System.getProperty("user.name"), Principal.PrincipalType.USER);
@@ -489,6 +494,7 @@ public class TestBase {
     if (programScheduler instanceof Service) {
       ((Service) programScheduler).stopAndWait();
     }
+    programLifecycleService.stopAndWait();
     streamCoordinatorClient.stopAndWait();
     metricsQueryService.stopAndWait();
     metricsCollectionService.stopAndWait();


### PR DESCRIPTION
Moving Scheduler out of ProgramLifecycleService to avoid a
circular dependency chain with ProgramLifecycleService to
CoreSchedulerService to ConstraintCheckerService back to
ProgramLifecycleService.

Also starting ProgramLifecycleService in TestBase in preparation
for cluster lifecycle changes, and to make sure that
ProgramLifecycleService can be instantiated.