### PR TITLE
CDAP-2388 Upgrade guice version to 4.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <grok.version>0.1.0</grok.version>
     <gson.version>2.2.4</gson.version>
     <guava.version>13.0.1</guava.version>
-    <guice.version>3.0</guice.version>
+    <guice.version>4.2.0</guice.version>
     <hadoop.version>2.3.0</hadoop.version>
     <hbase10.version>1.0.1.1</hbase10.version>
     <hbase10cdh.version>1.0.0-cdh5.4.4</hbase10cdh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <grok.version>0.1.0</grok.version>
     <gson.version>2.2.4</gson.version>
     <guava.version>13.0.1</guava.version>
-    <guice.version>4.2.0</guice.version>
+    <guice.version>4.0</guice.version>
     <hadoop.version>2.3.0</hadoop.version>
     <hbase10.version>1.0.1.1</hbase10.version>
     <hbase10cdh.version>1.0.0-cdh5.4.4</hbase10cdh.version>


### PR DESCRIPTION
[CDAP-2388](https://issues.cask.co/browse/CDAP-2388) This is in order to help support Java 8.
For changes, see: https://github.com/google/guice/wiki/Guice40

Unit tests: https://builds.cask.co/browse/CDAP-DUT6345-3
Integration tests: https://builds.cask.co/browse/IT-ITM-19