### PR TITLE
Temporarily ignore the ReportGenerationAppTest 

### DIFF
--- a/cdap-app-templates/cdap-program-report/src/test/java/co/cask/cdap/report/ReportGenerationAppTest.java
+++ b/cdap-app-templates/cdap-program-report/src/test/java/co/cask/cdap/report/ReportGenerationAppTest.java
@@ -56,6 +56,7 @@ import org.apache.twill.filesystem.Location;
 import org.apache.twill.internal.ApplicationBundler;
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
@@ -87,6 +88,7 @@ public class ReportGenerationAppTest extends TestBaseWithSpark2 {
   private static final Type REPORT_GEN_INFO_TYPE = new TypeToken<ReportGenerationInfo>() { }.getType();
   private static final Type REPORT_CONTENT_TYPE = new TypeToken<ReportContent>() { }.getType();
 
+  @Ignore
   @Test
   public void testGenerateReport() throws Exception {
     DatasetId metaFileset = NamespaceId.DEFAULT.dataset(ReportGenerationApp.RUN_META_FILESET);


### PR DESCRIPTION
The failure was introduced in the PR #10055 Will fix this test in a separate PR