### PR TITLE
deprecate and replace waitForStatus() calls in unit tests

### DIFF
--- a/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/test/DataQualityAppTest.java
+++ b/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/test/DataQualityAppTest.java
@@ -203,7 +203,7 @@ public class DataQualityAppTest extends TestBase {
 
     ServiceManager serviceManager = applicationManager.getServiceManager
       (DataQualityService.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     /* Test for aggregationsGetter handler */
 
@@ -248,7 +248,7 @@ public class DataQualityAppTest extends TestBase {
 
     ServiceManager serviceManager = applicationManager.getServiceManager
       (DataQualityService.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL url = new URL(serviceManager.getServiceURL(),
                       "v1/sources/logStream/fields/content_length/aggregations/DiscreteValuesHistogram/totals");
     HttpResponse httpResponse = HttpRequests.execute(HttpRequest.get(url).build());

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -2895,7 +2895,7 @@ public class DataPipelineTest extends HydratorTestBase {
     ServiceManager serviceManager = appManager.getServiceManager(ServiceApp.Name.SERVICE_NAME).start();
 
     // Wait service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     URL url = new URL(serviceManager.getServiceURL(), "name");
     HttpRequest httpRequest = HttpRequest.post(url).withBody("bob").build();

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsSparkSinkTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsSparkSinkTest.java
@@ -109,7 +109,7 @@ public class DataStreamsSparkSinkTest  extends HydratorTestBase {
   private void testSparkSink(ApplicationManager appManager, final String output) throws Exception {
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start(ImmutableMap.of("tablename", output));
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     Tasks.waitFor(true, new Callable<Boolean>() {
       @Override
@@ -134,7 +134,7 @@ public class DataStreamsSparkSinkTest  extends HydratorTestBase {
       }, 1, TimeUnit.MINUTES);
 
     sparkManager.stop();
-    sparkManager.waitForStatus(false, 10, 1);
+    sparkManager.waitForStopped(10, TimeUnit.SECONDS);
     sparkManager.waitForRun(ProgramRunStatus.KILLED, 10, TimeUnit.SECONDS);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
@@ -47,6 +47,7 @@ import co.cask.cdap.etl.mock.transform.StringValueFilterTransform;
 import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.etl.spark.Compat;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
@@ -156,7 +157,7 @@ public class DataStreamsTest extends HydratorTestBase {
                                        String val1, String val2, final String outputName) throws Exception {
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start(ImmutableMap.of("field", "name", "val1", val1, "val2", val2, "output", outputName));
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // since dataset name is a macro, the dataset isn't created until it is needed. Wait for it to exist
     Tasks.waitFor(true, new Callable<Boolean>() {
@@ -182,7 +183,7 @@ public class DataStreamsTest extends HydratorTestBase {
       TimeUnit.MINUTES);
 
     sparkManager.stop();
-    sparkManager.waitForStatus(false, 10, 1);
+    sparkManager.waitForStopped(10, TimeUnit.SECONDS);
   }
 
   @Test
@@ -238,7 +239,7 @@ public class DataStreamsTest extends HydratorTestBase {
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start(arguments);
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     final DataSetManager<Table> sink1 = getDataset("sink1");
     final DataSetManager<Table> sink2 = getDataset("sink2");
@@ -281,7 +282,7 @@ public class DataStreamsTest extends HydratorTestBase {
       TimeUnit.MINUTES);
 
     sparkManager.stop();
-    sparkManager.waitForStatus(false, 30, 1);
+    sparkManager.waitForStopped(30, TimeUnit.SECONDS);
 
     MockSink.clear(sink1);
     MockSink.clear(sink2);
@@ -293,7 +294,7 @@ public class DataStreamsTest extends HydratorTestBase {
     arguments.put("flagField", "dupe");
 
     sparkManager.start(arguments);
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     aggSchema = Schema.recordOf(
       "user.count",
@@ -383,7 +384,7 @@ public class DataStreamsTest extends HydratorTestBase {
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start();
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     Schema outputSchema1 = Schema.recordOf(
       "user.count",
@@ -440,7 +441,7 @@ public class DataStreamsTest extends HydratorTestBase {
       TimeUnit.MINUTES);
 
     sparkManager.stop();
-    sparkManager.waitForStatus(false, 10, 1);
+    sparkManager.waitForStopped(10, TimeUnit.SECONDS);
     
     validateMetric(appId, "source1.records.out", 2);
     validateMetric(appId, "source2.records.out", 3);
@@ -484,7 +485,7 @@ public class DataStreamsTest extends HydratorTestBase {
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start();
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // the sink should contain at least one record with count of 3, and no records with more than 3.
     // less than 3 if the window doesn't contain all 3 records yet, but there should eventually be a window
@@ -613,7 +614,7 @@ public class DataStreamsTest extends HydratorTestBase {
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start();
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     StructuredRecord joinRecordSamuel = StructuredRecord.builder(outSchema2)
       .set("customer_id", "1").set("customer_name", "samuel")
@@ -645,7 +646,7 @@ public class DataStreamsTest extends HydratorTestBase {
       TimeUnit.MINUTES);
 
     sparkManager.stop();
-    sparkManager.waitForStatus(false, 10, 1);
+    sparkManager.waitForStopped(10, TimeUnit.SECONDS);
 
     validateMetric(appId, "source1.records.out", 3);
     validateMetric(appId, "source2.records.out", 2);
@@ -722,7 +723,7 @@ public class DataStreamsTest extends HydratorTestBase {
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start();
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     Schema flattenSchema =
       Schema.recordOf("erroruser",
@@ -818,7 +819,7 @@ public class DataStreamsTest extends HydratorTestBase {
     // run pipeline
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start();
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // check output
     // sink1 should only have records where both name and email are null (user0)
@@ -857,7 +858,7 @@ public class DataStreamsTest extends HydratorTestBase {
       TimeUnit.MINUTES);
 
     sparkManager.stop();
-    sparkManager.waitForStatus(false, 10, 1);
+    sparkManager.waitForStopped(10, TimeUnit.SECONDS);
 
     validateMetric(appId, "source.records.out", 4);
     validateMetric(appId, "splitter1.records.in", 4);
@@ -902,7 +903,7 @@ public class DataStreamsTest extends HydratorTestBase {
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
     sparkManager.start();
-    sparkManager.waitForStatus(true, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     final Set<StructuredRecord> expectedRecords = ImmutableSet.of(record1, record2);
     final Set<Alert> expectedMessages = ImmutableSet.of(new Alert("nullAlert", new HashMap<String, String>()));
@@ -942,7 +943,7 @@ public class DataStreamsTest extends HydratorTestBase {
       TimeUnit.MINUTES);
 
     sparkManager.stop();
-    sparkManager.waitForStatus(false, 10, 1);
+    sparkManager.waitForStopped(10, TimeUnit.SECONDS);
 
     validateMetric(appId, "source.records.out", 3);
     validateMetric(appId, "nullAlert.records.in", 3);

--- a/cdap-examples/DataCleansing/src/test/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduceTest.java
+++ b/cdap-examples/DataCleansing/src/test/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduceTest.java
@@ -88,7 +88,7 @@ public class DataCleansingMapReduceTest extends TestBase {
     ApplicationManager applicationManager = deployApplication(DataCleansing.class);
 
     ServiceManager serviceManager = applicationManager.getServiceManager(DataCleansingService.NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL();
 
     // write a set of records to one partition and run the DataCleansingMapReduce job on that one partition

--- a/cdap-examples/DecisionTreeRegression/src/test/java/co/cask/cdap/examples/dtree/DecisionTreeRegressionAppTest.java
+++ b/cdap-examples/DecisionTreeRegression/src/test/java/co/cask/cdap/examples/dtree/DecisionTreeRegressionAppTest.java
@@ -58,7 +58,7 @@ public class DecisionTreeRegressionAppTest extends TestBaseWithSpark2 {
 
     // Start the Service
     ServiceManager serviceManager = appManager.getServiceManager(ModelDataService.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true, 30, 1);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 30, TimeUnit.SECONDS);
 
     URL serviceURL = serviceManager.getServiceURL(15, TimeUnit.SECONDS);
     URL addDataURL = new URL(serviceURL, "labels");

--- a/cdap-examples/FileSetExample/src/test/java/co/cask/cdap/examples/fileset/FileSetWordCountTest.java
+++ b/cdap-examples/FileSetExample/src/test/java/co/cask/cdap/examples/fileset/FileSetWordCountTest.java
@@ -66,7 +66,7 @@ public class FileSetWordCountTest extends TestBase {
 
     // discover the file set service
     ServiceManager serviceManager = applicationManager.getServiceManager("FileSetService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL();
 
     // write a file to the file set using the service

--- a/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
+++ b/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.examples.helloworld;
 
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.ServiceManager;
@@ -49,7 +50,7 @@ public class HelloWorldTest extends TestBase {
 
     // Start WhoFlow
     FlowManager flowManager = appManager.getFlowManager("WhoFlow").start();
-    flowManager.waitForStatus(true);
+    flowManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Send stream events to the "who" Stream
     StreamManager streamManager = getStreamManager("who");
@@ -72,7 +73,7 @@ public class HelloWorldTest extends TestBase {
     ServiceManager serviceManager = appManager.getServiceManager(HelloWorld.Greeting.SERVICE_NAME).start();
 
     // Wait service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     URL url = new URL(serviceManager.getServiceURL(), "greet");
     HttpURLConnection connection = (HttpURLConnection) url.openConnection();

--- a/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
+++ b/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
@@ -39,7 +39,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Unit test for {@link LogAnalysisApp}
@@ -131,13 +133,13 @@ public class LogAnalysisAppTest extends TestBase {
   }
 
   private ServiceManager getServiceManager(ApplicationManager appManager, String serviceName)
-    throws InterruptedException {
+    throws InterruptedException, TimeoutException, ExecutionException {
     // Start the service
     ServiceManager serviceManager =
       appManager.getServiceManager(serviceName).start();
 
     // Wait for service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     return serviceManager;
   }
 }

--- a/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
+++ b/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
@@ -35,7 +35,9 @@ import org.junit.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Test for {@link PurchaseApp}.
@@ -114,7 +116,7 @@ public class PurchaseAppTest extends TestBase {
       appManager.getServiceManager(PurchaseHistoryService.SERVICE_NAME).start();
 
     // Wait for service startup
-    purchaseHistoryServiceManager.waitForStatus(true);
+    purchaseHistoryServiceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Test service to retrieve a customer's purchase history
     URL url = new URL(purchaseHistoryServiceManager.getServiceURL(15, TimeUnit.SECONDS), "history/joe");
@@ -135,13 +137,14 @@ public class PurchaseAppTest extends TestBase {
     Assert.assertEquals(profileFromPurchaseHistory.getLastName(), "bernard");
   }
 
-  private ServiceManager getUserProfileServiceManager(ApplicationManager appManager) throws InterruptedException {
+  private ServiceManager getUserProfileServiceManager(ApplicationManager appManager)
+    throws InterruptedException, TimeoutException, ExecutionException {
     // Start UserProfileService
     ServiceManager userProfileServiceManager =
       appManager.getServiceManager(UserProfileServiceHandler.SERVICE_NAME).start();
 
     // Wait for service startup
-    userProfileServiceManager.waitForStatus(true);
+    userProfileServiceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     return userProfileServiceManager;
   }
 }

--- a/cdap-examples/SpamClassifier/src/test/java/co/cask/cdap/examples/sparkstreaming/SpamClassifierTest.java
+++ b/cdap-examples/SpamClassifier/src/test/java/co/cask/cdap/examples/sparkstreaming/SpamClassifierTest.java
@@ -119,7 +119,7 @@ public class SpamClassifierTest extends TestBase {
 
     // Start and wait for service to start
     final ServiceManager serviceManager = appManager.getServiceManager(SpamClassifier.SERVICE_HANDLER).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // wait for spark streaming program to write to dataset
     Tasks.waitFor(true, new Callable<Boolean>() {

--- a/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
+++ b/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
@@ -75,7 +75,7 @@ public class SparkKMeansAppTest extends TestBase {
     ServiceManager serviceManager = appManager.getServiceManager(SparkKMeansApp.CentersService.SERVICE_NAME).start();
 
     // Wait service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Request data and verify it
     String response = requestService(new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "centers/0"));

--- a/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
+++ b/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
@@ -66,7 +66,7 @@ public class SparkPageRankAppTest extends TestBase {
       .start();
 
     // Wait for service to start since the Spark program needs it
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Start the SparkPageRankProgram
     SparkManager sparkManager = appManager.getSparkManager(SparkPageRankApp.PageRankSpark.class.getSimpleName())

--- a/cdap-examples/SportResults/src/test/java/co/cask/cdap/examples/sportresults/SportResultsTest.java
+++ b/cdap-examples/SportResults/src/test/java/co/cask/cdap/examples/sportresults/SportResultsTest.java
@@ -61,7 +61,7 @@ public class SportResultsTest extends TestBase {
     // deploy the application and start the upload service
     ApplicationManager appManager = deployApplication(SportResults.class);
     ServiceManager serviceManager = appManager.getServiceManager("UploadService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // upload a few dummy results
     URL url = serviceManager.getServiceURL();

--- a/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
+++ b/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
@@ -57,7 +58,7 @@ public class UserProfilesTest extends TestBase {
     FlowManager flowManager = applicationManager.getFlowManager("ActivityFlow").start();
 
     ServiceManager serviceManager = applicationManager.getServiceManager("UserProfileService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL();
 
     // create a user through the service

--- a/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
+++ b/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
@@ -86,7 +87,7 @@ public class WordCountTest extends TestBase {
     ServiceManager serviceManager = appManager.getServiceManager(RetrieveCounts.SERVICE_NAME).start();
 
     // Wait service startup
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // First verify global statistics
     String response = requestService(new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "stats"));

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Test for {@link IntegrationTestBase}.
@@ -53,7 +55,7 @@ public class IntegrationTestBaseTest extends IntegrationTestBase {
   public void testFlowManager() throws Exception {
     ApplicationManager applicationManager = deployApplication(TestApplication.class);
     FlowManager flowManager = applicationManager.getFlowManager(TestFlow.NAME).start();
-    flowManager.waitForStatus(true);
+    flowManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     flowManager.stop();
   }
 
@@ -96,7 +98,7 @@ public class IntegrationTestBaseTest extends IntegrationTestBase {
 
     ApplicationManager appManager = deployApplication(NamespaceId.DEFAULT, AppUsingCustomModule.class);
     ServiceManager serviceManager = appManager.getServiceManager("MyService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     put(serviceManager, "a", "1");
     put(serviceManager, "b", "2");

--- a/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
@@ -87,6 +87,11 @@ public abstract class AbstractProgramManager<T extends ProgramManager> implement
     }, timeout, timeoutUnit);
   }
 
+  @Override
+  public void waitForStopped(long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException,
+    ExecutionException {
+    Tasks.waitFor(false, () -> isRunning(), timeout, timeUnit);
+  }
 
   @Override
   public void waitForStatus(boolean status) throws InterruptedException {

--- a/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
@@ -57,11 +57,28 @@ public interface ProgramManager<T extends ProgramManager> {
   boolean isRunning();
 
   /**
-   * Wait for the status of the program with 5 seconds timeout.
+   * Wait for the status of the program with 5 seconds timeout. A started program does not mean all functionality
+   * is available. For example, a started service may not yet have registered its url. In most cases,
+   * {@link #waitForRun(ProgramRunStatus, long, TimeUnit)} should be used
+   * with {@link ProgramRunStatus#RUNNING} to wait for a program to actually be running, and
+   * {@link #waitForStopped(long, TimeUnit)} should be used to wait for the program to stop.
+   *
    * @param status true if waiting for started, false if waiting for stopped.
    * @throws InterruptedException if the method is interrupted while waiting for the status.
+   * @deprecated use {@link #waitForRun(ProgramRunStatus, long, TimeUnit)} or {@link #waitForStopped(long, TimeUnit)}.
    */
+  @Deprecated
   void waitForStatus(boolean status) throws InterruptedException;
+
+  /**
+   * Wait for the program to be stopped.
+   *
+   * @throws InterruptedException if method is interrupted while waiting for runs
+   * @throws TimeoutException if timeout reached
+   * @throws ExecutionException if error getting program status
+   */
+  void waitForStopped(long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException,
+    ExecutionException;
 
   /**
    * Blocks until at least the one run record is available with the given {@link ProgramRunStatus}.
@@ -73,7 +90,6 @@ public interface ProgramManager<T extends ProgramManager> {
    * @throws TimeoutException if timeout reached
    * @throws ExecutionException if error getting runs
    */
-  @Beta
   void waitForRun(ProgramRunStatus status, long timeout, TimeUnit timeoutUnit)
     throws InterruptedException, ExecutionException, TimeoutException;
 
@@ -88,7 +104,6 @@ public interface ProgramManager<T extends ProgramManager> {
    * @throws TimeoutException if timeout reached
    * @throws ExecutionException if error getting runs
    */
-  @Beta
   void waitForRuns(ProgramRunStatus status, int runCount, long timeout, TimeUnit timeoutUnit)
     throws InterruptedException, ExecutionException, TimeoutException;
 
@@ -98,7 +113,9 @@ public interface ProgramManager<T extends ProgramManager> {
    * @param retries number of attempts to check for status.
    * @param timeout timeout in seconds between attempts.
    * @throws InterruptedException if the method is interrupted while waiting for the status.
+   * @deprecated use {@link #waitForRun(ProgramRunStatus, long, TimeUnit)} or {@link #waitForStopped(long, TimeUnit)}.
    */
+  @Deprecated
   void waitForStatus(boolean status, int retries, int timeout) throws InterruptedException;
 
   /**

--- a/cdap-unit-test-spark2_2.11/src/test/java/co/cask/cdap/spark/Spark2Test.java
+++ b/cdap-unit-test-spark2_2.11/src/test/java/co/cask/cdap/spark/Spark2Test.java
@@ -121,7 +121,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
     prepareInputData(keysManager);
 
     SparkManager sparkManager = applicationManager.getSparkManager(CharCountProgram.class.getSimpleName()).start();
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStopped(60, TimeUnit.SECONDS);
 
     DataSetManager<KeyValueTable> countManager = getDataset("count");
     checkOutputData(countManager);
@@ -162,7 +163,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
     prepareInputData(keysManager);
 
     SparkManager sparkManager = applicationManager.getSparkManager(ScalaCharCountProgram.class.getSimpleName()).start();
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStopped(60, TimeUnit.SECONDS);
 
     DataSetManager<KeyValueTable> countManager = getDataset("count");
     checkOutputData(countManager);
@@ -196,7 +198,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
                                                ScalaCrossNSProgram.DATASET_NAME(), "count");
     SparkManager sparkManager =
       applicationManager.getSparkManager(ScalaCrossNSProgram.class.getSimpleName()).start(args);
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStopped(60, TimeUnit.SECONDS);
 
     // get the dataset from the other namespace where we expect it to exist and compare the data
     DataSetManager<KeyValueTable> countManager = getDataset(crossNSDatasetMeta.getNamespaceId().dataset("count"));
@@ -223,7 +226,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
     ApplicationManager applicationManager = deploy(NamespaceId.DEFAULT, SparkAppUsingObjectStore.class);
     SparkManager sparkManager =
       applicationManager.getSparkManager(ScalaCharCountProgram.class.getSimpleName()).start(args);
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStopped(60, TimeUnit.SECONDS);
 
     DataSetManager<KeyValueTable> countManager = getDataset("count");
     checkOutputData(countManager);
@@ -281,7 +285,8 @@ public class Spark2Test extends TestBaseWithSpark2 {
 
     SparkManager sparkManager = applicationManager.getSparkManager(sparkProgram)
       .start(Collections.singletonMap(SparkAppUsingLocalFiles.LOCAL_FILE_RUNTIME_ARG, localFile.toString()));
-    sparkManager.waitForRun(ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.waitForStopped(120, TimeUnit.SECONDS);
 
     DataSetManager<KeyValueTable> kvTableManager = getDataset(SparkAppUsingLocalFiles.OUTPUT_DATASET_NAME);
     KeyValueTable kvTable = kvTableManager.get();

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/MapReduceServiceIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/MapReduceServiceIntegrationTestRun.java
@@ -35,7 +35,7 @@ public class MapReduceServiceIntegrationTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(TestMapReduceServiceIntegrationApp.class);
     ServiceManager serviceManager =
       applicationManager.getServiceManager(TestMapReduceServiceIntegrationApp.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     DataSetManager<MyKeyValueTableDefinition.KeyValueTable> inDataSet =
       getDataset(TestMapReduceServiceIntegrationApp.INPUT_DATASET);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionConsumingTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionConsumingTestRun.java
@@ -87,7 +87,7 @@ public class PartitionConsumingTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(AppWithPartitionConsumers.class);
 
     ServiceManager serviceManager = applicationManager.getServiceManager("DatasetService").start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL();
 
     // write a file to the file set using the service and run the WordCount MapReduce job on that one partition

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -276,7 +276,7 @@ public class AuthorizationTest extends TestBase {
     } catch (UnauthorizedException e) {
       // Expected
     }
-    flowManager.waitForStatus(false);
+    flowManager.waitForStopped(10, TimeUnit.SECONDS);
 
     authorizer.grant(Authorizable.fromEntityId(streamId1), ALICE, ImmutableSet.of(Action.READ));
     flowManager.start();
@@ -847,7 +847,7 @@ public class AuthorizationTest extends TestBase {
     // system namespace. Since the failure will lead to no metrics being emitted we cannot actually check it tried
     // processing or not. So stop the flow and check that the output dataset is empty
     flowManager.stop();
-    flowManager.waitForStatus(false);
+    flowManager.waitForStopped(10, TimeUnit.SECONDS);
 
     assertDatasetIsEmpty(NamespaceId.SYSTEM, "store");
 
@@ -1665,7 +1665,7 @@ public class AuthorizationTest extends TestBase {
       }
     }, 5, TimeUnit.MINUTES, "Not all program runs have failed status. Expected all run status to be failed");
 
-    programManager.waitForStatus(false);
+    programManager.waitForStopped(10, TimeUnit.SECONDS);
   }
 
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/ServiceArtifactTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/ServiceArtifactTestRun.java
@@ -107,6 +107,6 @@ public class ServiceArtifactTestRun extends TestFrameworkTestBase {
     }
 
     serviceManager.stop();
-    serviceManager.waitForStatus(false);
+    serviceManager.waitForStopped(10, TimeUnit.SECONDS);
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/ServiceLifeCycleTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/ServiceLifeCycleTestRun.java
@@ -122,7 +122,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
       }
     } finally {
       serviceManager.stop();
-      serviceManager.waitForStatus(false);
+      serviceManager.waitForStopped(10, TimeUnit.SECONDS);
       // Reset the http server properties to speed up test
       System.clearProperty(AbstractServiceHttpServer.HANDLER_CLEANUP_PERIOD_MILLIS);
     }
@@ -178,7 +178,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
       }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     } finally {
       serviceManager.stop();
-      serviceManager.waitForStatus(false);
+      serviceManager.waitForStopped(10, TimeUnit.SECONDS);
       // Reset the http server properties to speed up test
       System.clearProperty(AbstractServiceHttpServer.HANDLER_CLEANUP_PERIOD_MILLIS);
     }
@@ -268,7 +268,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
 
     } finally {
       serviceManager.stop();
-      serviceManager.waitForStatus(false);
+      serviceManager.waitForStopped(10, TimeUnit.SECONDS);
     }
   }
 
@@ -315,7 +315,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
 
     } finally {
       serviceManager.stop();
-      serviceManager.waitForStatus(false);
+      serviceManager.waitForStopped(10, TimeUnit.SECONDS);
     }
   }
 
@@ -377,7 +377,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
 
     } finally {
       serviceManager.stop();
-      serviceManager.waitForStatus(false);
+      serviceManager.waitForStopped(10, TimeUnit.SECONDS);
     }
   }
 
@@ -392,7 +392,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
     uploadLatch.countDown();
     Assert.assertEquals(500, completion.get().intValue());
     serviceManager.stop();
-    serviceManager.waitForStatus(false);
+    serviceManager.waitForStopped(10, TimeUnit.SECONDS);
   }
 
   @Test
@@ -435,7 +435,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
       Assert.assertEquals("0123456789", new String(ByteStreams.toByteArray(urlConn.getInputStream()), "UTF-8"));
     } finally {
       serviceManager.stop();
-      serviceManager.waitForStatus(false);
+      serviceManager.waitForStopped(10, TimeUnit.SECONDS);
       urlConn.disconnect();
     }
   }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/SparkServiceIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/SparkServiceIntegrationTestRun.java
@@ -33,7 +33,9 @@ import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Test Spark program integration with Service
@@ -63,11 +65,11 @@ public class SparkServiceIntegrationTestRun extends TestFrameworkTestBase {
   /**
    * Starts a Service
    */
-  private void startService(ApplicationManager applicationManager) {
+  private void startService(ApplicationManager applicationManager) throws TimeoutException, ExecutionException {
     ServiceManager serviceManager =
       applicationManager.getServiceManager(TestSparkServiceIntegrationApp.SERVICE_NAME).start();
     try {
-      serviceManager.waitForStatus(true);
+      serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       LOG.error("Failed to start {} service", TestSparkServiceIntegrationApp.SERVICE_NAME, e);
       throw Throwables.propagate(e);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.lib.cube.MeasureType;
 import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SlowTests;
@@ -68,7 +69,7 @@ public class TestAppWithCube extends TestBase {
 
     ServiceManager serviceManager = appManager.getServiceManager(AppWithCube.SERVICE_NAME).start();
     try {
-      serviceManager.waitForStatus(true);
+      serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
       URL url = serviceManager.getServiceURL();
 
       long tsInSec = System.currentTimeMillis() / 1000;
@@ -166,7 +167,7 @@ public class TestAppWithCube extends TestBase {
 
     } finally {
       serviceManager.stop();
-      serviceManager.waitForStatus(false);
+      serviceManager.waitForStopped(10, TimeUnit.SECONDS);
     }
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -195,7 +195,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     input.send("21");
 
     ServiceManager serviceManager = applicationManager.getServiceManager("CountService").start();
-    serviceManager.waitForStatus(true, 2, 1);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     Assert.assertEquals("1", new Gson().fromJson(
       callServiceGet(serviceManager.getServiceURL(), "result"), String.class));
@@ -254,7 +254,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     Assert.assertEquals(0, history.size());
 
     countService.start();
-    countService.waitForStatus(true);
+    countService.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     Assert.assertEquals(2, countService.getProvisionedInstances());
 
     // requesting with ProgramRunStatus.KILLED returns empty list
@@ -282,13 +282,13 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(testSpace, AppUsingNamespace.class);
     ServiceManager serviceManager = applicationManager.getServiceManager(AppUsingNamespace.SERVICE_NAME);
     serviceManager.start();
-    serviceManager.waitForStatus(true, 1, 10);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     URL serviceURL = serviceManager.getServiceURL(10, TimeUnit.SECONDS);
     Assert.assertEquals(testSpace.getNamespace(), callServiceGet(serviceURL, "ns"));
 
     serviceManager.stop();
-    serviceManager.waitForStatus(false, 1, 10);
+    serviceManager.waitForStopped(10, TimeUnit.SECONDS);
   }
 
   @Test
@@ -317,7 +317,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     final WorkerManager workerManager = appManager.getWorkerManager(AppWithPlugin.WORKER);
     workerManager.start();
-    workerManager.waitForStatus(false, 5, 1);
+    workerManager.waitForStopped(5, TimeUnit.SECONDS);
     Tasks.waitFor(false, new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
@@ -327,11 +327,11 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     final ServiceManager serviceManager = appManager.getServiceManager(AppWithPlugin.SERVICE);
     serviceManager.start();
-    serviceManager.waitForStatus(true, 1, 10);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = serviceManager.getServiceURL(5, TimeUnit.SECONDS);
     callServiceGet(serviceURL, "dummy");
     serviceManager.stop();
-    serviceManager.waitForStatus(false, 1, 10);
+    serviceManager.waitForStopped(10, TimeUnit.SECONDS);
     Tasks.waitFor(false, new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
@@ -412,13 +412,13 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager appManager = deployApplication(appId, createRequest);
     ServiceManager serviceManager = appManager.getServiceManager(ConfigTestApp.SERVICE_NAME);
     serviceManager.start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     URL serviceURL = serviceManager.getServiceURL();
     Gson gson = new Gson();
     Assert.assertEquals("tV1", gson.fromJson(callServiceGet(serviceURL, "ping"), String.class));
     serviceManager.stop();
-    serviceManager.waitForStatus(false);
+    serviceManager.waitForStopped(10, TimeUnit.SECONDS);
 
     appId = new ApplicationId(NamespaceId.DEFAULT.getNamespace(), "AppV1", "version2");
     createRequest = new AppRequest<>(
@@ -427,7 +427,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     appManager = deployApplication(appId, createRequest);
     serviceManager = appManager.getServiceManager(ConfigTestApp.SERVICE_NAME);
     serviceManager.start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     serviceURL = serviceManager.getServiceURL();
     Assert.assertEquals("tV2", gson.fromJson(callServiceGet(serviceURL, "ping"), String.class));
@@ -651,7 +651,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     ApplicationManager appManager = deployApplication(DatasetWithCustomActionApp.class);
     ServiceManager serviceManager = appManager.getServiceManager(DatasetWithCustomActionApp.CUSTOM_SERVICE).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(DatasetWithCustomActionApp.CUSTOM_WORKFLOW).start();
     workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
@@ -1073,7 +1073,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     TimeUnit.SECONDS.sleep(1);
 
     ServiceManager queryManager = applicationManager.getServiceManager("QueryService").start();
-    queryManager.waitForStatus(true, 2, 1);
+    queryManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     URL serviceURL = queryManager.getServiceURL();
     Gson gson = new Gson();
 
@@ -1094,13 +1094,13 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(AppUsingGetServiceURL.class);
     ServiceManager centralServiceManager =
       applicationManager.getServiceManager(AppUsingGetServiceURL.CENTRAL_SERVICE).start();
-    centralServiceManager.waitForStatus(true);
+    centralServiceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     WorkerManager pingingWorker = applicationManager.getWorkerManager(AppUsingGetServiceURL.PINGING_WORKER).start();
 
     // Test service's getServiceURL
     ServiceManager serviceManager = applicationManager.getServiceManager(AppUsingGetServiceURL.FORWARDING).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     String result = callServiceGet(serviceManager.getServiceURL(), "ping");
     String decodedResult = new Gson().fromJson(result, String.class);
     // Verify that the service was able to hit the CentralService and retrieve the answer.
@@ -1119,10 +1119,10 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     } catch (Throwable e) {
       LOG.error("Got exception while stopping pinging worker", e);
     }
-    pingingWorker.waitForStatus(false);
+    pingingWorker.waitForStopped(10, TimeUnit.SECONDS);
 
     centralServiceManager.stop();
-    centralServiceManager.waitForStatus(false);
+    centralServiceManager.waitForStopped(10, TimeUnit.SECONDS);
     centralServiceManager.waitForRun(ProgramRunStatus.KILLED, 10, TimeUnit.SECONDS);
   }
 
@@ -1166,7 +1166,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   public void testWorkerInstances() throws Exception {
     ApplicationManager applicationManager = deployApplication(testSpace, AppUsingGetServiceURL.class);
     WorkerManager workerManager = applicationManager.getWorkerManager(AppUsingGetServiceURL.PINGING_WORKER).start();
-    workerManager.waitForStatus(true);
+    workerManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Should be 5 instances when first started.
     workerInstancesCheck(workerManager, 5);
@@ -1185,7 +1185,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     WorkerManager lifecycleWorkerManager = applicationManager.getWorkerManager(AppUsingGetServiceURL.LIFECYCLE_WORKER);
     lifecycleWorkerManager.setInstances(3);
-    lifecycleWorkerManager.start().waitForStatus(true);
+    lifecycleWorkerManager.start().waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     workerInstancesCheck(lifecycleWorkerManager, 3);
     for (int i = 0; i < 3; i++) {
@@ -1204,12 +1204,12 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     }
 
     lifecycleWorkerManager.stop();
-    lifecycleWorkerManager.waitForStatus(false);
+    lifecycleWorkerManager.waitForStopped(10, TimeUnit.SECONDS);
 
     if (workerManager.isRunning()) {
       workerManager.stop();
     }
-    workerManager.waitForStatus(false);
+    workerManager.waitForStopped(10, TimeUnit.SECONDS);
 
     // Should be same instances after being stopped.
     workerInstancesCheck(lifecycleWorkerManager, 5);
@@ -1337,9 +1337,9 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
       flowManager.getFlowletMetrics(AppWithCustomTx.FLOWLET_NOTX).waitForProcessed(1, 10, TimeUnit.SECONDS);
       flowManager.stop();
-      flowManager.waitForStatus(false);
+      flowManager.waitForStopped(10, TimeUnit.SECONDS);
 
-      serviceManager.waitForStatus(true);
+      serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
       callServicePut(serviceManager.getServiceURL(), "tx", "hello");
       callServicePut(serviceManager.getServiceURL(), "tx", AppWithCustomTx.FAIL_PRODUCER, 200);
       callServicePut(serviceManager.getServiceURL(), "tx", AppWithCustomTx.FAIL_CONSUMER, 500);
@@ -1347,7 +1347,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       callServicePut(serviceManager.getServiceURL(), "notx", AppWithCustomTx.FAIL_PRODUCER, 200);
       callServicePut(serviceManager.getServiceURL(), "notx", AppWithCustomTx.FAIL_CONSUMER, 500);
       serviceManager.stop();
-      serviceManager.waitForStatus(false);
+      serviceManager.waitForStopped(10, TimeUnit.SECONDS);
 
       txMRManager.waitForRun(ProgramRunStatus.COMPLETED, 10L, TimeUnit.SECONDS);
       notxMRManager.waitForRun(ProgramRunStatus.COMPLETED, 10L, TimeUnit.SECONDS);
@@ -1577,7 +1577,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager manager = deployApplication(NoOpWorkerApp.class);
     WorkerManager workerManager = manager.getWorkerManager("NoOpWorker");
     workerManager.start();
-    workerManager.waitForStatus(false, 30, 1);
+    workerManager.waitForStopped(30, TimeUnit.SECONDS);
   }
 
   @Category(SlowTests.class)
@@ -1586,7 +1586,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(AppWithServices.class);
     LOG.info("Deployed.");
     ServiceManager serviceManager = applicationManager.getServiceManager(AppWithServices.SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     LOG.info("Service Started");
 
@@ -1639,10 +1639,10 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       .getServiceManager(AppWithServices.DATASET_WORKER_SERVICE_NAME).start(args);
     WorkerManager datasetWorker =
       applicationManager.getWorkerManager(AppWithServices.DATASET_UPDATE_WORKER).start(args);
-    datasetWorkerServiceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     ServiceManager noopManager = applicationManager.getServiceManager("NoOpService").start();
-    serviceManager.waitForStatus(true, 2, 1);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     String result = callServiceGet(noopManager.getServiceURL(), "ping/" + AppWithServices.DATASET_TEST_KEY);
     String decodedResult = new Gson().fromJson(result, String.class);
@@ -1667,10 +1667,10 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     datasetWorker.stop();
     datasetWorkerServiceManager.stop();
-    datasetWorkerServiceManager.waitForStatus(false);
+    datasetWorkerServiceManager.waitForStopped(10, TimeUnit.SECONDS);
     LOG.info("DatasetUpdateService Stopped");
     serviceManager.stop();
-    serviceManager.waitForStatus(false);
+    serviceManager.waitForStopped(10, TimeUnit.SECONDS);
     LOG.info("ServerService Stopped");
 
     result = callServiceGet(noopManager.getServiceURL(), "ping/" + AppWithServices.DATASET_TEST_KEY_STOP);
@@ -1689,7 +1689,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     ServiceManager serviceManager =
       applicationManager.getServiceManager(AppWithServices.TRANSACTIONS_SERVICE_NAME).start();
-    serviceManager.waitForStatus(true);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     LOG.info("Service Started");
 
     final URL baseUrl = serviceManager.getServiceURL(15, TimeUnit.SECONDS);
@@ -1736,7 +1736,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     executorService.shutdown();
     serviceManager.stop();
-    serviceManager.waitForStatus(false);
+    serviceManager.waitForStopped(10, TimeUnit.SECONDS);
 
     DataSetManager<KeyValueTable> dsManager = getDataset(testSpace.dataset(AppWithServices.TRANSACTIONS_DATASET_NAME));
     String value = Bytes.toString(dsManager.get().read(AppWithServices.DESTROY_KEY));
@@ -1763,7 +1763,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     // Query the result
     ServiceManager serviceManager = applicationManager.getServiceManager("WordFrequency").start();
-    serviceManager.waitForStatus(true, 2, 1);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // Verify the query result
     Type resultType = new TypeToken<Map<String, Long>>() { }.getType();
@@ -2096,7 +2096,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     ApplicationManager applicationManager = deployApplication(app);
     // Query the result
     ServiceManager serviceManager = applicationManager.getServiceManager(serviceName).start();
-    serviceManager.waitForStatus(true, 2, 1);
+    serviceManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     callServicePut(serviceManager.getServiceURL(), "key1", "value1");
     String response = callServiceGet(serviceManager.getServiceURL(), "key1");
     Assert.assertEquals("value1", new Gson().fromJson(response, String.class));
@@ -2142,7 +2142,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     WorkerManager workerManager = appManager.getWorkerManager(ConcurrentRunTestApp.TestWorker.class.getSimpleName());
     workerManager.start();
     // Start another time should fail as worker doesn't support concurrent run.
-    workerManager.waitForStatus(true);
+    workerManager.waitForRun(ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
     try {
       workerManager.start();
       Assert.fail("Expected failure to start worker");


### PR DESCRIPTION
This method is almost always subject to race conditions, where
a program is starting but not yet running, and other parts of the
unit test expect it to be running. The existing race conditions
will become much more likely once the additional provisioning
lifecycle stages are introduced, which causes programs to get to
the running state a little slower now.