### PR TITLE
 [CDAP-13306] Add HTTP handler for Operations Dashboard

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -48,6 +48,7 @@ import co.cask.cdap.gateway.handlers.MonitorHandler;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
 import co.cask.cdap.gateway.handlers.NotificationFeedHttpHandler;
 import co.cask.cdap.gateway.handlers.OperationalStatsHttpHandler;
+import co.cask.cdap.gateway.handlers.OperationsDashboardHttpHandler;
 import co.cask.cdap.gateway.handlers.PreferencesHttpHandler;
 import co.cask.cdap.gateway.handlers.ProfileHttpHandler;
 import co.cask.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
@@ -399,6 +400,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(AppLifecycleHttpHandler.class);
       handlerBinder.addBinding().to(DashboardHttpHandler.class);
       handlerBinder.addBinding().to(ProgramLifecycleHttpHandler.class);
+      // TODO: [CDAP-13355] Move OperationsDashboardHttpHandler into report generation app
+      handlerBinder.addBinding().to(OperationsDashboardHttpHandler.class);
       handlerBinder.addBinding().to(PreferencesHttpHandler.class);
       handlerBinder.addBinding().to(ConsoleSettingsHttpHandler.class);
       handlerBinder.addBinding().to(TransactionHttpHandler.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -239,6 +239,14 @@ public interface Store {
   Map<ProgramRunId, RunRecordMeta> getActiveRuns(NamespaceId namespaceId);
 
   /**
+   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records from the given NamespaceId's.
+   * @param namespaces the namespace id's to get active run records from
+   * @param filter predicate to be passed to filter the records
+   * @return map of logged runs
+   */
+  Map<ProgramRunId, RunRecordMeta> getActiveRuns(Set<NamespaceId> namespaces, Predicate<RunRecordMeta> filter);
+
+  /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records against a given ApplicationId.
    * @param applicationId the application id to match against
    * @return map of logged runs
@@ -251,6 +259,19 @@ public interface Store {
    * @return map of logged runs
    */
   Map<ProgramRunId, RunRecordMeta> getActiveRuns(ProgramId programId);
+
+  /**
+   * Fetches the historical (i.e COMPLETED or FAILED or KILLED) run records from a given set of namespaces
+   * which matches both the earliestStopTime and latestStartTime conditions.
+   *
+   * @param namespaces fetch run history that is belonged to one of these namespaces
+   * @param earliestStopTime fetch run history that has stopped at or after the earliestStopTime in seconds
+   * @param latestStartTime fetch run history that has started before the latestStartTime in seconds
+   * @param limit max number of entries to fetch for this history call
+   * @return map of logged runs
+   */
+  Map<ProgramRunId, RunRecordMeta> getHistoricalRuns(Set<NamespaceId> namespaces,
+                                                     long earliestStopTime, long latestStartTime, int limit);
 
   /**
    * Fetches the run record for particular run of a program.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandler.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.api.schedule.TriggeringScheduleInfo;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.ops.DashboardProgramRunRecord;
+import co.cask.http.HttpResponder;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+/**
+ * {@link co.cask.http.HttpHandler} to handle program run operation dashboard and reports for v3 REST APIs
+ *
+ * TODO: [CDAP-13355] Move this handler into report generation app
+ */
+@Singleton
+@Path(Constants.Gateway.API_VERSION_3)
+public class OperationsDashboardHttpHandler extends AbstractAppFabricHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(OperationsDashboardHttpHandler.class);
+  private static final Gson GSON = new Gson();
+  private final Store store;
+
+  @Inject
+  public OperationsDashboardHttpHandler(Store store) {
+    this.store = store;
+  }
+
+  // TODO: [CDAP-13351] Need to support getting scheduled program runs if start + duration is ahead of the current time
+  @GET
+  @Path("/dashboard")
+  public void readDashboardDetail(FullHttpRequest request, HttpResponder responder,
+                                  @QueryParam("start") long startTimeSecs,
+                                  @QueryParam("duration") int durationTimeSecs,
+                                  @QueryParam("namespace") Set<String> namespaces)
+    throws IOException, BadRequestException {
+    if (startTimeSecs < 0) {
+      throw new BadRequestException("'start' time cannot be smaller than 0.");
+    }
+    if (durationTimeSecs < 0) {
+      throw new BadRequestException("'duration' cannot be smaller than 0.");
+    }
+
+    Set<NamespaceId> namespaceIds = namespaces.stream().map(NamespaceId::new).collect(Collectors.toSet());
+    Map<ProgramRunId, RunRecordMeta> historicalRuns =
+      // TODO: [CDAP-13352] Currently, to get active program runs within a time range,
+      // a full table scan is required in AppMetaStore. Performance improvement will be done.
+      store.getHistoricalRuns(namespaceIds, startTimeSecs, startTimeSecs + durationTimeSecs, Integer.MAX_VALUE);
+    // get historical runs within the query time range
+    Stream<DashboardProgramRunRecord> historicalRecords =
+      historicalRuns.values().stream().map(OperationsDashboardHttpHandler::runRecordToDashboardRecord);
+    // get active runs with start time earlier than the end of query time range
+    Stream<DashboardProgramRunRecord> activeRecords =
+      store.getActiveRuns(namespaceIds, run -> run.getStartTs() < startTimeSecs + durationTimeSecs).values().stream()
+      .map(OperationsDashboardHttpHandler::runRecordToDashboardRecord);
+    responder.sendJson(HttpResponseStatus.OK,
+                       // combine historical runs and active runs
+                       GSON.toJson(Stream.concat(historicalRecords, activeRecords).collect(Collectors.toSet())));
+  }
+
+  /**
+   * Converts a {@link RunRecordMeta} to a {@link DashboardProgramRunRecord}
+   */
+  private static DashboardProgramRunRecord runRecordToDashboardRecord(RunRecordMeta meta) {
+    ProgramRunId runId = meta.getProgramRunId();
+    String startMethod = "manual";
+    String scheduleInfoJson = meta.getSystemArgs().get(ProgramOptionConstants.TRIGGERING_SCHEDULE_INFO);
+    if (scheduleInfoJson != null) {
+      TriggeringScheduleInfo scheduleInfo = GSON.fromJson(scheduleInfoJson, TriggeringScheduleInfo.class);
+      // assume there's no composite trigger, since composite is not supported in the UI yet
+      startMethod = scheduleInfo.getTriggerInfos().stream().findFirst()
+        .map(trigger -> trigger.getType().name())
+        // return "manual" if there's no trigger in the schedule info, but this should never happen
+        .orElseGet(() -> "manual");
+    }
+    return new DashboardProgramRunRecord(runId, meta, meta.getArtifactId(), meta.getPrincipal(), startMethod);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -78,6 +78,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -852,6 +853,20 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return getRuns(programRunIds, Integer.MAX_VALUE);
   }
 
+  public Map<ProgramRunId, RunRecordMeta> getActiveRuns(Set<NamespaceId> namespaces, Predicate<RunRecordMeta> filter) {
+    return namespaces.stream().flatMap(namespaceId -> {
+      MDSKey key = getNamespaceKeyBuilder(TYPE_RUN_RECORD_STARTING, namespaceId).build();
+      Map<ProgramRunId, RunRecordMeta> activeRuns = getProgramRunIdMap(listKV(key, null, RunRecordMeta.class,
+                                                                              Integer.MAX_VALUE, filter));
+
+      key = getNamespaceKeyBuilder(TYPE_RUN_RECORD_STARTED, namespaceId).build();
+      activeRuns.putAll(getProgramRunIdMap(listKV(key, null, RunRecordMeta.class, Integer.MAX_VALUE, filter)));
+      key = getNamespaceKeyBuilder(TYPE_RUN_RECORD_SUSPENDED, namespaceId).build();
+      activeRuns.putAll(getProgramRunIdMap(listKV(key, null, RunRecordMeta.class, Integer.MAX_VALUE, filter)));
+      return activeRuns.entrySet().stream();
+    }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
   public Map<ProgramRunId, RunRecordMeta> getActiveRuns(NamespaceId namespaceId) {
     // TODO CDAP-12361 should consolidate these methods and get rid of duplicate / unnecessary methods.
     Predicate<RunRecordMeta> timePredicate = getTimeRangePredicate(0, Long.MAX_VALUE);
@@ -1105,6 +1120,33 @@ public class AppMetadataStore extends MetadataStoreDataset {
       newRecords.putAll(oldRecords);
     }
     return newRecords;
+  }
+
+  /**
+   * Fetches the historical (i.e COMPLETED or FAILED or KILLED) run records from a given set of namespaces.
+   *
+   * @param namespaces fetch run history that is belonged to one of these namespaces
+   * @param earliestStopTime fetch run history that has stopped at or after the earliestStopTime in seconds
+   * @param latestStartTime fetch run history that has started before the latestStartTime in seconds
+   * @param limit max number of entries to fetch for this history call
+   * @return map of logged runs
+   */
+  public Map<ProgramRunId, RunRecordMeta> getHistoricalRuns(final Set<NamespaceId> namespaces,
+                                                            final long earliestStopTime, final long latestStartTime,
+                                                            final int limit) {
+    MDSKey keyPrefix = new MDSKey.Builder().add(TYPE_RUN_RECORD_COMPLETED).build();
+    //return all records in each namespace
+    return namespaces.stream()
+      .flatMap(ns -> getProgramRunIdMap(
+        listKV(new MDSKey.Builder(keyPrefix).add(ns.getNamespace()).build(), null,
+               RunRecordMeta.class, limit, key -> true,
+               // get active runs in a time window with range [earliestStopTime, latestStartTime),
+               // which excludes program run records that stopped before earliestStopTime and
+               // program run records that started after latestStartTime, all remaining records are active
+               // at some point within the time window and will be returned
+               meta -> meta.getStopTs() != null && meta.getStopTs() >= earliestStopTime
+                 && meta.getStartTs() < latestStartTime)).entrySet().stream())
+      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   private Map<ProgramRunId, RunRecordMeta> getHistoricalRuns(MDSKey historyKey, ProgramRunStatus status,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -380,6 +380,13 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public Map<ProgramRunId, RunRecordMeta> getActiveRuns(Set<NamespaceId> namespaces, Predicate<RunRecordMeta> filter) {
+    return Transactionals.execute(transactional, context -> {
+      return getAppMetadataStore(context).getActiveRuns(namespaces, filter);
+    });
+  }
+
+  @Override
   public Map<ProgramRunId, RunRecordMeta> getActiveRuns(ApplicationId applicationId) {
     return Transactionals.execute(transactional, context -> {
       return getAppMetadataStore(context).getActiveRuns(applicationId);
@@ -390,6 +397,14 @@ public class DefaultStore implements Store {
   public Map<ProgramRunId, RunRecordMeta> getActiveRuns(ProgramId programId) {
     return Transactionals.execute(transactional, context -> {
       return getAppMetadataStore(context).getActiveRuns(programId);
+    });
+  }
+
+  @Override
+  public Map<ProgramRunId, RunRecordMeta> getHistoricalRuns(Set<NamespaceId> namespaces,
+                                                            long earliestStopTime, long latestStartTime, int limit) {
+    return Transactionals.execute(transactional, context -> {
+      return getAppMetadataStore(context).getHistoricalRuns(namespaces, earliestStopTime, latestStartTime, limit);
     });
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.ops.DashboardProgramRunRecord;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.ByteStreams;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for {@link OperationsDashboardHttpHandler}
+ */
+public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
+  private static final Gson GSON = new Gson();
+  private static final String BASE_PATH = Constants.Gateway.API_VERSION_3;
+  private static final Type DASHBOARD_DETAIL_TYPE = new TypeToken<List<DashboardProgramRunRecord>>() { }.getType();
+  private static Store store;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    store = getInjector().getInstance(DefaultStore.class);
+  }
+
+  @Test
+  public void testDashboardDetail() throws Exception {
+    ProgramId programId1 = new ProgramId("ns1", "app", ProgramType.WORKFLOW, "program");
+    ArtifactId artifactId = new ArtifactId("ns1", new ArtifactVersion("1.0.0"), ArtifactScope.USER);
+    long sourceId = 0;
+    // a path to get ops dashboard results between time 100 and 100 + 1440 = 1540 from namesapce "ns1" and "ns2"
+    String opsDashboardQueryPath = BASE_PATH + "/dashboard?start=100&duration=1440&namespace=ns1&namespace=ns2";
+    // run1 will not be included in the query results since it stops before the query start time 100
+    ProgramRunId run1 = programId1.run(RunIds.generate(TimeUnit.SECONDS.toMillis(10)));
+    store.setProvisioning(run1, Collections.emptyMap(), Collections.emptyMap(),
+                          Bytes.toBytes(++sourceId), artifactId);
+    store.setStop(run1, 50, ProgramRunStatus.COMPLETED, Bytes.toBytes(++sourceId));
+    // run2 will be included in the query results since it starts before query end time
+    // and stops after query start time
+    ProgramRunId run2 = programId1.run(RunIds.generate(TimeUnit.SECONDS.toMillis(60)));
+    store.setProvisioning(run2, Collections.emptyMap(), Collections.emptyMap(),
+                          Bytes.toBytes(++sourceId), artifactId);
+    store.setStop(run2, 110, ProgramRunStatus.COMPLETED, Bytes.toBytes(++sourceId));
+    ProgramId programId2 = new ProgramId("ns2", "app", ProgramType.WORKFLOW, "program");
+    // run3 will be included in the query results since it starts before query end time
+    // and stops after query start time
+    ProgramRunId run3 = programId2.run(RunIds.generate(TimeUnit.SECONDS.toMillis(120)));
+    store.setProvisioning(run3, Collections.emptyMap(), Collections.emptyMap(),
+                          Bytes.toBytes(++sourceId), artifactId);
+    store.setStop(run3, 200, ProgramRunStatus.COMPLETED, Bytes.toBytes(++sourceId));
+    // run4 will be included in the query results since it starts before query end time
+    // and stops after query start time
+    ProgramRunId run4 = programId2.run(RunIds.generate(TimeUnit.SECONDS.toMillis(60)));
+    store.setProvisioning(run4, Collections.emptyMap(), Collections.emptyMap(),
+                          Bytes.toBytes(++sourceId), artifactId);
+    store.setStop(run4, 2200, ProgramRunStatus.COMPLETED, Bytes.toBytes(++sourceId));
+    // run5 will be included in the query results since it starts before query end time
+    // and stops after query start time
+    ProgramRunId run5 = programId2.run(RunIds.generate(TimeUnit.SECONDS.toMillis(60)));
+    store.setProvisioning(run5, Collections.emptyMap(), Collections.emptyMap(),
+                          Bytes.toBytes(++sourceId), artifactId);
+    store.setStart(run5, "twillId", Collections.emptyMap(), Bytes.toBytes(++sourceId));
+    // run6 will not be included in the query results since it starts after query end time
+    ProgramRunId run6 = programId2.run(RunIds.generate(TimeUnit.SECONDS.toMillis(2000)));
+    store.setProvisioning(run6, Collections.emptyMap(), Collections.emptyMap(),
+                          Bytes.toBytes(++sourceId), artifactId);
+    store.setStop(run6, 2200, ProgramRunStatus.COMPLETED, Bytes.toBytes(++sourceId));
+
+    ProgramId programId3 = new ProgramId("ns3", "app", ProgramType.WORKFLOW, "program");
+    // run7 will not be included in the query results since it does not belong the namespaces in the query
+    ProgramRunId run7 = programId3.run(RunIds.generate(TimeUnit.SECONDS.toMillis(120)));
+    store.setProvisioning(run7, Collections.emptyMap(), Collections.emptyMap(),
+                          Bytes.toBytes(++sourceId), artifactId);
+    store.setStop(run7, 200, ProgramRunStatus.COMPLETED, Bytes.toBytes(++sourceId));
+    // get ops dashboard query results
+    HttpResponse response = doGet(opsDashboardQueryPath);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    String content = new String(ByteStreams.toByteArray(response.getEntity().getContent()), Charsets.UTF_8);
+    List<DashboardProgramRunRecord> dashboardDetail = GSON.fromJson(content, DASHBOARD_DETAIL_TYPE);
+    // assert the result contains 4 entries and run2, run3, run4, and run5 are there
+    Assert.assertEquals(4, dashboardDetail.size());
+    Set<String> runs = dashboardDetail.stream().map(DashboardProgramRunRecord::getRun).collect(Collectors.toSet());
+    Assert.assertEquals(ImmutableSet.of(run2.getRun(), run3.getRun(), run4.getRun(), run5.getRun()), runs);
+  }
+}

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -92,6 +92,8 @@ public final class RouterPathLookup extends AbstractHttpHandler {
     if ((uriParts.length >= 2) && uriParts[1].equals("feeds")) {
       // TODO find a better way to handle that - this looks hackish
       return null;
+    } else if ("dashboard".equals(uriParts[1])) {
+      return APP_FABRIC_HTTP;
     } else if ((uriParts.length >= 11) && "versions".equals(uriParts[5]) && isUserServiceType(uriParts[7])
       && "methods".equals(uriParts[9])) {
       // User defined services (version specific) handle methods on them:

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -208,6 +208,11 @@ public class RouterPathTest {
   }
 
   @Test
+  public void testOpsDashboardPath() throws Exception {
+    assertRouting("/v3/dashboard", RouterPathLookup.APP_FABRIC_HTTP);
+  }
+
+  @Test
   public void testStreamPath() throws Exception {
     //Following URIs might not give actual results but we want to test resilience of Router Path Lookup
     String streamPath = "/v3/namespaces/default/streams";

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ops/DashboardProgramRunRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ops/DashboardProgramRunRecord.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.ops;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactSummary;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.proto.id.ProgramRunId;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a record of a program run information to be included in a dashboard detail view.
+ */
+public class DashboardProgramRunRecord {
+  private final String namespace;
+  private final ArtifactSummary artifact;
+  private final ApplicationNameVersion application;
+  private final String type;
+  private final String program;
+  private final String run;
+  private final String user;
+  private final String startMethod;
+  private final long start;
+  @Nullable
+  private final Long running;
+  @Nullable
+  private final Long end;
+  private final ProgramRunStatus status;
+
+  public DashboardProgramRunRecord(ProgramRunId runId, RunRecord runRecord, ArtifactId artifactId,
+                                   String user, String startMethod) {
+    this(runId.getNamespace(), ArtifactSummary.from(artifactId),
+         new ApplicationNameVersion(runId.getApplication(), runId.getVersion()),
+         runId.getType().name(), runId.getProgram(), runId.getRun(), user, startMethod,
+         runRecord.getStartTs(), runRecord.getRunTs(), runRecord.getStopTs(), runRecord.getStatus());
+  }
+
+  public DashboardProgramRunRecord(String namespace, ArtifactSummary artifact, ApplicationNameVersion application,
+                                   String type, String program, String run,
+                                   String user, String startMethod, long start,
+                                   @Nullable Long running, @Nullable Long end, ProgramRunStatus status) {
+    this.namespace = namespace;
+    this.artifact = artifact;
+    this.application = application;
+    this.type = type;
+    this.program = program;
+    this.run = run;
+    this.user = user;
+    this.startMethod = startMethod;
+    this.start = start;
+    this.running = running;
+    this.end = end;
+    this.status = status;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public ArtifactSummary getArtifact() {
+    return artifact;
+  }
+
+  public ApplicationNameVersion getApplication() {
+    return application;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getProgram() {
+    return program;
+  }
+
+  public String getRun() {
+    return run;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public String getStartMethod() {
+    return startMethod;
+  }
+
+  public long getStart() {
+    return start;
+  }
+
+  /**
+   * @return the time in seconds when the program run started running, or {@code null} if the program run has not
+   *         started running yet.
+   */
+  @Nullable
+  public Long getRunning() {
+    return running;
+  }
+
+  /**
+   * @return the time in seconds when the program run stopped, or {@code null} if the program run has not stopped yet.
+   */
+  @Nullable
+  public Long getEnd() {
+    return end;
+  }
+
+  public ProgramRunStatus getStatus() {
+    return status;
+  }
+
+  /**
+   * Represents the name and version of an application.
+   */
+  public static final class ApplicationNameVersion {
+    private final String name;
+    private final String version;
+
+    public ApplicationNameVersion(String name, String version) {
+      this.name = name;
+      this.version = version;
+    }
+
+    /**
+     * @return the name of the application
+     */
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * @return the version of the application
+     */
+    public String getVersion() {
+      return version;
+    }
+  }
+}


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-13306
https://builds.cask.co/browse/CDAP-DUT6387-4

The PR is organized in 4 commits:

1. add HTTP handler for ops dashboard and register the handler
2. a proto class representing the ops dashboard in HTTP response
3. add methods in stores to support getting historical runs for ops dashboard
4. test