### PR TITLE
update hash

### DIFF
--- a/cdap-docs/integrations/build.sh
+++ b/cdap-docs/integrations/build.sh
@@ -41,7 +41,7 @@ function download_includes() {
   download_file ${target_includes_dir} ${file_source} README.rst bcf5148f45a778a7bc9f842ba84cbc10 cdap-sentry-extension-readme.txt
   # Download Apache Ranger File
   local file_source="${base_source}${branch}cdap-ranger/"
-  download_file ${target_includes_dir} ${file_source} README.rst 27f52065c970f0c39945705342d16e29 cdap-ranger-extension-readme.txt
+  download_file ${target_includes_dir} ${file_source} README.rst 899b1568b5dbb29ae5f6df4a103bf2be cdap-ranger-extension-readme.txt
 }
 
 run_command ${1}


### PR DESCRIPTION
fixing the docs build failure 
```
build   28-Mar-2018 03:43:55    WARNING: cdap-ranger-extension-readme.txt has changed! Compare files and update hash!
build   28-Mar-2018 03:43:55    file: /var/bamboo/xml-data/build-dir/CDAP-DBT28-BCD/cdap/cdap-docs/integrations/target/_includes/cdap-ranger-extension-readme.txt
build   28-Mar-2018 03:43:55    Old MD5 Hash: 27f52065c970f0c39945705342d16e29 New MD5 Hash: 899b1568b5dbb29ae5f6df4a103bf2be
```