### PR TITLE
[CDAP-13484] Fixes profile customization in pipeline detailed view.

### DIFF
--- a/cdap-ui/app/cdap/components/Accordion/AccordionTitle/index.js
+++ b/cdap-ui/app/cdap/components/Accordion/AccordionTitle/index.js
@@ -20,6 +20,8 @@ import IconSVG from 'components/IconSVG';
 require('./AccordionTitle.scss');
 
 export default class AccordionTitle extends PureComponent {
+  static displayName = 'AccordionTitle';
+
   static propTypes = {
     id: PropTypes.string.isRequired,
     onTabPaneClick: PropTypes.func,


### PR DESCRIPTION
**Issue:**
- The cause of this problem lies within the `Accordion` component.
- Here we filter the rendering of children based on the `displayName` property which is set to `AccordionTitle`.
- During dev build this is not mangled and rendering works fine.
- But in the prod build minification mangles the component, hence the component name(display name). This was causing the `Accordion` to render empty UI.

**Solution:**
- Manually set a static variable in `AccordionTitle` component that cannot be mangled during minification.


JIRA: https://issues.cask.co/browse/CDAP-13484