### PR TITLE
[CDAP-13536] CDAP UI Header and Footer Changes

### DIFF
--- a/cdap-ui/app/cdap/components/Footer/index.js
+++ b/cdap-ui/app/cdap/components/Footer/index.js
@@ -14,28 +14,19 @@
  * the License.
  */
 
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 
 require('./Footer.scss');
 
-export default class Footer extends Component {
-  constructor(props) {
-    super(props);
-    var {copyrightYear, version} = props;
-    this.copyrightYear = copyrightYear || new Date().getFullYear();
-    this.version = version || '--unknown--';
-    this.props = props;
-  }
+export default class Footer extends PureComponent {
   render() {
     return (
       <footer>
         <div className="container">
           <div className="row text-muted">
-            <div className="text-uppercase">
+            <div>
               <p className="text-xs-center">
-                <span>Copyright &copy; {this.copyrightYear} Cask Data, Inc.</span>
+                <span>Licensed under the Apache License, Version 2.0</span>
               </p>
             </div>
           </div>
@@ -44,7 +35,3 @@ export default class Footer extends Component {
     );
   }
 }
-Footer.propTypes = {
-  version: PropTypes.string,
-  copyrightYear: PropTypes.string
-};

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/index.js
@@ -181,24 +181,6 @@ export default class ProductDropdown extends Component {
             <DropdownItem divider />
             <DropdownItem tag="li">
               <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href="http://cask.co/products/cdap/"
-              >
-                {T.translate('features.Navbar.ProductDropdown.prodWebsiteLabel')}
-              </a>
-            </DropdownItem>
-            <DropdownItem tag="li">
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href="http://cask.co/community"
-              >
-                {T.translate('features.Navbar.ProductDropdown.supportLabel')}
-              </a>
-            </DropdownItem>
-            <DropdownItem tag="li">
-              <a
                 href={docsUrl}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -125,7 +125,7 @@ class CDAP extends Component {
                 </Switch>
               </div>
           }
-          <Footer version={this.state.version} />
+          <Footer />
         </div>
       </BrowserRouter>
     );

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1414,8 +1414,6 @@ features:
         distributed: Distributed
         localSandbox: Local Sandbox
       olduilink: Switch to Classic View
-      prodWebsiteLabel: Product Website
-      supportLabel: Support
     rulesmgmt: Rules
   OpsDashboard:
     header: Dashboard


### PR DESCRIPTION
- Removes 'Product Website' and 'Support' links from CDAP header dropdown
- Modifies copyright in footer to have `Licensed under the Apache License, Version 2.0`

JIRA: https://issues.cask.co/browse/CDAP-13536