### PR TITLE
CDAP-13586 set secure store provider for clusters

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -409,6 +409,9 @@ public abstract class DistributedProgramRunner implements ProgramRunner {
 
       // TODO (CDAP-13410): Ideally we don't need ZK in isolated runtime cluster
       result.set(Constants.Zookeeper.QUORUM, masterBindAddrConf + ":2181/cdap");
+
+      // TODO (CDAP-13586): provisioners should set the secure store provider and properties
+      result.set(Constants.Security.Store.PROVIDER, "none");
     }
 
     return result;


### PR DESCRIPTION
Set the secure store provider to 'none' for clusters. This is
to prevent errors when it is configured to be something else on
the CDAP master. In the future, this will be configurable based
on the profile.