### PR TITLE
[CDAP-13473] Adds pagination to Reports detail view in UI

### DIFF
--- a/cdap-ui/app/cdap/components/PaginationWithTitle/index.js
+++ b/cdap-ui/app/cdap/components/PaginationWithTitle/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,34 +28,39 @@ export default class PaginationWithTitle extends Component {
     handlePageChange: PropTypes.func
   };
 
-  state = {
-    title: this.props.title || 'Pages',
-    currentPage: this.props.currentPage,
-    totalPages: this.props.totalPages,
+  renderPaginationComponent() {
+    if (this.props.totalPages < 2) {
+      return null;
+    }
+
+    return (
+      <ReactPaginate
+        pageCount={this.props.totalPages}
+        pageRangeDisplayed={3}
+        marginPagesDisplayed={1}
+        breakLabel={<span>...</span>}
+        breakClassName={"ellipsis"}
+        previousLabel={<span className="fa fa-angle-left"></span>}
+        nextLabel={<span className="fa fa-angle-right"></span>}
+        onPageChange={this.props.handlePageChange.bind(this)}
+        disableInitialCallback={true}
+        initialPage={this.props.currentPage-1}
+        forcePage={this.props.currentPage-1}
+        containerClassName={"page-list"}
+        activeClassName={"current-page"}
+      />
+    );
   }
+
   render() {
     return (
       <span className="pagination-with-title">
         <ul className="total-entities">
           <span>
-            {this.props.numberOfEntities} {this.state.title}
+            {this.props.numberOfEntities} {this.props.title || 'Pages'}
           </span>
         </ul>
-        <ReactPaginate
-          pageCount={this.props.totalPages}
-          pageRangeDisplayed={3}
-          marginPagesDisplayed={1}
-          breakLabel={<span>...</span>}
-          breakClassName={"ellipsis"}
-          previousLabel={<span className="fa fa-angle-left"></span>}
-          nextLabel={<span className="fa fa-angle-right"></span>}
-          onPageChange={this.props.handlePageChange.bind(this)}
-          disableInitialCallback={true}
-          initialPage={this.props.currentPage-1}
-          forcePage={this.props.currentPage-1}
-          containerClassName={"page-list"}
-          activeClassName={"current-page"}
-        />
+        {this.renderPaginationComponent()}
       </span>
     );
   }

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/RunsPagination/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/RunsPagination/index.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {handleRunsPageChange} from 'components/Reports/store/ActionCreator';
+import PaginationWithTitle from 'components/PaginationWithTitle';
+
+function RunsPaginationView({totalCount, offset, limit}) {
+  let totalPages = Math.ceil(totalCount / limit);
+  let currentPage;
+
+  if (offset === 0) {
+    currentPage = 1;
+  } else {
+    currentPage = Math.ceil((offset + 1) / limit);
+  }
+
+  return (
+    <PaginationWithTitle
+      handlePageChange={handleRunsPageChange}
+      currentPage={currentPage}
+      totalPages={totalPages}
+      title={totalCount > 1 ? "Runs" : "Run"}
+      numberOfEntities={totalCount}
+    />
+  );
+}
+
+RunsPaginationView.propTypes = {
+  totalCount: PropTypes.number,
+  offset: PropTypes.number,
+  limit: PropTypes.number
+};
+
+const mapStateToProps = (state) => {
+  return {
+    totalCount: state.details.totalRunsCount,
+    offset: state.details.runsOffset,
+    limit: state.details.runsLimit
+  };
+};
+
+const RunsPagination = connect(
+  mapStateToProps
+)(RunsPaginationView);
+
+export default RunsPagination;

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/index.js
@@ -19,9 +19,11 @@ import PropTypes from 'prop-types';
 import {MyReportsApi} from 'api/reports';
 import Summary from 'components/Reports/ReportsDetail/Summary';
 import Runs from 'components/Reports/ReportsDetail/Runs';
+import RunsPagination from 'components/Reports/ReportsDetail/RunsPagination';
 import SaveButton from 'components/Reports/ReportsDetail/SaveButton';
 import Expiry from 'components/Reports/ReportsDetail/Expiry';
 import ReportsStore, { ReportsActions } from 'components/Reports/store/ReportsStore';
+import {fetchRuns} from 'components/Reports/store/ActionCreator';
 import { Link } from 'react-router-dom';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import IconSVG from 'components/IconSVG';
@@ -69,33 +71,9 @@ class ReportsDetailView extends Component {
         });
 
         if (res.status === 'COMPLETED') {
-          this.fetchDetails();
+          fetchRuns(this.props.match.params.reportId);
         }
       }, (err) => {
-        ReportsStore.dispatch({
-          type: ReportsActions.setDetailsError,
-          payload: {
-            error: err.response
-          }
-        });
-      });
-  };
-
-  fetchDetails = () => {
-    let params = {
-      reportId: this.props.match.params.reportId
-    };
-
-    MyReportsApi.getDetails(params)
-      .subscribe((res) => {
-        ReportsStore.dispatch({
-          type: ReportsActions.setRuns,
-          payload: {
-            runs: res.details
-          }
-        });
-      }, (err) => {
-        console.log('err', err);
         ReportsStore.dispatch({
           type: ReportsActions.setDetailsError,
           payload: {
@@ -147,6 +125,8 @@ class ReportsDetailView extends Component {
         </div>
 
         <Summary />
+
+        <RunsPagination />
 
         <Runs />
       </div>

--- a/cdap-ui/app/cdap/components/Reports/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Reports/store/ActionCreator.js
@@ -179,6 +179,45 @@ export function listReports(id) {
     });
 }
 
+export function fetchRuns(reportId = ReportsStore.getState().details.reportId) {
+  let {runsOffset: offset, runsLimit: limit} = ReportsStore.getState().details;
+  let params = {
+    reportId,
+    offset,
+    limit
+  };
+
+  MyReportsApi.getDetails(params)
+    .subscribe((res) => {
+      ReportsStore.dispatch({
+        type: ReportsActions.setRuns,
+        payload: {
+          runs: res.details,
+          totalRunsCount: res.total
+        }
+      });
+    }, (err) => {
+      console.log('err', err);
+      ReportsStore.dispatch({
+        type: ReportsActions.setDetailsError,
+        payload: {
+          error: err.response
+        }
+      });
+    });
+}
+
+export function handleRunsPageChange({selected}) {
+  let {runsLimit} = ReportsStore.getState().details;
+  ReportsStore.dispatch({
+    type: ReportsActions.setRunsPagination,
+    payload: {
+      offset: selected * runsLimit
+    }
+  });
+  fetchRuns();
+}
+
 export function setNamespacesPick(namespacesPick) {
   ReportsStore.dispatch({
     type: ReportsActions.setNamespaces,

--- a/cdap-ui/app/cdap/components/Reports/store/ReportsStore.js
+++ b/cdap-ui/app/cdap/components/Reports/store/ReportsStore.js
@@ -23,6 +23,7 @@ const ReportsActions = {
   setList: 'REPORTS_SET_LIST',
   setTimeRange: 'REPORTS_SET_TIME_RANGE',
   setRuns: 'REPORTS_SET_RUNS',
+  setRunsPagination: 'REPORTS_SET_RUNS_PAGINATION',
   setInfoStatus: 'REPORTS_SET_INFO_STATUS',
   clearSelection: 'REPORTS_CUSTOMIZER_CLEAR',
   setActiveId: 'REPORTS_SET_ACTIVE_ID',
@@ -86,6 +87,9 @@ const defaultDetailsState = {
   status: null,
   summary: {},
   runs: [],
+  runsOffset: 0,
+  runsLimit: 20,
+  totalRunsCount: 0,
   error: null,
   detailError: null
 };
@@ -196,7 +200,13 @@ const details = (state = defaultDetailsState, action = defaultAction) => {
     case ReportsActions.setRuns:
       return {
         ...state,
-        runs: action.payload.runs
+        runs: action.payload.runs,
+        totalRunsCount: action.payload.totalRunsCount
+      };
+    case ReportsActions.setRunsPagination:
+      return {
+        ...state,
+        runsOffset: action.payload.offset
       };
     case ReportsActions.setDetailsError:
       return {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13473
BUILD: https://builds.cask.co/browse/CDAP-UDUT3-1

This PR:
- Adds pagination to reports detail view, which currently shows list of runs. The limit for number of runs per page right now is 20.
- Modifies `PaginationWithTitle` to not show the pagination component if there's only 1 page. This change will also affect MMDS.