### PR TITLE
[CDAP-13242] Admin page improvements

### DIFF
--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/AdminConfigTabContent.scss
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/AdminConfigTabContent.scss
@@ -80,10 +80,6 @@ $hover-active-color: $grey-08;
           .grid-header {
             background-color: $hover-active-color;
           }
-
-          .grid-row:hover {
-            background-color: $hover-active-color;
-          }
         }
       }
     }

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/NamespacesAccordion/NamespacesAccordion.scss
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/NamespacesAccordion/NamespacesAccordion.scss
@@ -14,13 +14,21 @@
  * the License.
 */
 
-@import "../../styles/variables.scss";
+@import '../../../../styles/variables.scss';
 
-.view-all-label-container {
-  margin: 5px 0;
+.namespaces-container-content {
+  .grid.grid-container {
+    .grid-body {
+      .grid-row {
+        &.grid-link {
+          color: $grey-01;
+        }
 
-  .view-all-label {
-    color: $blue-03;
-    cursor: pointer;
+        &:hover {
+          background-color: white;
+        }
+      }
+    }
+
   }
 }

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/SystemProfilesAccordion.scss
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/SystemProfilesAccordion.scss
@@ -24,6 +24,16 @@
           color: $grey-03;
         }
       }
+
+      .grid-body {
+        .grid-row:hover {
+          background-color: white;
+        }
+      }
     }
+  }
+
+  .view-all-label-container:first-child {
+    transform: translateY(10px);
   }
 }

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/index.js
@@ -15,6 +15,7 @@
 */
 
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReloadSystemArtifacts from 'components/Administration/AdminConfigTabContent/ReloadSystemArtifacts';
 import NamespacesAccordion from 'components/Administration/AdminConfigTabContent/NamespacesAccordion';
 import SystemProfilesAccordion from 'components/Administration/AdminConfigTabContent/SystemProfilesAccordion';
@@ -41,7 +42,15 @@ export default class AdminConfigTabContent extends Component {
     namespacesCountLoading: true,
     systemProfilesCountLoading: true,
     systemPrefsCountLoading: true,
-    expandedAccordion: null
+    expandedAccordion: this.props.accordionToExpand || ADMIN_CONFIG_ACCORDIONS.namespaces
+  };
+
+  static propTypes = {
+    accordionToExpand: PropTypes.string
+  };
+
+  static defaultProps = {
+    accordionToExpand: ADMIN_CONFIG_ACCORDIONS.namespaces
   };
 
   expandAccordion = (accordion) => {

--- a/cdap-ui/app/cdap/components/Administration/AdminTabSwitch/AdminTabSwitch.scss
+++ b/cdap-ui/app/cdap/components/Administration/AdminTabSwitch/AdminTabSwitch.scss
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import "../../../styles/variables.scss";
+
+$uptime_version_color: $grey-03;
+$font-color: $grey-01;
+
+.administration {
+  .tab-title-and-version {
+    padding: 0 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .tab-title {
+      h5 {
+        display: inline;
+        font-weight: bold;
+
+        a {
+          color: $font-color;
+        }
+
+        &.active {
+          pointer-events: none;
+
+          a {
+            text-decoration: underline;
+          }
+        }
+      }
+
+      .divider {
+        font-size: 1.25rem;
+        padding: 0 5px;
+      }
+    }
+    .uptime-version-container {
+      color: $uptime_version_color;
+      > span {
+        margin: 0 10px;
+      }
+      .cdap-version {
+        font-weight: 500;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/Administration/AdminTabSwitch/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminTabSwitch/index.js
@@ -1,0 +1,128 @@
+/*
+* Copyright © 2018 Cask Data, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {Link, Route, Switch} from 'react-router-dom';
+import {humanReadableDuration} from 'services/helpers';
+import VersionStore from 'services/VersionStore';
+import VersionActions from 'services/VersionStore/VersionActions';
+import MyCDAPVersionApi from 'api/version';
+import isNil from 'lodash/isNil';
+import classnames from 'classnames';
+import T from 'i18n-react';
+require('./AdminTabSwitch.scss');
+
+const PREFIX = 'features.Administration';
+
+export default class AdminTabSwitch extends Component {
+  state = {
+    version: null
+  };
+
+  static propTypes = {
+    uptime: PropTypes.number
+  };
+
+  componentDidMount() {
+    if (!VersionStore.getState().version) {
+      this.getCDAPVersion();
+    } else {
+      this.setState({ version : VersionStore.getState().version });
+    }
+  }
+
+  getCDAPVersion() {
+    MyCDAPVersionApi
+      .get()
+      .subscribe((res) => {
+        this.setState({ version : res.version });
+        VersionStore.dispatch({
+          type: VersionActions.updateVersion,
+          payload: {
+            version: res.version
+          }
+        });
+      });
+  }
+
+  renderTabTitle(isManagement = true) {
+    return (
+      <span className="tab-title">
+        <h5 className={classnames({"active": isManagement})}>
+          <Link to='/administration'>
+            {T.translate(`${PREFIX}.Tabs.management`)}
+          </Link>
+        </h5>
+        <span className="divider"> | </span>
+        <h5 className={classnames({"active": !isManagement})}>
+          <Link to='/administration/configuration'>
+            {T.translate(`${PREFIX}.Tabs.config`)}
+          </Link>
+        </h5>
+      </span>
+    );
+  }
+
+  renderUptimeVersion() {
+    return (
+      <span className="uptime-version-container">
+        <span>
+          {
+            this.props.uptime ?
+              T.translate(`${PREFIX}.uptimeLabel`, {
+                time: humanReadableDuration(Math.ceil(this.props.uptime / 1000))
+              })
+            :
+              null
+          }
+        </span>
+        {
+          isNil(this.state.version) ?
+            null
+          :
+            (
+              <i className="cdap-version">
+                {T.translate(`${PREFIX}.Top.version-label`)} - {this.state.version}
+              </i>
+            )
+        }
+      </span>
+    );
+  }
+
+  render() {
+    return (
+      <Switch>
+        <Route exact path="/administration" render={() => {
+          return (
+            <div className="tab-title-and-version">
+              {this.renderTabTitle()}
+              {this.renderUptimeVersion()}
+            </div>
+          );
+        }} />
+        <Route exact path="/administration/configuration" render={() => {
+          return (
+            <div className="tab-title-and-version">
+              {this.renderTabTitle(false)}
+            </div>
+          );
+        }} />
+      </Switch>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/Administration/Administration.scss
+++ b/cdap-ui/app/cdap/components/Administration/Administration.scss
@@ -14,8 +14,6 @@
  * the License.
 */
 
-$uptime_version_color: gray;
-
 .administration {
   height: 100%;
   padding: 20px 20px 0 20px;
@@ -23,44 +21,5 @@ $uptime_version_color: gray;
 
   > div {
     padding: 10px;
-  }
-
-  .primary-label {
-    display: inline-flex;
-    justify-content: space-around;
-  }
-
-  .tab-title-and-version {
-    padding: 0 10px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    .tab-title {
-      h5 {
-        display: inline;
-        font-weight: bold;
-        cursor: pointer;
-
-        &.active {
-          text-decoration: underline;
-          cursor: initial;
-        }
-      }
-
-      .divider {
-        font-size: 1.25rem;
-        padding: 0 5px;
-      }
-    }
-    .uptime-version-container {
-      color: $uptime_version_color;
-      > span {
-        margin: 0 10px;
-      }
-      .cdap-version {
-        font-weight: 500;
-      }
-    }
   }
 }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/CreateView.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/CreateView.scss
@@ -25,6 +25,12 @@
     padding: 0 30px;
     font-size: 1.3rem;
     font-weight: 500;
+
+    .close-create-view {
+      margin-left: auto;
+      cursor: pointer;
+      color: $grey-01;
+    }
   }
   .create-form-container {
     margin: 30px;

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -27,6 +27,8 @@ import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import {connect, Provider} from 'react-redux';
 import ProvisionerInfoStore from 'components/Cloud/Store';
 import {fetchProvisionerSpec} from 'components/Cloud/Store/ActionCreator';
+import {ADMIN_CONFIG_ACCORDIONS} from 'components/Administration/AdminConfigTabContent';
+import IconSVG from 'components/IconSVG';
 
 require('./CreateView.scss');
 
@@ -247,15 +249,29 @@ class ProfilesCreateView extends Component {
     if (this.state.redirectToAdmin) {
       return (
         <Redirect to={{
-          pathname: '/administration',
-          state: { showConfigTab: true }
+          pathname: '/administration/configuration',
+          state: { accordionToExpand: ADMIN_CONFIG_ACCORDIONS.systemProfiles }
         }}/>
       );
     }
+
+    let linkObj = this.state.isSystem ? {
+      pathname: '/administration/configuration',
+      state: { accordionToExpand: ADMIN_CONFIG_ACCORDIONS.systemProfiles }
+    } : `/ns/${getCurrentNamespace()}/details`;
+
     return (
       <div className="profile-create-view">
         <div className="create-view-top-panel">
-          Create a Google Dataproc Profile
+          <span>
+            Create a Google Dataproc Profile
+          </span>
+          <Link
+            className="close-create-view"
+            to={linkObj}
+          >
+            <IconSVG name="icon-close" />
+          </Link>
         </div>
         <div className="create-form-container">
           <fieldset disabled={this.state.creatingProfile}>
@@ -295,19 +311,9 @@ class ProfilesCreateView extends Component {
             disabled={!this.state.profileName.length || !this.state.profileDescription.length}
             label="Create Compute Profile"
           />
-          {
-            this.state.isSystem ?
-              <Link to={{
-                pathname: '/administration',
-                state: { showConfigTab: true }
-              }}>
-                Close
-              </Link>
-            :
-              <Link to={`/ns/${getCurrentNamespace()}/details`}>
-                Close
-              </Link>
-          }
+          <Link to={linkObj}>
+            Close
+          </Link>
         </div>
       </div>
     );

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
@@ -56,7 +56,7 @@ $row-height: 50px;
         > div {
           padding: 0 5px 0 0;
           margin-right: 20px;
-          margin-left: 5px;
+          margin-left: 10px;
           border: 0;
         }
       }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -82,6 +82,8 @@ const SORT_METHODS = {
   desc: 'desc'
 };
 
+const NUM_PROFILES_TO_SHOW = 5;
+
 export default class ProfilesListView extends Component {
   state = {
     profiles: [],
@@ -95,10 +97,6 @@ export default class ProfilesListView extends Component {
   static propTypes = {
     namespace: PropTypes.string.isRequired,
     onChange: PropTypes.func
-  };
-
-  static defaultProps = {
-    namespace: getCurrentNamespace()
   };
 
   componentDidMount() {
@@ -183,12 +181,6 @@ export default class ProfilesListView extends Component {
           {this.renderProfilesTableHeader()}
           {this.renderProfilesTableBody()}
         </div>
-        <ViewAllLabel
-          arrayToLimit={this.state.profiles}
-          limit={10}
-          viewAllState={this.state.viewAll}
-          toggleViewAll={this.toggleViewAll}
-        />
       </div>
     );
   }
@@ -253,8 +245,8 @@ export default class ProfilesListView extends Component {
   renderProfilesTableBody() {
     let profiles = [...this.state.profiles];
 
-    if (!this.state.viewAll && profiles.length > 10) {
-      profiles = profiles.slice(0, 10);
+    if (!this.state.viewAll && profiles.length > NUM_PROFILES_TO_SHOW) {
+      profiles = profiles.slice(0, NUM_PROFILES_TO_SHOW);
     }
 
     return (
@@ -305,7 +297,19 @@ export default class ProfilesListView extends Component {
     }
     return (
       <div className="profiles-list-view">
+        <ViewAllLabel
+          arrayToLimit={this.state.profiles}
+          limit={NUM_PROFILES_TO_SHOW}
+          viewAllState={this.state.viewAll}
+          toggleViewAll={this.toggleViewAll}
+        />
         {this.renderProfilesTable()}
+        <ViewAllLabel
+          arrayToLimit={this.state.profiles}
+          limit={NUM_PROFILES_TO_SHOW}
+          viewAllState={this.state.viewAll}
+          toggleViewAll={this.toggleViewAll}
+        />
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/NamespaceDetails/ComputeProfiles/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/ComputeProfiles/index.js
@@ -70,7 +70,10 @@ export default class NamespaceDetailsComputeProfiles extends Component {
     return (
       <div className="namespace-details-compute-profiles">
         {this.renderProfilesLabel()}
-        <ProfilesListView onChange={this.onChange} />
+        <ProfilesListView
+          namespace={getCurrentNamespace()}
+          onChange={this.onChange}
+        />
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/SortableStickyGrid/SortableStickyGrid.scss
+++ b/cdap-ui/app/cdap/components/SortableStickyGrid/SortableStickyGrid.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,57 +17,14 @@
 @import "../../styles/variables.scss";
 
 .sortable-sticky-grid {
-  margin-top: 15px;
-  .table {
-    margin-bottom: 0;
-  }
-  .grid-header {
-    display: flex;
-    border-bottom: 1px solid $grey-05;
-    padding-bottom: 5px;
-    font-weight: bold;
-    .grid-header-item {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      > span {
-        width: 100%;
-        display: inline-block;
-        > span {
-          width: 80%;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          display: inline-block;
-          vertical-align: top;
+  .grid.grid-container {
+    .grid-header {
+      .sortable-header {
+        cursor: pointer;
+
+        &.active {
+          text-decoration: underline;
         }
-      }
-      .fa-caret-down {
-        margin-left: 5px;
-      }
-    }
-  }
-  .grid-body-item,
-  .grid-header-item {
-    padding: 0 0 0 0.5rem;
-  }
-  .grid-body-row {
-    display: flex;
-    flex-wrap: wrap;
-    width: 100%;
-  }
-  .table-scroll {
-    overflow: auto;
-  }
-  .grid-body {
-    .grid-body-row {
-      border-bottom: 1px solid $grey-05;
-      .grid-body-item {
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-        display: inline;
-        padding: 0.7rem 0 0.7rem 0.5rem;
       }
     }
   }

--- a/cdap-ui/app/cdap/components/ViewAllLabel/index.js
+++ b/cdap-ui/app/cdap/components/ViewAllLabel/index.js
@@ -27,17 +27,19 @@ export default function ViewAllLabel({arrayToLimit, limit, viewAllState, toggleV
   }
 
   return (
-    <span
-      className="view-all-label"
-      onClick={toggleViewAll}
-    >
-      {
-        viewAllState ?
-          T.translate(`${PREFIX}.viewLess`)
-        :
-          T.translate(`${PREFIX}.viewAll`)
-      }
-    </span>
+    <div className="view-all-label-container">
+      <span
+        className="view-all-label"
+        onClick={toggleViewAll}
+      >
+        {
+          viewAllState ?
+            T.translate(`${PREFIX}.viewLess`)
+          :
+            T.translate(`${PREFIX}.viewAll`)
+        }
+      </span>
+    </div>
   );
 }
 

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -117,7 +117,7 @@ class CDAP extends Component {
                 <Switch>
                   <Route exact path="/" component={RouteToNamespace} />
                   <Route exact path="/notfound" component={Page404} />
-                  <Route exact path="/administration" component={Administration} />
+                  <Route path="/administration" component={Administration} />
                   <Route exact path="/ns" component={RouteToNamespace} />
                   <Route path="/ns/:namespace" history={history} component={Home} />
                   <Route path="/socket-example" component={ConnectionExample} />

--- a/cdap-ui/app/cdap/styles/common.scss
+++ b/cdap-ui/app/cdap/styles/common.scss
@@ -130,6 +130,10 @@ body {
           &:hover {
             background: $grey-08;
           }
+          &.highlighted {
+            border: 2px solid $green-03;
+            background-color: rgba($green-03, 0.1);
+          }
         }
         a {
           text-decoration: none;

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -372,6 +372,10 @@ footer {
         &:hover {
           background: @grey-08;
         }
+        &.highlighted {
+          border: 2px solid @green-03;
+          background-color: fade(@green-03, 10%);
+        }
       }
       a {
         text-decoration: none;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13242

Things done in this PR:
- Rewrites `SortableStickyGrid` component to use our current css grid.
- Modifies `NamespacesAccordion` and `SystemPrefsAccordion` to use the new `SortableStickyGrid`, so that their table headers are sortable. Didn't modify `Profiles/ListView` since it already has sortable table headers.
- Highlights newly added namespaces and system prefs. Couldn't highlight newly added system profiles, since we navigate to a different page, but at least opens up the profiles accordion after a new one is created.
- Changes the `Configuration` tab to be a separate route, and opens up namespace accordion by default when on this tab.