### PR TITLE
Add implementation of the FieldLineageDataset and publish the lineage graph to TMS.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramContainerModule.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditModule;
+import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.MessagingLineageWriter;
 import co.cask.cdap.data2.registry.MessagingUsageWriter;
@@ -121,6 +122,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
       protected void configure() {
         // Overrides the LineageWriter, UsageWriter to write to TMS instead
         bind(LineageWriter.class).to(MessagingLineageWriter.class);
+        bind(FieldLineageWriter.class).to(MessagingLineageWriter.class);
         bind(UsageWriter.class).to(MessagingUsageWriter.class);
       }
     }));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataSubscriberServiceTest.java
@@ -16,6 +16,12 @@
 
 package co.cask.cdap.metadata;
 
+import co.cask.cdap.api.lineage.field.EndPoint;
+import co.cask.cdap.api.lineage.field.InputField;
+import co.cask.cdap.api.lineage.field.Operation;
+import co.cask.cdap.api.lineage.field.ReadOperation;
+import co.cask.cdap.api.lineage.field.TransformOperation;
+import co.cask.cdap.api.lineage.field.WriteOperation;
 import co.cask.cdap.api.workflow.NodeStatus;
 import co.cask.cdap.api.workflow.Value;
 import co.cask.cdap.api.workflow.WorkflowToken;
@@ -26,6 +32,10 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.lineage.DefaultLineageStoreReader;
 import co.cask.cdap.data2.metadata.lineage.LineageStoreReader;
+import co.cask.cdap.data2.metadata.lineage.field.DefaultFieldLineageReader;
+import co.cask.cdap.data2.metadata.lineage.field.FieldLineageInfo;
+import co.cask.cdap.data2.metadata.lineage.field.FieldLineageReader;
+import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.MessagingLineageWriter;
 import co.cask.cdap.data2.registry.BasicUsageRegistry;
@@ -51,9 +61,11 @@ import co.cask.cdap.proto.id.WorkflowId;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -79,6 +91,7 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
   @Test
   public void testSubscriber() throws InterruptedException, ExecutionException, TimeoutException {
     DatasetId lineageDatasetId = NamespaceId.DEFAULT.dataset("testSubscriberLineage");
+    DatasetId fieldLineageDatasetId = NamespaceId.DEFAULT.dataset("testSubscriberFieldLineage");
     DatasetId usageDatasetId = NamespaceId.DEFAULT.dataset("testSubscriberUsage");
 
     // Write out some lineage information
@@ -94,6 +107,44 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
     Set<NamespacedEntityId> entities = lineageReader.getEntitiesForRun(run1);
     Assert.assertTrue(entities.isEmpty());
 
+    // Write the field level lineage
+    FieldLineageWriter fieldLineageWriter = getInjector().getInstance(MessagingLineageWriter.class);
+    ProgramRunId spark1Run1 = spark1.run(RunIds.generate());
+    ReadOperation read = new ReadOperation("read", "some read", EndPoint.of("ns", "endpoint1"), "offset", "body");
+    TransformOperation parse = new TransformOperation("parse", "parse body",
+                                                      Arrays.asList(InputField.of("read", "body")), "name", "address");
+    WriteOperation write = new WriteOperation("write", "write data", EndPoint.of("ns", "endpoint2"),
+                                              Arrays.asList(InputField.of("read", "offset"),
+                                                            InputField.of("parse", "name"),
+                                                            InputField.of("parse", "body")));
+
+    List<Operation> operations = new ArrayList<>();
+    operations.add(read);
+    operations.add(write);
+    operations.add(parse);
+    FieldLineageInfo info1 = new FieldLineageInfo(operations);
+    fieldLineageWriter.write(spark1Run1, info1);
+
+    ProgramRunId spark1Run2 = spark1.run(RunIds.generate());
+    fieldLineageWriter.write(spark1Run2, info1);
+
+    operations.clear();
+    read = new ReadOperation("read", "some read", EndPoint.of("ns", "endpoint1"), "offset", "body");
+    operations.add(read);
+    parse = new TransformOperation("parse", "parse body",
+                                                      Arrays.asList(InputField.of("read", "body")), "name", "address");
+    operations.add(parse);
+    TransformOperation normalize = new TransformOperation("normalize", "normalize address",
+                                                          Arrays.asList(InputField.of("parse", "address")), "address");
+    operations.add(normalize);
+    write = new WriteOperation("write", "write data", EndPoint.of("ns", "endpoint2"),
+                                              Arrays.asList(InputField.of("read", "offset"),
+                                                            InputField.of("parse", "name"),
+                                                            InputField.of("parse", "body")));
+    operations.add(write);
+    FieldLineageInfo info2 = new FieldLineageInfo(operations);
+    fieldLineageWriter.write(spark1Run2, info2);
+
     // Emit some usages
     UsageWriter usageWriter = getInjector().getInstance(MessagingUsageWriter.class);
     usageWriter.register(spark1, dataset1);
@@ -107,6 +158,7 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
     MetadataSubscriberService subscriberService = getInjector().getInstance(MetadataSubscriberService.class);
     subscriberService
       .setLineageDatasetId(lineageDatasetId)
+      .setFieldLineageDatasetId(fieldLineageDatasetId)
       .setUsageDatasetId(usageDatasetId)
       .startAndWait();
 
@@ -124,6 +176,12 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
 
       // There shouldn't be any lineage for the "spark1" program, as only usage has been emitted.
       Assert.assertTrue(lineageReader.getRelations(spark1, 0L, Long.MAX_VALUE, x -> true).isEmpty());
+
+      FieldLineageReader fieldLineageReader = new DefaultFieldLineageReader(getDatasetFramework(), getTxClient(),
+                                                                            fieldLineageDatasetId);
+      Tasks.waitFor(2, () -> fieldLineageReader.getFieldLineageInfos(EndPoint.of("ns", "endpoint2"), 0L,
+                                                                     Long.MAX_VALUE).size(),
+                    10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
       // Verifies usage has been written
       Set<EntityId> expectedUsage = new HashSet<>(Arrays.asList(dataset1, dataset3));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -29,6 +29,7 @@ import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
+import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework;
 import co.cask.cdap.data2.registry.BasicUsageRegistry;
@@ -71,6 +72,9 @@ public class DataSetsModules extends RuntimeModule {
 
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
+
+        bind(FieldLineageWriter.class).to(BasicLineageWriter.class);
+        expose(FieldLineageWriter.class);
 
         bind(UsageRegistry.class).to(BasicUsageRegistry.class).in(Scopes.SINGLETON);
         expose(UsageRegistry.class);
@@ -119,6 +123,9 @@ public class DataSetsModules extends RuntimeModule {
 
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
+
+        bind(FieldLineageWriter.class).to(BasicLineageWriter.class);
+        expose(FieldLineageWriter.class);
 
         bind(UsageRegistry.class).to(BasicUsageRegistry.class).in(Scopes.SINGLETON);
         expose(UsageRegistry.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
@@ -36,6 +36,7 @@ import co.cask.cdap.data2.dataset2.module.lib.leveldb.LevelDBMetricsTableModule;
 import co.cask.cdap.data2.dataset2.module.lib.leveldb.LevelDBTableModule;
 import co.cask.cdap.data2.metadata.dataset.MetadataDatasetModule;
 import co.cask.cdap.data2.metadata.lineage.LineageDatasetModule;
+import co.cask.cdap.data2.metadata.lineage.field.FieldLineageDatasetModule;
 import co.cask.cdap.data2.registry.UsageDatasetModule;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueDatasetModule;
 import com.google.inject.AbstractModule;
@@ -139,6 +140,7 @@ public class SystemDatasetRuntimeModule extends RuntimeModule {
     mapBinder.addBinding("usage").toInstance(new UsageDatasetModule());
     mapBinder.addBinding("metadata").toInstance(new MetadataDatasetModule());
     mapBinder.addBinding("lineage").toInstance(new LineageDatasetModule());
+    mapBinder.addBinding("fieldLineage").toInstance(new FieldLineageDatasetModule());
     mapBinder.addBinding("externalDataset").toInstance(new ExternalDatasetModule());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/preview/PreviewDataModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/preview/PreviewDataModules.java
@@ -27,7 +27,9 @@ import co.cask.cdap.data2.metadata.lineage.LineageStoreReader;
 import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
+import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
+import co.cask.cdap.data2.metadata.writer.NoOpLineageWriter;
 import co.cask.cdap.data2.registry.NoOpUsageRegistry;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.data2.registry.UsageWriter;
@@ -92,8 +94,11 @@ public class PreviewDataModules {
         // Need to expose LineageStoreReader as it's being used by the LineageHandler (through LineageAdmin)
         expose(LineageStoreReader.class);
 
-        bind(LineageWriter.class).to(BasicLineageWriter.class);
+        bind(LineageWriter.class).to(NoOpLineageWriter.class);
         expose(LineageWriter.class);
+
+        bind(FieldLineageWriter.class).to(NoOpLineageWriter.class);
+        expose(FieldLineageWriter.class);
 
         bind(UsageWriter.class).to(NoOpUsageRegistry.class).in(Scopes.SINGLETON);
         expose(UsageWriter.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/DefaultFieldLineageReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/DefaultFieldLineageReader.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.cdap.data2.metadata.lineage.field;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
+import co.cask.cdap.api.lineage.field.EndPoint;
+import co.cask.cdap.api.lineage.field.Operation;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import org.apache.tephra.TransactionSystemClient;
+
+import java.util.Set;
+
+/**
+ * Implementation of {@link FieldLineageReader} for reading the field lineage information
+ * from {@link FieldLineageDataset}.
+ */
+public class DefaultFieldLineageReader implements FieldLineageReader {
+  private final DatasetFramework datasetFramework;
+  private final Transactional transactional;
+  private final DatasetId fieldLineageDatasetId;
+
+  @Inject
+  DefaultFieldLineageReader(DatasetFramework datasetFramework, TransactionSystemClient txClient) {
+    this(datasetFramework, txClient, FieldLineageDataset.FIELDLINEAGE_DATASET_ID);
+  }
+
+  @VisibleForTesting
+  public DefaultFieldLineageReader(DatasetFramework datasetFramework, TransactionSystemClient txClient,
+                                   DatasetId fieldLineageDatasetId) {
+    this.datasetFramework = datasetFramework;
+    this.fieldLineageDatasetId = fieldLineageDatasetId;
+    this.transactional = Transactions.createTransactional(new MultiThreadDatasetCache(
+      new SystemDatasetInstantiator(datasetFramework), new TransactionSystemClientAdapter(txClient),
+      NamespaceId.SYSTEM, ImmutableMap.of(), null, null));
+  }
+
+  @Override
+  public Set<FieldLineageInfo> getFieldLineageInfos(EndPoint endPoint, long start, long end) {
+    return Transactionals.execute(transactional, context -> {
+      FieldLineageDataset fieldLineageDataset = FieldLineageDataset.getFieldLineageDataset(context, datasetFramework,
+                                                                                           fieldLineageDatasetId);
+      return fieldLineageDataset.getFieldLineageInfosInRange(endPoint, start, end);
+    });
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDataset.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.lineage.field;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.lineage.field.EndPoint;
+import co.cask.cdap.api.lineage.field.Operation;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.proto.codec.OperationTypeAdapter;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Dataset to store/retrieve field level lineage information.
+ */
+public class FieldLineageDataset extends AbstractDataset {
+
+  // Storage format
+  // --------------
+  //
+  // Checksum associated with the field lineage info:
+  //                               -------------------------------------------------------
+  //                               |            r          |          p                  |
+  // -------------------------------------------------------------------------------------
+  // | checksum | <checksum-value> | FieldLineageInfo obj  | <Presentation layer format> |
+  // -------------------------------------------------------------------------------------
+  //
+  // Run level row:
+  //                                                                           --------------------
+  //                                                                           |         c        |
+  // ----------------------------------------------------------------------------------------------
+  // | f | <endpoint_ns>  | <endpoint_name> | <inverted-start-time> | <id.run> | <checksum-value> |
+  // ----------------------------------------------------------------------------------------------
+  // | b | <endpoint_ns>  | <endpoint_name> | <inverted-start-time> | <id.run> | <checksum-value> |
+  // ----------------------------------------------------------------------------------------------
+
+  public static final DatasetId FIELDLINEAGE_DATASET_ID = NamespaceId.SYSTEM.dataset("fieldLineage");
+
+  private static final Logger LOG = LoggerFactory.getLogger(FieldLineageDataset.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Operation.class, new OperationTypeAdapter())
+    .create();
+
+  private static final byte[] RAW_FORMAT_COLS_BYTE = {'r'};
+  private static final byte[] PRESENTATION_FORMAT_COLS_BYTE = {'p'};
+  private static final byte[] CHECKSUM_COLS_BYTE = {'c'};
+
+  private static final char FORWARD_LINEAGE_MARKER = 'f';
+  private static final char BACKWARD_LINEAGE_MARKER = 'b';
+
+
+  private final Table table;
+
+  public FieldLineageDataset(String instanceName, Table table) {
+    super(instanceName, table);
+    this.table = table;
+  }
+
+  /**
+   * Gets an instance of {@link FieldLineageDataset}. The dataset instance will be created if it is not yet exist.
+   *
+   * @param datasetContext the {@link DatasetContext} for getting the dataset instance.
+   * @param datasetFramework the {@link DatasetFramework} for creating the dataset instance if missing
+   * @param datasetId the {@link DatasetId} of the {@link FieldLineageDataset}
+   * @return an instance of {@link FieldLineageDataset}
+   */
+  @VisibleForTesting
+  public static FieldLineageDataset getFieldLineageDataset(DatasetContext datasetContext,
+                                                           DatasetFramework datasetFramework, DatasetId datasetId) {
+    try {
+      return DatasetsUtil.getOrCreateDataset(datasetContext, datasetFramework, datasetId,
+                                             FieldLineageDataset.class.getName(), DatasetProperties.EMPTY);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Store the field lineage information.
+   *
+   * @param info the field lineage information
+   */
+  public void addFieldLineageInfo(FieldLineageInfo info) {
+    byte[] rowKey = getChecksumRowKey(info.getChecksum());
+    table.put(rowKey, RAW_FORMAT_COLS_BYTE, Bytes.toBytes(GSON.toJson(info)));
+  }
+
+  /**
+   * @return {@code true} if {@link FieldLineageInfo} exists in the store
+   * corresponding to the given checksum, otherwise false is returned
+   */
+  public boolean hasFieldLineageInfo(long checksum) {
+    return getFieldLineageInfo(checksum) != null;
+  }
+
+  /**
+   * Add records referring to the common operation record having the given checksum.
+   * Operations represent transformations from source endpoints to the destination endpoints.
+   * From source perspective the operations are added as forward lineage, while from
+   * destination perspective they are added as backward lineage.
+   *
+   * @param programRunId program run for which lineage is to be added
+   * @param info the FieldLineageInfo created by program run
+   */
+  public void addFieldLineageInfoReferenceRecords(ProgramRunId programRunId, FieldLineageInfo info) {
+    // For all the sources, operations represents the Forward lineage
+    for (EndPoint source : info.getSources()) {
+      addOperationReferenceRecord(programRunId, source, info.getChecksum(), FORWARD_LINEAGE_MARKER);
+    }
+
+    // For all the destinations, operations represents backward lineage
+    for (EndPoint destination : info.getDestinations()) {
+      addOperationReferenceRecord(programRunId, destination, info.getChecksum(), BACKWARD_LINEAGE_MARKER);
+    }
+  }
+
+  /**
+   * Get the field lineage information for a given endpoint within the given time range.
+   * TODO: Read methods are mainly for the testing purpose till representation from UI is finalized.
+   *
+   * @param endPoint the endpoint for which lineage information to be retrieved
+   * @param start start time in seconds
+   * @param end end time in seconds
+   * @return {@link Set} of {@link FieldLineageInfo} instances
+   */
+  public Set<FieldLineageInfo> getFieldLineageInfosInRange(EndPoint endPoint, long start, long end) {
+    Set<Long> checksums = getChecksumsInRange(getScanStartKey(endPoint, end, BACKWARD_LINEAGE_MARKER),
+                                              getScanEndKey(endPoint, start, BACKWARD_LINEAGE_MARKER));
+
+    Set<FieldLineageInfo> infos = new HashSet<>();
+    for (long checksum : checksums) {
+      infos.add(getFieldLineageInfo(checksum));
+    }
+    return infos;
+  }
+
+  private FieldLineageInfo getFieldLineageInfo(long checksum) {
+    byte[] rowKey = getChecksumRowKey(checksum);
+    byte[] bytes = table.get(rowKey, RAW_FORMAT_COLS_BYTE);
+    return GSON.fromJson(Bytes.toString(bytes), FieldLineageInfo.class);
+  }
+
+  private byte[] getScanStartKey(EndPoint endPoint, long end, char lineageDirectionMarker) {
+    // time is inverted, hence we need to have end time in start key.
+    return getScanKey(endPoint, end, lineageDirectionMarker);
+  }
+
+  private byte[] getScanEndKey(EndPoint endPoint, long start, char lineageDirectionMarker) {
+    // time is inverted, hence we need to have start time in end key.
+    return getScanKey(endPoint, start, lineageDirectionMarker);
+  }
+
+  private Set<Long> getChecksumsInRange(byte[] startKey, byte[] endKey) {
+    Set<Long> checksums = new HashSet<>();
+    try (Scanner scanner = table.scan(startKey, endKey)) {
+      Row row;
+      while ((row = scanner.next()) != null) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Got row key = {}", Bytes.toString(row.getRow()));
+        }
+
+        checksums.add(Bytes.toLong(row.get(CHECKSUM_COLS_BYTE)));
+      }
+    }
+    return checksums;
+  }
+
+  private byte[] getScanKey(EndPoint endPoint, long time, char lineageDirectionMarker) {
+    MDSKey.Builder builder = new MDSKey.Builder();
+    builder.add(lineageDirectionMarker);
+    addEndPoint(builder, endPoint);
+    builder.add(invertTime(time));
+    return builder.build().getKey();
+  }
+
+  private void addOperationReferenceRecord(ProgramRunId programRunId, EndPoint endPoint, long checksum,
+                                           char lineageDirectionMarker) {
+    byte[] bytes = getProgramRunKey(lineageDirectionMarker, programRunId, endPoint);
+    table.put(bytes, CHECKSUM_COLS_BYTE, Bytes.toBytes(checksum));
+  }
+
+  private byte[] getChecksumRowKey(long checksum) {
+    MDSKey.Builder builder = new MDSKey.Builder();
+    builder.add("c");
+    builder.add(checksum);
+    return builder.build().getKey();
+  }
+
+  private byte[] getProgramRunKey(char lineageDirectionMarker, ProgramRunId programRunId, EndPoint endPoint) {
+    long invertedStartTime = getInvertedStartTime(programRunId);
+    MDSKey.Builder builder = new MDSKey.Builder();
+    builder.add(lineageDirectionMarker);
+    addEndPoint(builder, endPoint);
+    builder.add(invertedStartTime);
+    addProgram(builder, programRunId.getParent());
+    builder.add(programRunId.getEntityName());
+    return builder.build().getKey();
+  }
+
+  private long invertTime(long time) {
+    return Long.MAX_VALUE - time;
+  }
+
+  private long getInvertedStartTime(ProgramRunId run) {
+    return invertTime(RunIds.getTime(RunIds.fromString(run.getEntityName()), TimeUnit.MILLISECONDS));
+  }
+
+  private void addEndPoint(MDSKey.Builder keyBuilder, EndPoint endPoint) {
+    keyBuilder.add(endPoint.getNamespace())
+      .add(endPoint.getName());
+  }
+
+  private void addProgram(MDSKey.Builder keyBuilder, ProgramId program) {
+    keyBuilder.add(program.getNamespace())
+      .add(program.getParent().getEntityName())
+      .add(program.getType().getCategoryName())
+      .add(program.getEntityName());
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDatasetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDatasetDefinition.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.lineage.field;
+
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.CompositeDatasetDefinition;
+import co.cask.cdap.api.dataset.table.Table;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * {@link DatasetDefinition} for {@link FieldLineageDataset}.
+ */
+public class FieldLineageDatasetDefinition extends CompositeDatasetDefinition<FieldLineageDataset> {
+  public FieldLineageDatasetDefinition(String name, DatasetDefinition<Table, ? extends DatasetAdmin> tableDefinition) {
+    super(name, "fieldLineage", tableDefinition);
+  }
+
+
+  @Override
+  public FieldLineageDataset getDataset(DatasetContext datasetContext, DatasetSpecification spec,
+                                        Map<String, String> arguments, ClassLoader classLoader) throws IOException {
+    Table table = getDataset(datasetContext, "fieldLineage", spec, arguments, classLoader);
+    return new FieldLineageDataset(spec.getName(), table);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDatasetModule.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.lineage.field;
+
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.dataset.table.Table;
+
+/**
+ * {@link DatasetModule} for the Field lineage dataset.
+ */
+public class FieldLineageDatasetModule implements DatasetModule {
+  @Override
+  public void register(DatasetDefinitionRegistry registry) {
+    DatasetDefinition<Table, ? extends DatasetAdmin> tableDef = registry.get(Table.class.getName());
+    registry.add(new FieldLineageDatasetDefinition(FieldLineageDataset.class.getName(), tableDef));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageReader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.lineage.field;
+
+import co.cask.cdap.api.lineage.field.EndPoint;
+import co.cask.cdap.api.lineage.field.Operation;
+
+import java.util.Set;
+
+/**
+ * Interface for reading the {@link FieldLineageDataset} store.
+ */
+public interface FieldLineageReader {
+
+  /**
+   * Get the set {@link FieldLineageInfo} recorded against the given {@link EndPoint} for
+   * a given time period.
+   *
+   * @param endPoint the {@link EndPoint} for which the lineage information to be returned
+   * @param start start time in seconds
+   * @param end end time seconds
+   * @return the {@link Set} of {@link FieldLineageInfo}s
+   */
+  Set<FieldLineageInfo> getFieldLineageInfos(EndPoint endPoint, long start, long end);
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/FieldLineageWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/FieldLineageWriter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.data2.metadata.lineage.field.FieldLineageInfo;
+import co.cask.cdap.proto.id.ProgramRunId;
+
+/**
+ * Defines an interface to write the lineage info for a program run.
+ */
+public interface FieldLineageWriter {
+
+  /**
+   * Write the lineage info associated with the given program run.
+   * @param programRunId run id of the program
+   * @param info a {@link FieldLineageInfo} associated with the program.
+   */
+  void write(ProgramRunId programRunId, FieldLineageInfo info);
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataMessage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataMessage.java
@@ -35,6 +35,7 @@ public final class MetadataMessage {
    */
   public enum Type {
     LINEAGE,
+    FIELD_LINEAGE,
     USAGE,
     WORKFLOW_TOKEN,
     WORKFLOW_STATE

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/NoOpLineageWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/NoOpLineageWriter.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.metadata.writer;
 
 import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.lineage.field.FieldLineageInfo;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.ProgramRunId;
@@ -27,7 +28,7 @@ import javax.annotation.Nullable;
 /**
  * No-op {@link LineageWriter}.
  */
-public class NoOpLineageWriter implements LineageWriter {
+public class NoOpLineageWriter implements LineageWriter, FieldLineageWriter {
   @Override
   public void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType) {
     // no-op
@@ -47,6 +48,11 @@ public class NoOpLineageWriter implements LineageWriter {
   @Override
   public void addAccess(ProgramRunId run, StreamId stream, AccessType accessType,
                         @Nullable NamespacedEntityId component) {
+    // no-op
+  }
+
+  @Override
+  public void write(ProgramRunId programRunId, FieldLineageInfo info) {
     // no-op
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -52,6 +52,7 @@ import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.metadata.lineage.LineageDataset;
 import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
+import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.NoOpLineageWriter;
 import co.cask.cdap.data2.registry.UsageDataset;
@@ -211,6 +212,7 @@ public class UpgradeTool {
                       .build(DatasetDefinitionRegistryFactory.class));
             // CDAP-5954 Upgrade tool does not need to record lineage and metadata changes for now.
             bind(LineageWriter.class).to(NoOpLineageWriter.class);
+            bind(FieldLineageWriter.class).to(NoOpLineageWriter.class);
           }
         }
       ),

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/OperationTypeAdapter.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/OperationTypeAdapter.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.lineage.field.codec;
+package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.lineage.field.Operation;
 import co.cask.cdap.api.lineage.field.OperationType;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13267

This PR is created on the top of #10048. So please review that before this one.
Following changes are implemented:
1. `FieldLineageDataset` implementation to store the collection of operations and retrieve it given the specific time range. Note that this will be updated once we have requirements about the data access from UI.
2. Ability to publish the LineageGraph to the TMS and subscriber which retrieves it and writes to the field lineage dataset.

Pending more unit test cases..
 