### PR TITLE
Fix DataProcClient NPE

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
@@ -246,11 +246,11 @@ public class DataProcClient implements AutoCloseable {
           requiredPorts.clear();
           addTag = true;
         } else if ("tcp".equals(protocol)) {
-          if (allowed.getPorts() != null && allowed.getPorts().contains(String.valueOf(FirewallPort.HTTPS.port))) {
+          if (allowed.getPorts() != null || allowed.getPorts().contains(String.valueOf(FirewallPort.HTTPS.port))) {
             requiredPorts.remove(FirewallPort.HTTPS);
             addTag = true;
           }
-          if (allowed.getPorts() != null && allowed.getPorts().contains(String.valueOf(FirewallPort.SSH.port))) {
+          if (allowed.getPorts() != null || allowed.getPorts().contains(String.valueOf(FirewallPort.SSH.port))) {
             requiredPorts.remove(FirewallPort.SSH);
             addTag = true;
           }

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
@@ -246,11 +246,11 @@ public class DataProcClient implements AutoCloseable {
           requiredPorts.clear();
           addTag = true;
         } else if ("tcp".equals(protocol)) {
-          if (allowed.getPorts().contains(String.valueOf(FirewallPort.HTTPS.port))) {
+          if (allowed.getPorts() != null && allowed.getPorts().contains(String.valueOf(FirewallPort.HTTPS.port))) {
             requiredPorts.remove(FirewallPort.HTTPS);
             addTag = true;
           }
-          if (allowed.getPorts().contains(String.valueOf(FirewallPort.SSH.port))) {
+          if (allowed.getPorts() != null && allowed.getPorts().contains(String.valueOf(FirewallPort.SSH.port))) {
             requiredPorts.remove(FirewallPort.SSH);
             addTag = true;
           }

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
@@ -246,11 +246,11 @@ public class DataProcClient implements AutoCloseable {
           requiredPorts.clear();
           addTag = true;
         } else if ("tcp".equals(protocol)) {
-          if (allowed.getPorts() != null || allowed.getPorts().contains(String.valueOf(FirewallPort.HTTPS.port))) {
+          if (allowed.getPorts() == null || allowed.getPorts().contains(String.valueOf(FirewallPort.HTTPS.port))) {
             requiredPorts.remove(FirewallPort.HTTPS);
             addTag = true;
           }
-          if (allowed.getPorts() != null || allowed.getPorts().contains(String.valueOf(FirewallPort.SSH.port))) {
+          if (allowed.getPorts() == null || allowed.getPorts().contains(String.valueOf(FirewallPort.SSH.port))) {
             requiredPorts.remove(FirewallPort.SSH);
             addTag = true;
           }


### PR DESCRIPTION
When provisioning a cluster, I encountered:
```
2018-06-13 16:13:24,053 - WARN  [provisioning-service-0:c.c.c.i.p.ProvisionTask@114] - Error provisioning cluster for program run program_run:default.GCSToGCS.-SNAPSHOT.workflow.DataPipelineWorkflow.759fdc64-6f5e-11e8-bdf8-acde48001122
java.lang.NullPointerException: null
        at co.cask.cdap.runtime.spi.provisioner.dataproc.DataProcClient.getFirewallTargetTags(DataProcClient.java:249) ~[na:na]
        at co.cask.cdap.runtime.spi.provisioner.dataproc.DataProcClient.createCluster(DataProcClient.java:111) ~[na:na]
        at co.cask.cdap.runtime.spi.provisioner.dataproc.DataProcProvisioner.createCluster(DataProcProvisioner.java:81) ~[na:na]
        at co.cask.cdap.internal.provision.ProvisionTask.run(ProvisionTask.java:74) ~[na:na]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_151]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_151]
        at java.lang.Thread.run(Thread.java:748) [na:1.8.0_151]
```

I put a breakpoint and found that `allowed.getPorts()` can return null.
The Firewall rules in GCP can have a protocol without having a port configured, resulting in this behavior. For example:
![image](https://user-images.githubusercontent.com/2440977/41383338-2444c936-6f25-11e8-87f9-2870c2b7725f.png)
