### PR TITLE
CDAP-13328 wait for scheduler to start in AppFabricTestBase

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -210,9 +210,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     Map<String, String> keyValueTableProperties = ImmutableMap.of("foo", "bar");
     Map<String, String> filesetProperties = ImmutableMap.of("anotherFoo", "anotherBar");
 
-    HttpResponse response = deploy(WorkflowAppWithLocalDatasets.class,
-                                   Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(WorkflowAppWithLocalDatasets.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     File waitFile = new File(tmpFolder.newFolder() + "/wait.file");
     File doneFile = new File(tmpFolder.newFolder() + "/done.file");
@@ -295,8 +293,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     File lastSimpleActionFile = new File(tmpFolder.newFolder() + "/lastsimpleaction.file");
     File lastSimpleActionDoneFile = new File(tmpFolder.newFolder() + "/lastsimpleaction.file.done");
 
-    HttpResponse response = deploy(PauseResumeWorklowApp.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(PauseResumeWorklowApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     Id.Program programId = Id.Program.from(TEST_NAMESPACE2, pauseResumeWorkflowApp, ProgramType.WORKFLOW,
                                            pauseResumeWorkflow);
@@ -411,8 +408,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
   @Category(XSlowTests.class)
   @Test
   public void testKillSuspendedWorkflow() throws Exception {
-    HttpResponse response = deploy(SleepingWorkflowApp.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(SleepingWorkflowApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     WorkflowId workflow = new WorkflowId(TEST_NAMESPACE2, "SleepWorkflowApp", "SleepWorkflow");
 
@@ -445,9 +441,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
 
     // create app in default namespace so that v2 and v3 api can be tested in the same test
     String defaultNamespace = Id.Namespace.DEFAULT.getId();
-    HttpResponse response = deploy(ConcurrentWorkflowApp.class, Constants.Gateway.API_VERSION_3_TOKEN,
-                                   defaultNamespace);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(ConcurrentWorkflowApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, defaultNamespace);
 
     Id.Program programId = Id.Program.from(Id.Namespace.DEFAULT, appWithConcurrentWorkflow, ProgramType.WORKFLOW,
                                            ConcurrentWorkflowApp.ConcurrentWorkflow.class.getSimpleName());
@@ -528,8 +522,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     runtimeArgs.put("branch2.file", branch2File.getAbsolutePath());
     runtimeArgs.put("branch2.donefile", branch2DoneFile.getAbsolutePath());
 
-    HttpResponse response = deploy(WorkflowAppWithFork.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(WorkflowAppWithFork.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     Id.Program programId = Id.Program.from(
       TEST_NAMESPACE2, WorkflowAppWithFork.class.getSimpleName(), ProgramType.WORKFLOW,
@@ -660,10 +653,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
   @Test
   public void testWorkflowScopedArguments() throws Exception {
     String workflowRunIdProperty = "workflowrunid";
-    HttpResponse response = deploy(WorkflowAppWithScopedParameters.class, Constants.Gateway.API_VERSION_3_TOKEN,
-                                   TEST_NAMESPACE2);
-
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(WorkflowAppWithScopedParameters.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     ProgramId programId = Ids.namespace(TEST_NAMESPACE2).app(WorkflowAppWithScopedParameters.APP_NAME)
       .workflow(WorkflowAppWithScopedParameters.ONE_WORKFLOW);
@@ -818,8 +808,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     String sampleSchedule = AppWithSchedule.SCHEDULE;
 
     // deploy app with schedule in namespace 2
-    HttpResponse response = deploy(AppWithSchedule.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(AppWithSchedule.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     Id.Program programId = Id.Program.from(TEST_NAMESPACE2, appName, ProgramType.WORKFLOW, workflowName);
 
@@ -930,9 +919,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     String appName = "WorkflowAppWithErrorRuns";
     String workflowName = "WorkflowWithErrorRuns";
 
-    HttpResponse response = deploy(WorkflowAppWithErrorRuns.class, Constants.Gateway.API_VERSION_3_TOKEN,
-                                   TEST_NAMESPACE2);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(WorkflowAppWithErrorRuns.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     Id.Program programId = Id.Program.from(TEST_NAMESPACE2, appName, ProgramType.WORKFLOW, workflowName);
 
@@ -1022,10 +1009,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     String conditionalWorkflowApp = "ConditionalWorkflowApp";
     String conditionalWorkflow = "ConditionalWorkflow";
 
-    HttpResponse response = deploy(ConditionalWorkflowApp.class, Constants.Gateway.API_VERSION_3_TOKEN,
-                                   TEST_NAMESPACE2);
-
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(ConditionalWorkflowApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     Id.Program programId = Id.Program.from(TEST_NAMESPACE2, conditionalWorkflowApp, ProgramType.WORKFLOW,
                                            conditionalWorkflow);
@@ -1149,7 +1133,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
   @Test
   @SuppressWarnings("ConstantConditions")
   public void testWorkflowToken() throws Exception {
-    Assert.assertEquals(200, deploy(AppWithWorkflow.class).getStatusLine().getStatusCode());
+    deploy(AppWithWorkflow.class, 200);
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, AppWithWorkflow.NAME);
     final Id.Workflow workflowId = Id.Workflow.from(appId, AppWithWorkflow.SampleWorkflow.NAME);
     String outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
@@ -1257,7 +1241,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testWorkflowTokenPut() throws Exception {
-    Assert.assertEquals(200, deploy(WorkflowTokenTestPutApp.class).getStatusLine().getStatusCode());
+    deploy(WorkflowTokenTestPutApp.class, 200);
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, WorkflowTokenTestPutApp.NAME);
     Id.Workflow workflowId = Id.Workflow.from(appId, WorkflowTokenTestPutApp.WorkflowTokenTestPut.NAME);
     Id.Program sparkId = Id.Program.from(appId, ProgramType.SPARK, WorkflowTokenTestPutApp.SparkTestApp.NAME);
@@ -1302,7 +1286,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     // 'FirstMapReduce' and 'SecondMapReduce' in parallel. Workflow is started with runtime argument
     // "mapreduce.SecondMapReduce.throw.exception", so that the MapReduce program 'SecondMapReduce'
     // fails. This causes the 'FirstMapReduce' program to get killed and Workflow is marked as failed.
-    Assert.assertEquals(200, deploy(WorkflowFailureInForkApp.class).getStatusLine().getStatusCode());
+    deploy(WorkflowFailureInForkApp.class, 200);
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, WorkflowFailureInForkApp.NAME);
     Id.Workflow workflowId = Id.Workflow.from(appId, WorkflowFailureInForkApp.WorkflowWithFailureInFork.NAME);
     Id.Program firstMRId = Id.Program.from(appId, ProgramType.MAPREDUCE,

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowStatsSLAHttpHandlerTest.java
@@ -90,7 +90,7 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testStatistics() throws Exception {
-    deploy(WorkflowApp.class);
+    deploy(WorkflowApp.class, 200);
     String workflowName = "FunWorkflow";
     String mapreduceName = "ClassicWordCount";
     String sparkName = "SparkWorkflowTest";
@@ -204,7 +204,7 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testDetails() throws Exception {
-    deploy(WorkflowApp.class);
+    deploy(WorkflowApp.class, 200);
     String workflowName = "FunWorkflow";
     String mapreduceName = "ClassicWordCount";
     String sparkName = "SparkWorkflowTest";
@@ -258,7 +258,7 @@ public class WorkflowStatsSLAHttpHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testCompare() throws Exception {
-    deploy(WorkflowApp.class);
+    deploy(WorkflowApp.class, 200);
     String workflowName = "FunWorkflow";
     String mapreduceName = "ClassicWordCount";
     String sparkName = "SparkWorkflowTest";

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WordCountApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WordCountApp.java
@@ -57,15 +57,17 @@ import javax.ws.rs.PathParam;
  * many places.
  */
 public class WordCountApp extends AbstractApplication {
-
+  public static final String NAME = "WordCountApp";
+  public static final String DATASET_NAME = "mydataset";
+  public static final String STREAM_NAME = "text";
   private static final Logger LOG = LoggerFactory.getLogger(WordCountApp.class);
 
   @Override
   public void configure() {
-    setName("WordCountApp");
+    setName(NAME);
     setDescription("Application for counting words");
-    addStream(new Stream("text"));
-    createDataset("mydataset", KeyValueTable.class);
+    addStream(new Stream(STREAM_NAME));
+    createDataset(DATASET_NAME, KeyValueTable.class);
     addFlow(new WordCountFlow());
     addService(new WordFrequencyService());
     addMapReduce(new VoidMapReduceJob());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
@@ -48,7 +48,6 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.collect.ImmutableMap;
-import org.apache.http.HttpResponse;
 import org.apache.twill.api.RunId;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -234,9 +233,7 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
   @Test
   public void testLocalDatasetDeleteion() throws Exception {
     // Create App with Flow and the deploy
-    HttpResponse response = deploy(WorkflowAppWithLocalDataset.class,
-                                   Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(WorkflowAppWithLocalDataset.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
 
     final ProgramId workflow = new NamespaceId(TEST_NAMESPACE1)
       .app(WorkflowAppWithLocalDataset.APP_NAME)

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -191,7 +191,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     response = createNamespace(METADATA_VALID, Id.Namespace.SYSTEM.getId());
     assertResponseCode(400, response);
     // we allow deleting the contents in default namespace. However, the namespace itself should never be deleted
-    deploy(AppWithDataset.class);
+    deploy(AppWithDataset.class, 200);
     response = deleteNamespace(Id.Namespace.DEFAULT.getId());
     assertResponseCode(200, response);
     response = getNamespace(Id.Namespace.DEFAULT.getId());
@@ -271,10 +271,10 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     DatasetFramework dsFramework = getInjector().getInstance(DatasetFramework.class);
     StreamAdmin streamAdmin = getInjector().getInstance(StreamAdmin.class);
 
-    deploy(AppWithServices.class, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
-    deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
-    deploy(AppWithStream.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
-    deploy(AppForUnrecoverableResetTest.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
+    deploy(AppWithServices.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
+    deploy(AppWithDataset.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
+    deploy(AppWithStream.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
+    deploy(AppForUnrecoverableResetTest.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
 
     DatasetId myDataset = new DatasetId(NAME, "myds");
     StreamId myStream = new StreamId(OTHER_NAME, "stream");
@@ -305,9 +305,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     // Create the namespace again and deploy the application containing schedules.
     // Application deployment should succeed.
     assertResponseCode(200, createNamespace(OTHER_NAME));
-    HttpResponse response = deploy(AppForUnrecoverableResetTest.class, Constants.Gateway.API_VERSION_3_TOKEN,
-                                   OTHER_NAME);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(AppForUnrecoverableResetTest.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
     assertResponseCode(200, deleteNamespace(OTHER_NAME));
   }
 
@@ -324,8 +322,8 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
 
     DatasetFramework dsFramework = getInjector().getInstance(DatasetFramework.class);
 
-    deploy(AppWithServices.class, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
-    deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
+    deploy(AppWithServices.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
+    deploy(AppWithDataset.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
 
     DatasetId myDataset = new DatasetId(NAME, "myds");
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/RouteConfigHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/RouteConfigHttpHandlerTest.java
@@ -55,9 +55,7 @@ public class RouteConfigHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(200, deploy(appIdV1, request).getStatusLine().getStatusCode());
     Assert.assertEquals(200, deploy(appIdV2, request).getStatusLine().getStatusCode());
 
-
-    HttpResponse response = deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    deploy(WordCountApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
 
     Map<String, Integer> routes = ImmutableMap.<String, Integer>builder().put("v1", 30).put("v2", 70).build();
     String routeAPI = getVersionedAPIPath(
@@ -78,7 +76,7 @@ public class RouteConfigHttpHandlerTest extends AppFabricTestBase {
 
     // Invalid Routes should return 400
     routes = ImmutableMap.<String, Integer>builder().put("v1", 50).build();
-    response = doPut(routeAPI, GSON.toJson(routes));
+    HttpResponse response = doPut(routeAPI, GSON.toJson(routes));
     Assert.assertEquals(400, response.getStatusLine().getStatusCode());
 
     // Valid Routes but non-existing services should return 400

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/scheduler/CoreSchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/scheduler/CoreSchedulerServiceTest.java
@@ -365,7 +365,7 @@ public class CoreSchedulerServiceTest extends AppFabricTestBase {
   @Category(XSlowTests.class)
   public void testProgramEvents() throws Exception {
     // Deploy the app
-    deploy(AppWithMultipleSchedules.class);
+    deploy(AppWithMultipleSchedules.class, 200);
 
     CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
     TopicId programEventTopic =


### PR DESCRIPTION
Also forcing tests that extend the class to pass in the expected
response code when deploying an application. There were a bunch
of test cases that try to deploy an app, then assume it was
successfully deployed. If it actually failed, some other assertion
in the test would fail, making it difficult to diagnose what
actually happened. Now, if the response code does not match, the
assertion failure message will include the response message from
the deploy call, making it very clear why the test failed.