### PR TITLE
[CDAP-13392] Fixes overflow key-value pairs in profiles detailed view.

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/resources/gce-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gce-dataproc.json
@@ -14,10 +14,11 @@
           }
         },
         {
-          "widget-type": "json-editor",
+          "widget-type": "textarea",
           "label": "Service Account Key",
           "name": "accountKey",
           "required": true,
+          "description": "A service account is a special type of Google account that belongs to your application or a virtual machine (VM), instead of to an individual end user. Paste the contents of the service account key JSON file that you can download from the service accounts section under IAM and admin on the Cloud Console.",
           "widget-attributes": {
             "placeholder": "Specify the GCP service account to use to run pipelines using this profile"
           }

--- a/cdap-ui/app/cdap/components/AbstractWidget/AbstractWidgetFactory.js
+++ b/cdap-ui/app/cdap/components/AbstractWidget/AbstractWidgetFactory.js
@@ -14,15 +14,12 @@
  * the License.
 */
 
-import React from 'react';
-import {Input} from 'reactstrap';
 import SelectWidget from 'components/AbstractWidget/SelectWidget';
 import NumberTextbox from 'components/AbstractWidget/NumberTextbox';
 import MemoryTextbox from 'components/AbstractWidget/MemoryTextbox';
 import MemorySelectWidget from 'components/AbstractWidget/MemorySelectWidget';
 import DefaultInput from 'components/AbstractWidget/DefaultInput';
-
-const TextArea = ({...props}) => <Input type="textarea" {...props} />;
+import TextArea from 'components/AbstractWidget/TextArea';
 
 const WIDGET_FACTORY = {
   text: DefaultInput,

--- a/cdap-ui/app/cdap/components/AbstractWidget/TextArea/TextAreaWidget.scss
+++ b/cdap-ui/app/cdap/components/AbstractWidget/TextArea/TextAreaWidget.scss
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+.text-area-widget {
+  min-height: 50px;
+  max-height: 120px;
+}

--- a/cdap-ui/app/cdap/components/AbstractWidget/TextArea/index.js
+++ b/cdap-ui/app/cdap/components/AbstractWidget/TextArea/index.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import {Input} from 'reactstrap';
+import {WIDGET_PROPTYPES, DEFAULT_WIDGET_PROPS} from 'components/AbstractWidget';
+require('./TextAreaWidget.scss');
+
+export default function TextArea({ onChange, value, widgetProps }) {
+  return (
+    <Input
+      type="textarea"
+      onChange={onChange}
+      value={value}
+      {...widgetProps}
+      className="text-area-widget"
+    />
+  );
+}
+
+TextArea.propTypes = WIDGET_PROPTYPES;
+TextArea.defaultProps = DEFAULT_WIDGET_PROPS;

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/DetailsInfo/DetailsInfo.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/DetailsInfo/DetailsInfo.scss
@@ -42,7 +42,7 @@ $details-row-border-color: $grey-05;
 
       .details-table {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(3, 33%);
         grid-auto-rows: 40px;
         grid-gap: 0px 20px;
 
@@ -56,6 +56,15 @@ $details-row-border-color: $grey-05;
           &:nth-child(2),
           &:nth-child(3) {
             border-top: 1px solid $details-row-border-color;
+          }
+          > .value-holder {
+            display: block;
+            width: 100%;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            height: 100%;
+            padding: 10px;
+            white-space: nowrap;
           }
         }
       }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/DetailsInfo/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/DetailsInfo/index.js
@@ -74,7 +74,12 @@ export default class ProfileDetailViewDetailsInfo extends Component {
               return (
                 <div className="details-row">
                   <strong>{`${property.name}:`}</strong>
-                  <span>{property.value}</span>
+                  <span
+                    className="value-holder"
+                    title={property.value}
+                  >
+                    {property.value}
+                  </span>
                 </div>
               );
             })


### PR DESCRIPTION
- Fixes the overflow values in profiles detail view
- Fixes `textarea` widget to be its own module to add `max-height` styling to it.
- Fixes `gce-dataproc.json` to use `textarea` for service api key for now instead of json-editor.

JIRA: https://issues.cask.co/browse/CDAP-13392