### PR TITLE
CDAP-13415 fix dataproc provisioner tags for firewalls

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
@@ -229,7 +229,7 @@ public class DataProcClient implements AutoCloseable {
       // network is a url like https://www.googleapis.com/compute/v1/projects/<project>/<region>/networks/<name>
       // we want to get the last section of the path and compare to the configured network name
       int idx = firewall.getNetwork().lastIndexOf('/');
-      String networkName = firewall.getNetwork().substring(idx + 1);
+      String networkName = idx >= 0 ? firewall.getNetwork().substring(idx + 1) : firewall.getNetwork();
       if (!networkName.equals(conf.getNetwork())) {
         continue;
       }


### PR DESCRIPTION
Fixing a bug in the dataproc provisioner where it was assuming
that there is always a firewall rule with target tag 'https-server'
that allows ingress traffic to port 443. The provisioner will
now query for firewall rules and make sure to find an ingress
rule for ports 22 and 443, using any target tags from those rules
when creating the cluster.