### PR TITLE
(CDAP-13418) Spark runtime in cloud

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunnerTxTimeoutTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunnerTxTimeoutTest.java
@@ -89,7 +89,7 @@ public class DistributedProgramRunnerTxTimeoutTest {
     serviceRunner = new DistributedServiceProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null);
     workerRunner = new DistributedWorkerProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null);
     mapreduceRunner = new DistributedMapReduceProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null);
-    sparkRunner = new DistributedSparkProgramRunner(SparkCompat.SPARK1_2_10, cConf, yConf, null, null, null,
+    sparkRunner = new DistributedSparkProgramRunner(SparkCompat.SPARK1_2_10, cConf, yConf, null, null,
                                                     ClusterMode.ON_PREMISE, null);
     workflowRunner = new DistributedWorkflowProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null, null);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/ConstantTransactionSystemClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/ConstantTransactionSystemClient.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.guice;
+
+import org.apache.tephra.InvalidTruncateTimeException;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionFailureException;
+import org.apache.tephra.TransactionNotInProgressException;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.TransactionType;
+import org.apache.tephra.TxConstants;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * An implementation of {@link TransactionSystemClient} that it always use the same Transaction for all transactions.
+ * This class is a temporary workaround for transactional operations in environments that doesn't really support/need
+ * transaction, until we can remove the strong dependency on Transaction in the runtime system.
+ */
+class ConstantTransactionSystemClient implements TransactionSystemClient {
+
+  public static final Transaction SHORT_TX = new Transaction(Long.MAX_VALUE - 1, 1, new long[0], new long[0],
+                                                             Transaction.NO_TX_IN_PROGRESS, TransactionType.SHORT);
+  public static final Transaction LONG_TX = new Transaction(Long.MAX_VALUE - 1, 1, new long[0], new long[0],
+                                                            Transaction.NO_TX_IN_PROGRESS, TransactionType.LONG);
+
+  @Override
+  public Transaction startShort() {
+    return SHORT_TX;
+  }
+
+  @Override
+  public Transaction startShort(int timeout) {
+    return startShort();
+  }
+
+  @Override
+  public Transaction startLong() {
+    return LONG_TX;
+  }
+
+  @Override
+  public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    return true;
+  }
+
+  @Override
+  public void canCommitOrThrow(Transaction tx, Collection<byte[]> changeIds) throws TransactionFailureException {
+    // no-op
+  }
+
+  @Override
+  public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    return true;
+  }
+
+  @Override
+  public void commitOrThrow(Transaction tx) throws TransactionFailureException {
+    // no-op
+  }
+
+  @Override
+  public void abort(Transaction tx) {
+    // no-op
+  }
+
+  @Override
+  public boolean invalidate(long tx) {
+    return true;
+  }
+
+  @Override
+  public Transaction checkpoint(Transaction tx) throws TransactionNotInProgressException {
+    return tx;
+  }
+
+  @Override
+  public InputStream getSnapshotInputStream() throws TransactionCouldNotTakeSnapshotException {
+    throw new UnsupportedOperationException("getSnapshotInputStream is not supported");
+  }
+
+  @Override
+  public String status() {
+    return TxConstants.STATUS_OK;
+  }
+
+  @Override
+  public void resetState() {
+    // no-op
+  }
+
+  @Override
+  public boolean truncateInvalidTx(Set<Long> invalidTxIds) {
+    return true;
+  }
+
+  @Override
+  public boolean truncateInvalidTxBefore(long time) throws InvalidTruncateTimeException {
+    return true;
+  }
+
+  @Override
+  public int getInvalidSize() {
+    return 0;
+  }
+
+  @Override
+  public void pruneNow() {
+    // no-op
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/UnsupportedPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/UnsupportedPluginFinder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.guice;
+
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginSelector;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
+import co.cask.cdap.internal.app.runtime.artifact.PluginFinder;
+import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+
+import java.util.Map;
+
+/**
+ * A {@link PluginFinder} implementation that throws {@link UnsupportedOperationException} on
+ * every method call. This is used in runtime environment that dynamic plugin loading is not supported.
+ */
+public class UnsupportedPluginFinder implements PluginFinder {
+
+  @Override
+  public Map.Entry<ArtifactDescriptor, PluginClass> findPlugin(NamespaceId pluginNamespaceId,
+                                                               ArtifactId parentArtifactId, String pluginType,
+                                                               String pluginName, PluginSelector selector)
+    throws PluginNotExistsException {
+
+    throw new UnsupportedOperationException("Dynamic plugin configuration is not supported");
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ProgramLaunchConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ProgramLaunchConfig.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.distributed;
 
 import ch.qos.logback.classic.Level;
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.twill.HadoopClassExcluder;
 import co.cask.cdap.internal.app.runtime.SystemArguments;
 import com.google.common.collect.Iterables;
@@ -46,7 +47,22 @@ public final class ProgramLaunchConfig {
   private final Map<String, RunnableDefinition> runnables = new HashMap<>();
   private final List<Set<String>> launchOrder = new ArrayList<>();
   private final Set<Class<?>> extraDependencies = new HashSet<>();
+  private final Map<String, String> extraSystemArguments = new HashMap<>();
   private ClassAcceptor classAcceptor = new HadoopClassExcluder();
+
+  /**
+   * Adds extra system arguments that will be available through the {@link ProgramOptions#getArguments()}
+   * in the program container.
+   */
+  public ProgramLaunchConfig addExtraSystemArguments(Map<String, String> args) {
+    extraSystemArguments.putAll(args);
+    return this;
+  }
+
+  public ProgramLaunchConfig addExtraSystemArgument(String key, String value) {
+    extraSystemArguments.put(key, value);
+    return this;
+  }
 
   public ProgramLaunchConfig addExtraResources(Map<String, LocalizeResource> resources) {
     extraResources.putAll(resources);
@@ -99,6 +115,13 @@ public final class ProgramLaunchConfig {
   public ProgramLaunchConfig addExtraDependencies(Iterable<? extends Class<?>> classes) {
     Iterables.addAll(extraDependencies, classes);
     return this;
+  }
+
+  /**
+   * Returns the set of extra system arguments.
+   */
+  public Map<String, String> getExtraSystemArguments() {
+    return extraSystemArguments;
   }
 
   public Map<String, LocalizeResource> getExtraResources() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
@@ -16,17 +16,22 @@
 
 package co.cask.cdap.internal.app.runtime.distributed;
 
+import co.cask.cdap.app.guice.ClusterMode;
 import co.cask.cdap.app.guice.DefaultProgramRunnerFactory;
 import co.cask.cdap.app.guice.DistributedArtifactManagerModule;
+import co.cask.cdap.app.guice.UnsupportedPluginFinder;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
+import co.cask.cdap.internal.app.runtime.artifact.PluginFinder;
 import co.cask.cdap.internal.app.runtime.batch.MapReduceProgramRunner;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramRunner;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
@@ -34,6 +39,9 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.TwillRunnable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The {@link TwillRunnable} for running a workflow driver.
@@ -54,8 +62,21 @@ public final class WorkflowTwillRunnable extends AbstractProgramTwillRunnable<Wo
   @Override
   protected Module createModule(CConfiguration cConf, Configuration hConf,
                                 ProgramOptions programOptions, ProgramRunId programRunId) {
-    Module module = super.createModule(cConf, hConf, programOptions, programRunId);
-    return Modules.combine(module, new DistributedArtifactManagerModule(), new PrivateModule() {
+    List<Module> modules = new ArrayList<>();
+
+    modules.add(super.createModule(cConf, hConf, programOptions, programRunId));
+    if (ProgramRunners.getClusterMode(programOptions) == ClusterMode.ON_PREMISE) {
+      modules.add(new DistributedArtifactManagerModule());
+    } else {
+      modules.add(new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(PluginFinder.class).to(UnsupportedPluginFinder.class);
+        }
+      });
+    }
+
+    modules.add(new PrivateModule() {
       @Override
       protected void configure() {
         // Bind ProgramRunner for MR, which is used by Workflow.
@@ -73,5 +94,7 @@ public final class WorkflowTwillRunnable extends AbstractProgramTwillRunnable<Wo
         expose(ProgramRunnerFactory.class);
       }
     });
+
+    return Modules.combine(modules);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/DefaultSSHContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/DefaultSSHContext.java
@@ -21,8 +21,13 @@ import co.cask.cdap.common.ssh.SSHConfig;
 import co.cask.cdap.runtime.spi.ssh.SSHContext;
 import co.cask.cdap.runtime.spi.ssh.SSHPublicKey;
 import co.cask.cdap.runtime.spi.ssh.SSHSession;
+import com.google.common.io.ByteStreams;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -30,24 +35,46 @@ import java.util.Map;
  */
 public class DefaultSSHContext implements SSHContext {
 
+  private final LocationFactory locationFactory;
   private final SSHKeyInfo sshKeyInfo;
 
-  public DefaultSSHContext(SSHKeyInfo sshKeyInfo) {
+  public DefaultSSHContext(LocationFactory locationFactory, SSHKeyInfo sshKeyInfo) {
+    this.locationFactory = locationFactory;
     this.sshKeyInfo = sshKeyInfo;
   }
 
   @Override
   public SSHPublicKey getSSHPublicKey() {
-    return new SSHPublicKey(sshKeyInfo.getUsername(), sshKeyInfo.getPublicKey());
+    try {
+      Location location = locationFactory.create(sshKeyInfo.getKeyDirectory()).append(sshKeyInfo.getPublicKeyFile());
+      try (InputStream is = location.getInputStream()) {
+        return new SSHPublicKey(sshKeyInfo.getUsername(),
+                                new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8));
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read public key from "
+                                   + sshKeyInfo.getKeyDirectory() + "/" + sshKeyInfo.getPublicKeyFile(), e);
+    }
   }
 
   @Override
   public SSHSession createSSHSession(String host, int port, Map<String, String> configs) throws IOException {
+    byte[] privateKey;
+    try {
+      Location location = locationFactory.create(sshKeyInfo.getKeyDirectory()).append(sshKeyInfo.getPrivateKeyFile());
+      try (InputStream is = location.getInputStream()) {
+        privateKey = ByteStreams.toByteArray(is);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read private key from "
+                                   + sshKeyInfo.getKeyDirectory() + "/" + sshKeyInfo.getPrivateKeyFile(), e);
+    }
+
     SSHConfig config = SSHConfig.builder(host)
       .setPort(port)
       .addConfigs(configs)
       .setUser(sshKeyInfo.getUsername())
-      .setPrivateKey(sshKeyInfo.getPrivateKey())
+      .setPrivateKey(privateKey)
       .build();
 
     return new DefaultSSHSession(config);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
@@ -52,7 +52,6 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -320,13 +319,12 @@ public class ProvisioningService extends AbstractIdleService {
       os.write(privateKey);
     }
 
-    return new SSHKeyInfo(keysDir.toURI(), publicKeyFile.getName(), privateKeyFile.getName(),
-                          new String(publicKey, StandardCharsets.UTF_8), privateKey, "cdap");
+    return new SSHKeyInfo(keysDir.toURI(), publicKeyFile.getName(), privateKeyFile.getName(), "cdap");
   }
 
   @Nullable
   private SSHContext createSSHContext(@Nullable SSHKeyInfo keyInfo) {
-    return keyInfo == null ? null : new DefaultSSHContext(keyInfo);
+    return keyInfo == null ? null : new DefaultSSHContext(locationFactory, keyInfo);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/SSHKeyInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/SSHKeyInfo.java
@@ -26,17 +26,12 @@ public final class SSHKeyInfo {
   private final URI keyDirectory;
   private final String publicKeyFile;
   private final String privateKeyFile;
-  private final String publicKey;
-  private final byte[] privateKey;
   private final String username;
 
-  SSHKeyInfo(URI keyDirectory, String publicKeyFile, String privateKeyFile,
-             String publicKey, byte[] privateKey, String username) {
+  SSHKeyInfo(URI keyDirectory, String publicKeyFile, String privateKeyFile, String username) {
     this.keyDirectory = keyDirectory;
     this.publicKeyFile = publicKeyFile;
     this.privateKeyFile = privateKeyFile;
-    this.publicKey = publicKey;
-    this.privateKey = privateKey;
     this.username = username;
   }
 
@@ -50,14 +45,6 @@ public final class SSHKeyInfo {
 
   public String getPrivateKeyFile() {
     return privateKeyFile;
-  }
-
-  public String getPublicKey() {
-    return publicKey;
-  }
-
-  public byte[] getPrivateKey() {
-    return privateKey;
   }
 
   public String getUsername() {

--- a/cdap-app-fabric/src/main/resources/setupSpark.py
+++ b/cdap-app-fabric/src/main/resources/setupSpark.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+#
+# Copyright © 2018 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# A simple python that runs with spark-submit to grab all SPARK environment variables
+import os
+for key, val in os.environ.items():
+    if key.startswith("SPARK_") or key.startswith("HADOOP_"):
+        print("export {}=\"{}\"".format(key, val))

--- a/cdap-app-fabric/src/main/resources/setupSpark.sh
+++ b/cdap-app-fabric/src/main/resources/setupSpark.sh
@@ -1,0 +1,20 @@
+# Copyright © 2018 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# Shell script to optionally setup spark environment variables for CDAP to use
+#!/bin/bash
+
+if [[ $(which spark-submit 2>/dev/null) ]]; then
+  spark-submit --master local[2] $1
+fi

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramCompletion.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramCompletion.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+/**
+ * An interface for notifying the completion of the user spark program execution.
+ */
+public interface SparkProgramCompletion {
+
+  void completed();
+
+  void completedWithException(Throwable t);
+}

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
@@ -44,11 +44,16 @@ public class SparkRuntimeContextConfig {
     .create();
 
   /**
-   * Configuration key for boolean value to tell whether Spark program is executed on a cluster or not.
+   * Program option key for boolean value to tell whether Spark program is executed on in distributed mode or not.
    */
-  public static final String HCONF_ATTR_CLUSTER_MODE = "cdap.spark.cluster.mode";
-  public static final String HCONF_ATTR_CREDENTIALS_UPDATE_INTERVAL_MS = "cdap.spark.credentials.update.interval.ms";
+  public static final String DISTRIBUTED_MODE = "cdap.spark.distributed.mode";
 
+  /**
+   * Program option key for delegation token update interval in milliseconds.
+   */
+  public static final String CREDENTIALS_UPDATE_INTERVAL_MS = "cdap.spark.credentials.update.interval.ms";
+
+  // Following are keys in the hConf for serializing program related information
   private static final String HCONF_ATTR_APP_SPEC = "cdap.spark.app.spec";
   private static final String HCONF_ATTR_PROGRAM_ID = "cdap.spark.program.id";
   private static final String HCONF_ATTR_PROGRAM_OPTIONS = "cdap.spark.program.options";
@@ -59,8 +64,8 @@ public class SparkRuntimeContextConfig {
   /**
    * Returns {@code true} if running in local mode.
    */
-  static boolean isLocal(Configuration hConf) {
-    return !hConf.getBoolean(HCONF_ATTR_CLUSTER_MODE, false);
+  static boolean isLocal(ProgramOptions programOptions) {
+    return !Boolean.parseBoolean(programOptions.getArguments().getOption(DISTRIBUTED_MODE));
   }
 
   /**
@@ -75,13 +80,6 @@ public class SparkRuntimeContextConfig {
    */
   public Configuration getConfiguration() {
     return hConf;
-  }
-
-  /**
-   * Returns true if in local mode.
-   */
-  public boolean isLocal() {
-    return isLocal(hConf);
   }
 
   /**

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionService.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionService.java
@@ -127,9 +127,14 @@ public final class SparkExecutionService extends AbstractIdleService {
     httpServer.stop();
   }
 
+  /**
+   * Shutdown this service without waiting for the `completed` call from the {@link SparkDriverService}.
+   * This method is used when the Spark application is terminated due to error, as there is no guarantees whether
+   * the `completed` call will be received or not.
+   */
   public void shutdownNow() {
     stopLatch.countDown();
-    stop();
+    stopAndWait();
   }
 
   /**

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/LocalSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/submit/LocalSparkSubmitter.java
@@ -18,7 +18,6 @@ package co.cask.cdap.app.runtime.spark.submit;
 
 import co.cask.cdap.app.runtime.spark.SparkMainWrapper;
 import com.google.common.collect.ImmutableList;
-import org.apache.twill.common.Cancellable;
 
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -51,6 +50,6 @@ public class LocalSparkSubmitter extends AbstractSparkSubmitter {
   protected void triggerShutdown() {
     // We just stop the SparkMainWrapper directly. Through the SparkClassLoader, we make sure that Spark
     // sees the same SparkMainWrapper class as this one
-    SparkMainWrapper.cancellable().cancel();
+    SparkMainWrapper.stop();
   }
 }


### PR DESCRIPTION
The changes has been broken down into commits. Please review one by one.

1. Handle exception from user spark program correctly to allow multiple attempts
   - This is a bug fix discovered along the way
2. Don’t store key content in memory and don’t serialize them
  - Yet another bug fix
3. Remove instance dependency on TokenSecureStoreRenewer
   - Just simplifying dependencies
4. Support Spark in Cloud
  - This is the final integration work