### PR TITLE
fix unauthorized metrics search call in pipeline

### DIFF
--- a/cdap-ui/app/cdap/api/metric.js
+++ b/cdap-ui/app/cdap/api/metric.js
@@ -21,5 +21,6 @@ let dataSrc = DataSourceConfigurer.getInstance();
 const basepath = '/metrics/query';
 
 export const MyMetricApi = {
-  query: apiCreator(dataSrc, 'POST', 'REQUEST', basepath )
+  query: apiCreator(dataSrc, 'POST', 'REQUEST', basepath),
+  search: apiCreator(dataSrc, 'POST', 'REQUEST', '/metrics/search')
 };

--- a/cdap-ui/app/cdap/services/PipelineMetricsStore/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/PipelineMetricsStore/ActionCreator.js
@@ -14,14 +14,10 @@
  * the License.
 */
 
-import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
-import MetricsQueryHelper from 'services/MetricsQueryHelper';
 import {MyMetricApi} from 'api/metric';
 import PipelineDetailStore from 'components/PipelineDetails/store';
 import PipelineMetricsStore, {PipelineMetricsActions} from 'services/PipelineMetricsStore';
 import {Observable} from 'rxjs/Observable';
-
-let dataSrc = DataSourceConfigurer.getInstance();
 
 const pollForMetrics = (params) => {
   return Observable.interval(2000).subscribe(() => {
@@ -30,13 +26,16 @@ const pollForMetrics = (params) => {
 };
 
 function getMetrics(params) {
-  let metricParams = MetricsQueryHelper.tagsToParams(params);
-  let metricSearchPath = '/metrics/search?target=metric&' + metricParams;
-  let metricsSearchReqObj = {
-    _cdapPath: metricSearchPath,
-    method: 'POST'
+  let tags = Object.keys(params).map((key) => {
+    return `${key}:${params[key]}`;
+  });
+
+  let searchMetricParams = {
+    target: 'metric',
+    tag: tags
   };
-  dataSrc.request(metricsSearchReqObj)
+
+  MyMetricApi.search(searchMetricParams)
     .subscribe(res => {
       let config = PipelineDetailStore.getState().config;
       let stagesArray, source, sinks, transforms;


### PR DESCRIPTION
The search metrics call is not using the normal UI API call, therefore there is no header property that contains the authentication token. 