### PR TITLE
CDAP-13296 fix race in program status call

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -329,9 +329,6 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     // Suspend the Workflow
     suspendWorkflow(programId, runId, 200);
 
-    // Workflow status should be SUSPENDED
-    waitState(programId, ProgramStatus.STOPPED.name());
-
     // Meta store information for this Workflow should reflect suspended run
     verifyProgramRuns(programId, ProgramRunStatus.SUSPENDED);
 
@@ -367,9 +364,6 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
 
     // Suspend the Workflow
     suspendWorkflow(programId, runId, 200);
-
-    // Status of the Workflow should be suspended
-    waitState(programId, ProgramStatus.STOPPED.name());
 
     // Store should reflect the suspended status of the Workflow
     verifyProgramRuns(programId, ProgramRunStatus.SUSPENDED);
@@ -420,7 +414,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     suspendWorkflow(Id.Program.fromEntityId(workflow), runId, 200);
 
     // Workflow status should be SUSPENDED
-    waitState(workflow, ProgramStatus.STOPPED.name());
+    verifyProgramRuns(workflow, ProgramRunStatus.SUSPENDED);
 
     stopProgram(Id.Program.fromEntityId(workflow), runId, 200);
     waitState(workflow, ProgramStatus.STOPPED.name());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -65,6 +65,7 @@ import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
@@ -172,18 +173,29 @@ public class ProgramLifecycleService {
       throw new NotFoundException(programId);
     }
 
-    // TODO: CDAP-13296 read these runs in a single transaction
-    // A program is RUNNING if there are any RUNNING run records
-    if (!store.getRuns(programId, ProgramRunStatus.RUNNING, 0, Long.MAX_VALUE, 1).isEmpty()) {
-      return ProgramStatus.RUNNING;
-    }
+    return getProgramStatus(store.getActiveRuns(programId).values());
+  }
 
-    // A program is starting if there are any PENDING or STARTING run records and no RUNNING run records
-    if (!store.getRuns(programId, ProgramRunStatus.STARTING, 0, Long.MAX_VALUE, 1).isEmpty() ||
-      !store.getRuns(programId, ProgramRunStatus.PENDING, 0, Long.MAX_VALUE, 1).isEmpty()) {
-      return ProgramStatus.STARTING;
+  /**
+   * Returns the program status based on the active run records of a program.
+   * A program is RUNNING if there are any RUNNING or SUSPENDED run records.
+   * A program is starting if there are any PENDING or STARTING run records and no RUNNING run records.
+   * Otherwise, it is STOPPED.
+   *
+   * @param runRecords run records for the program
+   * @return the program status
+   */
+  @VisibleForTesting
+  static ProgramStatus getProgramStatus(Collection<RunRecordMeta> runRecords) {
+    boolean hasStarting = false;
+    for (RunRecordMeta runRecord : runRecords) {
+      ProgramRunStatus runStatus = runRecord.getStatus();
+      if (runStatus == ProgramRunStatus.RUNNING || runStatus == ProgramRunStatus.SUSPENDED) {
+        return ProgramStatus.RUNNING;
+      }
+      hasStarting = hasStarting || runStatus == ProgramRunStatus.STARTING || runStatus == ProgramRunStatus.PENDING;
     }
-    return ProgramStatus.STOPPED;
+    return hasStarting ? ProgramStatus.STARTING : ProgramStatus.STOPPED;
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramStatus;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+
+/**
+ * ProgramLifecycleService tests.
+ */
+public class ProgramLifecycleServiceTest {
+
+  @Test
+  public void testEmptyRunsIsStopped() {
+    Assert.assertEquals(ProgramStatus.STOPPED, ProgramLifecycleService.getProgramStatus(Collections.emptyList()));
+  }
+
+  @Test
+  public void testProgramStatusFromSingleRun() {
+    RunRecordMeta record = RunRecordMeta.builder()
+      .setProgramRunId(NamespaceId.DEFAULT.app("app").mr("mr").run(RunIds.generate()))
+      .setStartTime(System.currentTimeMillis())
+      .setArtifactId(new ArtifactId("r", new ArtifactVersion("1.0"), ArtifactScope.USER))
+      .setStatus(ProgramRunStatus.PENDING)
+      .setSourceId(new byte[] { 0 })
+      .build();
+
+    // pending or starting -> starting
+    ProgramStatus status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    Assert.assertEquals(ProgramStatus.STARTING, status);
+
+    record = RunRecordMeta.builder(record).setStatus(ProgramRunStatus.STARTING).build();
+    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    Assert.assertEquals(ProgramStatus.STARTING, status);
+
+    // running, suspended, resuming -> running
+    record = RunRecordMeta.builder(record).setStatus(ProgramRunStatus.RUNNING).build();
+    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    Assert.assertEquals(ProgramStatus.RUNNING, status);
+
+    record = RunRecordMeta.builder(record).setStatus(ProgramRunStatus.SUSPENDED).build();
+    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    Assert.assertEquals(ProgramStatus.RUNNING, status);
+
+    // failed, killed, completed -> stopped
+    record = RunRecordMeta.builder(record).setStatus(ProgramRunStatus.FAILED).build();
+    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    Assert.assertEquals(ProgramStatus.STOPPED, status);
+
+    record = RunRecordMeta.builder(record).setStatus(ProgramRunStatus.KILLED).build();
+    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    Assert.assertEquals(ProgramStatus.STOPPED, status);
+
+    record = RunRecordMeta.builder(record).setStatus(ProgramRunStatus.COMPLETED).build();
+    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    Assert.assertEquals(ProgramStatus.STOPPED, status);
+  }
+
+  @Test
+  public void testProgramStatusFromMultipleRuns() {
+    ProgramId programId = NamespaceId.DEFAULT.app("app").mr("mr");
+    RunRecordMeta pending = RunRecordMeta.builder()
+      .setProgramRunId(programId.run(RunIds.generate()))
+      .setStartTime(System.currentTimeMillis())
+      .setArtifactId(new ArtifactId("r", new ArtifactVersion("1.0"), ArtifactScope.USER))
+      .setStatus(ProgramRunStatus.PENDING)
+      .setSourceId(new byte[] { 0 })
+      .build();
+    RunRecordMeta starting = RunRecordMeta.builder(pending)
+      .setProgramRunId(programId.run(RunIds.generate()))
+      .setStatus(ProgramRunStatus.STARTING).build();
+    RunRecordMeta running = RunRecordMeta.builder(pending)
+      .setProgramRunId(programId.run(RunIds.generate()))
+      .setStatus(ProgramRunStatus.RUNNING).build();
+    RunRecordMeta killed = RunRecordMeta.builder(pending)
+      .setProgramRunId(programId.run(RunIds.generate()))
+      .setStatus(ProgramRunStatus.KILLED).build();
+    RunRecordMeta failed = RunRecordMeta.builder(pending)
+      .setProgramRunId(programId.run(RunIds.generate()))
+      .setStatus(ProgramRunStatus.FAILED).build();
+    RunRecordMeta completed = RunRecordMeta.builder(pending)
+      .setProgramRunId(programId.run(RunIds.generate()))
+      .setStatus(ProgramRunStatus.COMPLETED).build();
+
+    // running takes precedence over others
+    ProgramStatus status = ProgramLifecycleService.getProgramStatus(
+      Arrays.asList(pending, starting, running, killed, failed, completed));
+    Assert.assertEquals(ProgramStatus.RUNNING, status);
+
+    // starting takes precedence over stopped
+    status = ProgramLifecycleService.getProgramStatus(Arrays.asList(pending, killed, failed, completed));
+    Assert.assertEquals(ProgramStatus.STARTING, status);
+    status = ProgramLifecycleService.getProgramStatus(Arrays.asList(starting, killed, failed, completed));
+    Assert.assertEquals(ProgramStatus.STARTING, status);
+
+    // end states are stopped
+    status = ProgramLifecycleService.getProgramStatus(Arrays.asList(killed, failed, completed));
+    Assert.assertEquals(ProgramStatus.STOPPED, status);
+  }
+}


### PR DESCRIPTION
The call to get a program status was suspectible to races because
run records for the program were not read in a single transaction.
If run state happened to change in between run record reads, the
state could incorrectly be returned as stopped.

This race condition would cascade and cause other tests to fail
that would wait for a program run to complete. If one of those
tests ran into this scenario, the test would move on assuming
the program had stopped when it in fact was still running.

Fixed to read run records in a single transaction, and added
missing unit tests.