### PR TITLE
[CDAP-13461] Cloud/pipeline cleanup

### DIFF
--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/PropertiesTab.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/PropertiesTab.js
@@ -25,7 +25,7 @@ export default function PropertiesTab({entity}) {
     <div className="properties-container">
       <div className="message-section">
         <strong>
-          {T.translate('features.DetailView.PropertiesTab.title', { entityType: 'Application', entityId: entity.name })}
+          {T.translate('features.DetailView.PropertiesTab.title', { entityType: 'application', entityId: entity.name })}
         </strong>
       </div>
 

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/PropertiesTab.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/Tabs/PropertiesTab.js
@@ -25,7 +25,7 @@ export default function PropertiesTab({entity}) {
     <div className="properties-container">
       <div className="message-section">
         <strong>
-          {T.translate('features.DetailView.PropertiesTab.title', { entityType: 'Dataset', entityId: entity.id })}
+          {T.translate('features.DetailView.PropertiesTab.title', { entityType: 'dataset', entityId: entity.id })}
         </strong>
       </div>
 

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -18,7 +18,6 @@ import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
 import isObject from 'lodash/isObject';
-import upperFirst from 'lodash/upperFirst';
 import orderBy from 'lodash/orderBy';
 import isEmpty from 'lodash/isEmpty';
 import T from 'i18n-react';
@@ -37,6 +36,8 @@ export const PREFERENCES_LEVEL = {
   SYSTEM: 'SYSTEM',
   NAMESPACE: 'NAMESPACE'
 };
+
+const PREFIX = 'features.FastAction.SetPreferences';
 
 export default class SetPreferenceModal extends Component {
   constructor(props) {
@@ -274,31 +275,31 @@ export default class SetPreferenceModal extends Component {
   }
 
   renderSpecifyPreferences() {
-    const actionLabel = T.translate('features.FastAction.setPreferencesActionLabel');
+    const actionLabel = T.translate(`${PREFIX}.actionLabel`);
     let entity, entityWithType, description, tooltipID;
     if (this.props.setAtLevel === PREFERENCES_LEVEL.SYSTEM) {
       entityWithType = 'CDAP';
-      description = T.translate('features.FastAction.setPreferencesDescriptionLabel.system');
+      description = T.translate(`${PREFIX}.DescriptionLabel.system`);
       tooltipID = `${entityWithType}-title`;
     } else {
       entity = this.params.namespace;
-      entityWithType = `Namespace "${entity}"`;
-      description = T.translate('features.FastAction.setPreferencesDescriptionLabel.namespace');
+      entityWithType = `namespace "${entity}"`;
+      description = T.translate(`${PREFIX}.DescriptionLabel.namespace`);
       tooltipID = `${entity}-title`;
       if (this.props.entity) {
         entity = this.props.entity.id;
-        entityWithType = `${upperFirst(this.props.entity.type)} "${entity}"`;
+        entityWithType = `${this.props.entity.type} "${entity}"`;
         tooltipID = `${this.props.entity.uniqueId}-title`;
         if (this.props.entity.type === 'application') {
-          description = T.translate('features.FastAction.setPreferencesDescriptionLabel.app');
+          description = T.translate(`${PREFIX}.DescriptionLabel.app`);
         } else {
-          description = T.translate('features.FastAction.setPreferencesDescriptionLabel.program');
+          description = T.translate(`${PREFIX}.DescriptionLabel.program`);
         }
       }
     }
     const title = `${actionLabel} for ${entityWithType}`;
-    const keyLabel = T.translate('features.FastAction.setPreferencesColumnLabel.key');
-    const valueLabel = T.translate('features.FastAction.setPreferencesColumnLabel.value');
+    const keyLabel = T.translate(`${PREFIX}.ColumnLabel.key`);
+    const valueLabel = T.translate(`${PREFIX}.ColumnLabel.value`);
     return (
       <div>
         {
@@ -380,9 +381,9 @@ export default class SetPreferenceModal extends Component {
     if (!this.getInheritedPreferencesApi) {
       return null;
     }
-    const titleLabel = T.translate('features.FastAction.setPreferencesInheritedPrefsLabel');
-    const keyLabel = T.translate('features.FastAction.setPreferencesColumnLabel.key');
-    const valueLabel = T.translate('features.FastAction.setPreferencesColumnLabel.value');
+    const titleLabel = T.translate(`${PREFIX}.inheritedPrefsLabel`);
+    const keyLabel = T.translate(`${PREFIX}.ColumnLabel.key`);
+    const valueLabel = T.translate(`${PREFIX}.ColumnLabel.value`);
     let numInheritedPreferences = this.state.inheritedPreferences.length;
     return (
       <div>
@@ -418,7 +419,7 @@ export default class SetPreferenceModal extends Component {
             </div>
           :
             <div className="text-xs-center">
-              No Inherited Preferences
+              {T.translate(`${PREFIX}.noInheritedPrefs`)}
             </div>
         }
         </div>
@@ -427,10 +428,10 @@ export default class SetPreferenceModal extends Component {
   }
 
   render() {
-    const modalLabel = T.translate('features.FastAction.setPreferencesModalLabel');
-    const savingLabel = T.translate('features.FastAction.setPreferencesButtonLabel.saving');
-    const saveAndCloseLabel = T.translate('features.FastAction.setPreferencesButtonLabel.saveAndClose');
-    const resetLink = T.translate('features.FastAction.setPreferencesReset');
+    const modalLabel = T.translate(`${PREFIX}.modalLabel`);
+    const savingLabel = T.translate(`${PREFIX}.ButtonLabel.saving`);
+    const saveAndCloseLabel = T.translate(`${PREFIX}.ButtonLabel.saveAndClose`);
+    const resetLink = T.translate(`${PREFIX}.reset`);
     return (
       <Modal
         isOpen={this.props.isOpen}

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,6 +24,8 @@ import classnames from 'classnames';
 import SetPreferenceModal, {PREFERENCES_LEVEL} from 'components/FastAction/SetPreferenceAction/SetPreferenceModal';
 import NamespaceStore from 'services/NamespaceStore';
 require('./SetPreferenceAction.scss');
+
+const PREFIX = 'features.FastAction.SetPreferences';
 
 export default class SetPreferenceAction extends Component {
   constructor(props) {
@@ -75,7 +77,7 @@ export default class SetPreferenceAction extends Component {
   }
 
   render() {
-    const actionLabel = T.translate('features.FastAction.setPreferencesActionLabel');
+    const actionLabel = T.translate(`${PREFIX}.actionLabel`);
     let iconClasses = classnames(
       {'fa-lg': this.props.setAtLevel === PREFERENCES_LEVEL.NAMESPACE},
       {'text-success': this.state.preferencesSaved}

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.scss
@@ -1,5 +1,5 @@
 /*
-* Copyright © 2016-2017 Cask Data, Inc.
+* Copyright © 2016-2018 Cask Data, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not
 * use this file except in compliance with the License. You may obtain a copy of
@@ -69,23 +69,30 @@ $star-color: #373a3c;
       padding-right: 10px;
     }
     .namespace-text {
-      width: 120px;
-      height: 50px;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-      display: inline-flex;
-      flex-direction: column;
-      float: left;
+      line-height: 16px;
+      height: 16px;
+      padding-top: 2px;
 
       small {
-        line-height: 0.5;
-        padding-top: 9px;
         color: gray;
         font-size: 10px;
       }
+    }
+
+    .namespace-and-caret {
+      display: flex;
+      align-items: center;
+
       span {
         line-height: 1.5;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .icon-caret-down {
+        margin-left: auto;
+        margin-right: 10px;
       }
     }
   }

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -225,7 +225,7 @@ export default class NamespaceDropdown extends Component {
     );
     let preferenceSpecificCardHeader = (
       <div className="preferences-saved-message">
-        <span>{T.translate('features.FastAction.setPreferencesSuccess.default', {entityType: 'Namespace'})}</span>
+        <span>{T.translate('features.FastAction.SetPreferences.success', {entityType: 'Namespace'})}</span>
         <IconSVG
           name='icon-close'
           onClick={(e) => {
@@ -247,11 +247,13 @@ export default class NamespaceDropdown extends Component {
           >
             <div className="namespace-text">
               <small>{T.translate('features.Navbar.NamespaceDropdown.namespaceLabel')}</small>
-              <span>{currentNamespace}</span>
             </div>
-            <span className="float-xs-right">
+            <div className="namespace-and-caret">
+              <span title={currentNamespace}>
+                {currentNamespace}
+              </span>
               <IconSVG name="icon-caret-down" />
-            </span>
+            </div>
           </div>
           <DropdownMenu>
             {

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineScheduleButton.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineScheduleButton.js
@@ -136,7 +136,7 @@ export default class PipelineScheduleButton extends Component {
     return (
       <div
         onClick={this.toggleScheduler}
-        className={classnames("btn pipeline-action-btn pipeline-scheduler-btn", {"btn-select" : this.state.showScheduler})}
+        className={classnames("btn pipeline-action-btn pipeline-scheduler-btn", {"btn-select" : this.state.showScheduler || this.state.showConfigModeless})}
         disabled={this.state.scheduleStatus === StatusMapper.statusMap['SCHEDULING']}
       >
         <div className="btn-container">
@@ -166,7 +166,7 @@ export default class PipelineScheduleButton extends Component {
     }
 
     return (
-      <div className={classnames("pipeline-action-container pipeline-scheduler-container", {"active" : this.state.showScheduler})}>
+      <div className={classnames("pipeline-action-container pipeline-scheduler-container", {"active" : this.state.showScheduler || this.state.showConfigModeless})}>
         {this.renderScheduleError()}
         {this.renderScheduleButton()}
         {

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineSummaryButton.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineSummaryButton.js
@@ -29,7 +29,7 @@ const PREFIX = 'features.PipelineDetails.TopPanel';
 export default class PipelineSummaryButton extends Component {
   static propTypes = {
     isBatch: PropTypes.bool,
-    pipelineName: PropTypes.string,
+    pipelineName: PropTypes.string
   };
 
   state = {

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -24,6 +24,7 @@ import {MyAppApi} from 'api/app';
 import PipelineExportModal from 'components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/PipelineExportModal';
 import TriggeredPipelineStore from 'components/TriggeredPipelines/store/TriggeredPipelineStore';
 import T from 'i18n-react';
+import classnames from 'classnames';
 require('./PipelineDetailsActionsButton.scss');
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
@@ -53,7 +54,14 @@ export default class PipelineDetailsActionsButton extends Component {
 
   state = {
     showExportModal: false,
-    showDeleteConfirmationModal: false
+    showDeleteConfirmationModal: false,
+    showPopover: false
+  };
+
+  togglePopover = (showPopover = !this.state.showPopover) => {
+    this.setState({
+      showPopover
+    });
   };
 
   pipelineConfig = {
@@ -185,7 +193,10 @@ export default class PipelineDetailsActionsButton extends Component {
   render() {
     const ActionsBtnAndLabel = () => {
       return (
-        <div className="btn pipeline-action-btn pipeline-actions-btn">
+        <div
+          className="btn pipeline-action-btn pipeline-actions-btn"
+          onClick={this.togglePopover}
+        >
           <div className="btn-container">
             <IconSVG name="icon-cog-empty" />
             <div className="button-label">
@@ -197,12 +208,15 @@ export default class PipelineDetailsActionsButton extends Component {
     };
 
     return (
-      <div className="pipeline-action-container pipeline-actions-container">
+      <div className={classnames("pipeline-action-container pipeline-actions-container", {"active" : this.state.showPopover})}>
         <Popover
           target={ActionsBtnAndLabel}
           placement="bottom"
           bubbleEvent={false}
+          enableInteractionInPopover={true}
           className="pipeline-actions-popper"
+          showPopover={this.state.showPopover}
+          onTogglePopover={this.togglePopover}
         >
           <ul>
             <li onClick={this.duplicateConfigAndNavigate}>

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsTopPanel.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsTopPanel.scss
@@ -18,7 +18,7 @@
 @import '../../../styles/mixins.scss';
 $pipeline-type-icon-size: 20px;
 $top-panel-height: 55px;
-$btn-border-color: $grey-03;
+$btn-border-color: transparent;
 
 .pipeline-details-top-panel {
   height: $top-panel-height;
@@ -85,7 +85,7 @@ $btn-border-color: $grey-03;
       display: inline-block;
       position: relative;
       height: 100%;
-      border-left: 1px solid white;
+      border-left: 1px solid $btn-border-color;
 
       &.active,
       &:hover {
@@ -105,7 +105,7 @@ $btn-border-color: $grey-03;
       }
 
       &.active {
-        border-bottom-color: white;
+        border-bottom-color: $btn-border-color;
       }
 
       .pipeline-action-btn {
@@ -201,6 +201,10 @@ $btn-border-color: $grey-03;
 
     .pipeline-actions-container {
       border-bottom: 1px solid $btn-border-color;
+
+      &.active {
+        border-bottom-color: $grey-05;
+      }
 
       .pipeline-actions-popper {
         height: 100%;

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/RunComputeProfile.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/RunComputeProfile.scss
@@ -25,6 +25,15 @@
       cursor: pointer;
       color: $blue-03;
       user-select: none;
+      display: flex;
+      justify-content: center;
+      height: 18px;
+
+      > div {
+        display: flex;
+        align-items: center;
+      }
+
       .btn.btn-link[disabled] {
         padding: 0;
         color: inherit;
@@ -36,6 +45,7 @@
       .icon-svg {
         margin-right: 5px;
         vertical-align: top;
+        height: 100%;
       }
     }
     .profile-preview-popover {

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/index.js
@@ -45,10 +45,10 @@ class RunLevelComputeProfile extends Component {
               <span>--</span>
             </button>
           :
-            <span>
+            <div>
               <IconSVG name="icon-cloud" />
-              {extractProfileName(this.props.profileName)}
-            </span>
+              <span>{extractProfileName(this.props.profileName)}</span>
+            </div>
           }
         </div>
       );

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
@@ -50,7 +50,7 @@ $border-color: $grey-05;
     padding-left: 0;
     padding-right: 20px;
     text-align: left;
-    bottom: 2px;
+    bottom: 1px;
 
     h4.run-number {
       font-weight: bold;

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLogs.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLogs.js
@@ -26,15 +26,6 @@ import T from 'i18n-react';
 
 const PREFIX = 'features.PipelineDetails.RunLevel';
 
-const mapStateToProps = (state) => {
-  return {
-    currentRun: state.currentRun,
-    runs: state.runs,
-    appId: state.name,
-    artifactName: state.artifact.name
-  };
-};
-
 const RunLogs = ({currentRun, runs, appId, artifactName}) => {
   const LogsBtnComp = () => (
     <div className="run-logs-btn">
@@ -77,6 +68,15 @@ RunLogs.propTypes = {
   runs: PropTypes.array,
   appId: PropTypes.string,
   artifactName: PropTypes.string
+};
+
+const mapStateToProps = (state) => {
+  return {
+    currentRun: state.currentRun,
+    runs: state.runs,
+    appId: state.name,
+    artifactName: state.artifact.name
+  };
 };
 
 const ConnectedRunLogs = connect(mapStateToProps)(RunLogs);

--- a/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModal.scss
+++ b/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModal.scss
@@ -136,6 +136,8 @@ $hightlight-color: #7f8c8d;
           color: white;
           border-radius: 3px;
           cursor: pointer;
+          line-height: 13px;
+          font-weight: normal;
         }
 
         &:hover {

--- a/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/PropertiesTab.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/Tabs/PropertiesTab.js
@@ -25,7 +25,7 @@ export default function PropertiesTab({entity}) {
     <div className="properties-container">
       <div className="message-section">
         <strong>
-          {T.translate('features.DetailView.PropertiesTab.title', { entityType: 'Stream', entityId: entity.id })}
+          {T.translate('features.DetailView.PropertiesTab.title', { entityType: 'stream', entityId: entity.id })}
         </strong>
       </div>
 

--- a/cdap-ui/app/cdap/components/Tags/Tag/Tag.scss
+++ b/cdap-ui/app/cdap/components/Tags/Tag/Tag.scss
@@ -21,6 +21,11 @@
     &.tag-btn {
       margin: 3px;
 
+      .tag-content {
+        display: flex;
+        align-items: center;
+      }
+
       .icon-close {
         font-size: 12px;
         margin-left: 5px;

--- a/cdap-ui/app/cdap/components/Tags/Tag/index.js
+++ b/cdap-ui/app/cdap/components/Tags/Tag/index.js
@@ -51,10 +51,10 @@ export default class Tag extends Component {
       "user-tag": this.props.scope === 'USER'
     });
     return (
-      <span>
+      <span className={tagClasses}>
         <span
           onClick = {this.toggleSearchModal}
-          className={tagClasses}
+          className="tag-content"
         >
           <span>{this.props.value}</span>
           {

--- a/cdap-ui/app/cdap/components/Tags/Tags.scss
+++ b/cdap-ui/app/cdap/components/Tags/Tags.scss
@@ -39,9 +39,18 @@ $input-width: 120px;
     align-items: center;
     justify-content: center;
     line-height: 1;
+    height: 18px;
 
     &.plus-button-container {
       margin-left: 3px;
+      height: 18px;
+      background-color: $grey-04;
+      border-radius: 4px;
+      border-color: white;
+
+      .icon-plus {
+        font-size: 7px;
+      }
     }
   }
 
@@ -55,12 +64,6 @@ $input-width: 120px;
     margin-right: 3px;
     vertical-align: middle;
     font-size: 12px;
-  }
-
-  .plus-button-container {
-    background-color: $grey-04;
-    border: 2px solid white;
-    border-radius: 4px;
   }
 
   .tags-popover {

--- a/cdap-ui/app/cdap/components/Tags/index.js
+++ b/cdap-ui/app/cdap/components/Tags/index.js
@@ -306,7 +306,10 @@ export default class Tags extends Component {
         className="btn btn-primary plus-button-container"
         onClick={this.toggleInputField}
       >
-        <span className="text-white">+</span>
+        <IconSVG
+          name="icon-plus"
+          className="text-white"
+        />
       </span>
     );
   }

--- a/cdap-ui/app/cdap/services/fast-action-message-helper.js
+++ b/cdap-ui/app/cdap/services/fast-action-message-helper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,7 @@ import T from 'i18n-react';
 export default function FastActionToMessage(action, options) {
   switch (action) {
     case 'setPreferences':
-      return T.translate('features.FastAction.setPreferencesSuccess.default', {entityType: options.entityType});
+      return T.translate('features.FastAction.SetPreferences.success', {entityType: options.entityType});
     case 'truncate':
       return T.translate('features.FastAction.truncateSuccess');
     default:

--- a/cdap-ui/app/cdap/styles/mixins.scss
+++ b/cdap-ui/app/cdap/styles/mixins.scss
@@ -20,6 +20,7 @@
     color: $color;
     font-weight: $font-weight;
 }
+
 @mixin appearance($value: none) {
   appearance: $value;
   -webkit-appearance: $value;

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -212,14 +212,14 @@ features:
     uptimeLabel: Uptime {time}
   AppDetailedView:
     History:
-      emptyMessage: No Runs found.
-      nameLabel: Program Name
+      emptyMessage: No runs found.
+      nameLabel: Program name
       runIDLabel: Run ID
       statusLabel: Status
-      startLabel: Start Time
+      startLabel: Start time
     Tabs:
       datasetsLabel: Datasets
-      historyLabel: Program Runs
+      historyLabel: Program runs
       programsLabel: Programs
       propertiesLabel: Properties
     Title: CDAP | Applications | {appId}
@@ -1215,49 +1215,50 @@ features:
     logNotAvailable: No logs available
     truncateConfirmation: Are you sure you want to truncate *_{entityId}_*?
     truncateLabel: Truncate
-    truncateSuccess: Truncated Successfully
+    truncateSuccess: Truncated successfully
     truncateFailed: Failed to truncate {entityId}.
-    sendEventsLabel: Send Events
-    setPreferencesModalLabel: Preferences
-    setPreferencesActionLabel: Set Preferences
-    setPreferencesDescriptionLabel:
-      app: Specify new or override existing system or namespace preferences. These preferences will be accessible in all programs within this application.
-      namespace: Specify new or override existing system preferences. These preferences will be accessible in all applications within this namespace.
-      program: Specify new or override existing system, namespace, or application preferences. These preferences will only be accessible within this program.
-      system: Specify new or edit existing system preferences. These preferences will be accessible in all namespaces, applications, and programs.
-    setPreferencesButtonLabel:
-      saveAndClose: Save & Close
-      saving: Saving
-    setPreferencesInheritedPrefsLabel: Inherited Preferences
-    setPreferencesColumnLabel:
-      key: KEY
-      value: VALUE
-    setPreferencesReset: Reset
-    setPreferencesFailed: Error - Set Preferences Failed.
-    setPreferencesSuccess:
-      default: "{entityType} Preferences Saved"
+    sendEventsLabel: Send events
+    SetPreferences:
+      actionLabel: Set preferences
+      ButtonLabel:
+        saveAndClose: Save & Close
+        saving: Saving
+      ColumnLabel:
+        key: KEY
+        value: VALUE
+      DescriptionLabel:
+        app: Specify new or override existing system or namespace preferences. These preferences will be accessible in all programs within this application.
+        namespace: Specify new or override existing system preferences. These preferences will be accessible in all applications within this namespace.
+        program: Specify new or override existing system, namespace, or application preferences. These preferences will only be accessible within this program.
+        system: Specify new or edit existing system preferences. These preferences will be accessible in all namespaces, applications, and programs.
+      failed: Error - Set preferences failed.
+      inheritedPrefsLabel: Inherited preferences
+      modalLabel: Preferences
+      noInheritedPrefs: No inherited preferences
+      reset: Reset
+      success: "{entityType} preferences saved"
     start: Start
     stop: Stop
     sendEventsButtonLabel: Send
     sendEventsClickLabel: Click to input events.
-    sendEventsFailed: Error - Send Events Failed.
+    sendEventsFailed: Error - Send events failed.
     sendEventsSuccess: Success - Events uploaded successfully.
     startConfirmLabel: Start
     stopConfirmLabel: Stop
     startConfirmation: "Are you sure you want to start the program: *_{entityId}_*?"
     stopConfirmation: "Are you sure you want to stop the program:  *_{entityId}_*?"
-    stopProgramHeader: Stop Program
-    startProgramHeader: Start Program
+    stopProgramHeader: Stop program
+    startProgramHeader: Start program
     viewEvents:
       button: View
       failedMessage: Failed to view events
       from: From
-      label: View Events
+      label: View events
       limit: Limit
-      modalHeader: "Filter and View Events for \"{entityId}\""
-      noResults: No Results
-      numEventsTitle: Set Number of Events
-      timeRangeTitle: Select Time Range
+      modalHeader: "Filter and view events for \"{entityId}\""
+      noResults: No results
+      numEventsTitle: Set number of events
+      timeRangeTitle: Select time range
       to: To
 
   HttpExecutor:
@@ -1459,14 +1460,14 @@ features:
       backpressure: Backpressure
       backpressureTooltip: Allows the Apache Spark Streaming engine to control the receiving rate based on the current batch scheduling delays and processing times so that the system receives only as fast as the system can process.
       contentHeading: Select the type of engine running your {pipelineTypeLabel} pipeline
-      customConfig: Custom Config
+      customConfig: Custom config
       customConfigCount:
         1: "{context} custom config"
         _: "{context} custom configs"
       customConfigTooltip: Enter key-value pairs of configuration parameters that will be passed to the underlying {engineDisplayLabel} program.
       numExecutors: Number of Executors
       numExecutorsTooltip: The number of executors to allocate for this pipeline on Apache Yarn.
-      showCustomConfig: Show Custom Config
+      showCustomConfig: Show custom config
       title: Engine Config
     PipelineConfig:
       batchInterval: Batch Interval
@@ -1492,9 +1493,9 @@ features:
       contentHeading: Specify the resources for the following processes of the {engineDisplayLabel} program
       title: Resources
     RuntimeArgs:
-      contentHeading1: Specify Runtime Arguments or Update the Ones Derived from Preferences
-      contentHeading2: Runtime Arguments used for this run
-      contentHeading3: No Runtime Arguments were used for this run
+      contentHeading1: Specify runtime arguments or update the ones derived from preferences
+      contentHeading2: Runtime arguments used for this run
+      contentHeading3: No Runtime arguments were used for this run
       contentSubtitle: By default, values for all runtime arguments must be provided before running the pipeline. If a stage in your pipeline provides the value of an argument, you can skip that argument by marking it as Provided.
       ProvidedPopover:
         clearAll: Clear All
@@ -1731,9 +1732,9 @@ features:
     EnabledTriggers:
       buttonLabel: Disable Trigger
       pipelineCount:
-        0: "No Pipelines set as trigger"
-        1: "1 Pipeline is set as trigger"
-        _: "{context.count} Pipelines is set as trigger"
+        0: "No pipelines set as trigger"
+        1: "1 pipeline is set as trigger"
+        _: "{context.count} pipelines is set as trigger"
       tabLabel: "View Enabled Triggers ({count})"
       title: "View pipelines enabled to trigger pipeline \"{pipelineName}\""
     Events:
@@ -2012,9 +2013,9 @@ features:
     helperText: "This pipeline is triggered when \"{pipelineName}\""
     namespace: Namespace
     pipelineCount:
-      "0": "No Pipelines triggered"
-      "1": "1 Pipeline triggered"
-      _: "{context.count} Pipelines triggered"
+      "0": "No pipelines triggered"
+      "1": "1 pipeline triggered"
+      _: "{context.count} pipelines triggered"
     pipelineName: Pipeline Name
     title: "Pipelines to be triggered by \"{pipelineName}\""
     viewPipeline: View Pipeline

--- a/cdap-ui/app/hydrator/adapters.less
+++ b/cdap-ui/app/hydrator/adapters.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2017 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -142,6 +142,12 @@ body.theme-cdap {
 
     .zoom-control {
       position: fixed;
+    }
+
+    .btn-group-vertical {
+      > .btn:not(:last-child) {
+        border-bottom: 0;
+      }
     }
   }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13461

Most of the code changes come in the 3rd commit. In that commit, I:
- Changed the vertical separators between buttons in the pipeline top panel to be actual divs, instead of being `:after` pseudo-elements. This is because I needed to do DOM manipulations, and it's not possible to manipulate `:after` elements in Javascript.
- Hid the vertical separators to the left and right of a button when hovering over that button, so it doesn't look line there are double lines. I did this by attaching `onMouseEnter` and `onMouseLeave` event handlers on the button.

Let me know if you guys think there's a cleaner approach for this.

In addition, the last commit is for changing some text in UI so that we follow sentence-style heading (e.g. 'Set preferences for application' instead of 'Set Preferences for Application'). I have the changed the ones mentioned in the JIRA, but there are still many other places in UI where we can change. Will talk with @leacd to see if we want to change all of them.