### PR TITLE
Feature/adding program options state writer

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -146,14 +146,11 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
       Program executableProgram = createProgram(cConf, runner, programDescriptor, artifactDetail, tempDir);
       cleanUpTask = createCleanupTask(cleanUpTask, executableProgram);
 
-
       RuntimeInfo runtimeInfo = createRuntimeInfo(runner.run(executableProgram, optionsWithPlugins), programId,
                                                   cleanUpTask);
       monitorProgram(runtimeInfo, cleanUpTask);
       return runtimeInfo;
     } catch (Exception e) {
-      // Set the program state to an error when an exception is thrown
-      programStateWriter.error(programId.run(runId), e);
       cleanUpTask.run();
       LOG.error("Exception while trying to run program", e);
       throw Throwables.propagate(e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/MessagingProgramStatePublisher.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/MessagingProgramStatePublisher.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.program;
+
+import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.common.service.RetryStrategy;
+import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
+import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
+import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.messaging.client.StoreRequestBuilder;
+import co.cask.cdap.proto.Notification;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.common.base.Throwables;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Publishes program state and heartbeat messages through the messaging service
+ */
+public class MessagingProgramStatePublisher implements ProgramStatePublisher {
+  private static final Logger LOG = LoggerFactory.getLogger(MessagingProgramStatePublisher.class);
+  private static final Gson GSON =
+    ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
+      .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
+      .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec()).create();
+  private final MessagingService messagingService;
+  private final TopicId topicId;
+  private final RetryStrategy retryStrategy;
+
+  MessagingProgramStatePublisher(MessagingService messagingService, TopicId topicId, RetryStrategy retryStrategy) {
+    this.messagingService = messagingService;
+    this.topicId = topicId;
+    this.retryStrategy = retryStrategy;
+  }
+
+  public void publish(Notification.Type notificationType, Map<String, String> properties) {
+    // ProgramRunId is always required in a notification
+    Notification programStatusNotification = new Notification(notificationType, properties);
+
+    int failureCount = 0;
+    long startTime = -1L;
+    boolean done = false;
+    // TODO CDAP-12255 this code was basically copied from MessagingMetricsCollectionService.TopicPayload#publish.
+    // This should be refactored into a common class for publishing to TMS with a retry strategy
+    while (!done) {
+      try {
+        messagingService.publish(StoreRequestBuilder.of(topicId)
+                                   .addPayloads(GSON.toJson(programStatusNotification))
+                                   .build());
+        LOG.trace("Published program status notification: {}", programStatusNotification);
+        done = true;
+      } catch (IOException e) {
+        Throwables.propagate(e);
+      } catch (TopicNotFoundException | ServiceUnavailableException e) {
+        // These exceptions are retry-able due to TMS not completely started
+        if (startTime < 0) {
+          startTime = System.currentTimeMillis();
+        }
+        long retryMillis = retryStrategy.nextRetry(++failureCount, startTime);
+        if (retryMillis < 0) {
+          LOG.error("Failed to publish messages to TMS and exceeded retry limit.", e);
+          Throwables.propagate(e);
+        }
+        LOG.debug("Failed to publish messages to TMS due to {}. Will be retried in {} ms.",
+                  e.getMessage(), retryMillis);
+        try {
+          TimeUnit.MILLISECONDS.sleep(retryMillis);
+        } catch (InterruptedException e1) {
+          // Something explicitly stopping this thread. Simply just break and reset the interrupt flag.
+          LOG.warn("Publishing message to TMS interrupted.");
+          Thread.currentThread().interrupt();
+          done = true;
+        }
+      }
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/ProgramStatePublisher.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/ProgramStatePublisher.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.program;
+
+import co.cask.cdap.proto.Notification;
+
+import java.util.Map;
+
+/**
+ * Publishing program state messages and heartbeats
+ */
+public interface ProgramStatePublisher {
+
+  /**
+   * Publish message which is identified by notificationType and the properties.
+   *
+   * @param notificationType type of the notification of the message
+   * @param properties properties of the message to publish
+   */
+  void publish(Notification.Type notificationType, Map<String, String> properties);
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/ProgramStateWriterWithHeartBeat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/ProgramStateWriterWithHeartBeat.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.program;
+
+import co.cask.cdap.app.program.ProgramDescriptor;
+import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.app.runtime.ProgramStateWriter;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.service.RetryStrategies;
+import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
+import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
+import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.proto.Notification;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Wrapper around {@link ProgramStateWriter} with additional hook to start a
+ * heartbeat thread on running or resuming program state and stop the thread on completed/error/suspend state.
+ */
+public class ProgramStateWriterWithHeartBeat {
+  private static final Logger LOG = LoggerFactory.getLogger(ProgramStateWriterWithHeartBeat.class);
+  private static final Gson GSON =
+    ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
+      .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
+      .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec()).create();
+  private final long heartBeatIntervalSeconds;
+  private final ProgramStateWriter programStateWriter;
+  private final ProgramRunId programRunId;
+  private final ProgramStatePublisher messagingProgramStatePublisher;
+  private ScheduledExecutorService scheduledExecutorService;
+
+
+  public ProgramStateWriterWithHeartBeat(ProgramRunId programRunId,
+                                         ProgramStateWriter programStateWriter,
+                                         MessagingService messagingService,
+                                         CConfiguration cConf) {
+    this(programRunId, programStateWriter, cConf.getLong(Constants.ProgramHeartbeat.HEARTBEAT_INTERVAL_SECONDS),
+         new MessagingProgramStatePublisher(messagingService,
+                                            NamespaceId.SYSTEM.topic(cConf.get(
+                                              Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)),
+                                            RetryStrategies.fromConfiguration(cConf, "system.program.state.")));
+  }
+
+  @VisibleForTesting
+  ProgramStateWriterWithHeartBeat(ProgramRunId programRunId,
+                                  ProgramStateWriter programStateWriter,
+                                  long heartBeatIntervalSeconds,
+                                  ProgramStatePublisher messagingProgramStatePublisher) {
+    this.programRunId = programRunId;
+    this.programStateWriter = programStateWriter;
+    this.heartBeatIntervalSeconds = heartBeatIntervalSeconds;
+    this.messagingProgramStatePublisher = messagingProgramStatePublisher;
+  }
+
+  public void start(ProgramOptions programOptions, @Nullable String twillRunId, ProgramDescriptor programDescriptor) {
+    programStateWriter.start(programRunId, programOptions, twillRunId, programDescriptor);
+  }
+
+  public void running(@Nullable String twillRunId) {
+    programStateWriter.running(programRunId, twillRunId);
+    scheduleHeartBeatThread();
+  }
+
+  public void completed() {
+    stopHeartbeatThread();
+    programStateWriter.completed(programRunId);
+  }
+
+  public void killed() {
+    stopHeartbeatThread();
+    programStateWriter.killed(programRunId);
+  }
+
+  public void error(Throwable failureCause) {
+    stopHeartbeatThread();
+    programStateWriter.error(programRunId, failureCause);
+  }
+
+  public void suspend() {
+    stopHeartbeatThread();
+    programStateWriter.suspend(programRunId);
+  }
+
+  public void resume() {
+    scheduleHeartBeatThread();
+    programStateWriter.resume(programRunId);
+  }
+
+  /**
+   * If executor service isn't initialized or if its shutdown
+   * create a new exector service and schedule a heartbeat thread
+   */
+  private void scheduleHeartBeatThread() {
+    if (scheduledExecutorService == null || scheduledExecutorService.isShutdown()) {
+      scheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("program-heart-beat"));
+      scheduledExecutorService.scheduleAtFixedRate(
+        () -> {
+          Map<String, String> properties = new HashMap<>();
+          properties.put(ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId));
+          properties.put(ProgramOptionConstants.HEART_BEAT_TIME, String.valueOf(System.currentTimeMillis()));
+          // publish as heart_beat type, so it can be handled appropriately at receiver
+          messagingProgramStatePublisher.publish(Notification.Type.PROGRAM_HEART_BEAT, properties);
+          LOG.trace("Sent heartbeat for program {}", programRunId);
+        }, heartBeatIntervalSeconds,
+        heartBeatIntervalSeconds, TimeUnit.SECONDS);
+    }
+  }
+
+  private void stopHeartbeatThread() {
+    if (scheduledExecutorService != null) {
+      scheduledExecutorService.shutdownNow();
+    }
+  }
+
+  /**
+   * This method is only used for testing
+   * @return true if the heart beat thread is active, false otherwise
+   */
+  @VisibleForTesting
+  boolean isHeartBeatThreadAlive() {
+    return scheduledExecutorService != null && !scheduledExecutorService.isShutdown();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -61,6 +61,8 @@ public final class ProgramOptionConstants {
 
   public static final String LOGICAL_START_TIME = "logical.start.time";
 
+  public static final String HEART_BEAT_TIME = "heartbeat.time";
+
   public static final String END_TIME = "endTime";
 
   public static final String PROGRAM_DESCRIPTOR = "programDescriptor";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -627,7 +627,7 @@ public abstract class DistributedProgramRunner implements ProgramRunner {
       return null;
     }
     return new TwillAppLifecycleEventHandler(cConf.getLong(Constants.CFG_TWILL_NO_CONTAINER_TIMEOUT, Long.MAX_VALUE),
-                                          this instanceof LongRunningDistributedProgramRunner, programRunId);
+                                             this instanceof LongRunningDistributedProgramRunner, programRunId);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
@@ -129,7 +129,6 @@ public abstract class RunRecordCorrectorService extends AbstractIdleService {
           String msg = String.format(
             "Fixed RunRecord for program run %s in %s state because it is actually not running",
             programRunId, record.getStatus());
-
           programStateWriter.error(programRunId, new ProgramRunAbortedException(msg));
           fixedPrograms.add(programRunId);
           LOG.warn(msg);
@@ -160,7 +159,7 @@ public abstract class RunRecordCorrectorService extends AbstractIdleService {
     long initialDelay = cConf.getLong(Constants.AppFabric.LOCAL_DATASET_DELETER_INITIAL_DELAY_SECONDS);
     if (initialDelay <= 0) {
       LOG.warn("Invalid initial delay specified for the local dataset deleter {}. Setting it to 300 seconds.",
-                                initialDelay);
+               initialDelay);
       initialDelay = 300L;
     }
 
@@ -175,8 +174,8 @@ public abstract class RunRecordCorrectorService extends AbstractIdleService {
     localDatasetDeleterService.shutdown();
     try {
       if (!localDatasetDeleterService.awaitTermination(5, TimeUnit.SECONDS)) {
-          localDatasetDeleterService.shutdownNow();
-        }
+        localDatasetDeleterService.shutdownNow();
+      }
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/program/ProgramStateWriterWithHeartBeatTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/program/ProgramStateWriterWithHeartBeatTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.program;
+
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.app.program.ProgramDescriptor;
+import co.cask.cdap.app.runtime.NoOpProgramStateWriter;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.internal.app.DefaultApplicationSpecification;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.proto.Notification;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class ProgramStateWriterWithHeartBeatTest {
+  private static class MockProgramStatePublisher implements ProgramStatePublisher {
+    long heartBeatCount = 0;
+
+    @Override
+    public void publish(Notification.Type notificationType, Map<String, String> properties) {
+      if (Notification.Type.PROGRAM_HEART_BEAT.equals(notificationType)) {
+        Assert.assertTrue(properties.containsKey(ProgramOptionConstants.HEART_BEAT_TIME));
+        heartBeatCount++;
+      }
+    }
+
+    long getHeartBeatCount() {
+      return heartBeatCount;
+    }
+  }
+
+  @Test
+  public void testHeartBeatThread() throws InterruptedException, ExecutionException, TimeoutException {
+    // configure program state writer to emit heart beat every second
+    ProgramStatePublisher programStatePublisher = new MockProgramStatePublisher();
+    NoOpProgramStateWriter programStateWriter = new NoOpProgramStateWriter();
+
+    // mock program configurations
+    ProgramId programId = NamespaceId.DEFAULT.app("someapp").program(ProgramType.SERVICE, "s");
+    Map<String, String> systemArguments = new HashMap<>();
+    systemArguments.put(ProgramOptionConstants.SKIP_PROVISIONING, Boolean.TRUE.toString());
+    ProgramOptions programOptions = new SimpleProgramOptions(programId, new BasicArguments(systemArguments),
+                                                             new BasicArguments());
+    ProgramRunId runId = programId.run(RunIds.generate());
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+
+    ProgramStateWriterWithHeartBeat programStateWriterWithHeartBeat =
+      new ProgramStateWriterWithHeartBeat(runId, programStateWriter, 1, programStatePublisher);
+    ApplicationSpecification appSpec = new DefaultApplicationSpecification(
+      "name", "1.0.0", "desc", null, artifactId,
+      Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+      Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+      Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    ProgramDescriptor programDescriptor = new ProgramDescriptor(programId, appSpec);
+
+    // start the program and ensure heart beat is 0 before we call running
+    programStateWriterWithHeartBeat.start(programOptions, null, programDescriptor);
+    Assert.assertEquals(0, ((MockProgramStatePublisher) programStatePublisher).getHeartBeatCount());
+    programStateWriterWithHeartBeat.running(null);
+
+    // on running, we start receiving heart beat messages, verify if we heart beat count goes to 2.
+    Tasks.waitFor(true , () -> ((MockProgramStatePublisher) programStatePublisher).getHeartBeatCount() > 1,
+                  10, TimeUnit.SECONDS, "Didn't receive expected heartbeat after 10 seconds");
+
+    // make sure suspending program suspended the heartbeat thread
+    programStateWriterWithHeartBeat.suspend();
+    Tasks.waitFor(false , () -> programStateWriterWithHeartBeat.isHeartBeatThreadAlive(),
+                  5, TimeUnit.SECONDS, "Heartbeat thread did not stop after 5 seconds");
+    long heartBeatAfterSuspend = ((MockProgramStatePublisher) programStatePublisher).getHeartBeatCount();
+
+    // resume the program and make sure that the heart beat messages goes up after resuming program
+    programStateWriterWithHeartBeat.resume();
+    long expected = heartBeatAfterSuspend + 1;
+    Tasks.waitFor(true , () -> ((MockProgramStatePublisher) programStatePublisher).getHeartBeatCount() > expected,
+                  10, TimeUnit.SECONDS, "Didn't receive expected heartbeat after 10 seconds after resuming program");
+
+    // kill the program and make sure the heart beat thread also gets stopped
+    programStateWriterWithHeartBeat.killed();
+    Tasks.waitFor(false , () -> programStateWriterWithHeartBeat.isHeartBeatThreadAlive(),
+                  5, TimeUnit.SECONDS, "Heartbeat thread did not stop after 5 seconds");
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -345,6 +345,14 @@ public final class Constants {
   }
 
   /**
+   * Program heartbeat store.
+   */
+  public static final class ProgramHeartbeat {
+    public static final String TABLE = "program.heartbeat";
+    public static final String HEARTBEAT_INTERVAL_SECONDS = "program.heartbeat.interval.seconds";
+  }
+
+  /**
    * Plugin Artifacts constants.
    */
   public static final class Plugin {

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3666,4 +3666,12 @@
     </description>
   </property>
 
+  <property>
+    <name>program.heartbeat.interval.seconds</name>
+    <value>1800</value>
+    <description>
+      Interval of heartbeat sent from program while its running, default 30 minutes.
+    </description>
+  </property>
+
 </configuration>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="1fb3b315cebee520b82de26d458728e3"
+DEFAULT_XML_MD5_HASH="54af3020050a16faf325627a1f84ff6c"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Notification.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Notification.java
@@ -46,7 +46,8 @@ public class Notification {
     TIME,
     STREAM_SIZE,
     PARTITION,
-    PROGRAM_STATUS
+    PROGRAM_STATUS,
+    PROGRAM_HEART_BEAT
   }
 
   private final Type notificationType;


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-13352
This covers Part-1 of changes required for CDAP-13352.
Changes
1) API change in ProgramStateWriter lifecycle methods to pass along ProgramOptions, required for  recording relevant additional details about the program status. 
2) Heartbeat thread to send heartbeat type notification while program is running based on configured interval, default : 30 mins


