### PR TITLE
CDAP-13330 set app name in google compute client

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcConf.java
@@ -135,7 +135,9 @@ public class DataProcConf {
     try (InputStream is = new ByteArrayInputStream(accountKey.getBytes(StandardCharsets.UTF_8))) {
       GoogleCredential credential = GoogleCredential.fromStream(is)
         .createScoped(Collections.singleton("https://www.googleapis.com/auth/cloud-platform"));
-      return new Compute.Builder(httpTransport, JacksonFactory.getDefaultInstance(), credential).build();
+      return new Compute.Builder(httpTransport, JacksonFactory.getDefaultInstance(), credential)
+        .setApplicationName("cdap")
+        .build();
     }
   }
 


### PR DESCRIPTION
This is to get rid of a warning written to stderr