### PR TITLE
[CDAP-13113][MMDS] New experiment/model create flow integration with backend

### DIFF
--- a/cdap-ui/app/cdap/api/experiments.js
+++ b/cdap-ui/app/cdap/api/experiments.js
@@ -28,7 +28,7 @@ export const myExperimentsApi = {
   getExperiment: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId`),
   getModelsInExperiment: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/models`),
   getModel: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId`),
-  setSplitToModel: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId/split`),
+  pollModel: apiCreator(dataSrc, 'GET', 'POLL', `${basePath}/experiments/:experimentId/models/:modelId`),
   getSplitDetails: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments/:experimentId/splits/:splitId`),
   getSplitStatus: apiCreator(dataSrc, 'GET', 'POLL', `${basePath}/experiments/:experimentId/splits/:splitId/status`),
   getAlgorithms: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/algorithms`),
@@ -41,7 +41,7 @@ export const myExperimentsApi = {
   deleteExperiment: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${basePath}/experiments/:experimentId`),
 
   createExperiment: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basePath}/experiments/:experimentId`),
-  createSplit: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/experiments/:experimentId/splits`),
+  createSplit: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId/split`),
   createModelInExperiment: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/experiments/:experimentId/models`),
 
   // Service management

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -795,5 +795,6 @@ DataPrepConnections.propTypes = {
   enableRouting: PropTypes.bool,
   onWorkspaceCreate: PropTypes.func,
   singleWorkspaceMode: PropTypes.bool,
-  sidePanelExpanded: PropTypes.bool
+  sidePanelExpanded: PropTypes.bool,
+  scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
 };

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
@@ -44,7 +44,7 @@ import Helmet from 'react-helmet';
 import queryString from 'query-string';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
-import {objectQuery} from 'services/helpers';
+import MyDataPrepApi from 'api/dataprep';
 
 require('./CreateView.scss');
 
@@ -67,11 +67,10 @@ export default class ExperimentCreateView extends Component {
   componentDidMount() {
     this.dataprepsubscription = DataPrepStore.subscribe(() => {
       let {dataprep} = DataPrepStore.getState();
-      let {headers = [], directives, workspaceInfo = {}} = dataprep;
+      let {headers = [], directives, workspaceInfo = {}, workspaceId} = dataprep;
       if (!headers.length) {
         return;
       }
-      let workspaceId = objectQuery(workspaceInfo, 'workspace', 'name');
       setWorkspace(workspaceId);
       setSrcPath(workspaceInfo.properties.path);
       setOutcomeColumns(headers);
@@ -115,6 +114,15 @@ export default class ExperimentCreateView extends Component {
     fetchAlgorithmsList();
   }
   componentWillUnmount() {
+    let {experiments_create} = createExperimentStore.getState();
+    let {workspaceId} = experiments_create;
+    if (workspaceId) {
+      // Every workspace created in experiments create view is temp. So don't worry about deleting it.
+      MyDataPrepApi.delete({
+        namespace: getCurrentNamespace(),
+        workspaceId
+      }).subscribe();
+    }
     DataPrepStore.dispatch({
       type: DataPrepActions.reset
     });
@@ -149,6 +157,7 @@ export default class ExperimentCreateView extends Component {
             setWorkspace(workspaceId);
             this.setState({workspaceId});
           }}
+          scope={true}
         />
       </span>
     );

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
@@ -129,6 +129,19 @@
         }
       }
     }
+    &.directives-list {
+      .grid-header {
+        .grid-row {
+          &:hover {
+            background: transparent;
+          }
+        }
+        strong {
+          padding-left: 0;
+          color: $grey-03;
+        }
+      }
+    }
     &.classification {
       .grid-header,
       .grid-body {

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
@@ -157,7 +157,7 @@ const renderFeaturesTable = (features) => {
 const renderDirectivesTables = (directives) => {
   return (
     <div className="grid-wrapper">
-      <div className="grid grid-container">
+      <div className="grid grid-container directives-list">
         <div className="grid-header">
           <div className="grid-row">
             <strong> Directives </strong>

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -40,25 +40,34 @@ const BASEPATH = '/';
 const PREFIX = 'features.FileBrowser';
 
 export default class FileBrowser extends Component {
-  constructor(props) {
-    super(props);
 
-    this.state = {
-      contents: [],
-      path: '',
-      statePath: objectQuery(this.props, 'match', 'url') || '',
-      error: null,
-      loading: true,
-      search: '',
-      sort: 'name',
-      sortOrder: 'asc',
-      searchFocus: true
-    };
+  state = {
+    contents: [],
+    path: '',
+    statePath: objectQuery(this.props, 'match', 'url') || '',
+    error: null,
+    loading: true,
+    search: '',
+    sort: 'name',
+    sortOrder: 'asc',
+    searchFocus: true
+  };
 
-    this.handleSearch = this.handleSearch.bind(this);
-    this.preventPropagation = this.preventPropagation.bind(this);
-    this.goToPath = this.goToPath.bind(this);
-  }
+  static defaultProps = {
+    enableRouting: true,
+    scope: false
+  };
+
+  static propTypes = {
+    location: PropTypes.object,
+    match: PropTypes.object,
+    initialDirectoryPath: PropTypes.string,
+    noState: PropTypes.bool,
+    toggle: PropTypes.func.isRequired,
+    enableRouting: PropTypes.bool,
+    onWorkspaceCreate: PropTypes.func,
+    scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  };
 
   componentWillMount() {
     if (!this.props.enableRouting) {
@@ -103,7 +112,7 @@ export default class FileBrowser extends Component {
     return filePath;
   }
 
-  preventPropagation(e) {
+  preventPropagation = (e) => {
     if (this.props.enableRouting) {
       return;
     }
@@ -127,7 +136,7 @@ export default class FileBrowser extends Component {
     this.goToPath(hdfsPath);
   }
 
-  goToPath(path) {
+  goToPath = (path) => {
     this.setState({
       loading: true,
       path
@@ -172,7 +181,7 @@ export default class FileBrowser extends Component {
     });
   }
 
-  handleSearch(e) {
+  handleSearch = (e) => {
     this.setState({search: e.target.value});
   }
 
@@ -190,13 +199,24 @@ export default class FileBrowser extends Component {
   }
   ingestFile(content) {
     let namespace = NamespaceStore.getState().selectedNamespace;
-
+    let {scope} = this.props;
     let params = {
       namespace,
       path: content.path,
       lines: 10000,
       sampler: 'first'
     };
+
+    if (scope) {
+      if (typeof scope === 'string') {
+        params.scope = scope;
+      } else if (typeof scope === 'boolean') {
+        // FIXME: Leaky. Why MMDS into filebrowser? This should be extracted out as a pure function.
+        // Or when backend adds a flag to create a new workspace everytime then use that
+        // instead of passing a hardcoded string for scope.
+        params.scope = 'mmds';
+      }
+    }
 
     let headers = {
       'Content-Type': content.type
@@ -540,16 +560,3 @@ export default class FileBrowser extends Component {
   }
 }
 
-FileBrowser.defaultProps = {
-  enableRouting: true
-};
-
-FileBrowser.propTypes = {
-  location: PropTypes.object,
-  match: PropTypes.object,
-  initialDirectoryPath: PropTypes.string,
-  noState: PropTypes.bool,
-  toggle: PropTypes.func.isRequired,
-  enableRouting: PropTypes.bool,
-  onWorkspaceCreate: PropTypes.func
-};

--- a/cdap-ui/app/cdap/components/PieChart/index.js
+++ b/cdap-ui/app/cdap/components/PieChart/index.js
@@ -49,11 +49,11 @@ export default class PieChart extends Component {
         radius = Math.min(width, height) / 2,
         g = svg.append("g").attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
 
-    var pie = d3Lib.layout.pie()
+    var pie = d3Lib.pie()
         .sort(null)
         .value(function(d) { return d.count; });
 
-    var path = d3Lib.svg.arc()
+    var path = d3Lib.arc()
         .outerRadius(radius - 10)
         .innerRadius(0);
 


### PR DESCRIPTION
**TL;DR**:
- Update Experiments/Models create view in UI based on changes in backend
- Changes include,
  - Create new workspace everytime user lands on create experiment or create model states in UI
  - This will involve UI using directives applied on the data from experiment or model.
  - Create split under a model so that model has a reference of split id all the time
  - Polling model status instead of split status as source of truth in split stage.

**Longer description**:
- Previously UI used to store the workspace Id in an experiment to go back to context while creating an experiment or model
- This caused issues while using same file across different experiments or creating multiple models under same experiment
- Since neither experiments nor models can share the workspace we have now moved the workspace information (srcpath & directives) to individual experiment and model.
- Now each time user creates an experiment/model UI goes through the following,

```
  1. Fetch the experiments details
  2. Get directives and srcpath from the details
  3. Create a workspace with the srcpath
  4. Once created execute it with the list of directives
  5. Once the workspace is setup and update the stores.
```
- Since UI has both `srcpath` and `directives` it will create a temporary workspace everytime a user creates a new model in an experiment
- Wrangler has modified its `readFile` api to accept a `scope` parameter which will allow users to create a new workspace for each api call on the same file (meaning isolate different experiments created from the same file).

**Reference diagram from @albertshau on backend states**:
![model_lifecycle 1](https://user-images.githubusercontent.com/1452845/38844099-d868b852-41a6-11e8-8103-0fe836c4c2cf.png)

**Things to improve**:
- Store the file type in experiment/model in addition to directives. This is needed while creating a new workspace
- Right now UI makes execute call twice (1. For updating the newly created workspace to have the directives and 2. When Dataprep loads the workspace to render the table). We should probably have a nice API while creating workspace to accept a list of directives.
- Error handling

JIRA: https://issues.cask.co/browse/CDAP-13113