### PR TITLE
CDAP-13391 log provisioner messages in program context

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -95,10 +95,11 @@ public interface Store {
    * Persists program run cluster status to {@link ProgramRunClusterStatus#DEPROVISIONED}.
    *
    * @param id run id of the program
+   * @param endTs timestamp for when the cluster was deprovisioned
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */
-  void setDeprovisioned(ProgramRunId id, byte[] sourceId);
+  void setDeprovisioned(ProgramRunId id, long endTs, byte[] sourceId);
 
   /**
    * Logs initialization of program run and persists program status to {@link ProgramRunStatus#STARTING}.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/preview/PreviewHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/preview/PreviewHttpHandler.java
@@ -178,8 +178,7 @@ public class PreviewHttpHandler extends AbstractLogHandler {
     ProgramRunId runId = getProgramRunId(namespaceId, previewId);
     RunRecordMeta runRecord = getRunRecord(namespaceId, previewId);
     LoggingContext loggingContext =
-      LoggingContextHelper.getLoggingContextWithRunId(namespaceId, previewId, runId.getProgram(), runId.getType(),
-                                                      runId.getRun(), runRecord.getSystemArgs());
+      LoggingContextHelper.getLoggingContextWithRunId(runId, runRecord.getSystemArgs());
 
     doGetLogs(responder, loggingContext, fromTimeSecsParam, toTimeSecsParam, escape, filterStr, runRecord, format,
               suppress);
@@ -199,8 +198,7 @@ public class PreviewHttpHandler extends AbstractLogHandler {
     ProgramRunId runId = getProgramRunId(namespaceId, previewId);
     RunRecordMeta runRecord = getRunRecord(namespaceId, previewId);
     LoggingContext loggingContext =
-      LoggingContextHelper.getLoggingContextWithRunId(namespaceId, previewId, runId.getProgram(), runId.getType(),
-                                                      runId.getRun(), runRecord.getSystemArgs());
+      LoggingContextHelper.getLoggingContextWithRunId(runId, runRecord.getSystemArgs());
     doPrev(responder, loggingContext, maxEvents, fromOffsetStr, escape, filterStr, runRecord, format, suppress);
   }
 
@@ -218,8 +216,7 @@ public class PreviewHttpHandler extends AbstractLogHandler {
     ProgramRunId runId = getProgramRunId(namespaceId, previewId);
     RunRecordMeta runRecord = getRunRecord(namespaceId, previewId);
     LoggingContext loggingContext =
-      LoggingContextHelper.getLoggingContextWithRunId(namespaceId, previewId, runId.getProgram(), runId.getType(),
-                                                      runId.getRun(), runRecord.getSystemArgs());
+      LoggingContextHelper.getLoggingContextWithRunId(runId, runRecord.getSystemArgs());
     doNext(responder, loggingContext, maxEvents, fromOffsetStr, escape, filterStr, runRecord, format, suppress);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -239,7 +239,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
   @Override
   public RunRecordMeta getRunRecord() {
-    return programStore.getRun(programId, runId.getRun());
+    return programStore.getRun(runId);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -45,6 +45,8 @@ public final class ProgramOptionConstants {
 
   public static final String CLUSTER_KEY_INFO = "clusterKeyInfo";
 
+  public static final String CLUSTER_END_TIME = "clusterEndTime";
+
   public static final String DEBUG_ENABLED = "debugEnabled";
 
   public static final String PROGRAM_STATUS = "programStatus";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -318,7 +318,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
           Boolean.parseBoolean(recordedRunRecord.getSystemArgs().get(ProgramOptionConstants.SKIP_PROVISIONING));
         if (isInWorkflow || skipProvisioning) {
           appMetadataStore.recordProgramDeprovisioning(programRunId, messageIdBytes);
-          appMetadataStore.recordProgramDeprovisioned(programRunId, messageIdBytes);
+          appMetadataStore.recordProgramDeprovisioned(programRunId, null, messageIdBytes);
         } else {
           // TODO: CDAP-13295 remove once runtime monitor emits this message
           provisionerNotifier.deprovisioning(programRunId);
@@ -335,6 +335,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
     ProgramOptions programOptions = createProgramOptions(programRunId.getParent(), properties);
     String userId = properties.get(ProgramOptionConstants.USER_ID);
 
+    long endTs = getTimeSeconds(properties, ProgramOptionConstants.CLUSTER_END_TIME);
     ProgramDescriptor programDescriptor =
       GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_DESCRIPTOR), ProgramDescriptor.class);
     switch (clusterStatus) {
@@ -382,10 +383,10 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         appMetadataStore.recordProgramDeprovisioning(programRunId, messageIdBytes);
         return Optional.of(provisioningService.deprovision(programRunId, datasetContext));
       case DEPROVISIONED:
-        appMetadataStore.recordProgramDeprovisioned(programRunId, messageIdBytes);
+        appMetadataStore.recordProgramDeprovisioned(programRunId, endTs, messageIdBytes);
         break;
       case ORPHANED:
-        appMetadataStore.recordProgramOrphaned(programRunId, messageIdBytes);
+        appMetadataStore.recordProgramOrphaned(programRunId, endTs, messageIdBytes);
         break;
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -477,8 +477,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
     // if the previous state was provisioning, that means we've transitioned here from a failure
     ProgramRunStatus newStatus = clusterStatus == ProgramRunClusterStatus.PROVISIONING ?
       ProgramRunStatus.FAILED : existing.getStatus();
-    ProgramRunCluster cluster = new ProgramRunCluster(ProgramRunClusterStatus.DEPROVISIONING,
-                                                      null, existing.getCluster().getNumNodes());
+    ProgramRunCluster cluster = new ProgramRunCluster(ProgramRunClusterStatus.DEPROVISIONING, null,
+                                                      existing.getCluster().getNumNodes());
     RunRecordMeta meta = RunRecordMeta.builder(existing)
       .setCluster(cluster)
       .setSourceId(sourceId)
@@ -498,10 +498,12 @@ public class AppMetadataStore extends MetadataStoreDataset {
    *                 run status notification in TMS. The source id must increase as the recording time of the program
    *                 run status increases, so that the attempt to persist program run status older than the existing
    *                 program run status will be ignored
+   * @param endTs timestamp in seconds for when the cluster was deprovisioned. This is null if the program is run
+   *              as part of a workflow
    * @return {@link RunRecordMeta} that was persisted, or {@code null} if the update was ignored.
    */
   @Nullable
-  public RunRecordMeta recordProgramDeprovisioned(ProgramRunId programRunId, byte[] sourceId) {
+  public RunRecordMeta recordProgramDeprovisioned(ProgramRunId programRunId, @Nullable Long endTs, byte[] sourceId) {
     MDSKey.Builder key = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent());
 
     RunRecordMeta existing = getRun(programRunId);
@@ -521,8 +523,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
     // if the previous state was provisioning, that means we've transitioned here from a failure
     ProgramRunStatus newStatus = clusterStatus == ProgramRunClusterStatus.PROVISIONING ?
       ProgramRunStatus.FAILED : existing.getStatus();
-    ProgramRunCluster cluster = new ProgramRunCluster(ProgramRunClusterStatus.DEPROVISIONED,
-                                                      null, existing.getCluster().getNumNodes());
+    ProgramRunCluster cluster = new ProgramRunCluster(ProgramRunClusterStatus.DEPROVISIONED, endTs,
+                                                      existing.getCluster().getNumNodes());
     RunRecordMeta meta = RunRecordMeta.builder(existing)
       .setCluster(cluster)
       .setSourceId(sourceId)
@@ -542,10 +544,11 @@ public class AppMetadataStore extends MetadataStoreDataset {
    *                 run status notification in TMS. The source id must increase as the recording time of the program
    *                 run status increases, so that the attempt to persist program run status older than the existing
    *                 program run status will be ignored
+   * @param endTs timestamp in seconds for when the cluster was orphaned
    * @return {@link RunRecordMeta} that was persisted, or {@code null} if the update was ignored.
    */
   @Nullable
-  public RunRecordMeta recordProgramOrphaned(ProgramRunId programRunId, byte[] sourceId) {
+  public RunRecordMeta recordProgramOrphaned(ProgramRunId programRunId, long endTs, byte[] sourceId) {
     MDSKey.Builder key = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent());
 
     RunRecordMeta existing = getRun(programRunId);
@@ -566,8 +569,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
     // if the previous state was provisioning, that means we've transitioned here from a failure
     ProgramRunStatus newStatus = clusterStatus == ProgramRunClusterStatus.PROVISIONING ?
       ProgramRunStatus.FAILED : existing.getStatus();
-    ProgramRunCluster cluster = new ProgramRunCluster(ProgramRunClusterStatus.ORPHANED,
-                                                      existing.getCluster().getExpiresAt(),
+    ProgramRunCluster cluster = new ProgramRunCluster(ProgramRunClusterStatus.ORPHANED, endTs,
                                                       existing.getCluster().getNumNodes());
     RunRecordMeta meta = RunRecordMeta.builder(existing)
       .setCluster(cluster)

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -194,9 +194,9 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void setDeprovisioned(ProgramRunId id, byte[] sourceId) {
+  public void setDeprovisioned(ProgramRunId id, long endTs, byte[] sourceId) {
     Transactionals.execute(transactional, context -> {
-      getAppMetadataStore(context).recordProgramDeprovisioned(id, sourceId);
+      getAppMetadataStore(context).recordProgramDeprovisioned(id, endTs, sourceId);
     });
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerNotifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerNotifier.java
@@ -43,6 +43,7 @@ import com.google.gson.GsonBuilder;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
@@ -102,15 +103,25 @@ public class ProvisionerNotifier {
   }
 
   public void deprovisioned(ProgramRunId programRunId) {
+    deprovisioned(programRunId, System.currentTimeMillis());
+  }
+
+  public void deprovisioned(ProgramRunId programRunId, long endTimestamp) {
     publish(ImmutableMap.of(
       ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId),
-      ProgramOptionConstants.CLUSTER_STATUS, ProgramRunClusterStatus.DEPROVISIONED.name()));
+      ProgramOptionConstants.CLUSTER_STATUS, ProgramRunClusterStatus.DEPROVISIONED.name(),
+      ProgramOptionConstants.CLUSTER_END_TIME, String.valueOf(endTimestamp)));
   }
 
   public void orphaned(ProgramRunId programRunId) {
+    orphaned(programRunId, System.currentTimeMillis());
+  }
+
+  public void orphaned(ProgramRunId programRunId, long endTimestamp) {
     publish(ImmutableMap.of(
       ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId),
-      ProgramOptionConstants.CLUSTER_STATUS, ProgramRunClusterStatus.ORPHANED.name()));
+      ProgramOptionConstants.CLUSTER_STATUS, ProgramRunClusterStatus.ORPHANED.name(),
+      ProgramOptionConstants.CLUSTER_END_TIME, String.valueOf(endTimestamp)));
   }
 
   private void publish(Map<String, String> properties) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/DeprovisionTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/DeprovisionTask.java
@@ -100,8 +100,8 @@ public class DeprovisionTask extends ProvisioningTask {
         case CREATING:
         case FAILED:
         case ORPHANED:
-          LOG.warn("Error deprovisioning cluster for program run {}. Cluster will be moved to orphaned state.",
-                   programRunId);
+          LOG.warn("Got unexpected cluster state {} while trying to delete the cluster. "
+                     + "The cluster will be marked as orphaned.", cluster.getStatus());
           provisionerNotifier.orphaned(programRunId);
           return Optional.of(ProvisioningOp.Status.ORPHANED);
       }
@@ -120,14 +120,11 @@ public class DeprovisionTask extends ProvisioningTask {
 
   @Override
   protected void handleSubtaskFailure(ProvisioningTaskInfo taskInfo, Exception e) {
-    LOG.warn("Error deprovisioning cluster for program run {} during {} step. Cluster will be moved to orphaned state.",
-             programRunId, taskInfo.getProvisioningOp().getStatus(), e);
     provisionerNotifier.orphaned(programRunId);
   }
 
   @Override
   protected void handleStateSaveFailure(ProvisioningTaskInfo taskInfo, TransactionFailureException e) {
-    LOG.warn("Error saving deprovision task state for program run {}", programRunId, e);
     provisionerNotifier.orphaned(programRunId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisionTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisionTask.java
@@ -96,15 +96,11 @@ public class ProvisionTask extends ProvisioningTask {
 
   @Override
   protected void handleSubtaskFailure(ProvisioningTaskInfo taskInfo, Exception e) {
-    LOG.warn("Error executing {} subtask while provisioning cluster for program run {}",
-             taskInfo.getProvisioningOp().getStatus(), programRunId, e);
     provisionerNotifier.deprovisioning(programRunId);
   }
 
   @Override
   protected void handleStateSaveFailure(ProvisioningTaskInfo taskInfo, TransactionFailureException e) {
-    LOG.warn("Error saving provision task state for program run {}", programRunId, e);
-
     if (taskInfo.getProvisioningOp().getStatus() == ProvisioningOp.Status.REQUESTING_CREATE) {
       // if we failed to write that we're requesting a cluster create, it means no cluster was created yet,
       // so we can transition directly to deprovisioned
@@ -120,8 +116,8 @@ public class ProvisionTask extends ProvisioningTask {
       if (cluster == null) {
         // this is in violation of the provisioner contract, but in case somebody writes a provisioner that
         // returns a null cluster.
-        LOG.error("Provisioner returned an invalid null cluster for program run {}. " +
-                    "Sending notification to de-provision it.", programRunId);
+        LOG.warn("Provisioner {} returned an invalid null cluster. " +
+                    "Sending notification to de-provision it.", provisioner.getSpec().getName());
         provisionerNotifier.deprovisioning(programRunId);
         // RequestingCreate --> Failed
         return Optional.of(ProvisioningOp.Status.FAILED);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -218,7 +218,7 @@ public class AppMetadataStoreTest {
       metadataStoreDataset.recordProgramProvisioning(programRunId2, Collections.emptyMap(), Collections.emptyMap(),
                                                      AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()),
                                                      ARTIFACT_ID);
-      metadataStoreDataset.recordProgramDeprovisioned(programRunId2,
+      metadataStoreDataset.recordProgramDeprovisioned(programRunId2, System.currentTimeMillis(),
                                                       AppFabricTestHelper.createSourceId(sourceId.incrementAndGet()));
 
       RunRecordMeta runRecordMeta = metadataStoreDataset.getRun(programRunId2);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunCluster.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunCluster.java
@@ -12,6 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
 package co.cask.cdap.proto;
@@ -24,14 +25,12 @@ import javax.annotation.Nullable;
  */
 public class ProgramRunCluster {
   private final ProgramRunClusterStatus status;
-  private final Long expiresAt;
+  private final Long end;
   private final Integer numNodes;
 
-  public ProgramRunCluster(ProgramRunClusterStatus status,
-                           @Nullable Long expiresAt,
-                           @Nullable Integer numNodes) {
+  public ProgramRunCluster(ProgramRunClusterStatus status, @Nullable Long endTs, @Nullable Integer numNodes) {
     this.status = status;
-    this.expiresAt = expiresAt;
+    this.end = endTs;
     this.numNodes = numNodes;
   }
 
@@ -40,11 +39,11 @@ public class ProgramRunCluster {
   }
 
   /**
-   * @return timestamp that the cluster expires at. Only applicable if the cluster is in the waiting state.
+   * @return timestamp in seconds when the cluster was deprovisioned or orphaned, or null if it is not in an end state
    */
   @Nullable
-  public Long getExpiresAt() {
-    return expiresAt;
+  public Long getEnd() {
+    return end;
   }
 
   /**
@@ -68,20 +67,20 @@ public class ProgramRunCluster {
     ProgramRunCluster that = (ProgramRunCluster) o;
 
     return Objects.equals(status, that.status) &&
-      Objects.equals(expiresAt, that.expiresAt) &&
+      Objects.equals(end, that.end) &&
       Objects.equals(numNodes, that.numNodes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, expiresAt, numNodes);
+    return Objects.hash(status, end, numNodes);
   }
 
   @Override
   public String toString() {
     return "ProgramRunCluster{" +
       "status=" + status +
-      ", expiresAt=" + expiresAt +
+      ", end=" + end +
       ", numNodes=" + numNodes +
       '}';
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunClusterStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunClusterStatus.java
@@ -12,6 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
 package co.cask.cdap.proto;
@@ -26,6 +27,13 @@ public enum ProgramRunClusterStatus {
   DEPROVISIONING,
   DEPROVISIONED,
   ORPHANED;
+
+  /**
+   * @return whether this state is an end state
+   */
+  public boolean isEndState() {
+    return this == DEPROVISIONED || this == ORPHANED;
+  }
 
   /**
    * Return whether this state can transition to the specified state.

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
@@ -30,6 +30,7 @@ import co.cask.cdap.logging.filter.MdcExpression;
 import co.cask.cdap.logging.filter.OrFilter;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -182,10 +183,10 @@ public final class LoggingContextHelper {
     return getLoggingContext(namespaceId, applicationId, entityId, programType, null, null);
   }
 
-  public static LoggingContext getLoggingContextWithRunId(String namespaceId, String applicationId, String entityId,
-                                                          ProgramType programType, String runId,
-                                                          Map<String, String> systemArgs) {
-    return getLoggingContext(namespaceId, applicationId, entityId, programType, runId, systemArgs);
+
+  public static LoggingContext getLoggingContextWithRunId(ProgramRunId programRun, Map<String, String> systemArgs) {
+    return getLoggingContext(programRun.getNamespace(), programRun.getApplication(), programRun.getProgram(),
+                             programRun.getType(), programRun.getRun(), systemArgs);
   }
 
   public static LoggingContext getLoggingContext(String namespaceId, String applicationId, String entityId,

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/AbstractLogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/AbstractLogHandler.java
@@ -223,9 +223,9 @@ public class AbstractLogHandler extends AbstractHttpHandler {
       fromTimeMillis = runStartMillis;
     }
 
-    if (runRecord.getStopTs() != null) {
+    if (runRecord.getCluster().getEnd() != null) {
       // Add a buffer to stop time due to CDAP-3100
-      long runStopMillis = TimeUnit.SECONDS.toMillis(runRecord.getStopTs() + 1);
+      long runStopMillis = TimeUnit.SECONDS.toMillis(runRecord.getCluster().getEnd() + 1);
       if (toTimeMillis > runStopMillis) {
         toTimeMillis = runStopMillis;
       }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/store/ProgramStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/store/ProgramStore.java
@@ -30,6 +30,7 @@ import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.tephra.RetryStrategies;
@@ -60,16 +61,15 @@ public class ProgramStore {
   /**
    * Returns run record for a given run.
    *
-   * @param id program id
-   * @param runId run id
+   * @param programRunId program run id
    * @return run record for runid
    */
-  public RunRecordMeta getRun(final ProgramId id, final String runId) {
+  public RunRecordMeta getRun(ProgramRunId programRunId) {
     return Transactionals.execute(transactional, context -> {
       Table table = DatasetsUtil.getOrCreateDataset(context, datasetFramework, APP_META_INSTANCE_ID,
                                                     Table.class.getName(), DatasetProperties.EMPTY);
       AppMetadataStore metaStore = new AppMetadataStore(table);
-      return metaStore.getRun(id, runId);
+      return metaStore.getRun(programRunId.getParent(), programRunId.getRun());
 
     });
   }


### PR DESCRIPTION
Modify the provisioner tasks to use a program logging context
instead of a system logging context in order to tie the logs to
the program run and not the system logs. Even though the provisioner
runs in the CDAP master, it's logs belong with the program run,
otherwise a provisioning error will cause a program run to fail
without any feedback given to the user.

Also adding a cluster end time to each run record. This is needed
because the log handler restricts the log query end time using
the end time in the run record if it exists. However, the end time
in the run record is the program run end, whereas the cluster end
time is usually minutes later. Adjusted the log handler to restrict
using the cluster end time, so that the deprovisioning logs will
be included in the program logs.