### PR TITLE
[CDAP-13180] Highlight newly added/edited prefs, and adds View All/View Less prefs labels in Namespace Details page

### DIFF
--- a/cdap-ui/app/cdap/components/Administration/index.js
+++ b/cdap-ui/app/cdap/components/Administration/index.js
@@ -279,7 +279,6 @@ class Administration extends Component {
           isOpen={this.state.preferenceModal}
           toggleModal={this.togglePreferenceModal}
           onSuccess={this.onSystemPreferencesSaved}
-          setAtSystemLevel={true}
         />
       </div>
     );

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
@@ -21,7 +21,7 @@ import FastActionButton from '../FastActionButton';
 import T from 'i18n-react';
 import {Tooltip} from 'reactstrap';
 import classnames from 'classnames';
-import SetPreferenceModal from 'components/FastAction/SetPreferenceAction/SetPreferenceModal';
+import SetPreferenceModal, {PREFERENCES_LEVEL} from 'components/FastAction/SetPreferenceAction/SetPreferenceModal';
 import NamespaceStore from 'services/NamespaceStore';
 require('./SetPreferenceAction.scss');
 
@@ -76,7 +76,10 @@ export default class SetPreferenceAction extends Component {
 
   render() {
     const actionLabel = T.translate('features.FastAction.setPreferencesActionLabel');
-    let iconClasses = classnames({'fa-lg': this.props.setAtNamespaceLevel}, {'text-success': this.state.preferencesSaved});
+    let iconClasses = classnames(
+      {'fa-lg': this.props.setAtLevel === PREFERENCES_LEVEL.NAMESPACE},
+      {'text-success': this.state.preferencesSaved}
+    );
     let tooltipID = `${this.namespace}-setpreferences`;
     if (this.props.entity) {
       tooltipID = `setpreferences-${this.props.entity.uniqueId}`;
@@ -107,6 +110,7 @@ export default class SetPreferenceAction extends Component {
               toggleModal={this.toggleModal}
               entity={this.props.entity}
               onSuccess={this.onSuccess}
+              setAtLevel={this.props.setAtLevel}
             />
           :
             null
@@ -124,14 +128,13 @@ SetPreferenceAction.propTypes = {
     type: PropTypes.oneOf(['application', 'program']).isRequired,
     programType: PropTypes.string
   }),
-  setAtNamespaceLevel: PropTypes.bool,
+  setAtLevel: PropTypes.string,
   modalIsOpen: PropTypes.func,
   onSuccess: PropTypes.func,
   savedMessageState: PropTypes.bool
 };
 
 SetPreferenceAction.defaultProps = {
-  setAtNamespaceLevel: false,
   modalIsOpen: () => {},
   onSuccess: () => {},
   savedMessageState: false

--- a/cdap-ui/app/cdap/components/NamespaceDetails/Mapping/Mapping.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/Mapping/Mapping.scss
@@ -14,23 +14,48 @@
  * the License.
 */
 
+$first-label-width: 150px;
+$last-label-width: 175px;
+
 .namespace-details-mapping {
   .mapping-values-group {
     .mapping-values {
-      strong {
+      display: inline-flex;
+      align-items: center;
+
+      strong,
+      span {
+        display: inline-block;
+      }
+
+      span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         display: inline-block;
       }
 
       &:first-child {
-        padding-right: 200px;
+        width: 40%;
+
         strong {
-          width: 150px;
+          width: $first-label-width;
+        }
+
+        span {
+          max-width: calc(100% - #{$first-label-width});
         }
       }
 
       &:last-child {
+        width: 60%;
+
         strong {
-          width: 175px;
+          width: $last-label-width;
+        }
+
+        span {
+          max-width: calc(100% - #{$last-label-width});
         }
       }
     }

--- a/cdap-ui/app/cdap/components/NamespaceDetails/Mapping/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/Mapping/index.js
@@ -40,21 +40,29 @@ const NamespaceDetailsMapping = ({hdfsRootDirectory, hbaseNamespaceName, hiveDat
       <div className="mapping-values-group">
         <span className="mapping-values">
           <strong>{T.translate(`${PREFIX}.hdfsRootDirectory`)}</strong>
-          <span>{hdfsRootDirectory || '- -'}</span>
+          <span title={hdfsRootDirectory}>
+            {hdfsRootDirectory || '- -'}
+          </span>
         </span>
         <span className="mapping-values">
           <strong>{T.translate(`${PREFIX}.hbaseNamespaceName`)}</strong>
-          <span>{hbaseNamespaceName || '- -'}</span>
+          <span title={hbaseNamespaceName}>
+            {hbaseNamespaceName || '- -'}
+          </span>
         </span>
       </div>
       <div className="mapping-values-group">
         <span className="mapping-values">
           <strong>{T.translate(`${PREFIX}.hiveDatabaseName`)}</strong>
-          <span>{hiveDatabaseName || '- -'}</span>
+          <span title={hiveDatabaseName}>
+            {hiveDatabaseName || '- -'}
+          </span>
         </span>
         <span className="mapping-values">
           <strong>{T.translate(`${PREFIX}.schedulerQueueName`)}</strong>
-          <span>{schedulerQueueName || '- -'}</span>
+          <span title={schedulerQueueName}>
+            {schedulerQueueName || '- -'}
+          </span>
         </span>
       </div>
     </div>

--- a/cdap-ui/app/cdap/components/NamespaceDetails/Preferences/Preferences.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/Preferences/Preferences.scss
@@ -31,16 +31,18 @@ $link-color: #0275d8;
     width: 100%;
     table-layout: fixed;
 
-    tbody {
-      display: block;
-      overflow: auto;
-      max-height: calc(#{$tr-height} * 5);
-    }
-
     tr {
       border-bottom: 1px solid $grey-05;
+      border-top: 2px solid white;
+      border-left: 2px solid white;
+      border-right: 2px solid white;
       display: table;
       width: 100%;
+
+      &.highlighted {
+        border: 2px solid $green-03;
+        background-color: rgba($green-03, 0.1);
+      }
 
       th {
         border-top: 0;
@@ -63,5 +65,10 @@ $link-color: #0275d8;
         white-space: nowrap;
       }
     }
+  }
+
+  .view-more-label {
+    color: $link-color;
+    cursor: pointer;
   }
 }

--- a/cdap-ui/app/cdap/components/NamespaceDetails/Security/Security.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/Security/Security.scss
@@ -14,11 +14,24 @@
  * the License.
 */
 
+$label-width: 90px;
+
 .namespace-details-security {
   .security-values {
+    display: flex;
+    align-items: center;
+
     strong {
       display: inline-block;
-      width: 90px;
+      width: $label-width;
+    }
+
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      display: inline-block;
+      max-width: calc(100% - #{$label-width});
     }
   }
 }

--- a/cdap-ui/app/cdap/components/NamespaceDetails/Security/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/Security/index.js
@@ -37,11 +37,15 @@ const NamespaceDetailsSecurity = ({principal, keytabURI}) => {
       </div>
       <div className="security-values">
         <strong>{T.translate(`${PREFIX}.principal`)}</strong>
-        <span>{principal || '- -'}</span>
+        <span title={principal}>
+          {principal || '- -'}
+        </span>
       </div>
       <div className="security-values">
         <strong>{T.translate(`${PREFIX}.keytabURI`)}</strong>
-        <span>{keytabURI || '- -'}</span>
+        <span title={keytabURI}>
+          {keytabURI || '- -'}
+        </span>
       </div>
     </div>
   );

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -22,6 +22,7 @@ import AbstractWizard from 'components/AbstractWizard';
 import NamespaceStore from 'services/NamespaceStore';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
 import SetPreferenceAction from 'components/FastAction/SetPreferenceAction';
+import {PREFERENCES_LEVEL} from 'components/FastAction/SetPreferenceAction/SetPreferenceModal';
 import IconSVG from 'components/IconSVG';
 import {MySearchApi} from 'api/search';
 import isObject from 'lodash/isObject';
@@ -319,7 +320,7 @@ export default class NamespaceDropdown extends Component {
                     <div className="current-namespace-preferences text-xs-center">
                       <h4 className="btn-group">
                         <SetPreferenceAction
-                          setAtNamespaceLevel={true}
+                          setAtLevel={PREFERENCES_LEVEL.NAMESPACE}
                           modalIsOpen={this.preferenceWizardIsOpen.bind(this)}
                           onSuccess={this.preferencesAreSaved.bind(this)}
                           savedMessageState={this.state.preferencesSavedMessage}

--- a/cdap-ui/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -67,7 +67,9 @@ const PublishPreferences = () => {
 
   if (state.preferences.keyValues && state.preferences.keyValues.pairs.length > 0) {
     state.preferences.keyValues.pairs.forEach((pair) => {
-      preferences[pair.key] = pair.value;
+      if (pair.key.length && pair.value.length) {
+        preferences[pair.key] = pair.value;
+      }
     });
 
     return MyNamespaceApi

--- a/cdap-ui/app/cdap/services/global-events.js
+++ b/cdap-ui/app/cdap/services/global-events.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,5 +25,6 @@ export default {
   NONAMESPACE: 'NO_NAMESPACE',
   OPENMARKET: 'OPEN_MARKET',
   PUBLISHPIPELINE: 'PUBLISH_PIPELINE',
-  STREAMCREATE: 'STREAM_CREATE'
+  STREAMCREATE: 'STREAM_CREATE',
+  NSPREFERENCESSAVED: 'NS_PREFERENCES_SAVED'
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1317,6 +1317,8 @@ features:
       labelWithCount: Preferences ({count})
       noPreferences: No Preferences set for this namespace
       scope: Scope
+      viewAll: View All
+      viewLess: View Less
     security:
       keytabURI: 'Keytab URI: '
       label: Security


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13180

This PR implements the following specs in the JIRA:
```
*Preferences Section*
1. Lists key value pairs of preferences for this namespace.
2. Lists 5 preferences, and display the link "View All" which opens as an accordion to display all preferences. (when accordion opens, the link changes to "View Less")
3. The Edit button opens the namespace preferences modal.

*New Preferences Added*
1. The user selects "Edit" link, opens the preference modal and adds new preferences. 
2. The preferences are added to the table and highlighted. 
Acceptance Criteria

The preferences are added in the sorting order selected by the user.
If there are more than 5 preferences and the new preferences are not in the first 5, all the preferences are displayed.
The page scrolls so that the first new preference added is in view
Row outline 2px Green_03, background Green_03 10% opacity
New label in Helvetica Bold (ALL CAPS) 11px Green_02
Treatment fades away after 3 seconds
```