### PR TITLE
CDAP-13496 increase timeouts for tests

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -123,6 +123,8 @@ public class AppFabricTestHelper {
       configuration.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder("data").getAbsolutePath());
       configuration.set(Constants.AppFabric.REST_PORT, Integer.toString(Networks.getRandomPort()));
       configuration.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
+      configuration.setLong(Constants.HTTP_CLIENT_READ_TIMEOUT_MS,
+                            TimeUnit.MILLISECONDS.convert(120, TimeUnit.SECONDS));
       // Speed up tests
       configuration.setLong(Constants.Scheduler.EVENT_POLL_DELAY_MILLIS, 100L);
       configuration.setLong(Constants.AppFabric.STATUS_EVENT_POLL_DELAY_MILLIS, 100L);
@@ -147,7 +149,7 @@ public class AppFabricTestHelper {
       // Wait for the scheduler to be functional.
       if (programScheduler instanceof CoreSchedulerService) {
         try {
-          ((CoreSchedulerService) programScheduler).waitUntilFunctional(10, TimeUnit.SECONDS);
+          ((CoreSchedulerService) programScheduler).waitUntilFunctional(30, TimeUnit.SECONDS);
         } catch (Exception e) {
           throw new RuntimeException(e);
         }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -252,7 +252,7 @@ public abstract class AppFabricTestBase {
     // Wait for the scheduler to be functional.
     if (programScheduler instanceof CoreSchedulerService) {
       try {
-        ((CoreSchedulerService) programScheduler).waitUntilFunctional(10, TimeUnit.SECONDS);
+        ((CoreSchedulerService) programScheduler).waitUntilFunctional(30, TimeUnit.SECONDS);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -279,6 +279,7 @@ public abstract class AppFabricTestBase {
 
   protected static CConfiguration createBasicCConf() throws IOException {
     CConfiguration cConf = CConfiguration.create();
+    cConf.setLong(Constants.HTTP_CLIENT_READ_TIMEOUT_MS, TimeUnit.MILLISECONDS.convert(120, TimeUnit.SECONDS));
     cConf.set(Constants.Service.MASTER_SERVICES_BIND_ADDRESS, hostname);
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder("data").getAbsolutePath());
     cConf.set(Constants.AppFabric.OUTPUT_DIR, System.getProperty("java.io.tmpdir"));

--- a/cdap-app-fabric/src/test/resources/logback-test.xml
+++ b/cdap-app-fabric/src/test/resources/logback-test.xml
@@ -34,7 +34,7 @@
         </encoder>
     </appender>
 
-    <logger name="co.cask.cdap" level="INFO" />
+    <logger name="co.cask.cdap" level="DEBUG" />
 
     <root level="WARN">
         <appender-ref ref="STDOUT"/>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -291,6 +291,7 @@ class DatasetServiceClient {
   }
 
   private HttpResponse doPut(String resource, String body) throws DatasetManagementException {
+    LOG.debug("Performing PUT on {} with body {}", resource, body);
     HttpRequest request = addUserIdHeader(remoteClient.requestBuilder(HttpMethod.PUT, resource)
       .withBody(body))
       .build();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -35,6 +35,8 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -58,6 +60,7 @@ import javax.ws.rs.QueryParam;
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class DatasetInstanceHandler extends AbstractHttpHandler {
 
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetInstanceHandler.class);
   private final DatasetInstanceService instanceService;
   private static final Gson GSON = new Gson();
 
@@ -115,6 +118,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   public void create(FullHttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId,
                      @PathParam("name") String name) throws Exception {
 
+    LOG.debug("Received a PUT to dataset {}", name);
     DatasetInstanceConfiguration creationProperties = ConversionHelpers.getInstanceConfiguration(request);
     try {
       instanceService.create(namespaceId, name, creationProperties);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -272,6 +272,8 @@ public class DatasetInstanceService {
    *  have {@link Action#WRITE} privilege on the #instance's namespace
    */
   void create(String namespaceId, String name, DatasetInstanceConfiguration props) throws Exception {
+    LOG.debug("Received request to create dataset {}.{}, type name: {}, properties: {}",
+              namespaceId, name, props.getTypeName(), props.getProperties());
     NamespaceId namespace = ConversionHelpers.toNamespaceId(namespaceId);
     DatasetId datasetId = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
     Principal requestingUser = authenticationContext.getPrincipal();
@@ -325,6 +327,9 @@ public class DatasetInstanceService {
 
       // Enable explore
       enableExplore(datasetId, spec, props);
+      LOG.info("Created dataset {}.{}, type name: {}, properties: {}",
+               namespaceId, name, props.getTypeName(), props.getProperties());
+
     } catch (Exception e) {
       // there was a problem in creating the dataset instance so delete the owner if it got added earlier
       ownerAdmin.delete(datasetId); // safe to call for entities which does not have an owner too

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminService.java
@@ -134,6 +134,7 @@ public class DatasetAdminService {
 
       // Writing system metadata should be done without impersonation since user may not have access to system tables.
       writeSystemMetadata(datasetInstanceId, spec, props, typeMeta, type, context, existing != null, ugi);
+      LOG.info("Created dataset instance {}, type meta: {}", datasetInstanceId, typeMeta);
       return spec;
     } catch (Exception e) {
       if (e instanceof IncompatibleUpdateException) {

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -319,7 +319,7 @@ public class TestBase {
       ((Service) scheduler).startAndWait();
     }
     if (scheduler instanceof CoreSchedulerService) {
-      ((CoreSchedulerService) scheduler).waitUntilFunctional(10, TimeUnit.SECONDS);
+      ((CoreSchedulerService) scheduler).waitUntilFunctional(30, TimeUnit.SECONDS);
     }
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       exploreExecutorService = injector.getInstance(ExploreExecutorService.class);
@@ -416,6 +416,7 @@ public class TestBase {
     cConf.setBoolean(Constants.Explore.EXPLORE_ENABLED, true);
     cConf.setBoolean(Constants.Explore.START_ON_DEMAND, false);
     cConf.set(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR, "");
+    cConf.setLong(Constants.HTTP_CLIENT_READ_TIMEOUT_MS, TimeUnit.MILLISECONDS.convert(120, TimeUnit.SECONDS));
 
     // Setup test case specific configurations.
     // The system properties are usually setup by TestConfiguration class using @ClassRule


### PR DESCRIPTION
Increase read timeout to see if this will fix the intermittent
SocketTimeoutExceptions that we see on the build VMs.
Also increase the time we wait for the CoreSchedulerService from
10 seconds to 30 seconds since we're still seeing failures to
start the scheduler.