### PR TITLE
[CDAP-13208] Allow users to add profiles to schedules in pipeline

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineScheduler/AdvancedView.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/AdvancedView.js
@@ -19,6 +19,8 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {setStateFromCron} from 'components/PipelineScheduler/Store/ActionCreator';
 import {ACTIONS as PipelineSchedulerActions} from 'components/PipelineScheduler/Store';
+import ProfilesForSchedule from 'components/PipelineScheduler/ProfilesForSchedule';
+import MaxConcurrentRuns from 'components/PipelineScheduler/BasicView/MaxConcurrentRuns';
 import T from 'i18n-react';
 
 const PREFIX = 'features.PipelineScheduler.advanced';
@@ -72,7 +74,7 @@ const ConnectedCronInput = connect(
   mapDispatchToCronInputProps
 )(CronInput);
 
-export default function AdvancedView() {
+export default function AdvancedView({isDetailView}) {
   return (
     <div className="schedule-type-content">
       <div className="schedule-advanced-header">
@@ -101,6 +103,13 @@ export default function AdvancedView() {
           colWidth={3}
         />
       </div>
+      <MaxConcurrentRuns />
+      {
+        isDetailView ? <ProfilesForSchedule /> : null
+      }
     </div>
   );
 }
+AdvancedView.propTypes = {
+  isDetailView: PropTypes.bool
+};

--- a/cdap-ui/app/cdap/components/PipelineScheduler/BasicView/IntervalOption.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/BasicView/IntervalOption.js
@@ -33,7 +33,7 @@ const mapDispatchToIntervalOptionProps = (dispatch) => {
   return {
     onChange: (e) => {
       dispatch({
-        type: PipelineSchedulerActions.RESET
+        type: PipelineSchedulerActions.CRON_RESET
       });
       dispatch({
         type: PipelineSchedulerActions.SET_INTERVAL_OPTION,

--- a/cdap-ui/app/cdap/components/PipelineScheduler/BasicView/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/BasicView/index.js
@@ -20,15 +20,24 @@ import RepeatEvery from 'components/PipelineScheduler/BasicView/RepeatEvery';
 import StartingAt from 'components/PipelineScheduler/BasicView/StartingAt';
 import MaxConcurrentRuns from 'components/PipelineScheduler/BasicView/MaxConcurrentRuns';
 import Summary from 'components/PipelineScheduler/BasicView/Summary';
+import ProfilesForSchedule from 'components/PipelineScheduler/ProfilesForSchedule';
+import PropTypes from 'prop-types';
 
-export default function BasicView() {
+export default function BasicView({isDetailView}) {
   return (
     <div className="schedule-type-content">
       <IntervalOption />
       <RepeatEvery />
       <StartingAt />
-      <MaxConcurrentRuns />
       <Summary />
+      <MaxConcurrentRuns />
+      {
+        isDetailView ? <ProfilesForSchedule /> : null
+      }
     </div>
   );
 }
+
+BasicView.propTypes = {
+  isDetailView: PropTypes.bool
+};

--- a/cdap-ui/app/cdap/components/PipelineScheduler/PipelineScheduler.scss
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/PipelineScheduler.scss
@@ -38,6 +38,9 @@ $secondary-btn-color: $brand-primary;
       margin: 16px 45px 30px 45px;
       font-size: $regular-font;
       position: relative;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
 
       .separator {
         margin-right: 5px;
@@ -55,13 +58,9 @@ $secondary-btn-color: $brand-primary;
       }
 
       fieldset {
-        /* 70px: height from bottom of buttons to horizontal line */
-        height: calc(100% - 70px);
-
         .schedule-types {
           display: flex;
           align-items: center;
-          height: 30px;
 
           .schedule-type {
             cursor: pointer;
@@ -81,10 +80,6 @@ $secondary-btn-color: $brand-primary;
 
         .schedule-type-content {
           border-bottom: 1px solid $border-color;
-
-          /*  30px: height of Basic | Advanced options */
-          height: calc(100% - 30px);
-
           label {
             font-weight: initial;
             margin-bottom: 0;
@@ -136,6 +131,7 @@ $secondary-btn-color: $brand-primary;
 
           .schedule-advanced-values {
             display: table;
+            height: 140px;
 
             .schedule-advanced-input {
               display: table-cell;
@@ -146,8 +142,7 @@ $secondary-btn-color: $brand-primary;
       }
 
       .schedule-navigation {
-        position: absolute;
-        bottom: 0;
+        margin: 10px 0;
 
         .schedule-notes {
           padding-bottom: 7px;
@@ -171,5 +166,11 @@ $secondary-btn-color: $brand-primary;
         }
       }
     }
+  }
+}
+
+body.state-hydrator-create {
+  .pipeline-scheduler-content {
+    height: $modeless-height - 50px;
   }
 }

--- a/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/ProfilesForSchedule.scss
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/ProfilesForSchedule.scss
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../styles/mixins.scss";
+
+.profiles-list-dropdown {
+  &.dropdown {
+    .dropdown-toggle {
+      display: flex;
+      justify-content: space-between;
+      min-width: 150px;
+      &.open {
+        width: 400px;
+      }
+    }
+    .dropdown-toggle,
+    .dropdown-toggle:hover,
+    .dropdown-toggle:active,
+    .dropdown-toggle:focus {
+      background: transparent;
+      box-shadow: none;
+    }
+    z-index: 1000;
+    .dropdown-menu {
+      width: 400px;
+      padding-bottom: 0;
+      outline: none;
+
+      .grid-wrapper {
+        max-height: 250px;
+      }
+      .grid.grid-container {
+        max-height: inherit;
+        .grid-body {
+          .grid-row {
+            &:hover,
+            &.active {
+              background: $yellow-02-lighter;
+            }
+            padding: 5px;
+          }
+        }
+        .grid-row {
+          grid-template-columns: 20px 1fr 1fr 1fr;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {getCurrentNamespace} from 'services/NamespaceStore';
+import {MyProfileApi} from 'api/cloud';
+import {UncontrolledDropdown} from 'components/UncontrolledComponents';
+import IconSVG from 'components/IconSVG';
+import {DropdownToggle, DropdownMenu} from 'reactstrap';
+import {setSelectedProfile} from 'components/PipelineScheduler/Store/ActionCreator';
+import classnames from 'classnames';
+import {connect} from 'react-redux';
+import {preventPropagation} from 'services/helpers';
+import StatusMapper from 'services/StatusMapper';
+require('./ProfilesForSchedule.scss');
+
+export const PROFILES_DROPDOWN_DOM_CLASS = 'profiles-list-dropdown';
+
+class ProfilesForSchedule extends Component {
+  static propTypes = {
+    selectedProfile: PropTypes.string,
+    scheduleStatus: PropTypes.string
+  };
+
+  state = {
+    profiles: null,
+    scheduleDetails: null,
+    selectedProfile: this.props.selectedProfile
+  };
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.selectedProfile !== this.state.selectedProfile) {
+      this.setState({
+        selectedProfile: nextProps.selectedProfile
+      });
+    }
+  }
+
+  componentDidMount() {
+    this.getProfiles();
+  }
+
+  getProfiles = () => {
+    MyProfileApi.list({
+      namespace: getCurrentNamespace()
+    })
+    .subscribe(
+      profiles => {
+        this.setState({
+          profiles
+        });
+      }
+    );
+  };
+
+  selectProfile = (profileName, e) => {
+    setSelectedProfile(profileName);
+    preventPropagation(e);
+  };
+
+  renderProfilesTable = () => {
+    return (
+      <div className="grid-wrapper">
+        <div className="grid grid-container">
+          <div className="grid-header">
+            <div className="grid-row">
+              <div />
+              <strong>Profile Name</strong>
+              <strong>Provisioner</strong>
+              <strong>Scope</strong>
+            </div>
+          </div>
+          <div className="grid-body">
+            {
+              this.state.profiles.map(profile => {
+                let isSelected = this.state.selectedProfile === profile.name;
+                return (
+                  <div
+                    className={classnames("grid-row grid-link", {
+                      'active': isSelected
+                    })}
+                    onClick={this.selectProfile.bind(this, profile.name)}
+                  >
+                    {
+                      isSelected ?
+                        <IconSVG name="icon-check" className="text-success" />
+                      :
+                        <div />
+                    }
+                    <div>{profile.name}</div>
+                    <div>{profile.provisioner.name}</div>
+                    <div>{profile.scope}</div>
+                  </div>
+                );
+              })
+            }
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  renderProfilesDropdown = () => {
+    if (!this.state.profiles) {
+      return null;
+    }
+    let selectedProfile = this.state.profiles.find(profile => profile.name === this.state.selectedProfile);
+    let isScheduled = this.props.scheduleStatus === StatusMapper.statusMap['SCHEDULED'];
+    return (
+      <UncontrolledDropdown
+        className={PROFILES_DROPDOWN_DOM_CLASS}
+        tether={{}} /* Apparently this attaches it to the body */
+        disabled={isScheduled}
+      >
+        <DropdownToggle
+          disabled={isScheduled}
+          caret
+        >
+          {
+            this.state.selectedProfile ?
+              <span> {`${this.state.selectedProfile} (${selectedProfile.provisioner.name})`}</span>
+            :
+              <span>Select a Profile</span>
+          }
+          <IconSVG name="icon-caret-down" />
+        </DropdownToggle>
+        <DropdownMenu>
+          { this.renderProfilesTable() }
+        </DropdownMenu>
+      </UncontrolledDropdown>
+    );
+  };
+
+  render() {
+    return (
+      <div className="form-group row">
+        <label className="col-xs-3 control-label">
+          Compute Profiles
+        </label>
+        <div className="col-xs-6 schedule-values-container">
+          {this.renderProfilesDropdown()}
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    selectedProfile: state.profiles.selectedProfile,
+    scheduleStatus: state.scheduleStatus
+  };
+};
+
+const ConnectedProfilesForSchedule = connect(mapStateToProps)(ProfilesForSchedule);
+
+export default ConnectedProfilesForSchedule;

--- a/cdap-ui/app/cdap/components/PipelineScheduler/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/Store/ActionCreator.js
@@ -17,7 +17,16 @@
 import moment from 'moment';
 import {isNumeric} from 'services/helpers';
 import {wholeArrayIsNumeric} from 'services/helpers';
-import PipelineSchedulerStore, {INTERVAL_OPTIONS, SCHEDULE_VIEWS, DEFAULT_SCHEDULE_OPTIONS, ACTIONS as PipelineSchedulerActions} from 'components/PipelineScheduler/Store';
+import PipelineSchedulerStore, {
+  INTERVAL_OPTIONS,
+  SCHEDULE_VIEWS,
+  DEFAULT_SCHEDULE_OPTIONS,
+  ACTIONS as PipelineSchedulerActions
+} from 'components/PipelineScheduler/Store';
+import {getCurrentNamespace} from 'services/NamespaceStore';
+import PipelineDetailStore from 'components/PipelineDetails/store';
+import {MyScheduleApi} from 'api/schedule';
+import {GLOBALS} from 'services/global-constants';
 
 function setStateFromCron(cron = PipelineSchedulerStore.getState().cron) {
   let cronValues = cron.split(' ');
@@ -162,8 +171,53 @@ function updateCron() {
   });
 }
 
+function setSelectedProfile(selectedProfile) {
+  PipelineSchedulerStore.dispatch({
+    type: PipelineSchedulerActions.SET_SELECTED_PROFILE,
+    payload: {
+      selectedProfile
+    }
+  });
+}
+
+function getTimeBasedSchedule() {
+  let {name: appId} = PipelineDetailStore.getState();
+  MyScheduleApi
+    .get({
+      namespace: getCurrentNamespace(),
+      appId,
+      scheduleName: GLOBALS.defaultScheduleId
+    })
+    .subscribe(
+      (currentBackendSchedule) => {
+        PipelineSchedulerStore.dispatch({
+          type: PipelineSchedulerActions.SET_CURRENT_BACKEND_SCHEDULE,
+          payload: {
+            currentBackendSchedule
+          }
+        });
+        setStateFromCron();
+      },
+      (err) => {
+        console.log('Failed to fetch dataPipelineSchedule Schedule from backend: ', err);
+      }
+    );
+}
+
+function setScheduleStatus(scheduleStatus) {
+  PipelineSchedulerStore.dispatch({
+    type: PipelineSchedulerActions.SET_SCHEDULE_STATUS,
+    payload: {
+      scheduleStatus
+    }
+  });
+}
+
 export {
   setStateFromCron,
+  setSelectedProfile,
+  getTimeBasedSchedule,
   getCronFromState,
-  updateCron
+  updateCron,
+  setScheduleStatus
 };

--- a/cdap-ui/app/cdap/components/PipelineScheduler/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/Store/index.js
@@ -25,10 +25,15 @@
   (in Studio view) or to PipelineDetailStore (in Detail view)
 */
 
-import {defaultAction, composeEnhancers} from 'services/helpers';
+import {
+  defaultAction,
+  composeEnhancers,
+  objectQuery
+} from 'services/helpers';
 import {createStore} from 'redux';
 import range from 'lodash/range';
 import {HYDRATOR_DEFAULT_VALUES} from 'services/global-constants';
+import {PROFILE_NAME_PREFERENCE_PROPERTY} from 'components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView';
 
 const INTERVAL_OPTIONS = {
   '5MIN': 'Every 5 min',
@@ -56,6 +61,7 @@ const SCHEDULE_VIEWS = {
 
 const ACTIONS = {
   SET_CRON: 'SET_CRON',
+  CRON_RESET: 'CRON_RESET',
   UPDATE_CRON: 'UPDATE_CRON',
   SET_STATE: 'SET_STATE',
   SET_INTERVAL_OPTION: 'SET_INTERVAL_OPTION',
@@ -70,11 +76,12 @@ const ACTIONS = {
   SET_STARTING_AT_AM_PM: 'SET_STARTING_AT_AM_PM',
   SET_MAX_CONCURRENT_RUNS: 'SET_MAXCURRENT_RUNS',
   SET_SCHEDULE_VIEW: 'SET_SCHEDULE_VIEW',
+  SET_SELECTED_PROFILE: 'SET_SELECTED_PROFILE',
+  SET_CURRENT_BACKEND_SCHEDULE: 'SET_CURRENT_BACKEND_SCHEDULE',
+  SET_SCHEDULE_STATUS: 'SET_SCHEDULE_STATUS',
   RESET: 'RESET'
 };
-
-const DEFAULT_SCHEDULE_OPTIONS = {
-  cron: HYDRATOR_DEFAULT_VALUES.schedule,
+const DEFAULT_CRON_OPTIONS = {
   intervalOption: INTERVAL_OPTIONS.DAILY,
   minInterval: 5,
   hourInterval: HOUR_OPTIONS_CLOCK[0],
@@ -84,9 +91,18 @@ const DEFAULT_SCHEDULE_OPTIONS = {
   monthInterval: MONTH_OPTIONS[0],
   startingAtMinute: MINUTE_OPTIONS[0],
   startingAtHour: HOUR_OPTIONS[0],
-  startingAtAMPM: AM_PM_OPTIONS[0],
+  startingAtAMPM: AM_PM_OPTIONS[0]
+};
+const DEFAULT_SCHEDULE_OPTIONS = {
+  cron: HYDRATOR_DEFAULT_VALUES.schedule,
+  ...DEFAULT_CRON_OPTIONS,
   maxConcurrentRuns: MAX_CONCURRENT_RUNS_OPTIONS[0],
-  scheduleView: Object.values(SCHEDULE_VIEWS)[0]
+  scheduleView: Object.values(SCHEDULE_VIEWS)[0],
+  profiles: {
+    selectedProfile: null
+  },
+  currentBackendSchedule: null,
+  scheduleStatus: null
 };
 
 const schedule = (state = DEFAULT_SCHEDULE_OPTIONS, action = defaultAction) => {
@@ -95,6 +111,16 @@ const schedule = (state = DEFAULT_SCHEDULE_OPTIONS, action = defaultAction) => {
       return {
         ...state,
         cron: action.payload.cron
+      };
+    case ACTIONS.SET_SCHEDULE_STATUS:
+      return {
+        ...state,
+        scheduleStatus: action.payload.scheduleStatus
+      };
+    case ACTIONS.CRON_RESET:
+      return {
+        ...state,
+        ...DEFAULT_CRON_OPTIONS
       };
     case ACTIONS.UPDATE_CRON: {
       let cronArray = state.cron.split(" ");
@@ -175,13 +201,40 @@ const schedule = (state = DEFAULT_SCHEDULE_OPTIONS, action = defaultAction) => {
         ...state,
         maxConcurrentRuns: parseInt(action.payload.maxConcurrentRuns, 10)
       };
+    case ACTIONS.SET_SELECTED_PROFILE:
+      return {
+        ...state,
+        profiles: {
+          selectedProfile: action.payload.selectedProfile
+        }
+      };
     case ACTIONS.SET_SCHEDULE_VIEW:
       return {
         ...state,
         scheduleView: action.payload.scheduleView
       };
+    case ACTIONS.SET_CURRENT_BACKEND_SCHEDULE: {
+      let {currentBackendSchedule} = action.payload;
+      let profileFromBackend = objectQuery(currentBackendSchedule, 'properties', PROFILE_NAME_PREFERENCE_PROPERTY);
+      let constraintFromBackend = (currentBackendSchedule.constraints || []).find(constraint => {
+        return constraint.type === 'CONCURRENCY';
+      });
+      let maxConcurrencyFromBackend = objectQuery(constraintFromBackend, 'maxConcurrency');
+      let cronFromBackend = objectQuery(currentBackendSchedule, 'trigger', 'cronExpression');
+      return {
+        ...state,
+        currentBackendSchedule: action.payload.currentBackendSchedule,
+        cron: cronFromBackend,
+        maxConcurrentRuns: maxConcurrencyFromBackend,
+        profiles: {
+          selectedProfile: profileFromBackend
+        }
+      };
+    }
     case ACTIONS.RESET:
+    default:
       return DEFAULT_SCHEDULE_OPTIONS;
+
   }
 };
 

--- a/cdap-ui/app/cdap/components/PipelineScheduler/ViewContainer.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/ViewContainer.js
@@ -21,22 +21,24 @@ import BasicView from 'components/PipelineScheduler/BasicView';
 import AdvancedView from 'components/PipelineScheduler/AdvancedView';
 import {SCHEDULE_VIEWS} from 'components/PipelineScheduler/Store';
 
-const mapStateToViewContainerProps = (state) => {
+const mapStateToViewContainerProps = (state, ownProps) => {
   return {
-    scheduleView: state.scheduleView
+    scheduleView: state.scheduleView,
+    isDetailView: ownProps.isDetailView
   };
 };
 
-const ViewContainerComponent = ({scheduleView}) => {
+const ViewContainerComponent = ({scheduleView, isDetailView}) => {
   if (scheduleView === SCHEDULE_VIEWS.BASIC) {
-    return <BasicView />;
+    return <BasicView isDetailView={isDetailView} />;
   } else {
-    return <AdvancedView />;
+    return <AdvancedView isDetailView={isDetailView} />;
   }
 };
 
 ViewContainerComponent.propTypes = {
-  scheduleView: PropTypes.string
+  scheduleView: PropTypes.string,
+  isDetailView: PropTypes.bool
 };
 
 const ConnectedViewContainer = connect(
@@ -44,6 +46,10 @@ const ConnectedViewContainer = connect(
   null
 )(ViewContainerComponent);
 
-export default function ViewContainer() {
-  return <ConnectedViewContainer />;
+export default function ViewContainer({isDetailView}) {
+  return <ConnectedViewContainer isDetailView={isDetailView} />;
 }
+ViewContainer.propTypes = {
+  isDetailView: PropTypes.bool
+};
+


### PR DESCRIPTION
- Stores `system.profile.name` to schedule properties when set in pipeline detailed view
- Fixes Schedule modeless in UI to consider schedule api response as the source of truth instead of app specification.
- For now hides profiles list in pipeline studio. TBD.
- Ideally we should isolate `PipelineScheduler` and `PipelineSchedulerStore` to be independent of `PipelineDetail*` components as once a pipeline is published all schedule information is now fetched/updated to individual schedule rather than app spec. This will happen in a subsequent PR.

JIRA: 
https://issues.cask.co/browse/CDAP-13208
https://issues.cask.co/browse/CDAP-13173