### PR TITLE
CDAP-13096 use mock provisioner in unit tests

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerExtensionLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerExtensionLoader.java
@@ -16,16 +16,21 @@
 
 package co.cask.cdap.internal.provision;
 
+import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.extension.AbstractExtensionLoader;
 import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 
+import java.io.File;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * Loads provisioners from the extensions directory.
  */
-public class ProvisionerExtensionLoader extends AbstractExtensionLoader<String, Provisioner> {
+public class ProvisionerExtensionLoader extends AbstractExtensionLoader<String, Provisioner>
+  implements ProvisionerProvider {
 
   public ProvisionerExtensionLoader(String extDirs) {
     super(extDirs);
@@ -34,5 +39,27 @@ public class ProvisionerExtensionLoader extends AbstractExtensionLoader<String, 
   @Override
   protected Set<String> getSupportedTypesForProvider(Provisioner provisioner) {
     return Collections.singleton(provisioner.getSpec().getName());
+  }
+
+  // filter all non-spi classes to provide isolation from CDAP's classes. For example, dataproc provisioner uses
+  // a different guava than CDAP's guava.
+  @Override
+  protected ClassLoader getExtensionParentClassLoader() {
+    return new FilterClassLoader(super.getExtensionParentClassLoader(), new FilterClassLoader.Filter() {
+      @Override
+      public boolean acceptResource(String resource) {
+        return resource.startsWith("co/cask/cdap/runtime/spi");
+      }
+
+      @Override
+      public boolean acceptPackage(String packageName) {
+        return packageName.startsWith("co/cask/cdap/runtime/spi");
+      }
+    });
+  }
+
+  @Override
+  public Map<String, Provisioner> loadProvisioners() {
+    return getAll();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerProvider.java
@@ -16,18 +16,17 @@
 
 package co.cask.cdap.internal.provision;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Scopes;
+import co.cask.cdap.runtime.spi.provisioner.Provisioner;
+
+import java.util.Map;
 
 /**
- * Guice module for provisioner classes.
+ * Provides provisioners.
  */
-public class ProvisionerModule extends AbstractModule {
+public interface ProvisionerProvider {
 
-  @Override
-  protected void configure() {
-    bind(ProvisioningService.class).in(Scopes.SINGLETON);
-    bind(ProvisionerProvider.class).to(ProvisionerExtensionLoader.class);
-  }
-
+  /**
+   * @return map from provisioner name to provisioner
+   */
+  Map<String, Provisioner> loadProvisioners();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
@@ -17,8 +17,6 @@
 package co.cask.cdap.internal.provision;
 
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 import com.google.inject.Inject;
@@ -37,13 +35,13 @@ import javax.annotation.Nullable;
  */
 public class ProvisioningService {
   private static final Logger LOG = LoggerFactory.getLogger(ProvisioningService.class);
-  private final ProvisionerExtensionLoader provisionerExtensionLoader;
   private final AtomicReference<ProvisionerInfo> provisionerInfo;
+  private final ProvisionerProvider provisionerProvider;
 
   @Inject
-  ProvisioningService(CConfiguration cConf) {
-    provisionerExtensionLoader = new ProvisionerExtensionLoader(cConf.get(Constants.Provisioner.EXTENSIONS_DIR));
-    provisionerInfo = new AtomicReference<>(new ProvisionerInfo(new HashMap<>(), new HashMap<>()));
+  ProvisioningService(ProvisionerProvider provisionerProvider) {
+    this.provisionerProvider = provisionerProvider;
+    this.provisionerInfo = new AtomicReference<>(new ProvisionerInfo(new HashMap<>(), new HashMap<>()));
     reloadProvisioners();
   }
 
@@ -52,7 +50,7 @@ public class ProvisioningService {
    * will be removed.
    */
   public void reloadProvisioners() {
-    Map<String, Provisioner> provisioners = provisionerExtensionLoader.getAll();
+    Map<String, Provisioner> provisioners = provisionerProvider.loadProvisioners();
     LOG.debug("Provisioners = {}", provisioners);
     Map<String, ProvisionerSpecification> specs = new HashMap<>(provisioners.size());
     for (Map.Entry<String, Provisioner> provisionerEntry : provisioners.entrySet()) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -37,6 +37,7 @@ import co.cask.cdap.data.stream.service.StreamServiceRuntimeModule;
 import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
+import co.cask.cdap.internal.provision.MockProvisionerModule;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
@@ -113,5 +114,6 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreModules().getInMemoryModules());
     install(new MessagingServerRuntimeModule().getInMemoryModules());
+    install(new MockProvisionerModule());
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.provision;
+
+import co.cask.cdap.runtime.spi.provisioner.Cluster;
+import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
+import co.cask.cdap.runtime.spi.provisioner.Provisioner;
+import co.cask.cdap.runtime.spi.provisioner.ProvisionerContext;
+import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
+import co.cask.cdap.runtime.spi.provisioner.RetryableProvisionException;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provisioner for unit tests. Has the same spec as the default yarn provisioner.
+ */
+public class MockProvisioner implements Provisioner {
+  private static final ProvisionerSpecification SPEC = new ProvisionerSpecification(
+    "yarn", "Default YARN Provisioner",
+    "Runs programs on the CDAP master cluster. Does not provision any resources.",
+    new HashMap<>());
+
+  @Override
+  public ProvisionerSpecification getSpec() {
+    return SPEC;
+  }
+
+  @Override
+  public void validateProperties(Map<String, String> properties) {
+    // no-op
+  }
+
+  @Override
+  public Cluster createCluster(ProvisionerContext context) throws RetryableProvisionException {
+    return new Cluster(context.getProgramRun().getRun(), ClusterStatus.RUNNING,
+                       Collections.emptyList(), Collections.emptyMap());
+  }
+
+  @Override
+  public ClusterStatus getClusterStatus(ProvisionerContext context,
+                                        Cluster cluster) throws RetryableProvisionException {
+    ClusterStatus status = cluster.getStatus();
+    return status == ClusterStatus.DELETING ? ClusterStatus.NOT_EXISTS : status;
+  }
+
+  @Override
+  public void deleteCluster(ProvisionerContext context, Cluster cluster) throws RetryableProvisionException {
+    // no-op
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisionerModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisionerModule.java
@@ -20,14 +20,14 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 
 /**
- * Guice module for provisioner classes.
+ * Test module for provisioner classes.
  */
-public class ProvisionerModule extends AbstractModule {
+public class MockProvisionerModule extends AbstractModule {
 
   @Override
   protected void configure() {
     bind(ProvisioningService.class).in(Scopes.SINGLETON);
-    bind(ProvisionerProvider.class).to(ProvisionerExtensionLoader.class);
+    bind(ProvisionerProvider.class).to(MockProvisionerProvider.class);
   }
 
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisionerProvider.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisionerProvider.java
@@ -16,18 +16,18 @@
 
 package co.cask.cdap.internal.provision;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Scopes;
+import co.cask.cdap.runtime.spi.provisioner.Provisioner;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
 
 /**
- * Guice module for provisioner classes.
+ * Provides provisioners for unit tests.
  */
-public class ProvisionerModule extends AbstractModule {
+public class MockProvisionerProvider implements ProvisionerProvider {
 
   @Override
-  protected void configure() {
-    bind(ProvisioningService.class).in(Scopes.SINGLETON);
-    bind(ProvisionerProvider.class).to(ProvisionerExtensionLoader.class);
+  public Map<String, Provisioner> loadProvisioners() {
+    return ImmutableMap.of("yarn", new MockProvisioner());
   }
-
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.provision;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.internal.guice.AppFabricTestModule;
+import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collection;
+
+/**
+ * Test for Provisioning Service.
+ */
+public class ProvisioningServiceTest {
+  private static ProvisioningService provisioningService;
+
+  @BeforeClass
+  public static void setupClass() {
+    CConfiguration cConf = CConfiguration.create();
+    Injector injector = Guice.createInjector(new AppFabricTestModule(cConf));
+    provisioningService = injector.getInstance(ProvisioningService.class);
+  }
+
+  @Test
+  public void testGetSpecs() {
+    Collection<ProvisionerSpecification> specs = provisioningService.getProvisionerSpecs();
+    Assert.assertEquals(1, specs.size());
+
+    ProvisionerSpecification expected = new MockProvisioner().getSpec();
+    Assert.assertEquals(expected, specs.iterator().next());
+
+    Assert.assertEquals(expected, provisioningService.getProvisionerSpec("yarn"));
+    Assert.assertNull(provisioningService.getProvisionerSpec("abc"));
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/extension/AbstractExtensionLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/extension/AbstractExtensionLoader.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.extension;
 
+import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.utils.DirUtils;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -271,7 +272,14 @@ public abstract class AbstractExtensionLoader<EXTENSION_TYPE, EXTENSION> {
       }
     }), URL.class);
 
-    URLClassLoader classLoader = new URLClassLoader(urls, getClass().getClassLoader());
+    URLClassLoader classLoader = new URLClassLoader(urls, getExtensionParentClassLoader());
     return ServiceLoader.load(extensionClass, classLoader);
+  }
+
+  /**
+   * @return parent classloader for extensions
+   */
+  protected ClassLoader getExtensionParentClassLoader() {
+    return getClass().getClassLoader();
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -79,6 +79,7 @@ import co.cask.cdap.internal.app.runtime.messaging.BasicMessagingAdmin;
 import co.cask.cdap.internal.app.runtime.messaging.MultiThreadMessagingContext;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.ProgramNotificationSubscriberService;
+import co.cask.cdap.internal.provision.MockProvisionerModule;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.MessagingService;
@@ -276,6 +277,7 @@ public class TestBase {
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
       new PreviewHttpModule(),
+      new MockProvisionerModule(),
       new AbstractModule() {
         @Override
         @SuppressWarnings("deprecation")


### PR DESCRIPTION
Use a mock provisioner in unit test. Also add classloader isolation
for provisioner extensions to prevent clashes with dependencies.
More specifically, the dataproc provisioner uses a newer guava
version than cdap, and needs to be shielded from that.