### PR TITLE
(CDAP-13316) Fix SingleThreadDatasetCache invalidation logic

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
@@ -43,6 +43,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -321,6 +322,30 @@ public abstract class DynamicDatasetCacheTest {
                           Iterables.size(cache.getTransactionAwares())
                             - Iterables.size(cache.getStaticTransactionAwares()));
     });
+  }
+
+  @Test
+  public void testAccessAwareCache() {
+    // Same dataset of different types should return the same instance
+    TestDataset a1 = cache.getDataset("a", Collections.emptyMap(), AccessType.READ);
+    TestDataset a2 = cache.getDataset("a", Collections.emptyMap(), AccessType.WRITE);
+
+    Assert.assertSame(a1, a2);
+
+    // Discarding one should automatically closed both
+    cache.discardDataset(a1);
+    Assert.assertTrue(a1.isClosed());
+    Assert.assertTrue(a2.isClosed());
+
+    // Getting the dataset again should return different instances than last one,
+    // but the two new one should be the same instance
+    TestDataset oldA1 = a1;
+    a1 = cache.getDataset("a", Collections.emptyMap(), AccessType.READ);
+    a2 = cache.getDataset("a", Collections.emptyMap(), AccessType.WRITE);
+
+    Assert.assertSame(a1, a2);
+    Assert.assertNotSame(oldA1, a1);
+    Assert.assertNotSame(oldA1, a2);
   }
 
   private Boolean verifyTxAwaresContains(List<TestDataset> txAwares, TestDataset... datasets) {

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
@@ -104,9 +104,7 @@ abstract class AbstractSparkExecutionContext(sparkClassLoader: SparkClassLoader,
   protected val runtimeContext = sparkClassLoader.getRuntimeContext
 
   private val taskLocalizationContext = new DefaultTaskLocalizationContext(localizeResources)
-  private val transactional = new SparkTransactional(runtimeContext.getTransactionSystemClient,
-                                                     runtimeContext.getDatasetCache,
-                                                     runtimeContext.getRetryStrategy)
+  private val transactional = new SparkTransactional(runtimeContext)
   private val workflowInfo = Option(runtimeContext.getWorkflowInfo)
   private val sparkTxHandler = new SparkTransactionHandler(runtimeContext.getTransactionSystemClient)
   private val sparkClassFileHandler = new SparkClassFileHandler


### PR DESCRIPTION
- All cached entries having the same dataset instance should be invalidated on discard
- Also fixed a missing change about app system namespace
  - Spark program in system namespace should be able to access system dataset