### PR TITLE
[CDAP-13562] Implements profile enabling/disabling in UI

### DIFF
--- a/cdap-ui/app/cdap/api/cloud.js
+++ b/cdap-ui/app/cdap/api/cloud.js
@@ -27,6 +27,8 @@ export const MyCloudApi = {
   create: apiCreator(dataSrc, 'PUT', 'REQUEST', `${profilesPath}/:profile`),
   get: apiCreator(dataSrc, 'GET', 'REQUEST', `${profilesPath}/:profile`),
   delete: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${profilesPath}/:profile`),
+  toggleProfileStatus: apiCreator(dataSrc, 'POST', 'REQUEST', `${profilesPath}/:profile/:action`),
+
   getProvisioners: apiCreator(dataSrc, 'GET', 'REQUEST', `${provisionersPath}`),
   getProvisionerDetailSpec: apiCreator(dataSrc, 'GET', 'REQUEST', `${provisionersPath}/:provisioner`)
 };

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ActionsPopover/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ActionsPopover/index.js
@@ -22,11 +22,11 @@ import T from 'i18n-react';
 
 require('./ActionsPopover.scss');
 
-export default function ProfileActionsPopover({target, namespace, profile, onDeleteClick}) {
+export default function ProfileActionsPopover({target, namespace, profile, onDeleteClick, className}) {
   return (
     <Popover
       target={target}
-      className="profile-actions-popover"
+      className={`profile-actions-popover ${className}`}
       placement="bottom"
       bubbleEvent={false}
       enableInteractionInPopover={true}
@@ -51,5 +51,6 @@ ProfileActionsPopover.propTypes = {
   target: PropTypes.element,
   namespace: PropTypes.string,
   profile: PropTypes.string,
-  onDeleteClick: PropTypes.func
+  onDeleteClick: PropTypes.func,
+  className: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/BasicInfo.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/BasicInfo.scss
@@ -16,30 +16,54 @@
 
 @import "../../../../../../styles/variables.scss";
 
+$disabled-switch-color: $red-02;
+$divider-color: $grey-05;
+$popover-hover-color: $blue-03;
+$grey-font-color: $grey-03;
+
 .profile-detail-view {
   .detail-view-content {
     .detail-view-basic-info {
-      .profile-name-delete {
+      .profile-detail-top-panel {
         display: flex;
         align-items: center;
+        justify-content: space-between;
 
         .profile-name {
           display: inline-block;
         }
 
+        .profile-actions-wrapper {
+          display: flex;
+          align-items: center;
+        }
+        .toggle-switch-container {
+          .toggle-switch.off {
+            background-color: $disabled-switch-color;
+          }
+        }
+
+        .divider:after {
+          content: "";
+          display: block;
+          height: 1px;
+          border-bottom: 1px solid $divider-color;
+          width: 33px;
+          transform: rotate(90deg);
+        }
+
         .profile-actions-popover {
-          margin-left: auto;
           text-align: center;
 
           &:hover {
-            color: $blue-03;
+            color: $popover-hover-color;
           }
         }
       }
 
       .profile-description {
         padding-top: 10px;
-        color: $grey-03;
+        color: $grey-font-color;
       }
 
       .profile-info-grid {
@@ -62,7 +86,7 @@
           .grid-header {
             .grid-row {
               strong {
-                color: $grey-03;
+                color: $grey-font-color;
                 font-weight: 600;
               }
             }
@@ -75,7 +99,7 @@
               .icon-cloud {
                 font-size: 1.5rem;
                 margin-right: 5px;
-                color: $grey-03;
+                color: $grey-font-color;
               }
             }
           }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import ConfirmationModal from 'components/ConfirmationModal';
+import ToggleSwitch from 'components/ToggleSwitch';
+import Alert from 'components/Alert';
+import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
+import {MyCloudApi} from 'api/cloud';
+import {extractProfileName, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
+import T from 'i18n-react';
+
+const PREFIX = 'features.Cloud.Profiles';
+
+export default class ProfileStatusToggle extends Component {
+  state = {
+    disableModalOpen: false,
+    disableErrMsg: '',
+    extendedDisableErrMsg: '',
+    disableLoading: false
+  };
+
+  static propTypes = {
+    profile: PropTypes.object,
+    namespace: PropTypes.string,
+    toggleProfileStatusCallback: PropTypes.func
+  };
+
+  toggleDisableModal = () => {
+    this.setState({
+      disableModalOpen: !this.state.disableModalOpen,
+      disableErrMsg: '',
+      extendedDisableErrMsg: '',
+      disableLoading: false
+    });
+  };
+
+  toggleProfileStatus = () => {
+    this.setState({
+      disableLoading: true
+    });
+
+    const profile = this.props.profile;
+    const action = PROFILE_STATUSES[profile.status] === 'enabled' ? 'disable' : 'enable';
+
+    MyCloudApi
+      .toggleProfileStatus({
+        namespace: this.props.namespace,
+        profile: profile.name,
+        action
+      })
+      .subscribe(
+        () => {
+          if (this.state.disableModalOpen) {
+            this.toggleDisableModal();
+          }
+          if (typeof this.props.toggleProfileStatusCallback === 'function') {
+            this.props.toggleProfileStatusCallback();
+          }
+        },
+        (err) => {
+          this.setState({
+            disableErrMsg: T.translate(`${PREFIX}.DetailView.disableError`),
+            extendedDisableErrMsg: err.response || err,
+            disableLoading: false
+          });
+        }
+    );
+  };
+
+  closeAlertBanner = () => {
+    this.setState({
+      extendedDisableErrMsg: '',
+    });
+  };
+
+  toggleFunction = (profileIsEnabled) => {
+    if (profileIsEnabled) {
+      this.toggleDisableModal();
+    } else {
+      this.toggleProfileStatus();
+    }
+  };
+
+  renderDisableConfirmationModal() {
+    if (!this.state.disableModalOpen) {
+      return null;
+    }
+
+    const profile = this.props.profile;
+    const confirmationText = T.translate(`${PREFIX}.DetailView.disableConfirmation`, {profile: profile.name});
+
+    return (
+      <ConfirmationModal
+        headerTitle={T.translate(`${PREFIX}.DetailView.disableTitle`)}
+        toggleModal={this.toggleDisableModal}
+        confirmationText={confirmationText}
+        confirmButtonText={T.translate(`${PREFIX}.DetailView.disableYes`)}
+        cancelButtonText={T.translate(`${PREFIX}.DetailView.disableNo`)}
+        confirmFn={this.toggleProfileStatus}
+        cancelFn={this.toggleDisableModal}
+        isOpen={this.state.disableModalOpen}
+        errorMessage={this.state.disableErrMsg}
+        extendedMessage={this.state.extendedDisableErrMsg}
+        isLoading={this.state.disableLoading}
+      />
+    );
+  }
+
+  // Since for enabling a profile, we don't show a confirmation modal,
+  // so if there's an error while enabling a profile, we show it in an
+  // Alert banner at the top of the screen
+  renderError() {
+    if (!this.state.extendedDisableErrMsg || this.state.disableModalOpen) {
+      return null;
+    }
+
+    const message = T.translate(`${PREFIX}.DetailView.enableError`, {
+      message: this.state.extendedDisableErrMsg
+    });
+
+    return (
+      <Alert
+        message={message}
+        type='error'
+        showAlert={true}
+        onClose={this.closeAlertBanner}
+      />
+    );
+  }
+
+  render() {
+    const profile = this.props.profile;
+    const profileIsDefault = profile.name === extractProfileName(DEFAULT_PROFILE_NAME);
+
+    if (profileIsDefault) {
+      return null;
+    }
+
+    const profileStatus = PROFILE_STATUSES[profile.status];
+    const profileIsEnabled = profileStatus === 'enabled';
+
+    return (
+      <div>
+        <ToggleSwitch
+          isOn={profileIsEnabled}
+          onToggle={this.toggleFunction.bind(this, profileIsEnabled)}
+          onLabel={T.translate(`${PREFIX}.common.${profileStatus}`)}
+          offLabel={T.translate(`${PREFIX}.common.${profileStatus}`)}
+        />
+        {this.renderDisableConfirmationModal()}
+        {this.renderError()}
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
@@ -26,6 +26,8 @@ import T from 'i18n-react';
 import ActionsPopover from 'components/Cloud/Profiles/ActionsPopover';
 import isEqual from 'lodash/isEqual';
 import {getProvisionerLabel} from 'components/Cloud/Profiles/Store/ActionCreator';
+import ProfileStatusToggle from 'components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle';
+import {extractProfileName, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
 
 require('./BasicInfo.scss');
 
@@ -44,7 +46,8 @@ export default class ProfileDetailViewBasicInfo extends Component {
   static propTypes = {
     profile: PropTypes.object,
     provisioners: PropTypes.array,
-    isSystem: PropTypes.bool
+    isSystem: PropTypes.bool,
+    toggleProfileStatusCallback: PropTypes.func
   };
 
   componentWillReceiveProps(nextProps) {
@@ -148,6 +151,13 @@ export default class ProfileDetailViewBasicInfo extends Component {
     );
   }
 
+  renderDivider(profileIsDefault) {
+    if (profileIsDefault) {
+      return null;
+    }
+    return <span className="divider"></span>;
+  }
+
   render() {
     let profile = this.props.profile;
     let redirectToObj = this.props.isSystem ? {
@@ -155,6 +165,7 @@ export default class ProfileDetailViewBasicInfo extends Component {
       state: { accordionToExpand: ADMIN_CONFIG_ACCORDIONS.systemProfiles }
     } : `/ns/${getCurrentNamespace()}/details`;
     let namespace = this.props.isSystem ? 'system' : getCurrentNamespace();
+    const profileIsDefault = profile.name === extractProfileName(DEFAULT_PROFILE_NAME);
 
     const actionsElem = () => {
       return (
@@ -167,16 +178,24 @@ export default class ProfileDetailViewBasicInfo extends Component {
 
     return (
       <div className="detail-view-basic-info">
-        <div className="profile-name-delete">
+        <div className="profile-detail-top-panel">
           <h2 className="profile-name">
             {profile.name}
           </h2>
-          <ActionsPopover
-            target={actionsElem}
-            namespace={namespace}
-            profile={profile}
-            onDeleteClick={this.toggleDeleteModal}
-          />
+          <div className="profile-actions-wrapper">
+            <ProfileStatusToggle
+              profile={profile}
+              namespace={namespace}
+              toggleProfileStatusCallback={this.props.toggleProfileStatusCallback}
+            />
+            {this.renderDivider(profileIsDefault)}
+            <ActionsPopover
+              target={actionsElem}
+              namespace={namespace}
+              profile={profile}
+              onDeleteClick={this.toggleDeleteModal}
+            />
+          </div>
         </div>
         <div className="profile-description">
           {profile.description}

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
@@ -54,7 +54,7 @@ export default class ProfileDetailView extends Component {
     document.querySelector('#header-namespace-dropdown').style.display = 'inline-block';
   }
 
-  getProfile() {
+  getProfile = () => {
     let {namespace, profileId} = this.props.match.params;
     MyCloudApi
       .get({
@@ -75,7 +75,7 @@ export default class ProfileDetailView extends Component {
           });
         }
       );
-  }
+  };
 
   getProvisioners() {
     getProvisionersMap().subscribe((state) => {
@@ -119,6 +119,7 @@ export default class ProfileDetailView extends Component {
               profile={this.state.profile}
               provisioners={this.state.provisioners}
               isSystem={this.state.isSystem}
+              toggleProfileStatusCallback={this.getProfile}
             />
         }
       </div>

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
@@ -17,6 +17,8 @@
 @import "../../../../styles/mixins.scss";
 @import "../../../../styles/variables.scss";
 $row-height: 50px;
+$enabled-color: $green-02;
+$disabled-color: $red-02;
 
 .profiles-list-view {
   .grid-wrapper {
@@ -81,6 +83,14 @@ $row-height: 50px;
               stroke: $blue-03;
             }
           }
+        }
+
+        .enabled-label {
+          color: $enabled-color;
+        }
+
+        .disabled-label {
+          color: $disabled-color;
         }
       }
     }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -25,7 +25,7 @@ import LoadingSVG from 'components/LoadingSVG';
 import orderBy from 'lodash/orderBy';
 import ViewAllLabel from 'components/ViewAllLabel';
 import ConfirmationModal from 'components/ConfirmationModal';
-import ProfilesStore from 'components/Cloud/Profiles/Store';
+import ProfilesStore, {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
 import {getProfiles, deleteProfile, setError} from 'components/Cloud/Profiles/Store/ActionCreator';
 import {connect, Provider} from 'react-redux';
 import Alert from 'components/Alert';
@@ -78,7 +78,8 @@ const PROFILES_TABLE_HEADERS = [
     label: T.translate(`${PREFIX}.ListView.triggers`)
   },
   {
-    label: ''
+    property: 'status',
+    label: 'Status'
   },
   {
     label: ''
@@ -293,6 +294,7 @@ class ProfilesListView extends Component {
             let namespace = profile.scope === 'SYSTEM' ? 'system' : this.props.namespace;
             let provisionerName = profile.provisioner.name;
             profile.provisioner.label = this.state.provisionersMap[provisionerName] || provisionerName;
+            let profileStatus = PROFILE_STATUSES[profile.status];
 
             return (
               <Link
@@ -312,7 +314,9 @@ class ProfilesListView extends Component {
                 <div />
                 <div />
                 <div />
-                <div />
+                <div className={`${profileStatus}-label`}>
+                  {T.translate(`${PREFIX}.common.${profileStatus}`)}
+                </div>
                 <div>
                   <ActionsPopover
                     target={actionsElem}

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Preview/Preview.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Preview/Preview.scss
@@ -17,6 +17,9 @@
 @import "../../../../styles/variables.scss";
 @import "../../../../styles/mixins.scss";
 
+$enabled-color: $green-02;
+$disabled-color: $red-02;
+
 .profile-preview {
   width: inherit;
   padding: 20px;
@@ -41,6 +44,7 @@
         > div {
           display: flex;
           align-items: flex-end;
+          font-weight: bold;
         }
       }
     }
@@ -59,7 +63,7 @@
     .grid-header,
     .grid-body {
       .grid-row {
-        grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
+        grid-template-columns: 2fr 1fr 1fr 1fr 1fr 1fr;
       }
       .grid-row,
       .grid-row > div {
@@ -69,6 +73,16 @@
         &:hover {
           background: inherit;
           cursor: default;
+        }
+
+        &.profile-status {
+          &.enabled {
+            color: $enabled-color;
+          }
+
+          &.disabled {
+            color: $disabled-color;
+          }
         }
       }
     }

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Preview/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Preview/index.js
@@ -21,6 +21,8 @@ import {getCurrentNamespace} from 'services/NamespaceStore';
 import LoadingSVG from 'components/LoadingSVG';
 import IconSVG from 'components/IconSVG';
 import {getProvisionerLabel} from 'components/Cloud/Profiles/Store/ActionCreator';
+import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
+import T from 'i18n-react';
 require('./Preview.scss');
 
 export default class ProfilePreview extends Component {
@@ -94,6 +96,7 @@ export default class ProfilePreview extends Component {
     let profileNamespace = this.state.profileDetails.scope === 'SYSTEM' ? 'system' : getCurrentNamespace();
     let profileDetailsLink = `${location.protocol}//${location.host}/cdap/ns/${profileNamespace}/profiles/details/${this.props.profileName}`;
     let profileProvisionerLabel = getProvisionerLabel(this.state.profileDetails, this.state.provisioners);
+    const profileStatus = PROFILE_STATUSES[this.state.profileDetails.status];
 
     return (
       <div className="profile-preview text-xs-left">
@@ -111,6 +114,7 @@ export default class ProfilePreview extends Component {
               <div>Last 24hr # runs</div>
               <div>Last 24hr node hr</div>
               <div>Creation Date</div>
+              <div>Current Status</div>
             </div>
           </div>
           <div className="grid-body">
@@ -127,6 +131,9 @@ export default class ProfilePreview extends Component {
               <div />
               <div />
               <div />
+              <div className={`profile-status ${profileStatus}`}>
+                {T.translate(`features.Cloud.Profiles.common.${profileStatus}`)}
+              </div>
             </div>
           </div>
         </div>

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
@@ -30,6 +30,11 @@ const DEFAULT_PROFILES_STATE = {
   error: null,
 };
 
+const PROFILE_STATUSES = {
+  ENABLED: 'enabled',
+  DISABLED: 'disabled'
+};
+
 const profiles = (state = DEFAULT_PROFILES_STATE, action = defaultAction) => {
   switch (action.type) {
     case PROFILES_ACTIONS.SET_PROFILES:
@@ -65,4 +70,4 @@ const ProfilesStore = createStore(
 );
 
 export default ProfilesStore;
-export {PROFILES_ACTIONS};
+export {PROFILES_ACTIONS, PROFILE_STATUSES};

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
@@ -17,6 +17,8 @@
 @import "../../../styles/mixins.scss";
 @import "../../../styles/variables.scss";
 
+$enabled-color: $green-02;
+
 .compute-tab-content {
   height: 100%;
 }
@@ -45,8 +47,24 @@
     height: 100%;
     grid-auto-rows: 40px;
     max-height: calc(100% - 50px); // 100% - 17px (title) - 30px (profile count)
+
     .grid-row {
-      grid-template-columns: 30px 1fr 1.5fr 1fr 50px 1fr;
+      grid-template-columns: 30px 110px 1.5fr 1fr 70px 1fr 50px;
+
+      &.enabled {
+        .profile-status {
+          color: $enabled-color;
+        }
+      }
+      &.disabled {
+        cursor: not-allowed;
+
+        > div {
+          &:not(:last-child) {
+            opacity: 0.5;
+          }
+        }
+      }
     }
     .grid-header {
       .grid-row {

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
@@ -29,13 +29,16 @@ import {isNilOrEmpty} from 'services/helpers';
 import isEqual from 'lodash/isEqual';
 import {getCustomizationMap} from 'components/PipelineConfigurations/Store/ActionCreator';
 import {getProvisionersMap} from 'components/Cloud/Profiles/Store/Provisioners';
+import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
+import T from 'i18n-react';
+
 require('./ProfilesListViewInPipeline.scss');
 
 export const PROFILE_NAME_PREFERENCE_PROPERTY = 'system.profile.name';
 export const PROFILE_PROPERTIES_PREFERENCE = 'system.profile.properties';
 export const extractProfileName = (name = '') => name.replace(/(user|system):/g, '');
 export const isSystemProfile = (name = '') => name.indexOf('system:') === 0;
-// NOTE: This is never actually saved to backend. This is hardcoded here until we figure out a 
+// NOTE: This is never actually saved to backend. This is hardcoded here until we figure out a
 // clean way to add `system.profiles.name` to namespace preference. If there is no `system.profiles.name` set
 // at namespace or app level UI show "default" profile selected
 export const DEFAULT_PROFILE_NAME = 'system:native';
@@ -89,16 +92,31 @@ export default class ProfilesListViewInPipeline extends Component {
     )
       .subscribe(
         ([profiles = [], systemProfiles = [], preferences = {}]) => {
-          let selectedProfile = this.state.selectedProfile || preferences[PROFILE_NAME_PREFERENCE_PROPERTY] || DEFAULT_PROFILE_NAME;
           let profileCustomizations = isNilOrEmpty(this.state.profileCustomizations) ?
             getCustomizationMap(preferences)
           :
             this.state.profileCustomizations;
 
           let allProfiles = profiles.concat(systemProfiles);
+
+          let selectedProfile = this.state.selectedProfile || preferences[PROFILE_NAME_PREFERENCE_PROPERTY] || DEFAULT_PROFILE_NAME;
+          let selectedProfileName = extractProfileName(selectedProfile);
+
+          // If currently selected profile has been disabled, then select 'default'
+          // profile, but only if the profiles list view is not disabled
+          if (!this.props.disabled) {
+            let selectedProfileIsDisabled = allProfiles.some(profile => {
+              return profile.name === selectedProfileName
+                && PROFILE_STATUSES[profile.status] === 'disabled';
+            });
+            if (selectedProfileIsDisabled) {
+              selectedProfile = DEFAULT_PROFILE_NAME;
+              selectedProfileName = extractProfileName(selectedProfile);
+            }
+          }
+
           // This is to surface the selected profile to the top
           // instead of hiding somewhere in the bottom.
-          let selectedProfileName = extractProfileName(selectedProfile);
           let sortedProfiles = [];
           allProfiles.forEach(profile => {
             if (profile.name === selectedProfileName) {
@@ -136,11 +154,15 @@ export default class ProfilesListViewInPipeline extends Component {
       selectedProfile: profileName
     });
     if (this.props.onProfileSelect) {
-      this.props.onProfileSelect(profileName, customizations, e);
+      this.props.onProfileSelect(profileName, customizations, true, e);
     }
   };
 
-  onProfileSelectWithoutCustomization = (profileName, e) => {
+  onProfileSelectWithoutCustomization = (profileName, profileIsEnabled, e) => {
+    if (!profileIsEnabled) {
+      return;
+    }
+
     this.onProfileSelect(profileName, {}, e);
   };
 
@@ -152,6 +174,7 @@ export default class ProfilesListViewInPipeline extends Component {
           <strong>Profile Name</strong>
           <strong>Provisioner</strong>
           <strong>Scope</strong>
+          <strong>Status</strong>
           <strong />
           <strong />
         </div>
@@ -167,32 +190,15 @@ export default class ProfilesListViewInPipeline extends Component {
     selectedProfile = extractProfileName(selectedProfile);
     let provisionerName = profile.provisioner.name;
     let provisionerLabel = this.state.provisionersMap[provisionerName] || provisionerName;
-    return (
-      <div
-        key={profileName}
-        className={classnames("grid-row grid-link", {
-          "active": this.state.selectedProfile === profileName
-        })}
-      >
-        {
-          /*
-            There is an onClick handler on each cell except the last one.
-            This is to prevent the user from selecting a profile while trying to click on the details link
-          */
-        }
-        <div onClick={this.onProfileSelectWithoutCustomization.bind(this, profileName)}>
-          {
-            this.state.selectedProfile === profileName ? (
-              <IconSVG name="icon-check" className="text-success" />
-            ) : null
-          }
-        </div>
-        <div onClick={this.onProfileSelectWithoutCustomization.bind(this, profileName)}>{profile.name}</div>
-        <div onClick={this.onProfileSelectWithoutCustomization.bind(this, profileName)}>{provisionerLabel}</div>
-        <div onClick={this.onProfileSelectWithoutCustomization.bind(this, profileName)}>{profile.scope}</div>
-        <div>
-          <a href={profileDetailsLink}> View </a>
-        </div>
+    const profileStatus = PROFILE_STATUSES[profile.status];
+    const profileIsEnabled = profileStatus === 'enabled';
+    const onProfileSelectHandler = this.onProfileSelectWithoutCustomization.bind(this, profileName, profileIsEnabled);
+
+    const CustomizeLabel = () => {
+      if (!profileIsEnabled) {
+        return <div>Customize</div>;
+      }
+      return (
         <ProfileCustomizePopover
           profile={profile}
           onProfileSelect={this.onProfileSelect}
@@ -204,6 +210,49 @@ export default class ProfilesListViewInPipeline extends Component {
               {}
           }
         />
+      );
+    };
+
+    return (
+      <div
+        key={profileName}
+        className={classnames(`grid-row grid-link ${profileStatus}`, {
+          "active": this.state.selectedProfile === profileName,
+          profileStatus
+        })}
+      >
+        {
+          /*
+            There is an onClick handler on each cell except the last one.
+            This is to prevent the user from selecting a profile while trying to click on the details link
+          */
+        }
+        <div onClick={onProfileSelectHandler}>
+          {
+            this.state.selectedProfile === profileName ? (
+              <IconSVG name="icon-check" className="text-success" />
+            ) : null
+          }
+        </div>
+        <div onClick={onProfileSelectHandler}>
+          {profile.name}
+        </div>
+        <div onClick={onProfileSelectHandler}>
+          {provisionerLabel}
+        </div>
+        <div onClick={onProfileSelectHandler}>
+          {profile.scope}
+        </div>
+        <div
+          className="profile-status"
+          onClick={onProfileSelectHandler}
+        >
+          {T.translate(`features.Cloud.Profiles.common.${profileStatus}`)}
+        </div>
+        <CustomizeLabel />
+        <div>
+          <a href={profileDetailsLink}> View </a>
+        </div>
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/index.js
@@ -18,7 +18,7 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import {objectQuery} from 'services/helpers';
-import {PROFILE_NAME_PREFERENCE_PROPERTY, extractProfileName, DEFAULT_PROFILE_NAME} from  'components/PipelineDetails/ProfilesListView';
+import {PROFILE_NAME_PREFERENCE_PROPERTY, extractProfileName, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
 import IconSVG from 'components/IconSVG';
 import ProfilePreview from 'components/Cloud/Profiles/Preview';
 import Popover from 'components/Popover';

--- a/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
@@ -21,11 +21,12 @@ import {Dropdown, DropdownToggle, DropdownMenu} from 'reactstrap';
 import {setSelectedProfile} from 'components/PipelineScheduler/Store/ActionCreator';
 import {connect} from 'react-redux';
 import StatusMapper from 'services/StatusMapper';
-import ProfilesListView, {extractProfileName, isSystemProfile} from 'components/PipelineDetails/ProfilesListView';
+import ProfilesListView, {extractProfileName, isSystemProfile, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
 import {MyCloudApi} from 'api/cloud';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import {getProvisionersMap} from 'components/Cloud/Profiles/Store/Provisioners';
 import {preventPropagation} from 'services/helpers';
+import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
 require('./ProfilesForSchedule.scss');
 
 export const PROFILES_DROPDOWN_DOM_CLASS = 'profiles-list-dropdown';
@@ -96,9 +97,11 @@ class ProfilesForSchedule extends Component {
     });
   }
 
-  setSelectedProfile = (selectedProfile, profileCustomizations = {}, e) => {
+  setSelectedProfile = (selectedProfile, profileCustomizations = {}, toggleDropdown = true, e) => {
     setSelectedProfile(selectedProfile, profileCustomizations);
-    this.toggleProfileDropdown(e);
+    if (toggleDropdown) {
+      this.toggleProfileDropdown(e);
+    }
   };
 
   renderProfilesTable = () => {
@@ -122,9 +125,18 @@ class ProfilesForSchedule extends Component {
 
   renderProfilesDropdown = () => {
     let isScheduled = this.props.scheduleStatus === StatusMapper.statusMap['SCHEDULED'];
-    let provisionerLabel;
+    let provisionerLabel, selectedProfile;
     if (this.state.selectedProfile) {
       let {profileDetails = {}} = this.state;
+      if (profileDetails.status
+          && PROFILE_STATUSES[profileDetails.status] === 'disabled'
+          && !isScheduled
+          && this.state.selectedProfile !== DEFAULT_PROFILE_NAME) {
+        selectedProfile = DEFAULT_PROFILE_NAME;
+        this.setSelectedProfile(DEFAULT_PROFILE_NAME, {}, false);
+      } else {
+        selectedProfile = this.state.selectedProfile;
+      }
       let {provisioner = {}} = profileDetails;
       let {name: provisionerName} = provisioner;
       provisionerLabel = this.state.provisionersMap[provisionerName] || provisionerName;
@@ -146,9 +158,9 @@ class ProfilesForSchedule extends Component {
               <span>
                 {
                   provisionerLabel ?
-                    `${extractProfileName(this.state.selectedProfile)} (${provisionerLabel})`
+                    `${extractProfileName(selectedProfile)} (${provisionerLabel})`
                   :
-                    `${extractProfileName(this.state.selectedProfile)}`
+                    `${extractProfileName(selectedProfile)}`
                 }
               </span>
             :

--- a/cdap-ui/app/cdap/components/PipelineScheduler/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/Store/index.js
@@ -33,7 +33,7 @@ import {
 import {createStore} from 'redux';
 import range from 'lodash/range';
 import {HYDRATOR_DEFAULT_VALUES} from 'services/global-constants';
-import {PROFILE_NAME_PREFERENCE_PROPERTY} from  'components/PipelineDetails/ProfilesListView';
+import {PROFILE_NAME_PREFERENCE_PROPERTY, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
 import {getCustomizationMap} from 'components/PipelineConfigurations/Store/ActionCreator';
 
 const INTERVAL_OPTIONS = {
@@ -100,7 +100,7 @@ const DEFAULT_SCHEDULE_OPTIONS = {
   maxConcurrentRuns: MAX_CONCURRENT_RUNS_OPTIONS[0],
   scheduleView: Object.values(SCHEDULE_VIEWS)[0],
   profiles: {
-    selectedProfile: null,
+    selectedProfile: DEFAULT_PROFILE_NAME,
     profileCustomizations: {}
   },
   currentBackendSchedule: null,
@@ -231,7 +231,7 @@ const schedule = (state = DEFAULT_SCHEDULE_OPTIONS, action = defaultAction) => {
         cron: cronFromBackend,
         maxConcurrentRuns: maxConcurrencyFromBackend,
         profiles: {
-          selectedProfile: profileFromBackend,
+          selectedProfile: profileFromBackend || DEFAULT_PROFILE_NAME,
           profileCustomizations
         }
       };

--- a/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/ComputeConfigTab/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/Tabs/ComputeConfigTab/index.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import T from 'i18n-react';
 import {connect} from 'react-redux';
-import ProfilesListViewInPipeline from  'components/PipelineDetails/ProfilesListView';
+import ProfilesListViewInPipeline from 'components/PipelineDetails/ProfilesListView';
 import {setSelectedProfile} from 'components/PipelineTriggers/ScheduleRuntimeArgs/ScheduleRuntimeArgsActions';
 
 const PREFIX = 'features.PipelineTriggers.ScheduleRuntimeArgs.Tabs.ComputeConfig';

--- a/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
@@ -31,7 +31,7 @@ import classnames from 'classnames';
 import {objectQuery} from 'services/helpers';
 import {Provider} from 'react-redux';
 import isNil from 'lodash/isNil';
-import {PROFILE_NAME_PREFERENCE_PROPERTY, PROFILE_PROPERTIES_PREFERENCE} from  'components/PipelineDetails/ProfilesListView';
+import {PROFILE_NAME_PREFERENCE_PROPERTY, PROFILE_PROPERTIES_PREFERENCE} from 'components/PipelineDetails/ProfilesListView';
 import {getCustomizationMap} from 'components/PipelineConfigurations/Store/ActionCreator';
 
 require('./ScheduleRuntimeArgs.scss');

--- a/cdap-ui/app/cdap/components/ToggleSwitch/index.js
+++ b/cdap-ui/app/cdap/components/ToggleSwitch/index.js
@@ -19,21 +19,36 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 require('./ToggleSwitch.scss');
 
-export default function ToggleSwitch({isOn, onToggle, disabled}) {
+export default function ToggleSwitch({isOn, onToggle, disabled, onLabel, offLabel}) {
   return (
     <div className={classnames("toggle-switch-container", {"disabled": disabled})}>
       <div
         className={classnames("toggle-switch", {"on": isOn, 'off': !isOn})}
         onClick={onToggle}
       >
-        <span className="switch-button"></span>
+        <div className="switch-button"></div>
+        <div className={classnames("label", {"on-label": isOn, 'off-label': !isOn})}>
+          {
+            isOn ?
+              onLabel
+            :
+              offLabel
+          }
+        </div>
       </div>
     </div>
   );
 }
 
+ToggleSwitch.defaultProps = {
+  onLabel: 'On',
+  offLabel: 'Off'
+};
+
 ToggleSwitch.propTypes = {
   isOn: PropTypes.bool,
   onToggle: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  onLabel: PropTypes.string,
+  offLabel: PropTypes.string
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -239,7 +239,9 @@ features:
       common:
         deleteConfirmation: Are you sure you want to delete the profile *_{profile}_*?
         deleteError: There was a problem deleting the profile
-        deleteTitle: Delete Profile
+        deleteTitle: Delete profile
+        disabled: Disabled
+        enabled: Enabled
         export: Export
         last24HrNodeHr: Last 24 hrs node/hr
         last24HrRuns: Last 24 hrs runs
@@ -248,6 +250,12 @@ features:
         totalRuns: Total runs
       DetailView:
         creation: Creation date and time
+        disableConfirmation: Are you sure you want to disable the profile *_{profile}_*? The pipelines currently using this profile will start using the *_native_* profile.
+        disableError: There was a problem disabling the profile
+        disableNo: No, keep the profile enabled
+        disableTitle: Disable profile
+        disableYes: Yes, disable profile
+        enableError: "There was a problem enabling the profile: {message}"
         hideDetails: Hide Details
         noProperties: No properties available for this profile
         profileDetails: Profile Details

--- a/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.html
+++ b/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2017 Cask Data, Inc.
+  Copyright © 2017-2018 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -14,11 +14,15 @@
   the License.
 -->
 
-<div class="toggle-switch-container"
+<div class="ng-toggle-switch-container"
     ng-class="{'disabled': isDisabled}">
   <div class="toggle-switch"
        ng-class="{'on': isOn, 'off': !isOn }"
        ng-click="onToggle()">
-      <span class="switch-button"></span>
+      <div class="switch-button"></div>
+      <div class="label"
+           ng-class="{'on-label': isOn, 'off-label': !isOn }">
+        <span ng-if="isOn">On</span>
+        <span ng-if="!isOn">Off</span>
   </div>
 </div>

--- a/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.less
+++ b/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.less
@@ -14,53 +14,64 @@
  * the License.
  */
 
-@import '../../styles/variables.scss';
-$switch-btn-width: 14px;
-$widget-height: 32px;
-$switch-button-margin-top: 2px;
-$on-color: $green-02;
-$off-color: $blue-02;
+@import "../../../styles/variables.less";
+@container-width: 50px;
+@switch-btn-width: 14px;
+@widget-height: 32px;
+@switch-button-margin-top: 2px;
+@on-color: @green-02;
+@off-color: @blue-02;
 
-.toggle-switch-container {
+.ng-toggle-switch-container {
   display: inline-block;
+  height: @widget-height;
+  width: @container-width;
 
   .toggle-switch {
+    height: 100%;
+    width: 100%;
+    position: relative;
     vertical-align: middle;
     border-radius: 5px;
     font-weight: 500;
     color: white;
     user-select: none;
     cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: space-evenly;
-    padding: 2px;
 
     .switch-button {
-      width: $switch-btn-width;
-      height: $widget-height - ($switch-button-margin-top * 2);
+      position: absolute;
+      top: @switch-button-margin-top;
+      width: @switch-btn-width;
+      height: @widget-height - (@switch-button-margin-top * 2);
       background-color: white;
       border-radius: 5px;
     }
 
     .label {
       height: 100%;
+      width: @container-width - @switch-btn-width;
       font-size: 11px;
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 0 8px;
+
+      &.off-label {
+        margin-left: @switch-btn-width;
+      }
     }
 
     &.on {
-      background-color: $on-color;
+      background-color: @on-color;
       .switch-button {
-        order: 2;
+        right: 2px;
       }
     }
 
     &.off {
-      background-color: $off-color;
+      background-color: @off-color;
+      .switch-button {
+        left: 2px;
+      }
     }
   }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13562
BUILD: https://builds.cask.co/browse/CDAP-UDUT1

Things done in this PR:
- Adds a toggle widget in the profile detail view to allow enabling/disabling, but don't show it for 'default' profile, since it cannot be disabled. 
- Shows a confirmation modal when the user wants to disable profile.
- Adds a 'Status' column in the profiles list view and profile preview to show current enabled/disabled status. In the list view, the disabled profiles are greyed out.
- Automatically switches profile selection to 'default' profile, if previously selected profile is now disabled. But for current schedules/triggers, still show the disabled profile, until the user unschedules/deletes the trigger.