### PR TITLE
CDAP-13567: Fix cdap-spark-scala and cdap-mapreduce archetype

### DIFF
--- a/cdap-archetypes/cdap-mapreduce-archetype/src/main/resources/archetype-resources/src/main/java/MapReduceApp.java
+++ b/cdap-archetypes/cdap-mapreduce-archetype/src/main/resources/archetype-resources/src/main/java/MapReduceApp.java
@@ -51,7 +51,7 @@ public class MapReduceApp extends AbstractApplication {
     }
 
     @Override
-    public void destroy() throws Exception {
+    public void destroy() {
       // TODO: whatever is necessary after job finishes
     }
   }

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/src/main/scala/SparkKMeansProgram.scala
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/src/main/scala/SparkKMeansProgram.scala
@@ -22,6 +22,13 @@
 
 package $package
 
+import breeze.linalg.{DenseVector, Vector, squaredDistance}
+import co.cask.cdap.api.common.Bytes
+import co.cask.cdap.api.spark.{SparkExecutionContext, SparkMain}
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.slf4j.{Logger, LoggerFactory}
+
 /**
  * Implementation of KMeans Clustering Spark Program.
  */


### PR DESCRIPTION
## Background
- CDAP Archetype had compile issue in 4.3.4 release (and possibly in some release before that too).
- The issue was reported here: https://groups.google.com/forum/#!topic/cdap-user/Ja_Foc9mjaw

## Summary of Changes
- The following changes fixes the compilation issues in our archetypes
- Have tested all of other two archetypes too and they compile.

## Misc
- Issue: Issue: https://issues.cask.co/browse/CDAP-13567
- Future Work: Opened an issue to add automated testing capability in our builds to test all archetypes: https://issues.cask.co/browse/CDAP-13568

## Tasks
- [x] Build: Not needed as these changes will not affect the build at all. 
- [x] Manual testing: Installed and tested mapreduce and spark-scala archetype locally.
