### PR TITLE
[CDAP-13474][CDAP-13475] Adds i18n for Ops Dashboard and Reports

### DIFF
--- a/cdap-ui/app/cdap/components/NamespacesPicker/NamespacesPopover.js
+++ b/cdap-ui/app/cdap/components/NamespacesPicker/NamespacesPopover.js
@@ -22,6 +22,9 @@ import IconSVG from 'components/IconSVG';
 import {connect} from 'react-redux';
 import {UncontrolledDropdown} from 'components/UncontrolledComponents';
 import { DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
+import T from 'i18n-react';
+
+const PREFIX = 'features.NamespacesPicker';
 
 class NamespacesPopoverView extends Component {
   static propTypes = {
@@ -77,9 +80,15 @@ class NamespacesPopoverView extends Component {
   };
 
   render() {
+    const targetElem = (
+      <div className="monitor-more text-xs-right">
+        {T.translate(`${PREFIX}.monitorMore`)}
+      </div>
+    );
+
     return (
       <Popover
-        target={() => <div className="monitor-more text-xs-right"> Monitor More </div>}
+        target={() => targetElem}
         className="namespaces-list-popover"
         placement="top"
         bubbleEvent={false}
@@ -87,11 +96,13 @@ class NamespacesPopoverView extends Component {
       >
         <div className="popover-content">
           <div className="title">
-            Select Namespaces to monitor
+            {T.translate(`${PREFIX}.popoverHeader`)}
           </div>
 
           <div className="namespaces-count">
-            {this.state.namespaces.length + 1} namespaces
+            {T.translate(`${PREFIX}.namespacesCount`, {
+              context: this.state.namespaces.length + 1
+            })}
           </div>
 
           <div className="namespaces-list">
@@ -108,20 +119,20 @@ class NamespacesPopoverView extends Component {
                       className="toggle-option"
                       onClick={this.selectAll}
                     >
-                      Select All
+                      {T.translate(`${PREFIX}.selectAll`)}
                     </DropdownItem>
                     <DropdownItem
                       className="toggle-option"
                       onClick={this.clearAll}
                     >
-                      Clear All
+                      {T.translate(`${PREFIX}.clearAll`)}
                     </DropdownItem>
                   </DropdownMenu>
                 </UncontrolledDropdown>
               </div>
 
               <div className="namespace-section">
-                Namespace name
+                {T.translate(`${PREFIX}.namespaceName`)}
               </div>
             </div>
 

--- a/cdap-ui/app/cdap/components/NamespacesPicker/index.js
+++ b/cdap-ui/app/cdap/components/NamespacesPicker/index.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import NamespacesPopover from 'components/NamespacesPicker/NamespacesPopover';
+import T from 'i18n-react';
+
+const PREFIX = 'features.NamespacesPicker';
 
 require('./NamespacesPicker.scss');
 
@@ -28,13 +31,13 @@ function NamespacesPickerView({namespacesPick, setNamespacesPick}) {
   if (namespacesPick.length === 0) {
     monitorTitle = (
       <div className="namespace-list-monitor">
-        Monitor Namespace {`'${getCurrentNamespace()}'`}
+        {T.translate(`${PREFIX}.monitorNamespace`, {namespace: getCurrentNamespace()})}
       </div>
     );
   } else {
     let namespacesList = [getCurrentNamespace()].concat(namespacesPick);
 
-    let text = namespacesList.map((ns) => `'${ns}'`).join('; ');
+    let namespaces = namespacesList.map((ns) => `'${ns}'`).join('; ');
     let title = namespacesList.join('\n');
 
     monitorTitle = (
@@ -42,7 +45,12 @@ function NamespacesPickerView({namespacesPick, setNamespacesPick}) {
         className="namespace-list-monitor"
         title={title}
       >
-        Monitor {namespacesPick.length + 1} Namespaces {text}
+        {
+          T.translate(`${PREFIX}.monitorMultipleNamespaces`, {
+            count: namespacesPick.length + 1,
+            namespaces
+          })
+        }
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/Legends/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/Legends/index.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import IconSVG from 'components/IconSVG';
 import {connect} from 'react-redux';
 import {DashboardActions} from 'components/OpsDashboard/store/DashboardStore';
+import T from 'i18n-react';
+
+const PREFIX = 'features.OpsDashboard.RunsGraph.Legends';
 
 function LegendsView({onClick, manual, schedule, running, success, failed, delay}) {
   return (
@@ -33,7 +36,7 @@ function LegendsView({onClick, manual, schedule, running, success, failed, delay
             name="icon-circle"
             className="manual"
           />
-          <span>Manually started runs</span>
+          <span>{T.translate(`${PREFIX}.manuallyStarted`)}</span>
         </div>
 
         <div
@@ -45,7 +48,7 @@ function LegendsView({onClick, manual, schedule, running, success, failed, delay
             name="icon-circle"
             className="schedule"
           />
-          <span>Scheduled/triggered runs</span>
+          <span>{T.translate(`${PREFIX}.scheduledTriggered`)}</span>
         </div>
       </div>
 
@@ -59,7 +62,7 @@ function LegendsView({onClick, manual, schedule, running, success, failed, delay
             name="icon-circle"
             className="running"
           />
-          <span>Running</span>
+          <span>{T.translate(`${PREFIX}.running`)}</span>
         </div>
 
         <div
@@ -71,7 +74,7 @@ function LegendsView({onClick, manual, schedule, running, success, failed, delay
             name="icon-circle"
             className="successful"
           />
-          <span>Successful runs</span>
+          <span>{T.translate(`${PREFIX}.successful`)}</span>
         </div>
 
         <div
@@ -83,7 +86,7 @@ function LegendsView({onClick, manual, schedule, running, success, failed, delay
             name="icon-circle"
             className="failed"
           />
-          <span>Failed runs</span>
+          <span>{T.translate(`${PREFIX}.failed`)}</span>
         </div>
       </div>
 
@@ -97,7 +100,7 @@ function LegendsView({onClick, manual, schedule, running, success, failed, delay
             name="icon-circle"
             className="delay"
           />
-          <span>Delay between starting and running</span>
+          <span>{T.translate(`${PREFIX}.delay`)}</span>
         </div>
       </div>
     </div>

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsTable/index.js
@@ -20,6 +20,9 @@ import {connect} from 'react-redux';
 import moment from 'moment';
 import {DashboardActions} from 'components/OpsDashboard/store/DashboardStore';
 import {humanReadableDuration} from 'services/helpers';
+import T from 'i18n-react';
+
+const PREFIX = 'features.OpsDashboard.RunsGraph.RunsTable';
 
 require('./RunsTable.scss');
 
@@ -28,34 +31,34 @@ const renderHeader = () => {
     <div className="grid-header">
       <div className="grid-row">
         <div>
-          Time
+          {T.translate(`${PREFIX}.time`)}
         </div>
         <div>
-          Date
+          {T.translate(`${PREFIX}.date`)}
         </div>
         <div>
-          Total Runs Started
+          {T.translate(`${PREFIX}.totalRunsStarted`)}
         </div>
         <div>
-          Scheduled / Triggered
+          {T.translate(`${PREFIX}.scheduledTriggered`)}
         </div>
         <div>
-          Manually
+          {T.translate(`${PREFIX}.manually`)}
         </div>
         <div>
-          Total Runs Ended
+          {T.translate(`${PREFIX}.totalRunsEnded`)}
         </div>
         <div>
-          Successful
+          {T.translate(`${PREFIX}.successful`)}
         </div>
         <div>
-          Failed
+          {T.translate(`${PREFIX}.failed`)}
         </div>
         <div>
-          Running
+          {T.translate(`${PREFIX}.running`)}
         </div>
         <div>
-          Total Start Delay
+          {T.translate(`${PREFIX}.totalStartDelay`)}
         </div>
       </div>
     </div>

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/ToggleRunsList.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/ToggleRunsList.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import IconSVG from 'components/IconSVG';
 import {connect} from 'react-redux';
 import {DashboardActions} from 'components/OpsDashboard/store/DashboardStore';
+import T from 'i18n-react';
+
+const PREFIX = 'features.OpsDashboard.RunsGraph.ToggleRunsList';
 
 function ToggleRunsListView({onClick, displayRunsList}) {
   return (
@@ -31,9 +34,9 @@ function ToggleRunsListView({onClick, displayRunsList}) {
         <span>
           {
             displayRunsList ?
-              'Hide runs'
+              T.translate(`${PREFIX}.hideRuns`)
             :
-              'Show runs'
+              T.translate(`${PREFIX}.showRuns`)
           }
         </span>
       </span>

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/TypeSelector/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/TypeSelector/index.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import IconSVG from 'components/IconSVG';
 import {connect} from 'react-redux';
 import {DashboardActions} from 'components/OpsDashboard/store/DashboardStore';
+import T from 'i18n-react';
+
+const PREFIX = 'features.OpsDashboard.RunsGraph.TypeSelector';
 
 function TypeSelectorView({togglePipeline, toggleCustomApp, pipeline, customApp, pipelineCount, customAppCount}) {
   return (
@@ -28,7 +31,7 @@ function TypeSelectorView({togglePipeline, toggleCustomApp, pipeline, customApp,
         onClick={togglePipeline}
       >
         <IconSVG name={pipeline ? 'icon-check-square' : 'icon-square-o'} />
-        <span>Pipelines ({pipelineCount})</span>
+        <span>{T.translate(`${PREFIX}.pipelinesWithCount`, {count: pipelineCount})}</span>
       </div>
 
       <div
@@ -36,7 +39,7 @@ function TypeSelectorView({togglePipeline, toggleCustomApp, pipeline, customApp,
         onClick={toggleCustomApp}
       >
         <IconSVG name={customApp ? 'icon-check-square' : 'icon-square-o'} />
-        <span>Custom Apps ({customAppCount})</span>
+        <span>{T.translate(`${PREFIX}.customAppsWithCount`, {count: customAppCount})}</span>
       </div>
     </div>
   );

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/index.js
@@ -28,6 +28,9 @@ import RunsTable from 'components/OpsDashboard/RunsGraph/RunsTable';
 import {DashboardActions} from 'components/OpsDashboard/store/DashboardStore';
 import classnames from 'classnames';
 import {getData} from 'components/OpsDashboard/store/ActionCreator';
+import T from 'i18n-react';
+
+const PREFIX = 'features.OpsDashboard.RunsGraph';
 
 require('./RunsGraph.scss');
 
@@ -99,7 +102,7 @@ class RunsGraphView extends Component {
       <div className="runs-graph-container">
         <div className="top-panel">
           <div className="title">
-            Runs Timeline
+            {T.translate(`${PREFIX}.header`)}
           </div>
 
           <TypeSelector />
@@ -107,7 +110,7 @@ class RunsGraphView extends Component {
           <div className="display-picker">
             <div className="time-picker">
               <div onClick={this.last24Hour}>
-                Last 24 hours
+                {T.translate(`${PREFIX}.last24Hours`)}
               </div>
             </div>
 
@@ -118,7 +121,7 @@ class RunsGraphView extends Component {
                 })}
                 onClick={this.props.changeDisplay.bind(this, 'chart')}
               >
-                Chart
+                {T.translate(`${PREFIX}.chart`)}
               </span>
               <span className="separator">|</span>
               <span
@@ -127,7 +130,7 @@ class RunsGraphView extends Component {
                 })}
                 onClick={this.props.changeDisplay.bind(this, 'table')}
               >
-                Table
+                {T.translate(`${PREFIX}.table`)}
               </span>
             </div>
           </div>

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsList/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsList/index.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import {connect} from 'react-redux';
 import {humanReadableDuration} from 'services/helpers';
+import T from 'i18n-react';
+
+const PREFIX = 'features.OpsDashboard.RunsList';
 
 require('./RunsList.scss');
 
@@ -26,13 +29,13 @@ function renderHeader() {
   return (
     <div className="grid-header">
       <div className="grid-row">
-        <div>Namespace</div>
-        <div>Name</div>
-        <div>Type</div>
-        <div>Duration</div>
-        <div>User</div>
-        <div>Start Method</div>
-        <div>Status</div>
+        <div>{T.translate(`${PREFIX}.namespace`)}</div>
+        <div>{T.translate(`${PREFIX}.name`)}</div>
+        <div>{T.translate(`${PREFIX}.type`)}</div>
+        <div>{T.translate(`${PREFIX}.duration`)}</div>
+        <div>{T.translate(`${PREFIX}.user`)}</div>
+        <div>{T.translate(`${PREFIX}.startMethod`)}</div>
+        <div>{T.translate(`${PREFIX}.status`)}</div>
       </div>
     </div>
   );
@@ -69,7 +72,9 @@ function renderGrid(data) {
   if (data.length === 0) {
     return (
       <div className="list-view">
-        <h3 className="text-xs-center">No runs</h3>
+        <h3 className="text-xs-center">
+          {T.translate(`${PREFIX}.noRuns`)}
+        </h3>
       </div>
     );
   }
@@ -91,7 +96,9 @@ function RunsListView({bucketInfo, displayRunsList}) {
   if (!bucketInfo) {
     return (
       <div className="runs-list-container">
-        <h3 className="text-xs-center">No data</h3>
+        <h3 className="text-xs-center">
+          {T.translate(`${PREFIX}.noData`)}
+        </h3>
       </div>
     );
   }
@@ -105,28 +112,38 @@ function RunsListView({bucketInfo, displayRunsList}) {
     <div className="runs-list-container">
       <div className="top-panel-data">
         <div className="date">
-          <div className="title">Date</div>
+          <div className="title">
+            {T.translate(`${PREFIX}.date`)}
+          </div>
           <div>{moment(date).format('ddd, MMM D, YYYY')}</div>
         </div>
 
         <div className="time-range">
-          <div className="title">Time range</div>
+          <div className="title">
+            {T.translate(`${PREFIX}.timeRange`)}
+          </div>
           <div>{timeRangeStart} - {timeRangeStop}</div>
         </div>
 
         <div className="type">
-          <div className="title">Type</div>
-          <div>All</div>
+          <div className="title">
+            {T.translate(`${PREFIX}.type`)}
+          </div>
+          <div>{T.translate(`${PREFIX}.all`)}</div>
         </div>
 
         <div className="start-method">
-          <div className="title">Start method</div>
-          <div>View All</div>
+          <div className="title">
+            {T.translate(`${PREFIX}.startMethod`)}
+          </div>
+          <div>{T.translate(`${PREFIX}.viewAll`)}</div>
         </div>
 
         <div className="status">
-          <div className="title">Status</div>
-          <div>All</div>
+          <div className="title">
+            {T.translate(`${PREFIX}.status`)}
+          </div>
+          <div>{T.translate(`${PREFIX}.all`)}</div>
         </div>
       </div>
 

--- a/cdap-ui/app/cdap/components/OpsDashboard/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/index.js
@@ -22,6 +22,10 @@ import RunsList from 'components/OpsDashboard/RunsList';
 import {getData} from 'components/OpsDashboard/store/ActionCreator';
 import NamespacesPicker from 'components/NamespacesPicker';
 import {setNamespacesPick} from 'components/OpsDashboard/store/ActionCreator';
+import T from 'i18n-react';
+import Helmet from 'react-helmet';
+
+const PREFIX = 'features.OpsDashboard';
 
 require('./OpsDashboard.scss');
 
@@ -40,9 +44,10 @@ export default class OpsDashboard extends Component {
     return (
       <Provider store={DashboardStore}>
         <div className="ops-dashboard">
+          <Helmet title={T.translate(`${PREFIX}.pageTitle`)} />
           <div className="header clearfix">
             <div className="links float-xs-left">
-              <span>Dashboard</span>
+              <span>{T.translate(`${PREFIX}.header`)}</span>
             </div>
 
             <NamespacesPicker setNamespacesPick={setNamespacesPick} />

--- a/cdap-ui/app/cdap/components/Reports/Customizer/ActionButtons/index.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/ActionButtons/index.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {ReportsActions} from 'components/Reports/store/ReportsStore';
 import {generateReport} from 'components/Reports/store/ActionCreator';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.Customizer';
 
 function ActionButtonsView({clearSelection, timeRange, customizer, status}) {
   let disabled = (!timeRange.selection) ||
@@ -33,14 +36,14 @@ function ActionButtonsView({clearSelection, timeRange, customizer, status}) {
         onClick={generateReport}
         disabled={disabled}
       >
-        Generate Report
+        {T.translate(`${PREFIX}.generate`)}
       </button>
 
       <button
         className="btn btn-link"
         onClick={clearSelection}
       >
-        Clear Selection
+        {T.translate(`${PREFIX}.clear`)}
       </button>
     </div>
   );

--- a/cdap-ui/app/cdap/components/Reports/Customizer/AppTypeSelector/index.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/AppTypeSelector/index.js
@@ -40,7 +40,7 @@ function AppTypeSelectorView(props) {
   return (
     <div className="app-type-selector">
       <div className="title">
-        Customize Runs View
+        {T.translate(`${PREFIX}.header`)}
       </div>
 
       {

--- a/cdap-ui/app/cdap/components/Reports/Customizer/ColumnsSelector/index.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/ColumnsSelector/index.js
@@ -49,7 +49,7 @@ function ColumnsSelectorView(props) {
   return (
     <div className="columns-selector">
       <div className="title">
-        Select Columns
+        {T.translate(`${PREFIX}.selectColumns`)}
       </div>
 
       {

--- a/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusPopover.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusPopover.js
@@ -21,6 +21,8 @@ import IconSVG from 'components/IconSVG';
 import {connect} from 'react-redux';
 import {ReportsActions, STATUS_OPTIONS} from 'components/Reports/store/ReportsStore';
 import StatusViewer from 'components/Reports/Customizer/StatusSelector/StatusViewer';
+import StatusMapper from 'services/StatusMapper';
+import T from 'i18n-react';
 
 class StatusPopoverView extends Component {
   static propTypes = {
@@ -97,7 +99,7 @@ class StatusPopoverView extends Component {
                   <IconSVG name="icon-circle" className={option.toLowerCase()} />
 
                   <span>
-                    {option}
+                    {StatusMapper.lookupDisplayStatus(option)}
                   </span>
                 </div>
               );
@@ -109,7 +111,7 @@ class StatusPopoverView extends Component {
             className="btn btn-primary"
             onClick={this.apply}
           >
-            Apply
+            {T.translate('commons.apply')}
           </button>
         </div>
       </Popover>

--- a/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusViewer.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/StatusViewer.js
@@ -18,16 +18,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import IconSVG from 'components/IconSVG';
 import {STATUS_OPTIONS} from 'components/Reports/store/ReportsStore';
+import {getStatusSelectionsLabels} from 'components/Reports/store/ActionCreator';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.Customizer.StatusSelector';
 
 function StatusViewer(selections) {
-  let text = 'Select one';
+  let text = T.translate(`${PREFIX}.selectOne`);
   let numSelections = selections.length;
 
   if (numSelections > 0) {
     if (numSelections === STATUS_OPTIONS.length) {
-      text = 'All statuses';
+      text = T.translate(`${PREFIX}.allStatuses`);
     } else {
-      text = selections.join(', ');
+      text = getStatusSelectionsLabels(selections).join(', ');
       if (numSelections > 1) {
         text = `(${numSelections}) ` + text;
       }

--- a/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/index.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/StatusSelector/index.js
@@ -16,6 +16,9 @@
 
 import React from 'react';
 import StatusPopover from 'components/Reports/Customizer/StatusSelector/StatusPopover';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.Customizer.StatusSelector';
 
 require('./StatusSelector.scss');
 
@@ -23,7 +26,7 @@ export default function StatusSelector() {
   return (
     <div className="status-selector">
       <div className="title">
-        Select Status
+        {T.translate(`${PREFIX}.selectStatus`)}
       </div>
 
       <StatusPopover />

--- a/cdap-ui/app/cdap/components/Reports/Customizer/TimeRangeSelector/TimeRangePopover.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/TimeRangeSelector/TimeRangePopover.js
@@ -21,6 +21,9 @@ import IconSVG from 'components/IconSVG';
 import TimeRangePicker from 'components/TimeRangePicker';
 import {connect} from 'react-redux';
 import {ReportsActions} from 'components/Reports/store/ReportsStore';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.Customizer.TimeRangeSelector';
 
 class TimeRangePopoverView extends Component {
   static propTypes = {
@@ -103,7 +106,7 @@ class TimeRangePopoverView extends Component {
           disabled={disabled}
           onClick={this.apply}
         >
-          Apply
+          {T.translate('commons.apply')}
         </button>
       </div>
     );
@@ -120,7 +123,7 @@ class TimeRangePopoverView extends Component {
         injectOnToggle={true}
       >
         <div className="title">
-          Select Time Range:
+          {T.translate(`${PREFIX}.labelWithColon`)}
         </div>
 
         <div className="options">
@@ -129,7 +132,7 @@ class TimeRangePopoverView extends Component {
             onClick={this.changeSelection.bind(this, 'last30')}
           >
             <IconSVG name={this.state.selection === 'last30' ? 'icon-circle' : 'icon-circle-o'} />
-            Last 30 min
+            {T.translate(`${PREFIX}.last30Min`)}
           </div>
 
           <div
@@ -137,7 +140,7 @@ class TimeRangePopoverView extends Component {
             onClick={this.changeSelection.bind(this, 'lastHour')}
           >
             <IconSVG name={this.state.selection === 'lastHour' ? 'icon-circle' : 'icon-circle-o'} />
-            Last 1 hour
+            {T.translate(`${PREFIX}.lastHour`)}
           </div>
 
           <div
@@ -145,7 +148,7 @@ class TimeRangePopoverView extends Component {
             onClick={this.changeSelection.bind(this, 'custom')}
           >
             <IconSVG name={this.state.selection === 'custom' ? 'icon-circle' : 'icon-circle-o'} />
-            Custom range
+            {T.translate(`${PREFIX}.customRange`)}
           </div>
         </div>
 

--- a/cdap-ui/app/cdap/components/Reports/Customizer/TimeRangeSelector/index.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/TimeRangeSelector/index.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import TimeRangePopover from 'components/Reports/Customizer/TimeRangeSelector/TimeRangePopover';
 import {connect} from 'react-redux';
 import moment from 'moment';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.Customizer.TimeRangeSelector';
 
 require('./TimeRangeSelector.scss');
 
@@ -35,13 +38,13 @@ function renderDisplay(selection, start, end) {
 
   switch (selection) {
     case 'last30':
-      return 'Last 30 minutes';
+      return T.translate(`${PREFIX}.last30Minutes`);
     case 'lastHour':
-      return 'Last 1 hour';
+      return T.translate(`${PREFIX}.lastHour`);
     case 'custom':
-      return `${startTime} to ${endTime}`;
+      return T.translate(`${PREFIX}.timeRange`, {startTime, endTime});
     default:
-      return 'Select time';
+      return T.translate(`${PREFIX}.select`);
   }
 }
 
@@ -49,7 +52,7 @@ function TimeRangeSelectorView({selection, start, end}) {
   return (
     <div className="reports-time-range-selector">
       <div className="title">
-        Select Time Range
+        {T.translate(`${PREFIX}.label`)}
       </div>
 
       <div className="time-selector-value">

--- a/cdap-ui/app/cdap/components/Reports/Customizer/index.js
+++ b/cdap-ui/app/cdap/components/Reports/Customizer/index.js
@@ -22,6 +22,9 @@ import AppTypeSelector from 'components/Reports/Customizer/AppTypeSelector';
 import ActionButtons from 'components/Reports/Customizer/ActionButtons';
 import StatusSelector from 'components/Reports/Customizer/StatusSelector';
 import classnames from 'classnames';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.Customizer';
 
 require('./Customizer.scss');
 
@@ -62,7 +65,12 @@ export default class Customizer extends Component {
             onClick={this.toggleCollapsed}
           >
             <IconSVG name={this.state.isCollapsed ? 'icon-caret-right' : 'icon-caret-down'} />
-            {this.state.isCollapsed ? 'Show generate a report' : 'Hide generate a report'}
+            {
+              this.state.isCollapsed ?
+                T.translate(`${PREFIX}.show`)
+              :
+                T.translate(`${PREFIX}.hide`)
+            }
           </div>
         </div>
 

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/Expiry/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/Expiry/index.js
@@ -18,6 +18,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import Duration from 'components/Duration';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.ReportsDetail';
 
 require('./Expiry.scss');
 
@@ -25,14 +28,14 @@ function ExpiryView({expiry}) {
   if (!expiry) {
     return (
       <span className="expiry-saved">
-        Saved
+        {T.translate(`${PREFIX}.saved`)}
       </span>
     );
   }
 
   return (
     <span className="expiry">
-      <span>Expires in</span>
+      <span>{T.translate(`${PREFIX}.expiresIn`)}</span>
 
       <Duration
         targetTime={expiry}

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/Runs/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/Runs/index.js
@@ -21,6 +21,11 @@ import {GLOBALS} from 'services/global-constants';
 import {humanReadableDate, humanReadableDuration} from 'services/helpers';
 import {DefaultSelection} from 'components/Reports/store/ActionCreator';
 import difference from 'lodash/difference';
+import capitalize from 'lodash/capitalize';
+import StatusMapper from 'services/StatusMapper';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.Customizer.Options';
 
 require('./Runs.scss');
 
@@ -41,31 +46,36 @@ function getName(run) {
 function getType(run) {
   switch (run.artifactName) {
     case GLOBALS.etlDataPipeline:
-      return 'Batch Pipeline';
+      return T.translate('features.Reports.ReportsDetail.batch');
     case GLOBALS.etlDataStreams:
-      return 'Realtime Pipeline';
+      return T.translate('features.Reports.ReportsDetail.realtime');
     default:
       return run.programType;
   }
 }
 
 function renderHeader(headers) {
+  let nameLabel = T.translate('commons.nameLabel');
+  let typeLabel = T.translate('commons.typeLabel');
+
   return (
     <div className="grid-header">
       <div className="grid-row">
-        <div title='Name'>
-          Name
+        <div title={nameLabel}>
+          {nameLabel}
         </div>
 
-        <div title='Type'>
-          Type
+        <div title={typeLabel}>
+          {typeLabel}
         </div>
 
         {
           headers.map((head) => {
+            let headerLabel = T.translate(`${PREFIX}.${head}`);
+
             return (
-              <div title={head}>
-                {head}
+              <div title={headerLabel}>
+                {headerLabel}
               </div>
             );
           })
@@ -103,11 +113,19 @@ function renderBody(runs, headers) {
                     value = humanReadableDate(value);
                   }
 
-                  if (head === 'duration') {
+                  else if (head === 'duration') {
                     value = humanReadableDuration(value);
                   }
 
-                  if (head === 'runtimeArgs') {
+                  else if (head === 'status') {
+                    value = StatusMapper.lookupDisplayStatus(value);
+                  }
+
+                  else if (head === 'startMethod') {
+                    value = capitalize(value);
+                  }
+
+                  else if (head === 'runtimeArgs') {
                     let keyValuePairs = Object.entries(value).map(keyValuePair => {
                       return `${keyValuePair[0]} = ${keyValuePair[1]}`;
                     });

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/SaveButton/SaveModal.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/SaveButton/SaveModal.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import {MyReportsApi} from 'api/reports';
 import ReportsStore, { ReportsActions } from 'components/Reports/store/ReportsStore';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.ReportsDetail';
 
 export default class SaveModal extends Component {
   static propTypes = {
@@ -95,7 +98,7 @@ export default class SaveModal extends Component {
       >
         <ModalHeader>
           <span>
-            Save Report
+            {T.translate(`${PREFIX}.saveReport`)}
           </span>
 
           <div
@@ -108,7 +111,7 @@ export default class SaveModal extends Component {
         <ModalBody>
           <div className="field-row">
             <label className="control-label">
-              Report Name
+              {T.translate('features.Reports.reportName')}
             </label>
 
             <input
@@ -126,7 +129,7 @@ export default class SaveModal extends Component {
             onClick={this.save}
             disabled={this.state.name.length === 0}
           >
-            Save
+            {T.translate(`${PREFIX}.save`)}
           </button>
 
           {this.renderError()}

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/SaveButton/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/SaveButton/index.js
@@ -18,6 +18,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import SaveModal from 'components/Reports/ReportsDetail/SaveButton/SaveModal';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.ReportsDetail';
 
 require('./SaveButton.scss');
 
@@ -59,7 +62,7 @@ class SaveButtonView extends Component {
           className="btn btn-primary"
           onClick={this.toggleModal}
         >
-          Save Report
+          {T.translate(`${PREFIX}.saveReport`)}
         </button>
 
         {this.renderModal()}

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/Summary/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/Summary/index.js
@@ -19,6 +19,9 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {humanReadableDate, humanReadableDuration} from 'services/helpers';
 import {GLOBALS} from 'services/global-constants';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.ReportsDetail';
 
 require('./Summary.scss');
 
@@ -27,7 +30,7 @@ function renderNamespaces(summary) {
 
   return summary.namespaces
     .map((ns) => {
-      return `${ns.namespace} (${ns.runs} runs)`;
+      return ns.namespace + T.translate(`${PREFIX}.numRuns`, {num: ns.runs});
     })
     .join(', ');
 }
@@ -35,10 +38,12 @@ function renderNamespaces(summary) {
 function renderAppType(summary) {
   if (!summary.artifacts) { return null; }
 
+  const customAppLabel = T.translate(`${PREFIX}.customApp`);
+
   let counts = {
     batch: 0,
     realtime: 0,
-    'Custom App': 0
+    [customAppLabel]: 0
   };
   // BatchPipeline and RealtimePipeline case should be removed once going to real API
   summary.artifacts.forEach((artifact) => {
@@ -52,7 +57,7 @@ function renderAppType(summary) {
         counts.realtime = artifact.runs;
         break;
       default:
-        counts['Custom App'] += artifact.runs;
+        counts[customAppLabel] += artifact.runs;
     }
   });
 
@@ -71,7 +76,7 @@ function renderDuration(summary) {
   let max = humanReadableDuration(durations.max);
   let average = humanReadableDuration(Math.round(durations.average));
 
-  return `Min: ${min}; Max: ${max}; Average: ${average}`;
+  return T.translate(`${PREFIX}.runDuration`, {min, max, average});
 }
 
 function renderLastStarted(summary) {
@@ -79,7 +84,10 @@ function renderLastStarted(summary) {
 
   if (!starts) { return null; }
 
-  return `Newest: ${humanReadableDate(starts.newest)}; Oldest: ${humanReadableDate(starts.oldest)}`;
+  return T.translate(`${PREFIX}.lastStarted`, {
+    newest: humanReadableDate(starts.newest),
+    oldest: humanReadableDate(starts.oldest)
+  });
 }
 
 function renderOwners(summary) {
@@ -93,9 +101,9 @@ function renderOwners(summary) {
 function renderStartMethod(summary) {
   if (!summary.startMethods) { return null; }
   const labelMap = {
-    MANUAL: 'manually',
-    SCHEDULED: 'by schedule',
-    PROGRAM_STATUS: 'by trigger'
+    MANUAL: T.translate(`${PREFIX}.manually`),
+    SCHEDULED: T.translate(`${PREFIX}.bySchedule`),
+    PROGRAM_STATUS: T.translate(`${PREFIX}.byTrigger`)
   };
 
   return summary.startMethods
@@ -112,13 +120,15 @@ function SummaryView({summary}) {
             <tbody>
               <tr className="no-border">
                 <td colSpan="2">
-                  <strong>Report Summary</strong>
+                  <strong>
+                    {T.translate(`${PREFIX}.reportSummary`)}
+                  </strong>
                 </td>
               </tr>
 
               <tr className="no-border">
                 <td>
-                  Namespace:
+                  {T.translate(`${PREFIX}.namespaceLabel`)}
                 </td>
 
                 <td>
@@ -128,17 +138,20 @@ function SummaryView({summary}) {
 
               <tr>
                 <td>
-                  Time range:
+                  {T.translate(`${PREFIX}.timeRangeLabel`)}
                 </td>
 
                 <td>
-                  {humanReadableDate(summary.start)} to {humanReadableDate(summary.end)}
+                  {T.translate(`${PREFIX}.timeRange`, {
+                    start: humanReadableDate(summary.start),
+                    end: humanReadableDate(summary.end)
+                  })}
                 </td>
               </tr>
 
               <tr>
                 <td>
-                  App Type:
+                  {T.translate(`${PREFIX}.appTypeLabel`)}
                 </td>
 
                 <td>
@@ -154,7 +167,7 @@ function SummaryView({summary}) {
             <tbody>
               <tr className="no-border">
                 <td>
-                  Run Duration:
+                  {T.translate(`${PREFIX}.runDurationLabel`)}
                 </td>
 
                 <td>
@@ -164,7 +177,7 @@ function SummaryView({summary}) {
 
               <tr>
                 <td>
-                  Last Started:
+                  {T.translate(`${PREFIX}.lastStartedLabel`)}
                 </td>
 
                 <td>
@@ -174,7 +187,7 @@ function SummaryView({summary}) {
 
               <tr>
                 <td>
-                  Owners
+                  {T.translate(`${PREFIX}.ownersLabel`)}
                 </td>
 
                 <td>
@@ -184,7 +197,7 @@ function SummaryView({summary}) {
 
               <tr>
                 <td>
-                  Started
+                  {T.translate(`${PREFIX}.startedLabel`)}
                 </td>
 
                 <td>

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/index.js
@@ -27,6 +27,9 @@ import {getCurrentNamespace} from 'services/NamespaceStore';
 import IconSVG from 'components/IconSVG';
 import {connect} from 'react-redux';
 import {humanReadableDate} from 'services/helpers';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.ReportsDetail';
 
 require('./ReportsDetail.scss');
 
@@ -127,7 +130,9 @@ class ReportsDetailView extends Component {
       <div className="reports-detail-container">
         <div className="action-section clearfix">
           <div className="date-container float-xs-left">
-            Report generated on {humanReadableDate(this.props.created)}
+            {T.translate(`${PREFIX}.generatedTime`, {
+              time: humanReadableDate(this.props.created)
+            })}
             <span className="separator">-</span>
             <Expiry />
           </div>
@@ -136,7 +141,7 @@ class ReportsDetailView extends Component {
             <SaveButton />
 
             <button className="btn btn-link">
-              Export
+              {T.translate(`${PREFIX}.export`)}
             </button>
           </div>
         </div>
@@ -155,7 +160,7 @@ class ReportsDetailView extends Component {
           <div className="reports-view-options">
             <Link to={`/ns/${getCurrentNamespace()}/reports`}>
               <IconSVG name="icon-angle-double-left" />
-              <span>Reports</span>
+              <span>{T.translate('features.Reports.header')}</span>
             </Link>
             <span className="separator">|</span>
             <span>

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/ActionPopover.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/ActionPopover.js
@@ -24,6 +24,9 @@ import {DefaultSelection} from 'components/Reports/store/ActionCreator';
 import difference from 'lodash/difference';
 import ReportsStore, { ReportsActions } from 'components/Reports/store/ReportsStore';
 import {getCurrentNamespace} from 'services/NamespaceStore';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.ReportsList';
 
 export default class ActionPopover extends Component {
   static propTypes = {
@@ -134,7 +137,7 @@ export default class ActionPopover extends Component {
             className="option"
             onClick={this.cloneCriteria}
           >
-            Clone criteria
+            {T.translate(`${PREFIX}.cloneCriteria`)}
           </div>
 
           <hr/>
@@ -143,7 +146,7 @@ export default class ActionPopover extends Component {
             className="option text-danger"
             onClick={this.delete}
           >
-            Delete
+            {T.translate('commons.delete')}
           </div>
         </Popover>
       </span>

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/index.js
@@ -29,6 +29,9 @@ import classnames from 'classnames';
 import ActionPopover from 'components/Reports/ReportsList/ActionPopover';
 import NamespacesPicker from 'components/NamespacesPicker';
 import {setNamespacesPick} from 'components/Reports/store/ActionCreator';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.ReportsList';
 
 require('./ReportsList.scss');
 
@@ -56,7 +59,7 @@ class ReportsListView extends Component {
     }
 
     if (report.status === 'FAILED') {
-      return 'Failed';
+      return T.translate(`${PREFIX}.failed`);
     }
 
     return (
@@ -64,7 +67,7 @@ class ReportsListView extends Component {
         <span className="fa fa-spin">
           <IconSVG name="icon-spinner" />
         </span>
-        <span>Generating</span>
+        <span>{T.translate(`${PREFIX}.generating`)}</span>
       </div>
     );
   }
@@ -84,9 +87,9 @@ class ReportsListView extends Component {
     return (
       <div className="grid-header">
         <div className="grid-row">
-          <div>Report Name</div>
-          <div>Created</div>
-          <div>Expiration</div>
+          <div>{T.translate('features.Reports.reportName')}</div>
+          <div>{T.translate(`${PREFIX}.created`)}</div>
+          <div>{T.translate(`${PREFIX}.expiration`)}</div>
           <div></div>
         </div>
       </div>
@@ -155,10 +158,10 @@ class ReportsListView extends Component {
     return (
       <div className="list-container empty">
         <div className="text-xs-center">
-          No reports are available
+          {T.translate(`${PREFIX}.noReports`)}
         </div>
         <div className="text-xs-center">
-          Make a selection to specify your criteria and generate new report.
+          {T.translate(`${PREFIX}.makeSelection`)}
         </div>
       </div>
     );
@@ -184,7 +187,7 @@ class ReportsListView extends Component {
       <div className="reports-container">
         <div className="header">
           <div className="reports-view-options float-xs-left">
-            <span>Reports</span>
+            <span>{T.translate('features.Reports.header')}</span>
           </div>
 
           <NamespacesPicker setNamespacesPick={setNamespacesPick} />
@@ -194,7 +197,7 @@ class ReportsListView extends Component {
 
           <div className="list-view">
             <div className="section-title">
-              Select a report to view
+              {T.translate(`${PREFIX}.selectAReport`)}
             </div>
 
             {this.renderTable()}

--- a/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/index.js
@@ -21,7 +21,10 @@ import {MyArtifactApi} from 'api/artifact';
 import {MyReportsApi} from 'api/reports';
 import IconSVG from 'components/IconSVG';
 import BtnWithLoading from 'components/BtnWithLoading';
+import T from 'i18n-react';
+import Helmet from 'react-helmet';
 
+const PREFIX = 'features.Reports.ReportsServiceControl';
 const ReportsArtifact = 'cdap-program-report';
 
 export default class ReportsServiceControl extends Component {
@@ -88,13 +91,15 @@ export default class ReportsServiceControl extends Component {
 
   renderAvailableOrEnableBtn = () => {
     if (!this.state.artifactNotAvailable && !this.state.showEnableButton) {
-      return (<span>Checking if Reports is available</span>);
+      return (
+        <span>{T.translate(`${PREFIX}.checking`)}</span>
+      );
     }
     if (this.state.artifactNotAvailable) {
       return (
         <div className="action-container">
           <span className="mail-to-link">
-            contact support@cask.co
+            {T.translate(`${PREFIX}.contact`)}
           </span>
         </div>
       );
@@ -104,7 +109,7 @@ export default class ReportsServiceControl extends Component {
         <div className="action-container">
           <BtnWithLoading
             className="btn-primary"
-            label="Enable Reports"
+            label={T.translate(`${PREFIX}.enable`)}
             loading={this.state.loading}
             onClick={this.enableReports}
           />
@@ -121,7 +126,7 @@ export default class ReportsServiceControl extends Component {
       <div className="experiments-service-control-error">
         <h5 className="text-danger">
           <IconSVG name="icon-exclamation-triangle" />
-          <span>Unable to start Reports service</span>
+          <span>{T.translate(`${PREFIX}.unableToStart`)}</span>
         </h5>
         <p className="text-danger">
           {this.state.error}
@@ -135,6 +140,7 @@ export default class ReportsServiceControl extends Component {
 
     return (
       <div className="reports-service-control text-xs-center">
+        <Helmet title={T.translate('features.Reports.pageTitle')} />
         <br />
         {this.renderAvailableOrEnableBtn()}
         {this.renderError()}

--- a/cdap-ui/app/cdap/components/Reports/index.js
+++ b/cdap-ui/app/cdap/components/Reports/index.js
@@ -24,6 +24,10 @@ import {MyReportsApi} from 'api/reports';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import ReportsServiceControl from 'components/Reports/ReportsServiceControl';
 import ReportsAppDelete from 'components/Reports/ReportsAppDelete';
+import T from 'i18n-react';
+import Helmet from 'react-helmet';
+
+const PREFIX = 'features.Reports';
 
 require('./Reports.scss');
 
@@ -74,11 +78,14 @@ export default class Reports extends Component {
 
     return (
       <Provider store={ReportsStore}>
-        <Switch>
-          <Route exact path="/ns/:namespace/reports" component={ReportsList} />
-          <Route exact path="/ns/:namespace/reports/details/:reportId" component={ReportsDetail} />
-          <Route exact path="/ns/:namespace/reports/delete-app" component={ReportsAppDelete} />
-        </Switch>
+        <div>
+          <Helmet title={T.translate(`${PREFIX}.pageTitle`)} />
+          <Switch>
+            <Route exact path="/ns/:namespace/reports" component={ReportsList} />
+            <Route exact path="/ns/:namespace/reports/details/:reportId" component={ReportsDetail} />
+            <Route exact path="/ns/:namespace/reports/delete-app" component={ReportsAppDelete} />
+          </Switch>
+        </div>
       </Provider>
     );
   }

--- a/cdap-ui/app/cdap/components/Reports/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Reports/store/ActionCreator.js
@@ -20,6 +20,10 @@ import {MyReportsApi} from 'api/reports';
 import orderBy from 'lodash/orderBy';
 import {GLOBALS} from 'services/global-constants';
 import {getCurrentNamespace} from 'services/NamespaceStore';
+import StatusMapper from 'services/StatusMapper';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Reports.ReportsDetail';
 
 export const DefaultSelection = [
   'artifactName',
@@ -63,9 +67,13 @@ function getName(start, end) {
 
   let statusSelections = ReportsStore.getState().status.statusSelections;
 
-  let statusLabel = statusSelections.join(', ');
+  let statusLabel = getStatusSelectionsLabels(statusSelections).join(', ');
 
-  return `${statusLabel} Runs - ${startDate} to ${endDate}`;
+  return T.translate(`${PREFIX}.getReportName`, {
+    statusLabel,
+    startDate,
+    endDate
+  });
 }
 
 function getFilters() {
@@ -177,5 +185,11 @@ export function setNamespacesPick(namespacesPick) {
     payload: {
       namespacesPick
     }
+  });
+}
+
+export function getStatusSelectionsLabels(selections) {
+  return selections.map(selection => {
+    return StatusMapper.lookupDisplayStatus(selection);
   });
 }

--- a/cdap-ui/app/cdap/components/TimeRangePicker/index.js
+++ b/cdap-ui/app/cdap/components/TimeRangePicker/index.js
@@ -22,7 +22,7 @@ import classnames from 'classnames';
 
 require('./TimeRangePicker.scss');
 
-const format = 'MM-DD-YYYY HH:mm A';
+const format = 'MM-DD-YYYY hh:mm A';
 
 export default class TimeRangePicker extends Component {
   static propTypes = {

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -93,7 +93,7 @@ function humanReadableDate(date, isMilliseconds) {
     return '--';
   }
 
-  const format = 'MM-DD-YYYY HH:mm:ss A';
+  const format = 'MM-DD-YYYY hh:mm:ss A';
   if (isMilliseconds) {
     return moment(date).format(format);
   }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2,6 +2,7 @@
 # Please keep this file alphabetically sorted!
 commons:
   application: Application
+  apply: Apply
   as: as
   back: Back
   cask: CASK
@@ -1369,6 +1370,17 @@ features:
       keytabURI: 'Keytab URI: '
       label: Security
       principal: 'Principal: '
+  NamespacesPicker:
+    clearAll: Clear All
+    monitorNamespace: Monitoring namespace '{namespace}'
+    monitorMore: Monitor more
+    monitorMultipleNamespaces: Monitoring {count} namespaces {namespaces}
+    namespaceName: Namespace name
+    namespacesCount:
+      1: "{context} namespace"
+      _: "{context} namespaces"
+    popoverHeader: Select namespaces to monitor
+    selectAll: Select All
   Navbar:
     ControlCenter:
       dashboard: Dashboard
@@ -1405,6 +1417,53 @@ features:
       prodWebsiteLabel: Product Website
       supportLabel: Support
     rulesmgmt: Rules
+  OpsDashboard:
+    header: Dashboard
+    pageTitle: CDAP | Dashboard
+    RunsGraph:
+      chart: Chart
+      header: Runs timeline
+      last24Hours: Last 24 hours
+      Legends:
+        delay: Delay between starting and running
+        failed: Failed runs
+        manuallyStarted: Manually started runs
+        running: Running
+        scheduledTriggered: Scheduled/triggered runs
+        successful: Successful runs
+      RunsTable:
+        date: Date
+        failed: Failed
+        manually: Manually
+        running: Running
+        scheduledTriggered: Scheduled / Triggered
+        successful: Successful
+        time: Time
+        totalRunsEnded: Total runs ended
+        totalRunsStarted: Total runs started
+        totalStartDelay: Total start delay
+      table: Table
+      ToggleRunsList:
+        hideRuns: Hide runs
+        showRuns: Show runs
+      TypeSelector:
+        customAppsWithCount: Custom apps ({count})
+        pipelinesWithCount: Pipelines ({count})
+    RunsList:
+      all: All
+      date: Date
+      duration: Duration
+      name: Name
+      namespace: Namespace
+      noData: No data
+      noRuns: No runs
+      startMethod: Start method
+      status: Status
+      timeRange: Time range
+      type: Type
+      user: User
+      viewAll: View All
+
   Overview:
     DatasetTab:
       title: "Datasets and Streams used by \"{appId}\""
@@ -1815,8 +1874,12 @@ features:
 
   Reports:
     Customizer:
+      clear: Clear Selection
+      generate: Generate Report
+      header: Customize runs view
+      hide: Hide generate a report
       Options:
-        customApps: Custom Apps runs
+        customApps: Custom apps runs
         duration: Duration
         end: End time
         namespace: Namespace
@@ -1829,6 +1892,64 @@ features:
         startMethod: Start method
         status: Status
         user: User
+      selectColumns: Select columns
+      show: Show generate a report
+      StatusSelector:
+        allStatuses: All statuses
+        selectOne: Select one
+        selectStatus: Select status
+      TimeRangeSelector:
+        customRange: Custom range
+        label: Select time range
+        labelWithColon: "Select time range: "
+        last30Min: Last 30 min
+        last30Minutes: Last 30 minutes
+        lastHour: Last 1 hour
+        select: Select time
+        timeRange: "{startTime} to {endTime}"
+    header: Reports
+    pageTitle: CDAP | Reports
+    reportName: Report name
+    ReportsDetail:
+      appTypeLabel: "App type:"
+      batch: Batch Pipeline
+      bySchedule: By schedule
+      byTrigger: By trigger
+      customApp: custom app
+      expiresIn: Expires in
+      export: Export
+      generatedTime: Report generated on {time}
+      getReportName: "{statusLabel} runs - {startDate} to {endDate}"
+      lastStarted: "Newest: {newest}; Oldest: {oldest}"
+      lastStartedLabel: "Last started:"
+      manually: Manually
+      namespaceLabel: "Namespace:"
+      numRuns: " ({num} runs)"
+      ownersLabel: "Owners:"
+      realtime: Realtime Pipeline
+      reportSummary: Report summary
+      runDuration: "Min: {min}; Max: {max}; Average: {average}"
+      runDurationLabel: "Run duration:"
+      save: Save
+      saved: Saved
+      saveReport: Save Report
+      startedLabel: "Started:"
+      timeRange: "{start} to {end}"
+      timeRangeLabel: "Time range:"
+    ReportsList:
+      cloneCriteria: Clone criteria
+      created: Created
+      expiration: Expiration
+      failed: Failed
+      generating: Generating
+      makeSelection: Make a selection to specify your criteria and generate new report.
+      noReports: No reports are available
+      selectAReport: Select a report to view
+    ReportsServiceControl:
+      checking: Checking if Reports is available
+      contact: contact support@cask.co
+      enable: Enable Reports
+      unableToStart: Unable to start Reports service
 
   Resource-Center:
     Application:


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-13474
- https://issues.cask.co/browse/CDAP-13475

In this PR, I:
- Moved existing text in Ops Dashboard and Reports to `text-en.yaml`
- Converted some text to sentence-style to follow Google style (e.g. 'Customize Runs View' -> 'Customize runs view')
- Converted from backend statuses to user-friendly labels (e.g. 'STOPPED' -> 'Stopped')
- Converted start methods to title case (e.g. 'MANUAL' -> 'Manual')
- Changed the columns in Reports Detail table to show labels instead of variables (e.g. 'runtimeArgs' -> 'Runtime args')
- Added Helmet titles to Ops Dashboard and Reports pages