### PR TITLE
Feature/update eclipse cookbook chef 13

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -13,8 +13,8 @@
     {
       "type": "virtualbox-iso",
       "guest_os_type": "Ubuntu_64",
-      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-server-amd64.iso",
-      "iso_checksum": "10fcd20619dce11fe094e960c85ba4a9",
+      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.4-server-amd64.iso",
+      "iso_checksum": "6a7f31eb125a0b2908cf2333d7777c82",
       "iso_checksum_type": "md5",
       "ssh_username": "cdap",
       "ssh_password": "cdap",

--- a/cdap-distributions/src/packer/scripts/eclipse-cookbook.sh
+++ b/cdap-distributions/src/packer/scripts/eclipse-cookbook.sh
@@ -22,7 +22,7 @@ cd /var/chef/cookbooks || (echo "Cannot change to cookbook directory" && exit 1)
 
 # Check out the cookbook from GitHub
 which git || (echo "Cannot locate git" && exit 1)
-git clone https://github.com/geocent-cookbooks/eclipse.git || (echo "Cannot checkout eclipse cookbook" && exit 1)
+git clone https://github.com/appcelerator/eclipse.git || (echo "Cannot checkout eclipse cookbook" && exit 1)
 
 # Remove .git, so it's no longer tracked by git
 rm -rf eclipse/.git


### PR DESCRIPTION
Fixes VM build after https://github.com/caskdata/cdap/pull/10043
- [x] uses an updated fork of the same eclipse cookbook, as the original hasn't been maintained in 5 years.
- [x] updates to the ubuntu ISO patch, required as the old one isn't available anymore