### PR TITLE
CDAP-13358 rename 'default' profile to 'native'

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultEntityEnsurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultEntityEnsurer.java
@@ -68,7 +68,7 @@ public final class DefaultEntityEnsurer extends AbstractService {
         }
 
         try {
-          profileService.createIfNotExists(ProfileId.DEFAULT, Profile.DEFAULT);
+          profileService.createIfNotExists(ProfileId.NATIVE, Profile.NATIVE);
         } catch (Exception e) {
           failed = true;
           if (failureException == null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -296,7 +296,7 @@ public class ProgramLifecycleService {
     LOG.info("{} tries to run {} Program {}", authenticationContext.getPrincipal().getName(), programId.getType(),
              programId.getProgram());
     ProfileId profileId =
-      SystemArguments.getProfileIdFromArgs(programId.getNamespaceId(), userArgs).orElse(ProfileId.DEFAULT);
+      SystemArguments.getProfileIdFromArgs(programId.getNamespaceId(), userArgs).orElse(ProfileId.NATIVE);
     Profile profile = profileService.getProfile(profileId);
     if (profile.getStatus() == ProfileStatus.DISABLED) {
       throw new ProfileConflictException(String.format("Profile %s in namespace %s is disabled. It cannot be " +
@@ -316,11 +316,11 @@ public class ProgramLifecycleService {
     // add the rest of the profile properties to system properties
     SystemArguments.addProfileArgs(systemArgs, profile);
 
-    // Set the ClusterMode. If it is DEFAULT profile, then it is ON_PREMISE, otherwise is ISOLATED
+    // Set the ClusterMode. If it is NATIVE profile, then it is ON_PREMISE, otherwise is ISOLATED
     // This should probably move into the provisioner later once we have a better contract for the
     // provisioner to actually pick what launching mechanism it wants to use.
     systemArgs.put(ProgramOptionConstants.CLUSTER_MODE,
-                   (ProfileId.DEFAULT.equals(profileId) ? ClusterMode.ON_PREMISE : ClusterMode.ISOLATED).name());
+                   (ProfileId.NATIVE.equals(profileId) ? ClusterMode.ON_PREMISE : ClusterMode.ISOLATED).name());
 
     ProgramOptions programOptions = new SimpleProgramOptions(programId, new BasicArguments(systemArgs),
                                                              new BasicArguments(userArgs), debug);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/config/UserPreferencesStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/config/UserPreferencesStoreTest.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.config;
 
-import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ProfileConflictException;
 import co.cask.cdap.common.id.Id;
@@ -276,7 +275,7 @@ public class UserPreferencesStoreTest extends AppFabricTestBase {
 
     // add the profile and disable it
     ProfileId profileId = new ProfileId("myspace", "userProfile");
-    profileStore.saveProfile(profileId, Profile.DEFAULT);
+    profileStore.saveProfile(profileId, Profile.NATIVE);
     profileStore.disableProfile(profileId);
 
     // this set call should fail since the profile is disabled

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/SystemArgumentsTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/SystemArgumentsTest.java
@@ -168,18 +168,18 @@ public class SystemArgumentsTest {
     Assert.assertFalse(SystemArguments.getProfileIdFromArgs(NamespaceId.DEFAULT, args).isPresent());
 
     // without scope the profile will be considered in user scope
-    args.put("system.profile.name", "MyProfile");
     ProfileId expected = NamespaceId.DEFAULT.profile("MyProfile");
+    args.put("system.profile.name", expected.getProfile());
     Assert.assertEquals(expected, SystemArguments.getProfileIdFromArgs(NamespaceId.DEFAULT, args).get());
 
     // put a profile with scope SYSTEM, the profile we get should be in system namespace
-    args.put("system.profile.name", "SYSTEM:MyProfile");
     expected = NamespaceId.SYSTEM.profile("MyProfile");
+    args.put("system.profile.name", expected.getScopedName());
     Assert.assertEquals(expected, SystemArguments.getProfileIdFromArgs(NamespaceId.DEFAULT, args).get());
 
     // put a profile with scope USER, the profile we get should be in the user namespace
-    args.put("system.profile.name", "USER:MyProfile");
     expected = NamespaceId.DEFAULT.profile("MyProfile");
+    args.put("system.profile.name", expected.getScopedName());
     Assert.assertEquals(expected, SystemArguments.getProfileIdFromArgs(NamespaceId.DEFAULT, args).get());
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -542,7 +542,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
   public void testDeployAppWithDisabledProfileInSchedule() throws Exception {
     // put my profile and disable it
     ProfileId profileId = new NamespaceId(TEST_NAMESPACE1).profile("MyProfile");
-    putProfile(profileId, Profile.DEFAULT, 200);
+    putProfile(profileId, Profile.NATIVE, 200);
     disableProfile(profileId, 200);
 
     // deploy an app with schedule with some disabled profile in the schedule property

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerTest.java
@@ -178,7 +178,7 @@ public class PreferencesHttpHandlerTest extends AppFabricTestBase {
   public void testSetPreferenceWithProfiles() throws Exception {
     // put my profile
     ProfileId myProfile = new ProfileId(TEST_NAMESPACE1, "MyProfile");
-    putProfile(myProfile, Profile.DEFAULT, 200);
+    putProfile(myProfile, Profile.NATIVE, 200);
 
     // put some properties with my profile, it should work fine
     Map<String, String> properties = new HashMap<>();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProfileHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProfileHttpHandlerTest.java
@@ -57,11 +57,11 @@ public class ProfileHttpHandlerTest extends AppFabricTestBase {
     // try to list all profiles including system namespace before putting a new one, there should only exist a default
     // profile
     profiles = listProfiles(NamespaceId.DEFAULT, true, 200);
-    Assert.assertEquals(Collections.singletonList(Profile.DEFAULT), profiles);
+    Assert.assertEquals(Collections.singletonList(Profile.NATIVE), profiles);
 
     // test get single profile endpoint
-    Profile defaultProfile = getProfile(NamespaceId.SYSTEM.profile("default"), 200).get();
-    Assert.assertEquals(Profile.DEFAULT, defaultProfile);
+    Profile defaultProfile = getProfile(ProfileId.NATIVE, 200).get();
+    Assert.assertEquals(Profile.NATIVE, defaultProfile);
 
     // get a nonexisting profile should get a not found code
     getProfile(NamespaceId.DEFAULT.profile("nonExisting"), 404);
@@ -86,7 +86,7 @@ public class ProfileHttpHandlerTest extends AppFabricTestBase {
 
     // list all profiles, should get 2 profiles
     List<Profile> profiles = listProfiles(NamespaceId.DEFAULT, true, 200);
-    Set<Profile> expectedList = ImmutableSet.of(Profile.DEFAULT, expected);
+    Set<Profile> expectedList = ImmutableSet.of(Profile.NATIVE, expected);
     Assert.assertEquals(expectedList.size(), profiles.size());
     Assert.assertEquals(expectedList, new HashSet<>(profiles));
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1278,7 +1278,7 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
   public void testStartProgramWithDisabledRuntimeArgs() throws Exception {
     // We will use default profile now for testing since we treat it as on premise and all other profiles as isolated
     // See ProgramLifeCycleService runInternal() method for more information
-    disableProfile(ProfileId.DEFAULT, 200);
+    disableProfile(ProfileId.NATIVE, 200);
 
     // deploy, check the status
     deploy(AppWithWorkflow.class, 200, Constants.Gateway.API_VERSION_3_TOKEN,
@@ -1291,12 +1291,12 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(STOPPED, getProgramStatus(programId));
 
     // start workflow should give a 409 since we have a runtime argument associated with a disabled profile
-    ImmutableMap<String, String> args = ImmutableMap.of(SystemArguments.PROFILE_NAME, "SYSTEM:default");
+    ImmutableMap<String, String> args = ImmutableMap.of(SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
     startProgram(programId, args, 409);
     Assert.assertEquals(STOPPED, getProgramStatus(programId));
 
     // enable the profile and flow should be able to start
-    enableProfile(ProfileId.DEFAULT, 200);
+    enableProfile(ProfileId.NATIVE, 200);
 
     // start a flow and check the status
     startProgram(programId, args, 200);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileServiceTest.java
@@ -91,10 +91,10 @@ public class ProfileServiceTest {
     profileService.saveProfile(profileId2, profile2);
 
     // add default profile
-    profileService.saveProfile(ProfileId.DEFAULT, Profile.DEFAULT);
+    profileService.saveProfile(ProfileId.NATIVE, Profile.NATIVE);
 
     // get all profiles
-    List<Profile> profiles = ImmutableList.of(expected, profile2, Profile.DEFAULT);
+    List<Profile> profiles = ImmutableList.of(expected, profile2, Profile.NATIVE);
     Assert.assertEquals(profiles, profileService.getProfiles(NamespaceId.DEFAULT, true));
 
     // by default the profile status should be enabled

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
@@ -249,7 +249,7 @@ public class ProvisioningServiceTest {
     Map<String, String> systemArgs = new HashMap<>();
     Map<String, String> userArgs = new HashMap<>();
 
-    Profile profile = new Profile(ProfileId.DEFAULT.getProfile(), "desc", provisionerInfo);
+    Profile profile = new Profile(ProfileId.NATIVE.getProfile(), "desc", provisionerInfo);
     SystemArguments.addProfileArgs(systemArgs, profile);
     ProgramOptions programOptions = new SimpleProgramOptions(programRunId.getParent(),
                                                              new BasicArguments(systemArgs),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/scheduler/CoreSchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/scheduler/CoreSchedulerServiceTest.java
@@ -434,7 +434,7 @@ public class CoreSchedulerServiceTest extends AppFabricTestBase {
   public void testAddScheduleWithDisabledProfile() throws Exception {
     // put my profile and by default it is enabled
     ProfileId profileId = NS_ID.profile("MyProfile");
-    putProfile(profileId, Profile.DEFAULT, 200);
+    putProfile(profileId, Profile.NATIVE, 200);
 
     // add a schedule, it should succeed since the profile is enabled.
     ProgramSchedule tsched1 =

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProfileId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProfileId.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Uniquely identifies an artifact.
  */
 public class ProfileId extends NamespacedEntityId implements ParentedId<NamespaceId> {
-  public static final ProfileId DEFAULT = NamespaceId.SYSTEM.profile("default");
+  public static final ProfileId NATIVE = NamespaceId.SYSTEM.profile("native");
   private final String profileName;
   private transient Integer hashCode;
 
@@ -58,6 +58,17 @@ public class ProfileId extends NamespacedEntityId implements ParentedId<Namespac
   @Override
   public Iterable<String> toIdParts() {
     return Collections.unmodifiableList(Arrays.asList(namespace, profileName));
+  }
+
+  /**
+   * Return the scoped name. If it is a system profile, the profile name will be prefixed by 'SYSTEM:'. Otherwise,
+   * the profile name will be prefixed by 'USER:'.
+   *
+   * @return the scoped profile name
+   */
+  public String getScopedName() {
+    EntityScope scope = NamespaceId.SYSTEM.equals(getNamespaceId()) ? EntityScope.SYSTEM : EntityScope.USER;
+    return String.format("%s:%s", scope.name(), profileName);
   }
 
   @SuppressWarnings("unused")

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/profile/Profile.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/profile/Profile.java
@@ -28,9 +28,9 @@ import java.util.Objects;
  * environment. A profile is identified by name and must be assigned a provisioner and its related configuration.
  */
 public class Profile {
-  public static final Profile DEFAULT = new Profile("default", "Runs programs locally on the cluster",
-                                                    EntityScope.SYSTEM,
-                                                    new ProvisionerInfo("yarn", Collections.emptyList()));
+  public static final Profile NATIVE = new Profile("native", "Runs programs locally on the cluster",
+                                                   EntityScope.SYSTEM,
+                                                   new ProvisionerInfo("yarn", Collections.emptyList()));
   private final String name;
   private final String description;
   private final EntityScope scope;

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
@@ -38,7 +38,7 @@ export const isSystemProfile = (name = '') => name.indexOf('system:') === 0;
 // NOTE: This is never actually saved to backend. This is hardcoded here until we figure out a 
 // clean way to add `system.profiles.name` to namespace preference. If there is no `system.profiles.name` set
 // at namespace or app level UI show "default" profile selected
-export const DEFAULT_PROFILE_NAME = 'system:default';
+export const DEFAULT_PROFILE_NAME = 'system:native';
 
 export default class ProfilesListViewInPipeline extends Component {
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -362,7 +362,7 @@ public class TestBase {
       // but does not remove it entirely
       namespaceAdmin.create(NamespaceMeta.DEFAULT);
       ProfileService profileService = injector.getInstance(ProfileService.class);
-      profileService.saveProfile(ProfileId.DEFAULT, Profile.DEFAULT);
+      profileService.saveProfile(ProfileId.NATIVE, Profile.NATIVE);
     }
     secureStore = injector.getInstance(SecureStore.class);
     secureStoreManager = injector.getInstance(SecureStoreManager.class);


### PR DESCRIPTION
This rename is to avoid confusion, since the word default has
meaning about how a profile is used, but not what the profile is.
For example, the default profile for a namespace is actually
whatever profile is set for that namespace, which might be a user
created profile. Changing it to 'native' so that it describes
what the profile does.