### PR TITLE
CDAP-13489 another dynamic partioning test fix

### DIFF
--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DynamicPartitioningTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DynamicPartitioningTestRun.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
@@ -129,10 +130,9 @@ public class DynamicPartitioningTestRun extends TestFrameworkTestBase {
 
     Map<String, String> arguments = ImmutableMap.of("outputs", outputArg);
     MapReduceManager mrManager = appManager.getMapReduceManager("DynamicPartitioningMR");
-    int numRuns = mrManager.getHistory().size();
+    int numRuns = mrManager.getHistory(ProgramRunStatus.FAILED).size();
     mrManager.start(arguments);
-    Tasks.waitFor(numRuns + 1, () -> mrManager.getHistory().size(), 300, TimeUnit.SECONDS);
-    mrManager.waitForStopped(300, TimeUnit.SECONDS);
+    Tasks.waitFor(numRuns + 1, () -> mrManager.getHistory(ProgramRunStatus.FAILED).size(), 300, TimeUnit.SECONDS);
 
     for (String dataset : outputs) {
       validatePartitions(dataset, dataset.equals(dsWithExistingPartition));


### PR DESCRIPTION
The previous fix can fail due to a race in program status
(CDAP-13296) where run records are not fetched in a single
transaction. If a run transitions state during a status call,
the status can incorrectly be returned as STOPPED.
Instead, just wait for the number of failed runs to increase,
which should always indicate that the run has completed.