### PR TITLE
CDAP-13088 Support backward compatibility for Metadata APIs

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataEntity.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataEntity.java
@@ -17,46 +17,56 @@ package co.cask.cdap.api.metadata;
 
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
  * <p>
  * Represents either a CDAP entity or a custom entity in metadata APIs. A {@code MetadataEntity} is an ordered
- * sequence of key/value pairs.
+ * sequence of key/value pairs constructed using {@link MetadataEntity.Builder}. Keys are case insensitive.
  * </p>
  * <p>
  * Example usage:
  * Creating a MetadataEntity for Dataset
  * </p>
  * <pre>
- *  MetadataEntity metadataEntity =
- *    MetadataEntity.ofNamespace("myNamespace").appendAsType(MetadataEntity.DATASET, "myDataset");
+ *   MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+ *     .appendAsType(MetadataEntity.DATASET, "myDataset").build();
  * </pre>
  * <p>
  * Creating a {@code MetadataEntity} for a custom entity: a field in a dataset:
  * </p>
  * <pre>
- * MetadataEntity metadataEntity = MetadataEntity.ofNamespace("myNamespace")
- *   .append(MetadataEntity.DATASET, "myDataset").appendAsType("field", "myField");
+ *   MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").append(MetadataEntity.DATASET, "ds")
+ *    .appendAsType("field", "myField").build();
  * </pre>
  * <p>
- * Every metadata entity has a type. The type can be changed during append by using
- * {@link #appendAsType(String, String)} which does not necessarily have to be the last append.
- * In some cases, the type is a key in middle. An example of this is ApplicationId which ends with "version"
+ * Every metadata entity has a type. If a type is not specifically specified by calling
+ * {@link MetadataEntity.Builder#appendAsType(String, String)} the last key in the hierarchy will be the type by
+ * default. In some cases, the type is a key in middle and {@link MetadataEntity.Builder#appendAsType(String, String)}
+ * helps in representing these. An example of this is ApplicationId which ends with "version"
  * although the type is "application".
  * </p>
  * <pre>
- * MetadataEntity metadataEntity = MetadataEntity.ofNamespace("myNamespace")
- *   .append(MetadataEntity.APPLICATION, "myApplication")
- *   .appendAsType(MetadataEntity.VERSION, "appVersion");
- * metadataEntity = metadataEntity.changeType(MetadataEntity.APPLICATION);
+ *   MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+ *     .appendAsType(MetadataEntity.APPLICATION, "myApp").append(MetadataEntity.VERSION, "1").build();
  * </pre>
+ * This class also provide helper methods for creating {@link MetadataEntity} for:
+ * <ul>
+ * <li>CDAP Namespace: {@link #ofNamespace(String)}</li>
+ * <li>CDAP Dataset: {@link #ofDataset(String, String)} and {@link #ofDataset(String)}.
+ * The {@link #ofDataset(String)} lacks namespace information and does not represent complete information to
+ * represent a Dataset. It is provided to conveniently refer to a Dataset in current namespace and should only be
+ * used when it is known that the handler can fill in the namespace information.</li>
+ * </ul>
  */
 public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
 
@@ -77,20 +87,147 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
   private final LinkedHashMap<String, String> details;
   private String type;
 
-  /**
-   * Creates a {@link MetadataEntity} with the given key and value and sets the type to the given key
-   * @param key the key which will also be set as the type of the {@link MetadataEntity}
-   * @param value the value
-   */
-  public MetadataEntity(String key, String value) {
-    this.details = new LinkedHashMap<>();
-    this.details.put(key, value);
-    this.type = key;
+  private static final Map<String, String[][]> TYPES_TO_KEY_SEQUENCES;
+
+  static {
+    Map<String, String[][]> typesToKeys = new HashMap<>();
+    typesToKeys.put(NAMESPACE, new String[][]{{NAMESPACE}});
+    typesToKeys.put(DATASET, new String[][]{{NAMESPACE, DATASET}, {DATASET}});
+    typesToKeys.put(STREAM, new String[][]{{NAMESPACE, STREAM}});
+    typesToKeys.put(APPLICATION, new String[][]{{NAMESPACE, APPLICATION, VERSION}, {NAMESPACE, APPLICATION}});
+    typesToKeys.put(ARTIFACT, new String[][]{{NAMESPACE, ARTIFACT, VERSION}});
+    typesToKeys.put(VIEW, new String[][]{{NAMESPACE, STREAM, VIEW}});
+    typesToKeys.put(PROGRAM, new String[][]{{NAMESPACE, APPLICATION, VERSION, TYPE, PROGRAM},
+      {NAMESPACE, APPLICATION, TYPE, PROGRAM}});
+    typesToKeys.put(SCHEDULE, new String[][]{{NAMESPACE, APPLICATION, VERSION, SCHEDULE},
+      {NAMESPACE, APPLICATION, SCHEDULE}});
+    typesToKeys.put(FLOWLET, new String[][]{{NAMESPACE, APPLICATION, VERSION, FLOW, FLOWLET},
+      {NAMESPACE, APPLICATION, FLOW, FLOWLET}});
+    typesToKeys.put(PROGRAM_RUN, new String[][]{{NAMESPACE, APPLICATION, VERSION, TYPE, PROGRAM, PROGRAM_RUN},
+      {NAMESPACE, APPLICATION, TYPE, PROGRAM, PROGRAM_RUN}});
+    TYPES_TO_KEY_SEQUENCES = Collections.unmodifiableMap(typesToKeys);
   }
 
-  private MetadataEntity(MetadataEntity metadataEntity) {
-    this.details = new LinkedHashMap<>(metadataEntity.details);
+  /**
+   * Used by Builder to build the {@link MetadataEntity}
+   */
+  private MetadataEntity(LinkedHashMap<String, String> details, String type) {
+    this.details = details;
+    this.type = type;
+  }
+
+  /**
+   * Builder for {@link MetadataEntity}
+   */
+  public static class Builder {
+    private final LinkedHashMap<String, String> parts;
+    private String type;
+
+    Builder() {
+      parts = new LinkedHashMap<>();
+    }
+
+    private Builder(MetadataEntity metadataEntity) {
+      this.parts = new LinkedHashMap<>(metadataEntity.details);
+      this.type = metadataEntity.type;
+    }
+
+    /**
+     * Put the given key (case insensitive) with the given value in {@link MetadataEntity.Builder}.
+     * The returned {@link MetadataEntity.Builder} is of the same type. If the type needs to
+     * changed during append then {@link #appendAsType(String, String)}  should be used.
+     *
+     * @param key the key (case insensitive) to be added
+     * @param value the value to be added
+     * @return a new {@link MetadataEntity.Builder} which is of same type of this {@link MetadataEntity.Builder}
+     * but consists of the given key and value in addition
+     */
+    public Builder append(String key, String value) {
+      validateKey(key);
+      parts.put(key.toLowerCase(), value);
+      return this;
+    }
+
+    /**
+     * Put the given key (case insensitive) with the given value in {@link MetadataEntity.Builder}.
+     * The returned {@link MetadataEntity} type is set to the given key. If an append is required without the
+     * type change then {@link #append(String, String)} should be used.
+     *
+     * @param key the key (case insensitive) to be added
+     * @param value the value to be added
+     * @return a new {@link MetadataEntity.Builder} whose type is set to the given key and consists of the given
+     * key and value in addition
+     */
+    public Builder appendAsType(String key, String value) {
+      validateKey(key);
+      parts.put(key.toLowerCase(), value);
+      this.type = key.toLowerCase();
+      return this;
+    }
+
+    /**
+     * Builds a {@link MetadataEntity} from the builder.
+     *
+     * @return {@link MetadataEntity} from the builder
+     * @throws IllegalArgumentException if the key is a CDAP entity and the MetadataEntity is not correct to represent
+     * the CDAP entity
+     */
+    public MetadataEntity build() {
+      if (parts.isEmpty()) {
+        throw new IllegalArgumentException("key-value pair must be specified");
+      }
+      if (type == null) {
+        // traverse till the last key and make that the type
+        parts.keySet().forEach(x -> type = x);
+      }
+      validateHierarchy();
+      return new MetadataEntity(new LinkedHashMap<>(parts), type);
+    }
+
+    private void validateKey(String key) {
+      if (key == null || key.isEmpty()) {
+        throw new IllegalArgumentException("Key cannot be null or empty");
+      }
+      if (parts.containsKey(key)) {
+        throw new IllegalArgumentException(String.format("key '%s' already exists in '%s'", key, parts));
+      }
+    }
+
+    private void validateHierarchy() {
+      if (TYPES_TO_KEY_SEQUENCES.containsKey(type)) {
+        String[][] validSequences = TYPES_TO_KEY_SEQUENCES.get(type);
+        for (String[] validSequence : validSequences) {
+          if (Arrays.equals(validSequence, parts.keySet().toArray())) {
+            // valid sequence found
+            return;
+          }
+        }
+        throw new IllegalArgumentException(String.format("Failed to build MetadataEntity of type '%s' from '%s'. " +
+                                                           "Type '%s is a CDAP entity type and must follow one of " +
+                                                           "the following key hierarchies '%s'." +
+                                                           "If you want to represent a CDAP Entity please follow the " +
+                                                           "correct hierarchy. If you are trying to represent a " +
+                                                           "custom resource please use a different type name.",
+                                                         type, parts, type, Arrays.toString(validSequences)));
+      }
+    }
+  }
+
+  public MetadataEntity(MetadataEntity metadataEntity) {
+    this.details = metadataEntity.details;
     this.type = metadataEntity.type;
+  }
+
+  /**
+   * Creates a {@link MetadataEntity} representing the given namespace.
+   *
+   * @param namespace the name of the namespace
+   * @return {@link MetadataEntity} representing the namespace name
+   * @throws IllegalArgumentException if the key is a CDAP entity and the MetadataEntity is not correct to represent
+   * the CDAP entity
+   */
+  public static MetadataEntity ofNamespace(String namespace) {
+    return builder().appendAsType(MetadataEntity.NAMESPACE, namespace).build();
   }
 
   /**
@@ -101,7 +238,7 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
    * @return {@link MetadataEntity} representing the dataset name
    */
   public static MetadataEntity ofDataset(String datasetName) {
-    return new MetadataEntity(DATASET, datasetName);
+    return builder().appendAsType(MetadataEntity.DATASET, datasetName).build();
   }
 
   /**
@@ -110,52 +247,34 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
    * @param namespace the name of the namespace
    * @param datasetName the name of the dataset
    * @return {@link MetadataEntity} representing the dataset name
+   * @throws IllegalArgumentException if the key is a CDAP entity and the MetadataEntity is not correct to represent
+   * the CDAP entity
    */
   public static MetadataEntity ofDataset(String namespace, String datasetName) {
-    return MetadataEntity.ofNamespace(namespace).appendAsType(MetadataEntity.DATASET, datasetName);
+    return builder().append(MetadataEntity.NAMESPACE, namespace)
+      .appendAsType(MetadataEntity.DATASET, datasetName).build();
   }
 
   /**
-   * Creates a {@link MetadataEntity} representing the given namespace.
+   * Returns a List of {@link KeyValue} till the given splitKey (inclusive)
    *
-   * @param namespace the name of the namespace
-   * @return {@link MetadataEntity} representing the namespace name
+   * @param splitKey the splitKey (inclusive)
+   * @return List of {@link KeyValue}
    */
-  public static MetadataEntity ofNamespace(String namespace) {
-    return new MetadataEntity(NAMESPACE, namespace);
-  }
-
-  /**
-   * Returns a new {@link MetadataEntity} which consists of the given key and values following the key and values of
-   * this {@link MetadataEntity}. The returned {@link MetadataEntity} is of the same type. If the type needs to
-   * changed during append then {@link #appendAsType(String, String)}  should be used.
-   *
-   * @param key the key to be added
-   * @param value the value to be added
-   * @return a new {@link MetadataEntity} which is of same type of this {@link MetadataEntity} but consists of
-   * the given key and value following the key and values of this {@link MetadataEntity}
-   */
-  public MetadataEntity append(String key, String value) {
-    MetadataEntity metadataEntity = new MetadataEntity(this);
-    metadataEntity.details.put(key, value);
-    return metadataEntity;
-  }
-
-  /**
-   * Returns a new {@link MetadataEntity} which consists of the given key and values following the key and values of
-   * this {@link MetadataEntity}. The returned {@link MetadataEntity} type is set to the given key. If an append is
-   * required without the type change then {@link #append(String, String)} should be used.
-   *
-   * @param key the key to be added
-   * @param value the value to be added
-   * @return a new {@link MetadataEntity} whose type is set to the given key and consists of the given key and value
-   * following the key and values of this {@link MetadataEntity}
-   */
-  public MetadataEntity appendAsType(String key, String value) {
-    MetadataEntity metadataEntity = new MetadataEntity(this);
-    metadataEntity.details.put(key, value);
-    metadataEntity.type = key;
-    return metadataEntity;
+  public List<MetadataEntity.KeyValue> head(String splitKey) {
+    splitKey = splitKey.toLowerCase();
+    if (!containsKey(splitKey)) {
+      throw new IllegalArgumentException(String.format("The given key %s does not exists in %s", splitKey, toString()));
+    }
+    List<MetadataEntity.KeyValue> subParts = new ArrayList<>();
+    for (KeyValue keyValue : this) {
+      subParts.add(keyValue);
+      if (keyValue.getKey().equalsIgnoreCase(splitKey)) {
+        // reached till the key which is inclusive so stop
+        break;
+      }
+    }
+    return subParts;
   }
 
   /**
@@ -183,15 +302,23 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
   /**
    * @return all the values in the MetadataEntity
    */
-  public Iterable<String> getValues() {
-    return Collections.unmodifiableList(new ArrayList<>(details.values()));
+  Iterable<String> getValues() {
+    return details.values();
   }
 
   /**
    * @return all the keys in the MetadataEntity
    */
   public Iterable<String> getKeys() {
-    return Collections.unmodifiableList(new ArrayList<>(details.keySet()));
+    return details.keySet();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static Builder builder(MetadataEntity metadataEntity) {
+    return new Builder(metadataEntity);
   }
 
   /**
@@ -237,7 +364,7 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
     private final String key;
     private final String value;
 
-    KeyValue(String key, String value) {
+    public KeyValue(String key, String value) {
       this.key = key;
       this.value = value;
     }
@@ -248,6 +375,24 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
 
     public String getValue() {
       return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      KeyValue keyValue = (KeyValue) o;
+      return Objects.equals(key, keyValue.key) &&
+        Objects.equals(value, keyValue.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(key, value);
     }
   }
 }

--- a/cdap-api/src/test/java/co/cask/cdap/api/metadata/MetadataEntityTest.java
+++ b/cdap-api/src/test/java/co/cask/cdap/api/metadata/MetadataEntityTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.metadata;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Test for  {@link MetadataEntity}
+ */
+public class MetadataEntityTest {
+
+  @Test
+  public void testInvalidKeys() {
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+        .appendAsType(MetadataEntity.DATASET, "ds").append(MetadataEntity.DATASET, "soemthing");
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    try {
+      MetadataEntity.builder().append("", "ns");
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testImmutability() {
+    MetadataEntity.Builder builder = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.DATASET, "ds");
+    MetadataEntity original = builder.build();
+    // add more to the builder
+    MetadataEntity modified = builder.appendAsType("field", "f1").build();
+
+    Assert.assertEquals(MetadataEntity.DATASET, original.getType());
+    assertEquals(original.getKeys(), MetadataEntity.NAMESPACE, MetadataEntity.DATASET);
+    assertEquals(original.getValues(), "ns", "ds");
+
+    Assert.assertEquals("field", modified.getType());
+    assertEquals(modified.getKeys(), MetadataEntity.NAMESPACE, MetadataEntity.DATASET, "field");
+    assertEquals(modified.getValues(), "ns", "ds", "f1");
+  }
+
+  @Test
+  public void testOf() {
+    MetadataEntity metadataEntity = MetadataEntity.ofNamespace("ns");
+    assertEquals(metadataEntity.getKeys(), MetadataEntity.NAMESPACE);
+    assertEquals(metadataEntity.getValues(), "ns");
+
+    metadataEntity = MetadataEntity.ofDataset("ns", "ds");
+    assertEquals(metadataEntity.getKeys(), MetadataEntity.NAMESPACE, MetadataEntity.DATASET);
+    assertEquals(metadataEntity.getValues(), "ns", "ds");
+
+    metadataEntity = MetadataEntity.ofDataset("ds");
+    assertEquals(metadataEntity.getKeys(), MetadataEntity.DATASET);
+    assertEquals(metadataEntity.getValues(), "ds");
+  }
+
+  @Test
+  public void testBuilder() {
+    // empty builder should fail
+    try {
+      MetadataEntity.builder().build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    // test that builder builds metadata entity correctly
+    MetadataEntity metadataEntity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.DATASET, "myDataset").build();
+    assertEquals(metadataEntity.getKeys(), MetadataEntity.NAMESPACE, MetadataEntity.DATASET);
+    assertEquals(metadataEntity.getValues(), "ns", "myDataset");
+  }
+
+  @Test
+  public void testValidateHierarchy() {
+    // test which tests building of various system metadata entity to verify the hierarchy
+
+    // test dataset
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.DATASET, "myDataset").build();
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").append("b", "c")
+        .appendAsType(MetadataEntity.DATASET, "myDataset").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      MetadataEntity.builder().append("unknown", "a").appendAsType(MetadataEntity.DATASET, "ds").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // should pass since
+    MetadataEntity.builder().appendAsType(MetadataEntity.DATASET, "myDataset").build();
+
+    // should not fail
+    MetadataEntity metadataEntity = MetadataEntity.builder().append(MetadataEntity.DATASET, "myDataset").build();
+    Assert.assertEquals(MetadataEntity.DATASET, metadataEntity.getType());
+
+    // test custom types
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").append(MetadataEntity.DATASET, "ds")
+      .appendAsType("field", "myField").build();
+
+    // test stream
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.STREAM, "myStream").build();
+    try {
+      MetadataEntity.builder().appendAsType(MetadataEntity.STREAM, "myStream").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // test application
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.APPLICATION, "myApp").build();
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.APPLICATION, "myApp").append(MetadataEntity.VERSION, "1").build();
+
+    // test artifact
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.ARTIFACT, "myArt").append(MetadataEntity.VERSION, "1").build();
+
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+        .appendAsType(MetadataEntity.ARTIFACT, "myArt").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // test program
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.TYPE, "worflow").appendAsType(MetadataEntity.PROGRAM, "someProg").build();
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.VERSION, "1").append(MetadataEntity.TYPE, "worflow")
+      .appendAsType(MetadataEntity.PROGRAM, "someProg").build();
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").append(MetadataEntity.TYPE, "worflow")
+        .appendAsType(MetadataEntity.PROGRAM, "someProg").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").append(MetadataEntity.VERSION, "1")
+        .append(MetadataEntity.TYPE, "worflow").appendAsType(MetadataEntity.PROGRAM, "someProg").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // test view
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.STREAM, "myStream")
+      .appendAsType(MetadataEntity.VIEW, "myVieW").build();
+
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+        .appendAsType(MetadataEntity.VIEW, "myVieW").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // test schedule
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .appendAsType(MetadataEntity.SCHEDULE, "sched").build();
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.VERSION, "1").appendAsType(MetadataEntity.SCHEDULE, "sched").build();
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+        .appendAsType(MetadataEntity.SCHEDULE, "sched").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").append(MetadataEntity.VERSION, "1")
+        .appendAsType(MetadataEntity.SCHEDULE, "sched").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // test program run
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.TYPE, "worflow").append(MetadataEntity.PROGRAM, "someProg")
+      .appendAsType(MetadataEntity.PROGRAM_RUN, "r1").build();
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.VERSION, "1").append(MetadataEntity.TYPE, "worflow")
+      .append(MetadataEntity.PROGRAM, "someProg").appendAsType(MetadataEntity.PROGRAM_RUN, "r1").build();
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+        .append(MetadataEntity.TYPE, "worflow").appendAsType(MetadataEntity.PROGRAM_RUN, "r1").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    // test flowlet
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.FLOW, "flow").appendAsType(MetadataEntity.FLOWLET, "ft").build();
+    MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.VERSION, "1").append(MetadataEntity.FLOW, "flow")
+      .appendAsType(MetadataEntity.FLOWLET, "ft").build();
+    try {
+      MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+        .append(MetadataEntity.FLOW, "flow").appendAsType(MetadataEntity.FLOWLET, "ft").build();
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testGetTill() {
+    MetadataEntity metadataEntity = MetadataEntity.builder(MetadataEntity.ofNamespace("ns"))
+      .appendAsType(MetadataEntity.APPLICATION, "myApp").append(MetadataEntity.TYPE, "worflow")
+      .appendAsType(MetadataEntity.PROGRAM, "someProg").build();
+
+    List<MetadataEntity.KeyValue> till = metadataEntity.head(MetadataEntity.APPLICATION);
+    Assert.assertEquals(2, till.size());
+    Assert.assertEquals(new MetadataEntity.KeyValue(MetadataEntity.NAMESPACE, "ns"), till.get(0));
+    Assert.assertEquals(new MetadataEntity.KeyValue(MetadataEntity.APPLICATION, "myApp"), till.get(1));
+
+    try {
+      metadataEntity.head("nonExisting");
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  private void assertEquals(Iterable<String> iterator, String... expected) {
+    List<String> actual = new ArrayList<>();
+    iterator.forEach(actual::add);
+    Assert.assertEquals(Arrays.asList(expected), actual);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageAdmin.java
@@ -22,7 +22,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.entity.EntityExistenceVerifier;
-import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.lineage.DefaultLineageStoreReader;
 import co.cask.cdap.data2.metadata.lineage.Lineage;
@@ -158,7 +158,7 @@ public class LineageAdmin {
   /**
    * @return metadata associated with a run
    */
-  public Set<MetadataRecord> getMetadataForRun(ProgramRunId run) {
+  public Set<MetadataRecordV2> getMetadataForRun(ProgramRunId run) {
     try {
       entityExistenceVerifier.ensureExists(run);
     } catch (NotFoundException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -19,11 +19,11 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.InvalidMetadataException;
-import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
-import co.cask.cdap.proto.metadata.MetadataSearchResponse;
+import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
 
 import java.util.Map;
 import java.util.Set;
@@ -55,17 +55,17 @@ public interface MetadataAdmin {
   void addTags(MetadataEntity metadataEntity, String... tags) throws InvalidMetadataException;
 
   /**
-   * Returns a set of {@link MetadataRecord} representing all metadata (including properties and tags) for the specified
-   * {@link MetadataEntity} in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
+   * Returns a set of {@link MetadataRecordV2} representing all metadata (including properties and tags) for the
+   * specified {@link MetadataEntity} in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
    */
-  Set<MetadataRecord> getMetadata(MetadataEntity metadataEntity);
+  Set<MetadataRecordV2> getMetadata(MetadataEntity metadataEntity);
 
   /**
-   * Returns a set of {@link MetadataRecord} representing all metadata (including properties and tags) for the specified
-   * {@link MetadataEntity} in the specified {@link MetadataScope}.
+   * Returns a set of {@link MetadataRecordV2} representing all metadata (including properties and tags) for the
+   * specified {@link MetadataEntity} in the specified {@link MetadataScope}.
    */
   // TODO: Should this return a single metadata record instead or is a set of one record ok?
-  Set<MetadataRecord> getMetadata(MetadataScope scope, MetadataEntity metadataEntity);
+  Set<MetadataRecordV2> getMetadata(MetadataScope scope, MetadataEntity metadataEntity);
 
   /**
    * @return a {@link Map} representing the metadata of the specified {@link MetadataEntity} in both
@@ -153,9 +153,9 @@ public interface MetadataAdmin {
    * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
    *                    or not.
    * @param entityScope a set which specifies which scope of entities to display.
-   * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
+   * @return the {@link MetadataSearchResponseV2} containing search results for the specified search query and filters
    */
-  MetadataSearchResponse search(String namespaceId, String searchQuery, Set<EntityTypeSimpleName> types,
-                                SortInfo sortInfo, int offset, int limit, int numCursors,
-                                String cursor, boolean showHidden, Set<EntityScope> entityScope) throws Exception;
+  MetadataSearchResponseV2 search(String namespaceId, String searchQuery, Set<EntityTypeSimpleName> types,
+                                  SortInfo sortInfo, int offset, int limit, int numCursors,
+                                  String cursor, boolean showHidden, Set<EntityScope> entityScope) throws Exception;
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -39,7 +39,7 @@ import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
-import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.common.test.AppJarHelper;
 import co.cask.cdap.common.test.PluginJarHelper;
 import co.cask.cdap.common.utils.DirUtils;
@@ -155,8 +155,8 @@ public class ArtifactRepositoryTest {
 
   @Test
   public void testDeletingArtifact() throws Exception {
-    MetadataRecord record = metadataStore.getMetadata(MetadataScope.SYSTEM,
-                                                      APP_ARTIFACT_ID.toEntityId().toMetadataEntity());
+    MetadataRecordV2 record = metadataStore.getMetadata(MetadataScope.SYSTEM,
+                                                        APP_ARTIFACT_ID.toEntityId().toMetadataEntity());
     Assert.assertFalse(record.getProperties().isEmpty());
     artifactRepository.deleteArtifact(APP_ARTIFACT_ID);
     record = metadataStore.getMetadata(MetadataScope.SYSTEM, APP_ARTIFACT_ID.toEntityId().toMetadataEntity());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -22,7 +22,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.entity.EntityExistenceVerifier;
-import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.lineage.DefaultLineageStoreReader;
@@ -117,14 +117,14 @@ public class LineageAdminTest extends AppFabricTestBase {
                                                  new NoOpEntityExistenceVerifier());
 
     // Define metadata
-    MetadataRecord run1AppMeta = new MetadataRecord(program1.getParent(), MetadataScope.USER,
-                                                    toMap("pk1", "pk1"), toSet("pt1"));
-    MetadataRecord run1ProgramMeta = new MetadataRecord(program1, MetadataScope.USER,
+    MetadataRecordV2 run1AppMeta = new MetadataRecordV2(program1.getParent(), MetadataScope.USER,
                                                         toMap("pk1", "pk1"), toSet("pt1"));
-    MetadataRecord run1Data1Meta = new MetadataRecord(dataset1, MetadataScope.USER,
-                                                      toMap("dk1", "dk1"), toSet("dt1"));
-    MetadataRecord run1Data2Meta = new MetadataRecord(dataset2, MetadataScope.USER,
-                                                      toMap("dk2", "dk2"), toSet("dt2"));
+    MetadataRecordV2 run1ProgramMeta = new MetadataRecordV2(program1, MetadataScope.USER,
+                                                            toMap("pk1", "pk1"), toSet("pt1"));
+    MetadataRecordV2 run1Data1Meta = new MetadataRecordV2(dataset1, MetadataScope.USER,
+                                                          toMap("dk1", "dk1"), toSet("dt1"));
+    MetadataRecordV2 run1Data2Meta = new MetadataRecordV2(dataset2, MetadataScope.USER,
+                                                          toMap("dk2", "dk2"), toSet("dt2"));
 
     // Add metadata
     metadataStore.setProperties(MetadataScope.USER, program1.getParent().toMetadataEntity(),
@@ -583,14 +583,14 @@ public class LineageAdminTest extends AppFabricTestBase {
                                                  new NoOpEntityExistenceVerifier());
 
     // Define metadata
-    MetadataRecord run1AppMeta = new MetadataRecord(program1.getParent(), MetadataScope.USER,
-                                                    toMap("pk1", "pk1"), toSet("pt1"));
-    MetadataRecord run1ProgramMeta = new MetadataRecord(program1, MetadataScope.USER,
+    MetadataRecordV2 run1AppMeta = new MetadataRecordV2(program1.getParent(), MetadataScope.USER,
                                                         toMap("pk1", "pk1"), toSet("pt1"));
-    MetadataRecord run1Data1Meta = new MetadataRecord(dataset1, MetadataScope.USER,
-                                                      toMap("dk1", "dk1"), toSet("dt1"));
-    MetadataRecord run1Data2Meta = new MetadataRecord(dataset2, MetadataScope.USER,
-                                                      toMap("dk2", "dk2"), toSet("dt2"));
+    MetadataRecordV2 run1ProgramMeta = new MetadataRecordV2(program1, MetadataScope.USER,
+                                                            toMap("pk1", "pk1"), toSet("pt1"));
+    MetadataRecordV2 run1Data1Meta = new MetadataRecordV2(dataset1, MetadataScope.USER,
+                                                          toMap("dk1", "dk1"), toSet("dt1"));
+    MetadataRecordV2 run1Data2Meta = new MetadataRecordV2(dataset2, MetadataScope.USER,
+                                                          toMap("dk2", "dk2"), toSet("dt2"));
 
     // Add metadata
     metadataStore.setProperties(MetadataScope.USER, program1.getParent().toMetadataEntity(),

--- a/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/testclasses/StreamBatchSource.java
+++ b/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/testclasses/StreamBatchSource.java
@@ -132,12 +132,11 @@ public class StreamBatchSource extends BatchSource<LongWritable, Object, Structu
     propogateMetadata(context, sourceEntity, sinkEntity);
 
     // Propagate metadata of some fields
-    MetadataEntity sourceFieldEntity = sourceEntity.append("field", "empName");
-    MetadataEntity sinkFieldEntity = sinkEntity.append("field", "empName");
+    MetadataEntity sourceFieldEntity = MetadataEntity.builder(sourceEntity).appendAsType("field", "empName").build();
+    MetadataEntity sinkFieldEntity = MetadataEntity.builder(sinkEntity).appendAsType("field", "empName").build();
     propogateMetadata(context, sourceFieldEntity, sinkFieldEntity);
 
     for (Schema.Field field : context.getInputSchema().getFields()) {
-      sourceFieldEntity = sourceEntity.append("field", field.getName());
       Metadata metadata = context.getMetadata(MetadataScope.USER, sourceFieldEntity);
       if (metadata.getTags().contains("confidential")) {
         // do some thing

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -126,15 +126,10 @@ public class CLIMainTest extends CLITestBase {
   private static final ApplicationId FAKE_APP_ID_V_1 = NamespaceId.DEFAULT.app(FakeApp.NAME, V1_SNAPSHOT);
   private static final ArtifactId FAKE_PLUGIN_ID = NamespaceId.DEFAULT.artifact(FakePlugin.NAME, V1);
   private static final ProgramId FAKE_WORKFLOW_ID = FAKE_APP_ID.workflow(FakeWorkflow.NAME);
-  private static final ProgramId FAKE_WORKFLOW_ID_V_1 = FAKE_APP_ID_V_1.workflow(FakeWorkflow.NAME);
   private static final ProgramId FAKE_FLOW_ID = FAKE_APP_ID.flow(FakeFlow.NAME);
-  private static final ProgramId FAKE_FLOW_ID_V_1 = FAKE_APP_ID_V_1.flow(FakeFlow.NAME);
   private static final ProgramId FAKE_SPARK_ID = FAKE_APP_ID.spark(FakeSpark.NAME);
-  private static final ProgramId FAKE_SPARK_ID_V_1 = FAKE_APP_ID_V_1.spark(FakeSpark.NAME);
   private static final ServiceId PING_SERVICE_ID = FAKE_APP_ID.service(PingService.NAME);
-  private static final ServiceId PING_SERVICE_ID_V_1 = FAKE_APP_ID_V_1.service(PingService.NAME);
   private static final ServiceId PREFIXED_ECHO_HANDLER_ID = FAKE_APP_ID.service(PrefixedEchoHandler.NAME);
-  private static final ServiceId PREFIXED_ECHO_HANDLER_ID_V_1 = FAKE_APP_ID_V_1.service(PrefixedEchoHandler.NAME);
   private static final DatasetId FAKE_DS_ID = NamespaceId.DEFAULT.dataset(FakeApp.DS_NAME);
   private static final StreamId FAKE_STREAM_ID = NamespaceId.DEFAULT.stream(FakeApp.STREAM_NAME);
 
@@ -864,9 +859,8 @@ public class CLIMainTest extends CLITestBase {
     testCommandOutputContains(cli, "search metadata fake* filtered by target-type app", FAKE_APP_ID.toString());
     output = getCommandOutput(cli, "search metadata fake* filtered by target-type program");
     lines = Arrays.asList(output.split("\\r?\\n"));
-    List<String> expected = ImmutableList.of("Entity", FAKE_WORKFLOW_ID.toString(), FAKE_WORKFLOW_ID_V_1.toString(),
-                                             FAKE_SPARK_ID.toString(), FAKE_SPARK_ID_V_1.toString(),
-                                             FAKE_FLOW_ID.toString(), FAKE_FLOW_ID_V_1.toString());
+    List<String> expected = ImmutableList.of("Entity", FAKE_WORKFLOW_ID.toString(), FAKE_SPARK_ID.toString(),
+                                             FAKE_FLOW_ID.toString());
     Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
     testCommandOutputContains(cli, "search metadata fake* filtered by target-type dataset", FAKE_DS_ID.toString());
     testCommandOutputContains(cli, "search metadata fake* filtered by target-type stream", FAKE_STREAM_ID.toString());
@@ -882,14 +876,12 @@ public class CLIMainTest extends CLITestBase {
     testCommandOutputContains(cli, "search metadata bat* filtered by target-type dataset", FAKE_DS_ID.toString());
     output = getCommandOutput(cli, "search metadata batch filtered by target-type program");
     lines = Arrays.asList(output.split("\\r?\\n"));
-    expected = ImmutableList.of("Entity", FAKE_SPARK_ID.toString(), FAKE_SPARK_ID_V_1.toString(),
-                                FAKE_WORKFLOW_ID.toString(), FAKE_WORKFLOW_ID_V_1.toString());
+    expected = ImmutableList.of("Entity", FAKE_SPARK_ID.toString(), FAKE_WORKFLOW_ID.toString());
     Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
     output = getCommandOutput(cli, "search metadata realtime filtered by target-type program");
     lines = Arrays.asList(output.split("\\r?\\n"));
-    expected = ImmutableList.of("Entity", FAKE_FLOW_ID.toString(), FAKE_FLOW_ID_V_1.toString(),
-                                PING_SERVICE_ID.toString(), PING_SERVICE_ID_V_1.toString(), PREFIXED_ECHO_HANDLER_ID
-                                  .toString(), PREFIXED_ECHO_HANDLER_ID_V_1.toString());
+    expected = ImmutableList.of("Entity", FAKE_FLOW_ID.toString(), PING_SERVICE_ID.toString(),
+                                PREFIXED_ECHO_HANDLER_ID.toString());
     Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
     output = getCommandOutput(cli, "search metadata fake* filtered by target-type dataset,stream");
     lines = Arrays.asList(output.split("\\r?\\n"));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
@@ -64,7 +64,7 @@ public class GetMetadataCommand extends AbstractCommand {
           @Override
           public List<String> apply(MetadataRecord record) {
             return Lists.newArrayList(
-              record.getMetadataEntity().toString(),
+              record.toString(),
               Joiner.on("\n").join(record.getTags()),
               Joiner.on("\n").withKeyValueSeparator(":").join(record.getProperties()),
               record.getScope().name());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
@@ -19,7 +19,6 @@ package co.cask.cdap.cli.command.metadata;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
-import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
@@ -34,7 +33,6 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
 import java.io.PrintStream;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -67,12 +65,8 @@ public class SearchMetadataCommand extends AbstractCommand {
     Set<MetadataSearchResultRecord> searchResults = metadataSearchResponse.getResults();
     Table table = Table.builder()
       .setHeader("Entity")
-      .setRows(Lists.newArrayList(searchResults), new RowMaker<MetadataSearchResultRecord>() {
-        @Override
-        public List<?> makeRow(MetadataSearchResultRecord searchResult) {
-          return Lists.newArrayList(searchResult.getEntityId().toString());
-        }
-      }).build();
+      .setRows(Lists.newArrayList(searchResults), searchResult ->
+        Lists.newArrayList(searchResult.getEntityId().toString())).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
@@ -29,6 +30,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
+import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
@@ -106,11 +108,11 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected Set<MetadataRecord> getMetadata(MetadataEntity metadataEntity) throws Exception {
+  protected Set<MetadataRecordV2> getMetadata(MetadataEntity metadataEntity) throws Exception {
     return getMetadata(metadataEntity, null);
   }
 
-  protected Set<MetadataRecord> getMetadata(MetadataEntity metadataEntity, @Nullable MetadataScope scope)
+  protected Set<MetadataRecordV2> getMetadata(MetadataEntity metadataEntity, @Nullable MetadataScope scope)
     throws Exception {
     return metadataClient.getMetadata(metadataEntity, scope);
   }
@@ -120,7 +122,7 @@ public abstract class MetadataTestBase extends ClientTestBase {
   }
 
   protected Set<MetadataRecord> getMetadata(EntityId entityId, @Nullable MetadataScope scope) throws Exception {
-    return getMetadata(entityId.toMetadataEntity(), scope);
+    return metadataClient.getMetadata(entityId, scope);
   }
 
   protected Map<String, String> getProperties(MetadataEntity metadataEntity, MetadataScope scope) throws Exception {
@@ -203,6 +205,15 @@ public abstract class MetadataTestBase extends ClientTestBase {
                                          cursor, showHiddden);
   }
 
+  protected MetadataSearchResponseV2 searchMetadata(NamespaceId namespaceId, String query,
+                                                    Set<EntityTypeSimpleName> targets,
+                                                    @Nullable String sort, int offset, int limit, int numCursors,
+                                                    @Nullable String cursor, boolean showHiddden,
+                                                    boolean showCustom) throws Exception {
+    return metadataClient.searchMetadata(namespaceId, query, targets, sort, offset, limit, numCursors,
+                                         cursor, showHiddden, showCustom);
+  }
+
   protected Set<String> getTags(MetadataEntity metadataEntity, MetadataScope scope) throws Exception {
     return metadataClient.getTags(metadataEntity, scope);
   }
@@ -272,6 +283,10 @@ public abstract class MetadataTestBase extends ClientTestBase {
     return lineageClient.getLineage(stream, start, end, collapseTypes, levels);
   }
 
+  protected void getPropertiesFromInvalidEntity(EntityId entityId) throws Exception {
+    Map<String, String> properties = getProperties(entityId, MetadataScope.USER);
+    Assert.assertTrue(properties.isEmpty());
+  }
 
   protected void assertRunMetadataNotFound(ProgramRunId run) throws Exception {
     Set<MetadataRecord> metadataRecords = getMetadata(run);

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/MetadataCompat.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/MetadataCompat.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.metadata;
+
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.metadata.MetadataSearchResponse;
+import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecordV2;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Class containing helper methods to convert some of Metadata classes to older version for backward compatibility.
+ */
+public class MetadataCompat {
+
+  /**
+   * @return a Set of {@link MetadataRecord} which only contains the {@link MetadataRecord} which are backward
+   * compatible i.e. the record do not represent a custom entity
+   */
+  public static Set<MetadataRecord> filterForCompatibility(Set<MetadataRecordV2> metadataRecordsV2) {
+    // use linked hashset since the records are ordered and we want to maintain the ordering
+    Set<MetadataRecord> metadataRecords = new LinkedHashSet<>();
+    metadataRecordsV2.forEach(record -> {
+      Optional<MetadataRecord> metadataRecord = MetadataCompat.makeCompatible(record);
+      metadataRecord.ifPresent(metadataRecords::add);
+    });
+    return metadataRecords;
+  }
+
+  /**
+   * @return An {@link Optional} which contains {@link MetadataRecord} if the given metadataRecordV2 is compatible i.e.
+   * the record do not represent a custom entity else is absent.
+   */
+  @VisibleForTesting
+  static Optional<MetadataRecord> makeCompatible(MetadataRecordV2 metadataRecordV2) {
+    MetadataEntity metadataEntity = metadataRecordV2.getMetadataEntity();
+    try {
+      NamespacedEntityId entityId = EntityId.fromMetadataEntity(metadataEntity);
+      return Optional.of(new MetadataRecord(entityId, metadataRecordV2.getScope(),
+                                            metadataRecordV2.getProperties(), metadataRecordV2.getTags()));
+    } catch (IllegalArgumentException e) {
+      // ignore the custom entities for backward compatibility
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Filters the given metadataSearchResponseV2 for backward compatibility by dropping entries for custom entity.
+   *
+   * @param metadataSearchResponseV2 the {@link MetadataSearchResponseV2} to be filtered
+   * @return {@link MetadataSearchResponse} which does not contain records for custom entities.
+   */
+  public static MetadataSearchResponse makeCompatible(MetadataSearchResponseV2 metadataSearchResponseV2) {
+    // use linked hashset since the search response is ordered and we want to maintain the ordering
+    Set<MetadataSearchResultRecord> filteredResults = new LinkedHashSet<>();
+    Set<MetadataSearchResultRecordV2> results = metadataSearchResponseV2.getResults();
+    results.forEach(record -> {
+      try {
+        NamespacedEntityId entityId = EntityId.fromMetadataEntity(record.getMetadataEntity());
+        filteredResults.add(new MetadataSearchResultRecord(entityId, record.getMetadata()));
+      } catch (IllegalArgumentException e) {
+        // ignore the custom entities for backward compatibility
+      }
+    });
+    return new MetadataSearchResponse(metadataSearchResponseV2.getSort(), metadataSearchResponseV2.getOffset(),
+                                      metadataSearchResponseV2.getLimit(), metadataSearchResponseV2.getNumCursors(),
+                                      metadataSearchResponseV2.getTotal(), filteredResults,
+                                      metadataSearchResponseV2.getCursors(), metadataSearchResponseV2.isShowHidden(),
+                                      metadataSearchResponseV2.getEntityScope());
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/MetadataRecord.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/MetadataRecord.java
@@ -16,9 +16,7 @@
 
 package co.cask.cdap.common.metadata;
 
-import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 
 import java.util.Collections;
@@ -27,12 +25,15 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents the complete metadata of a {@link MetadataEntity} including its properties, tags in a given
+ * Represents the complete metadata of a {@link NamespacedEntityId} including its properties, tags in a given
  * {@link MetadataScope}
  * this class was in cdap-api earlier and has been moved from cdap-common as its used only internally
+ *
+ * @deprecated As of release 5.0, replaced by {@link MetadataRecordV2}
  */
+@Deprecated
 public class MetadataRecord {
-  private final MetadataEntity metadataEntity;
+  private final NamespacedEntityId entityId;
   private final MetadataScope scope;
   private final Map<String, String> properties;
   private final Set<String> tags;
@@ -41,45 +42,26 @@ public class MetadataRecord {
    * Returns an empty {@link MetadataRecord} in the specified {@link MetadataScope}.
    */
   public MetadataRecord(NamespacedEntityId entityId, MetadataScope scope) {
-    this(entityId.toMetadataEntity(), scope);
-  }
-
-  /**
-   * Returns an empty {@link MetadataRecord} in the specified {@link MetadataScope}.
-   */
-  public MetadataRecord(MetadataEntity metadataEntity, MetadataScope scope) {
-    this(metadataEntity, scope, Collections.emptyMap(), Collections.emptySet());
+    this(entityId, scope, Collections.emptyMap(), Collections.emptySet());
   }
 
   /**
    * Returns a new {@link MetadataRecord} from the specified existing {@link MetadataRecord}.
    */
   public MetadataRecord(MetadataRecord other) {
-    this(other.getMetadataEntity(), other.getScope(), other.getProperties(), other.getTags());
+    this(other.getEntityId(), other.getScope(), other.getProperties(), other.getTags());
   }
 
-  /**
-   * Returns an empty {@link MetadataRecord} in the specified {@link MetadataScope}.
-   */
   public MetadataRecord(NamespacedEntityId entityId, MetadataScope scope, Map<String, String> properties,
                         Set<String> tags) {
-    this(entityId.toMetadataEntity(), scope, properties, tags);
-  }
-
-  public MetadataRecord(MetadataEntity metadataEntity, MetadataScope scope, Map<String, String> properties,
-                        Set<String> tags) {
-    this.metadataEntity = metadataEntity;
+    this.entityId = entityId;
     this.scope = scope;
     this.properties = properties;
     this.tags = tags;
   }
 
-  public MetadataEntity getMetadataEntity() {
-    return metadataEntity;
-  }
-
   public NamespacedEntityId getEntityId() {
-    return EntityId.fromMetadataEntity(metadataEntity);
+    return entityId;
   }
 
   public MetadataScope getScope() {
@@ -105,7 +87,7 @@ public class MetadataRecord {
 
     MetadataRecord that = (MetadataRecord) o;
 
-    return Objects.equals(metadataEntity, that.metadataEntity) &&
+    return Objects.equals(entityId, that.entityId) &&
       scope == that.scope &&
       Objects.equals(properties, that.properties) &&
       Objects.equals(tags, that.tags);
@@ -113,13 +95,13 @@ public class MetadataRecord {
 
   @Override
   public int hashCode() {
-    return Objects.hash(metadataEntity, scope, properties, tags);
+    return Objects.hash(entityId, scope, properties, tags);
   }
 
   @Override
   public String toString() {
     return "MetadataRecord{" +
-      "metadataEntity=" + metadataEntity +
+      "entityId=" + entityId +
       ", scope=" + scope +
       ", properties=" + properties +
       ", tags=" + tags +

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/MetadataRecordV2.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/MetadataRecordV2.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.metadata;
+
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents the complete metadata of a {@link MetadataEntity} including its properties, tags in a given
+ * {@link MetadataScope}
+ * this class was in cdap-api earlier and has been moved from cdap-common as its used only internally
+ */
+public class MetadataRecordV2 {
+  private final MetadataEntity metadataEntity;
+  private final MetadataScope scope;
+  private final Map<String, String> properties;
+  private final Set<String> tags;
+
+  /**
+   * Returns an empty {@link MetadataRecordV2} in the specified {@link MetadataScope}.
+   */
+  public MetadataRecordV2(NamespacedEntityId entityId, MetadataScope scope) {
+    this(entityId.toMetadataEntity(), scope);
+  }
+
+  /**
+   * Returns an empty {@link MetadataRecordV2} in the specified {@link MetadataScope}.
+   */
+  public MetadataRecordV2(MetadataEntity metadataEntity, MetadataScope scope) {
+    this(metadataEntity, scope, Collections.emptyMap(), Collections.emptySet());
+  }
+
+  /**
+   * Returns a new {@link MetadataRecordV2} from the specified existing {@link MetadataRecordV2}.
+   */
+  public MetadataRecordV2(MetadataRecordV2 other) {
+    this(other.getMetadataEntity(), other.getScope(), other.getProperties(), other.getTags());
+  }
+
+  /**
+   * Returns an empty {@link MetadataRecordV2} in the specified {@link MetadataScope}.
+   */
+  public MetadataRecordV2(NamespacedEntityId entityId, MetadataScope scope, Map<String, String> properties,
+                          Set<String> tags) {
+    this(entityId.toMetadataEntity(), scope, properties, tags);
+  }
+
+  /**
+   * Returns an empty {@link MetadataRecordV2} in the specified {@link MetadataScope} containing the specified
+   * properties and tags
+   */
+  public MetadataRecordV2(MetadataEntity metadataEntity, MetadataScope scope, Map<String, String> properties,
+                          Set<String> tags) {
+    this.metadataEntity = metadataEntity;
+    this.scope = scope;
+    this.properties = new HashMap<>(properties);
+    this.tags = new HashSet<>(tags);
+  }
+
+  /**
+   * @return the {@link MetadataEntity} whose metadata this {@link MetadataRecordV2} represents
+   */
+  public MetadataEntity getMetadataEntity() {
+    return metadataEntity;
+  }
+
+  /**
+   * @return the {@link MetadataScope} of this {@link MetadataRecordV2}
+   */
+  public MetadataScope getScope() {
+    return scope;
+  }
+
+  /**
+   * @return the properties of this {@link MetadataRecordV2}
+   */
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  /**
+   * @return the tags of this {@link MetadataRecordV2}
+   */
+  public Set<String> getTags() {
+    return tags;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MetadataRecordV2 that = (MetadataRecordV2) o;
+
+    return Objects.equals(metadataEntity, that.metadataEntity) &&
+      scope == that.scope &&
+      Objects.equals(properties, that.properties) &&
+      Objects.equals(tags, that.tags);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metadataEntity, scope, properties, tags);
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataRecordV2{" +
+      "metadataEntity=" + metadataEntity +
+      ", scope=" + scope +
+      ", properties=" + properties +
+      ", tags=" + tags +
+      '}';
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/metadata/MetadataCompatTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/metadata/MetadataCompatTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.metadata;
+
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.metadata.MetadataSearchResponse;
+import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecordV2;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+
+/**
+ * Tests for {@link MetadataCompat}
+ */
+public class MetadataCompatTest {
+
+  @Test
+  public void testMakeCompatibleMetadataRecordV2() {
+    // should be compatible since the metadata entity represents a known cdap entity
+    ImmutableMap<String, String> properties = ImmutableMap.of("k1", "v1");
+    ImmutableSet<String> tags = ImmutableSet.of("t1");
+    MetadataRecordV2 record =
+      new MetadataRecordV2(MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+                             .appendAsType(MetadataEntity.APPLICATION, "app")
+                             .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION).build(),
+                           MetadataScope.USER, properties, tags);
+    MetadataRecord expected = new MetadataRecord(new ApplicationId("ns", "app"), MetadataScope.USER, properties, tags);
+    // should be compatible since the metadata entity represents a known cdap entity
+    Optional<MetadataRecord> actual = MetadataCompat.makeCompatible(record);
+    Assert.assertTrue(actual.isPresent());
+    Assert.assertEquals(expected, actual.get());
+
+    record = new MetadataRecordV2(MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+                                    .appendAsType(MetadataEntity.APPLICATION, "app")
+                                    .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+                                    .appendAsType("something", "another").build(),
+                                  MetadataScope.USER, properties, tags);
+
+    actual = MetadataCompat.makeCompatible(record);
+    Assert.assertFalse(actual.isPresent());
+  }
+
+  @Test
+  public void testFilterForCompatibility() {
+    ImmutableMap<String, String> properties = ImmutableMap.of("k1", "v1");
+    ImmutableSet<String> tags = ImmutableSet.of("t1");
+    MetadataRecordV2 compatibleRecord =
+      new MetadataRecordV2(MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+                             .appendAsType(MetadataEntity.APPLICATION, "app")
+                             .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+                             .build(),
+                           MetadataScope.USER, properties, tags);
+    MetadataRecordV2 incompatibleRecord =
+      new MetadataRecordV2(MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+                             .appendAsType(MetadataEntity.APPLICATION, "app")
+                             .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+                             .appendAsType("something", "another").build(), MetadataScope.USER, properties, tags);
+    MetadataRecord expected = new MetadataRecord(new ApplicationId("ns", "app"), MetadataScope.USER, properties, tags);
+    Set<MetadataRecordV2> recordV2s = new HashSet<>(Arrays.asList(compatibleRecord, incompatibleRecord));
+    // should only contain the compatible record which which belongs to the application
+    Set<MetadataRecord> records = MetadataCompat.filterForCompatibility(recordV2s);
+    Assert.assertEquals(1, records.size());
+    Assert.assertEquals(expected, records.iterator().next());
+  }
+
+  @Test
+  public void testMakeCompatibleMetadataSearchResultRecordV2() {
+    Metadata systemMetadata = new Metadata(ImmutableMap.of("k1", "v1"), ImmutableSet.of("t1"));
+    Metadata userMetadata = new Metadata(ImmutableMap.of("uk1", "uv1"), ImmutableSet.of("ut1"));
+    MetadataSearchResultRecordV2 compatRecord =
+      new MetadataSearchResultRecordV2(new DatasetId("ns", "ds").toMetadataEntity(),
+                                       ImmutableMap.of(MetadataScope.SYSTEM, systemMetadata, MetadataScope.USER,
+                                                       userMetadata));
+
+    MetadataSearchResultRecordV2 incompatRecord =
+      new MetadataSearchResultRecordV2(MetadataEntity.builder(new DatasetId("ns", "ds").toMetadataEntity())
+                                         .appendAsType("field", "f1").build(),
+                                       ImmutableMap.of(MetadataScope.SYSTEM, systemMetadata, MetadataScope.USER,
+                                                       userMetadata));
+
+    MetadataSearchResponseV2 metadataSearchResponseV2 =
+      new MetadataSearchResponseV2("asc", 1, 1, 1, 1, new HashSet<>(Arrays.asList(incompatRecord, compatRecord)),
+                                   new ArrayList<>(), true, new HashSet<>());
+
+    MetadataSearchResultRecord expected =
+      new MetadataSearchResultRecord(new DatasetId("ns", "ds"), ImmutableMap.of(MetadataScope.SYSTEM, systemMetadata,
+                                                                                MetadataScope.USER,
+                                                                                userMetadata));
+
+    // should only contains the compatible record which belong to the dataset
+    MetadataSearchResponse metadataSearchResponse = MetadataCompat.makeCompatible(metadataSearchResponseV2);
+    Assert.assertEquals(1, metadataSearchResponse.getResults().size());
+    Assert.assertEquals(expected, metadataSearchResponse.getResults().iterator().next());
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/metadata/MetadataRecordV2Test.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/metadata/MetadataRecordV2Test.java
@@ -42,9 +42,9 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Tests for {@link MetadataRecord}
+ * Tests for {@link MetadataRecordV2}
  */
-public class MetadataRecordTest {
+public class MetadataRecordV2Test {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .create();
@@ -70,44 +70,44 @@ public class MetadataRecordTest {
     tags.add("tag1");
     tags.add("t1");
     // verify with ApplicationId
-    MetadataRecord appRecord = new MetadataRecord(applicationId, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 appRecord = new MetadataRecordV2(applicationId, MetadataScope.USER, properties, tags);
     String appRecordJson = GSON.toJson(appRecord);
-    Assert.assertEquals(appRecord, GSON.fromJson(appRecordJson, MetadataRecord.class));
+    Assert.assertEquals(appRecord, GSON.fromJson(appRecordJson, MetadataRecordV2.class));
     // verify with ProgramId
-    MetadataRecord programRecord = new MetadataRecord(flowId1, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 programRecord = new MetadataRecordV2(flowId1, MetadataScope.USER, properties, tags);
     String programRecordJson = GSON.toJson(programRecord);
-    Assert.assertEquals(programRecord, GSON.fromJson(programRecordJson, MetadataRecord.class));
+    Assert.assertEquals(programRecord, GSON.fromJson(programRecordJson, MetadataRecordV2.class));
     // verify with FlowId
-    MetadataRecord flowRecord = new MetadataRecord(flowId2, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 flowRecord = new MetadataRecordV2(flowId2, MetadataScope.USER, properties, tags);
     String flowRecordJson = GSON.toJson(flowRecord);
-    Assert.assertEquals(flowRecord, GSON.fromJson(flowRecordJson, MetadataRecord.class));
+    Assert.assertEquals(flowRecord, GSON.fromJson(flowRecordJson, MetadataRecordV2.class));
     // verify with FlowletId
-    MetadataRecord flowletRecord = new MetadataRecord(flowletId, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 flowletRecord = new MetadataRecordV2(flowletId, MetadataScope.USER, properties, tags);
     String flowletRecordJson = GSON.toJson(flowletRecord);
-    Assert.assertEquals(flowletRecord, GSON.fromJson(flowletRecordJson, MetadataRecord.class));
+    Assert.assertEquals(flowletRecord, GSON.fromJson(flowletRecordJson, MetadataRecordV2.class));
     // verify with Id.Service
-    MetadataRecord serviceRecord = new MetadataRecord(serviceId, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 serviceRecord = new MetadataRecordV2(serviceId, MetadataScope.USER, properties, tags);
     String serviceRecordJson = GSON.toJson(serviceRecord);
-    Assert.assertEquals(serviceRecord, GSON.fromJson(serviceRecordJson, MetadataRecord.class));
+    Assert.assertEquals(serviceRecord, GSON.fromJson(serviceRecordJson, MetadataRecordV2.class));
     // verify with Id.Schedule
-    MetadataRecord scheduleRecord = new MetadataRecord(scheduleId, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 scheduleRecord = new MetadataRecordV2(scheduleId, MetadataScope.USER, properties, tags);
     String scheduleRecordJson = GSON.toJson(scheduleRecord);
-    Assert.assertEquals(scheduleRecord, GSON.fromJson(scheduleRecordJson, MetadataRecord.class));
+    Assert.assertEquals(scheduleRecord, GSON.fromJson(scheduleRecordJson, MetadataRecordV2.class));
     // verify with Id.Worker
-    MetadataRecord workerRecord = new MetadataRecord(workerId, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 workerRecord = new MetadataRecordV2(workerId, MetadataScope.USER, properties, tags);
     String workerRecordJson = GSON.toJson(workerRecord);
-    Assert.assertEquals(workerRecord, GSON.fromJson(workerRecordJson, MetadataRecord.class));
+    Assert.assertEquals(workerRecord, GSON.fromJson(workerRecordJson, MetadataRecordV2.class));
     // verify with Id.Workflow
-    MetadataRecord workflowRecord = new MetadataRecord(workflowId, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 workflowRecord = new MetadataRecordV2(workflowId, MetadataScope.USER, properties, tags);
     String workflowRecordJson = GSON.toJson(workflowRecord);
-    Assert.assertEquals(workflowRecord, GSON.fromJson(workflowRecordJson, MetadataRecord.class));
+    Assert.assertEquals(workflowRecord, GSON.fromJson(workflowRecordJson, MetadataRecordV2.class));
     // verify with Id.DatasetInstance
-    MetadataRecord datasetRecord = new MetadataRecord(datasetId, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 datasetRecord = new MetadataRecordV2(datasetId, MetadataScope.USER, properties, tags);
     String datasetRecordJson = GSON.toJson(datasetRecord);
-    Assert.assertEquals(datasetRecord, GSON.fromJson(datasetRecordJson, MetadataRecord.class));
+    Assert.assertEquals(datasetRecord, GSON.fromJson(datasetRecordJson, MetadataRecordV2.class));
     // verify with Id.Stream
-    MetadataRecord streamRecord = new MetadataRecord(streamId, MetadataScope.USER, properties, tags);
+    MetadataRecordV2 streamRecord = new MetadataRecordV2(streamId, MetadataScope.USER, properties, tags);
     String streamRecordJson = GSON.toJson(streamRecord);
-    Assert.assertEquals(streamRecord, GSON.fromJson(streamRecordJson, MetadataRecord.class));
+    Assert.assertEquals(streamRecord, GSON.fromJson(streamRecordJson, MetadataRecordV2.class));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/audit/payload/builder/MetadataPayloadBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/audit/payload/builder/MetadataPayloadBuilder.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.audit.payload.builder;
 
 import co.cask.cdap.api.metadata.Metadata;
 import co.cask.cdap.api.metadata.MetadataScope;
-import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.proto.audit.payload.metadata.MetadataPayload;
 
 import java.util.HashMap;
@@ -38,7 +38,7 @@ public class MetadataPayloadBuilder {
    * @param record previous value of metadata record
    * @return the builder object
    */
-  public MetadataPayloadBuilder addPrevious(MetadataRecord record) {
+  public MetadataPayloadBuilder addPrevious(MetadataRecordV2 record) {
     previous.put(record.getScope(), new Metadata(record.getProperties(), record.getTags()));
     return this;
   }
@@ -49,7 +49,7 @@ public class MetadataPayloadBuilder {
    * @param record additions to the metadata
    * @return the builder object
    */
-  public MetadataPayloadBuilder addAdditions(MetadataRecord record) {
+  public MetadataPayloadBuilder addAdditions(MetadataRecordV2 record) {
     additions.put(record.getScope(), new Metadata(record.getProperties(), record.getTags()));
     return this;
   }
@@ -60,7 +60,7 @@ public class MetadataPayloadBuilder {
    * @param record deletions to metadata
    * @return the builder object
    */
-  public MetadataPayloadBuilder addDeletions(MetadataRecord record) {
+  public MetadataPayloadBuilder addDeletions(MetadataRecordV2 record) {
     deletions.put(record.getScope(), new Metadata(record.getProperties(), record.getTags()));
     return this;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataKey.java
@@ -105,19 +105,17 @@ class MetadataKey {
   private static MetadataEntity getTargetIdIdFromKey(MDSKey.Splitter keySplitter) {
     // get the type
     String targetType = keySplitter.getString();
-    MetadataEntity metadataEntity = null;
     String key = keySplitter.getString();
     String value = keySplitter.getString();
+    MetadataEntity.Builder builder = MetadataEntity.builder();
     while (keySplitter.hasRemaining()) {
       // add the last read key and value in metadata entity and read the ones ahead for next loop
       // we do this since we don't want the last part as its metadata info ([key] or [key][index])
       if (key.equalsIgnoreCase(targetType)) {
-        metadataEntity = metadataEntity == null ? new MetadataEntity(key, value) :
-          metadataEntity.appendAsType(key, value);
         // if the current key is the targetType then append it as the type for MetadataEntity
-        metadataEntity = metadataEntity.appendAsType(key, value);
+        builder = builder.appendAsType(key, value);
       } else {
-        metadataEntity = metadataEntity == null ? new MetadataEntity(key, value) : metadataEntity.append(key, value);
+        builder = builder.append(key, value);
       }
       key = keySplitter.getString();
       if (keySplitter.hasRemaining()) {
@@ -126,7 +124,7 @@ class MetadataKey {
         break;
       }
     }
-    return metadataEntity;
+    return builder.build();
   }
 
   static byte[] getValueRowPrefix() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -19,13 +19,13 @@ package co.cask.cdap.data2.metadata.store;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
-import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
-import co.cask.cdap.proto.metadata.MetadataSearchResponse;
+import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
 
 import java.io.IOException;
 import java.util.Map;
@@ -72,22 +72,22 @@ public interface MetadataStore {
   void addTags(MetadataScope scope, MetadataEntity metadataEntity, String... tagsToAdd);
 
   /**
-   * @return a set of {@link MetadataRecord} representing all the metadata (including properties and tags) for the
+   * @return a set of {@link MetadataRecordV2} representing all the metadata (including properties and tags) for the
    * specified {@link MetadataEntity} in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
    */
-  Set<MetadataRecord> getMetadata(MetadataEntity metadataEntity);
+  Set<MetadataRecordV2> getMetadata(MetadataEntity metadataEntity);
 
   /**
-   * @return a {@link MetadataRecord} representing all the metadata (including properties and tags) for the specified
+   * @return a {@link MetadataRecordV2} representing all the metadata (including properties and tags) for the specified
    * {@link MetadataEntity} in the specified {@link MetadataScope}.
    */
-  MetadataRecord getMetadata(MetadataScope scope, MetadataEntity metadataEntity);
+  MetadataRecordV2 getMetadata(MetadataScope scope, MetadataEntity metadataEntity);
 
   /**
-   * @return a set of {@link MetadataRecord}s representing all the metadata (including properties and tags)
+   * @return a set of {@link MetadataRecordV2}s representing all the metadata (including properties and tags)
    * for the specified set of {@link MetadataEntity}s in the specified {@link MetadataScope}.
    */
-  Set<MetadataRecord> getMetadata(MetadataScope scope, Set<MetadataEntity> metadataEntitys);
+  Set<MetadataRecordV2> getMetadata(MetadataScope scope, Set<MetadataEntity> metadataEntitys);
 
   /**
    * @return the properties for the specified {@link MetadataEntity} in both {@link MetadataScope#USER} and
@@ -181,13 +181,13 @@ public interface MetadataStore {
    * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
    *                    or not.
    * @param entityScope a set which specifies which scope of entities to display.
-   * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
+   * @return the {@link MetadataSearchResponseV2} containing search results for the specified search query and filters
    */
-  MetadataSearchResponse search(String namespaceId, String searchQuery,
-                                Set<EntityTypeSimpleName> types,
-                                SortInfo sortInfo, int offset, int limit,
-                                int numCursors, String cursor, boolean showHidden,
-                                Set<EntityScope> entityScope);
+  MetadataSearchResponseV2 search(String namespaceId, String searchQuery,
+                                  Set<EntityTypeSimpleName> types,
+                                  SortInfo sortInfo, int offset, int limit,
+                                  int numCursors, String cursor, boolean showHidden,
+                                  Set<EntityScope> entityScope);
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in both {@link MetadataScope#USER}
@@ -197,7 +197,7 @@ public interface MetadataStore {
    * @param timeMillis time in milliseconds
    * @return the snapshot of the metadata for entities on or before the given time
    */
-  Set<MetadataRecord> getSnapshotBeforeTime(Set<MetadataEntity> metadataEntitys, long timeMillis);
+  Set<MetadataRecordV2> getSnapshotBeforeTime(Set<MetadataEntity> metadataEntitys, long timeMillis);
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in the specified
@@ -208,8 +208,8 @@ public interface MetadataStore {
    * @param timeMillis time in milliseconds
    * @return the snapshot of the metadata for entities on or before the given time
    */
-  Set<MetadataRecord> getSnapshotBeforeTime(MetadataScope scope, Set<MetadataEntity> metadataEntitys,
-                                            long timeMillis);
+  Set<MetadataRecordV2> getSnapshotBeforeTime(MetadataScope scope, Set<MetadataEntity> metadataEntitys,
+                                              long timeMillis);
 
   /**
    * Rebuild stale metadata indexes.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -18,13 +18,13 @@ package co.cask.cdap.data2.metadata.store;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
-import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
-import co.cask.cdap.proto.metadata.MetadataSearchResponse;
-import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecordV2;
 import com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
@@ -54,18 +54,18 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public Set<MetadataRecord> getMetadata(MetadataEntity metadataEntity) {
-    return ImmutableSet.of(new MetadataRecord(metadataEntity, MetadataScope.USER),
-                           new MetadataRecord(metadataEntity, MetadataScope.SYSTEM));
+  public Set<MetadataRecordV2> getMetadata(MetadataEntity metadataEntity) {
+    return ImmutableSet.of(new MetadataRecordV2(metadataEntity, MetadataScope.USER),
+                           new MetadataRecordV2(metadataEntity, MetadataScope.SYSTEM));
   }
 
   @Override
-  public MetadataRecord getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
-    return new MetadataRecord(metadataEntity, scope);
+  public MetadataRecordV2 getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
+    return new MetadataRecordV2(metadataEntity, scope);
   }
 
   @Override
-  public Set<MetadataRecord> getMetadata(MetadataScope scope, Set<MetadataEntity> metadataEntities) {
+  public Set<MetadataRecordV2> getMetadata(MetadataScope scope, Set<MetadataEntity> metadataEntities) {
     return Collections.emptySet();
   }
 
@@ -120,29 +120,29 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public MetadataSearchResponse search(String namespaceId, String searchQuery,
-                                       Set<EntityTypeSimpleName> types,
-                                       SortInfo sort, int offset, int limit, int numCursors, String cursor,
-                                       boolean showHidden, Set<EntityScope> entityScope) {
-    return new MetadataSearchResponse(sort.toString(), offset, limit, numCursors, 0,
-                                      Collections.<MetadataSearchResultRecord>emptySet(),
-                                      Collections.<String>emptyList(), showHidden, entityScope);
+  public MetadataSearchResponseV2 search(String namespaceId, String searchQuery,
+                                         Set<EntityTypeSimpleName> types,
+                                         SortInfo sort, int offset, int limit, int numCursors, String cursor,
+                                         boolean showHidden, Set<EntityScope> entityScope) {
+    return new MetadataSearchResponseV2(sort.toString(), offset, limit, numCursors, 0,
+                                        Collections.<MetadataSearchResultRecordV2>emptySet(),
+                                        Collections.<String>emptyList(), showHidden, entityScope);
   }
 
   @Override
-  public Set<MetadataRecord> getSnapshotBeforeTime(Set<MetadataEntity> metadataEntities, long timeMillis) {
-    return ImmutableSet.<MetadataRecord>builder()
+  public Set<MetadataRecordV2> getSnapshotBeforeTime(Set<MetadataEntity> metadataEntities, long timeMillis) {
+    return ImmutableSet.<MetadataRecordV2>builder()
       .addAll(getSnapshotBeforeTime(MetadataScope.USER, metadataEntities, timeMillis))
       .addAll(getSnapshotBeforeTime(MetadataScope.SYSTEM, metadataEntities, timeMillis))
       .build();
   }
 
   @Override
-  public Set<MetadataRecord> getSnapshotBeforeTime(MetadataScope scope, Set<MetadataEntity> metadataEntities,
-                                                   long timeMillis) {
-    ImmutableSet.Builder<MetadataRecord> builder = ImmutableSet.builder();
+  public Set<MetadataRecordV2> getSnapshotBeforeTime(MetadataScope scope, Set<MetadataEntity> metadataEntities,
+                                                     long timeMillis) {
+    ImmutableSet.Builder<MetadataRecordV2> builder = ImmutableSet.builder();
     for (MetadataEntity metadataEntity : metadataEntities) {
-      builder.add(new MetadataRecord(metadataEntity, scope));
+      builder.add(new MetadataRecordV2(metadataEntity, scope));
     }
     return builder.build();
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -81,10 +81,13 @@ public class  MetadataDatasetTest {
   private final MetadataEntity stream1 = new StreamId("ns1", "s1").toMetadataEntity();
   private final MetadataEntity view1 = new StreamViewId("ns1", "s1", "v1").toMetadataEntity();
   private final MetadataEntity artifact1 = new ArtifactId("ns1", "a1", "1.0.0").toMetadataEntity();
-  private final MetadataEntity fileEntity = MetadataEntity.ofDataset("ns1", "ds1").append("file", "f1");
-  private final MetadataEntity partitionFileEntity = MetadataEntity.ofDataset("ns1", "ds1").append("partition", "p1")
-    .append("file", "f1");
-  private final MetadataEntity jarEntity = MetadataEntity.ofNamespace("ns1").append("jar", "jar1");
+  private final MetadataEntity fileEntity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns1")
+    .append(MetadataEntity.DATASET, "ds1").appendAsType("file", "f1").build();
+  private final MetadataEntity partitionFileEntity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns1")
+    .append(MetadataEntity.DATASET, "ds1").append("partition", "p1")
+    .appendAsType("file", "f1").build();
+  private final MetadataEntity jarEntity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns1")
+    .appendAsType("jar", "jar1").build();
 
   @Before
   public void before() throws Exception {
@@ -414,10 +417,10 @@ public class  MetadataDatasetTest {
 
   @Test
   public void testSearchOnTypes() throws Exception {
-    MetadataEntity myField1 = MetadataEntity.ofDataset(NamespaceId.DEFAULT.getEntityName(),
-                                                       "myDs").appendAsType("field", "myField1");
-    MetadataEntity myField2 = MetadataEntity.ofDataset(NamespaceId.DEFAULT.getEntityName(),
-                                                       "myDs").appendAsType("field", "myField2");
+    MetadataEntity myField1 = MetadataEntity.builder(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getEntityName(),
+                                                       "myDs")).appendAsType("field", "myField1").build();
+    MetadataEntity myField2 = MetadataEntity.builder(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getEntityName(),
+                                                       "myDs")).appendAsType("field", "myField2").build();
     final MetadataEntry myFieldEntry1 = new MetadataEntry(myField1, "testKey1", "testValue1");
     final MetadataEntry myFieldEntry2 = new MetadataEntry(myField2, "testKey2", "testValue2");
     txnl.execute(() -> {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataTest.java
@@ -32,8 +32,9 @@ public class MetadataTest {
     Metadata metadata1 = new Metadata(myDs);
     Assert.assertEquals(myDs, metadata1.getEntityId());
 
-    MetadataEntity metadataEntity = MetadataEntity.ofDataset(NamespaceId.DEFAULT.getEntityName(), "myDs")
-      .append("field", "myField");
+    MetadataEntity metadataEntity =
+      MetadataEntity.builder(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getEntityName(), "myDs"))
+        .appendAsType("field", "myField").build();
     Metadata metadata2 = new Metadata(metadataEntity);
     try {
       metadata2.getEntityId();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriterTest.java
@@ -22,7 +22,7 @@ import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -95,9 +95,9 @@ public class AbstractSystemMetadataWriterTest {
                                       123456L, null, null, "description1");
     datasetSystemMetadataWriter.write();
 
-    MetadataRecord expected =
-      new MetadataRecord(dsInstance, MetadataScope.SYSTEM,
-                         ImmutableMap.of(AppSystemMetadataWriter.ENTITY_NAME_KEY, dsInstance.getEntityName(),
+    MetadataRecordV2 expected =
+      new MetadataRecordV2(dsInstance, MetadataScope.SYSTEM,
+                           ImmutableMap.of(AppSystemMetadataWriter.ENTITY_NAME_KEY, dsInstance.getEntityName(),
                                          AbstractSystemMetadataWriter.DESCRIPTION_KEY, "description1",
                                          AbstractSystemMetadataWriter.CREATION_TIME_KEY, String.valueOf(123456L),
                                          AbstractSystemMetadataWriter.TTL_KEY, "100"), ImmutableSet.of());
@@ -109,8 +109,8 @@ public class AbstractSystemMetadataWriterTest {
     datasetSystemMetadataWriter.write();
 
     expected =
-      new MetadataRecord(dsInstance, MetadataScope.SYSTEM,
-                         ImmutableMap.of(AppSystemMetadataWriter.ENTITY_NAME_KEY, dsInstance.getEntityName(),
+      new MetadataRecordV2(dsInstance, MetadataScope.SYSTEM,
+                           ImmutableMap.of(AppSystemMetadataWriter.ENTITY_NAME_KEY, dsInstance.getEntityName(),
                                          AbstractSystemMetadataWriter.DESCRIPTION_KEY, "description2",
                                          AbstractSystemMetadataWriter.CREATION_TIME_KEY, String.valueOf(123456L),
                                          DatasetSystemMetadataWriter.TYPE, "dsType"), ImmutableSet.of());

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
@@ -65,9 +65,10 @@ public class ApplicationId extends NamespacedEntityId implements ParentedId<Name
 
   @Override
   public MetadataEntity toMetadataEntity() {
-    return MetadataEntity.ofNamespace(namespace)
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
       .appendAsType(MetadataEntity.APPLICATION, application)
-      .append(MetadataEntity.VERSION, version);
+      .append(MetadataEntity.VERSION, version)
+      .build();
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
@@ -92,8 +92,10 @@ public class ArtifactId extends NamespacedEntityId implements ParentedId<Namespa
 
   @Override
   public MetadataEntity toMetadataEntity() {
-    return MetadataEntity.ofNamespace(namespace).appendAsType(MetadataEntity.ARTIFACT, artifact)
-      .append(MetadataEntity.VERSION, version);
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
+      .appendAsType(MetadataEntity.ARTIFACT, artifact)
+      .append(MetadataEntity.VERSION, version)
+      .build();
   }
 
   public String getVersion() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Vector;
@@ -152,21 +153,77 @@ public abstract class EntityId {
    * metadataEntity.
    */
   public static <T extends EntityId> T fromMetadataEntity(MetadataEntity metadataEntity) {
-    EntityType entityType = EntityType.valueOf(metadataEntity.getType().toUpperCase());
-    if ((entityType == EntityType.APPLICATION || entityType == EntityType.PROGRAM) &&
-      metadataEntity.getValue(MetadataEntity.VERSION) == null) {
-      // if the EntityType is application or program and a version is not specified in the MetadataEntity then add it
-      if (entityType == EntityType.APPLICATION) {
-        metadataEntity = metadataEntity.append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION);
-      } else {
-        metadataEntity = MetadataEntity.ofNamespace(metadataEntity.getValue(MetadataEntity.NAMESPACE))
-          .append(MetadataEntity.APPLICATION, metadataEntity.getValue(MetadataEntity.APPLICATION))
-          .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
-          .append(MetadataEntity.TYPE, metadataEntity.getValue(MetadataEntity.TYPE))
-          .append(MetadataEntity.PROGRAM, metadataEntity.getValue(MetadataEntity.PROGRAM));
+    // check that the type of teh metadata entity is known type
+    EntityType.valueOf(metadataEntity.getType().toUpperCase());
+    return getSelfOrParentEntityId(metadataEntity);
+  }
+
+  /**
+   * Creates a valid known CDAP entity which can be considered as the parent for the MetadataEntity by walking up the
+   * key-value hierarchy of the MetadataEntity till a known CDAP {@link EntityType} is found. If the last node itself
+   * is known type then that will be considered as the parent.
+   *
+   * @param metadataEntity whose parent entityId needs to be found
+   * @return {@link EntityId} of the given metadataEntity
+   * @throws IllegalArgumentException if the metadataEntity does not have any know entity type in it's hierarchy or if
+   * it does not have all the required key-value pairs to construct the identified EntityId.
+   */
+  public static <T extends EntityId> T getSelfOrParentEntityId(MetadataEntity metadataEntity) {
+    EntityType entityType = findParentType(metadataEntity);
+    if (entityType == null) {
+      throw new IllegalArgumentException(String.format("No known type found in the hierarchy of %s", metadataEntity));
+    }
+    List<String> values = new LinkedList<>();
+    // get the key-value pair till the known entity-type. Note: for application the version comes after application
+    // key-value pair and needs to be included too
+    List<MetadataEntity.KeyValue> extractedParts = metadataEntity.head(entityType.toString());
+    // if a version was specified extract that else use the default version
+    String version = metadataEntity.containsKey(MetadataEntity.VERSION) ?
+      metadataEntity.getValue(MetadataEntity.VERSION) : ApplicationId.DEFAULT_VERSION;
+    if (entityType == EntityType.APPLICATION) {
+      // if the entity is an application our extractParts will not contain the version info since we extracted till
+      // application so append it
+      extractedParts.add(new MetadataEntity.KeyValue(MetadataEntity.VERSION, version));
+    }
+    if (entityType == EntityType.PROGRAM) {
+      // if the entity is program the add the version information at its correct position i.e. 2
+      // (namespace, application, version) if the version information is not present
+      if (!metadataEntity.containsKey(MetadataEntity.VERSION)) {
+        extractedParts.add(2, new MetadataEntity.KeyValue(MetadataEntity.VERSION, version));
       }
     }
-    return entityType.fromIdParts(metadataEntity.getValues());
+    // for artifacts get till version (artifacts always have version
+    if (entityType == EntityType.ARTIFACT) {
+      extractedParts = metadataEntity.head(MetadataEntity.VERSION);
+    }
+    extractedParts.iterator().forEachRemaining(keyValue -> values.add(keyValue.getValue()));
+    return entityType.fromIdParts(values);
+  }
+
+  /**
+   * Finds a valid known CDAP entity which can be considered as the parent for the MetadataEntity by walking up the
+   * key-value hierarchy of the MetadataEntity
+   *
+   * @param metadataEntity whose EntityType needs to be determined
+   * @return {@link EntityType} of the given metadataEntity
+   */
+  @Nullable
+  private static EntityType findParentType(MetadataEntity metadataEntity) {
+    List<String> keys = new ArrayList<>();
+    metadataEntity.getKeys().forEach(keys::add);
+    int curIndex = keys.size() - 1;
+    EntityType entityType = null;
+    while (curIndex >= 0) {
+      try {
+        entityType = EntityType.valueOf(keys.get(curIndex).toUpperCase());
+        // found a valid entity type;
+        break;
+      } catch (IllegalArgumentException e) {
+        // the current key is not a valid cdap entity type so try up in hierarchy
+        curIndex--;
+      }
+    }
+    return entityType;
   }
 
   public final EntityType getEntityType() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
@@ -81,9 +81,10 @@ public class FlowletId extends NamespacedEntityId implements ParentedId<ProgramI
 
   @Override
   public MetadataEntity toMetadataEntity() {
-    return MetadataEntity.ofNamespace(namespace)
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
       .append(MetadataEntity.APPLICATION, application).append(MetadataEntity.VERSION, version)
-      .append(MetadataEntity.FLOW, flow).appendAsType(MetadataEntity.FLOWLET, flowlet);
+      .append(MetadataEntity.FLOW, flow).appendAsType(MetadataEntity.FLOWLET, flowlet)
+      .build();
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
@@ -80,9 +80,11 @@ public class ProgramId extends NamespacedEntityId implements ParentedId<Applicat
 
   @Override
   public MetadataEntity toMetadataEntity() {
-    return MetadataEntity.ofNamespace(namespace).append(MetadataEntity.APPLICATION, application)
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
+      .append(MetadataEntity.APPLICATION, application)
       .append(MetadataEntity.VERSION, version).append(MetadataEntity.TYPE, type.getPrettyName())
-      .appendAsType(MetadataEntity.PROGRAM, program);
+      .appendAsType(MetadataEntity.PROGRAM, program)
+      .build();
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
@@ -118,10 +118,12 @@ public class ProgramRunId extends NamespacedEntityId implements ParentedId<Progr
 
   @Override
   public MetadataEntity toMetadataEntity() {
-    return MetadataEntity.ofNamespace(namespace).append(MetadataEntity.APPLICATION, application)
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
+      .append(MetadataEntity.APPLICATION, application)
       .append(MetadataEntity.VERSION, version).append(MetadataEntity.TYPE, type.getPrettyName())
       .append(MetadataEntity.PROGRAM, program)
-      .appendAsType(MetadataEntity.PROGRAM_RUN, run);
+      .appendAsType(MetadataEntity.PROGRAM_RUN, run)
+      .build();
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
@@ -62,9 +62,10 @@ public class ScheduleId extends NamespacedEntityId implements ParentedId<Applica
 
   @Override
   public MetadataEntity toMetadataEntity() {
-    return MetadataEntity.ofNamespace(namespace)
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
       .append(MetadataEntity.APPLICATION, application).append(MetadataEntity.VERSION, version)
-      .appendAsType(MetadataEntity.SCHEDULE, schedule);
+      .appendAsType(MetadataEntity.SCHEDULE, schedule)
+      .build();
   }
 
   public String getApplication() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
@@ -52,7 +52,9 @@ public class StreamId extends NamespacedEntityId implements ParentedId<Namespace
 
   @Override
   public MetadataEntity toMetadataEntity() {
-    return MetadataEntity.ofNamespace(namespace).appendAsType(MetadataEntity.STREAM, stream);
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
+      .appendAsType(MetadataEntity.STREAM, stream)
+      .build();
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
@@ -60,8 +60,9 @@ public class StreamViewId extends NamespacedEntityId implements ParentedId<Strea
 
   @Override
   public MetadataEntity toMetadataEntity() {
-    return MetadataEntity.ofNamespace(namespace).append(MetadataEntity.STREAM, stream)
-      .appendAsType(MetadataEntity.VIEW, view);
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace).append(MetadataEntity.STREAM, stream)
+      .appendAsType(MetadataEntity.VIEW, view)
+      .build();
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponseV2.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponseV2.java
@@ -23,24 +23,21 @@ import java.util.Set;
 
 /**
  * Denotes the response of the metadata search API.
- *
- * @deprecated As of release 5.0, replaced by {@link MetadataSearchResponseV2}
  */
-@Deprecated
-public class MetadataSearchResponse {
+public class MetadataSearchResponseV2 {
   private final String sort;
   private final int offset;
   private final int limit;
   private final int numCursors;
   private final int total;
-  private final Set<MetadataSearchResultRecord> results;
+  private final Set<MetadataSearchResultRecordV2> results;
   private final List<String> cursors;
   private final boolean showHidden;
   private final Set<EntityScope> entityScope;
 
-  public MetadataSearchResponse(String sort, int offset, int limit, int numCursors, int total,
-                                Set<MetadataSearchResultRecord> results, List<String> cursors, boolean showHidden,
-                                Set<EntityScope> entityScope) {
+  public MetadataSearchResponseV2(String sort, int offset, int limit, int numCursors, int total,
+                                  Set<MetadataSearchResultRecordV2> results, List<String> cursors, boolean showHidden,
+                                  Set<EntityScope> entityScope) {
     this.sort = sort;
     this.offset = offset;
     this.limit = limit;
@@ -72,7 +69,7 @@ public class MetadataSearchResponse {
     return total;
   }
 
-  public Set<MetadataSearchResultRecord> getResults() {
+  public Set<MetadataSearchResultRecordV2> getResults() {
     return results;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResultRecordV2.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResultRecordV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,35 +17,47 @@ package co.cask.cdap.proto.metadata;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 /**
  * Represent the Metadata search result record.
- * @deprecated As of release 5.0, replaced by {@link MetadataSearchResultRecordV2}
  */
 @Beta
-@Deprecated
-public class MetadataSearchResultRecord {
-  private final NamespacedEntityId entityId;
+public class MetadataSearchResultRecordV2 {
+  private final MetadataEntity metadataEntity;
   private final Map<MetadataScope, Metadata> metadata;
 
-  public MetadataSearchResultRecord(NamespacedEntityId entityId) {
-    this.entityId = entityId;
-    this.metadata = Collections.emptyMap();
+  public MetadataSearchResultRecordV2(NamespacedEntityId entityId) {
+    this(entityId.toMetadataEntity());
   }
 
-  public MetadataSearchResultRecord(NamespacedEntityId entityId, Map<MetadataScope, Metadata> metadata) {
-    this.entityId = entityId;
-    this.metadata = metadata;
+  public MetadataSearchResultRecordV2(MetadataEntity metadataEntity) {
+    this(metadataEntity, Collections.emptyMap());
+  }
+
+  public MetadataSearchResultRecordV2(NamespacedEntityId entityId, Map<MetadataScope, Metadata> metadata) {
+    this(entityId.toMetadataEntity(), metadata);
+  }
+
+  public MetadataSearchResultRecordV2(MetadataEntity metadataEntity, Map<MetadataScope, Metadata> metadata) {
+    this.metadataEntity = metadataEntity;
+    this.metadata = new HashMap<>(metadata);
   }
 
   public NamespacedEntityId getEntityId() {
-    return entityId;
+    return EntityId.fromMetadataEntity(metadataEntity);
+  }
+
+  public MetadataEntity getMetadataEntity() {
+    return metadataEntity;
   }
 
   public Map<MetadataScope, Metadata> getMetadata() {
@@ -57,23 +69,23 @@ public class MetadataSearchResultRecord {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof MetadataSearchResultRecord)) {
+    if (!(o instanceof MetadataSearchResultRecordV2)) {
       return false;
     }
-    MetadataSearchResultRecord that = (MetadataSearchResultRecord) o;
-    return Objects.equals(entityId, that.entityId) &&
+    MetadataSearchResultRecordV2 that = (MetadataSearchResultRecordV2) o;
+    return Objects.equals(metadataEntity, that.metadataEntity) &&
       Objects.equals(metadata, that.metadata);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entityId, metadata);
+    return Objects.hash(metadataEntity, metadata);
   }
 
   @Override
   public String toString() {
-    return "MetadataSearchResultRecord{" +
-      "entityId=" + entityId +
+    return "MetadataSearchResultRecordV2{" +
+      "metadataEntity=" + metadataEntity +
       ", metadata=" + metadata +
       '}';
   }


### PR DESCRIPTION
## Background
- In CDAP 5.0 we introduced the concept of MetadataEntity which supports adding metadata for custom entity.
- The above caused changes in the Metadata API to support such capability and now Metadata APIs return MetadataEntity rather than EntityId

The changes for this is in this PR: https://github.com/caskdata/cdap/pull/10039

## Summary of Changes
- Metadata API before when required for backward compatibility convert MetadataEntity to EntityId.
- The follow APIs needed changed for backward compatibility
    1. search()
    2. getMetadata()
- In backward compatible mode the custom MetadataEntities are dropped from the result.
- By default the APIs serve backward compatible result so that CDAP UI can function without any changes.
- It is possible for users to override the backward compatibility mode and retrieve custom MetadataEntities too by setting query param `showCustom` to true. If a user choses to do so we expect that the user or the client understand such custom entities and can process it.
- Marked the above API which are currently operating in backward compatible mode `deprecated` so that they can be removed in the next release. 

## Misc
- The PR's line of change is large but that is mostly because of class renames. The actual change is well contained to just support backward compatibility.

## Related Tasks
- [x] Merge blocked by https://github.com/caskdata/cdap/pull/10039
- [x] Build - https://builds.cask.co/browse/CDAP-DUT6482-6 (Pending)
- [x] ITN - Will run after initial review
- [x] ~~Two unit tests are ignored in this PR currently working on fixing them.~~ Fixed