### PR TITLE
Metadata Plugin API

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageContext.java
@@ -19,6 +19,8 @@ package co.cask.cdap.etl.api;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.metadata.MetadataReaderContext;
+import co.cask.cdap.api.metadata.MetadataWriterContext;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.plugin.PluginProperties;
@@ -30,7 +32,7 @@ import javax.annotation.Nullable;
  * Context for a pipeline stage, providing access to information about the stage, metrics, and plugins.
  */
 @Beta
-public interface StageContext extends ServiceDiscoverer {
+public interface StageContext extends ServiceDiscoverer, MetadataReaderContext, MetadataWriterContext {
 
   /**
    * Gets the unique stage name.

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractStageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractStageContext.java
@@ -17,8 +17,10 @@
 package co.cask.cdap.etl.common;
 
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.plugin.PluginProperties;
-import co.cask.cdap.etl.api.Arguments;
 import co.cask.cdap.etl.api.StageContext;
 import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.common.plugin.Caller;
@@ -186,5 +188,55 @@ public abstract class AbstractStageContext implements StageContext {
         return pipelineRuntime.getServiceDiscoverer().getServiceURL(serviceId);
       }
     });
+  }
+
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
+    return null;
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
+    return null;
+  }
+
+  @Override
+  public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
+
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, String... tags) {
+
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
+
+  }
+
+  @Override
+  public void removeMetadata(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity, String... keys) {
+
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity, String... tags) {
+
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractTransformContext.java
@@ -16,6 +16,9 @@
 
 package co.cask.cdap.etl.common;
 
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.TransformContext;
@@ -40,5 +43,55 @@ public abstract class AbstractTransformContext extends AbstractStageContext impl
   @Override
   public <T> Lookup<T> provide(String table, Map<String, String> arguments) {
     return lookup.provide(table, arguments);
+  }
+
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
+    return null;
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
+    return null;
+  }
+
+  @Override
+  public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
+
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, String... tags) {
+
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
+
+  }
+
+  @Override
+  public void removeMetadata(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity, String... keys) {
+
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity, String... tags) {
+
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockActionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockActionContext.java
@@ -18,6 +18,9 @@ package co.cask.cdap.etl.mock.action;
 
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.security.store.SecureStoreData;
 import co.cask.cdap.etl.api.StageMetrics;
@@ -159,5 +162,54 @@ public class MockActionContext implements ActionContext {
     // no-op; unused
   }
 
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
+    return null;
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
+    return null;
+  }
+
+  @Override
+  public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
+
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, String... tags) {
+
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
+
+  }
+
+  @Override
+  public void removeMetadata(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity, String... keys) {
+
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity, String... tags) {
+
+  }
 }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/MockTransformContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/MockTransformContext.java
@@ -17,6 +17,9 @@
 package co.cask.cdap.etl.mock.transform;
 
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.Arguments;
 import co.cask.cdap.etl.api.Lookup;
@@ -142,6 +145,56 @@ public class MockTransformContext implements TransformContext {
   @Override
   public <T> Lookup<T> provide(String table, Map<String, String> arguments) {
     return lookup.provide(table, arguments);
+  }
+
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
+    return null;
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
+    return null;
+  }
+
+  @Override
+  public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
+
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, String... tags) {
+
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
+
+  }
+
+  @Override
+  public void removeMetadata(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity, String... keys) {
+
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity) {
+
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity, String... tags) {
+
   }
 
   @Nullable


### PR DESCRIPTION
- This PR exposes the MetadataReaderContext and WriterContext to PluginContext allowing user to use these API to do metadata operation.
- There is no implementation to the apis as of now and the purpose is to just show how the api look like and how the user will use it.
- There is a sample example of how the api will be used but as obvious it does nothing actually.
