### PR TITLE
CDAP-13405 increase default twill reserved memory

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -191,7 +191,7 @@
 
   <property>
     <name>twill.java.reserved.memory.mb</name>
-    <value>300</value>
+    <value>768</value>
     <description>
       Desired reserved non-heap memory in megabytes for all launched Apache Twill containers.
       The actual value is bounded by the ${twill.java.heap.memory.ratio} setting of the container memory size.

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="516960d3839c8c2764916963db738f24"
+DEFAULT_XML_MD5_HASH="d49562e8ed651602c39355a91d2ef7a2"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Increasing the default twill reserved memory from 300 to 768.
I have seen YARN kill containers due to physical memory limits
when this is set to 512, but not when it is set to 768.