### PR TITLE
CDAP-13293 changes to add auth and sharing reports

### DIFF
--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/proto/ReportIdentifier.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/proto/ReportIdentifier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+/**
+ * ReportIdentifier represented by userName and reportId
+ */
+public class ReportIdentifier {
+  private final String userName;
+  private final String reportId;
+
+  public ReportIdentifier(String userName, String reportId) {
+    this.userName = userName;
+    this.reportId = reportId;
+  }
+
+  public String getUserName() {
+    return userName;
+  }
+
+  public String getReportId() {
+    return reportId;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/proto/ShareId.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/proto/ShareId.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.report.proto;
+
+/**
+ * ShareId representing the shared report id
+ */
+public class ShareId {
+  public final String shareId;
+
+  public ShareId(String shareId) {
+    this.shareId = shareId;
+  }
+  public String getShareId() {
+    return shareId;
+  }
+}

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/util/Constants.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/util/Constants.java
@@ -20,6 +20,16 @@ package co.cask.cdap.report.util;
  * Constants used by the report generation app and file schema.
  */
 public final class Constants {
+  /**
+   * Constants releated to security key encryption
+   */
+  public static final class Security {
+    public static final String ENCRYPTION_ALGORITHM = "AES";
+    public static final String KEY_FILE_NAME = "security_key";
+    public static final String KEY_FILE_PERMISSION = "700";
+    public static final int ENCRYPTION_KEY_BITSIZE = 128;
+  }
+
   public static final String NAMESPACE = "namespace";
   public static final String ARTIFACT_SCOPE = "artifactScope";
   public static final String ARTIFACT_NAME = "artifactName";


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-13293

Added authentication support in reporting app using authenticated user name passed from router to ReportingApplicationService through headers. 

Using the authenticated user name to create user directories under which user generated reports will be stored/retrieved/deleted.

Sharing of reports is done by encoding and decoding the object containing the userId and reportId to uniquely identify a report. 

Pending changes : Since the REST API for report info and downloading report changed, need to update the UI correspondingly once the review is approved.