### PR TITLE
(CDAP-12907) Update JVM options for Java 8

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -5,7 +5,7 @@ Cask Data Application Platform - CDAP
 Prerequisites
 =============
 
-- Java 7+ SDK
+- Java 8+ SDK
 - Maven 3.1+
 - Git
 
@@ -20,10 +20,10 @@ CDAP Sandbox and Distributed CDAP
 
 - Run all tests, fail at the end::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn test -fae
+    MAVEN_OPTS="-Xmx1024m" mvn test -fae
 
 - Run tests skipping repeated compat module tests::
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn test -Pskip-hbase-compat-tests -fae
+    MAVEN_OPTS="-Xmx1024m" mvn test -Pskip-hbase-compat-tests -fae
 
 - Build all modules::
 
@@ -39,28 +39,28 @@ CDAP Sandbox and Distributed CDAP
 
 - Run selected test::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn -Dtest=TestClass,TestMore*Class,TestClassMethod#methodName \
+    MAVEN_OPTS="-Xmx1024m" mvn -Dtest=TestClass,TestMore*Class,TestClassMethod#methodName \
     -DfailIfNoTests=false test
 
 - Run App-Template tests::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn test -fae -am -amd -P templates -pl cdap-app-templates/cdap-etl
+    MAVEN_OPTS="-Xmx1024m" mvn test -fae -am -amd -P templates -pl cdap-app-templates/cdap-etl
 
   See `Surefire doc <http://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html>`__ for details
 
 - Build all examples::
 
-    MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=128m" mvn clean package -DskipTests -pl cdap-examples -am -amd -P examples
+    MAVEN_OPTS="-Xmx512m" mvn clean package -DskipTests -pl cdap-examples -am -amd -P examples
 
 - Build CDAP Sandbox distribution ZIP::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package \
+    MAVEN_OPTS="-Xmx1024m" mvn clean package \
     -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-app-templates/cdap-program-report,cdap-examples \
     -am -amd -DskipTests -P examples,templates,dist,release,unit-tests
 
 - Build CDAP Sandbox distribution ZIP with additional system artifacts::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package \
+    MAVEN_OPTS="-Xmx1024m" mvn clean package \
     -pl cdap-standalone,cdap-app-templates/cdap-etl,cdap-app-templates/cdap-data-quality,cdap-app-templates/cdap-program-report,cdap-examples \
     -am -amd -DskipTests -P examples,templates,dist,release,unit-tests \
     -Dadditional.artifacts.dir=</path/to/additional/artifacts>
@@ -73,22 +73,22 @@ CDAP Sandbox and Distributed CDAP
 
 - Build the limited set of Javadocs, including the ETL Application Templates, included in the CDAP documentation::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests \
+    MAVEN_OPTS="-Xmx1024m" mvn clean install -P examples,templates,release -DskipTests \
     -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
 
 - Build the complete set of Javadocs, for all modules and examples::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests \
+    MAVEN_OPTS="-Xmx1024m" mvn clean install -P examples,templates,release -DskipTests \
     -Dgpg.skip=true && mvn clean javadoc:aggregate -DskipTests -P examples,templates -DisOffline=false
 
 - Build distributions (rpm, deb, tgz)::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -DskipTests \
+    MAVEN_OPTS="-Xmx1024m" mvn clean package -DskipTests \
     -P examples,templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests
 
 - Build Cloudera Manager parcel::
 
-    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -DskipTests \
+    MAVEN_OPTS="-Xmx1024m" mvn clean package -DskipTests \
     -P templates,dist,tgz && ./cdap-distributions/bin/build_parcel.sh
 
 - Show dependency tree::

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/ExternalSparkProgram.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/ExternalSparkProgram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,9 +29,6 @@ import co.cask.cdap.etl.common.DefaultMacroEvaluator;
 import co.cask.cdap.etl.spec.PluginSpec;
 import co.cask.cdap.etl.spec.StageSpec;
 import com.google.gson.Gson;
-import org.apache.spark.SparkConf;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,8 +39,6 @@ import java.util.UUID;
  * spark program.
  */
 public class ExternalSparkProgram extends AbstractSpark {
-
-  private static final Logger LOG = LoggerFactory.getLogger(ExternalSparkProgram.class);
 
   public static final String STAGE_NAME = "stage.name";
   private static final Gson GSON = new Gson();
@@ -94,13 +89,6 @@ public class ExternalSparkProgram extends AbstractSpark {
   @Override
   protected void initialize() throws Exception {
     SparkClientContext context = getContext();
-
-    SparkConf sparkConf = new SparkConf();
-    sparkConf.set("spark.driver.extraJavaOptions",
-                  "-XX:MaxPermSize=256m " + sparkConf.get("spark.driver.extraJavaOptions", ""));
-    sparkConf.set("spark.executor.extraJavaOptions",
-                  "-XX:MaxPermSize=256m " + sparkConf.get("spark.executor.extraJavaOptions", ""));
-    context.setSparkConf(sparkConf);
 
     String stageName = context.getSpecification().getProperty(STAGE_NAME);
     Class<?> externalProgramClass = context.loadPluginClass(stageName);

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2016 Cask Data, Inc.
+  ~ Copyright © 2016-2018 Cask Data, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of
@@ -242,7 +242,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.14.1</version>
         <configuration>
-          <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=1024m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p" -Djava.net.preferIPv4Stack=true</argLine>
+          <argLine>-Xmx5000m -Djava.awt.headless=true -XX:+UseG1GC -XX:OnOutOfMemoryError="kill -9 %p" -Djava.net.preferIPv4Stack=true</argLine>
           <reuseForks>false</reuseForks>
           <reportFormat>plain</reportFormat>
           <systemPropertyVariables>

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -73,7 +73,7 @@ public final class DataStreamsConfig extends ETLConfig {
   }
 
   public String getExtraJavaOpts() {
-    return extraJavaOpts == null || extraJavaOpts.isEmpty() ? "-XX:MaxPermSize=256m" : extraJavaOpts;
+    return extraJavaOpts == null ? "" : extraJavaOpts;
   }
 
   public Boolean getStopGracefully() {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -122,8 +122,6 @@ public class ETLSpark extends AbstractSpark {
     List<Finisher> finishers = new ArrayList<>();
 
     SparkConf sparkConf = new SparkConf();
-    sparkConf.set("spark.driver.extraJavaOptions", "-XX:MaxPermSize=256m");
-    sparkConf.set("spark.executor.extraJavaOptions", "-XX:MaxPermSize=256m");
     sparkConf.set("spark.speculation", "false");
     context.setSparkConf(sparkConf);
 

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright © 2016-2017 Cask Data, Inc.
+# Copyright © 2016-2018 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -348,8 +348,8 @@ cdap_set_java () {
   __java_version=$("${__java}" -version 2>&1 | grep version | awk '{print $3}' | awk -F '.' '{print $2}')
   if [[ -z ${__java_version} ]]; then
     die "Could not detect Java version. Aborting..."
-  elif [[ ${__java_version} -ne 7 ]] && [[ ${__java_version} -ne 8 ]]; then
-    die "Java version not supported. Please install Java 7 or 8 - other versions of Java are not supported."
+  elif [[ ${__java_version} -lt 8 ]]; then
+    die "Java version not supported. Please install Java 8 - other versions of Java are not supported."
   fi
   export JAVA=${__java}
   return 0
@@ -1455,7 +1455,7 @@ export IDENT_STRING=${USER}
 # Below are what we set by default.  May only work with SUN JVM.
 # For more on why as well as other possible settings,
 # see http://wiki.apache.org/hadoop/PerformanceTuning
-export OPTS="-XX:+UseConcMarkSweepGC -XX:MaxPermSize=256m"
+export OPTS="-XX:+UseG1GC"
 
 # The directory where PID files are stored. Default: /var/cdap/run
 export PID_DIR=${CDAP_PID_DIR:-/var/cdap/run}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -201,7 +201,7 @@
 
   <property>
     <name>twill.jvm.gc.opts</name>
-    <value>-verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
+    <value>-XX:+UseG1GC -verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
     <description>
       Java garbage collection options for all Apache Twill containers;
       "&lt;LOG_DIR&gt;" is the location of the log directory in the
@@ -370,7 +370,7 @@
 
   <property>
     <name>app.program.jvm.opts</name>
-    <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts}</value>
+    <value>${twill.jvm.gc.opts}</value>
     <description>
       Java options for all Apache Twill containers
     </description>

--- a/cdap-data-fabric/bin/tx-debugger.bat
+++ b/cdap-data-fabric/bin/tx-debugger.bat
@@ -1,6 +1,6 @@
 :: ##############################################################################
 :: ##
-:: ## Copyright (c) 2014-2017 Cask Data, Inc.
+:: ## Copyright (c) 2014-2018 Cask Data, Inc.
 :: ##
 :: ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 :: ## use this file except in compliance with the License. You may obtain a copy
@@ -27,7 +27,7 @@ IF /i NOT "%CDAP_HOME: =%"=="%CDAP_HOME%" (
 )
 
 SET JAVACMD=%JAVA_HOME%\bin\java.exe
-SET DEFAULT_JVM_OPTS=-Xmx2048m -XX:MaxPermSize=128m
+SET DEFAULT_JVM_OPTS=-Xmx2048m
 SET HADOOP_HOME_OPTS=-Dhadoop.home.dir=%CDAP_HOME%\libexec
 
 SET CLASSPATH=%CDAP_HOME%\lib\*;%CDAP_HOME%\conf\

--- a/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
+++ b/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2017 Cask Data, Inc.
+# Copyright © 2017-2018 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -25,7 +25,7 @@ if [ -f /tmp/mavenrepo.tar.bz2 ]; then
 fi
 
 chown -R cdap ${__tmpdir} ~cdap
-su - cdap -c "cd ${__tmpdir}/examples && MAVEN_OPTS='-Xmx4096m -XX:MaxPermSize=256m' mvn package -DskipTests" || exit 1
+su - cdap -c "cd ${__tmpdir}/examples && MAVEN_OPTS='-Xmx4096m' mvn package -DskipTests" || exit 1
 rm -rf ${__tmpdir}
 
 exit 0

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="139ba91afd48d166baf43f893c1a8ad8"
+DEFAULT_XML_MD5_HASH="516960d3839c8c2764916963db738f24"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
@@ -283,7 +283,7 @@ In addition, the property ``app.program.jvm.opts`` must be set in the ``cdap-sit
 
   <property>
     <name>app.program.jvm.opts</name>
-    <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Dhdp.version=<version> -Dspark.yarn.am.extraJavaOptions=-Dhdp.version=<version></value>
+    <value>${twill.jvm.gc.opts} -Dhdp.version=<version> -Dspark.yarn.am.extraJavaOptions=-Dhdp.version=<version></value>
     <description>Java options for all Apache Twill containers</description>
   </property>
 
@@ -291,7 +291,7 @@ Using the same example as above, substituting ``2.2.6.0-2800`` for ``<version>``
 
   <property>
     <name>app.program.jvm.opts</name>
-    <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Dhdp.version=2.2.6.0-2800 -Dspark.yarn.am.extraJavaOptions=-Dhdp.version=2.2.6.0-2800</value>
+    <value>${twill.jvm.gc.opts} -Dhdp.version=2.2.6.0-2800 -Dspark.yarn.am.extraJavaOptions=-Dhdp.version=2.2.6.0-2800</value>
     <description>Java options for all Apache Twill containers</description>
   </property>
 

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2016-2017 Cask Data, Inc.
+# Copyright © 2016-2018 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -241,7 +241,7 @@ function build_javadocs() {
   fi
   local start=`date`
   cd ${PROJECT_PATH}
-  MAVEN_OPTS="-Xmx4g -XX:MaxPermSize=256m" # match other CDAP builds
+  MAVEN_OPTS="-Xmx4g" # match other CDAP builds
   local temp_repo="${TARGET_PATH}/temp-repo"
   echo "Building temp_repo ${temp_repo}"
   mkdir -p ${temp_repo}

--- a/cdap-docs/developer-manual/source/getting-started/dev-env.rst
+++ b/cdap-docs/developer-manual/source/getting-started/dev-env.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2017 Cask Data, Inc.
+    :copyright: Copyright © 2014-2018 Cask Data, Inc.
 
 .. _dev-env:
 
@@ -133,7 +133,7 @@ To do so, follow these steps:
    1. Select ``Run > Edit`` Configurations...
    #. Add a new "Application" run configuration.
    #. Set "Main class" to be ``co.cask.cdap.StandaloneMain``.
-   #. Set "VM options" to ``-Xmx1024m -XX:MaxPermSize=128m`` (for in-memory MapReduce jobs).
+   #. Set "VM options" to ``-Xmx1024m`` (for in-memory MapReduce jobs).
    #. Click "OK".
    #. You can now use this run configuration to start an instance of CDAP Sandbox.
 

--- a/cdap-docs/developer-manual/source/testing/testing.rst
+++ b/cdap-docs/developer-manual/source/testing/testing.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2017 Cask Data, Inc.
+    :copyright: Copyright © 2014-2018 Cask Data, Inc.
 
 .. _test-cdap:
 
@@ -69,7 +69,7 @@ When running tests from an IDE such IntelliJ or Eclipse, set the memory setting 
 ``JUnit`` tests that are run from the IDE to an increased amount of memory. We suggest
 starting with::
 
-  -Xmx1024m -XX:MaxPermSize=128m
+  -Xmx1024m
 
 .. _test-framework-strategies-flow:
 

--- a/cdap-docs/faqs/source/applications.txt
+++ b/cdap-docs/faqs/source/applications.txt
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2015-2018 Cask Data, Inc.
 
 :titles-only-global-toc: true
 
@@ -87,7 +87,7 @@ There are a number of ways to solve problems with Spark:
 
       <property>
           <name>app.program.jvm.opts</name>
-          <value>-Dhdp.version=${hdp.version} -XX:MaxPermSize=128M ${twill.jvm.gc.opts}</value>
+          <value>-Dhdp.version=${hdp.version} ${twill.jvm.gc.opts}</value>
           <description>Java options for all Apache Twill containers</description>
       </property>
     

--- a/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
+++ b/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2015-2016 Cask Data, Inc.
+  Copyright © 2015-2018 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -655,7 +655,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.14.1</version>
         <configuration>
-          <argLine>-Xmx3g -Djava.awt.headless=true -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true</argLine>
+          <argLine>-Xmx3g -Djava.awt.headless=true -XX:+UseG1GC -Djava.net.preferIPv4Stack=true</argLine>
           <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
           <reuseForks>false</reuseForks>
           <reportFormat>plain</reportFormat>

--- a/cdap-examples/SpamClassifier/src/main/scala/co/cask/cdap/examples/sparkstreaming/SpamClassifierProgram.scala
+++ b/cdap-examples/SpamClassifier/src/main/scala/co/cask/cdap/examples/sparkstreaming/SpamClassifierProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,12 +20,12 @@ import co.cask.cdap.api.common.Bytes
 import co.cask.cdap.api.spark.{AbstractSpark, SparkExecutionContext, SparkMain}
 import com.google.common.base.Strings
 import kafka.serializer.{DefaultDecoder, StringDecoder}
+import org.apache.spark.SparkContext
 import org.apache.spark.mllib.classification.NaiveBayes
 import org.apache.spark.mllib.feature.HashingTF
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.streaming.kafka.KafkaUtils
 import org.apache.spark.streaming.{Seconds, StreamingContext}
-import org.apache.spark.{SparkConf, SparkContext}
 import org.slf4j.{Logger, LoggerFactory}
 
 /**
@@ -46,11 +46,6 @@ class SpamClassifierProgram(name: String) extends AbstractSpark with SparkMain {
     setDescription("Spark Streaming Based Kaka Message Classifier");
     setDriverResources(new Resources(2048))
     setExecutorResources(new Resources(1024))
-  }
-
-
-  override def initialize(): Unit = {
-    getContext().setSparkConf(new SparkConf().set("spark.driver.extraJavaOptions", "-XX:MaxPermSize=256m"))
   }
 
   override def run(implicit sec: SparkExecutionContext) {

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,7 +42,6 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
-import org.apache.spark.SparkConf;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -118,11 +117,6 @@ public class SparkPageRankApp extends AbstractApplication {
       setMainClass(SparkPageRankProgram.class);
       setDriverResources(new Resources(1024));
       setExecutorResources(new Resources(1024));
-    }
-
-    @Override
-    public void initialize() throws Exception {
-      getContext().setSparkConf(new SparkConf().set("spark.driver.extraJavaOptions", "-XX:MaxPermSize=256m"));
     }
   }
 

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/SparkWikipediaClustering.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/SparkWikipediaClustering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -48,10 +48,5 @@ public class SparkWikipediaClustering extends AbstractSpark {
     setName(NAME + "-" + appConfig.clusteringAlgorithm.toUpperCase());
     setDriverResources(new Resources(1024));
     setExecutorResources(new Resources(1024));
-  }
-
-  @Override
-  protected void initialize() throws Exception {
-    getContext().setSparkConf(new SparkConf().set("spark.driver.extraJavaOptions", "-XX:MaxPermSize=256m"));
   }
 }

--- a/cdap-examples/deploy_pom.xml
+++ b/cdap-examples/deploy_pom.xml
@@ -123,7 +123,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.14.1</version>
           <configuration>
-            <argLine>-Xmx2048m -Djava.awt.headless=true -XX:MaxPermSize=256m</argLine>
+            <argLine>-Xmx2048m -Djava.awt.headless=true</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <reportFormat>plain</reportFormat>

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -1,6 +1,6 @@
 :: ##############################################################################
 :: ##
-:: ## Copyright (c) 2014-2017 Cask Data, Inc.
+:: ## Copyright (c) 2014-2018 Cask Data, Inc.
 :: ##
 :: ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 :: ## use this file except in compliance with the License. You may obtain a copy
@@ -38,7 +38,7 @@ REM As JAVACMD can include a space, any use of it needs to be surrounded in doub
 SET "JAVACMD=%JAVA_HOME%\bin\java.exe"
 
 SET DEFAULT_DEBUG_PORT=5005
-SET "DEFAULT_JVM_OPTS=-Xmx3096m -XX:MaxPermSize=256m"
+SET "DEFAULT_JVM_OPTS=-Xmx3096m"
 REM These double-quotes are included in string
 SET HADOOP_HOME_OPTS=-Dhadoop.home.dir="%CDAP_HOME%\libexec"
 SET HIVE_SCRATCH_DIR="%CDAP_HOME%\data\explore\tmp"

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014-2017 Cask Data, Inc.
+  Copyright © 2014-2018 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -1650,7 +1650,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.14.1</version>
           <configuration>
-            <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError</argLine>
+            <argLine>-Xmx5000m -Djava.awt.headless=true -XX:+UseG1GC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <reportFormat>plain</reportFormat>


### PR DESCRIPTION
- Remove usage of MaxPermSize everywhere
  - Useless in Java 8 but print a warning message on startup
- Use G1GC as the default GC