### PR TITLE
CDAP-13088 Make metadata version independent

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -889,8 +889,7 @@ public class CLIMainTest extends CLITestBase {
     Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
     output = getCommandOutput(cli, "search metadata fake* filtered by target-type dataset,stream,app");
     lines = Arrays.asList(output.split("\\r?\\n"));
-    expected = ImmutableList.of("Entity", FAKE_DS_ID.toString(), FAKE_STREAM_ID.toString(), FAKE_APP_ID.toString(),
-                                FAKE_APP_ID_V_1.toString());
+    expected = ImmutableList.of("Entity", FAKE_DS_ID.toString(), FAKE_STREAM_ID.toString(), FAKE_APP_ID.toString());
     Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
     output = getCommandOutput(cli, "search metadata wfTag* filtered by target-type program");
     lines = Arrays.asList(output.split("\\r?\\n"));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -185,8 +185,8 @@ public abstract class EntityId {
       // application so append it
       extractedParts.add(new MetadataEntity.KeyValue(MetadataEntity.VERSION, version));
     }
-    if (entityType == EntityType.PROGRAM) {
-      // if the entity is program the add the version information at its correct position i.e. 2
+    if (entityType == EntityType.PROGRAM || entityType == EntityType.SCHEDULE) {
+      // if the entity is program or schedule then add the version information at its correct position i.e. 2
       // (namespace, application, version) if the version information is not present
       if (!metadataEntity.containsKey(MetadataEntity.VERSION)) {
         extractedParts.add(2, new MetadataEntity.KeyValue(MetadataEntity.VERSION, version));

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
@@ -290,8 +290,15 @@ public class EntityIdTest {
     ProgramId programId = new ProgramId(applicationId, ProgramType.WORKER, "testWorker");
     Assert.assertEquals(programId, EntityId.fromMetadataEntity(programId.toMetadataEntity()));
 
+    // artifact
     ArtifactId artifactId = new ArtifactId("testNs", "testArtifact-1.0.0.jar");
     Assert.assertEquals(artifactId, EntityId.fromMetadataEntity(artifactId.toMetadataEntity()));
+
+    // schedule
+    ScheduleId scheduleId = applicationId.schedule("sch");
+    metadataEntity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "testNs")
+      .append(MetadataEntity.APPLICATION, "app1").appendAsType(MetadataEntity.SCHEDULE, "sch").build();
+    Assert.assertEquals(scheduleId, EntityId.fromMetadataEntity(metadataEntity));
   }
 
   @Test


### PR DESCRIPTION
- Keep metadata version independent
- The version key is not stored as the part of the metadata key

Also see: https://issues.cask.co/browse/CDAP-13597

Build: https://builds.cask.co/browse/CDAP-DUT6500-1