### PR TITLE
(CDAP-13234) Record the program starting state immediately

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -121,10 +121,6 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
   @Override
   public final RuntimeInfo run(ProgramDescriptor programDescriptor, ProgramOptions options, RunId runId) {
     ProgramId programId = programDescriptor.getProgramId();
-
-    // Publish the program's starting state. We don't know the Twill RunId yet, hence always passing in null.
-    programStateWriter.start(programId.run(runId), options, null, programDescriptor);
-
     ClusterMode clusterMode = ProgramRunners.getClusterMode(options);
 
     // Creates the ProgramRunner based on the cluster mode

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -329,6 +329,10 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         ProgramOptions newProgramOptions = new SimpleProgramOptions(programOptions.getProgramId(),
                                                                     new BasicArguments(systemArgs),
                                                                     programOptions.getUserArguments());
+
+        // Publish the program STARTING state before starting the program
+        programStateWriter.start(programRunId, newProgramOptions, null, programDescriptor);
+
         // start the program run
         tasks.add(() -> {
           String oldUser = SecurityRequestContext.getUserId();


### PR DESCRIPTION
- Recording of the STARTING is fast
- Actual launching of a program is slow
- Decoupling them so we record the starting of the program in the message subscriber tx, but actual launching of the program asynchronously
- Also fixes couple misuse of the waitForStop
  - Safer to make sure a program is running before calling waitForStop,
    otherwise the waitForStop will return immediately if there is
    nothing running yet, since recording of the "STARTING" state in the
    metadata table asynchronous.