### PR TITLE
[CDAP-13207][Cloud] Allow users to select a profile while manually running a pipeline

### DIFF
--- a/cdap-ui/app/cdap/api/cloud.js
+++ b/cdap-ui/app/cdap/api/cloud.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
+import {apiCreator} from 'services/resource-helper';
+let dataSrc = DataSourceConfigurer.getInstance();
+
+var basepath = '/namespaces/:namespace';
+export const MyProfileApi = {
+  list: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/profiles`)
+};

--- a/cdap-ui/app/cdap/components/KeyValuePairs/KeyValuePair.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/KeyValuePair.js
@@ -40,6 +40,10 @@ class KeyValuePair extends Component {
     onPaste: PropTypes.func
   };
 
+  static defaultProps = {
+    getResettedKeyValue: () => {}
+  };
+
   handlePaste = (e) => {
     let data = e.clipboardData.getData('text');
     try {
@@ -135,8 +139,9 @@ class KeyValuePair extends Component {
   }
 
   renderProvidedCheckboxAndResetBtn() {
-    if (!this.props.notDeletable) { return null; }
-
+    if (typeof this.props.provided !== 'boolean') {
+      return null;
+    }
     return (
       <span>
         <input

--- a/cdap-ui/app/cdap/components/KeyValuePairs/KeyValueStore.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/KeyValueStore.js
@@ -27,6 +27,13 @@ const initialState = {
   pairs: []
 };
 
+export const getDefaultKeyValuePair = () => ({
+  key : '',
+  value : '',
+  uniqueId: uuidV4(),
+  provided: null
+});
+
 const keyValues = (state = initialState, action = defaultAction) => {
   let stateCopy;
   switch (action.type) {
@@ -53,23 +60,13 @@ const keyValues = (state = initialState, action = defaultAction) => {
       return stateCopy;
     case KeyValueStoreActions.addPair:
       stateCopy = Object.assign({}, state);
-      stateCopy.pairs.splice(action.payload.index + 1, 0, {
-        key : '',
-        value: '',
-        uniqueId: uuidV4(),
-        provided: false
-      });
+      stateCopy.pairs.splice(action.payload.index + 1, 0, getDefaultKeyValuePair());
       return stateCopy;
     case KeyValueStoreActions.deletePair:
       stateCopy = Object.assign({}, state);
       stateCopy.pairs.splice(action.payload.index, 1);
       if (!stateCopy.pairs.length) {
-        stateCopy.pairs.push({
-          key : '',
-          value : '',
-          uniqueId: uuidV4(),
-          provided: false
-        });
+        stateCopy.pairs.push(getDefaultKeyValuePair());
       }
       return stateCopy;
     case KeyValueStoreActions.onReset:

--- a/cdap-ui/app/cdap/components/KeyValuePairs/KeyValueStoreActions.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/KeyValueStoreActions.js
@@ -15,6 +15,7 @@
 */
 
 import uuid from 'uuid/v4';
+import {getDefaultKeyValuePair} from 'components/KeyValuePairs/KeyValueStore';
 
 const KeyValueStoreActions = {
   setKey: 'SET-KEY',
@@ -36,11 +37,7 @@ const convertMapToKeyValuePairsObj = (obj) => {
     };
   });
   if (!keyValuePairsObj.pairs.length) {
-    keyValuePairsObj.pairs.push({
-      key: '',
-      value: '',
-      uniqueId: 'id-' + uuid()
-    });
+    keyValuePairsObj.pairs.push(getDefaultKeyValuePair());
   }
   return keyValuePairsObj;
 };

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ListViewInPipeline.scss
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ListViewInPipeline.scss
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../../styles/mixins.scss";
+@import "../../../../styles/variables.scss";
+
+.profiles-list-view-on-pipeline {
+  @include grid();
+
+  .grid.grid-container {
+    .grid-item {
+      grid-template-columns: 30px 1fr 1fr 1fr;
+    }
+    .grid-header {
+      .grid-item {
+        background: $grey-07;
+        padding: 5px 0;
+      }
+    }
+    .grid-body {
+      .grid-item {
+        padding: 3px 0;
+        &:hover,
+        &.active {
+          background: $yellow-02-lighter;
+        }
+      }
+    }
+  }
+  .profiles-count {
+    color: $grey-04;
+    margin: 5px 0;
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView.js
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component} from 'react';
+import {MyProfileApi} from 'api/cloud';
+import {getCurrentNamespace} from 'services/NamespaceStore';
+import LoadingSVG from 'components/LoadingSVG';
+import classnames from 'classnames';
+import IconSVG from 'components/IconSVG';
+import {MyPreferenceApi} from 'api/preference';
+import {Observable} from 'rxjs/Observable';
+import PipelineDetailStore from 'components/PipelineDetails/store';
+import PipelineConfigurationsStore, {ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
+import {updatePipelineEditStatus} from 'components/PipelineConfigurations/Store/ActionCreator';
+import findIndex from 'lodash/findIndex';
+import uuidV4 from 'uuid/v4';
+
+require('./ListViewInPipeline.scss');
+
+export const PROFILE_NAME_PREFERENCE_PROPERTY = 'system.profile.name';
+export default class ProfilesListViewInPipeline extends Component {
+
+  state = {
+    profiles: [],
+    loading: true,
+    selectedProfile: null
+  };
+
+  componentWillMount() {
+    let appId = PipelineDetailStore.getState().name;
+    Observable.forkJoin(
+      MyProfileApi.list({
+        namespace: getCurrentNamespace()
+      }),
+      MyPreferenceApi.getAppPreferences({
+        namespace: getCurrentNamespace(),
+        appId
+      })
+    )
+      .subscribe(
+        ([profiles = [], preferences = {}]) => {
+          let selectedProfile = preferences[PROFILE_NAME_PREFERENCE_PROPERTY];
+          this.setState({
+            loading: false,
+            profiles,
+            selectedProfile
+          });
+        },
+        (err) => {
+          console.log('ERROR in fetching profiles from backend: ', err);
+        }
+      );
+  }
+
+  onProfileSelect = (profileName) => {
+    this.setState({
+      selectedProfile: profileName
+    });
+    let {runtimeArgs} = PipelineConfigurationsStore.getState();
+    let pairs = [...runtimeArgs.pairs];
+    pairs = pairs.filter(pair => pair.key.length);
+    let existingProfile = findIndex(pairs, (pair) => pair.key === PROFILE_NAME_PREFERENCE_PROPERTY);
+    if (existingProfile === -1) {
+      pairs.push({
+        key: PROFILE_NAME_PREFERENCE_PROPERTY,
+        value: profileName,
+        uniqueId: 'id-' + uuidV4()
+      });
+    } else {
+      pairs[existingProfile].value = profileName;
+    }
+    PipelineConfigurationsStore.dispatch({
+      type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
+      payload: { runtimeArgs: { pairs } }
+    });
+    updatePipelineEditStatus();
+  };
+
+  renderGridHeader = () => {
+    return (
+      <div className="grid-header">
+        <div className="grid-item">
+          <div></div>
+          <strong>Profile Name</strong>
+          <strong>Provider</strong>
+          <strong>Scope</strong>
+        </div>
+      </div>
+    );
+  };
+
+  renderGridBody = () => {
+    return (
+      <div className="grid-body">
+        {
+          this.state.profiles.map(profile => {
+            return (
+              <div
+                className={classnames("grid-item", {
+                  "active": this.state.selectedProfile === profile.name
+                })}
+                onClick={this.onProfileSelect.bind(this, profile.name)}
+              >
+                <div>
+                  {
+                    this.state.selectedProfile === profile.name ? (
+                      <IconSVG name="icon-check" className="text-success" />
+                    ) : null
+                  }
+                </div>
+                <div>{profile.name}</div>
+                <div>{profile.provisionerInfo.name}</div>
+                <div>{profile.scope}</div>
+              </div>
+            );
+          })
+        }
+      </div>
+    );
+  };
+
+  renderGrid = () => {
+    if (!this.state.profiles.length) {
+      return (
+        <div>
+          <strong> No Profiles created </strong>
+          <div>
+            <a href={`/cdap/ns/${getCurrentNamespace()}/create-profile`}>
+              Click here
+            </a>
+            <span> to create one </span>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div>
+        <strong> Select the compute profile you want to use to run this pipeline</strong>
+        <div className="profiles-count text-right">{this.state.profiles.length} Compute Profiles</div>
+        <div className="grid grid-container">
+          {this.renderGridHeader()}
+          {this.renderGridBody()}
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+    if (this.state.loading) {
+      return (
+        <div>
+          <LoadingSVG />
+        </div>
+      );
+    }
+    return (
+      <div className="profiles-list-view-on-pipeline">
+        {this.renderGrid()}
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/index.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, { Component } from 'react';
+import ProfilesListViewInPipeline from 'components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView';
+
+export default class ComputeTabContent extends Component {
+  render() {
+    return (
+      <div className="compute-tab-content">
+        <ProfilesListViewInPipeline />
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessRuntimeArgsCount.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessRuntimeArgsCount.js
@@ -21,6 +21,7 @@ import T from 'i18n-react';
 import {TAB_OPTIONS} from 'components/PipelineConfigurations/Store';
 import {convertKeyValuePairsObjToMap} from 'components/KeyValuePairs/KeyValueStoreActions';
 import isEmpty from 'lodash/isEmpty';
+import {getFilteredRuntimeArgs} from 'components/PipelineConfigurations/Store/ActionCreator';
 
 const PREFIX = 'features.PipelineConfigurations.ActionButtons';
 
@@ -40,7 +41,7 @@ const ConfigModelessRuntimeArgsCount = ({runtimeArgs, activeTab, isHistoricalRun
 
   return (
     <span className="num-runtime-args">
-      {T.translate(`${PREFIX}.runtimeArgsCount`, {context: runtimeArgs.pairs.length})}
+      {T.translate(`${PREFIX}.runtimeArgsCount`, {context: getFilteredRuntimeArgs().pairs.length})}
     </span>
   );
 };

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.js
@@ -16,12 +16,19 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {applyRuntimeArgs, updatePipeline, runPipeline, schedulePipeline} from 'components/PipelineConfigurations/Store/ActionCreator';
+import {
+  applyRuntimeArgs,
+  updatePipeline,
+  runPipeline,
+  schedulePipeline,
+  updatePreferences
+} from 'components/PipelineConfigurations/Store/ActionCreator';
 import ConfigModelessSaveAndRunBtn from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessSaveAndRunBtn';
 import ConfigModelessSaveAndScheduleBtn from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessSaveAndScheduleBtn';
 import ConfigModelessSaveBtn from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessSaveBtn';
 import ConfigModelessRuntimeArgsCount from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessRuntimeArgsCount';
 import ConfigModelessCopyRuntimeArgsBtn from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessCopyRuntimeArgsBtn';
+import {Observable} from 'rxjs/Observable';
 
 require('./ConfigModelessActionButtons.scss');
 
@@ -62,27 +69,30 @@ export default class ConfigModelessActionButtons extends Component {
 
   saveAndRun = (pipelineEdited) => {
     this.saveAndAction(pipelineEdited, 'saveAndRunLoading', this.closeModelessAndRun);
-  }
+  };
 
   saveAndSchedule = (pipelineEdited) => {
     this.saveAndAction(pipelineEdited, 'saveAndScheduleLoading', this.closeModelessAndSchedule);
-  }
+  };
 
   saveConfig = (pipelineEdited) => {
     this.saveAndAction(pipelineEdited, 'saveLoading', this.closeModeless);
   };
 
-  saveAndAction(pipelineEdited, loadingState, actionFn) {
-    applyRuntimeArgs();
+  saveAndAction = (pipelineEdited, loadingState, actionFn) => {
     if (!pipelineEdited) {
       actionFn();
       return;
     }
+    applyRuntimeArgs();
 
     this.setState({
       [loadingState]: true
     });
-    updatePipeline()
+    Observable.forkJoin(
+      updatePipeline(),
+      updatePreferences()
+    )
       .subscribe(() => {
         actionFn();
       }, (err) => {
@@ -92,7 +102,7 @@ export default class ConfigModelessActionButtons extends Component {
           [loadingState]: false
         });
       });
-  }
+  };
 
   setRuntimeArgsCopiedState = () => {
     this.setState({

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/RuntimeArgsTabContent/RuntimeArgsPairs.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/RuntimeArgsTabContent/RuntimeArgsPairs.js
@@ -17,11 +17,15 @@
 import KeyValuePairs from 'components/KeyValuePairs';
 import {connect} from 'react-redux';
 import {ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
-import {updateKeyValueStore} from 'components/PipelineConfigurations/Store/ActionCreator';
+import {
+  updateKeyValueStore,
+  getFilteredRuntimeArgs,
+  updateRunTimeArgs
+} from 'components/PipelineConfigurations/Store/ActionCreator';
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    keyValues: state.runtimeArgs,
+    keyValues: getFilteredRuntimeArgs(ownProps.disabled),
     disabled: ownProps.disabled,
     onPaste: ownProps.onPaste
   };
@@ -29,12 +33,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    onKeyValueChange: (keyValues) => {
-      dispatch({
-        type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
-        payload: { runtimeArgs: keyValues }
-      });
-    },
+    onKeyValueChange: updateRunTimeArgs,
     getResettedKeyValue: (index) => {
       dispatch({
         type: PipelineConfigurationsActions.RESET_RUNTIME_ARG_TO_RESOLVED_VALUE,

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/index.js
@@ -23,6 +23,7 @@ import EngineConfigTabContent from 'components/PipelineConfigurations/Configurat
 import ResourcesTabContent from 'components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent';
 import AlertsTabContent from 'components/PipelineConfigurations/ConfigurationsContent/AlertsTabContent';
 import ConfigModelessActionButtons from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons';
+import ComputeTabContent from 'components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent';
 import classnames from 'classnames';
 require('./ConfigurationsContent.scss');
 
@@ -43,6 +44,9 @@ export default function ConfigurationsContent({isBatch, activeTab, isDetailView,
       break;
     case TAB_OPTIONS.ALERTS:
       ContentToShow = AlertsTabContent;
+      break;
+    case TAB_OPTIONS.COMPUTECONFIG:
+      ContentToShow = ComputeTabContent;
       break;
   }
   return (

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsSidePanel/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsSidePanel/index.js
@@ -74,6 +74,12 @@ export default function ConfigurationsSidePanel({isDetailView, isPreview, isBatc
                 {T.translate(`${PREFIX}.PipelineConfig.title`)}
               </div>
               <div
+                className={classnames("configuration-tab", {"active": activeTab === TAB_OPTIONS.COMPUTECONFIG})}
+                onClick={onTabChange.bind(null, TAB_OPTIONS.COMPUTECONFIG)}
+              >
+                {T.translate(`${PREFIX}.ComputeConfig.title`)}
+              </div>
+              <div
                 className={classnames("configuration-tab", {"active": activeTab === TAB_OPTIONS.ENGINE_CONFIG})}
                 onClick={onTabChange.bind(null, TAB_OPTIONS.ENGINE_CONFIG)}
               >

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -17,20 +17,74 @@
 import PipelineConfigurationsStore, {ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
 import PipelineDetailStore, {ACTIONS as PipelineDetailActions} from 'components/PipelineDetails/store';
 import {setRunButtonLoading, setRunError, setScheduleButtonLoading, setScheduleError, fetchScheduleStatus} from 'components/PipelineDetails/store/ActionCreator';
-import KeyValueStore from 'components/KeyValuePairs/KeyValueStore';
-import KeyValueStoreActions from 'components/KeyValuePairs/KeyValueStoreActions';
-import {convertKeyValuePairsObjToMap} from 'components/KeyValuePairs/KeyValueStoreActions';
+import KeyValueStore, {getDefaultKeyValuePair} from 'components/KeyValuePairs/KeyValueStore';
+import KeyValueStoreActions, {convertKeyValuePairsObjToMap} from 'components/KeyValuePairs/KeyValueStoreActions';
 import {GLOBALS} from 'services/global-constants';
 import {MyPipelineApi} from 'api/pipeline';
 import {MyProgramApi} from 'api/program';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import cloneDeep from 'lodash/cloneDeep';
+import { MyPreferenceApi } from 'api/preference';
+import {Observable} from 'rxjs/Observable';
+import difference from 'lodash/difference';
+import {PROFILE_NAME_PREFERENCE_PROPERTY} from 'components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView';
+
+const RUNTIME_ARGS_TO_SKIP_DURING_DISPLAY = [
+  PROFILE_NAME_PREFERENCE_PROPERTY,
+  'logical.start.time'
+];
 
 const applyRuntimeArgs = () => {
   let runtimeArgs = PipelineConfigurationsStore.getState().runtimeArgs;
   PipelineConfigurationsStore.dispatch({
     type: PipelineConfigurationsActions.SET_SAVED_RUNTIME_ARGS,
     payload: { savedRuntimeArgs: cloneDeep(runtimeArgs) }
+  });
+};
+
+// Filter certain preferences from being shown in the run time arguments 
+// They are being represented in other places (like selected compute profile).
+const getFilteredRuntimeArgs = (hideProvided) => {
+  let {runtimeArgs, resolvedMacros} = PipelineConfigurationsStore.getState();
+  let modifiedRuntimeArgs = {};
+  let pairs = [...runtimeArgs.pairs];
+  pairs = pairs
+    .filter(pair => (RUNTIME_ARGS_TO_SKIP_DURING_DISPLAY.indexOf(pair.key) === -1))
+    .map(pair => {
+      if (pair.key in resolvedMacros) {
+        return {
+          notDeletable: true,
+          provided: hideProvided ? null : pair.provided || false,
+          ...pair
+        };
+      }
+      return {
+        ...pair,
+        // This is needed because KeyValuePair will render a checkbox only if the provided is a boolean.
+        provided: null
+      };
+    });
+  if (!pairs.length) {
+    pairs.push(getDefaultKeyValuePair());
+  }
+  modifiedRuntimeArgs.pairs = pairs;
+  return modifiedRuntimeArgs;
+};
+
+// While adding runtime argument make sure to include the excluded preferences
+const updateRunTimeArgs = (rtArgs) => {
+  let {runtimeArgs} = PipelineConfigurationsStore.getState();
+  let modifiedRuntimeArgs = {};
+  let excludedPairs = [...runtimeArgs.pairs];
+  const preferencesToFilter = [PROFILE_NAME_PREFERENCE_PROPERTY];
+  excludedPairs = excludedPairs.filter(pair => preferencesToFilter.indexOf(pair.key) !== -1);
+  modifiedRuntimeArgs.pairs = rtArgs.pairs.concat(excludedPairs);
+  updatePipelineEditStatus();
+  PipelineConfigurationsStore.dispatch({
+    type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,
+    payload: {
+      runtimeArgs: modifiedRuntimeArgs
+    }
   });
 };
 
@@ -72,6 +126,22 @@ const getMacrosResolvedByPrefs = (resolvedPrefs = {}, macrosMap = {}) => {
   return resolvedMacros;
 };
 
+const updatePreferences = () => {
+  let {runtimeArgs} = PipelineConfigurationsStore.getState();
+  let appId = PipelineDetailStore.getState().name;
+  let prefObj = convertKeyValuePairsObjToMap(runtimeArgs);
+
+  if (!Object.keys(prefObj).length) {
+    return Observable.create((observer) => {
+      observer.next();
+    });
+  }
+  return MyPreferenceApi.setAppPreferences({
+    namespace: getCurrentNamespace(),
+    appId
+  }, prefObj);
+};
+
 const updatePipelineEditStatus = () => {
   const isResourcesEqual = (oldvalue, newvalue) => {
     return oldvalue.memoryMB === newvalue.memoryMB && oldvalue.virtualCores === newvalue.virtualCores;
@@ -86,8 +156,16 @@ const updatePipelineEditStatus = () => {
   let isInstrumentationModified = oldConfig.processTimingEnabled !== updatedConfig.processTimingEnabled;
   let isStageLoggingModified = oldConfig.stageLoggingEnabled !== updatedConfig.stageLoggingEnabled;
   let isCustomEngineConfigModified = oldConfig.properties !== updatedConfig.properties;
+  let isRunTimeArgsModified = difference(updatedConfig.runtimeArgs, updatedConfig.savedRuntimeArgs);
 
-  let isModified = isResourcesModified || isDriverResourcesModidified || isInstrumentationModified || isStageLoggingModified || isCustomEngineConfigModified;
+  let isModified = (
+    isResourcesModified ||
+    isDriverResourcesModidified ||
+    isInstrumentationModified ||
+    isStageLoggingModified ||
+    isCustomEngineConfigModified ||
+    isRunTimeArgsModified
+  );
 
   if (PipelineDetailStore.getState().artifact.name === GLOBALS.etlDataStreams) {
     let isClientResourcesModified = !isResourcesEqual(oldConfig.clientResources, updatedConfig.clientResources);
@@ -181,7 +259,6 @@ const updatePipeline = () => {
 const runPipeline = () => {
   setRunButtonLoading(true);
   let { name, artifact } = PipelineDetailStore.getState();
-  let { runtimeArgs  } = PipelineConfigurationsStore.getState();
 
   let params = {
     namespace: getCurrentNamespace(),
@@ -190,8 +267,7 @@ const runPipeline = () => {
     programId: GLOBALS.programId[artifact.name],
     action: 'start'
   };
-  runtimeArgs = convertKeyValuePairsObjToMap(runtimeArgs);
-  MyProgramApi.action(params, runtimeArgs)
+  MyProgramApi.action(params)
   .subscribe(
     () => {},
     (err) => {
@@ -235,11 +311,14 @@ const reset = () => {
 
 export {
   applyRuntimeArgs,
+  getFilteredRuntimeArgs,
+  updateRunTimeArgs,
   revertConfigsToSavedValues,
   updateKeyValueStore,
   getMacrosResolvedByPrefs,
   updatePipelineEditStatus,
   updatePipeline,
+  updatePreferences,
   runPipeline,
   schedulePipeline,
   suspendSchedule,

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
@@ -30,6 +30,7 @@ import {createStore} from 'redux';
 import {HYDRATOR_DEFAULT_VALUES} from 'services/global-constants';
 import range from 'lodash/range';
 import {convertMapToKeyValuePairsObj, keyValuePairsHaveMissingValues} from 'components/KeyValuePairs/KeyValueStoreActions';
+import {getDefaultKeyValuePair} from 'components/KeyValuePairs/KeyValueStore';
 import uuidV4 from 'uuid/v4';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -67,7 +68,8 @@ const TAB_OPTIONS = {
   PIPELINE_CONFIG: 'pipelineConfig',
   ENGINE_CONFIG: 'engineConfig',
   RESOURCES: 'resources',
-  ALERTS: 'alerts'
+  ALERTS: 'alerts',
+  COMPUTECONFIG: 'computeConfig'
 };
 
 const BATCH_INTERVAL_RANGE = range(1, 61);
@@ -89,11 +91,7 @@ const ENGINE_OPTIONS = {
 };
 
 const DEFAULT_RUNTIME_ARGS = {
-  'pairs': [{
-    key : '',
-    value : '',
-    uniqueId : uuidV4()
-  }]
+  'pairs': [getDefaultKeyValuePair()]
 };
 
 const DEFAULT_CONFIGURE_OPTIONS = {

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/index.js
@@ -93,13 +93,13 @@ export default class PipelineConfigurations extends Component {
     this.setState({
       activeTab: tab
     });
-  }
+  };
 
   toggleAdvancedTabs = () => {
     this.setState({
       showAdvancedTabs: !this.state.showAdvancedTabs
     });
-  }
+  };
 
   renderHeader() {
     let headerLabel;

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineConfigureButton.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineConfigureButton.js
@@ -19,12 +19,8 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import IconSVG from 'components/IconSVG';
 import PipelineConfigurations from 'components/PipelineConfigurations';
-import {MyPreferenceApi} from 'api/preference';
-import {getCurrentNamespace} from 'services/NamespaceStore';
-import PipelineConfigurationsStore, {ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
-import {revertConfigsToSavedValues, getMacrosResolvedByPrefs} from 'components/PipelineConfigurations/Store/ActionCreator';
-import isEqual from 'lodash/isEqual';
 import T from 'i18n-react';
+import {fetchAndUpdateRuntimeArgs} from 'components/PipelineDetails/store/ActionCreator';
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
 
@@ -42,35 +38,7 @@ export default class PipelineConfigureButton extends Component {
 
   getRuntimeArgumentsAndToggleModeless = () => {
     if (!this.state.showModeless) {
-      if (Object.keys(this.props.resolvedMacros).length !== 0) {
-        MyPreferenceApi
-          .getAppPreferencesResolved({
-            namespace: getCurrentNamespace(),
-            appId: this.props.pipelineName
-          })
-          .subscribe(res => {
-            let newResolvedMacros = getMacrosResolvedByPrefs(res, this.props.resolvedMacros);
-
-            // If preferences have changed, then update macro values with new preferences.
-            // Otherwise, keep the values as they are
-            if (!isEqual(newResolvedMacros, this.props.resolvedMacros)) {
-              PipelineConfigurationsStore.dispatch({
-                type: PipelineConfigurationsActions.SET_RESOLVED_MACROS,
-                payload: { resolvedMacros: newResolvedMacros }
-              });
-            }
-            revertConfigsToSavedValues();
-            this.toggleModeless();
-          }, (err) => {
-            console.log(err);
-          });
-      } else {
-        revertConfigsToSavedValues();
-        // Have to set timeout here to make sure any other config modeless will be closed
-        // before opening this one
-        setTimeout(() => this.toggleModeless());
-      }
-
+      fetchAndUpdateRuntimeArgs().subscribe(this.toggleModeless);
     } else {
       this.toggleModeless();
     }

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
@@ -21,13 +21,9 @@ import PipelineDetailsButtons from 'components/PipelineDetails/PipelineDetailsTo
 import PipelineDetailsDetailsActions from 'components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions';
 import PipelineDetailStore from 'components/PipelineDetails/store';
 import PipelineConfigurationsStore, {ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
-import {getMacrosResolvedByPrefs} from 'components/PipelineConfigurations/Store/ActionCreator';
 import PlusButton from 'components/PlusButton';
-import {getCurrentNamespace} from 'services/NamespaceStore';
-import {MyPipelineApi} from 'api/pipeline';
-import {MyPreferenceApi} from 'api/preference';
-import {objectQuery} from 'services/helpers';
 import {GLOBALS} from 'services/global-constants';
+import {fetchAndUpdateRuntimeArgs} from 'components/PipelineDetails/store/ActionCreator';
 
 require('./PipelineDetailsTopPanel.scss');
 
@@ -59,42 +55,12 @@ export default class PipelineDetailsTopPanel extends Component {
     });
   }
   componentDidMount() {
-    const params = {
-      namespace: getCurrentNamespace(),
-      appId: PipelineDetailStore.getState().name
-    };
-
-    MyPipelineApi.fetchMacros(params)
-      .combineLatest(MyPreferenceApi.getAppPreferencesResolved(params))
-      .subscribe((res) => {
-        let macrosSpec = res[0];
-        let macrosMap = {};
-        let macros = [];
-        macrosSpec.map(ms => {
-          if (objectQuery(ms, 'spec', 'properties', 'macros', 'lookupProperties')) {
-            macros = macros.concat(ms.spec.properties.macros.lookupProperties);
-          }
-        });
-        macros.forEach(macro => {
-          macrosMap[macro] = '';
-        });
-
-        let currentAppPrefs = res[1];
-        let resolvedMacros = getMacrosResolvedByPrefs(currentAppPrefs, macrosMap);
-
-        PipelineConfigurationsStore.dispatch({
-          type: PipelineConfigurationsActions.SET_RESOLVED_MACROS,
-          payload: { resolvedMacros }
-        });
-      }, (err) => {
-        console.log(err);
-      }
-    );
+    fetchAndUpdateRuntimeArgs();
   }
   render() {
     return (
       <Provider store={PipelineDetailStore}>
-        <div className = "pipeline-details-top-panel">
+        <div className="pipeline-details-top-panel">
           <PipelineDetailsMetadata />
           <ConnectedPipelineDetailsButtons />
           <PipelineDetailsDetailsActions />

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunConfigs.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunConfigs.js
@@ -49,7 +49,7 @@ export default class RunConfigs extends Component {
       let runtimeArgs = objectQuery(this.props.currentRun, 'properties', 'runtimeArgs') || '';
       try {
         runtimeArgs = JSON.parse(runtimeArgs);
-        delete runtimeArgs['logical.start.time'];
+        delete runtimeArgs[''];
       } catch (e) {
         console.log('ERROR: Cannot parse runtime arguments');
         runtimeArgs = {};

--- a/cdap-ui/app/cdap/styles/variables.scss
+++ b/cdap-ui/app/cdap/styles/variables.scss
@@ -143,6 +143,7 @@ $red-02: #d40001;
 $red-03: #d15668;
 $yellow-01: #ffba01;
 $yellow-02: #ffd500;
+$yellow-02-lighter: transparentize($color: $yellow-02, $amount: 0.7);
 $green-01: #01b133;
 $green-02: #3cc801;
 $green-03: #8af302;

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1404,6 +1404,8 @@ features:
     Alerts:
       contentHeading: Set alerts for your batch pipeline
       title: Alerts
+    ComputeConfig:
+      title: Compute Config
     EngineConfig:
       backpressure: Backpressure
       backpressureTooltip: Allows the Apache Spark Streaming engine to control the receiving rate based on the current batch scheduling delays and processing times so that the system receives only as fast as the system can process.


### PR DESCRIPTION
- Adds the "Compute Config" to the pipeline configure modeless
- Adds the ability to save the run time arguments in app preference to make it persistent across runs
  - This will happen when we fetch resolved app preferences + macros and form the run time arguments everytime when we open the configure modeless
  - The same done when the pipeline is loaded for the first time
  - And when the pipeline is run.
- To summarize this is the change in the way we surface run time arguments in UI
  1. A pipeline developer sets 5 macros in his pipeline
  2. the UI shows all 5 in the modeless
  3. If any of those have been defined at either the pipeline or the namespace level, the UI resolves them
  4. If a value is not available as a preference, and the user does not set it, and the user does not select the provided box, the UI doesn’t allow the user to run the pipeline.
  5. If the provided checkbox is checked, the UI removes that restriction
- This is a follow up PR after this: https://github.com/caskdata/cdap/pull/9972. 

JIRA: https://issues.cask.co/browse/CDAP-13207

#### Note:
- There is a usecase where, when the pipeline has macros, the user would be forced to fill out the macros in run time arguments pane before trying to save/change a profile for the pipeline.
