### PR TITLE
CDAP-13261 Support reading metadata in program (in-prem only) Part 1

### DIFF
--- a/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContextBase.java
+++ b/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContextBase.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -54,7 +55,8 @@ import javax.annotation.Nullable;
  */
 @Beta
 public abstract class JavaSparkExecutionContextBase implements SchedulableProgramContext, RuntimeContext, Transactional,
-                                                               WorkflowInfoProvider, SecureStore {
+                                                               WorkflowInfoProvider,
+                                                               SecureStore, MetadataReader {
 
   /**
    * @return The specification used to configure this {@link Spark} job instance.

--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContextBase.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContextBase.scala
@@ -16,28 +16,25 @@
 
 package co.cask.cdap.api.spark
 
-import co.cask.cdap.api.RuntimeContext
-import co.cask.cdap.api.ServiceDiscoverer
-import co.cask.cdap.api.TaskLocalizationContext
-import co.cask.cdap.api.Transactional
-import co.cask.cdap.api.TxRunnable
+import java.io.IOException
+
+import co.cask.cdap.api.{RuntimeContext, ServiceDiscoverer, TaskLocalizationContext, Transactional, TxRunnable}
 import co.cask.cdap.api.annotation.Beta
 import co.cask.cdap.api.data.batch.Split
 import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.messaging.MessagingContext
+import co.cask.cdap.api.metadata.MetadataReader
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo
 import co.cask.cdap.api.security.store.SecureStore
 import co.cask.cdap.api.spark.dynamic.SparkInterpreter
 import co.cask.cdap.api.stream.GenericStreamEventData
-import co.cask.cdap.api.workflow.WorkflowInfo
-import co.cask.cdap.api.workflow.WorkflowToken
+import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.tephra.TransactionFailureException
-import java.io.IOException
 
 import scala.reflect.ClassTag
 
@@ -100,6 +97,14 @@ trait SparkExecutionContextBase extends RuntimeContext with Transactional {
     * @return A [[co.cask.cdap.api.messaging.MessagingContext]]
     */
   def getMessagingContext: MessagingContext
+
+  /**
+    * Returns a [[co.cask.cdap.api.metadata.MetadataReader]] which can be used to read metadata.
+    * Currently the returned instance can only be used in the Spark driver process.
+    *
+    * @return A [[co.cask.cdap.api.metadata.MetadataReader]]
+    */
+  def getMetadataReader: MetadataReader
 
   /**
     * Returns the [[co.cask.cdap.api.workflow.WorkflowToken]] if the Spark program

--- a/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionContext.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
@@ -31,7 +32,7 @@ import co.cask.cdap.api.workflow.WorkflowInfoProvider;
  * Represents runtime context of the {@link CustomAction} in the Workflow.
  */
 public interface CustomActionContext extends SchedulableProgramContext, RuntimeContext, DatasetContext, Transactional,
-  WorkflowInfoProvider, PluginContext, SecureStore, ServiceDiscoverer, MessagingContext {
+  WorkflowInfoProvider, PluginContext, SecureStore, ServiceDiscoverer, MessagingContext, MetadataReader {
 
   /**
    * Return the specification of the custom action.

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
@@ -21,13 +21,14 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.security.store.SecureStore;
 
 /**
  * This interface represents the Flowlet context.
  */
 public interface FlowletContext extends RuntimeContext, DatasetContext, ServiceDiscoverer,
-  SecureStore, Transactional, MessagingContext {
+  SecureStore, Transactional, MessagingContext, MetadataReader {
   /**
    * @return Number of instances of this flowlet.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
@@ -35,7 +36,8 @@ import co.cask.cdap.api.workflow.WorkflowInfoProvider;
  * MapReduce job execution context.
  */
 public interface MapReduceContext extends SchedulableProgramContext, RuntimeContext, DatasetContext, ServiceDiscoverer,
-  Transactional, PluginContext, ClientLocalizationContext, WorkflowInfoProvider, SecureStore, MessagingContext {
+  Transactional, PluginContext, ClientLocalizationContext, WorkflowInfoProvider, SecureStore, MessagingContext,
+  MetadataReader {
 
   /**
    * @return The specification used to configure this {@link MapReduce} job instance.

--- a/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.metadata;
+
+
+/**
+ * Exception which is thrown when a metadata operation fails
+ */
+public class MetadataException extends Exception {
+  public MetadataException(String message) {
+    super(message);
+  }
+
+  public MetadataException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MetadataException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataReader.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataReader.java
@@ -20,20 +20,24 @@ import java.util.Map;
 /**
  * The context for reading metadata from program
  */
-public interface MetadataReaderContext {
+public interface MetadataReader {
 
   /**
    * Returns a Map of {@link MetadataScope} to {@link Metadata} representing all metadata (including properties
    * and tags) for the specified {@link MetadataEntity} in both {@link MetadataScope#USER} and
    * {@link MetadataScope#SYSTEM}. The map will be empty if the there is no metadata associated with the given
    * metadataEntity.
+   *
+   * @throws MetadataException if the metadata operation fails
    */
-  Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity);
+  Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) throws MetadataException;
 
   /**
    * Returns a {@link Metadata} representing all metadata (including properties and tags) for the specified
    * {@link MetadataEntity} in the specified {@link MetadataScope}. {@link Metadata} will be empty if the there is no
    * metadata associated with the given metadataEntity.
+   *
+   * @throws MetadataException if the metadata operation fails
    */
-  Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity);
+  Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) throws MetadataException;
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataWriter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataWriter.java
@@ -20,7 +20,7 @@ import java.util.Map;
 /**
  * The context for emitting metadata from programs
  */
-public interface MetadataWriterContext {
+public interface MetadataWriter {
 
   /**
    * Adds the specified {@link Map} to the metadata of the specified {@link MetadataEntity metadataEntity}.

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.artifact.ArtifactManager;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -30,7 +31,7 @@ import co.cask.cdap.api.security.store.SecureStore;
  * {@link HttpServiceHandlerSpecification} and the runtime arguments passed by the user.
  */
 public interface HttpServiceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, MessagingContext,
-  PluginContext, SecureStore, Transactional, ArtifactManager {
+  PluginContext, SecureStore, Transactional, ArtifactManager, MetadataReader {
 
   /**
    * @return the specification bound to this HttpServiceContext

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkClientContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkClientContext.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -41,7 +42,7 @@ import java.net.URI;
 @Beta
 public interface SparkClientContext extends SchedulableProgramContext, RuntimeContext, DatasetContext,
   ClientLocalizationContext, Transactional, ServiceDiscoverer, PluginContext, WorkflowInfoProvider,
-  SecureStore, MessagingContext {
+  SecureStore, MessagingContext, MetadataReader {
 
   /**
    * @return The specification used to configure this {@link Spark} job instance.

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -29,7 +30,7 @@ import co.cask.cdap.api.security.store.SecureStore;
  * Context for {@link Worker}.
  */
 public interface WorkerContext extends RuntimeContext, ServiceDiscoverer, StreamWriter, MessagingContext,
-  DatasetContext, PluginContext, Transactional, SecureStore {
+  DatasetContext, PluginContext, Transactional, SecureStore, MetadataReader {
 
   /**
    * Returns the specification used to configure {@link Worker} bounded to this context.

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -34,7 +35,7 @@ import java.util.Map;
  * available to {@link Condition}.
  */
 public interface WorkflowContext extends SchedulableProgramContext, RuntimeContext, Transactional, MessagingContext,
-  ServiceDiscoverer, DatasetContext, PluginContext, SecureStore {
+  ServiceDiscoverer, DatasetContext, PluginContext, SecureStore, MetadataReader {
 
   WorkflowSpecification getWorkflowSpecification();
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramContainerModule.java
@@ -52,6 +52,7 @@ import co.cask.cdap.logging.appender.LogAppender;
 import co.cask.cdap.logging.appender.LogMessage;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.guice.MessagingClientModule;
+import co.cask.cdap.metadata.MetadataReaderWriterModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -154,6 +155,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
     modules.add(new AuditModule().getDistributedModules());
     modules.add(new AuthorizationEnforcementModule().getDistributedModules());
     modules.add(new SecureStoreModules().getDistributedModules());
+    modules.add(new MetadataReaderWriterModules().getDistributedModules());
     modules.add(new AbstractModule() {
       @Override
       protected void configure() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunnerModule.java
@@ -44,6 +44,8 @@ import co.cask.cdap.internal.app.runtime.workflow.WorkflowStateWriter;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.internal.app.store.preview.DefaultPreviewStore;
 import co.cask.cdap.internal.pipeline.SynchronousPipelineFactory;
+import co.cask.cdap.metadata.DefaultMetadataAdmin;
+import co.cask.cdap.metadata.MetadataAdmin;
 import co.cask.cdap.pipeline.PipelineFactory;
 import co.cask.cdap.route.store.LocalRouteStore;
 import co.cask.cdap.route.store.RouteStore;
@@ -135,6 +137,9 @@ public class PreviewRunnerModule extends PrivateModule {
     bind(NamespaceQueryAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
     expose(NamespaceAdmin.class);
     expose(NamespaceQueryAdmin.class);
+
+    bind(MetadataAdmin.class).to(DefaultMetadataAdmin.class);
+    expose(MetadataAdmin.class);
 
     bind(PreviewRunner.class).to(DefaultPreviewRunner.class).in(Scopes.SINGLETON);
     expose(PreviewRunner.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -50,6 +50,7 @@ import co.cask.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
 import co.cask.cdap.internal.provision.ProvisionerModule;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
+import co.cask.cdap.metadata.MetadataReaderWriterModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.artifact.AppRequest;
@@ -231,6 +232,7 @@ public class DefaultPreviewManager implements PreviewManager {
       new LoggingModules().getStandaloneModules(),
       new NamespaceStoreModule().getStandaloneModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new MetadataReaderWriterModules().getInMemoryModules(),
       new ProvisionerModule(),
       new AbstractModule() {
         @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -36,6 +36,11 @@ import co.cask.cdap.api.messaging.MessageFetcher;
 import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataException;
+import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
@@ -120,7 +125,7 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractContext extends AbstractServiceDiscoverer
   implements SecureStore, LineageDatasetContext, Transactional, SchedulableProgramContext, RuntimeContext,
-  PluginContext, MessagingContext, Closeable {
+  PluginContext, MessagingContext, MetadataReader, Closeable {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractContext.class);
   private static final Gson GSON = TriggeringScheduleInfoAdapter.addTypeAdapters(new GsonBuilder())
@@ -148,6 +153,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   private final int defaultTxTimeout;
   private final MessagingService messagingService;
   private final MultiThreadMessagingContext messagingContext;
+  private final MetadataReader metadataReader;
   private volatile ClassLoader programInvocationClassLoader;
   protected final DynamicDatasetCache datasetCache;
   protected final RetryStrategy retryStrategy;
@@ -161,7 +167,8 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
                             @Nullable MetricsCollectionService metricsService, Map<String, String> metricsTags,
                             SecureStore secureStore, SecureStoreManager secureStoreManager,
                             MessagingService messagingService,
-                            @Nullable PluginInstantiator pluginInstantiator) {
+                            @Nullable PluginInstantiator pluginInstantiator,
+                            MetadataReader metadataReader) {
     super(program.getId());
 
     this.artifactId = ProgramRunners.getArtifactId(programOptions);
@@ -215,7 +222,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.secureStore = secureStore;
     this.defaultTxTimeout = determineTransactionTimeout(cConf);
     this.transactional = Transactions.createTransactional(getDatasetCache(), defaultTxTimeout);
-
+    this.metadataReader = metadataReader;
   }
 
   private MetricsCollectionService getMetricsService(CConfiguration cConf, MetricsCollectionService metricsService,
@@ -714,6 +721,16 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
    */
   protected MessagingContext getMessagingContext() {
     return messagingContext;
+  }
+
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) throws MetadataException {
+    return metadataReader.getMetadata(metadataEntity);
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) throws MetadataException {
+    return metadataReader.getMetadata(scope, metadataEntity);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -107,10 +108,10 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
                         @Nullable PluginInstantiator pluginInstantiator,
                         SecureStore secureStore,
                         SecureStoreManager secureStoreManager,
-                        MessagingService messagingService) {
+                        MessagingService messagingService, MetadataReader metadataReader) {
     super(program, programOptions, cConf, spec.getDataSets(), dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
-          messagingService, pluginInstantiator);
+          messagingService, pluginInstantiator, metadataReader);
 
     this.workflowProgramInfo = workflowProgramInfo;
     this.loggingContext = createLoggingContext(program.getId(), getRunId(), workflowProgramInfo);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -31,6 +31,7 @@ import co.cask.cdap.api.messaging.MessageFetcher;
 import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -135,11 +136,12 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                             SecureStoreManager secureStoreManager,
                             AuthorizationEnforcer authorizationEnforcer,
                             AuthenticationContext authenticationContext,
-                            MessagingService messagingService, MapReduceClassLoader mapReduceClassLoader) {
-    super(program, programOptions, cConf, ImmutableSet.<String>of(), dsFramework, txClient, discoveryServiceClient,
+                            MessagingService messagingService, MapReduceClassLoader mapReduceClassLoader,
+                            MetadataReader metadataReader) {
+    super(program, programOptions, cConf, ImmutableSet.of(), dsFramework, txClient, discoveryServiceClient,
           true, metricsCollectionService, createMetricsTags(programOptions,
                                                             taskId, type, workflowProgramInfo), secureStore,
-          secureStoreManager, messagingService, pluginInstantiator);
+          secureStoreManager, messagingService, pluginInstantiator, metadataReader);
     this.cConf = cConf;
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -33,6 +33,10 @@ import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.messaging.MessageFetcher;
 import co.cask.cdap.api.messaging.MessagePublisher;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataException;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo;
@@ -323,5 +327,15 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   public MessageFetcher getMessageFetcher() {
     // TODO: CDAP-7807
     throw new UnsupportedOperationException("Messaging is not supported in MapReduce task-level context");
+  }
+
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) throws MetadataException {
+  return delegate.getMetadata(metadataEntity);
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) throws MetadataException {
+    return delegate.getMetadata(scope, metadataEntity);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.batch;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.mapreduce.MapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -92,6 +93,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final AuthorizationEnforcer authorizationEnforcer;
   private final AuthenticationContext authenticationContext;
   private final MessagingService messagingService;
+  private final MetadataReader metadataReader;
 
   @Inject
   public MapReduceProgramRunner(Injector injector, CConfiguration cConf, Configuration hConf,
@@ -104,7 +106,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                 SecureStore secureStore, SecureStoreManager secureStoreManager,
                                 AuthorizationEnforcer authorizationEnforcer,
                                 AuthenticationContext authenticationContext,
-                                MessagingService messagingService) {
+                                MessagingService messagingService, MetadataReader metadataReader) {
     super(cConf);
     this.injector = injector;
     this.cConf = cConf;
@@ -120,6 +122,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.authorizationEnforcer = authorizationEnforcer;
     this.authenticationContext = authenticationContext;
     this.messagingService = messagingService;
+    this.metadataReader = metadataReader;
   }
 
   @Override
@@ -169,7 +172,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
         new BasicMapReduceContext(program, options, cConf, spec, workflowInfo, discoveryServiceClient,
                                   metricsCollectionService, txSystemClient, programDatasetFramework, streamAdmin,
                                   getPluginArchive(options), pluginInstantiator, secureStore, secureStoreManager,
-                                  messagingService);
+                                  messagingService, metadataReader);
       closeables.add(context);
 
       Reflections.visit(mapReduce, mapReduce.getClass(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.batch;
 
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -177,6 +178,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
     final MessagingService messagingService = injector.getInstance(MessagingService.class);
     // Multiple instances of BasicMapReduceTaskContext can share the same program.
     final AtomicReference<Program> programRef = new AtomicReference<>();
+    final MetadataReader metadataReader = injector.getInstance(MetadataReader.class);
 
     return new CacheLoader<ContextCacheKey, BasicMapReduceTaskContext>() {
       @Override
@@ -247,7 +249,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           spec, workflowInfo, discoveryServiceClient, metricsCollectionService, txClient,
           transaction, programDatasetFramework, classLoader.getPluginInstantiator(),
           contextConfig.getLocalizedResources(), secureStore, secureStoreManager,
-          authorizationEnforcer, authenticationContext, messagingService, mapReduceClassLoader
+          authorizationEnforcer, authenticationContext, messagingService, mapReduceClassLoader, metadataReader
         );
       }
     };

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.customaction;
 import co.cask.cdap.api.ProgramState;
 import co.cask.cdap.api.customaction.CustomActionContext;
 import co.cask.cdap.api.customaction.CustomActionSpecification;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -54,12 +55,12 @@ public class BasicCustomActionContext extends AbstractContext implements CustomA
                                   DiscoveryServiceClient discoveryServiceClient,
                                   @Nullable PluginInstantiator pluginInstantiator,
                                   SecureStore secureStore, SecureStoreManager secureStoreManager,
-                                  MessagingService messagingService) {
+                                  MessagingService messagingService, MetadataReader metadataReader) {
 
     super(workflow, programOptions, cConf, customActionSpecification.getDatasets(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, workflowProgramInfo.updateMetricsTags(new HashMap<String, String>()), secureStore,
-          secureStoreManager, messagingService, pluginInstantiator);
+          secureStoreManager, messagingService, pluginInstantiator, metadataReader);
 
     this.customActionSpecification = customActionSpecification;
     this.workflowProgramInfo = workflowProgramInfo;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.flow;
 
 import co.cask.cdap.api.flow.flowlet.FlowletContext;
 import co.cask.cdap.api.flow.flowlet.FlowletSpecification;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -69,11 +70,12 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
                       SecureStore secureStore,
                       SecureStoreManager secureStoreManager,
                       MessagingService messagingService,
+                      MetadataReader metadataReader,
                       CConfiguration cConf) {
     super(program, programOptions, cConf, datasets, dsFramework, txClient, discoveryServiceClient, false,
           metricsService, ImmutableMap.of(Constants.Metrics.Tag.FLOWLET, flowletId.getFlowlet(),
                                           Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
-          secureStore, secureStoreManager, messagingService, null);
+          secureStore, secureStoreManager, messagingService, null, metadataReader);
 
     this.flowletId = flowletId;
     this.groupId = FlowUtils.generateConsumerGroupId(program.getId(), flowletId.getFlowlet());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -33,6 +33,7 @@ import co.cask.cdap.api.flow.flowlet.FlowletSpecification;
 import co.cask.cdap.api.flow.flowlet.InputContext;
 import co.cask.cdap.api.flow.flowlet.OutputEmitter;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -147,6 +148,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
   private final SecureStore secureStore;
   private final SecureStoreManager secureStoreManager;
   private final MessagingService messageService;
+  private final MetadataReader metadataReader;
 
   @Inject
   public FlowletProgramRunner(CConfiguration cConfiguration,
@@ -162,7 +164,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
                               UsageWriter usageWriter,
                               SecureStore secureStore,
                               SecureStoreManager secureStoreManager,
-                              MessagingService messagingService) {
+                              MessagingService messagingService, MetadataReader metadataReader) {
     this.cConf = cConfiguration;
     this.schemaGenerator = schemaGenerator;
     this.datumWriterFactory = datumWriterFactory;
@@ -177,6 +179,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
     this.messageService = messagingService;
+    this.metadataReader = metadataReader;
   }
 
   @SuppressWarnings("unchecked")
@@ -228,7 +231,8 @@ public final class FlowletProgramRunner implements ProgramRunner {
       flowletContext = new BasicFlowletContext(program, options, flowletId, instanceId, instanceCount,
                                                flowletDef.getDatasets(), flowletDef.getFlowletSpec(),
                                                metricsCollectionService, discoveryServiceClient, txClient,
-                                               dsFramework, secureStore, secureStoreManager, messageService, cConf);
+                                               dsFramework, secureStore, secureStoreManager, messageService,
+                                               metadataReader, cConf);
 
       // Creates tx related objects
       DataFabricFacade dataFabricFacade =

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.service;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.artifact.ArtifactManager;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -69,6 +70,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final SecureStoreManager secureStoreManager;
   private final MessagingService messagingService;
   private final ArtifactManagerFactory artifactManagerFactory;
+  private final MetadataReader metadataReader;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -76,7 +78,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               TransactionSystemClient txClient, ServiceAnnouncer serviceAnnouncer,
                               SecureStore secureStore, SecureStoreManager secureStoreManager,
                               MessagingService messagingService,
-                              ArtifactManagerFactory artifactManagerFactory) {
+                              ArtifactManagerFactory artifactManagerFactory,
+                              MetadataReader metadataReader) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -87,6 +90,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.secureStoreManager = secureStoreManager;
     this.messagingService = messagingService;
     this.artifactManagerFactory = artifactManagerFactory;
+    this.metadataReader = metadataReader;
   }
 
   @Override
@@ -127,7 +131,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           metricsCollectionService, datasetFramework,
                                                           txClient, discoveryServiceClient,
                                                           pluginInstantiator, secureStore, secureStoreManager,
-                                                          messagingService, artifactManager);
+                                                          messagingService, artifactManager, metadataReader);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton((Closeable) pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.service.http;
 import co.cask.cdap.api.artifact.ArtifactInfo;
 import co.cask.cdap.api.artifact.ArtifactManager;
 import co.cask.cdap.api.artifact.CloseableClassLoader;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -32,7 +33,6 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.messaging.MessagingService;
-import co.cask.cdap.proto.id.NamespaceId;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -78,11 +78,11 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
                                  TransactionSystemClient txClient, @Nullable PluginInstantiator pluginInstantiator,
                                  SecureStore secureStore, SecureStoreManager secureStoreManager,
                                  MessagingService messagingService,
-                                 ArtifactManager artifactManager) {
+                                 ArtifactManager artifactManager, MetadataReader metadataReader) {
     super(program, programOptions, cConf, spec == null ? Collections.emptySet() : spec.getDatasets(),
           dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(spec, instanceId),
-          secureStore, secureStoreManager, messagingService, pluginInstantiator);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader);
     this.spec = spec;
     this.instanceId = instanceId;
     this.instanceCount = instanceCount;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.worker;
 
 import co.cask.cdap.api.data.stream.StreamBatchWriter;
 import co.cask.cdap.api.data.stream.StreamWriter;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -68,11 +69,11 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
                      @Nullable PluginInstantiator pluginInstantiator,
                      SecureStore secureStore,
                      SecureStoreManager secureStoreManager,
-                     MessagingService messagingService) {
+                     MessagingService messagingService, MetadataReader metadataReader) {
     super(program, programOptions, cConf, spec.getDatasets(),
           datasetFramework, transactionSystemClient, discoveryServiceClient, true,
           metricsCollectionService, ImmutableMap.of(Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
-          secureStore, secureStoreManager, messagingService, pluginInstantiator);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader);
 
     this.specification = spec;
     this.instanceId = instanceId;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime.worker;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -65,13 +66,14 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final SecureStore secureStore;
   private final SecureStoreManager secureStoreManager;
   private final MessagingService messagingService;
+  private final MetadataReader metadataReader;
 
   @Inject
   public WorkerProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                              DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
                              TransactionSystemClient txClient, StreamWriterFactory streamWriterFactory,
                              SecureStore secureStore, SecureStoreManager secureStoreManager,
-                             MessagingService messagingService) {
+                             MessagingService messagingService, MetadataReader metadataReader) {
     super(cConf);
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
@@ -82,6 +84,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
     this.messagingService = messagingService;
+    this.metadataReader = metadataReader;
   }
 
   @Override
@@ -124,7 +127,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           metricsCollectionService, datasetFramework, txClient,
                                                           discoveryServiceClient, streamWriterFactory,
                                                           pluginInstantiator, secureStore, secureStoreManager,
-                                                          messagingService);
+                                                          messagingService, metadataReader);
 
       WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.ProgramState;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -61,12 +62,13 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
                        DiscoveryServiceClient discoveryServiceClient, Map<String, WorkflowNodeState> nodeStates,
                        @Nullable PluginInstantiator pluginInstantiator,
                        SecureStore secureStore, SecureStoreManager secureStoreManager,
-                       MessagingService messagingService, @Nullable ConditionSpecification conditionSpecification) {
+                       MessagingService messagingService, @Nullable ConditionSpecification conditionSpecification,
+                       MetadataReader metadataReader) {
     super(program, programOptions, cConf, new HashSet(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, Collections.singletonMap(Constants.Metrics.Tag.WORKFLOW_RUN_ID,
                                                              ProgramRunners.getRunId(programOptions).getId()),
-          secureStore, secureStoreManager, messagingService, pluginInstantiator);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader);
     this.workflowSpec = workflowSpec;
     this.conditionSpecification = conditionSpecification;
     this.token = token;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.common.Scope;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -137,6 +138,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   private final SecureStore secureStore;
   private final SecureStoreManager secureStoreManager;
   private final MessagingService messagingService;
+  private final MetadataReader metadataReader;
 
   private volatile Thread runningThread;
   private boolean suspended;
@@ -149,7 +151,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                  TransactionSystemClient txClient, WorkflowStateWriter workflowStateWriter, CConfiguration cConf,
                  @Nullable PluginInstantiator pluginInstantiator, SecureStore secureStore,
                  SecureStoreManager secureStoreManager, MessagingService messagingService,
-                 ProgramStateWriter programStateWriter) {
+                 ProgramStateWriter programStateWriter, MetadataReader metadataReader) {
     this.program = program;
     this.programOptions = options;
     this.workflowSpec = workflowSpec;
@@ -172,7 +174,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                     basicWorkflowToken, program, programOptions, cConf,
                                                     metricsCollectionService, this.datasetFramework, txClient,
                                                     discoveryServiceClient, nodeStates, pluginInstantiator,
-                                                    secureStore, secureStoreManager, messagingService, null);
+                                                    secureStore, secureStoreManager, messagingService, null,
+                                                    metadataReader);
 
     this.loggingContext = new WorkflowLoggingContext(program.getNamespaceId(), program.getApplicationId(),
                                                      program.getName(), workflowRunId.getRun());
@@ -180,6 +183,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
     this.messagingService = messagingService;
+    this.metadataReader = metadataReader;
   }
 
   @Override
@@ -399,7 +403,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                                     metricsCollectionService, datasetFramework,
                                                                     txClient, discoveryServiceClient,
                                                                     pluginInstantiator, secureStore,
-                                                                    secureStoreManager, messagingService);
+                                                                    secureStoreManager, messagingService,
+                                                                    metadataReader);
     customActionExecutor = new CustomActionExecutor(context, instantiator, classLoader);
     status.put(node.getNodeId(), node);
     workflowStateWriter.addWorkflowNodeState(workflowRunId,
@@ -455,7 +460,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                                   cConf, metricsCollectionService, datasetFramework,
                                                                   txClient, discoveryServiceClient, nodeStates,
                                                                   pluginInstantiator, secureStore, secureStoreManager,
-                                                                  messagingService, node.getConditionSpecification());
+                                                                  messagingService, node.getConditionSpecification(),
+                                                                  metadataReader);
     final Iterator<WorkflowNode> iterator;
     Class<?> clz = classLoader.loadClass(node.getPredicateClassName());
     Predicate<WorkflowContext> predicate = instantiator.get(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -65,6 +66,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MessagingService messagingService;
   private final CConfiguration cConf;
   private final ProgramStateWriter programStateWriter;
+  private final MetadataReader metadataReader;
 
   @Inject
   public WorkflowProgramRunner(ProgramRunnerFactory programRunnerFactory,
@@ -72,7 +74,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                DiscoveryServiceClient discoveryServiceClient, TransactionSystemClient txClient,
                                WorkflowStateWriter workflowStateWriter, CConfiguration cConf, SecureStore secureStore,
                                SecureStoreManager secureStoreManager, MessagingService messagingService,
-                               ProgramStateWriter programStateWriter) {
+                               ProgramStateWriter programStateWriter, MetadataReader metadataReader) {
     super(cConf);
     this.programRunnerFactory = programRunnerFactory;
     this.metricsCollectionService = metricsCollectionService;
@@ -85,6 +87,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.messagingService = messagingService;
     this.cConf = cConf;
     this.programStateWriter = programStateWriter;
+    this.metadataReader = metadataReader;
   }
 
   @Override
@@ -119,7 +122,8 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
       WorkflowDriver driver = new WorkflowDriver(program, options, workflowSpec, programRunnerFactory,
                                                  metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                  txClient, workflowStateWriter, cConf, pluginInstantiator,
-                                                 secureStore, secureStoreManager, messagingService, programStateWriter);
+                                                 secureStore, secureStoreManager, messagingService,
+                                                 programStateWriter, metadataReader);
 
       // Controller needs to be created before starting the driver so that the state change of the driver
       // service can be fully captured by the controller.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.TxCallable;
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.artifact.ArtifactManager;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -80,7 +81,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                            @Nullable PluginInstantiator pluginInstantiator,
                            SecureStore secureStore, SecureStoreManager secureStoreManager,
                            MessagingService messagingService,
-                           ArtifactManager artifactManager) {
+                           ArtifactManager artifactManager, MetadataReader metadataReader) {
     super(host, program, programOptions, instanceId, serviceAnnouncer, TransactionControl.IMPLICIT);
 
     this.cConf = cConf;
@@ -89,7 +90,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
     this.contextFactory = createContextFactory(program, programOptions, instanceId, this.instanceCount,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
-                                               messagingService, artifactManager);
+                                               messagingService, artifactManager, metadataReader);
     this.context = contextFactory.create(null);
   }
 
@@ -139,11 +140,12 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                               SecureStore secureStore,
                                                               SecureStoreManager secureStoreManager,
                                                               MessagingService messagingService,
-                                                              ArtifactManager artifactManager) {
+                                                              ArtifactManager artifactManager,
+                                                              MetadataReader metadataReader) {
     return spec -> new BasicHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
-                                               messagingService, artifactManager);
+                                               messagingService, artifactManager, metadataReader);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataReader.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import com.google.inject.Inject;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * <p>{@link MetadataReader} which should be used in local/in-memory mode where {@link MetadataAdmin} can be accessed
+ * directly i.e. the process is running as cdap system user and it can access the {@link MetadataDataset} which belongs
+ * to cdap user.</p>
+ *
+ * <p>This implementation should not be used in distributed program container or any process which is not running as
+ * cdap system user because the dataset operation will fail due to lack of privileges.</p>
+ */
+public class DefaultMetadataReader implements MetadataReader {
+  private final MetadataAdmin metadataAdmin;
+
+  @Inject
+  public DefaultMetadataReader(MetadataAdmin metadataAdmin) {
+    this.metadataAdmin = metadataAdmin;
+  }
+
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
+    Map<MetadataScope, Metadata> scopeMetadata = new HashMap<>();
+    Set<MetadataRecordV2> metadata = metadataAdmin.getMetadata(metadataEntity);
+    metadata.forEach(record -> scopeMetadata.put(record.getScope(),
+                                                 new Metadata(record.getProperties(), record.getTags())));
+    return scopeMetadata;
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
+    final Metadata[] metadata = new Metadata[1];
+    metadataAdmin.getMetadata(scope, metadataEntity).forEach(record -> {
+      if (record.getScope() == scope) {
+        metadata[0] = new Metadata(record.getProperties(), record.getTags());
+      }
+    });
+    return metadata[0];
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataReaderWriterModules.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataReaderWriterModules.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
+import co.cask.cdap.common.metadata.AbstractMetadataClient;
+import co.cask.cdap.common.runtime.RuntimeModule;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+
+/**
+ * Guice binding for {@link MetadataReader} and {@link MetadataWriter} for service binding see
+ * {@link MetadataServiceModule}.
+ */
+public class MetadataReaderWriterModules extends RuntimeModule {
+
+  @Override
+  public Module getInMemoryModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(MetadataReader.class).to(DefaultMetadataReader.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getStandaloneModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(MetadataReader.class).to(DefaultMetadataReader.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getDistributedModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        // CDAP-13610 We should be binding MetadataAdmin which the AbstractMetadataAdmin implements.
+        // Currently AbstractMetadataAdmin is just a gigantic class which has it's own apis which is exposed as
+        // metadata client apis.
+        bind(AbstractMetadataClient.class).to(RemoteMetadataClient.class);
+        // TODO: Bind to cloud implementation in cloud mode. How to check cdap is in cloud mode?
+        bind(MetadataReader.class).to(RemoteMetadataReader.class);
+      }
+    };
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/RemoteMetadataClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/RemoteMetadataClient.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
+import co.cask.cdap.common.internal.remote.RemoteClient;
+import co.cask.cdap.common.metadata.AbstractMetadataClient;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpResponse;
+import com.google.inject.Inject;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Metadata client which should be used in program container to make request to metadata service which is discovered
+ * through {@link DiscoveryServiceClient}.
+ */
+public class RemoteMetadataClient extends AbstractMetadataClient {
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteMetadataClient.class);
+
+  private final RemoteClient remoteClient;
+  private final AuthenticationContext authenticationContext;
+
+  @Inject
+  RemoteMetadataClient(final DiscoveryServiceClient discoveryClient,
+                       AuthenticationContext authenticationContext) {
+    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.METADATA_SERVICE,
+                                         new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
+    this.authenticationContext = authenticationContext;
+  }
+
+  @Override
+  protected HttpResponse execute(HttpRequest request, int... allowedErrorCodes) throws IOException,
+    UnauthorizedException {
+    LOG.trace("Making metadata request {}", request);
+    HttpResponse response = remoteClient.execute(addUserIdHeader(request));
+    LOG.trace("Received response {} for request {}", response, request);
+    return response;
+  }
+
+  @Override
+  protected URL resolve(NamespaceId namespace, String resource) {
+    // this is only required for search which we don't support from program containers as of now
+    throw new UnsupportedOperationException("Namespaced operations is not supported from programs");
+  }
+
+  @Override
+  protected URL resolve(String resource) {
+    URL url = remoteClient.resolve(resource);
+    LOG.trace("Resolved URL {} for resources {}", url, resource);
+    return url;
+  }
+
+  private HttpRequest addUserIdHeader(HttpRequest request) {
+    return new HttpRequest.Builder(request).addHeader(Constants.Security.Headers.USER_ID,
+                                                      authenticationContext.getPrincipal().getName()).build();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/RemoteMetadataReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/RemoteMetadataReader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataException;
+import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.common.metadata.AbstractMetadataClient;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation for {@link MetadataReader} which used {@link RemoteMetadataClient} to read metadata.
+ * This implementation should only be used while running in-prem mode where the {@link MetadataService} is
+ * discoverable.
+ * Note: This implementation should not be used in cloud/local mode.
+ */
+public class RemoteMetadataReader implements MetadataReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteMetadataReader.class);
+
+  private final AbstractMetadataClient metadataClient;
+
+  @Inject
+  public RemoteMetadataReader(AbstractMetadataClient metadataClient) {
+    this.metadataClient = metadataClient;
+  }
+
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) throws MetadataException {
+    Map<MetadataScope, Metadata> scopeMetadata = new HashMap<>();
+    Set<MetadataRecordV2> metadata;
+    try {
+      metadata = metadataClient.getMetadata(metadataEntity);
+    } catch (Exception e) {
+      throw new MetadataException(e);
+    }
+    metadata.forEach(record -> scopeMetadata.put(record.getScope(),
+                                                 new Metadata(record.getProperties(), record.getTags())));
+    LOG.trace("Returning metadata record {} for {}", scopeMetadata, metadataEntity);
+    return scopeMetadata;
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) throws MetadataException {
+    Metadata metadata = getMetadata(metadataEntity).get(scope);
+    LOG.trace("Returning metadata {} for {} in scope {}", metadata, metadataEntity, scope);
+    return metadata;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -41,6 +41,7 @@ import co.cask.cdap.internal.provision.ProvisionerModule;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
+import co.cask.cdap.metadata.MetadataReaderWriterModules;
 import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
@@ -95,6 +96,7 @@ public class DefaultPreviewManagerTest {
       new StreamServiceRuntimeModule().getInMemoryModules(),
       new NamespaceStoreModule().getStandaloneModules(),
       new MetadataServiceModule(),
+      new MetadataReaderWriterModules().getInMemoryModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getStandaloneModules(),
       new SecureStoreModules().getInMemoryModules(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -32,6 +32,9 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.messaging.MessageFetcher;
 import co.cask.cdap.api.messaging.MessagePublisher;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.metrics.NoopMetricsContext;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
@@ -844,6 +847,16 @@ public class HttpHandlerGeneratorTest {
     @Override
     public CloseableClassLoader createClassLoader(ArtifactInfo artifactInfo,
                                                   @Nullable ClassLoader parentClassLoader) throws IOException {
+      return null;
+    }
+
+    @Override
+    public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
+      return null;
+    }
+
+    @Override
+    public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
       return null;
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -40,6 +40,7 @@ import co.cask.cdap.internal.provision.MockProvisionerModule;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
+import co.cask.cdap.metadata.MetadataReaderWriterModules;
 import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
@@ -111,6 +112,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new AuthorizationModule());
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreModules().getInMemoryModules());
+    install(new MetadataReaderWriterModules().getInMemoryModules());
     install(new MessagingServerRuntimeModule().getInMemoryModules());
     install(new MockProvisionerModule());
   }

--- a/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/testclasses/StreamBatchSource.java
+++ b/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/testclasses/StreamBatchSource.java
@@ -28,6 +28,7 @@ import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.metadata.Metadata;
 import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataException;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.stream.GenericStreamEventData;
@@ -40,6 +41,7 @@ import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -145,7 +147,12 @@ public class StreamBatchSource extends BatchSource<LongWritable, Object, Structu
   }
 
   private void propogateMetadata(BatchRuntimeContext context, MetadataEntity source, MetadataEntity destination) {
-    Metadata metadata = context.getMetadata(MetadataScope.USER, source);
+    Metadata metadata;
+    try {
+      metadata = context.getMetadata(MetadataScope.USER, source);
+    } catch (MetadataException e) {
+      throw Throwables.propagate(e);
+    }
     context.addProperties(destination, metadata.getProperties());
     context.addTags(destination, metadata.getTags());
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageContext.java
@@ -19,8 +19,8 @@ package co.cask.cdap.etl.api;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.api.metadata.MetadataReaderContext;
-import co.cask.cdap.api.metadata.MetadataWriterContext;
+import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.plugin.PluginProperties;
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
  * Context for a pipeline stage, providing access to information about the stage, metrics, and plugins.
  */
 @Beta
-public interface StageContext extends ServiceDiscoverer, MetadataReaderContext, MetadataWriterContext {
+public interface StageContext extends ServiceDiscoverer, MetadataReader, MetadataWriter {
 
   /**
    * Gets the unique stage name.

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
@@ -28,6 +28,10 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.messaging.MessageFetcher;
 import co.cask.cdap.api.messaging.MessagePublisher;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataException;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
@@ -395,5 +399,15 @@ final class BasicSparkClientContext implements SparkClientContext {
 
   boolean isPySpark() {
     return getPySparkScript() != null || getPySparkScriptLocation() != null;
+  }
+
+  @Override
+  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) throws MetadataException {
+    return sparkRuntimeContext.getMetadata(metadataEntity);
+  }
+
+  @Override
+  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) throws MetadataException {
+    return sparkRuntimeContext.getMetadata(scope, metadataEntity);
   }
 }

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -102,6 +103,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
   private final MessagingService messagingService;
   private final ServiceAnnouncer serviceAnnouncer;
   private final PluginFinder pluginFinder;
+  private final MetadataReader metadataReader;
 
   @Inject
   SparkProgramRunner(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
@@ -111,7 +113,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                      SecureStore secureStore, SecureStoreManager secureStoreManager,
                      AuthorizationEnforcer authorizationEnforcer, AuthenticationContext authenticationContext,
                      MessagingService messagingService, ServiceAnnouncer serviceAnnouncer,
-                     PluginFinder pluginFinder) {
+                     PluginFinder pluginFinder, MetadataReader metadataReader) {
     super(cConf);
     this.cConf = cConf;
     this.hConf = hConf;
@@ -128,6 +130,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
     this.messagingService = messagingService;
     this.serviceAnnouncer = serviceAnnouncer;
     this.pluginFinder = pluginFinder;
+    this.metadataReader = metadataReader;
   }
 
   @Override
@@ -177,7 +180,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                                                                    pluginInstantiator, secureStore, secureStoreManager,
                                                                    authorizationEnforcer, authenticationContext,
                                                                    messagingService, serviceAnnouncer, pluginFinder,
-                                                                   locationFactory);
+                                                                   locationFactory, metadataReader);
       closeables.addFirst(runtimeContext);
 
       Spark spark;

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.app.runtime.spark;
 
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -92,10 +93,11 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
                       AuthorizationEnforcer authorizationEnforcer,
                       AuthenticationContext authenticationContext,
                       MessagingService messagingService, ServiceAnnouncer serviceAnnouncer,
-                      PluginFinder pluginFinder, LocationFactory locationFactory) {
+                      PluginFinder pluginFinder, LocationFactory locationFactory,
+                      MetadataReader metadataReader) {
     super(program, programOptions, cConf, getSparkSpecification(program).getDatasets(), datasetFramework, txClient,
           discoveryServiceClient, true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
-          secureStore, secureStoreManager, messagingService, pluginInstantiator);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader);
     this.cConf = cConf;
     this.hConf = hConf;
     this.hostname = hostname;

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -257,7 +258,8 @@ public final class SparkRuntimeContextProvider {
         injector.getInstance(MessagingService.class),
         serviceAnnouncer,
         injector.getInstance(PluginFinder.class),
-        injector.getInstance(LocationFactory.class)
+        injector.getInstance(LocationFactory.class),
+        injector.getInstance(MetadataReader.class)
       );
       LoggingContextAccessor.setLoggingContext(sparkRuntimeContext.getLoggingContext());
       return sparkRuntimeContext;

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
@@ -26,6 +26,7 @@ import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.dataset.Dataset
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.messaging.MessagingContext
+import co.cask.cdap.api.metadata.MetadataReader
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.preview.DataTracer
@@ -222,6 +223,8 @@ abstract class AbstractSparkExecutionContext(sparkClassLoader: SparkClassLoader,
 
   // TODO: CDAP-7807. Returns one that is serializable
   override def getMessagingContext: MessagingContext = runtimeContext
+
+  override def getMetadataReader: MetadataReader = runtimeContext
 
   override def getPluginContext: PluginContext = new SparkPluginContext(runtimeContext)
 

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.batch.Split
 import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.messaging.MessagingContext
+import co.cask.cdap.api.metadata.{Metadata, MetadataEntity, MetadataReader, MetadataScope}
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.preview.DataTracer
@@ -254,6 +255,13 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
       .mapPartitions(createStreamMap(decoderClass))
   }
 
+  override def getMetadata(metadataEntity: MetadataEntity): util.Map[MetadataScope, Metadata] = {
+    return sec.getMetadataReader.getMetadata(metadataEntity);
+  }
+
+  override def getMetadata(scope: MetadataScope, metadataEntity: MetadataEntity): Metadata = {
+    return sec.getMetadataReader.getMetadata(scope, metadataEntity);
+  }
 }
 
 /**

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -110,6 +110,8 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
 
   override def getMessagingContext = delegate.getMessagingContext
 
+  override def getMetadataReader = delegate.getMetadataReader
+
   override def getPluginContext = delegate.getPluginContext
 
   override def getMetrics = delegate.getMetrics

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -63,6 +63,7 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
 import co.cask.cdap.messaging.server.MessagingHttpService;
+import co.cask.cdap.metadata.MetadataReaderWriterModules;
 import co.cask.cdap.metadata.MetadataService;
 import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metadata.MetadataSubscriberService;
@@ -495,6 +496,7 @@ public class StandaloneMain {
       new StreamAdminModules().getStandaloneModules(),
       new NamespaceStoreModule().getStandaloneModules(),
       new MetadataServiceModule(),
+      new MetadataReaderWriterModules().getStandaloneModules(),
       new AuditModule().getStandaloneModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getStandaloneModules(),

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -85,6 +85,9 @@ import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.messaging.context.BasicMessagingAdmin;
 import co.cask.cdap.messaging.context.MultiThreadMessagingContext;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
+import co.cask.cdap.metadata.MetadataReaderWriterModules;
+import co.cask.cdap.metadata.MetadataService;
+import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.metrics.query.MetricsQueryService;
@@ -254,6 +257,8 @@ public class TestBase {
       new ServiceStoreModules().getInMemoryModules(),
       new ProgramRunnerRuntimeModule(LocalStreamWriter.class).getInMemoryModules(),
       new SecureStoreModules().getInMemoryModules(),
+      new MetadataReaderWriterModules().getInMemoryModules(),
+      new MetadataServiceModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithMetadataPrograms.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithMetadataPrograms.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataException;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.api.service.BasicService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.UnauthenticatedException;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * App which has programs interacting with cdap metadata for tests
+ */
+public class AppWithMetadataPrograms extends AbstractApplication {
+  public static final String APP_NAME = "AppWithMetadataPrograms";
+  static final String METADATA_SERVICE_NAME = "MetadataService";
+  static final String METADATA_SERVICE_DATASET = "MetadataServiceDataset";
+
+  @Override
+  public void configure() {
+    setName(APP_NAME);
+    addService(new BasicService(METADATA_SERVICE_NAME, new MetadataHandler()));
+  }
+
+  public static final class MetadataHandler extends AbstractHttpServiceHandler {
+    @GET
+    @Path("metadata/{dataset}")
+    public void ping(HttpServiceRequest request, HttpServiceResponder responder,
+                     @PathParam("dataset") String dataset) {
+      Map<MetadataScope, Metadata> metadata = null;
+      try {
+        metadata = getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+      } catch (MetadataException e) {
+        if (e.getCause() instanceof UnauthorizedException) {
+          responder.sendStatus(((UnauthorizedException) e.getCause()).getStatusCode());
+        } else if (e.getCause() instanceof UnauthenticatedException) {
+          responder.sendStatus(((UnauthenticatedException) e.getCause()).getStatusCode());
+        } else if (e.getCause() instanceof BadRequestException) {
+          responder.sendStatus(((BadRequestException) e.getCause()).getStatusCode());
+        } else {
+          responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+        }
+      }
+      responder.sendJson(HttpResponseStatus.OK.code(), metadata);
+    }
+
+    @Override
+    protected void configure() {
+      createDataset(METADATA_SERVICE_DATASET, KeyValueTable.class);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds support for reading metadata in CDAP programs
- In 5.0 read is only supported in in-prem mode and not cloud mode.
- For the in-prem mode the implementation of MetadataReaderContext uses MetadataAdmin to get the metadata directly from the store.
- Added a unit test where a `service` reads the metadata

## Misc
- Part 2 will add support for emitting metadata to TMS (broken down to keep pr small)
- Part 3 will add more extensive unit tests which will have unit tests for all the programs reading and writing metadata (broken down to keep pr small)
- Currently, have tested modified PurchaseHistoryBuilder `mapreduce` job being able to access metadata in standalone and in-prem (single node).

## Tasks:
- [x] Build: https://builds.cask.co/browse/CDAP-DUT6497-2
- [x] Integration Tests:
- [x] Test on multinode cluster
- [ ] Test behavior inside spark's closures 