### PR TITLE
Feature/cherry pick gh10043 rel 40

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -43,7 +43,7 @@ COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
 # Install Chef, setup APT, run Chef cdap::sdk recipe, then clean up
-RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.21.31 && \
+RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 13.8.5 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -26,7 +26,7 @@ CDAP_TAG='v4.0.2'
 # The CDAP package version passed to Chef
 CDAP_VERSION=${CDAP_VERSION:-4.0.2-1}
 # The version of Chef to install
-CHEF_VERSION=${CHEF_VERSION:-12.21.31}
+CHEF_VERSION=${CHEF_VERSION:-13.8.5}
 # cdap-site.xml configuration parameters
 EXPLORE_ENABLED='true'
 # Sleep delay before starting services (in seconds)
@@ -120,7 +120,8 @@ test -d /var/chef/cookbooks && sudo rm -rf /var/chef/cookbooks
 sudo ${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
 
 # Install cookbooks via knife
-sudo ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
+mkdir -p ${__tmpdir}/cookbook-download
+(cd ${__tmpdir}/cookbook-download && sudo ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks")
 
 # Get IP
 __ipaddr=$(ifconfig eth0 | grep addr: | cut -d: -f2 | head -n 1 | awk '{print $1}')

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -22,7 +22,7 @@
 # The git branch to clone
 CDAP_BRANCH=${CDAP_BRANCH:-release/4.0}
 # Optional tag to checkout - All released versions of this script should set this
-CDAP_TAG='v4.0.2'
+CDAP_TAG=${CDAP_TAG:+emr4.0}
 # The CDAP package version passed to Chef
 CDAP_VERSION=${CDAP_VERSION:-4.0.2-1}
 # The version of Chef to install

--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -26,7 +26,7 @@ CDAP_TAG='hdi4.0'
 # The CDAP package version passed to Chef
 CDAP_VERSION='4.0.2-1'
 # The version of Chef to install
-CHEF_VERSION='12.21.31'
+CHEF_VERSION='13.8.5'
 # cdap-site.xml configuration parameters
 EXPLORE_ENABLED='true'
 
@@ -72,7 +72,8 @@ test -d /var/chef/cookbooks && rm -rf /var/chef/cookbooks
 ${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
 
 # Install cookbooks via knife
-${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
+mkdir -p ${__tmpdir}/cookbook-download
+(cd ${__tmpdir}/cookbook-download && ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks")
 
 # CDAP cli install, ensures package dependencies are present
 # We must specify the cdap version

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -80,7 +80,7 @@
     },
     {
       "type": "chef-solo",
-      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.21.31",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 13.8.5",
       "remote_cookbook_paths": "/var/chef/cookbooks"
     },
     {

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -23,8 +23,40 @@ die() { echo $*; exit 1; }
 export GIT_MERGE_AUTOEDIT=no
 
 # Grab cookbooks using knife
-for cb in cdap idea maven openssh; do
-  knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
+# Due to https://issues.cask.co/browse/CDAP-13308, we can no longer use knife cookbook site install
+# for cb in cdap idea maven openssh; do
+#   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
+# done
+
+# Instead we must manually download and extract known good versions
+knife cookbook site download --force ambari 0.4.0 || die "Cannot download cookbook ambari"
+knife cookbook site download --force apt 6.1.4 || die "Cannot download cookbook apt"
+knife cookbook site download --force ark 3.1.0 || die "Cannot download cookbook ark"
+knife cookbook site download --force build-essential 8.1.1 || die "Cannot download cookbook build-essential"
+knife cookbook site download --force cdap 3.3.3 || die "Cannot download cookbook cdap"
+knife cookbook site download --force dpkg_autostart 0.2.0 || die "Cannot download cookbook dpkg_autostart"
+knife cookbook site download --force hadoop 2.13.0 || die "Cannot download cookbook hadoop"
+knife cookbook site download --force homebrew 5.0.4 || die "Cannot download cookbook homebrew"
+knife cookbook site download --force idea 0.6.0 || die "Cannot download cookbook idea"
+knife cookbook site download --force iptables 4.3.4 || die "Cannot download cookbook iptables"
+knife cookbook site download --force java 1.50.0 || die "Cannot download cookbook java"
+knife cookbook site download --force krb5 2.2.1 || die "Cannot download cookbook krb5"
+knife cookbook site download --force maven 5.1.0 || die "Cannot download cookbook maven"
+knife cookbook site download --force mingw 2.0.2 || die "Cannot download cookbook mingw"
+knife cookbook site download --force nodejs 5.0.0 || die "Cannot download cookbook nodejs"
+knife cookbook site download --force ntp 3.5.6 || die "Cannot download cookbook ntp"
+knife cookbook site download --force ohai 5.2.2 || die "Cannot download cookbook ohai"
+knife cookbook site download --force openssh 2.6.3 || die "Cannot download cookbook openssh"
+knife cookbook site download --force selinux 2.1.0 || die "Cannot download cookbook selinux"
+knife cookbook site download --force seven_zip 2.0.2 || die "Cannot download cookbook seven_zip"
+knife cookbook site download --force sysctl 1.0.3 || die "Cannot download cookbook sysctl"
+knife cookbook site download --force ulimit 1.0.0 || die "Cannot download cookbook ulimit"
+knife cookbook site download --force windows 4.1.4 || die "Cannot download cookbook windows"
+knife cookbook site download --force yum 5.1.0 || die "Cannot download cookbook yum"
+
+# extract to /var/chef/cookbooks
+for cb in `ls *.tar.gz`; do
+  tar xf $cb -C /var/chef/cookbooks
 done
 
 # Do not change HOME for cdap user


### PR DESCRIPTION
- [x] cherry-pick of #10043 
- [x] additionally changing the EMR install script to check out a dedicated `emrX.Y` tag rather than the release, to accommodate changes like these.  HDInsight already uses a similar `hdiX.Y` tag.