### PR TITLE
Avoid using a guava classes which is not compatible with later versions of guava.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -50,7 +50,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import com.google.common.io.Closeables;
-import com.google.common.io.Files;
 import com.google.common.util.concurrent.AbstractIdleService;
 import org.apache.twill.api.RunId;
 import org.apache.twill.common.Threads;
@@ -61,6 +60,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -161,7 +161,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
     try {
       File programJar = Locations.linkOrCopy(programJarLocation, new File(tempDir, "program.jar"));
       // Unpack the JAR file
-      BundleJarUtil.unJar(Files.newInputStreamSupplier(programJar), unpackedDir);
+      BundleJarUtil.unJar(() -> Files.newInputStream(programJar.toPath()), unpackedDir);
     } catch (IOException ioe) {
       throw ioe;
     } catch (Exception e) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/LoadArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/LoadArtifactCommand.java
@@ -27,10 +27,10 @@ import co.cask.cdap.common.id.Id;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.cli.Arguments;
-import com.google.common.io.Files;
 import com.google.inject.Inject;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.PrintStream;
 import java.util.Map;
 
@@ -72,12 +72,12 @@ public class LoadArtifactCommand extends AbstractAuthCommand {
     NamespaceId namespace = artifactId.getParent();
     if (configPath == null) {
       artifactClient.add(namespace, artifactId.getEntityName(),
-                         Files.newInputStreamSupplier(artifactFile), artifactId.getVersion());
+                         () -> new FileInputStream(artifactFile), artifactId.getVersion());
     } else {
       File configFile = resolver.resolvePathToFile(configPath);
       ArtifactConfig artifactConfig = configReader.read(Id.Namespace.fromEntityId(namespace), configFile);
       artifactClient.add(namespace, artifactId.getEntityName(),
-                         Files.newInputStreamSupplier(artifactFile), artifactId.getVersion(),
+                         () -> new FileInputStream(artifactFile), artifactId.getVersion(),
                          artifactConfig.getParents(), artifactConfig.getPlugins());
 
       Map<String, String> properties = artifactConfig.getProperties();

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ApplicationClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ApplicationClientTestRun.java
@@ -40,7 +40,6 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.common.io.Files;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -171,10 +171,10 @@ public class ApplicationClientTestRun extends ClientTestBase {
     ApplicationId appId = NamespaceId.DEFAULT.app("ProgramsApp");
 
     artifactClient.add(NamespaceId.DEFAULT, artifactName,
-      Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp.class)),
-      "1.0.0");
+                       () -> Files.newInputStream(createAppJarFile(ConfigurableProgramsApp.class).toPath()),
+                       "1.0.0");
     artifactClient.add(NamespaceId.DEFAULT, artifactName,
-      Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp2.class)),
+                       () -> Files.newInputStream(createAppJarFile(ConfigurableProgramsApp2.class).toPath()),
       "2.0.0");
 
     try {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -18,6 +18,7 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.api.artifact.ArtifactRange;
 import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.client.app.ConfigurableProgramsApp2;
 import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.id.Id;
@@ -36,11 +37,11 @@ import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
 import com.google.common.collect.Iterators;
-import com.google.common.io.Files;
 import org.junit.Assert;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -78,12 +79,12 @@ public abstract class MetadataTestBase extends ClientTestBase {
   }
 
   protected void addAppArtifact(ArtifactId artifactId, Class<?> cls) throws Exception {
-    artifactClient.add(artifactId, null, Files.newInputStreamSupplier(createAppJarFile(cls)));
+      artifactClient.add(artifactId, null, () -> Files.newInputStream(createAppJarFile(cls).toPath()));
   }
 
   protected void addPluginArtifact(ArtifactId artifactId, Class<?> cls, Manifest manifest,
                                    @Nullable Set<ArtifactRange> parents) throws Exception {
-    artifactClient.add(artifactId, parents, Files.newInputStreamSupplier(createArtifactJarFile(cls, manifest)));
+    artifactClient.add(artifactId, parents, () -> Files.newInputStream(createArtifactJarFile(cls, manifest).toPath()));
   }
 
   protected void addProperties(ApplicationId app, @Nullable Map<String, String> properties) throws Exception {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ServiceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ServiceClientTestRun.java
@@ -239,13 +239,8 @@ public class ServiceClientTestRun extends ClientTestBase {
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(ManifestFields.BUNDLE_VERSION, "1.0.0");
     final Location appJarLoc = AppJarHelper.createDeploymentJar(locationFactory, AppReturnsArgs.class, manifest);
-    InputSupplier<InputStream> inputSupplier = new InputSupplier<InputStream>() {
-      @Override
-      public InputStream getInput() throws IOException {
-        return appJarLoc.getInputStream();
-      }
-    };
-    artifactClient.add(NamespaceId.DEFAULT, artifactId.getArtifact(), inputSupplier, artifactId.getVersion());
+    artifactClient.add(NamespaceId.DEFAULT, artifactId.getArtifact(),
+                       appJarLoc::getInputStream, artifactId.getVersion());
     appJarLoc.delete();
   }
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -39,12 +39,12 @@ import co.cask.cdap.proto.artifact.PluginSummary;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.common.ContentProvider;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
 import com.google.common.base.Joiner;
-import com.google.common.io.InputSupplier;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -436,7 +436,7 @@ public class ArtifactClient {
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(ArtifactId artifactId, @Nullable Set<ArtifactRange> parentArtifacts,
-                  InputSupplier<? extends InputStream> artifactContents)
+                  ContentProvider<? extends InputStream> artifactContents)
     throws UnauthenticatedException, BadRequestException, ArtifactRangeNotFoundException,
     ArtifactAlreadyExistsException, IOException, UnauthorizedException {
 
@@ -449,7 +449,7 @@ public class ArtifactClient {
    *
    * @param namespace the namespace to add the artifact to
    * @param artifactName the name of the artifact to add
-   * @param artifactContents an input supplier for the contents of the artifact
+   * @param artifactContents a provider for the contents of the artifact
    * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
    *                        manifest of the artifact.
    * @throws ArtifactAlreadyExistsException if the artifact already exists
@@ -459,7 +459,7 @@ public class ArtifactClient {
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(NamespaceId namespace, String artifactName,
-                  InputSupplier<? extends InputStream> artifactContents,
+                  ContentProvider<? extends InputStream> artifactContents,
                   @Nullable String artifactVersion)
     throws ArtifactAlreadyExistsException, BadRequestException, IOException,
     UnauthenticatedException, ArtifactRangeNotFoundException, UnauthorizedException {
@@ -472,7 +472,7 @@ public class ArtifactClient {
    *
    * @param namespace the namespace to add the artifact to
    * @param artifactName the name of the artifact to add
-   * @param artifactContents an input supplier for the contents of the artifact
+   * @param artifactContents a provider for the contents of the artifact
    * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
    *                        manifest of the artifact
    * @param parentArtifacts the set of artifacts this artifact extends
@@ -482,7 +482,7 @@ public class ArtifactClient {
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
-  public void add(NamespaceId namespace, String artifactName, InputSupplier<? extends InputStream> artifactContents,
+  public void add(NamespaceId namespace, String artifactName, ContentProvider<? extends InputStream> artifactContents,
                   @Nullable String artifactVersion, @Nullable Set<ArtifactRange> parentArtifacts)
     throws ArtifactAlreadyExistsException, BadRequestException, IOException,
     UnauthenticatedException, ArtifactRangeNotFoundException, UnauthorizedException {
@@ -495,7 +495,7 @@ public class ArtifactClient {
    *
    * @param namespace the namespace to add the artifact to
    * @param artifactName the name of the artifact to add
-   * @param artifactContents an input supplier for the contents of the artifact
+   * @param artifactContents a provider for the contents of the artifact
    * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
    *                        manifest of the artifact
    * @param parentArtifacts the set of artifacts this artifact extends
@@ -510,7 +510,7 @@ public class ArtifactClient {
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    */
   public void add(NamespaceId namespace, String artifactName,
-                  InputSupplier<? extends InputStream> artifactContents,
+                  ContentProvider<? extends InputStream> artifactContents,
                   @Nullable String artifactVersion,
                   @Nullable Set<ArtifactRange> parentArtifacts,
                   @Nullable Set<PluginClass> additionalPlugins)

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetricsClient.java
@@ -32,7 +32,6 @@ import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
 import com.google.common.base.Joiner;
-import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -275,8 +274,10 @@ public class MetricsClient {
 
         // Min sleep time is 10ms, max sleep time is 1 seconds
         long sleepMillis = Math.max(10, Math.min(timeoutUnit.toMillis(timeout) / 10, TimeUnit.SECONDS.toMillis(1)));
-        Stopwatch stopwatch = new Stopwatch().start();
-        while (value < count && stopwatch.elapsedTime(timeoutUnit) < timeout) {
+        long startTime = System.currentTimeMillis();
+        long timeoutMillis = timeoutUnit.toMillis(timeout);
+
+        while (value < count && (System.currentTimeMillis() - startTime < timeoutMillis)) {
           TimeUnit.MILLISECONDS.sleep(sleepMillis);
           value = getTotalCounter(tags, name);
         }

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -33,6 +33,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.common.ContentProvider;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
@@ -40,10 +41,9 @@ import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
-import com.google.common.io.Files;
-import com.google.common.io.InputSupplier;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -51,6 +51,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -231,7 +232,8 @@ public class StreamClient {
    */
   public void sendFile(StreamId stream, String contentType,
                        File file) throws IOException, StreamNotFoundException, UnauthenticatedException {
-    sendBatch(stream, contentType, Files.newInputStreamSupplier(file));
+    Preconditions.checkNotNull(file);
+    sendBatch(stream, contentType, () -> new FileInputStream(file));
   }
 
   /**
@@ -244,7 +246,7 @@ public class StreamClient {
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendBatch(StreamId stream, String contentType,
-                        InputSupplier<? extends InputStream> inputSupplier)
+                        ContentProvider<? extends InputStream> inputSupplier)
     throws IOException, StreamNotFoundException, UnauthenticatedException {
 
     URL url = config.resolveNamespacedURLV3(stream.getParent(),

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/guava/ClassPath.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/guava/ClassPath.java
@@ -22,7 +22,6 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Splitter;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -43,6 +42,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +50,7 @@ import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -136,7 +137,10 @@ public final class ClassPath {
    * @since 16.0
    */
   public ImmutableSet<ClassInfo> getAllClasses() {
-    return FluentIterable.from(resources).filter(ClassInfo.class).toImmutableSet();
+    return resources.stream()
+      .filter(ClassInfo.class::isInstance)
+      .map(ClassInfo.class::cast)
+      .collect(Collectors.collectingAndThen(Collectors.toCollection(LinkedHashSet::new), ImmutableSet::copyOf));
   }
 
   /**
@@ -160,7 +164,11 @@ public final class ClassPath {
 
   /** Returns all top level classes loadable from the current class path. */
   public ImmutableSet<ClassInfo> getTopLevelClasses() {
-    return FluentIterable.from(resources).filter(ClassInfo.class).filter(IS_TOP_LEVEL).toImmutableSet();
+    return resources.stream()
+      .filter(ClassInfo.class::isInstance)
+      .map(ClassInfo.class::cast)
+      .filter(IS_TOP_LEVEL::apply)
+      .collect(Collectors.collectingAndThen(Collectors.toCollection(LinkedHashSet::new), ImmutableSet::copyOf));
   }
 
   /** Returns all top level classes whose package name is {@code packageName}. */

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -250,7 +250,7 @@ class DatasetServiceClient {
 
     HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.PUT, "modules/" + moduleName)
       .addHeader("X-Class-Name", className)
-      .withBody(Locations.newInputSupplier(jarLocation));
+      .withBody(jarLocation::getInputStream);
     HttpResponse response = doRequest(requestBuilder);
 
     if (HttpResponseStatus.CONFLICT.code() == response.getResponseCode()) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -326,7 +326,7 @@ public abstract class DatasetServiceTestBase {
     urlPath = force ? urlPath + "?force=true" : urlPath;
     HttpRequest request = HttpRequest.put(getUrl(module.getNamespace(), urlPath))
       .addHeader("X-Class-Name", moduleClass.getName())
-      .withBody(Locations.newInputSupplier(moduleJar)).build();
+      .withBody(moduleJar::getInputStream).build();
     return HttpRequests.execute(request);
   }
 
@@ -337,7 +337,7 @@ public abstract class DatasetServiceTestBase {
     Location moduleJar = createModuleJar(moduleClass, bundleEmbeddedJars);
     HttpRequest request = HttpRequest.put(getUrl("/data/modules/" + moduleName))
       .addHeader("X-Class-Name", moduleClassName)
-      .withBody(Locations.newInputSupplier(moduleJar)).build();
+      .withBody(moduleJar::getInputStream).build();
     return HttpRequests.execute(request).getResponseCode();
   }
 

--- a/cdap-examples/DecisionTreeRegression/src/test/java/co/cask/cdap/examples/dtree/DecisionTreeRegressionAppTest.java
+++ b/cdap-examples/DecisionTreeRegression/src/test/java/co/cask/cdap/examples/dtree/DecisionTreeRegressionAppTest.java
@@ -29,15 +29,12 @@ import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
-import com.google.common.io.InputSupplier;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -63,12 +60,7 @@ public class DecisionTreeRegressionAppTest extends TestBaseWithSpark2 {
     URL serviceURL = serviceManager.getServiceURL(15, TimeUnit.SECONDS);
     URL addDataURL = new URL(serviceURL, "labels");
     HttpRequest request = HttpRequest.builder(HttpMethod.PUT, addDataURL)
-      .withBody(new InputSupplier<InputStream>() {
-        @Override
-        public InputStream getInput() throws IOException {
-          return getClass().getClassLoader().getResourceAsStream("sample_libsvm_data.txt");
-        }
-      })
+      .withBody(() -> getClass().getClassLoader().getResourceAsStream("sample_libsvm_data.txt"))
       .build();
     HttpResponse response = HttpRequests.execute(request);
     Assert.assertEquals(200, response.getResponseCode());

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -53,7 +53,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -245,7 +244,7 @@ public abstract class IntegrationTestBase {
 
   private void checkServicesWithRetry(Callable<Boolean> callable,
                                       String exceptionMessage) throws TimeoutException, InterruptedException {
-    Stopwatch sw = new Stopwatch().start();
+    long startTime = System.currentTimeMillis();
     do {
       try {
         if (callable.call()) {
@@ -262,7 +261,7 @@ public abstract class IntegrationTestBase {
         }
       }
       TimeUnit.SECONDS.sleep(1);
-    } while (sw.elapsedTime(TimeUnit.SECONDS) <= SERVICE_CHECK_TIMEOUT_SECONDS);
+    } while (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime) <= SERVICE_CHECK_TIMEOUT_SECONDS);
 
     // when we have passed the timeout and the check for services is not successful
     throw new TimeoutException(exceptionMessage);

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -214,7 +214,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
 
   @Override
   public ClassLoader createProgramClassLoaderParent() {
-    return new FilterClassLoader(getClass().getClassLoader(), SparkRuntimeUtils.SPARK_PROGRAM_CLASS_LOADER_FILTER);
+    return new FilterClassLoader(getClass().getClassLoader(), SparkResourceFilters.SPARK_PROGRAM_CLASS_LOADER_FILTER);
   }
 
   /**

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkResourceFilters.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkResourceFilters.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.common.internal.guava.ClassPath;
+import co.cask.cdap.common.lang.ClassPathResources;
+import co.cask.cdap.common.lang.FilterClassLoader;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.spark.streaming.StreamingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A util class for hosting filtering spark resources for classloader. It is in its own class to minizie the dependency
+ * of this class.
+ */
+public final class SparkResourceFilters {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkResourceFilters.class);
+
+  @VisibleForTesting
+  public static final FilterClassLoader.Filter SPARK_PROGRAM_CLASS_LOADER_FILTER = new FilterClassLoader.Filter() {
+
+    final FilterClassLoader.Filter defaultFilter = FilterClassLoader.defaultFilter();
+    volatile Set<ClassPath.ResourceInfo> sparkStreamingResources;
+
+    @Override
+    public boolean acceptResource(final String resource) {
+      // All Spark API, Spark, Scala, Akka and Kryo classes should come from parent.
+      if (resource.startsWith("co/cask/cdap/api/spark/")) {
+        return true;
+      }
+      if (resource.startsWith("scala/")) {
+        return true;
+      }
+      if (resource.startsWith("akka/")) {
+        return true;
+      }
+      if (resource.startsWith("com/esotericsoftware/kryo/")) {
+        return true;
+      }
+      if (resource.startsWith("org/apache/spark/")) {
+        // Only allows the core Spark Streaming classes, but not any streaming extensions (like Kafka).
+        // cdh 5.5+ package streaming kafka and flume into their spark assembly jar, but they don't package their
+        // dependencies. For example, streaming kafka is packaged, but kafka is not.
+        if (resource.startsWith("org/apache/spark/streaming/kafka") ||
+          resource.startsWith("org/apache/spark/streaming/flume")) {
+          return false;
+        }
+        if (resource.startsWith("org/apache/spark/streaming")) {
+          return getSparkStreamingResources().stream().anyMatch(info -> info.getResourceName().equals(resource));
+        }
+        return true;
+      }
+      if (resource.startsWith("com/google/common/base/Optional")) {
+        return true;
+      }
+      return defaultFilter.acceptResource(resource);
+    }
+
+    @Override
+    public boolean acceptPackage(final String packageName) {
+      if (packageName.equals("co.cask.cdap.api.spark") || packageName.startsWith("co.cask.cdap.api.spark.")) {
+        return true;
+      }
+      if (packageName.equals("scala") || packageName.startsWith("scala.")) {
+        return true;
+      }
+      if (packageName.equals("akka") || packageName.startsWith("akka.")) {
+        return true;
+      }
+      if (packageName.equals("com.esotericsoftware.kryo") || packageName.startsWith("com.esotericsoftware.kryo.")) {
+        return true;
+      }
+      // cdh 5.5 and on package kafka and flume streaming in their assembly jar
+      if (packageName.equals("org.apache.spark") || packageName.startsWith("org.apache.spark.")) {
+        // Only allows the core Spark Streaming classes, but not any streaming extensions (like Kafka).
+        if (packageName.startsWith("org.apache.spark.streaming.kafka") ||
+          packageName.startsWith("org.apache.spark.streaming.flume")) {
+          return false;
+        }
+        if (packageName.equals("org.apache.spark.streaming") || packageName.startsWith("org.apache.spark.streaming.")) {
+          return getSparkStreamingResources().stream()
+            .filter(ClassPath.ClassInfo.class::isInstance)
+            .map(ClassPath.ClassInfo.class::cast)
+            .anyMatch(info -> info.getPackageName().equals(packageName));
+        }
+        return true;
+      }
+      return defaultFilter.acceptResource(packageName);
+    }
+
+    /**
+     * Gets the set of resources information that are from the Spark Streaming Core. It excludes any
+     * Spark streaming extensions, such as Kafka or Flume. They need to be excluded since they are not
+     * part of Spark distribution and it should be loaded from the user program ClassLoader. This filtering
+     * is needed for unit-testing because in unit-test, those extension classes are loadable from the system
+     * classloader, causing same classes being loaded through different classloader.
+     */
+    private Set<ClassPath.ResourceInfo> getSparkStreamingResources() {
+      if (sparkStreamingResources != null) {
+        return sparkStreamingResources;
+      }
+      synchronized (this) {
+        if (sparkStreamingResources != null) {
+          return sparkStreamingResources;
+        }
+
+        try {
+          sparkStreamingResources = ClassPathResources.getClassPathResources(getClass().getClassLoader(),
+                                                                             StreamingContext.class);
+        } catch (IOException e) {
+          LOG.warn("Failed to find resources for Spark StreamingContext.", e);
+          sparkStreamingResources = Collections.emptySet();
+        }
+        return sparkStreamingResources;
+      }
+    }
+  };
+}

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -289,7 +289,7 @@ public final class SparkRuntimeContextProvider {
     File programDir = new File(PROGRAM_JAR_EXPANDED_NAME);
 
     ClassLoader parentClassLoader = new FilterClassLoader(SparkRuntimeContextProvider.class.getClassLoader(),
-                                               SparkRuntimeUtils.SPARK_PROGRAM_CLASS_LOADER_FILTER);
+                                                          SparkResourceFilters.SPARK_PROGRAM_CLASS_LOADER_FILTER);
     ClassLoader classLoader = new ProgramClassLoader(cConf, programDir, parentClassLoader);
 
     return new DefaultProgram(new ProgramDescriptor(contextConfig.getProgramId(),

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
@@ -19,14 +19,8 @@ package co.cask.cdap.app.runtime.spark;
 import co.cask.cdap.api.spark.SparkExecutionContext;
 import co.cask.cdap.app.runtime.spark.classloader.SparkRunnerClassLoader;
 import co.cask.cdap.app.runtime.spark.distributed.SparkDriverService;
-import co.cask.cdap.common.internal.guava.ClassPath;
 import co.cask.cdap.common.lang.ClassLoaders;
-import co.cask.cdap.common.lang.ClassPathResources;
-import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import com.google.common.io.OutputSupplier;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractService;
@@ -36,7 +30,6 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.gson.Gson;
 import org.apache.spark.SparkConf;
 import org.apache.spark.streaming.DStreamGraph;
-import org.apache.spark.streaming.StreamingContext;
 import org.apache.twill.common.Cancellable;
 import org.apache.twill.common.Threads;
 import org.apache.twill.internal.ServiceListenerAdapter;
@@ -73,116 +66,6 @@ public final class SparkRuntimeUtils {
   private static final String LOCALIZED_RESOURCES = "spark.cdap.localized.resources";
   private static final Logger LOG = LoggerFactory.getLogger(SparkRuntimeUtils.class);
   private static final Gson GSON = new Gson();
-
-  // ClassLoader filter
-  @VisibleForTesting
-  public static final FilterClassLoader.Filter SPARK_PROGRAM_CLASS_LOADER_FILTER = new FilterClassLoader.Filter() {
-
-    final FilterClassLoader.Filter defaultFilter = FilterClassLoader.defaultFilter();
-    volatile Set<ClassPath.ResourceInfo> sparkStreamingResources;
-
-    @Override
-    public boolean acceptResource(final String resource) {
-      // All Spark API, Spark, Scala, Akka and Kryo classes should come from parent.
-      if (resource.startsWith("co/cask/cdap/api/spark/")) {
-        return true;
-      }
-      if (resource.startsWith("scala/")) {
-        return true;
-      }
-      if (resource.startsWith("akka/")) {
-        return true;
-      }
-      if (resource.startsWith("com/esotericsoftware/kryo/")) {
-        return true;
-      }
-      if (resource.startsWith("org/apache/spark/")) {
-        // Only allows the core Spark Streaming classes, but not any streaming extensions (like Kafka).
-        // cdh 5.5+ package streaming kafka and flume into their spark assembly jar, but they don't package their
-        // dependencies. For example, streaming kafka is packaged, but kafka is not.
-        if (resource.startsWith("org/apache/spark/streaming/kafka") ||
-          resource.startsWith("org/apache/spark/streaming/flume")) {
-          return false;
-        }
-        if (resource.startsWith("org/apache/spark/streaming")) {
-          return Iterables.any(getSparkStreamingResources(), new Predicate<ClassPath.ResourceInfo>() {
-            @Override
-            public boolean apply(ClassPath.ResourceInfo input) {
-              return input.getResourceName().equals(resource);
-            }
-          });
-        }
-        return true;
-      }
-      if (resource.startsWith("com/google/common/base/Optional")) {
-        return true;
-      }
-      return defaultFilter.acceptResource(resource);
-    }
-
-    @Override
-    public boolean acceptPackage(final String packageName) {
-      if (packageName.equals("co.cask.cdap.api.spark") || packageName.startsWith("co.cask.cdap.api.spark.")) {
-        return true;
-      }
-      if (packageName.equals("scala") || packageName.startsWith("scala.")) {
-        return true;
-      }
-      if (packageName.equals("akka") || packageName.startsWith("akka.")) {
-        return true;
-      }
-      if (packageName.equals("com.esotericsoftware.kryo") || packageName.startsWith("com.esotericsoftware.kryo.")) {
-        return true;
-      }
-      // cdh 5.5 and on package kafka and flume streaming in their assembly jar
-      if (packageName.equals("org.apache.spark") || packageName.startsWith("org.apache.spark.")) {
-        // Only allows the core Spark Streaming classes, but not any streaming extensions (like Kafka).
-        if (packageName.startsWith("org.apache.spark.streaming.kafka") ||
-          packageName.startsWith("org.apache.spark.streaming.flume")) {
-          return false;
-        }
-        if (packageName.equals("org.apache.spark.streaming") || packageName.startsWith("org.apache.spark.streaming.")) {
-          return Iterables.any(
-            Iterables.filter(getSparkStreamingResources(), ClassPath.ClassInfo.class),
-            new Predicate<ClassPath.ClassInfo>() {
-              @Override
-              public boolean apply(ClassPath.ClassInfo input) {
-                return input.getPackageName().equals(packageName);
-              }
-            });
-        }
-        return true;
-      }
-      return defaultFilter.acceptResource(packageName);
-    }
-
-    /**
-     * Gets the set of resources information that are from the Spark Streaming Core. It excludes any
-     * Spark streaming extensions, such as Kafka or Flume. They need to be excluded since they are not
-     * part of Spark distribution and it should be loaded from the user program ClassLoader. This filtering
-     * is needed for unit-testing because in unit-test, those extension classes are loadable from the system
-     * classloader, causing same classes being loaded through different classloader.
-     */
-    private Set<ClassPath.ResourceInfo> getSparkStreamingResources() {
-      if (sparkStreamingResources != null) {
-        return sparkStreamingResources;
-      }
-      synchronized (this) {
-        if (sparkStreamingResources != null) {
-          return sparkStreamingResources;
-        }
-
-        try {
-          sparkStreamingResources = ClassPathResources.getClassPathResources(getClass().getClassLoader(),
-                                                                             StreamingContext.class);
-        } catch (IOException e) {
-          LOG.warn("Failed to find resources for Spark StreamingContext.", e);
-          sparkStreamingResources = Collections.emptySet();
-        }
-        return sparkStreamingResources;
-      }
-    }
-  };
 
   /**
    * Creates a zip file which contains a serialized {@link Properties} with a given zip entry name, together with

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -29,8 +29,8 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.spark.SparkPackageUtils;
 import co.cask.cdap.app.runtime.spark.SparkProgramRuntimeProvider;
+import co.cask.cdap.app.runtime.spark.SparkResourceFilters;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeContextConfig;
-import co.cask.cdap.app.runtime.spark.SparkRuntimeUtils;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.FilterClassLoader;
@@ -188,6 +188,6 @@ public final class DistributedSparkProgramRunner extends DistributedProgramRunne
 
   @Override
   public ClassLoader createProgramClassLoaderParent() {
-    return new FilterClassLoader(getClass().getClassLoader(), SparkRuntimeUtils.SPARK_PROGRAM_CLASS_LOADER_FILTER);
+    return new FilterClassLoader(getClass().getClassLoader(), SparkResourceFilters.SPARK_PROGRAM_CLASS_LOADER_FILTER);
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -28,7 +28,7 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.app.DefaultApplicationContext;
 import co.cask.cdap.app.MockAppConfigurer;
 import co.cask.cdap.app.program.ManifestFields;
-import co.cask.cdap.app.runtime.spark.SparkRuntimeUtils;
+import co.cask.cdap.app.runtime.spark.SparkResourceFilters;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.StickyEndpointStrategy;
@@ -116,7 +116,7 @@ public class UnitTestManager extends AbstractTestManager {
         // allow developers to exclude spark-core module from their unit tests (it'll work if they don't use spark)
         getClass().getClassLoader().loadClass("co.cask.cdap.app.runtime.spark.SparkRuntimeUtils");
         // If it is loading by spark framework, don't include it in the app JAR
-        return !SparkRuntimeUtils.SPARK_PROGRAM_CLASS_LOADER_FILTER.acceptResource(resourceName);
+        return !SparkResourceFilters.SPARK_PROGRAM_CLASS_LOADER_FILTER.acceptResource(resourceName);
       } catch (ClassNotFoundException e) {
         if (logWarnOnce.compareAndSet(false, true)) {
           LOG.warn("Spark will not be available for unit tests.");

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <async.http.version>1.7.18</async.http.version>
     <avro.version>1.6.2</avro.version>
     <cask.common.cli.version>0.8.0</cask.common.cli.version>
-    <cask.common.version>0.10.0</cask.common.version>
+    <cask.common.version>0.11.0-SNAPSHOT</cask.common.version>
     <cdap.client.version>1.2.0</cdap.client.version>
     <commons.cli.version>1.2</commons.cli.version>
     <commons.codec.version>1.6</commons.codec.version>


### PR DESCRIPTION
For instance, in Integration test framework, avoid using a StopWatch class which is not compatible with later versions of guava (18, for instance).