### PR TITLE
(CDAP-13218) Distinguish program state based on user actions

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -567,6 +567,11 @@ public class AppMetadataStore extends MetadataStoreDataset implements TopicMessa
    */
   private boolean validateExistingRecord(@Nullable RunRecordMeta existing, ProgramId programId, String pid,
                                          byte[] sourceId, String recordType, ProgramRunStatus status) {
+    // If there is no change of the state, no need to update and no need to log
+    if (existing != null && existing.getStatus() == status) {
+      return false;
+    }
+
     Set<ProgramRunStatus> allowedStatuses = ALLOWED_STATUSES.get(status);
     Set<ProgramRunStatus> allowedWithLogStatuses = ALLOWED_WITH_LOG_STATUSES.get(status);
     if (allowedStatuses == null || allowedWithLogStatuses == null) {


### PR DESCRIPTION
- Fix for Workflow, MR, and Spark that when user initiate a stop, emit KILLED instead of FAILED
- Ignore program run status event that won’t change the state in run record