### PR TITLE
[MMDS][CDAP-13547] Fix button label while creating experiment vs adding a model in MMDS

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -796,5 +796,6 @@ DataPrepConnections.propTypes = {
   onWorkspaceCreate: PropTypes.func,
   singleWorkspaceMode: PropTypes.bool,
   sidePanelExpanded: PropTypes.bool,
-  scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  browserTitle: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/ExperimentPopovers.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/Popovers/ExperimentPopovers.scss
@@ -75,12 +75,9 @@ $popover_container_border_color: $grey-05;
     width: 100%;
   }
 }
-.popover {
-  &.create_new_experiment_popover-element {
-    margin: 10px;
-    &:before,
-    &after {
-      display: none;
-    }
+.create_new_experiment_popover {
+  .popper {
+    min-width: 270px;
+    text-align: left;
   }
 }

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
@@ -23,7 +23,7 @@ import DataPrepHome from 'components/DataPrepHome';
 import {Prompt, Link, Redirect} from 'react-router-dom';
 import createExperimentStore, {CREATION_STEPS} from 'components/Experiments/store/createExperimentStore';
 import {getCurrentNamespace} from 'services/NamespaceStore';
-import UncontrolledPopover from 'components/UncontrolledComponents/Popover';
+import Popover from 'components/Popover';
 import ExperimentPopovers from 'components/Experiments/CreateView/Popovers';
 import DataPrepStore from 'components/DataPrep/store';
 import {
@@ -67,7 +67,7 @@ export default class ExperimentCreateView extends Component {
     active_step: createExperimentStore.getState().active_step.step_name,
     redirectToExperimentDetail: false
   };
-  title = 'Create a New Experiment';
+  title = 'Create a new experiment';
   componentWillMount() {
     setAlgorithmsListForCreateView();
   }
@@ -170,7 +170,7 @@ export default class ExperimentCreateView extends Component {
       <span>
         {this.renderTopPanel(this.title)}
         <DataPrepConnections
-          sidePanelExpanded={true}
+          sidePanelExpanded={false}
           enableRouting={false}
           singleWorkspaceMode={true}
           onWorkspaceCreate={(workspaceId) => {
@@ -178,6 +178,7 @@ export default class ExperimentCreateView extends Component {
             this.setState({workspaceId});
           }}
           scope={true}
+          browserTitle="Select a file to use in your experiment"
         />
       </span>
     );
@@ -188,35 +189,46 @@ export default class ExperimentCreateView extends Component {
         Update Model
       </div>
     );
+    const {experimentId, addModel} = queryString.parse(this.props.location.search);
+    let popoverElementLabel = 'Create experiment';
+
+    if (addModel) {
+      popoverElementLabel = 'Add model';
+    }
     const popoverElement = (
       <div className="btn btn-primary">
-        Add a model
+        {popoverElementLabel}
       </div>
     );
     const createModelBtn = (
-      <UncontrolledPopover
-        popoverElement={popoverElement}
-        tag="div"
-        tetherOption={{
-          classPrefix: 'create_new_experiment_popover',
-        }}
+      <Popover
+        target={() => popoverElement}
+        enableInteractionInPopover={true}
+        targetDimension={{ width: "auto" }}
+        placement="bottom"
+        className="create_new_experiment_popover"
+        showPopover={!experimentId ? true : false}
       >
         <ExperimentPopovers />
-      </UncontrolledPopover>
+      </Popover>
     );
 
-    const {experimentId, addModel} = queryString.parse(this.props.location.search);
+
     let topPanelTitle = 'Create a new experiment';
     if (addModel) {
       topPanelTitle = `Add model to '${experimentId}'`;
     }
+    const renderAddBtn = () => {
+      if (!this.state.workspaceId) {
+        return null;
+      }
+      return this.state.modelId ? updateModelBtn : createModelBtn;
+    };
     return (
       <span>
         {this.renderTopPanel(topPanelTitle)}
         <div className="experiments-model-panel">
-          {
-            this.state.modelId ? updateModelBtn : createModelBtn
-          }
+          {renderAddBtn()}
         </div>
         <DataPrepHome
           singleWorkspaceMode={true}

--- a/cdap-ui/app/cdap/components/Experiments/store/createExperimentStore.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/createExperimentStore.js
@@ -275,13 +275,13 @@ const active_step = (state = DEFAULT_ACTIVE_STEP, action = defaultAction) => {
     }
     let {name, workspaceId} = state.experiments_create;
     let {modelId, isSplitFinalized, algorithm} = state.model_create;
-    if (!name) {
-      return {
-        ...state.active_step,
-        step_name: CREATION_STEPS.DATAPREP
-      };
-    }
     if (!workspaceId) {
+      if (name) {
+        return {
+          ...state.active_step,
+          step_name: CREATION_STEPS.DATAPREP
+        };
+      }
       return {
         ...state.active_step,
         step_name: CREATION_STEPS.DATAPREP_CONNECTIONS
@@ -339,6 +339,22 @@ const active_step = (state = DEFAULT_ACTIVE_STEP, action = defaultAction) => {
           ...state.active_step,
           override: false
         }
+      };
+      return getActiveStep(newState);
+    }
+    case ACTIONS.SET_EXPERIMENT_METADATA_FOR_EDIT: {
+      let {name, description, outcome, srcpath, workspaceId} = action.payload.experimentDetails;
+      const newState = {
+        experiments_create: {
+          ...state.experiments_create,
+          name,
+          description,
+          outcome,
+          srcpath,
+          workspaceId
+        },
+        model_create: state.model_create,
+        active_step: state.active_step
       };
       return getActiveStep(newState);
     }

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -55,7 +55,8 @@ export default class FileBrowser extends Component {
 
   static defaultProps = {
     enableRouting: true,
-    scope: false
+    scope: false,
+    browserTitle: T.translate(`${PREFIX}.TopPanel.selectData`)
   };
 
   static propTypes = {
@@ -66,7 +67,8 @@ export default class FileBrowser extends Component {
     toggle: PropTypes.func.isRequired,
     enableRouting: PropTypes.bool,
     onWorkspaceCreate: PropTypes.func,
-    scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+    scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    browserTitle: PropTypes.string
   };
 
   componentWillMount() {
@@ -518,7 +520,7 @@ export default class FileBrowser extends Component {
               </span>
 
               <span>
-                {T.translate(`${PREFIX}.TopPanel.selectData`)}
+                {this.props.browserTitle}
               </span>
             </h5>
           </div>


### PR DESCRIPTION
- While creating an experiment the button should say "Create experiment"
- While adding a model to an experiment it should say "Add model"
- Replaces `UncontrolledPopover` to `Popover` for create experiment and add model popovers
- Change title of the file browser while choosing a file to be relevant to creating an experiment 
- Automatically open the create experiment popover when the user chooses a file and lands in dataprep.

JIRA: https://issues.cask.co/browse/CDAP-13547

