### PR TITLE
CDAP-13463 fix pipeline planner when conditions are on branches

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ControlDag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ControlDag.java
@@ -18,15 +18,12 @@ package co.cask.cdap.etl.planner;
 
 import co.cask.cdap.etl.proto.Connection;
 import com.google.common.base.Joiner;
-import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multiset;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -39,34 +36,13 @@ import java.util.UUID;
  */
 public class ControlDag extends Dag {
   private static final Set<String> EMPTY = ImmutableSet.of();
-  private final Multiset<String> nodeVisits;
 
   public ControlDag(Collection<Connection> connections) {
     super(connections);
-    this.nodeVisits = HashMultiset.create();
   }
 
   public ControlDag(Dag dag) {
     super(dag);
-    this.nodeVisits = HashMultiset.create();
-  }
-
-  /**
-   * Record that this node was visited.
-   *
-   * @param node node that was visited
-   * @return the number of times this node was visited, including the visit from this call
-   */
-  public int visit(String node) {
-    nodeVisits.add(node);
-    return nodeVisits.count(node);
-  }
-
-  /**
-   * Resets the number of times each node was visited back to 0.
-   */
-  public void resetVisitCounts() {
-    nodeVisits.clear();
   }
 
   /**
@@ -82,7 +58,7 @@ public class ControlDag extends Dag {
    *      |           v
    *      |--> n4 --> n6
    *
-   *  There are many ways to turn this a fork-join while still respecting all happens-before relationships,
+   *  There are many ways to turn this into a fork-join while still respecting all happens-before relationships,
    *  but for simplicity we'll use an algorithm that doesn't have any nested forks and will turn the above into:
    *
    *       |--> n2 --|
@@ -301,34 +277,5 @@ public class ControlDag extends Dag {
       name += UUID.randomUUID().toString();
     }
     return name;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-
-    ControlDag that = (ControlDag) o;
-
-    return Objects.equals(nodeVisits, that.nodeVisits);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), nodeVisits);
-  }
-
-  @Override
-  public String toString() {
-    return "ControlDag{" +
-      "nodeVisits=" + nodeVisits +
-      "} " + super.toString();
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -365,6 +365,8 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
    * All inputs into a stage have the same schema.
    * ErrorTransforms only have BatchSource, Transform, or BatchAggregator as input stages.
    * AlertPublishers have at least one input and no outputs and don't have SparkSink or BatchSink as input.
+   * Action stages can only be at the start or end of the pipeline.
+   * Condition stages have at most 2 outputs. Each stage on a condition's output branch has at most a single input.
    *
    * Returns the stages in the order they should be configured to ensure that all input stages are configured
    * before their output.

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ConnectorDagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ConnectorDagTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -869,7 +870,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testSubdagMerge() throws Exception {
+  public void testSubdagMerge() {
     /*
         n1 -----|
                 |-- n4(r) -- n6
@@ -921,7 +922,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testSimpleCondition() throws Exception {
+  public void testSimpleCondition() {
 
     /*
       file - csv - condition - sink1
@@ -936,7 +937,7 @@ public class ConnectorDagTest {
       new Connection("condition", "sink2")
     );
 
-    Set<String> conditions = new HashSet<>(Arrays.asList("condition"));
+    Set<String> conditions = Collections.singleton("condition");
     Set<String> reduceNodes = new HashSet<>();
     Set<String> isolationNodes = new HashSet<>();
     Set<String> multiPortNodes = new HashSet<>();
@@ -956,7 +957,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testSimpleConditionWithReducers() throws Exception {
+  public void testSimpleConditionWithReducers() {
     /*
              |--- n2
         n1 --|
@@ -974,8 +975,8 @@ public class ConnectorDagTest {
       new Connection("condition", "n6")
     );
 
-    Set<String> conditions = new HashSet<>(Arrays.asList("condition"));
-    Set<String> reduceNodes = new HashSet<>(Arrays.asList("n3"));
+    Set<String> conditions = Collections.singleton("condition");
+    Set<String> reduceNodes = Collections.singleton("n3");
     Set<String> isolationNodes = new HashSet<>();
     Set<String> multiPortNodes = new HashSet<>();
     Set<Dag> actual = PipelinePlanner.split(connections, conditions, reduceNodes, isolationNodes, EMPTY_ACTIONS,
@@ -997,7 +998,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testSimpleConditionWithMultipleSources() throws Exception {
+  public void testSimpleConditionWithMultipleSources() {
     /*
              |--- n2
         n1 --|
@@ -1016,8 +1017,8 @@ public class ConnectorDagTest {
       new Connection("n11", "n3")
     );
 
-    Set<String> conditions = new HashSet<>(Arrays.asList("condition"));
-    Set<String> reduceNodes = new HashSet<>(Arrays.asList("n3"));
+    Set<String> conditions = Collections.singleton("condition");
+    Set<String> reduceNodes = Collections.singleton("n3");
     Set<String> isolationNodes = new HashSet<>();
     Set<String> multiPortNodes = new HashSet<>();
     Set<Dag> actual = PipelinePlanner.split(connections, conditions, reduceNodes, isolationNodes, EMPTY_ACTIONS,
@@ -1040,7 +1041,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testConditionDag() throws Exception {
+  public void testConditionDag() {
 
     /*
           file - csv - c1 - t1---agg1--agg2---sink1
@@ -1102,7 +1103,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testMultipleNonNestedConditions() throws Exception {
+  public void testMultipleNonNestedConditions() {
     /*
        n1-c1-n2-n3-c2-n4
      */

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -561,7 +562,7 @@ public class DagTest {
   }
 
   @Test
-  public void testSplitByControlNodes() throws Exception {
+  public void testSplitByControlNodes() {
 
     // In following test cases note that Action nodes are named as (a0, a1...) and condition nodes are named
     // as (c0, c1, ..)
@@ -708,6 +709,38 @@ public class DagTest {
     expectedDags.clear();
     expectedDags.add(dag);
     Assert.assertEquals(expectedDags, actual);
+  }
+
+  @Test
+  public void testConditionsOnBranches() {
+    /*
+                        |--> n2
+              |--> c1 --|
+         n1 --|         |--> n3
+              |
+              |                |--> n5
+              |--> n4 --> c2 --|
+                               |--> n6
+     */
+
+    Dag dag = new Dag(ImmutableSet.of(
+      new Connection("n1", "c1"),
+      new Connection("n1", "n4"),
+      new Connection("c1", "n2"),
+      new Connection("c1", "n3"),
+      new Connection("n4", "c2"),
+      new Connection("c2", "n5"),
+      new Connection("c2", "n6")));
+    Set<Dag> actual = dag.splitByControlNodes(ImmutableSet.of("c1", "c2"), Collections.<String>emptySet());
+
+    Set<Dag> expected = ImmutableSet.of(
+      new Dag(ImmutableSet.of(new Connection("n1", "n4"), new Connection("n1", "c1"), new Connection("n4", "c2"))),
+      new Dag(ImmutableSet.of(new Connection("c1", "n2"))),
+      new Dag(ImmutableSet.of(new Connection("c1", "n3"))),
+      new Dag(ImmutableSet.of(new Connection("c2", "n5"))),
+      new Dag(ImmutableSet.of(new Connection("c2", "n6"))));
+
+    Assert.assertEquals(expected, actual);
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/condition/MockCondition.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/condition/MockCondition.java
@@ -115,8 +115,7 @@ public class MockCondition extends Condition {
   /**
    * Read the value for the specified rowKey and columnKey.
    */
-  public static String readOutput(DataSetManager<Table> tableManager, String rowKey, String columnKey)
-    throws Exception {
+  public static String readOutput(DataSetManager<Table> tableManager, String rowKey, String columnKey) {
     Table table = tableManager.get();
     return Bytes.toString(table.get(Bytes.toBytes(rowKey), Bytes.toBytes(columnKey)));
   }


### PR DESCRIPTION
SmartWorkflow had a bug where it assumed that all programs
on a branch would not fork or be conditions. It is still true
that they won't fork, but it has never been true that they cannot
be conditions. Fixing to handle that scenario, adding unit tests,
and performing general cleanup to fix warnings.