### PR TITLE
(CDAP-13532) (Release-4.3) Fix the workflow resources setting to honor runtime arguments

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/common/RuntimeArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/RuntimeArguments.java
@@ -114,9 +114,7 @@ public final class RuntimeArguments {
     String prefix = scope + DOT + name + DOT;
     String wildCardPrefix = scope + DOT + ASTERISK + DOT;
 
-    Map<String, String> result = new HashMap<>();
-    result.putAll(arguments);
-
+    Map<String, String> result = new HashMap<>(arguments);
     Map<String, String> prefixMatchedArgs = new HashMap<>();
     Map<String, String> wildCardPrefixMatchedArgs = new HashMap<>();
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowActionNode.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowActionNode.java
@@ -83,7 +83,7 @@ public class WorkflowActionNode extends WorkflowNode {
   public String toString() {
     StringBuilder sb = new StringBuilder("WorkflowActionNode{");
     sb.append("nodeId=").append(nodeId);
-    sb.append("program=").append(program);
+    sb.append(", program=").append(program);
     sb.append(", actionSpecification=").append(actionSpecification);
     sb.append(", customActionSpecification=").append(customActionSpecification);
     sb.append('}');

--- a/cdap-app-fabric-tests/pom.xml
+++ b/cdap-app-fabric-tests/pom.xml
@@ -95,6 +95,12 @@ the License.
       <artifactId>jcl-over-slf4j</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-hbase-compat-0.98</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.distributed;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.app.DefaultAppConfigurer;
+import co.cask.cdap.app.DefaultApplicationContext;
+import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
+import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
+import co.cask.cdap.app.guice.ServiceStoreModules;
+import co.cask.cdap.app.guice.TwillModule;
+import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.ProgramDescriptor;
+import co.cask.cdap.app.program.Programs;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.app.runtime.ProgramRunnerFactory;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
+import co.cask.cdap.common.guice.IOModule;
+import co.cask.cdap.common.guice.KafkaClientModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.test.AppJarHelper;
+import co.cask.cdap.data.runtime.DataFabricModules;
+import co.cask.cdap.data.runtime.DataSetServiceModules;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.stream.StreamAdminModules;
+import co.cask.cdap.data.view.ViewAdminModules;
+import co.cask.cdap.data2.audit.AuditModule;
+import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.internal.app.runtime.SystemArguments;
+import co.cask.cdap.internal.app.runtime.distributed.DistributedProgramRunner.LaunchConfig;
+import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
+import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.metrics.guice.MetricsStoreModule;
+import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
+import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
+import co.cask.cdap.operations.guice.OperationalStatsModule;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.guice.SecureStoreModules;
+import co.cask.cdap.store.guice.NamespaceStoreModule;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.api.Configs;
+import org.apache.twill.api.ResourceSpecification;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Unit tests for the {@link DistributedWorkflowProgramRunner}.
+ * This test class uses {@link DistributedWorkflowTestApp} for testing various aspect of the program runner.
+ */
+public class DistributedWorkflowProgramRunnerTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static CConfiguration cConf;
+  private static ProgramRunnerFactory programRunnerFactory;
+
+  @BeforeClass
+  public static void init() throws IOException {
+    cConf = createCConf();
+    programRunnerFactory = createProgramRunnerFactory(cConf);
+  }
+
+  @Test
+  public void testDefaultResources() throws IOException {
+    // By default the workflow driver would have 768m if none of the children is setting it to higher
+    // (default for programs are 512m)
+    testDriverResources(DistributedWorkflowTestApp.SequentialWorkflow.class.getSimpleName(),
+                        Collections.<String, String>emptyMap(), new Resources(768));
+  }
+
+  @Test
+  public void testExplicitResources() throws IOException {
+    // Explicitly set the resources for the workflow, it should always get honored.
+    // The one prefixed with "task.workflow." should override the one without.
+    testDriverResources(DistributedWorkflowTestApp.ComplexWorkflow.class.getSimpleName(),
+                        ImmutableMap.of(
+                          SystemArguments.MEMORY_KEY, "4096",
+                          "task.workflow." + SystemArguments.MEMORY_KEY, "1024"
+                        ),
+                        new Resources(1024));
+  }
+
+  @Test
+  public void testInferredResources() throws IOException {
+    // Inferred from the largest memory usage from children
+    testDriverResources(DistributedWorkflowTestApp.SequentialWorkflow.class.getSimpleName(),
+                        Collections.singletonMap("mapreduce.mr1." + SystemArguments.MEMORY_KEY, "2048"),
+                        new Resources(2048));
+  }
+
+  @Test
+  public void testForkJoinInferredResources() throws IOException {
+    // The complex workflow has 4 parallel executions at max, hence the memory setting should be summation of them
+    // For vcores, it should pick the max
+    testDriverResources(DistributedWorkflowTestApp.ComplexWorkflow.class.getSimpleName(),
+                        ImmutableMap.of(
+                          "spark.s2." + SystemArguments.MEMORY_KEY, "1024",
+                          "mapreduce.mr3." + SystemArguments.CORES_KEY, "3"
+                        ),
+                        new Resources(512 + 512 + 1024 + 512, 3));
+  }
+
+  @Test
+  public void testConditionInferredResources() throws IOException {
+    // Set one of the branch to have memory > fork memory
+    testDriverResources(DistributedWorkflowTestApp.ComplexWorkflow.class.getSimpleName(),
+                        Collections.singletonMap("spark.s4." + SystemArguments.MEMORY_KEY, "4096"),
+                        new Resources(4096));
+  }
+
+  @Test
+  public void testInferredWithMaxResources() throws IOException {
+    // Set to use large memory for the first node in the complex workflow to have it larger than the sum of all forks
+    testDriverResources(DistributedWorkflowTestApp.ComplexWorkflow.class.getSimpleName(),
+                        Collections.singletonMap("mapreduce.mr1." + SystemArguments.MEMORY_KEY, "4096"),
+                        new Resources(4096));
+  }
+
+  @Test
+  public void testInferredScopedResources() throws IOException {
+    // Inferred from the largest memory usage from children.
+    // Make sure the children arguments have scope resolved correctly.
+    testDriverResources(DistributedWorkflowTestApp.SequentialWorkflow.class.getSimpleName(),
+                        ImmutableMap.of(
+                          "mapreduce.mr1.task.mapper." + SystemArguments.MEMORY_KEY, "2048",
+                          "spark.s1.task.client." + SystemArguments.MEMORY_KEY, "1024",
+                          "spark.s1.task.driver." + SystemArguments.MEMORY_KEY, "4096"
+                        ),
+                        // Should pick the spark client memory
+                        new Resources(1024));
+  }
+
+  @Test
+  public void testOverrideInferredResources() throws IOException {
+    // Explicitly setting memory always override what's inferred from children
+    testDriverResources(DistributedWorkflowTestApp.SequentialWorkflow.class.getSimpleName(),
+                        ImmutableMap.of(
+                          "task.workflow." + SystemArguments.MEMORY_KEY, "512",
+                          "mapreduce.mr1." + SystemArguments.MEMORY_KEY, "2048",
+                          "spark.s1." + SystemArguments.MEMORY_KEY, "1024"
+                        ), new Resources(512));
+  }
+
+  @Test
+  public void testReservedMemoryOverride() throws IOException {
+    // Sets the reserved memory override for the workflow
+    String workflowName = DistributedWorkflowTestApp.SequentialWorkflow.class.getSimpleName();
+    LaunchConfig launchConfig = setupWorkflowRuntime(workflowName,
+                                                            ImmutableMap.of(
+                                                              SystemArguments.RESERVED_MEMORY_KEY_OVERRIDE, "400",
+                                                              SystemArguments.MEMORY_KEY, "800"
+                                                            ));
+
+    RunnableDefinition runnableDefinition = launchConfig.getRunnables().get(workflowName);
+    Assert.assertNotNull(runnableDefinition);
+
+    Map<String, String> twillConfigs = runnableDefinition.getTwillRunnableConfigs();
+    Assert.assertEquals("400", twillConfigs.get(Configs.Keys.JAVA_RESERVED_MEMORY_MB));
+    Assert.assertEquals("0.50", twillConfigs.get(Configs.Keys.HEAP_RESERVED_MIN_RATIO));
+  }
+
+
+  /**
+   * Helper method to help testing workflow driver resources settings based on varying user arguments
+   *
+   * @param workflowName name of the workflow as defined in the {@link DistributedWorkflowTestApp}.
+   * @param runtimeArgs the runtime arguments for the workflow program
+   * @param expectedDriverResources the expected {@link Resources} setting for the workflow driver
+   */
+  private void testDriverResources(String workflowName, Map<String, String> runtimeArgs,
+                                   Resources expectedDriverResources) throws IOException {
+
+    LaunchConfig launchConfig = setupWorkflowRuntime(workflowName, runtimeArgs);
+
+    // Validate the resources setting
+    RunnableDefinition runnableDefinition = launchConfig.getRunnables().get(workflowName);
+    Assert.assertNotNull(runnableDefinition);
+
+    ResourceSpecification resources = runnableDefinition.getResources();
+    Assert.assertEquals(expectedDriverResources.getMemoryMB(), resources.getMemorySize());
+    Assert.assertEquals(expectedDriverResources.getVirtualCores(), resources.getVirtualCores());
+  }
+
+  /**
+   * Setup the {@link LaunchConfig} for the given workflow.
+   */
+  private LaunchConfig setupWorkflowRuntime(String workflowName,
+                                                   Map<String, String> runtimeArgs) throws IOException {
+    // Create the distributed workflow program runner
+    ProgramRunner programRunner = programRunnerFactory.create(ProgramType.WORKFLOW);
+    Assert.assertTrue(programRunner instanceof DistributedWorkflowProgramRunner);
+    DistributedWorkflowProgramRunner workflowRunner = (DistributedWorkflowProgramRunner) programRunner;
+
+    // Create the Workflow Program
+    Program workflowProgram = createWorkflowProgram(cConf, programRunner, workflowName);
+    LaunchConfig launchConfig = new LaunchConfig();
+    ProgramOptions programOpts = new SimpleProgramOptions(workflowProgram.getId(),
+                                                          new BasicArguments(), new BasicArguments(runtimeArgs));
+
+    // Setup the launching config
+    workflowRunner.setupLaunchConfig(launchConfig, workflowProgram, programOpts,
+                                     cConf, new Configuration(), TEMP_FOLDER.newFolder());
+    return launchConfig;
+  }
+
+  /**
+   * Creates a workflow {@link Program}.
+   */
+  private Program createWorkflowProgram(CConfiguration cConf, ProgramRunner programRunner,
+                                        String workflowName) throws IOException {
+    Location appJarLocation = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TEMP_FOLDER.newFolder()),
+                                                               DistributedWorkflowTestApp.class);
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("test", "1.0.0");
+    DistributedWorkflowTestApp app = new DistributedWorkflowTestApp();
+    DefaultAppConfigurer configurer = new DefaultAppConfigurer(Id.Namespace.DEFAULT, artifactId.toId(), app);
+    app.configure(configurer, new DefaultApplicationContext<>());
+
+    ApplicationSpecification appSpec = configurer.createSpecification(null);
+    ProgramId programId = NamespaceId.DEFAULT
+      .app(appSpec.getName())
+      .program(ProgramType.WORKFLOW, workflowName);
+
+    return Programs.create(cConf, programRunner, new ProgramDescriptor(programId, appSpec),
+                           appJarLocation, TEMP_FOLDER.newFolder());
+  }
+
+  private static ProgramRunnerFactory createProgramRunnerFactory(CConfiguration cConf) {
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new ZKClientModule(),
+      new LoggingModules().getDistributedModules(),
+      new LocationRuntimeModule().getStandaloneModules(),
+      new IOModule(),
+      new KafkaClientModule(),
+      new DiscoveryRuntimeModule().getDistributedModules(),
+      new DataSetServiceModules().getDistributedModules(),
+      new DataFabricModules("cdap.master").getDistributedModules(),
+      new DataSetsModules().getDistributedModules(),
+      new MetricsClientRuntimeModule().getDistributedModules(),
+      new MetricsStoreModule(),
+      new MessagingClientModule(),
+      new ExploreClientModule(),
+      new NotificationFeedServiceRuntimeModule().getDistributedModules(),
+      new NotificationServiceRuntimeModule().getDistributedModules(),
+      new ViewAdminModules().getDistributedModules(),
+      new StreamAdminModules().getDistributedModules(),
+      new NamespaceStoreModule().getDistributedModules(),
+      new AuditModule().getDistributedModules(),
+      new AuthorizationModule(),
+      new AuthorizationEnforcementModule().getMasterModule(),
+      new TwillModule(),
+      new ServiceStoreModules().getDistributedModules(),
+      new AppFabricServiceRuntimeModule().getDistributedModules(),
+      new ProgramRunnerRuntimeModule().getDistributedModules(),
+      new SecureStoreModules().getDistributedModules(),
+      new OperationalStatsModule()
+    );
+
+    return injector.getInstance(ProgramRunnerFactory.class);
+  }
+
+  private static CConfiguration createCConf() throws IOException {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+
+    return cConf;
+  }
+}

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowTestApp.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowTestApp.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.distributed;
+
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.customaction.AbstractCustomAction;
+import co.cask.cdap.api.customaction.CustomAction;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.spark.AbstractSpark;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.api.workflow.WorkflowContext;
+
+import javax.annotation.Nullable;
+
+public class DistributedWorkflowTestApp extends AbstractApplication<Config> {
+
+  @Override
+  public void configure() {
+    addMapReduce(new TestMapReduce("mr1"));
+    addMapReduce(new TestMapReduce("mr2"));
+    addMapReduce(new TestMapReduce("mr3"));
+    addMapReduce(new TestMapReduce("mr4"));
+
+    addSpark(new TestSpark("s1"));
+    addSpark(new TestSpark("s2"));
+    addSpark(new TestSpark("s3"));
+    addSpark(new TestSpark("s4"));
+
+    addWorkflow(new ActionOnlyWorkflow());
+    addWorkflow(new SequentialWorkflow());
+    addWorkflow(new ComplexWorkflow());
+  }
+
+  /**
+   * A workflow that only contains {@link CustomAction}.
+   */
+  public static final class ActionOnlyWorkflow extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      addAction(new NoopAction());
+    }
+
+    public static final class NoopAction extends AbstractCustomAction {
+
+      @Override
+      public void run() throws Exception {
+        // no-op
+      }
+    }
+  }
+
+  /**
+   * A workflow that executes jobs sequentially.
+   */
+  public static final class SequentialWorkflow extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      addMapReduce("mr1");
+      addSpark("s1");
+    }
+  }
+
+  /**
+   * A workflow that has complex structure, including fork-join and condition.
+   */
+  public static final class ComplexWorkflow extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      // The workflow has the following structure
+      //
+      //              |- mr3 -|  |-(if)-   s4  -|
+      //  mr1 -> mr2 -         --                -- (end)
+      //              |- s1  -|  |-(else)- mr4 -|
+      //              |- s2  -|
+      //              |- s3  -|
+
+      addMapReduce("mr1");
+      addMapReduce("mr2");
+      fork()
+        .addMapReduce("mr3")
+      .also()
+        .fork()
+          .addSpark("s1")
+        .also()
+          .addSpark("s2")
+        .also()
+          .addSpark("s3")
+        .join()
+      .join();
+
+      condition(new Predicate<WorkflowContext>() {
+        @Override
+        public boolean apply(@Nullable WorkflowContext input) {
+          return true;
+        }
+      })
+        .addSpark("s4")
+      .otherwise()
+        .addMapReduce("mr4")
+      .end();
+    }
+  }
+
+  /**
+   * MapReduce for the {@link DistributedWorkflowProgramRunnerTest}.
+   */
+  public static final class TestMapReduce extends AbstractMapReduce {
+
+    private final String name;
+
+    TestMapReduce(String name) {
+      this.name = name;
+    }
+
+    @Override
+    protected void configure() {
+      setName(name);
+    }
+  }
+
+  /**
+   * Spark for the {@link DistributedWorkflowProgramRunnerTest}.
+   */
+  public static final class TestSpark extends AbstractSpark {
+
+    private final String name;
+
+    TestSpark(String name) {
+      this.name = name;
+    }
+
+    @Override
+    protected void configure() {
+      setName(name);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Programs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Programs.java
@@ -48,11 +48,10 @@ public final class Programs {
    * @param programJarLocation the {@link Location} of the program jar file
    * @param unpackedDir a directory that the program jar file was unpacked to
    * @return a new {@link Program} instance.
-   * @throws IOException If failed to create the program
    */
   public static Program create(CConfiguration cConf, @Nullable ProgramRunner programRunner,
                                ProgramDescriptor programDescriptor,
-                               Location programJarLocation, File unpackedDir) throws IOException {
+                               Location programJarLocation, File unpackedDir) {
     ClassLoader parentClassLoader = null;
     if (programRunner instanceof ProgramClassLoaderProvider) {
       parentClassLoader = ((ProgramClassLoaderProvider) programRunner).createProgramClassLoaderParent();
@@ -79,10 +78,9 @@ public final class Programs {
    *                      Otherwise, the {@link ClassLoader} will only have visibility
    *                      to cdap-api and hadoop classes.
    * @return a new {@link Program} instance for the given programId
-   * @throws IOException If failed to create the program
    */
   public static Program create(CConfiguration cConf, Program originalProgram,
-                               ProgramId programId, @Nullable ProgramRunner programRunner) throws IOException {
+                               ProgramId programId, @Nullable ProgramRunner programRunner) {
     ClassLoader classLoader = originalProgram.getClassLoader();
     // The classloader should be ProgramClassLoader
     Preconditions.checkArgument(classLoader instanceof ProgramClassLoader,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -81,7 +81,6 @@ public final class DistributedMapReduceProgramRunner extends DistributedProgramR
   @Override
   protected void setupLaunchConfig(LaunchConfig launchConfig, Program program, ProgramOptions options,
                                    CConfiguration cConf, Configuration hConf, File tempDir) throws IOException {
-
     ApplicationSpecification appSpec = program.getApplicationSpecification();
     MapReduceSpecification spec = appSpec.getMapReduce().get(program.getName());
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -18,12 +18,13 @@ package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.app.ApplicationSpecification;
-import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
-import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowActionNode;
+import co.cask.cdap.api.workflow.WorkflowConditionNode;
+import co.cask.cdap.api.workflow.WorkflowForkNode;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowNodeType;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
@@ -35,36 +36,47 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.internal.app.runtime.SystemArguments;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreRenewer;
 import co.cask.cdap.security.impersonation.Impersonator;
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.ClassAcceptor;
+import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * A {@link ProgramRunner} to start a {@link Workflow} program in distributed mode.
  */
 public final class DistributedWorkflowProgramRunner extends DistributedProgramRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DistributedWorkflowProgramRunner.class);
 
   private final ProgramRunnerFactory programRunnerFactory;
 
@@ -113,26 +125,33 @@ public final class DistributedWorkflowProgramRunner extends DistributedProgramRu
     WorkflowSpecification spec = program.getApplicationSpecification().getWorkflows().get(program.getName());
     List<ClassAcceptor> acceptors = new ArrayList<>();
 
-    // Only interested in MapReduce and Spark nodes
+    // Only interested in MapReduce and Spark nodes.
+    // This is because CUSTOM_ACTION types are running inside the driver
     Set<SchedulableProgramType> runnerTypes = EnumSet.of(SchedulableProgramType.MAPREDUCE,
                                                          SchedulableProgramType.SPARK);
-    for (WorkflowActionNode node : Iterables.filter(spec.getNodeIdMap().values(), WorkflowActionNode.class)) {
-      // For each type, we only need one node to setup the launch context
-      ScheduleProgramInfo programInfo = node.getProgram();
-      if (!runnerTypes.remove(programInfo.getProgramType())) {
+
+    for (WorkflowActionNode actionNode : Iterables.filter(spec.getNodeIdMap().values(), WorkflowActionNode.class)) {
+      ScheduleProgramInfo programInfo = actionNode.getProgram();
+      if (!runnerTypes.contains(programInfo.getProgramType())) {
         continue;
       }
 
-      // Find the ProgramRunner of the given type and setup the launch context
       ProgramType programType = ProgramType.valueOfSchedulableType(programInfo.getProgramType());
       ProgramRunner runner = programRunnerFactory.create(programType);
       try {
         if (runner instanceof DistributedProgramRunner) {
-          // Call setupLaunchConfig with the corresponding program
+          // Call setupLaunchConfig with the corresponding program.
+          // Need to constructs a new ProgramOptions with the scope extracted for the given program
           ProgramId programId = program.getId().getParent().program(programType, programInfo.getProgramName());
+          Map<String, String> programUserArgs = RuntimeArguments.extractScope(programId.getType().getScope(),
+                                                                              programId.getProgram(),
+                                                                              options.getUserArguments().asMap());
+          ProgramOptions programOptions = new SimpleProgramOptions(programId, options.getArguments(),
+                                                                   new BasicArguments(programUserArgs));
+
           ((DistributedProgramRunner) runner).setupLaunchConfig(launchConfig,
                                                                 Programs.create(cConf, program, programId, runner),
-                                                                options, cConf, hConf, tempDir);
+                                                                programOptions, cConf, hConf, tempDir);
           acceptors.add(launchConfig.getClassAcceptor());
         }
       } finally {
@@ -140,57 +159,79 @@ public final class DistributedWorkflowProgramRunner extends DistributedProgramRu
           Closeables.closeQuietly((Closeable) runner);
         }
       }
-
     }
 
     // Set the class acceptor
     launchConfig.setClassAcceptor(new AndClassAcceptor(acceptors));
 
-    // Clear and set the runnable for the workflow driver
-    launchConfig.clearRunnables();
-    Resources defaultResources = findDriverResources(program.getApplicationSpecification().getSpark(),
-                                                     program.getApplicationSpecification().getMapReduce(), spec);
+    // Find out the default resources requirements based on the programs inside the workflow
+    // At least gives the Workflow driver 768 mb of container memory
+    Map<String, Resources> runnablesResources = Maps.transformValues(
+      launchConfig.getRunnables(), new Function<RunnableDefinition, Resources>() {
+        @Override
+        public Resources apply(RunnableDefinition runnableDefinition) {
+          return getResources(runnableDefinition);
+        }
+      });
+    Resources defaultResources = maxResources(new Resources(768),
+                                              findDriverResources(spec.getNodes(), runnablesResources));
 
+    // Clear and set the runnable for the workflow driver.
+    launchConfig.clearRunnables();
+    // Extract scoped runtime arguments that only meant for the workflow but not for child nodes
+    Map<String, String> runtimeArgs = RuntimeArguments.extractScope("task", "workflow",
+                                                                    options.getUserArguments().asMap());
     launchConfig.addRunnable(spec.getName(), new WorkflowTwillRunnable(spec.getName()), 1,
-                             options.getArguments().asMap(), defaultResources, 0);
+                             runtimeArgs, defaultResources, 0);
   }
 
   /**
    * Returns the {@link Resources} requirement for the workflow runnable deduced by Spark
    * or MapReduce driver resources requirement.
    */
-  private Resources findDriverResources(Map<String, SparkSpecification> sparkSpecs,
-                                        Map<String, MapReduceSpecification> mrSpecs,
-                                        WorkflowSpecification spec) {
-    // Find the resource requirements from the workflow with 768MB as minimum.
-    // It is the largest memory and cores from all Spark and MapReduce programs inside the workflow
-    Resources resources = new Resources(768);
+  private Resources findDriverResources(Collection<WorkflowNode> nodes, Map<String, Resources> runnablesResources) {
+    // Find the resource requirements for the workflow based on the nodes memory requirements
+    Resources resources = new Resources();
 
-    for (WorkflowNode node : spec.getNodeIdMap().values()) {
-      if (WorkflowNodeType.ACTION == node.getType()) {
-        ScheduleProgramInfo programInfo = ((WorkflowActionNode) node).getProgram();
-        SchedulableProgramType programType = programInfo.getProgramType();
-        if (programType == SchedulableProgramType.SPARK || programType == SchedulableProgramType.MAPREDUCE) {
-          // The program spec shouldn't be null, otherwise the Workflow is not valid
-          Resources driverResources;
-          if (programType == SchedulableProgramType.SPARK) {
-            driverResources = sparkSpecs.get(programInfo.getProgramName()).getClientResources();
-          } else {
-            driverResources = mrSpecs.get(programInfo.getProgramName()).getDriverResources();
+    for (WorkflowNode node : nodes) {
+      switch (node.getType()) {
+        case ACTION:
+          String programName = ((WorkflowActionNode) node).getProgram().getProgramName();
+          Resources runnableResources = runnablesResources.get(programName);
+          if (runnableResources != null) {
+            resources = maxResources(resources, runnableResources);
           }
-          if (driverResources != null) {
-            resources = max(resources, driverResources);
+          break;
+        case FORK:
+          Resources forkResources = null;
+          for (List<WorkflowNode> branch : ((WorkflowForkNode) node).getBranches()) {
+            Resources branchResources = findDriverResources(branch, runnablesResources);
+            forkResources = mergeForkResources(branchResources, forkResources);
           }
-        }
+          if (forkResources != null) {
+            resources = maxResources(resources, forkResources);
+          }
+          break;
+        case CONDITION:
+          Resources branchesResources =
+            maxResources(findDriverResources(((WorkflowConditionNode) node).getIfBranch(), runnablesResources),
+                         findDriverResources(((WorkflowConditionNode) node).getElseBranch(), runnablesResources));
+
+          resources = maxResources(resources, branchesResources);
+          break;
+        default:
+          // This shouldn't happen unless we add new node type
+          LOG.warn("Ignoring unsupported Workflow node type {}", node.getType());
       }
     }
+
     return resources;
   }
 
   /**
    * Returns a {@link Resources} that has the maximum of memory and virtual cores among two Resources.
    */
-  private Resources max(Resources r1, Resources r2) {
+  private Resources maxResources(Resources r1, Resources r2) {
     int memory1 = r1.getMemoryMB();
     int memory2 = r2.getMemoryMB();
     int vcores1 = r1.getVirtualCores();
@@ -204,6 +245,25 @@ public final class DistributedWorkflowProgramRunner extends DistributedProgramRu
     }
     return new Resources(Math.max(memory1, memory2),
                          Math.max(vcores1, vcores2));
+  }
+
+  /**
+   * Merges resources usage across two branches in a fork. It returns a new {@link Resources} that
+   * sum up the memory and take the max of the vcores.
+   *
+   * @param r1 the first {@link Resources} for the merging
+   * @param r2 the second {@link Resources} for the merging. If it is {@code null}, then {@code r1} will be returned.
+   */
+  private Resources mergeForkResources(Resources r1, @Nullable Resources r2) {
+    if (r2 == null) {
+      return r1;
+    }
+    return new Resources(r1.getMemoryMB() + r2.getMemoryMB(), Math.max(r1.getVirtualCores(), r2.getVirtualCores()));
+  }
+
+  private Resources getResources(RunnableDefinition runnableDefinition) {
+    ResourceSpecification resourceSpec = runnableDefinition.getResources();
+    return new Resources(resourceSpec.getMemorySize(), resourceSpec.getVirtualCores());
   }
 
   /**

--- a/cdap-docs/developer-manual/source/advanced/configuring-resources.rst
+++ b/cdap-docs/developer-manual/source/advanced/configuring-resources.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2016 Cask Data, Inc.
+    :copyright: Copyright © 2016-2018 Cask Data, Inc.
 
 .. _advanced-configuring-resources:
 
@@ -57,6 +57,7 @@ a prefix can be added to limit the scope of the arguments.
 
 **Workflow**
 
+- Prefix with ``task.workflow.`` to set resources for the Workflow driver only
 - Prefix with ``mapreduce.<workflowNodeName>.`` to set resources for a particular MapReduce node in a workflow
 - Prefix with ``spark.<workflowNodeName>.`` to set resources for a particular MapReduce node in a workflow
 

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkPackageUtils.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkPackageUtils.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.internal.app.runtime.LocalizationUtils;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
@@ -131,19 +132,29 @@ public final class SparkPackageUtils {
     // In future, we could have SPARK1 and SPARK2 home.
     String sparkHome = System.getenv(SPARK_HOME);
     if (sparkLibrary == null && sparkHome == null) {
-      throw new IllegalStateException("Spark not found. Please set environment variable " + SPARK_HOME);
-    }
+      // If both SPARK_LIBRARY and SPARK_HOME are not set, it should be in standalone mode, in which
+      // Spark classes are in the classloader of this class, which is loaded via the program runtime provider extension.
+      // This class shouldn't have dependency on Spark itself, hence using the resource name
+      URL sparkContextURL = SparkPackageUtils.class.getClassLoader().getResource("org/apache/spark/SparkContext.class");
+      if (sparkContextURL == null) {
+        // This error message is for user to read. Usage of SPARK_LIBRARY / classloader is internal, hence not showing.
+        throw new IllegalStateException("Spark not found. Please set environment variable " + SPARK_HOME);
+      }
 
-    switch (sparkCompat) {
-      case SPARK1_2_10:
-        LOCAL_SPARK_LIBRARIES.put(sparkCompat, Collections.singleton(getSpark1AssemblyJar(sparkLibrary, sparkHome)));
-        break;
-      case SPARK2_2_11:
-        LOCAL_SPARK_LIBRARIES.put(sparkCompat, getSpark2LibraryJars(sparkLibrary, sparkHome));
-        break;
-      default:
-        // This shouldn't happen
-        throw new IllegalStateException("Unsupported Spark version " + sparkCompat);
+      URL sparkURL = ClassLoaders.getClassPathURL("org.apache.spark.SparkContext", sparkContextURL);
+      LOCAL_SPARK_LIBRARIES.put(sparkCompat, Collections.singleton(new File(sparkURL.getPath())));
+    } else {
+      switch (sparkCompat) {
+        case SPARK1_2_10:
+          LOCAL_SPARK_LIBRARIES.put(sparkCompat, Collections.singleton(getSpark1AssemblyJar(sparkLibrary, sparkHome)));
+          break;
+        case SPARK2_2_11:
+          LOCAL_SPARK_LIBRARIES.put(sparkCompat, getSpark2LibraryJars(sparkLibrary, sparkHome));
+          break;
+        default:
+          // This shouldn't happen
+          throw new IllegalStateException("Unsupported Spark version " + sparkCompat);
+      }
     }
 
     return LOCAL_SPARK_LIBRARIES.get(sparkCompat);


### PR DESCRIPTION
Backport #10195 to release/4.3 branch.

- Mainly changing Java 8 streams back to loops
- Also picked a change in `SparkPackageUtils.java` to allow running unit-test