### PR TITLE
[CDAP-13279][UI] Renames grid-item to grid-row for better readability

### DIFF
--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
@@ -21,7 +21,7 @@ $row-height: 50px;
 .profiles-list-view {
   .grid.grid-container {
     max-height: 550px;
-    .grid-item {
+    .grid-row {
       grid-template-columns: 20px 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 20px;
 
       .sortable-header {
@@ -60,12 +60,12 @@ $row-height: 50px;
       }
     }
     .grid-header {
-      .grid-item {
+      .grid-row {
         padding-top: 0;
       }
     }
     .grid-body {
-      .grid-item {
+      .grid-row {
         height: $row-height;
 
         &:last-child {

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
@@ -19,15 +19,16 @@
 $row-height: 50px;
 
 .profiles-list-view {
+  .grid-wrapper {
+    max-height: none;
+  }
   .grid.grid-container {
-    max-height: 550px;
+    max-height: none;
     .grid-row {
       grid-template-columns: 20px 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 20px;
 
       .sortable-header {
         cursor: pointer;
-        display: flex;
-        align-items: center;
 
         &.active {
           text-decoration: underline;
@@ -56,6 +57,7 @@ $row-height: 50px;
           padding: 0 5px 0 0;
           margin-right: 20px;
           margin-left: 5px;
+          border: 0;
         }
       }
     }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -155,7 +155,7 @@ export default class ProfilesListView extends Component {
     }
 
     return (
-      <div>
+      <div className="grid-wrapper">
         <div className="grid grid-container">
           {this.renderProfilesTableHeader()}
           {this.renderProfilesTableBody()}
@@ -235,7 +235,7 @@ export default class ProfilesListView extends Component {
           profiles.map((profile, i) => {
             return (
               <div
-                className="grid-row"
+                className="grid-row grid-link"
                 key={i}
               >
                 <div></div>
@@ -244,6 +244,14 @@ export default class ProfilesListView extends Component {
                 </div>
                 <div>{profile.provisioner.name}</div>
                 <div>{profile.scope}</div>
+                <div />
+                <div />
+                <div />
+                <div />
+                <div />
+                <div />
+                <div />
+                <div />
               </div>
             );
           })

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -181,7 +181,7 @@ export default class ProfilesListView extends Component {
   renderProfilesTableHeader() {
     return (
       <div className="grid-header">
-        <div className="grid-item sub-header">
+        <div className="grid-row sub-header">
           <div />
           <div />
           <div />
@@ -195,7 +195,7 @@ export default class ProfilesListView extends Component {
           <div/>
           <div/>
         </div>
-        <div className="grid-item">
+        <div className="grid-row">
           {
             PROFILES_TABLE_HEADERS.map((header, i) => {
               if (header.property) {
@@ -235,7 +235,7 @@ export default class ProfilesListView extends Component {
           profiles.map((profile, i) => {
             return (
               <div
-                className="grid-item"
+                className="grid-row"
                 key={i}
               >
                 <div></div>

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
@@ -36,9 +36,12 @@
     }
   }
 
+  .grid-wrapper {
+    height: calc(100% - 32px);
+    overflow: auto;
+  }
   .grid.grid-container {
-    max-height: calc(100% - 32px);
-    height: 100%;
+    max-height: 100%;
     .grid-header {
       .sortable-header {
         cursor: pointer;
@@ -56,7 +59,6 @@
     .grid-body {
       .grid-row {
         grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 1fr 20px;
-        padding: 7px;
         &:hover {
           [class*="icon-"] {
             color: $blue-03;

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
@@ -54,7 +54,7 @@
     }
     .grid-header,
     .grid-body {
-      .grid-item {
+      .grid-row {
         grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 1fr 20px;
         padding: 7px;
         &:hover {
@@ -65,7 +65,7 @@
       }
     }
     .grid-body {
-      .grid-item {
+      .grid-row {
         &.opened {
           grid-template-columns: 20px 1fr 1fr 1fr 1fr 20px;
           background: $grey-08;
@@ -91,7 +91,7 @@
             .grid.grid-container {
               max-height: 300px;
               padding: 0 10px;
-              .grid-item {
+              .grid-row {
                 grid-template-columns: 1fr;
               }
             }
@@ -130,12 +130,12 @@
     &.classification {
       .grid-header,
       .grid-body {
-        .grid-item {
+        .grid-row {
           grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 20px;
         }
       }
       .grid-body {
-        .grid-item {
+        .grid-row {
           &.opened {
             grid-template-columns: 20px 1fr 1fr 1fr 1fr 20px;
             cursor: auto;

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
@@ -142,12 +142,12 @@ const renderFeaturesTable = (features) => {
     <div className="features-grid-wrapper">
       <div className="grid grid-container">
         <div className="grid-header">
-          <div className="grid-item">
+          <div className="grid-row">
             <strong> Features </strong>
           </div>
         </div>
         <div className="grid-body">
-          {features.map(feature => (<div className="grid-item"> {feature}</div>))}
+          {features.map(feature => (<div className="grid-row"> {feature}</div>))}
         </div>
       </div>
     </div>
@@ -159,12 +159,12 @@ const renderDirectivesTables = (directives) => {
     <div className="features-grid-wrapper">
       <div className="grid grid-container">
         <div className="grid-header">
-          <div className="grid-item">
+          <div className="grid-row">
             <strong> Directives </strong>
           </div>
         </div>
         <div className="grid-body">
-          {directives.map(directive => (<div className="grid-item"> {directive}</div>))}
+          {directives.map(directive => (<div className="grid-row"> {directive}</div>))}
         </div>
       </div>
     </div>
@@ -192,7 +192,7 @@ const constructModelTrainingLogs = (model, experimentId) => {
 const renderModelDetails = (model, newlyTrainingModel, experimentId) => {
   let newlyTrainingModelId = objectQuery(newlyTrainingModel, 'modelId');
   let props = {
-    className: classnames("grid-item", {
+    className: classnames("grid-row", {
       "opened": model.detailedView,
       "active": model.active,
       "highlight": model.id === newlyTrainingModelId,
@@ -279,7 +279,7 @@ const renderModel = (model, outcomeType, experimentId, newlyTrainingModel) => {
   let newlyTrainingModelId = objectQuery(newlyTrainingModel, 'modelId');
   let Component = 'div';
   let props = {
-    className: classnames("grid-item", {
+    className: classnames("grid-row", {
       "opened": model.detailedView,
       "active": model.active,
       "highlight": model.id === newlyTrainingModelId
@@ -349,7 +349,7 @@ function renderGrid(models, outcomeType, experimentId, newlyTrainingModel, model
       "classification": NUMBER_TYPES.indexOf(outcomeType) === -1
     })}>
       <div className="grid-header">
-        <div className="grid-item">
+        <div className="grid-row">
           <strong></strong>
           {
             newHeaders.map(header => {

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
@@ -139,7 +139,7 @@ const renderMetrics = (newHeaders, model) => {
 
 const renderFeaturesTable = (features) => {
   return (
-    <div className="features-grid-wrapper">
+    <div className="grid-wrapper">
       <div className="grid grid-container">
         <div className="grid-header">
           <div className="grid-row">
@@ -156,7 +156,7 @@ const renderFeaturesTable = (features) => {
 
 const renderDirectivesTables = (directives) => {
   return (
-    <div className="features-grid-wrapper">
+    <div className="grid-wrapper">
       <div className="grid grid-container">
         <div className="grid-header">
           <div className="grid-row">
@@ -279,7 +279,7 @@ const renderModel = (model, outcomeType, experimentId, newlyTrainingModel) => {
   let newlyTrainingModelId = objectQuery(newlyTrainingModel, 'modelId');
   let Component = 'div';
   let props = {
-    className: classnames("grid-row", {
+    className: classnames("grid-row grid-link", {
       "opened": model.detailedView,
       "active": model.active,
       "highlight": model.id === newlyTrainingModelId
@@ -418,7 +418,9 @@ function ModelsTable({
           numberOfEntities={modelsTotalCount}
         />
       </div>
-      {renderGrid(modelsList, outcomeType, experimentId, newlyTrainingModel, modelsSortColumn, modelsSortMethod)}
+      <div className="grid-wrapper">
+        {renderGrid(modelsList, outcomeType, experimentId, newlyTrainingModel, modelsSortColumn, modelsSortMethod)}
+      </div>
     </div>
   );
 }

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
@@ -62,7 +62,7 @@
     max-height: calc(100% - 411px);
 
     .grid-header {
-      .grid-item {
+      .grid-row {
         grid-template-rows: auto;
       }
       .sortable-header {
@@ -78,7 +78,7 @@
       }
     }
 
-    .grid-item {
+    .grid-row {
       grid-template-columns: repeat(5, 1fr);
       grid-template-rows: 50px;
       > div {
@@ -88,7 +88,7 @@
         color: $cdap-lightgray;
       }
     }
-    a.grid-item {
+    a.grid-row {
       color: inherit;
     }
   }

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListView.scss
@@ -57,10 +57,13 @@
     }
   }
 
-  .grid.grid-container {
+  .grid-wrapper {
     // 50px (top panel) + 310 for chart + 51px for pagination
     max-height: calc(100% - 411px);
-
+    overflow: auto;
+  }
+  .grid.grid-container {
+    max-height: 100%;
     .grid-header {
       .grid-row {
         grid-template-rows: auto;

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListViewWrapper.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListViewWrapper.js
@@ -115,7 +115,7 @@ const renderGrid = (experiments, sortMethod, sortColumn) => {
   return (
     <div className="grid grid-container">
       <div className="grid-header">
-        <div className="grid-item">
+        <div className="grid-row">
           {
             tableHeaders.map((header, i) => {
               if (sortColumn === header.property) {
@@ -145,7 +145,7 @@ const renderGrid = (experiments, sortMethod, sortColumn) => {
             return (
               <Link
                 to={`/ns/${getCurrentNamespace()}/experiments/${experiment.name}`}
-                className="grid-item"
+                className="grid-row"
               >
                 <div>
                   <h5>

--- a/cdap-ui/app/cdap/components/Experiments/ListView/ListViewWrapper.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/ListViewWrapper.js
@@ -145,7 +145,7 @@ const renderGrid = (experiments, sortMethod, sortColumn) => {
             return (
               <Link
                 to={`/ns/${getCurrentNamespace()}/experiments/${experiment.name}`}
-                className="grid-row"
+                className="grid-row grid-link"
               >
                 <div>
                   <h5>
@@ -239,7 +239,9 @@ function ExperimentsListView({
           numberOfEntities={totalCount}
         />
       </div>
-      { renderGrid(list, sortMethod, sortColumn) }
+      <div className="grid-wrapper">
+        { renderGrid(list, sortMethod, sortColumn) }
+      </div>
     </div>
   );
 }

--- a/cdap-ui/app/cdap/components/NamespaceDetails/ComputeProfiles/ComputeProfiles.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/ComputeProfiles/ComputeProfiles.scss
@@ -28,11 +28,4 @@
       margin-top: 10px;
     }
   }
-
-  .profiles-list-view {
-    .grid.grid-container {
-      margin-top: -10px;
-      max-height: none;
-    }
-  }
 }

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/RunsTable.scss
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/RunsTable.scss
@@ -23,8 +23,13 @@ $header-bg-color: $grey-08;
 .runs-table-container {
   padding: 10px 75px;
 
+  .grid-wrapper {
+    height: 300px;
+    overflow: auto;
+  }
+
   .grid.grid-container {
-    max-height: 300px;
+    max-height: 100%;
     border-bottom: 1px solid $border-color;
 
     .grid-header,

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/RunsTable.scss
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/RunsTable.scss
@@ -29,7 +29,7 @@ $header-bg-color: $grey-08;
 
     .grid-header,
     .grid-body {
-      .grid-item {
+      .grid-row {
         grid-template-columns: 75px 150px 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
         padding: 0;
 
@@ -44,11 +44,11 @@ $header-bg-color: $grey-08;
       background-color: $header-bg-color;
       border-bottom: 2px solid $border-color;
 
-      .grid-item { align-items: end; }
+      .grid-row { align-items: end; }
     }
 
     .grid-body {
-      .grid-item {
+      .grid-row {
         > div:not(.column-date):not(.column-delay) {
           color: $column-color;
         }

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/index.js
@@ -25,7 +25,7 @@ require('./RunsTable.scss');
 const renderHeader = () => {
   return (
     <div className="grid-header">
-      <div className="grid-item">
+      <div className="grid-row">
         <div>
           Time
         </div>
@@ -71,7 +71,7 @@ const renderBody = (data, onRowClick) => {
           return (
             <div
               key={row.time}
-              className="grid-item"
+              className="grid-row"
               onClick={onRowClick.bind(this, row)}
             >
               <div className="column-time">

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/index.js
@@ -114,7 +114,7 @@ const renderBody = (data, onRowClick) => {
 
 function RunsTableView({data, onRowClick}) {
   return (
-    <div className="runs-table-container">
+    <div className="runs-table-container grid-wrapper">
       <div className="grid grid-container">
         {renderHeader()}
 

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ListViewInPipeline.scss
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ListViewInPipeline.scss
@@ -20,17 +20,17 @@
 .profiles-list-view-on-pipeline {
 
   .grid.grid-container {
-    .grid-item {
+    .grid-row {
       grid-template-columns: 30px 1fr 1fr 1fr;
     }
     .grid-header {
-      .grid-item {
+      .grid-row {
         background: $grey-07;
         padding: 5px 0;
       }
     }
     .grid-body {
-      .grid-item {
+      .grid-row {
         padding: 3px 0;
         // FIXME: This should be moved to the common styles. We should use the same
         // pattern in all the tables.

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ListViewInPipeline.scss
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ListViewInPipeline.scss
@@ -17,16 +17,26 @@
 @import "../../../../styles/mixins.scss";
 @import "../../../../styles/variables.scss";
 
+.compute-tab-content {
+  height: 100%;
+}
 .profiles-list-view-on-pipeline {
-
+  height: calc(100% - 40px); // 40px for the buttons at the bottom
+  > div {
+    height: 100%;
+  }
+  .grid-wrapper {
+    height: 100%;
+    overflow: auto;
+  }
   .grid.grid-container {
+    max-height: 100%;
     .grid-row {
       grid-template-columns: 30px 1fr 1fr 1fr;
     }
     .grid-header {
       .grid-row {
         background: $grey-07;
-        padding: 5px 0;
       }
     }
     .grid-body {

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView.js
@@ -109,7 +109,7 @@ export default class ProfilesListViewInPipeline extends Component {
           this.state.profiles.map(profile => {
             return (
               <div
-                className={classnames("grid-row", {
+                className={classnames("grid-row grid-link", {
                   "active": this.state.selectedProfile === profile.name
                 })}
                 onClick={this.onProfileSelect.bind(this, profile.name)}
@@ -147,7 +147,7 @@ export default class ProfilesListViewInPipeline extends Component {
       );
     }
     return (
-      <div>
+      <div className="profiles-listview grid-wrapper">
         <strong> Select the compute profile you want to use to run this pipeline</strong>
         <div className="profiles-count text-right">{this.state.profiles.length} Compute Profiles</div>
         <div className="grid grid-container">

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView.js
@@ -92,7 +92,7 @@ export default class ProfilesListViewInPipeline extends Component {
   renderGridHeader = () => {
     return (
       <div className="grid-header">
-        <div className="grid-item">
+        <div className="grid-row">
           <div></div>
           <strong>Profile Name</strong>
           <strong>Provider</strong>
@@ -109,7 +109,7 @@ export default class ProfilesListViewInPipeline extends Component {
           this.state.profiles.map(profile => {
             return (
               <div
-                className={classnames("grid-item", {
+                className={classnames("grid-row", {
                   "active": this.state.selectedProfile === profile.name
                 })}
                 onClick={this.onProfileSelect.bind(this, profile.name)}

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/ReportsList.scss
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/ReportsList.scss
@@ -45,7 +45,7 @@ $table-color: white;
 
       .grid-header,
       .grid-body {
-        .grid-item {
+        .grid-row {
           grid-template-columns: 2fr 250px 250px 1fr 50px;
           padding: 5px 25px;
         }

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/ReportsList.scss
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/ReportsList.scss
@@ -38,16 +38,18 @@ $table-color: white;
 
   .list-container {
     background-color: $table-color;
-    padding-bottom: 40px;
+    padding: 10px 10px 40px;
 
-    .grid.grid-container {
+    .grid-wrapper {
       max-height: 500px;
-
+      overflow: auto;
+    }
+    .grid.grid-container {
+      max-height: 100%;
       .grid-header,
       .grid-body {
         .grid-row {
           grid-template-columns: 2fr 250px 250px 1fr 50px;
-          padding: 5px 25px;
         }
       }
 

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/index.js
@@ -125,7 +125,7 @@ class ReportsListView extends Component {
             Select a report to view
           </div>
 
-          <div className="list-container">
+          <div className="list-container grid-wrapper">
             <div className="grid grid-container">
               {this.renderHeader()}
               {this.renderBody()}

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/index.js
@@ -75,7 +75,7 @@ class ReportsListView extends Component {
   renderHeader() {
     return (
       <div className="grid-header">
-        <div className="grid-item">
+        <div className="grid-row">
           <div>Report Name</div>
           <div>Created</div>
           <div>Expiration</div>
@@ -94,7 +94,7 @@ class ReportsListView extends Component {
             return (
               <div
                 key={report.id}
-                className="grid-item"
+                className="grid-row"
               >
                 <div className="report-name">{report.name}</div>
                 <div>

--- a/cdap-ui/app/cdap/styles/common.scss
+++ b/cdap-ui/app/cdap/styles/common.scss
@@ -46,7 +46,7 @@ body {
     &.grid-container {
       max-height: $maxGridHeight;
       overflow-y: auto;
-      .grid-item {
+      .grid-row {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax($minGridWidth, $maxGridWidth));
 
@@ -65,7 +65,7 @@ body {
         position: sticky;
         top: 0;
         background: $headerBgColor;
-        > .grid-item {
+        > .grid-row {
           border-bottom: 1px solid $grey-04;
           padding: 10px 0;
           border-left: 0;
@@ -74,7 +74,7 @@ body {
         }
       }
       .grid-body {
-        .grid-item {
+        .grid-row {
           padding: 7px 0;
           cursor: pointer;
           align-content: center;

--- a/cdap-ui/app/cdap/styles/common.scss
+++ b/cdap-ui/app/cdap/styles/common.scss
@@ -42,10 +42,53 @@ body {
   $headerBgColor: white;
   $borderColor: $grey-04;
 
+  /* This is the fallback for browsers that doesn't support css grid */
+
+  .grid.grid-container {
+    display: table;
+    border-collapse: collapse;
+    width: 100%;
+
+    .grid-row {
+      width: 100%;
+      display: table-row;
+      > strong,
+      > div {
+        display: table-cell;
+      }
+    }
+    .grid-header {
+      display: table-header-group;
+      .grid-row {
+        > * {
+          display: table-cell;
+          padding: 10px;
+        }
+      }
+    }
+    .grid-body {
+      display: table-row-group;
+      .grid-row {
+        &:hover {
+          background: $grey-08;
+        }
+        &:last-of-type,
+        &:first-of-type {
+          > div {
+            border: 0;
+          }
+        }
+      }
+    }
+  }
+
+  /* End of css grid fallback */
+
   .grid {
     &.grid-container {
       max-height: $maxGridHeight;
       overflow-y: auto;
+      display: grid;
       .grid-row {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax($minGridWidth, $maxGridWidth));
@@ -63,23 +106,27 @@ body {
       }
       .grid-header {
         position: sticky;
+        display: grid;
         top: 0;
         background: $headerBgColor;
         > .grid-row {
           border-bottom: 1px solid $grey-04;
-          padding: 10px 0;
+          padding: 0;
           border-left: 0;
           border-right: 0;
           border-top: 0;
         }
       }
       .grid-body {
+        display: grid;
         .grid-row {
-          padding: 7px 0;
-          cursor: pointer;
+          padding: 7px 5px;
           align-content: center;
           align-items: center;
           border-bottom: 1px solid $grey-04;
+          &.grid-link {
+            cursor: pointer;
+          }
           &:hover {
             background: $grey-08;
           }

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -288,7 +288,7 @@ footer {
   &.grid-container {
     max-height: @maxGridHeight;
     overflow-y: auto;
-    .grid-item {
+    .grid-row {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(@minGridWidth, @maxGridWidth));
 
@@ -307,7 +307,7 @@ footer {
       position: sticky;
       top: 0;
       background: @headerBgColor;
-      > .grid-item {
+      > .grid-row {
         border-bottom: 1px solid @grey-04;
         padding: 10px 0;
         border-left: 0;
@@ -316,7 +316,7 @@ footer {
       }
     }
     .grid-body {
-      .grid-item {
+      .grid-row {
         padding: 7px 0;
         cursor: pointer;
         align-content: center;

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -284,10 +284,53 @@ footer {
 @headerBgColor: white;
 @borderColor: @grey-04;
 
+/* This is the fallback for browsers that doesn't support css grid */
+
+.grid.grid-container {
+  display: table;
+  width: 100%;
+  border-collapse: collapse;
+
+  .grid-row {
+    width: 100%;
+    display: table-row;
+    > strong,
+    > div {
+      display: table-cell;
+    }
+  }
+  .grid-header {
+    display: table-header-group;
+    .grid-row {
+      > * {
+        display: table-cell;
+        padding: 10px;
+      }
+    }
+  }
+  .grid-body {
+    display: table-row-group;
+    .grid-row {
+      &:hover {
+        background: @grey-08;
+      }
+      &:last-of-type,
+      &:first-of-type {
+        > div {
+          border: 0;
+        }
+      }
+    }
+  }
+}
+
+/* End of css grid fallback */
+
 .grid {
   &.grid-container {
     max-height: @maxGridHeight;
     overflow-y: auto;
+    display: grid;
     .grid-row {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(@minGridWidth, @maxGridWidth));
@@ -305,23 +348,27 @@ footer {
     }
     .grid-header {
       position: sticky;
+      display: grid;
       top: 0;
       background: @headerBgColor;
       > .grid-row {
         border-bottom: 1px solid @grey-04;
-        padding: 10px 0;
+        padding: 0;
         border-left: 0;
         border-right: 0;
         border-top: 0;
       }
     }
     .grid-body {
+      display: grid;
       .grid-row {
-        padding: 7px 0;
-        cursor: pointer;
+        padding: 7px 5px;
         align-content: center;
         align-items: center;
         border-bottom: 1px solid @grey-04;
+        &.grid-link {
+          cursor: pointer;
+        }
         &:hover {
           background: @grey-08;
         }


### PR DESCRIPTION
- Modifies `grid-row` to grid-item for better readability.
- Adds a css fallback for browsers that doesn't support `grid`.

JIRA: https://issues.cask.co/browse/CDAP-13279