### PR TITLE
CDAP-13348 fix bugs around dataproc cluster name

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -43,6 +43,7 @@ public class DataProcProvisioner implements Provisioner {
     "gce-dataproc", "GCE DataProc Provisioner",
     "Runs programs on the GCE DataProc clusters.",
     new HashMap<>());
+  private static final String CLUSTER_PREFIX = "cdap-";
 
   @Override
   public ProvisionerSpecification getSpec() {
@@ -123,11 +124,11 @@ public class DataProcProvisioner implements Provisioner {
   @VisibleForTesting
   static String getClusterName(ProgramRun programRun) {
     String cleanedAppName = programRun.getApplication().replaceAll("[^A-Za-z0-9\\-]", "").toLowerCase();
-    // 51 is max length, 5 is from 'cdap-' prefix, 1 is for '-' separating app name and run id
-    int maxAppLength = 51 - 5 - 1 - programRun.getRun().length();
+    // 51 is max length, need to subtract the prefix and 1 extra for the '-' separating app name and run id
+    int maxAppLength = 51 - CLUSTER_PREFIX.length() - 1 - programRun.getRun().length();
     if (cleanedAppName.length() > maxAppLength) {
       cleanedAppName = cleanedAppName.substring(0, maxAppLength);
     }
-    return "cdap-" + cleanedAppName + "-" + programRun.getRun();
+    return CLUSTER_PREFIX + cleanedAppName + "-" + programRun.getRun();
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -117,16 +117,17 @@ public class DataProcProvisioner implements Provisioner {
     return ip;
   }
 
-  // Name must start with a lowercase letter followed by up to 54 lowercase letters,
+  // Name must start with a lowercase letter followed by up to 51 lowercase letters,
   // numbers, or hyphens, and cannot end with a hyphen
   // We'll use app-runid, where app is truncated to fit, lowercased, and stripped of invalid characters
   @VisibleForTesting
   static String getClusterName(ProgramRun programRun) {
     String cleanedAppName = programRun.getApplication().replaceAll("[^A-Za-z0-9\\-]", "").toLowerCase();
-    int maxAppLength = 53 - programRun.getRun().length();
+    // 51 is max length, 5 is from 'cdap-' prefix, 1 is for '-' separating app name and run id
+    int maxAppLength = 51 - 5 - 1 - programRun.getRun().length();
     if (cleanedAppName.length() > maxAppLength) {
       cleanedAppName = cleanedAppName.substring(0, maxAppLength);
     }
-    return cleanedAppName + "-" + programRun.getRun();
+    return "cdap-" + cleanedAppName + "-" + programRun.getRun();
   }
 }

--- a/cdap-runtime-ext-dataproc/src/test/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisionerTest.java
@@ -31,16 +31,10 @@ public class DataProcProvisionerTest {
   public void testClusterName() {
     // test basic
     ProgramRun programRun = new ProgramRun("ns", "app", "program", UUID.randomUUID().toString());
-    Assert.assertEquals("app-" + programRun.getRun(), DataProcProvisioner.getClusterName(programRun));
+    Assert.assertEquals("cdap-app-" + programRun.getRun(), DataProcProvisioner.getClusterName(programRun));
 
-    // test lowercasing and stripping of invalid characters
+    // test lowercasing, stripping of invalid characters, and truncation
     programRun = new ProgramRun("ns", "My@Appl!cation", "program", UUID.randomUUID().toString());
-    Assert.assertEquals("myapplcation-" + programRun.getRun(), DataProcProvisioner.getClusterName(programRun));
-
-    // test truncating long
-    String longName = "abcdefghijklmnopqrstuvwxyz01234567890";
-    programRun = new ProgramRun("ns", longName, "program", UUID.randomUUID().toString());
-    Assert.assertEquals("abcdefghijklmnopq-" + programRun.getRun(),
-                        DataProcProvisioner.getClusterName(programRun));
+    Assert.assertEquals("cdap-myapplcat-" + programRun.getRun(), DataProcProvisioner.getClusterName(programRun));
   }
 }


### PR DESCRIPTION
Fixing bugs with cluster name where it could generate invalid
names. Ensuring the name is at most 51 characters instead of 54,
and adding a 'cdap-' prefix to ensure that the cluster name always
starts with a lowercase letter, and to help distinguish cdap
clusters from other clusters.