### PR TITLE
[CDAP-13457][CDAP-13470][CDAP-13476] Bugfixes/improvements in Reports UI

### DIFF
--- a/cdap-ui/app/cdap/components/Popover/index.js
+++ b/cdap-ui/app/cdap/components/Popover/index.js
@@ -55,7 +55,6 @@ export default class Popover extends PureComponent {
     bubbleEvent: true,
     enableInteractionInPopover: false,
     injectOnToggle: false,
-    showPopover: false,
     modifiers: {
       preventOverflow: {
         enabled: true,
@@ -83,7 +82,8 @@ export default class Popover extends PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.showPopover !== this.state.showPopover) {
+    if (typeof nextProps.showPopover === 'boolean' &&
+        nextProps.showPopover !== this.state.showPopover) {
       this.togglePopover();
     }
   }

--- a/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusPopover.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusPopover.js
@@ -19,15 +19,8 @@ import PropTypes from 'prop-types';
 import Popover from 'components/Popover';
 import IconSVG from 'components/IconSVG';
 import {connect} from 'react-redux';
-import {ReportsActions} from 'components/Reports/store/ReportsStore';
+import {ReportsActions, STATUS_OPTIONS} from 'components/Reports/store/ReportsStore';
 import StatusViewer from 'components/Reports/Customizer/StatusSelector/StatusViewer';
-
-const OPTIONS = [
-  'FAILED',
-  'COMPLETED',
-  'RUNNING',
-  'STOPPED'
-];
 
 class StatusPopoverView extends Component {
   static propTypes = {
@@ -72,19 +65,29 @@ class StatusPopoverView extends Component {
     document.body.click();
   };
 
+  // Setting selections to previous selections when the user clicks outside
+  onTogglePopover = (showPopover) => {
+    if (!showPopover) {
+      this.setState({
+        selections: this.props.selections
+      });
+    }
+  };
+
   render() {
     return (
       <Popover
-        target={StatusViewer}
+        target={StatusViewer.bind(null, this.state.selections)}
         className="status-selector-popover"
         placement="bottom"
         bubbleEvent={false}
         enableInteractionInPopover={true}
         injectOnToggle={true}
+        onTogglePopover={this.onTogglePopover}
       >
         <div className="options">
           {
-            OPTIONS.map((option) => {
+            STATUS_OPTIONS.map((option) => {
               return (
                 <div
                   className="option"
@@ -101,10 +104,9 @@ class StatusPopoverView extends Component {
             })
           }
         </div>
-
         <div className="action">
           <button
-            className="btn btn-link"
+            className="btn btn-primary"
             onClick={this.apply}
           >
             Apply

--- a/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusSelector.scss
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusSelector.scss
@@ -63,8 +63,6 @@ $caret-width: 25px;
 
       .action {
         margin-top: 15px;
-
-        .btn { padding: 0; }
       }
 
       .running { color: $running; }

--- a/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusViewer.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusViewer.js
@@ -17,13 +17,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import IconSVG from 'components/IconSVG';
-import {connect} from 'react-redux';
+import {STATUS_OPTIONS} from 'components/Reports/store/ReportsStore';
 
-function StatusViewerView({selections}) {
+function StatusViewer(selections) {
   let text = 'Select one';
+  let numSelections = selections.length;
 
-  if (selections.length > 0) {
-    text = selections.join(', ');
+  if (numSelections > 0) {
+    if (numSelections === STATUS_OPTIONS.length) {
+      text = 'All statuses';
+    } else {
+      text = selections.join(', ');
+      if (numSelections > 1) {
+        text = `(${numSelections}) ` + text;
+      }
+    }
   }
 
   return (
@@ -39,18 +47,8 @@ function StatusViewerView({selections}) {
   );
 }
 
-StatusViewerView.propTypes = {
+StatusViewer.propTypes = {
   selections: PropTypes.array
 };
-
-const mapStateToProps = (state) => {
-  return {
-    selections: state.status.statusSelections
-  };
-};
-
-const StatusViewer = connect(
-  mapStateToProps
-)(StatusViewerView);
 
 export default StatusViewer;

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/Runs/Runs.scss
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/Runs/Runs.scss
@@ -58,6 +58,17 @@ $border-color: $grey-03;
 
       .grid-row {
         padding: 3px 0;
+
+        &:hover {
+          background-color: white;
+        }
+
+        .runtime-args-row {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          margin-bottom: 0;
+          margin-top: 0.5rem;
+        }
       }
     }
   }

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/ReportsList.scss
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/ReportsList.scss
@@ -58,6 +58,9 @@ $active-border-color: $green-01;
     }
     .grid.grid-container {
       max-height: 100%;
+      height: 100%;
+      grid-auto-rows: 45px;
+
       .grid-header,
       .grid-body {
         .grid-row {

--- a/cdap-ui/app/cdap/components/Reports/store/ReportsStore.js
+++ b/cdap-ui/app/cdap/components/Reports/store/ReportsStore.js
@@ -33,6 +33,13 @@ const ReportsActions = {
   reset: 'REPORTS_RESET'
 };
 
+const STATUS_OPTIONS = [
+  'FAILED',
+  'COMPLETED',
+  'RUNNING',
+  'STOPPED'
+];
+
 const defaultCustomizerState = {
   pipelines: false,
   customApps: false,
@@ -50,7 +57,7 @@ const defaultCustomizerState = {
 };
 
 const defaultStatusState = {
-  statusSelections: []
+  statusSelections: [STATUS_OPTIONS[0]]
 };
 
 const defaultTimeRangeState = {
@@ -225,4 +232,4 @@ const ReportsStore = createStore(
 );
 
 export default ReportsStore;
-export {ReportsActions};
+export {ReportsActions, STATUS_OPTIONS};


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-13457: Changes status popover in Reports page to automatically show selections. Also sets default selection to 'FAILED'

- https://issues.cask.co/browse/CDAP-13470: Fixes regression in Popover component that was causing every click to close the popover

- https://issues.cask.co/browse/CDAP-13476: Changes how we display runtime arguments in reports detail page (from JSON 'key1: val1' to 'key1 = val1')