### PR TITLE
[CDAP-13382] Uses Provisioner label for all profile references in UI

### DIFF
--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
@@ -24,6 +24,8 @@ import {ADMIN_CONFIG_ACCORDIONS} from 'components/Administration/AdminConfigTabC
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import ActionsPopover from 'components/Cloud/Profiles/ActionsPopover';
+import isEqual from 'lodash/isEqual';
+import {getProvisionerLabel} from 'components/Cloud/Profiles/Store/ActionCreator';
 
 require('./BasicInfo.scss');
 
@@ -36,12 +38,22 @@ export default class ProfileDetailViewBasicInfo extends Component {
     extendedDeleteErrMsg: '',
     deleteLoading: false,
     redirectToListView: false,
+    provisionerLabel: getProvisionerLabel(this.props.profile, this.props.provisioners)
   };
 
   static propTypes = {
     profile: PropTypes.object,
+    provisioners: PropTypes.array,
     isSystem: PropTypes.bool
   };
+
+  componentWillReceiveProps(nextProps) {
+    if (!isEqual(nextProps.provisioners, this.props.provisioners)) {
+      this.setState({
+        provisionerLabel: getProvisionerLabel(nextProps.profile, nextProps.provisioners)
+      });
+    }
+  }
 
   toggleDeleteModal = () => {
     this.setState({
@@ -121,7 +133,7 @@ export default class ProfileDetailViewBasicInfo extends Component {
             <div className="grid-row">
               <div>
                 <IconSVG name="icon-cloud" />
-                <span>{profile.provisioner.name}</span>
+                <span>{this.state.provisionerLabel}</span>
               </div>
               <div>{profile.scope}</div>
               <div />

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/DetailsInfo/DetailsInfo.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/DetailsInfo/DetailsInfo.scss
@@ -16,6 +16,7 @@
 
 @import "../../../../../../styles/variables.scss";
 $details-row-border-color: $grey-05;
+$label-width: 150px;
 
 .profile-detail-view {
   .detail-view-content {
@@ -57,14 +58,21 @@ $details-row-border-color: $grey-05;
           &:nth-child(3) {
             border-top: 1px solid $details-row-border-color;
           }
-          > .value-holder {
-            display: block;
-            width: 100%;
+
+          > .label-holder {
+            width: $label-width;
             text-overflow: ellipsis;
             overflow: hidden;
-            height: 100%;
-            padding: 10px;
             white-space: nowrap;
+          }
+
+          > .value-holder {
+            display: block;
+            width: calc(100% - #{$label-width});
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            padding-left: 10px;
           }
         }
       }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/DetailsInfo/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/DetailsInfo/index.js
@@ -29,7 +29,8 @@ export default class ProfileDetailViewDetailsInfo extends Component {
   };
 
   static propTypes = {
-    profile: PropTypes.object
+    profile: PropTypes.object,
+    provisioners: PropTypes.object
   };
 
   toggleViewDetails = () => {
@@ -64,6 +65,17 @@ export default class ProfileDetailViewDetailsInfo extends Component {
       );
     }
 
+    const propertyToLabelMap = {};
+    this.props.provisioners.forEach(provisioner => {
+      if (provisioner.name === this.props.profile.provisioner.name) {
+        provisioner['configuration-groups'].forEach(provisionerGroup => {
+          provisionerGroup.properties.forEach(prop => {
+            propertyToLabelMap[prop.name] = prop.label;
+          });
+        });
+      }
+    });
+
     return (
       <div className="details-table">
         {
@@ -71,9 +83,15 @@ export default class ProfileDetailViewDetailsInfo extends Component {
             .provisioner
             .properties
             .map(property => {
+              let propertyLabel = propertyToLabelMap[property.name];
               return (
                 <div className="details-row">
-                  <strong>{`${property.name}:`}</strong>
+                  <strong
+                    className="label-holder"
+                    title={propertyLabel}
+                  >
+                    {`${propertyLabel}:`}
+                  </strong>
                   <span
                     className="value-holder"
                     title={property.value}

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Preview/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Preview/index.js
@@ -20,6 +20,7 @@ import {MyCloudApi} from 'api/cloud';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import LoadingSVG from 'components/LoadingSVG';
 import IconSVG from 'components/IconSVG';
+import {getProvisionerLabel} from 'components/Cloud/Profiles/Store/ActionCreator';
 require('./Preview.scss');
 
 export default class ProfilePreview extends Component {
@@ -31,10 +32,16 @@ export default class ProfilePreview extends Component {
   state = {
     profileDetails: null,
     loading: true,
-    error: null
+    error: null,
+    provisioners: []
   };
 
   componentDidMount() {
+    this.getProfileDetails();
+    this.getProvisioners();
+  }
+
+  getProfileDetails() {
     let namespace = getCurrentNamespace();
     if (this.props.profileScope === 'system') {
       namespace = 'system';
@@ -59,6 +66,23 @@ export default class ProfilePreview extends Component {
     );
   }
 
+  getProvisioners() {
+    MyCloudApi
+      .getProvisioners()
+      .subscribe(
+        (provisioners) => {
+          this.setState({
+            provisioners
+          });
+        },
+        (error) => {
+          this.setState({
+            error: error.response || error
+          });
+        }
+      );
+  }
+
   render() {
     if (this.state.loading) {
       return (
@@ -69,6 +93,8 @@ export default class ProfilePreview extends Component {
     }
     let profileNamespace = this.state.profileDetails.scope === 'SYSTEM' ? 'system' : getCurrentNamespace();
     let profileDetailsLink = `${location.protocol}//${location.host}/cdap/ns/${profileNamespace}/profiles/details/${this.props.profileName}`;
+    let profileProvisionerLabel = getProvisionerLabel(this.state.profileDetails, this.state.provisioners);
+
     return (
       <div className="profile-preview text-xs-left">
         <strong>{this.props.profileName}</strong>
@@ -92,7 +118,7 @@ export default class ProfilePreview extends Component {
               <div>
                 <IconSVG name="icon-cloud" />
                 <span className="provisioner-name truncate-text">
-                  {this.state.profileDetails.provisioner.name}
+                  {profileProvisionerLabel}
                 </span>
               </div>
               <div className="truncate-text">

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/ActionCreator.js
@@ -141,3 +141,15 @@ export const resetProfiles = () => {
     type: PROFILES_ACTIONS.RESET
   });
 };
+
+export const getProvisionerLabel = (profile, provisioners) => {
+  if (provisioners.length) {
+    let matchingProvisioner = provisioners.find((prov) => {
+      return prov.name === profile.provisioner.name;
+    });
+    if (matchingProvisioner) {
+      return matchingProvisioner.label;
+    }
+  }
+  return profile.provisioner.name;
+};

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/ProfilesListView.js
@@ -1,0 +1,293 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import {MyCloudApi} from 'api/cloud';
+import {getCurrentNamespace} from 'services/NamespaceStore';
+import LoadingSVG from 'components/LoadingSVG';
+import classnames from 'classnames';
+import IconSVG from 'components/IconSVG';
+import {MyPreferenceApi} from 'api/preference';
+import {Observable} from 'rxjs/Observable';
+import PipelineDetailStore from 'components/PipelineDetails/store';
+
+require('./ListViewInPipeline.scss');
+
+export const PROFILE_NAME_PREFERENCE_PROPERTY = 'system.profile.name';
+export default class ProfilesListViewInPipeline extends Component {
+
+  static propTypes = {
+    onProfileSelect: PropTypes.func,
+    selectedProfile: PropTypes.object,
+    tableTitle: PropTypes.string,
+    disabled: PropTypes.bool
+  };
+
+  static defaultProps = {
+    selectedProfile: {},
+    disabled: false
+  };
+
+  state = {
+    profiles: [],
+    provisionersMap: {},
+    loading: true,
+    selectedProfile: this.props.selectedProfile.name || null
+  };
+
+  componentWillReceiveProps(nextProps) {
+    if (this.state.selectedProfile !== nextProps.selectedProfile.name) {
+      this.setState({
+        selectedProfile: nextProps.selectedProfile.name
+      });
+    }
+  }
+
+  componentWillMount() {
+    this.getProfiles();
+    this.getProvisionersMap();
+  }
+
+  getProfiles() {
+    let appId = PipelineDetailStore.getState().name;
+    Observable.forkJoin(
+      MyCloudApi.list({ namespace: getCurrentNamespace() }),
+      MyCloudApi.list({ namespace: 'system' }),
+      MyPreferenceApi.getAppPreferences({
+        namespace: getCurrentNamespace(),
+        appId
+      })
+    )
+      .subscribe(
+        ([profiles = [], systemProfiles = [], preferences = {}]) => {
+          let selectedProfile = preferences[PROFILE_NAME_PREFERENCE_PROPERTY] || this.state.selectedProfile;
+          let allProfiles = profiles.concat(systemProfiles);
+          this.setState({
+            loading: false,
+            profiles: allProfiles,
+            selectedProfile
+          });
+        },
+        (err) => {
+          this.setState({
+            error: err.response || err
+          });
+          console.log('ERROR in fetching profiles from backend: ', err);
+        }
+      );
+  }
+
+  getProvisionersMap() {
+    MyCloudApi
+      .getProvisioners()
+      .subscribe(
+        (provisioners) => {
+          let provisionersMap = {};
+          provisioners.forEach(provisioner => {
+            provisionersMap[provisioner.name] = provisioner.label;
+          });
+          this.setState({
+            provisionersMap
+          });
+        },
+        (err) => {
+          this.setState({
+            error: err.response || err
+          });
+          console.log('ERROR in fetching provisioners from backend: ', err);
+        }
+      );
+  }
+
+  onProfileSelect = (profileName) => {
+    if (this.props.disabled) {
+      return;
+    }
+    this.setState({
+      selectedProfile: profileName
+    });
+    if (this.props.onProfileSelect) {
+      this.props.onProfileSelect(profileName);
+    }
+  };
+
+  renderGridHeader = () => {
+    return (
+      <div className="grid-header">
+        <div className="grid-row">
+          <div></div>
+          <strong>Profile Name</strong>
+          <strong>Provisioner</strong>
+          <strong>Scope</strong>
+          <strong />
+        </div>
+      </div>
+    );
+  };
+
+  renderGridBody = () => {
+    if (this.props.disabled) {
+      let match = this.state.profiles.filter(profile => profile.name === this.state.selectedProfile);
+      if (match.length) {
+        return (
+          match.map(profile => {
+            let profileNamespace = profile.scope === 'SYSTEM' ? 'system' : getCurrentNamespace();
+            let profileDetailsLink = `${location.protocol}//${location.host}/cdap/ns/${profileNamespace}/profiles/details/${profile.name}`;
+            let profileName = profile.scope === 'SYSTEM' ? `system:${profile.name}` : `user:${profile.name}`;
+            let provisionerName = profile.provisioner.name;
+            let provisionerLabel = this.state.provisionersMap[provisionerName] || provisionerName;
+
+            return (
+              <div
+                className={classnames("grid-row grid-link", {
+                  "active": this.state.selectedProfile === profileName
+                })}
+              >
+                <div onClick={this.onProfileSelect.bind(this, profileName)}>
+                  {
+                    this.state.selectedProfile === profileName ? (
+                      <IconSVG name="icon-check" className="text-success" />
+                    ) : null
+                  }
+                </div>
+                <div onClick={this.onProfileSelect.bind(this, profileName)}>
+                  {profile.name}
+                </div>
+                <div onClick={this.onProfileSelect.bind(this, profileName)}>
+                  {provisionerLabel}
+                </div>
+                <div onClick={this.onProfileSelect.bind(this, profileName)}>
+                  {profile.scope}
+                </div>
+                <div>
+                  <a href={profileDetailsLink}>
+                    View
+                  </a>
+                </div>
+              </div>
+            );
+          })
+        );
+      }
+    }
+    return (
+      <div className="grid-body">
+        {
+          this.state.profiles.map(profile => {
+            let profileNamespace = profile.scope === 'SYSTEM' ? 'system' : getCurrentNamespace();
+            let profileDetailsLink = `${location.protocol}//${location.host}/cdap/ns/${profileNamespace}/profiles/details/${profile.name}`;
+            let profileName = profile.scope === 'SYSTEM' ? `system:${profile.name}` : `user:${profile.name}`;
+            let provisionerName = profile.provisioner.name;
+            let provisionerLabel = this.state.provisionersMap[provisionerName] || provisionerName;
+
+            return (
+              <div
+                className={classnames("grid-row grid-link", {
+                  "active": this.state.selectedProfile === profileName
+                })}
+              >
+                {
+                  /*
+                    There is an onClick handler on each cell except the last one.
+                    This is to prevent the user from selecting a profile while trying to click on the details link
+                  */
+                }
+                <div onClick={this.onProfileSelect.bind(this, profileName)}>
+                  {
+                    this.state.selectedProfile === profileName ? (
+                      <IconSVG name="icon-check" className="text-success" />
+                    ) : null
+                  }
+                </div>
+                <div onClick={this.onProfileSelect.bind(this, profileName)}>
+                  {profile.name}
+                </div>
+                <div onClick={this.onProfileSelect.bind(this, profileName)}>
+                  {provisionerLabel}
+                </div>
+                <div onClick={this.onProfileSelect.bind(this, profileName)}>
+                  {profile.scope}
+                </div>
+                <div>
+                  <a href={profileDetailsLink}> View </a>
+                </div>
+              </div>
+            );
+          })
+        }
+      </div>
+    );
+  };
+
+  renderGrid = () => {
+    if (!this.state.profiles.length) {
+      return (
+        <div>
+          <strong> No Profiles created </strong>
+          <div>
+            <a href={`/cdap/ns/${getCurrentNamespace()}/profiles/create`}>
+              Click here
+            </a>
+            <span> to create one </span>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="profiles-listview grid-wrapper">
+        <strong>{this.props.tableTitle}</strong>
+        {
+          this.props.disabled ?
+            null
+          :
+            <div className="profiles-count text-right">{this.state.profiles.length} Compute Profiles</div>
+        }
+        <div className={classnames('grid grid-container', {
+          disabled: this.props.disabled
+        })}>
+          {this.renderGridHeader()}
+          {this.renderGridBody()}
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+    if (this.state.loading) {
+      return (
+        <div>
+          <LoadingSVG />
+        </div>
+      );
+    }
+    if (this.props.disabled) {
+      let match = this.state.profiles.filter(profile => profile.name === this.state.selectedProfile);
+      if (!match.length) {
+        return (
+          <div className="profiles-list-view-on-pipeline empty-container">
+            <h4>No Profile selected</h4>
+          </div>
+        );
+      }
+    }
+    return (
+      <div className="profiles-list-view-on-pipeline">
+        {this.renderGrid()}
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
@@ -45,7 +45,8 @@ export default class ProfilesListViewInPipeline extends Component {
     selectedProfile: PropTypes.object,
     tableTitle: PropTypes.string,
     showProfilesCount: PropTypes.bool,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+    provisionersMap: PropTypes.object
   };
 
   static defaultProps = {
@@ -56,6 +57,7 @@ export default class ProfilesListViewInPipeline extends Component {
 
   state = {
     profiles: [],
+    provisionersMap: {},
     loading: true,
     selectedProfile: this.props.selectedProfile.name || '',
     profileCustomizations: this.props.selectedProfile.profileCustomizations || {}
@@ -116,6 +118,29 @@ export default class ProfilesListViewInPipeline extends Component {
       );
   }
 
+  componentDidMount() {
+    this.getProvisionersMap();
+  }
+
+  getProvisionersMap() {
+    MyCloudApi
+      .getProvisioners()
+      .subscribe(
+        (provisioners) => {
+          let provisionersMap = {};
+          provisioners.forEach(provisioner => {
+            provisionersMap[provisioner.name] = provisioner.label;
+          });
+          this.setState({
+            provisionersMap
+          });
+        },
+        (err) => {
+          console.log('ERROR in fetching provisioners from backend: ', err);
+        }
+      );
+  }
+
   onProfileSelect = (profileName, customizations = {}) => {
     if (this.props.disabled) {
       return;
@@ -153,6 +178,8 @@ export default class ProfilesListViewInPipeline extends Component {
     let profileName = profile.scope === 'SYSTEM' ? `system:${profile.name}` : `user:${profile.name}`;
     let selectedProfile = this.state.selectedProfile || '';
     selectedProfile = extractProfileName(selectedProfile);
+    let provisionerName = profile.provisioner.name;
+    let provisionerLabel = this.state.provisionersMap[provisionerName] || provisionerName;
     return (
       <div
         key={profileName}
@@ -174,8 +201,7 @@ export default class ProfilesListViewInPipeline extends Component {
           }
         </div>
         <div onClick={this.onProfileSelectWithoutCustomization.bind(this, profileName)}>{profile.name}</div>
-
-        <div onClick={this.onProfileSelectWithoutCustomization.bind(this, profileName)}>{profile.provisioner.name}</div>
+        <div onClick={this.onProfileSelectWithoutCustomization.bind(this, profileName)}>{provisionerLabel}</div>
         <div onClick={this.onProfileSelectWithoutCustomization.bind(this, profileName)}>{profile.scope}</div>
         <div>
           <a href={profileDetailsLink}> View </a>

--- a/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
@@ -21,6 +21,7 @@ import IconSVG from 'components/IconSVG';
 import {DropdownToggle, DropdownMenu} from 'reactstrap';
 import {setSelectedProfile} from 'components/PipelineScheduler/Store/ActionCreator';
 import {connect} from 'react-redux';
+import {preventPropagation} from 'services/helpers';
 import StatusMapper from 'services/StatusMapper';
 import ProfilesListView, {extractProfileName} from 'components/PipelineDetails/ProfilesListView';
 
@@ -52,6 +53,11 @@ class ProfilesForSchedule extends Component {
     });
   }
 
+  selectProfile = (profileName, e) => {
+    setSelectedProfile(profileName);
+    preventPropagation(e);
+  };
+
   renderProfilesTable = () => {
     let isScheduled = this.props.scheduleStatus === StatusMapper.statusMap['SCHEDULED'];
     let selectedProfile = {
@@ -70,6 +76,12 @@ class ProfilesForSchedule extends Component {
 
   renderProfilesDropdown = () => {
     let isScheduled = this.props.scheduleStatus === StatusMapper.statusMap['SCHEDULED'];
+    let provisionerLabel;
+    if (this.state.selectedProfile) {
+      let provisionerName = this.state.selectedProfile.provisioner.name;
+      provisionerLabel = this.state.provisionersMap[provisionerName] || provisionerName;
+    }
+
     return (
       <UncontrolledDropdown
         className={PROFILES_DROPDOWN_DOM_CLASS}
@@ -82,7 +94,7 @@ class ProfilesForSchedule extends Component {
         >
           {
             this.state.selectedProfile ?
-              <span> {`${extractProfileName(this.state.selectedProfile)}`}</span>
+              <span> {`${extractProfileName(this.state.selectedProfile)} (${provisionerLabel})`}</span>
             :
               <span>Select a Profile</span>
           }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13382

Currently when we list out profiles and their associated provisioner, we use the provisioner id/name (e.g. `gce-dataproc`) instead of its label (e.g. `GCE DataProc Provisioner`). This PR switches to using the provisioner label when it's available, and falls back to using the id when it's not, since someone can add a new provisioner without a `label` property.