### PR TITLE
CDAP-13354 fix incorrect response code for putting a profile

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProfileHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProfileHttpHandler.java
@@ -181,6 +181,9 @@ public class ProfileHttpHandler extends AbstractHttpHandler {
     Collection<ProvisionerPropertyValue> provisionerProperties = provisionerInfo.getProperties();
     if (provisionerProperties != null) {
       for (ProvisionerPropertyValue value : provisionerProperties) {
+        if (value == null) {
+          continue;
+        }
         properties.put(value.getName(), value.getValue());
       }
     }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/profile/ProfileCreateRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/profile/ProfileCreateRequest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.proto.profile;
 import co.cask.cdap.proto.provisioner.ProvisionerInfo;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Information about a profile.
@@ -32,8 +33,12 @@ public class ProfileCreateRequest {
     this.provisioner = provisioner;
   }
 
+  // this will only return null if there is no such field in json
+  @Nullable
   public ProvisionerInfo getProvisioner() {
-    return provisioner;
+    // This is to make sure there is no null value in provisioner properties,
+    // since Gson will deserialize non-existing property to null value.
+    return provisioner == null ? null : new ProvisionerInfo(provisioner.getName(), provisioner.getProperties());
   }
 
   public String getDescription() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerInfo.java
@@ -17,7 +17,9 @@
 package co.cask.cdap.proto.provisioner;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Information about a provisioner name and properties.
@@ -28,7 +30,8 @@ public class ProvisionerInfo {
 
   public ProvisionerInfo(String name, Collection<ProvisionerPropertyValue> properties) {
     this.name = name;
-    this.properties = properties;
+    this.properties = Collections.unmodifiableList(
+      properties.stream().filter(Objects::nonNull).collect(Collectors.toList()));
   }
 
   public String getName() {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13354
Build: https://builds.cask.co/browse/CDAP-DUT6464-1

If we provide a json file like this: 
```{
  "provisioner": {
    "name": "gce-dataproc",
    "properties": [
      {
        "name": "accountKey",
        "value": ""
      },
      {
        "name": "region",
        "value": "global"
      },
      {
        "name": "zone",
        "value": "us-central1-a"
      },
      {
        "name": "projectId",
        "value": "pid37638"
      },
    ]
  }
} 
```
Gson will deserialize the list comma as a null property value, which will throw a NPE, we should throw it with a correct response code and message