### PR TITLE
CDAP-13573 configure sandbox with secure storage

### DIFF
--- a/cdap-standalone/src/main/resources/cdap-security.xml
+++ b/cdap-standalone/src/main/resources/cdap-security.xml
@@ -1,0 +1,34 @@
+<!--
+  Copyright © 2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+<!--
+  This file is reserved for sensitive configuration settings. In production systems, the file
+  permissions should be set such that only the user that runs CDAP has permission to read or edit
+  the file.
+   -->
+<configuration>
+
+  <property>
+    <name>security.store.file.password</name>
+    <value>your-password</value>
+    <description>
+      This password is used when generating keys to encrypt and decrypt data that is written to
+      the secure store. If the password is changed, all existing data in the secure store
+      will become invalid and should be deleted. This is only used for the 'file' secure store
+      provider. In distributed environments, the 'kms' secure store provider should be used instead.
+    </description>
+  </property>
+
+</configuration>

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2014-2017 Cask Data, Inc.
+  Copyright © 2014-2018 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -250,6 +250,21 @@
     <value>false</value>
     <description>
       Determines if Kerberos authentication is enabled
+    </description>
+  </property>
+
+  <!-- Secure Storage Configuration -->
+  <property>
+    <name>security.store.provider</name>
+    <value>file</value>
+    <description>
+      The secure store provider that defines the actual storage system backing the CDAP secure
+      store APIs. Secure store APIs are used by custom programs that need to write or look up
+      sensitive information, such as password. It is also used to look up values whenever the
+      ${secure(my-key)} macro is used in pipelines or compute profiles.
+      The 'file' provider is only used in the sandbox. In distributed environments, this should
+      be set to 'kms', presuming your cluster has been configured to use KMS. The 'file' provider
+      will not work in distributed environments.
     </description>
   </property>
 


### PR DESCRIPTION
Include configuration in the sandbox such that the secure store
APIs will be available by default. Though secure storage is not
really a concern in local development environments, users may
still want to try out secure macros in the sandbox.