### PR TITLE
[CDAP-13276] Adds import/export/delete profile functionality in UI

### DIFF
--- a/cdap-ui/app/cdap/api/cloud.js
+++ b/cdap-ui/app/cdap/api/cloud.js
@@ -25,6 +25,7 @@ export const MyCloudApi = {
   list: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/profiles`),
   create: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basepath}/profiles/:profile`),
   get: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/profiles/:profile`),
+  delete: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${basepath}/profiles/:profile`),
   getProvisioners: apiCreator(dataSrc, 'GET', 'REQUEST', `${provisionersPath}`),
   getProvisionerDetailSpec: apiCreator(dataSrc, 'GET', 'REQUEST', `${provisionersPath}/:provisioner`)
 };

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/SystemProfilesAccordion.scss
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/SystemProfilesAccordion.scss
@@ -17,23 +17,39 @@
 @import '../../../../styles/variables.scss';
 
 .system-profiles-container {
-  .profiles-list-view {
-    .grid.grid-container {
-      .grid-row {
-        &.sub-header {
-          color: $grey-03;
+  .system-profiles-container-content {
+    .profiles-list-view {
+      .grid.grid-container {
+        .grid-row {
+          &.sub-header {
+            color: $grey-03;
+          }
         }
-      }
 
-      .grid-body {
-        .grid-row:hover {
-          background-color: white;
+        .grid-body {
+          .grid-row:hover {
+            background-color: white;
+          }
         }
       }
     }
-  }
 
-  .view-all-label-container:first-child {
-    transform: translateY(10px);
+    .create-import-profile {
+      display: flex;
+      align-items: center;
+
+      .btn.btn-secondary.create-profile-button {
+        margin-top: 0;
+      }
+
+      .import-profile-label {
+        margin-bottom: 0;
+        margin-left: 10px;
+      }
+    }
+
+    .view-all-label-container:first-child {
+      margin-bottom: 0;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
@@ -21,34 +21,25 @@ import ProfilesListView from 'components/Cloud/Profiles/ListView';
 import classnames from 'classnames';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
+import ProfilesStore from 'components/Cloud/Profiles/Store';
+import {importProfile} from 'components/Cloud/Profiles/Store/ActionCreator';
+import {connect, Provider} from 'react-redux';
+import {Label, Input} from 'reactstrap';
+import {getProfiles} from 'components/Cloud/Profiles/Store/ActionCreator';
 require('./SystemProfilesAccordion.scss');
 
 const PREFIX = 'features.Administration.Accordions.SystemProfiles';
 
-export default class SystemProfilesAccordion extends Component {
-  state = {
-    profilesCount: this.props.profiles.length
-  };
-
+class SystemProfilesAccordion extends Component {
   static propTypes = {
-    profiles: PropTypes.array,
+    profilesCount: PropTypes.number,
     loading: PropTypes.bool,
     expanded: PropTypes.bool,
     onExpand: PropTypes.func
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.profiles.length !== this.props.profiles.length) {
-      this.setState({
-        profilesCount: nextProps.profiles.length
-      });
-    }
-  }
-
-  onChange = (profiles) => {
-    this.setState({
-      profilesCount: profiles.length
-    });
+  componentDidMount() {
+    getProfiles('system');
   }
 
   renderLabel() {
@@ -68,7 +59,7 @@ export default class SystemProfilesAccordion extends Component {
                 </h5>
               )
             :
-              <h5>{T.translate(`${PREFIX}.labelWithCount`, {count: this.state.profilesCount})}</h5>
+              <h5>{T.translate(`${PREFIX}.labelWithCount`, {count: this.props.profilesCount})}</h5>
           }
         </span>
         <span className="admin-config-container-description">
@@ -85,16 +76,27 @@ export default class SystemProfilesAccordion extends Component {
 
     return (
       <div className="admin-config-container-content system-profiles-container-content">
-        <Link
-          className="btn btn-secondary"
-          to='/create-profile'
-        >
-          {T.translate(`${PREFIX}.create`)}
-        </Link>
-        <ProfilesListView
-          namespace='system'
-          onChange={this.onChange}
-        />
+        <div className="create-import-profile">
+          <Link
+            className="btn btn-secondary create-profile-button"
+            to='/create-profile'
+          >
+            {T.translate(`${PREFIX}.create`)}
+          </Link>
+          <Label
+            className="import-profile-label"
+            for="import-profile"
+          >
+            {T.translate(`${PREFIX}.import`)}
+            <Input
+              type="file"
+              accept='.json'
+              id="import-profile"
+              onChange={importProfile.bind(this, 'system')}
+            />
+          </Label>
+        </div>
+        <ProfilesListView namespace='system' />
       </div>
     );
   }
@@ -110,4 +112,21 @@ export default class SystemProfilesAccordion extends Component {
       </div>
     );
   }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    profilesCount: state.profiles.length,
+    loading: state.loading
+  };
+};
+
+const ConnectedSystemProfilesAccordion = connect(mapStateToProps)(SystemProfilesAccordion);
+
+export default function SystemProfilesAccordionFn(props) {
+  return (
+    <Provider store={ProfilesStore}>
+      <ConnectedSystemProfilesAccordion {...props}/>
+    </Provider>
+  );
 }

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/index.js
@@ -22,7 +22,6 @@ import SystemProfilesAccordion from 'components/Administration/AdminConfigTabCon
 import SystemPrefsAccordion from 'components/Administration/AdminConfigTabContent/SystemPrefsAccordion';
 import {MyNamespaceApi} from 'api/namespace';
 import {MyPreferenceApi} from 'api/preference';
-import {MyCloudApi} from 'api/cloud';
 import {Link} from 'react-router-dom';
 import T from 'i18n-react';
 
@@ -37,10 +36,8 @@ export const ADMIN_CONFIG_ACCORDIONS = {
 export default class AdminConfigTabContent extends Component {
   state = {
     namespaces: 0,
-    systemProfiles: 0,
     systemPrefs: 0,
     namespacesCountLoading: true,
-    systemProfilesCountLoading: true,
     systemPrefsCountLoading: true,
     expandedAccordion: this.props.accordionToExpand || ADMIN_CONFIG_ACCORDIONS.namespaces
   };
@@ -67,7 +64,6 @@ export default class AdminConfigTabContent extends Component {
 
   componentDidMount() {
     this.getNamespaces();
-    this.getSystemProfiles();
     this.getSystemPrefs();
   }
 
@@ -79,20 +75,6 @@ export default class AdminConfigTabContent extends Component {
           this.setState({
             namespaces: res,
             namespacesCountLoading: false
-          });
-        },
-        (err) => console.log(err)
-      );
-  }
-
-  getSystemProfiles() {
-    MyCloudApi
-      .list({namespace: 'system'})
-      .subscribe(
-        (res) => {
-          this.setState({
-            systemProfiles: res,
-            systemProfilesCountLoading: false
           });
         },
         (err) => console.log(err)
@@ -132,8 +114,6 @@ export default class AdminConfigTabContent extends Component {
           onExpand={this.expandAccordion.bind(this, ADMIN_CONFIG_ACCORDIONS.namespaces)}
         />
         <SystemProfilesAccordion
-          profiles={this.state.systemProfiles}
-          loading={this.state.systemProfilesCountLoading}
           expanded={this.state.expandedAccordion === ADMIN_CONFIG_ACCORDIONS.systemProfiles}
           onExpand={this.expandAccordion.bind(this, ADMIN_CONFIG_ACCORDIONS.systemProfiles)}
         />

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
@@ -25,7 +25,7 @@ $row-height: 50px;
   .grid.grid-container {
     max-height: none;
     .grid-row {
-      grid-template-columns: 20px 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 20px;
+      grid-template-columns: 20px 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 30px;
 
       .sortable-header {
         cursor: pointer;
@@ -43,7 +43,7 @@ $row-height: 50px;
         border: 0;
         padding: 0;
         color: $grey-05;
-        grid-template-columns: 20px 1.5fr 1fr 1fr 1fr 1fr 2fr 0fr 2fr 0fr 1fr 20px;
+        grid-template-columns: 20px 1.5fr 1fr 1fr 1fr 1fr 2fr 0fr 2fr 0fr 1fr 30px;
 
         .sub-title {
           border-bottom: 2px solid gray;
@@ -73,11 +73,60 @@ $row-height: 50px;
         &:last-child {
           border-bottom: 0;
         }
+
+        .profile-actions-popover {
+          .icon-cog-empty {
+            fill: white;
+            font-size: 23px;
+            stroke: $grey-04;
+          }
+
+          .popper {
+            width: 90px;
+            min-width: 90px;
+
+            ul {
+              hr {
+                height: 1px;
+                margin: 5px 8px;
+                border-top: 0;
+                background-color: $grey-03;
+              }
+
+              li.delete-action {
+                color: $red-02;
+              }
+            }
+
+            .popper__arrow {
+              border-right-color: $grey-05;
+              border-bottom-color: $grey-05;
+            }
+          }
+        }
+
+        &:hover {
+          .profile-actions-popover {
+            .icon-cog-empty {
+              stroke: $blue-03;
+            }
+          }
+        }
       }
     }
   }
 
   a {
     color: $blue-03;
+  }
+}
+
+.import-profile-label {
+  color: $blue-03;
+  cursor: pointer;
+  font-size: 13px;
+
+  #import-profile {
+    display: none;
   }
 }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/ActionCreator.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import ProfilesStore, {PROFILES_ACTIONS} from 'components/Cloud/Profiles/Store';
+import {MyCloudApi} from 'api/cloud';
+import fileDownload from 'js-file-download';
+import {objectQuery} from 'services/helpers';
+
+export const getProfiles = (namespace) => {
+  ProfilesStore.dispatch({
+    type: PROFILES_ACTIONS.SET_LOADING,
+    payload: {
+      loading: true
+    }
+  });
+
+  MyCloudApi
+    .list({ namespace })
+    .subscribe(
+      (profiles) => {
+        ProfilesStore.dispatch({
+          type: PROFILES_ACTIONS.SET_PROFILES,
+          payload: { profiles }
+        });
+      },
+      (error) => {
+        ProfilesStore.dispatch({
+          type: PROFILES_ACTIONS.SET_ERROR,
+          payload: { error }
+        });
+      }
+    );
+};
+
+export const exportProfile = (namespace, profile) => {
+  MyCloudApi
+    .get({
+      namespace,
+      profile: profile.name
+    })
+    .subscribe(
+      (res) => {
+        let json = JSON.stringify(res, null, 2);
+        let fileName = `${profile.name}-${profile.provisioner.name}-profile.json`;
+        fileDownload(json, fileName);
+      },
+      (error) => {
+        ProfilesStore.dispatch({
+          type: PROFILES_ACTIONS.SET_ERROR,
+          payload: { error }
+        });
+      }
+    );
+};
+
+export const deleteProfile = (namespace, profile) => {
+  let deleteObservable = MyCloudApi.delete({
+    namespace,
+    profile
+  });
+  deleteObservable.subscribe(() => {
+    getProfiles(namespace);
+  });
+  return deleteObservable;
+};
+
+export const importProfile = (namespace, e) => {
+  if (!objectQuery(e, 'target', 'files', 0)) {
+    return;
+  }
+
+  let uploadedFile = e.target.files[0];
+  let reader = new FileReader();
+  reader.readAsText(uploadedFile, 'UTF-8');
+
+  reader.onload =  (evt) => {
+    let jsonSpec = evt.target.result;
+    try {
+      jsonSpec = JSON.parse(jsonSpec);
+    } catch (error) {
+      ProfilesStore.dispatch({
+        type: PROFILES_ACTIONS.SET_ERROR,
+        payload: {
+          error: error.message || error
+        }
+      });
+      return;
+    }
+
+    MyCloudApi
+      .create({
+        namespace,
+        profile: jsonSpec.name
+      }, jsonSpec)
+      .subscribe(
+        () => {
+          getProfiles(namespace);
+        },
+        (error) => {
+          ProfilesStore.dispatch({
+            type: PROFILES_ACTIONS.SET_ERROR,
+            payload: {
+              error: error.response || error
+            }
+          });
+        }
+      );
+  };
+};
+
+export const setError = (error) => {
+  ProfilesStore.dispatch({
+    type: PROFILES_ACTIONS.SET_ERROR,
+    payload: { error }
+  });
+};

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {createStore} from 'redux';
+import {defaultAction, composeEnhancers} from 'services/helpers';
+
+const PROFILES_ACTIONS = {
+  SET_PROFILES: 'SET_PROFILES',
+  SET_LOADING: 'SET_LOADING',
+  SET_ERROR: 'SET_ERROR'
+};
+
+const DEFAULT_PROFILES_STATE = {
+  profiles: [],
+  loading: false,
+  error: null,
+};
+
+const profiles = (state = DEFAULT_PROFILES_STATE, action = defaultAction) => {
+  switch (action.type) {
+    case PROFILES_ACTIONS.SET_PROFILES:
+      return {
+        ...state,
+        profiles: action.payload.profiles,
+        error: null,
+        loading: false
+      };
+    case PROFILES_ACTIONS.SET_LOADING:
+      return {
+        ...state,
+        error: null,
+        loading: action.payload.loading
+      };
+    case PROFILES_ACTIONS.SET_ERROR:
+      return {
+        ...state,
+        error: action.payload.error,
+        loading: false
+      };
+    case PROFILES_ACTIONS.RESET:
+      return DEFAULT_PROFILES_STATE;
+    default:
+      return state;
+  }
+};
+
+const ProfilesStore = createStore(
+  profiles,
+  DEFAULT_PROFILES_STATE,
+  composeEnhancers('ProfilesStore')()
+);
+
+export default ProfilesStore;
+export {PROFILES_ACTIONS};

--- a/cdap-ui/app/cdap/components/NamespaceDetails/ComputeProfiles/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/ComputeProfiles/index.js
@@ -15,32 +15,31 @@
 */
 
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import T from 'i18n-react';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import {Link} from 'react-router-dom';
 import ProfilesListView from 'components/Cloud/Profiles/ListView';
+import ProfilesStore from 'components/Cloud/Profiles/Store';
+import {importProfile} from 'components/Cloud/Profiles/Store/ActionCreator';
+import {connect, Provider} from 'react-redux';
+import {Label, Input} from 'reactstrap';
 
 require('./ComputeProfiles.scss');
 
 const PREFIX = 'features.NamespaceDetails.computeProfiles';
 
-export default class NamespaceDetailsComputeProfiles extends Component {
-  state = {
-    profilesCount: 0
-  };
-
-  onChange = (profiles) => {
-    this.setState({
-      profilesCount: profiles.length
-    });
+class NamespaceDetailsComputeProfiles extends Component {
+  static propTypes = {
+    profilesCount: PropTypes.number
   }
 
   renderProfilesLabel() {
     let label;
-    if (!this.state.profilesCount) {
+    if (!this.props.profilesCount) {
       label = <strong>{T.translate(`${PREFIX}.label`)}</strong>;
     } else {
-      label = <strong>{T.translate(`${PREFIX}.labelWithCount`, {count: this.state.profilesCount})}</strong>;
+      label = <strong>{T.translate(`${PREFIX}.labelWithCount`, {count: this.props.profilesCount})}</strong>;
     }
 
     return (
@@ -52,8 +51,21 @@ export default class NamespaceDetailsComputeProfiles extends Component {
         >
           {T.translate(`${PREFIX}.create`)}
         </Link>
+        <span> | </span>
+        <Label
+          className="import-profile-label"
+          for="import-profile"
+        >
+          {T.translate(`${PREFIX}.import`)}
+          <Input
+            type="file"
+            accept='.json'
+            id="import-profile"
+            onChange={importProfile.bind(this, getCurrentNamespace())}
+          />
+        </Label>
         {
-          this.state.profilesCount ?
+          this.props.profilesCount ?
             (
               <p className="create-new-profile-description">
                 {T.translate(`${PREFIX}.description`)}
@@ -72,9 +84,24 @@ export default class NamespaceDetailsComputeProfiles extends Component {
         {this.renderProfilesLabel()}
         <ProfilesListView
           namespace={getCurrentNamespace()}
-          onChange={this.onChange}
         />
       </div>
     );
   }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    profilesCount: state.profiles.length
+  };
+};
+
+const ConnectedComputeProfilesSection = connect(mapStateToProps)(NamespaceDetailsComputeProfiles);
+
+export default function NamespaceDetailsComputeProfilesFn() {
+  return (
+    <Provider store={ProfilesStore}>
+      <ConnectedComputeProfilesSection />
+    </Provider>
+  );
 }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -8,6 +8,7 @@ commons:
   cdap: CDAP
   clickhere: click here
   close: Close
+  delete: Delete
   descriptionLabel: Description
   DSVEditor:
     placeholder: value
@@ -146,6 +147,7 @@ features:
         description: Manage compute profiles available to launch programs in all namespaces
         label: "System Compute Profiles "
         labelWithCount: "System Compute Profiles ({count})"
+        import: Import
     Component-Overview:
       emptyMessage: Available only in Distributed mode
       headers:
@@ -247,10 +249,15 @@ features:
       ListView:
         assosciations: Assosciations
         createOne: "creating one"
+        deleteConfirmation: Are you sure you want to delete the profile *_{profile}_*?
+        deleteError: There was a problem deleting the profile
+        deleteTitle: Delete Profile
+        export: Export
         last24HrNodeHr: Last 24 hrs node/hr
         last24HrRuns: Last 24 hrs runs
         noProfiles: "No compute profiles have been defined in this namespace. Start by "
         noProfilesSystem: "No compute profiles have been defined in the system. Start by "
+        importError: Unable to import profile
         profileName: Profile Name
         profileUsage: Profile usage
         provisioner: Provisioner
@@ -1338,10 +1345,11 @@ features:
     version: "Version :"
   NamespaceDetails:
     computeProfiles:
-      create: Create New Profile
+      create: Create New
       description: Select a row to view details about the compute profile
       label: Compute Profiles
       labelWithCount: Compute Profiles ({count})
+      import: Import
     edit: Edit
     entityCounts:
       customApps: Custom Apps


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13276

This PR:
- Moves `getProfiles` method to `Cloud/Profiles/Store/ActionCreator` instead of having it inside `Cloud/Profiles/ListView` component
- Changes several components to be Redux-connected, to get profile list data from `Cloud/Profiles/Store`, instead of listening to the `onChange` from the `ListView` component
- Adds import/export/delete profile functionality. 'Export' and 'Delete' is available as a dropdown under the gear icon for each profile row. 'Import' is added next to the 'Create New Profile' button in both the namespace details page and the admin page.
