### PR TITLE
[CDAP-13236] Allows editing of keytabURI of a namespace in UI

### DIFF
--- a/cdap-ui/app/cdap/api/namespace.js
+++ b/cdap-ui/app/cdap/api/namespace.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,5 +25,6 @@ export const MyNamespaceApi = {
   get: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/:namespace`),
   pollList: apiCreator(dataSrc, 'GET', 'POLL', basepath),
   create: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basepath}/:namespace`),
-  setPreferences: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basepath}/:namespace/preferences`)
+  setPreferences: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basepath}/:namespace/preferences`),
+  editProperties: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basepath}/:namespace/properties`)
 };

--- a/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/GeneralInfoStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/GeneralInfoStep/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,8 @@ const mapStateToNamespaceNameProps = (state) => {
   return {
     value: state.general.name,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step1.name-placeholder')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step1.name-placeholder'),
+    disabled: state.editableFields.fields.indexOf('name') === -1
   };
 };
 
@@ -46,7 +47,8 @@ const mapStateToNamespaceDescriptionProps = (state) => {
   return {
     value: state.general.description,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step1.description-placeholder')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step1.description-placeholder'),
+    disabled: state.editableFields.fields.indexOf('description') === -1
   };
 };
 

--- a/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/MappingStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/MappingStep/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,8 @@ const mapStateToHDFSRootDirectoryProps = (state) => {
   return {
     value: state.mapping.hdfsDirectory,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.hdfs-root-directory-placeholder')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.hdfs-root-directory-placeholder'),
+    disabled: state.editableFields.fields.indexOf('hdfsDirectory') === -1
   };
 };
 
@@ -46,7 +47,8 @@ const mapStateToHiveDatabaseNameProps = (state) => {
   return {
     value: state.mapping.hiveDatabaseName,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.hive-db-name-placeholder')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.hive-db-name-placeholder'),
+    disabled: state.editableFields.fields.indexOf('hiveDatabaseName') === -1
   };
 };
 
@@ -66,7 +68,8 @@ const mapStateToHBASENamespaceNameProps = (state) => {
   return {
     value: state.mapping.hbaseNamespace,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.hbase-nm-name-placeholder')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.hbase-nm-name-placeholder'),
+    disabled: state.editableFields.fields.indexOf('hbaseNamespace') === -1
   };
 };
 
@@ -85,7 +88,8 @@ const mapStateToSchedulerQueueNameProps = (state) => {
   return {
     value: state.mapping.schedulerQueueName,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.scheduler-queue-placeholder')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step2.scheduler-queue-placeholder'),
+    disabled: state.editableFields.fields.indexOf('schedulerQueueName') === -1
   };
 };
 const mapDispatchToSchedulerQueueNameProps = (dispatch) => {

--- a/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/PreferencesStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/PreferencesStep/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,7 +24,8 @@ export default function PreferencesStep() {
 
   const mapStateToKeyValProps = (state) => {
     return {
-      keyValues : state.preferences.keyValues
+      keyValues : state.preferences.preferences,
+      disabled: state.editableFields.fields.indexOf('preferences') === -1
     };
   };
 

--- a/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/SecurityStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/SecurityStep/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,8 @@ const mapStateToPrincipalProps = (state) => {
   return {
     value: state.security.principal,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step3.principal-placeholder')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step3.principal-placeholder'),
+    disabled: state.editableFields.fields.indexOf('principal') === -1
   };
 };
 
@@ -46,7 +47,8 @@ const mapStateTokeytabURIProps = (state) => {
   return {
     value: state.security.keyTab,
     type: 'text',
-    placeholder: T.translate('features.Wizard.Add-Namespace.Step3.keytab-uri-placeholder')
+    placeholder: T.translate('features.Wizard.Add-Namespace.Step3.keytab-uri-placeholder'),
+    disabled: state.editableFields.fields.indexOf('keyTab') === -1
   };
 };
 

--- a/cdap-ui/app/cdap/components/KeyValuePairs/KeyValueStoreActions.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/KeyValueStoreActions.js
@@ -14,8 +14,8 @@
 * the License.
 */
 
-import uuid from 'uuid/v4';
 import {getDefaultKeyValuePair} from 'components/KeyValuePairs/KeyValueStore';
+import {convertMapToKeyValuePairs, convertKeyValuePairsToMap} from 'services/helpers';
 
 const KeyValueStoreActions = {
   setKey: 'SET-KEY',
@@ -28,14 +28,9 @@ const KeyValueStoreActions = {
 };
 
 const convertMapToKeyValuePairsObj = (obj) => {
-  let keyValuePairsObj = {};
-  keyValuePairsObj.pairs = Object.keys(obj).map(objKey => {
-    return {
-      key: objKey,
-      value: obj[objKey],
-      uniqueId: 'id-' + uuid()
-    };
-  });
+  let keyValuePairsObj = {
+    pairs: convertMapToKeyValuePairs(obj)
+  };
   if (!keyValuePairsObj.pairs.length) {
     keyValuePairsObj.pairs.push(getDefaultKeyValuePair());
   }
@@ -43,16 +38,7 @@ const convertMapToKeyValuePairsObj = (obj) => {
 };
 
 const convertKeyValuePairsObjToMap = (keyValues) => {
-  let map = {};
-  if (keyValues.pairs) {
-    keyValues.pairs.forEach((currentPair) => {
-      if (currentPair.key.length > 0 && currentPair.value.length > 0) {
-        let key = currentPair.key;
-        map[key] = currentPair.value;
-      }
-    });
-  }
-  return map;
+  return convertKeyValuePairsToMap(keyValues.pairs || []);
 };
 
 const keyValuePairsHaveMissingValues = (keyValues) => {

--- a/cdap-ui/app/cdap/components/NamespaceDetails/NamespaceDetails.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/NamespaceDetails.scss
@@ -15,6 +15,7 @@
 */
 
 @import "../../styles/variables.scss";
+$link-color: #0275d8;
 
 .namespace-details-container {
   height: inherit;
@@ -38,6 +39,12 @@
       margin-bottom: 10px;
       font-size: 14px;
       line-height: 14px;
+
+      .edit-label {
+        color: $link-color;
+        margin-left: 10px;
+        cursor: pointer;
+      }
     }
   }
 }

--- a/cdap-ui/app/cdap/components/NamespaceDetails/Security/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/Security/index.js
@@ -14,47 +14,104 @@
  * the License.
 */
 
-import React from 'react';
+import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import T from 'i18n-react';
+import AddNamespaceWizard from 'components/CaskWizards/AddNamespace';
+import {getNamespaceProperties} from 'components/NamespaceDetails/store/ActionCreator';
 require('./Security.scss');
 
 const PREFIX = 'features.NamespaceDetails.security';
 
 const mapStateToProps = (state) => {
   return {
+    name: state.name,
+    description: state.description,
+    namespacePrefs: state.namespacePrefs,
+    hdfsRootDirectory: state.hdfsRootDirectory,
+    hbaseNamespaceName: state.hbaseNamespaceName,
+    hiveDatabaseName: state.hiveDatabaseName,
+    schedulerQueueName: state.schedulerQueueName,
     principal: state.principal,
     keytabURI: state.keytabURI
   };
 };
 
-const NamespaceDetailsSecurity = ({principal, keytabURI}) => {
-  return (
-    <div className="namespace-details-security">
-      <div className="namespace-details-section-label">
-        <strong>{T.translate(`${PREFIX}.label`)}</strong>
-      </div>
-      <div className="security-values">
-        <strong>{T.translate(`${PREFIX}.principal`)}</strong>
-        <span title={principal}>
-          {principal || '- -'}
-        </span>
-      </div>
-      <div className="security-values">
-        <strong>{T.translate(`${PREFIX}.keytabURI`)}</strong>
-        <span title={keytabURI}>
-          {keytabURI || '- -'}
-        </span>
-      </div>
-    </div>
-  );
-};
+class NamespaceDetailsSecurity extends Component {
+  state = {
+    modalOpen: false
+  };
 
-NamespaceDetailsSecurity.propTypes = {
-  principal: PropTypes.string,
-  keytabURI: PropTypes.string
-};
+  static propTypes = {
+    name: PropTypes.string,
+    description: PropTypes.string,
+    namespacePrefs: PropTypes.object,
+    hdfsRootDirectory: PropTypes.string,
+    hbaseNamespaceName: PropTypes.string,
+    hiveDatabaseName: PropTypes.string,
+    schedulerQueueName: PropTypes.string,
+    principal: PropTypes.string,
+    keytabURI: PropTypes.string
+  };
+
+  toggleModal = (namespaceEdited) => {
+    if (namespaceEdited) {
+      getNamespaceProperties();
+    }
+    this.setState({
+      modalOpen: !this.state.modalOpen
+    });
+  };
+
+  render() {
+    return (
+      <div className="namespace-details-security">
+        <div className="namespace-details-section-label">
+          <strong>{T.translate(`${PREFIX}.label`)}</strong>
+          {
+            this.props.principal && this.props.keytabURI ?
+              (
+                <span
+                  className="edit-label"
+                  onClick={this.toggleModal}
+                >
+                  {T.translate('features.NamespaceDetails.edit')}
+                </span>
+              )
+            :
+              null
+          }
+        </div>
+        <div className="security-values">
+          <strong>{T.translate(`${PREFIX}.principal`)}</strong>
+          <span title={this.props.principal}>
+            {this.props.principal || '- -'}
+          </span>
+        </div>
+        <div className="security-values">
+          <strong>{T.translate(`${PREFIX}.keytabURI`)}</strong>
+          <span title={this.props.keytabURI}>
+            {this.props.keytabURI || '- -'}
+          </span>
+        </div>
+        {
+          this.state.modalOpen ?
+            <AddNamespaceWizard
+              isOpen={this.state.modalOpen}
+              onClose={this.toggleModal}
+              isEdit={true}
+              editableFields={['keyTab']}
+              properties={{...this.props}}
+              activeStepId='security'
+            />
+          :
+            null
+        }
+      </div>
+    );
+  }
+}
 
 const ConnectedNamespaceDetailsSecurity = connect(mapStateToProps)(NamespaceDetailsSecurity);
 export default ConnectedNamespaceDetailsSecurity;

--- a/cdap-ui/app/cdap/components/NamespaceDetails/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/store/ActionCreator.js
@@ -48,6 +48,33 @@ function getNamespacePrefs() {
     );
 }
 
+function getNamespaceProperties() {
+  let namespace = getCurrentNamespace();
+
+  MyNamespaceApi
+    .get({namespace})
+    .subscribe(
+      (res) => {
+        let config = res.config;
+
+        NamespaceDetailsStore.dispatch({
+          type: NamespaceDetailsActions.setData,
+          payload: {
+            name: res.name,
+            description: res.description,
+            hdfsRootDirectory: config['root.directory'],
+            hbaseNamespaceName: config['hbase.namespace'],
+            hiveDatabaseName: config['hive.database'],
+            schedulerQueueName: config['scheduler.queue.name'],
+            principal: config.principal,
+            keytabURI: config.keytabURI
+          }
+        });
+      },
+      (err) => console.log(err)
+    );
+}
+
 function getData() {
   enableLoading();
 
@@ -118,5 +145,6 @@ function getData() {
 
 export {
   getData,
+  getNamespaceProperties,
   getNamespacePrefs
 };

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/RuntimeArgsTabContent/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/RuntimeArgsTabContent/index.js
@@ -18,7 +18,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import PipelineConfigurationsStore, {ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
 import {updateKeyValueStore} from 'components/PipelineConfigurations/Store/ActionCreator';
-import {convertMapToKeyValuePairsObj, convertKeyValuePairsObjToMap} from 'components/KeyValuePairs/KeyValueStoreActions';
+import {convertKeyValuePairsObjToMap} from 'components/KeyValuePairs/KeyValueStoreActions';
+import {convertMapToKeyValuePairs} from 'services/helpers';
 import RuntimeArgsPairs from 'components/PipelineConfigurations/ConfigurationsContent/RuntimeArgsTabContent/RuntimeArgsPairs';
 import ProvidedPopover from 'components/PipelineConfigurations/ConfigurationsContent/RuntimeArgsTabContent/ProvidedPopover';
 import classnames from 'classnames';
@@ -59,8 +60,8 @@ const onPaste = (dataObj, index) => {
     }
   });
   if (!isEmpty(dataObj)) {
-    let remainingRuntimeArgs = convertMapToKeyValuePairsObj(dataObj);
-    runtimeArgs.pairs = runtimeArgs.pairs.concat(remainingRuntimeArgs.pairs);
+    let remainingRuntimeArgs = convertMapToKeyValuePairs(dataObj);
+    runtimeArgs.pairs = runtimeArgs.pairs.concat(remainingRuntimeArgs);
   }
   PipelineConfigurationsStore.dispatch({
     type: PipelineConfigurationsActions.SET_RUNTIME_ARGS,

--- a/cdap-ui/app/cdap/components/Wizard/index.js
+++ b/cdap-ui/app/cdap/components/Wizard/index.js
@@ -50,7 +50,7 @@ export default class Wizard extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      activeStep: this.props.wizardConfig.steps[0].id,
+      activeStep: this.props.activeStepId || this.props.wizardConfig.steps[0].id,
       loading: false,
       loadingCTA: false,
       error: '',
@@ -513,4 +513,5 @@ Wizard.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   successInfo: PropTypes.object,
   onClose: PropTypes.func.isRequired,
+  activeStepId: PropTypes.string
 };

--- a/cdap-ui/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/AddNamespace/ActionCreator.js
@@ -16,7 +16,15 @@
 import AddNamespaceStore from 'services/WizardStores/AddNamespace/AddNamespaceStore';
 import {MyNamespaceApi} from 'api/namespace';
 
-const PublishNamespace = () => {
+const createNamespace = () => {
+  return createOrEditNamespace(MyNamespaceApi.create);
+};
+
+const editNamespaceProperties = () => {
+  return createOrEditNamespace(MyNamespaceApi.editProperties);
+};
+
+const createOrEditNamespace = (api) => {
   let state = AddNamespaceStore.getState();
   let urlParams = {
     namespace: state.general.name
@@ -54,19 +62,18 @@ const PublishNamespace = () => {
     putParams["config"]["scheduler.queue.name"] = state.mapping.schedulerQueueName;
   }
 
-  return MyNamespaceApi
-    .create(urlParams, putParams);
+  return api(urlParams, putParams);
 };
 
-const PublishPreferences = () => {
+const setNamespacePreferences = () => {
   let state = AddNamespaceStore.getState();
   let urlParams = {
     namespace: state.general.name
   };
   let preferences = {};
 
-  if (state.preferences.keyValues && state.preferences.keyValues.pairs.length > 0) {
-    state.preferences.keyValues.pairs.forEach((pair) => {
+  if (state.preferences.preferences && state.preferences.preferences.pairs.length > 0) {
+    state.preferences.preferences.pairs.forEach((pair) => {
       if (pair.key.length && pair.value.length) {
         preferences[pair.key] = pair.value;
       }
@@ -77,4 +84,8 @@ const PublishPreferences = () => {
   }
 };
 
-export {PublishNamespace, PublishPreferences};
+export {
+  createNamespace,
+  editNamespaceProperties,
+  setNamespacePreferences
+};

--- a/cdap-ui/app/cdap/services/WizardStores/AddNamespace/AddNamespaceActions.js
+++ b/cdap-ui/app/cdap/services/WizardStores/AddNamespace/AddNamespaceActions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,7 +27,9 @@ const AddNamespaceActions = {
   onError: 'FORM-SUBMIT-FAILURE',
   onSuccess: 'FORM-SUBMIT-SUCCESS',
   onReset: 'FORM-RESET',
-  setPreferences: 'SET-PREFERENCES'
+  setPreferences: 'SET-PREFERENCES',
+  setProperties: 'SET-PROPERTIES',
+  setEditableFields: 'SET-EDITABLE-FIELDS'
 };
 
 export default AddNamespaceActions;

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -21,6 +21,7 @@ import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import T from 'i18n-react';
 import {compose} from 'redux';
+import uuidV4 from 'uuid/v4';
 
 /*
   Purpose: Query a json object or an array of json objects
@@ -295,6 +296,39 @@ const reverseArrayWithoutMutating = (array) => {
   return newArray;
 };
 
+const convertMapToKeyValuePairs = (map, addUniqueId = true) => {
+  if (addUniqueId) {
+    return Object.entries(map).map(([key, value]) => {
+      return {
+        key,
+        value,
+        uniqueId: 'id-' + uuidV4()
+      };
+    });
+  }
+  return Object.entries(map).map(([key, value]) => {
+    return {
+      key,
+      value,
+    };
+  });
+};
+
+const convertKeyValuePairsToMap = (keyValuePairs) => {
+  let map = {};
+  keyValuePairs.forEach((currentPair) => {
+    if (
+      currentPair.key &&
+      currentPair.key.length > 0 &&
+      currentPair.value &&
+      currentPair.value.length > 0
+    ) {
+      map[currentPair.key] = currentPair.value;
+    }
+  });
+  return map;
+};
+
 export {
   objectQuery,
   convertBytesToHumanReadable,
@@ -324,5 +358,7 @@ export {
   ONE_YEAR_SECONDS,
   isNumeric,
   wholeArrayIsNumeric,
-  reverseArrayWithoutMutating
+  reverseArrayWithoutMutating,
+  convertMapToKeyValuePairs,
+  convertKeyValuePairsToMap
 };


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13236

Backend PR: https://github.com/caskdata/cdap/pull/9701

Allows editing of `keytabURI` property of a namespace in UI, from its Namespace Details page. Currently only `keytabURI` is editable since we don't have backend code to allow editing of principal yet.
