### PR TITLE
Fix exclusions of dependencies

### DIFF
--- a/cdap-explore/pom.xml
+++ b/cdap-explore/pom.xml
@@ -104,16 +104,6 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.janino</groupId>
-          <artifactId>janino</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.janino</groupId>
-          <artifactId>commons-compiler</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/cdap-formats/pom.xml
+++ b/cdap-formats/pom.xml
@@ -48,12 +48,6 @@
     <dependency>
       <groupId>io.thekraken</groupId>
       <artifactId>grok</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1019,6 +1019,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1256,6 +1260,14 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>  
+          <exclusion>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>commons-compiler</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
**TLDR: All exclusions for a particular dependency should be defined in one place, otherwise one set of exclusions may not be respected.**

[This PR](https://github.com/caskdata/cdap/pull/9891) added an exclusion to the grok dependency.
However, it then ignored the exclusion (on slf4j-log4j12) in the root pom.xml, and so `slf4j-log4j12` was being brought in.
Logging was then being messed up - integration tests logging were not being seen, for instance.

[This change](https://github.com/caskdata/cdap/commit/40d13e9eee4f5debdf0d676eb081a3c608bf5c4e#diff-121e2347eb44291a8c85846c63681454) does a similar thing - also fixed in this PR.