### PR TITLE
[MMDS][CDAP-13365][CDAP-13080] [CDAP-13458] Allows a user to resplit a previously failed split in a model

### DIFF
--- a/cdap-ui/app/cdap/api/experiments.js
+++ b/cdap-ui/app/cdap/api/experiments.js
@@ -39,7 +39,8 @@ export const myExperimentsApi = {
 
   deleteModelInExperiment: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId`),
   deleteExperiment: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${basePath}/experiments/:experimentId`),
-
+  updateDirectivesInModel: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId/directives`),
+  deleteSplitInModel: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId/split`),
   createExperiment: apiCreator(dataSrc, 'PUT', 'REQUEST', `${basePath}/experiments/:experimentId`),
   createSplit: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/experiments/:experimentId/models/:modelId/split`),
   createModelInExperiment: apiCreator(dataSrc, 'POST', 'REQUEST', `${basePath}/experiments/:experimentId/models`),

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/ExperimentMetadata/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/ExperimentMetadata/index.js
@@ -17,13 +17,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect, Provider} from 'react-redux';
-import createExperimentStore from 'components/Experiments/store/createExperimentStore';
+import createExperimentStore, {CREATION_STEPS} from 'components/Experiments/store/createExperimentStore';
+import {overrideCreationStep} from 'components/Experiments/store/CreateExperimentActionCreator';
 import classnames from 'classnames';
 import isNil from 'lodash/isNil';
 
 require('./ExperimentMetadata.scss');
 
-const ExperimentMetadataWrapper = ({modelName, modelDescription, directives, algorithm}) => {
+const ExperimentMetadataWrapper = ({modelName, modelDescription, directives, algorithm, active_step}) => {
   let isAlgorithmEmpty = () => isNil(algorithm) || !algorithm.length;
   return (
     <div className="experiment-metadata">
@@ -38,10 +39,31 @@ const ExperimentMetadataWrapper = ({modelName, modelDescription, directives, alg
       <div>
         <strong>No of Directives: </strong>
         <span>{directives.length}</span>
+        {
+          directives.length ? (
+            <div
+              className="btn btn-link"
+              onClick={overrideCreationStep.bind(null, CREATION_STEPS.DATAPREP)}
+            >
+              Edit
+            </div>
+          ) : null
+        }
       </div>
       <div>
         <strong>Split Method: </strong>
         <span>Random</span>
+        {
+          active_step === CREATION_STEPS.ALGORITHM_SELECTION ?
+            <div
+              className="btn btn-link"
+              onClick={overrideCreationStep.bind(null, CREATION_STEPS.DATASPLIT)}
+            >
+              Edit
+            </div>
+          :
+            null
+        }
       </div>
       <div className={classnames({
         "grayed": isAlgorithmEmpty()
@@ -59,12 +81,14 @@ ExperimentMetadataWrapper.propTypes = {
   modelName: PropTypes.string,
   modelDescription: PropTypes.string,
   directives: PropTypes.array,
-  algorithm: PropTypes.string
+  algorithm: PropTypes.string,
+  active_step: PropTypes.string
 };
 const mapStateToProps = (state) => ({
   modelName: state.model_create.name,
   modelDescription: state.model_create.description,
   directives: state.model_create.directives,
+  active_step: state.active_step.step_name,
   algorithm: !state.model_create.algorithm.name.length
     ? '' :
     state.model_create.validAlgorithmsList

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfoTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/SplitDataStep/SplitInfoTable/index.js
@@ -20,7 +20,7 @@ import IconSVG from 'components/IconSVG';
 import {Input} from 'reactstrap';
 import {NUMBER_TYPES} from 'services/global-constants';
 import SortableTable from 'components/SortableTable';
-import {objectQuery} from 'services/helpers';
+import {objectQuery, roundDecimalToNDigits} from 'services/helpers';
 import findLast from 'lodash/findLast';
 import classnames from 'classnames';
 
@@ -161,8 +161,8 @@ export default class SplitInfoTable extends Component {
                 <td>{field.numTotal}</td>
                 <td>{field.numEmpty}</td>
                 <td>{field.numZero}</td>
-                <td>{field.mean}</td>
-                <td>{field.stddev}</td>
+                <td>{roundDecimalToNDigits(field.mean, 4)}</td>
+                <td>{roundDecimalToNDigits(field.stddev, 4)}</td>
                 <td>{field.min}</td>
                 <td>{field.max}</td>
               </tr>

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
@@ -27,7 +27,7 @@ import {
   getModelStatus
 } from 'components/Experiments/store/ExperimentDetailActionCreator';
 import {getAlgorithmLabel} from 'components/Experiments/store/SharedActionCreator';
-import {humanReadableDate} from 'services/helpers';
+import {humanReadableDate, roundDecimalToNDigits} from 'services/helpers';
 import {NUMBER_TYPES} from 'services/global-constants';
 import classnames from 'classnames';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
@@ -46,9 +46,15 @@ import CopyableID from 'components/CopyableID';
 import CollapsibleWrapper from 'components/CollapsibleWrapper';
 import LoadingSVG from 'components/LoadingSVG';
 import Alert from 'components/Alert';
+import {MODEL_STATUS} from 'components/Experiments/store/ModelStatus';
 
 require('./DetailedViewModelsTable.scss');
-const MODELSTATES = ['PREPARING', 'SPLITTING', 'DATA_READY'];
+const MODELSTATES = [
+  MODEL_STATUS.PREPARING,
+  MODEL_STATUS.SPLITTING,
+  MODEL_STATUS.DATA_READY,
+  MODEL_STATUS.SPLIT_FAILED
+];
 let tableHeaders = [
   {
     label: 'Model Name',
@@ -132,12 +138,18 @@ const wrapContentWithTitleAttr = (content) => (
     {content}
   </div>
 );
-
+const wrapMetricWithTitleAttr = (content, property) => {
+  const ROUNDABLE_METRIC = regressionMetrics.map(metric => metric.property);
+  if (ROUNDABLE_METRIC.indexOf(property) !== -1) {
+    return wrapContentWithTitleAttr(roundDecimalToNDigits(content, 4));
+  }
+  return wrapContentWithTitleAttr(content);
+};
 const renderMetrics = (newHeaders, model) => {
   let commonHeadersLen = tableHeaders.length;
   let len = newHeaders.length;
   let metrics = newHeaders.slice(commonHeadersLen, len);
-  return metrics.map(t => wrapContentWithTitleAttr(model.evaluationMetrics[t.property] || '--'));
+  return metrics.map(t => wrapMetricWithTitleAttr(model.evaluationMetrics[t.property] || '--', t.property));
 };
 
 const renderFeaturesTable = (features) => {

--- a/cdap-ui/app/cdap/components/Experiments/store/ModelStatus.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/ModelStatus.js
@@ -14,25 +14,15 @@
  * the License.
 */
 
-@import "../../../../styles/variables.scss";
+const MODEL_STATUS = {
+  PREPARING: 'Preparing',
+  SPLITTING: 'Splitting',
+  SPLIT_FAILED: 'Split Failed',
+  DATA_READY: 'Data Ready',
+  TRAINING: 'Training',
+  TRAINED: 'Trained',
+  TRAINING_FAILED: 'Training Failed',
+  DEPLOYED: 'Deployed'
+};
 
-.experiment-metadata {
-  display: flex;
-  flex-wrap: wrap;
-  padding: 20px;
-  border-bottom: 1px solid $grey-05;
-  > div {
-    margin: 0 20px 0 0;
-    &.grayed {
-      color: $grey-05;
-    }
-    > * {
-      margin: 0 5px;
-    }
-  }
-  .btn.btn-link {
-    padding: 0;
-    margin: 0;
-    vertical-align: top;
-  }
-}
+export {MODEL_STATUS};

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -22,6 +22,7 @@ import isEmpty from 'lodash/isEmpty';
 import T from 'i18n-react';
 import {compose} from 'redux';
 import uuidV4 from 'uuid/v4';
+import round from 'lodash/round';
 
 /*
   Purpose: Query a json object or an array of json objects
@@ -337,6 +338,17 @@ const convertKeyValuePairsToMap = (keyValuePairs, ignoreNonNilValues = false) =>
   return map;
 };
 
+const roundDecimalToNDigits = (num, digits = 2) => {
+  let newNum = num;
+  if (typeof num !== 'number') {
+    newNum = parseFloat(num, 10);
+  }
+  if (isNaN(num)) {
+    return num;
+  }
+  return round(newNum, digits);
+};
+
 export {
   objectQuery,
   convertBytesToHumanReadable,
@@ -369,5 +381,6 @@ export {
   reverseArrayWithoutMutating,
   convertMapToKeyValuePairs,
   convertKeyValuePairsToMap,
-  isNilOrEmpty
+  isNilOrEmpty,
+  roundDecimalToNDigits
 };


### PR DESCRIPTION
- Allows a user to replit a previously failed split from experiment detail view (Analytics -> Experiment 1 (Experiment detailed view)-> Model 3 (in Models table))
- Allows the user to edit the directives from split step and edit the split from the algorithm selection step. This allows user to reiterate the changes in the same model instead of creating a new model everytime he/she decides to make a change.
- Rounds off huge numbers to 4 digits after the decimal. Makes is readable in UI.

JIRA:
- https://issues.cask.co/browse/CDAP-13458
- https://issues.cask.co/browse/CDAP-13080
- https://issues.cask.co/browse/CDAP-13365
