### PR TITLE
Fix preferences levels in UI to not default to system

### DIFF
--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/AdminConfigTabContent.scss
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/AdminConfigTabContent.scss
@@ -28,7 +28,7 @@ $hover-active-color: $grey-08;
   }
 
   .action-buttons {
-    margin: 10px 0;
+    margin-bottom: 10px;
 
     .btn:first-child {
       margin-right: 15px;

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemPrefsAccordion/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemPrefsAccordion/index.js
@@ -25,6 +25,7 @@ import ViewAllLabel from 'components/ViewAllLabel';
 import T from 'i18n-react';
 import isEqual from 'lodash/isEqual';
 import SortableStickyGrid from 'components/SortableStickyGrid';
+import {PREFERENCES_LEVEL} from 'components/FastAction/SetPreferenceAction/SetPreferenceModal';
 
 const PREFIX = 'features.Administration.Accordions.SystemPrefs';
 
@@ -203,6 +204,7 @@ export default class SystemPrefsAccordion extends Component {
               isOpen={this.state.prefsModalOpen}
               toggleModal={this.togglePrefsModal}
               onSuccess={this.fetchPrefs}
+              setAtLevel={PREFERENCES_LEVEL.SYSTEM}
             />
           :
             null

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -551,6 +551,5 @@ SetPreferenceModal.propTypes = {
 };
 
 SetPreferenceModal.defaultProps = {
-  setAtLevel: PREFERENCES_LEVEL.SYSTEM,
   onSuccess: () => {}
 };


### PR DESCRIPTION
In a previous commit we changed the default preference level in `SetPreferenceModal` to be system level(https://github.com/caskdata/cdap/commit/51bcca296b474b86cdef613a21cc2c47e46f8b6e#diff-6b9b9351ea577ae4998f03bf771d359cR557), causing any component calling `SetPreferenceModal` without a `setAtLevel` prop to default to system level props. 

This was causing a problem when we try to set program level props, but were showing the modal for system level props instead.