### PR TITLE
[CDAP-13263] Consume Metadata Changes from TMS

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -36,8 +36,6 @@ import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Set;
@@ -46,7 +44,6 @@ import java.util.Set;
  * Implementation of {@link MetadataAdmin} that interacts directly with {@link MetadataStore}.
  */
 public class DefaultMetadataAdmin implements MetadataAdmin {
-  private static final Logger LOG = LoggerFactory.getLogger(DefaultMetadataAdmin.class);
 
   private static final CharMatcher KEY_AND_TAG_MATCHER = CharMatcher.inRange('A', 'Z')
     .or(CharMatcher.inRange('a', 'z'))
@@ -84,7 +81,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   }
 
   @Override
-  public void addTags(MetadataEntity metadataEntity, String... tags) throws InvalidMetadataException {
+  public void addTags(MetadataEntity metadataEntity, Set<String> tags) throws InvalidMetadataException {
     validateTags(metadataEntity, tags);
     metadataStore.addTags(MetadataScope.USER, metadataEntity, tags);
   }
@@ -130,7 +127,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   }
 
   @Override
-  public void removeProperties(MetadataEntity metadataEntity, String... keys) {
+  public void removeProperties(MetadataEntity metadataEntity, Set<String> keys) {
     metadataStore.removeProperties(MetadataScope.USER, metadataEntity, keys);
   }
 
@@ -140,7 +137,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   }
 
   @Override
-  public void removeTags(MetadataEntity metadataEntity, String... tags) {
+  public void removeTags(MetadataEntity metadataEntity, Set<String> tags) {
     metadataStore.removeTags(MetadataScope.USER, metadataEntity, tags);
   }
 
@@ -164,6 +161,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
    */
   private MetadataSearchResponseV2 filterAuthorizedSearchResult(final MetadataSearchResponseV2 results)
     throws Exception {
+    //noinspection ConstantConditions
     return new MetadataSearchResponseV2(
       results.getSort(), results.getOffset(), results.getLimit(), results.getNumCursors(), results.getTotal(),
       // For authorization either use the known entity and if it is custom entity do enforcement on the parent.
@@ -190,7 +188,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
     }
   }
 
-  private void validateTags(MetadataEntity metadataEntity, String... tags) throws InvalidMetadataException {
+  private void validateTags(MetadataEntity metadataEntity, Set<String> tags) throws InvalidMetadataException {
     for (String tag : tags) {
       validateKeyAndTagsFormat(metadataEntity, tag);
       validateLength(metadataEntity, tag);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -52,7 +52,7 @@ public interface MetadataAdmin {
    *
    * @throws InvalidMetadataException if some of the properties violate metadata validation rules
    */
-  void addTags(MetadataEntity metadataEntity, String... tags) throws InvalidMetadataException;
+  void addTags(MetadataEntity metadataEntity, Set<String> tags) throws InvalidMetadataException;
 
   /**
    * Returns a set of {@link MetadataRecordV2} representing all metadata (including properties and tags) for the
@@ -115,7 +115,7 @@ public interface MetadataAdmin {
    * @param metadataEntity the {@link MetadataEntity} to remove the specified properties for
    * @param keys the metadata property keys to remove
    */
-  void removeProperties(MetadataEntity metadataEntity, String... keys);
+  void removeProperties(MetadataEntity metadataEntity, Set<String> keys);
 
   /**
    * Removes all tags from the specified {@link MetadataEntity}. This API only supports removing tags in
@@ -132,7 +132,7 @@ public interface MetadataAdmin {
    * @param metadataEntity the {@link MetadataEntity} to remove the specified tags for
    * @param tags the tags to remove
    */
-  void removeTags(MetadataEntity metadataEntity, String ... tags);
+  void removeTags(MetadataEntity metadataEntity, Set<String> tags);
 
   /**
    * Executes a search for CDAP entities in the specified namespace with the specified search query and

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -19,7 +19,6 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.app.store.Store;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.entity.EntityExistenceVerifier;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
@@ -130,20 +129,16 @@ public class LineageAdminTest extends AppFabricTestBase {
     metadataStore.setProperties(MetadataScope.USER, program1.getParent().toMetadataEntity(),
                                 run1AppMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, program1.getParent().toMetadataEntity(),
-                          run1AppMeta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, program1.getParent().toMetadataEntity(), run1AppMeta.getTags());
     metadataStore.setProperties(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, program1.toMetadataEntity(),
-                          run1ProgramMeta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getTags());
     metadataStore.setProperties(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, dataset1.toMetadataEntity(),
-                          run1Data1Meta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getTags());
     metadataStore.setProperties(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, dataset2.toMetadataEntity(),
-                          run1Data2Meta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getTags());
 
     // Add accesses for D3 -> P2 -> D2 -> P1 -> D1 <-> P3
     // We need to use current time here as metadata store stores access time using current time
@@ -596,20 +591,16 @@ public class LineageAdminTest extends AppFabricTestBase {
     metadataStore.setProperties(MetadataScope.USER, program1.getParent().toMetadataEntity(),
                                 run1AppMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, program1.getParent().toMetadataEntity(),
-                          run1AppMeta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, program1.getParent().toMetadataEntity(), run1AppMeta.getTags());
     metadataStore.setProperties(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, program1.toMetadataEntity(),
-                          run1ProgramMeta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getTags());
     metadataStore.setProperties(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, dataset1.toMetadataEntity(),
-                          run1Data1Meta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getTags());
     metadataStore.setProperties(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, dataset2.toMetadataEntity(),
-                          run1Data2Meta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getTags());
 
     // Add accesses for D3 -> P2 -> D2 -> P1 -> D1 <-> P3
     // We need to use current time here as metadata store stores access time using current time
@@ -821,7 +812,7 @@ public class LineageAdminTest extends AppFabricTestBase {
 
   private static final class NoOpEntityExistenceVerifier implements EntityExistenceVerifier<EntityId> {
     @Override
-    public void ensureExists(EntityId entityId) throws NotFoundException {
+    public void ensureExists(EntityId entityId) {
       // no-op
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2017 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -69,7 +69,7 @@ public interface MetadataStore {
    * @param metadataEntity the {@link MetadataEntity} to add the tags to
    * @param tagsToAdd the tags to add
    */
-  void addTags(MetadataScope scope, MetadataEntity metadataEntity, String... tagsToAdd);
+  void addTags(MetadataScope scope, MetadataEntity metadataEntity, Set<String> tagsToAdd);
 
   /**
    * @return a set of {@link MetadataRecordV2} representing all the metadata (including properties and tags) for the
@@ -143,7 +143,7 @@ public interface MetadataStore {
    * @param metadataEntity the {@link MetadataEntity} to remove the specified keys for
    * @param keys the keys to remove
    */
-  void removeProperties(MetadataScope scope, MetadataEntity metadataEntity, String... keys);
+  void removeProperties(MetadataScope scope, MetadataEntity metadataEntity, Set<String> keys);
 
   /**
    * Removes tags of the {@link MetadataEntity} in the specified {@link MetadataScope}.
@@ -160,7 +160,7 @@ public interface MetadataStore {
    * @param metadataEntity the {@link MetadataEntity} to remove the specified tags for
    * @param tagsToRemove the tags to remove
    */
-  void removeTags(MetadataScope scope, MetadataEntity metadataEntity, String ... tagsToRemove);
+  void removeTags(MetadataScope scope, MetadataEntity metadataEntity, Set<String> tagsToRemove);
 
   /**
    * Search the Metadata Dataset for the specified target types in both {@link MetadataScope#USER} and
@@ -190,16 +190,6 @@ public interface MetadataStore {
                                   Set<EntityScope> entityScope);
 
   /**
-   * Returns the snapshot of the metadata for entities on or before the given time in both {@link MetadataScope#USER}
-   * and {@link MetadataScope#SYSTEM}.
-   *
-   * @param metadataEntitys entity ids
-   * @param timeMillis time in milliseconds
-   * @return the snapshot of the metadata for entities on or before the given time
-   */
-  Set<MetadataRecordV2> getSnapshotBeforeTime(Set<MetadataEntity> metadataEntitys, long timeMillis);
-
-  /**
    * Returns the snapshot of the metadata for entities on or before the given time in the specified
    * {@link MetadataScope}.
    *
@@ -215,11 +205,6 @@ public interface MetadataStore {
    * Rebuild stale metadata indexes.
    */
   void rebuildIndexes(MetadataScope scope, RetryStrategy retryStrategy);
-
-  /**
-   * Delete all existing metadata indexes.
-   */
-  void deleteAllIndexes(MetadataScope scope) throws DatasetManagementException, IOException;
 
   /**
    * Creates the MetadataDataset if its not already created. Otherwise, upgrades it if required.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 Cask Data, Inc.
+ * Copyright 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,7 +15,6 @@
  */
 package co.cask.cdap.data2.metadata.store;
 
-import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
@@ -24,10 +23,8 @@ import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
-import co.cask.cdap.proto.metadata.MetadataSearchResultRecordV2;
 import com.google.common.collect.ImmutableSet;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +46,7 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void addTags(MetadataScope scope, MetadataEntity metadataEntity, String... tagsToAdd) {
+  public void addTags(MetadataScope scope, MetadataEntity metadataEntity, Set<String> tagsToAdd) {
     // NO-OP
   }
 
@@ -105,7 +102,7 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void removeProperties(MetadataScope scope, MetadataEntity metadataEntity, String... keys) {
+  public void removeProperties(MetadataScope scope, MetadataEntity metadataEntity, Set<String> keys) {
     // NO-OP
   }
 
@@ -115,7 +112,7 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void removeTags(MetadataScope scope, MetadataEntity metadataEntity, String... tagsToRemove) {
+  public void removeTags(MetadataScope scope, MetadataEntity metadataEntity, Set<String> tagsToRemove) {
     // NO-OP
   }
 
@@ -125,16 +122,8 @@ public class NoOpMetadataStore implements MetadataStore {
                                          SortInfo sort, int offset, int limit, int numCursors, String cursor,
                                          boolean showHidden, Set<EntityScope> entityScope) {
     return new MetadataSearchResponseV2(sort.toString(), offset, limit, numCursors, 0,
-                                        Collections.<MetadataSearchResultRecordV2>emptySet(),
-                                        Collections.<String>emptyList(), showHidden, entityScope);
-  }
-
-  @Override
-  public Set<MetadataRecordV2> getSnapshotBeforeTime(Set<MetadataEntity> metadataEntities, long timeMillis) {
-    return ImmutableSet.<MetadataRecordV2>builder()
-      .addAll(getSnapshotBeforeTime(MetadataScope.USER, metadataEntities, timeMillis))
-      .addAll(getSnapshotBeforeTime(MetadataScope.SYSTEM, metadataEntities, timeMillis))
-      .build();
+                                        Collections.emptySet(),
+                                        Collections.emptyList(), showHidden, entityScope);
   }
 
   @Override
@@ -153,22 +142,17 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void deleteAllIndexes(MetadataScope scope) {
+  public void createOrUpgrade(MetadataScope scope) {
     // NO-OP
   }
 
   @Override
-  public void createOrUpgrade(MetadataScope scope) throws DatasetManagementException, IOException {
-    return;
+  public void markUpgradeComplete(MetadataScope scope) {
+    // NO-OP
   }
 
   @Override
-  public void markUpgradeComplete(MetadataScope scope) throws DatasetManagementException, IOException {
-    return;
-  }
-
-  @Override
-  public boolean isUpgradeRequired(MetadataScope scope) throws DatasetManagementException {
+  public boolean isUpgradeRequired(MetadataScope scope) {
     return false;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -80,7 +80,7 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
    *
    * @return an array of tags to add to this {@link NamespacedEntityId entity} in {@link MetadataScope#SYSTEM}
    */
-  protected abstract String[] getSystemTagsToAdd();
+  protected abstract Set<String> getSystemTagsToAdd();
 
   /**
    * Define the {@link MetadataScope#SYSTEM system} schema to add for this entity.
@@ -101,8 +101,7 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
     Set<String> existingProperties = metadataStore.getProperties(MetadataScope.SYSTEM, metadataEntity).keySet();
     Sets.SetView<String> removeProperties = Sets.difference(existingProperties, PRESERVE_PROPERTIES);
     if (!removeProperties.isEmpty()) {
-      String[] propertiesArray = removeProperties.toArray(new String[removeProperties.size()]);
-      metadataStore.removeProperties(MetadataScope.SYSTEM, metadataEntity, propertiesArray);
+      metadataStore.removeProperties(MetadataScope.SYSTEM, metadataEntity, removeProperties);
     }
     metadataStore.removeTags(MetadataScope.SYSTEM, metadataEntity);
 
@@ -116,8 +115,8 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
     if (allProperties.size() > 0) {
       metadataStore.setProperties(MetadataScope.SYSTEM, metadataEntity, allProperties);
     }
-    String[] tags = getSystemTagsToAdd();
-    if (tags.length > 0) {
+    Set<String> tags = getSystemTagsToAdd();
+    if (!tags.isEmpty()) {
       metadataStore.addTags(MetadataScope.SYSTEM, metadataEntity, tags);
     }
     // store additional properties that we want to index separately

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AppSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AppSystemMetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,6 +29,7 @@ import co.cask.cdap.proto.id.ApplicationId;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -81,10 +82,8 @@ public class AppSystemMetadataWriter extends AbstractSystemMetadataWriter {
   }
 
   @Override
-  protected String[] getSystemTagsToAdd() {
-    return new String[] {
-      appSpec.getArtifactId().getName()
-    };
+  protected Set<String> getSystemTagsToAdd() {
+    return Collections.singleton(appSpec.getArtifactId().getName());
   }
 
   private void addPrograms(ImmutableMap.Builder<String, String> properties) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ArtifactSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ArtifactSystemMetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,7 +25,9 @@ import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.id.ArtifactId;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A {@link AbstractSystemMetadataWriter} for an {@link Id.Artifact artifact}.
@@ -57,7 +59,7 @@ public class ArtifactSystemMetadataWriter extends AbstractSystemMetadataWriter {
   }
 
   @Override
-  protected String[] getSystemTagsToAdd() {
-    return new String[] { };
+  protected Set<String> getSystemTagsToAdd() {
+    return Collections.emptySet();
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -36,9 +36,9 @@ import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -110,8 +110,8 @@ public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
   }
 
   @Override
-  protected String[] getSystemTagsToAdd() {
-    List<String> tags = new ArrayList<>();
+  protected Set<String> getSystemTagsToAdd() {
+    Set<String> tags = new HashSet<>();
     if (dataset instanceof RecordScannable) {
       tags.add(EXPLORE_TAG);
     }
@@ -131,7 +131,7 @@ public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
     if (isLocalDataset) {
       tags.add(LOCAL_DATASET_TAG);
     }
-    return tags.toArray(new String[tags.size()]);
+    return tags;
   }
 
   @Nullable

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ProgramSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ProgramSystemMetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,12 +25,10 @@ import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -66,13 +64,12 @@ public class ProgramSystemMetadataWriter extends AbstractSystemMetadataWriter {
   }
 
   @Override
-  protected String[] getSystemTagsToAdd() {
-    List<String> tags = ImmutableList.<String>builder()
+  protected Set<String> getSystemTagsToAdd() {
+    return ImmutableSet.<String>builder()
       .add(programId.getType().getPrettyName())
       .add(getMode())
       .addAll(getWorkflowNodes())
       .build();
-    return tags.toArray(new String[tags.size()]);
   }
 
   private String getMode() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,7 +22,9 @@ import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -62,10 +64,8 @@ public class StreamSystemMetadataWriter extends AbstractSystemMetadataWriter {
   }
 
   @Override
-  protected String[] getSystemTagsToAdd() {
-    return new String[] {
-      EXPLORE_TAG
-    };
+  protected Set<String> getSystemTagsToAdd() {
+    return Collections.singleton(EXPLORE_TAG);
   }
 
   @Nullable

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,7 +28,9 @@ import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -59,10 +61,8 @@ public class ViewSystemMetadataWriter extends AbstractSystemMetadataWriter {
   }
 
   @Override
-  protected String[] getSystemTagsToAdd() {
-    return new String[] {
-      viewId.getStream()
-    };
+  protected Set<String> getSystemTagsToAdd() {
+    return Collections.singleton(viewId.getStream());
   }
 
   @Nullable

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MessagingMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MessagingMetadataWriter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.service.Retries;
+import co.cask.cdap.common.service.RetryStrategies;
+import co.cask.cdap.common.service.RetryStrategy;
+import co.cask.cdap.data2.metadata.writer.MetadataMessage.Type;
+import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.messaging.StoreRequest;
+import co.cask.cdap.messaging.client.StoreRequestBuilder;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.gson.Gson;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+/**
+ * An implementation of {@link LineageWriter} that publish lineage information to TMS.
+ */
+public class MessagingMetadataWriter implements MetadataWriter {
+
+  private static final Gson GSON = new Gson();
+
+  private final TopicId topic;
+  private final MessagingService messagingService;
+  private final RetryStrategy retryStrategy;
+
+  @Inject
+  MessagingMetadataWriter(CConfiguration cConf, MessagingService messagingService) {
+    this.topic = NamespaceId.SYSTEM.topic(cConf.get(Constants.Metadata.MESSAGING_TOPIC));
+    this.messagingService = messagingService;
+    this.retryStrategy = RetryStrategies.fromConfiguration(cConf, "system.metadata.");
+  }
+
+  @Override
+  public void add(ProgramRunId run, MetadataEntity entity,
+                  @Nullable Map<String, String> propertiesToAdd,
+                  @Nullable Set<String> tagsToAdd) {
+    Metadata metadata = new Metadata(propertiesToAdd != null ? propertiesToAdd : Collections.emptyMap(),
+                                     tagsToAdd != null ? tagsToAdd : Collections.emptySet());
+    MetadataOperation operation = new MetadataOperation(entity, MetadataOperation.Type.PUT, metadata);
+    publish(run, operation);
+  }
+
+  @Override
+  public void remove(ProgramRunId run, MetadataEntity entity,
+                     @Nullable Set<String> propertiesToDelete,
+                     @Nullable Set<String> tagsToDelete) {
+    Map<String, String> props = new HashMap<>();
+    if (propertiesToDelete != null) {
+      propertiesToDelete.forEach(prop -> props.put(prop, ""));
+    }
+    Metadata metadata = new Metadata(props, tagsToDelete != null ? tagsToDelete : Collections.emptySet());
+    MetadataOperation operation = new MetadataOperation(entity, MetadataOperation.Type.DELETE, metadata);
+    publish(run, operation);
+  }
+
+  private void publish(ProgramRunId programRunId, MetadataOperation operation) {
+    MetadataMessage message = new MetadataMessage(Type.METADATA_OPERATION, programRunId, GSON.toJsonTree(operation));
+    StoreRequest request = StoreRequestBuilder.of(topic).addPayloads(GSON.toJson(message)).build();
+    try {
+      Retries.callWithRetries(() -> messagingService.publish(request), retryStrategy, Retries.ALWAYS_TRUE);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to publish metadata operation: " + operation, e);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataMessage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataMessage.java
@@ -37,7 +37,8 @@ public final class MetadataMessage {
     LINEAGE,
     USAGE,
     WORKFLOW_TOKEN,
-    WORKFLOW_STATE
+    WORKFLOW_STATE,
+    METADATA_OPERATION
   }
 
   private final Type type;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataOperation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataOperation.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+
+/**
+ * Represents a meta data operation - either a put or a delete - for an entity.
+ * <ul>
+ *   <li>
+ *     For a put, the metadata to be added is given as a {@link Metadata} object.
+ *   </li><li>
+ *     For a delete, the {@link Metadata} contains the tags to be deleted, and an
+ *     entry in the properties for each property to be deleted (the values are
+ *     ignored).
+ *   </li>
+ * </ul>
+ */
+public class MetadataOperation {
+
+  /**
+   * Type of the operation:
+   * <ul><li>
+   *   PUT for adding metadata;
+   * </li><li>
+   *   DELETE for removing metadata.
+   * </li></ul>
+   */
+  public enum Type { PUT, DELETE }
+
+  private final MetadataEntity entity;
+  private final Type type;
+  private final Metadata metadata;
+
+  public MetadataOperation(MetadataEntity entity, Type type, Metadata metadata) {
+    this.entity = entity;
+    this.type = type;
+    this.metadata = metadata;
+  }
+
+  public MetadataEntity getEntity() {
+    return entity;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public Metadata getMetadata() {
+    return metadata;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataWriter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.proto.id.ProgramRunId;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Record metadata for entities.
+ */
+public interface MetadataWriter {
+
+  /**
+   * Add metadata for an entity.
+   */
+  void add(ProgramRunId run, MetadataEntity entity,
+           @Nullable Map<String, String> propertiesToAdd,
+           @Nullable Set<String> tagsToAdd);
+
+  /**
+   * Delete metadata for an entity.
+   */
+  void remove(ProgramRunId run, MetadataEntity entity,
+              @Nullable Set<String> propertiesToDelete,
+              @Nullable Set<String> tagsToDelete);
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Cask Data, Inc.
+ * Copyright 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -581,7 +581,7 @@ public class  MetadataDatasetTest {
                           Sets.newHashSet(results));
 
       // Using empty filter should also search for all target types
-      results = searchByDefaultIndex("ns1", "  valu*  sVal* ", ImmutableSet.<EntityTypeSimpleName>of());
+      results = searchByDefaultIndex("ns1", "  valu*  sVal* ", ImmutableSet.of());
       Assert.assertEquals(Sets.newHashSet(flowEntry1, flowEntry2, streamEntry1, streamEntry2),
                           Sets.newHashSet(results));
     });
@@ -692,13 +692,13 @@ public class  MetadataDatasetTest {
     txnl.execute(() -> {
       Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key1", "value1")),
                           searchByDefaultIndex(flow1.getValue(MetadataEntity.NAMESPACE), "value1",
-                                               ImmutableSet.<EntityTypeSimpleName>of()));
+                                               Collections.emptySet()));
       Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key2", "value2")),
                           searchByDefaultIndex(flow1.getValue(MetadataEntity.NAMESPACE), "value2",
-                                               ImmutableSet.<EntityTypeSimpleName>of()));
+                                               Collections.emptySet()));
       Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, MetadataDataset.TAGS_KEY, "tag1,tag2")),
                           searchByDefaultIndex(flow1.getValue(MetadataEntity.NAMESPACE), "tag2",
-                                               ImmutableSet.<EntityTypeSimpleName>of()));
+                                               Collections.emptySet()));
     });
 
     // Update key1
@@ -712,15 +712,15 @@ public class  MetadataDatasetTest {
       // Searching for value1 should be empty
       Assert.assertEquals(ImmutableList.of(),
                           searchByDefaultIndex(flow1.getValue(MetadataEntity.NAMESPACE), "value1",
-                                               ImmutableSet.<EntityTypeSimpleName>of()));
+                                               Collections.emptySet()));
       // Instead key1 has value value3 now
       Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key1", "value3")),
                           searchByDefaultIndex(flow1.getValue(MetadataEntity.NAMESPACE), "value3",
-                                               ImmutableSet.<EntityTypeSimpleName>of()));
+                                               Collections.emptySet()));
       // key2 was deleted
       Assert.assertEquals(ImmutableList.of(),
                           searchByDefaultIndex(flow1.getValue(MetadataEntity.NAMESPACE), "value2",
-                                               ImmutableSet.<EntityTypeSimpleName>of()));
+                                               Collections.emptySet()));
       // tag2 was deleted
       Assert.assertEquals(
         ImmutableList.of(),
@@ -1077,7 +1077,7 @@ public class  MetadataDatasetTest {
   }
 
   private void assertSingleIndex(final MetadataDataset dataset, final String indexColumn, final String namespaceId,
-                                 final String value) throws InterruptedException, TransactionFailureException {
+                                 final String value) {
     final String searchQuery = namespaceId + MetadataDataset.KEYVALUE_SEPARATOR + value;
     try (Scanner scan = dataset.searchByIndex(indexColumn, searchQuery)) {
       Assert.assertNotNull(scan.next());
@@ -1285,10 +1285,12 @@ public class  MetadataDatasetTest {
     return ImmutableMap.of(prefix + k1, v1);
   }
 
+  @SuppressWarnings("SameParameterValue")
   private Map<String, String> toProps(String prefix, String k1, String v1, String k2, String v2) {
     return ImmutableMap.of(prefix + k1, v1, prefix + k2, v2);
   }
 
+  @SuppressWarnings("SameParameterValue")
   private Map<String, String>
   toProps(String prefix, String k1, String v1, String k2, String v2, String k3, String v3) {
     return ImmutableMap.of(prefix + k1, v1, prefix + k2, v2, prefix + k3, v3);


### PR DESCRIPTION
- adds a new message type METADATA_OPERATION
- adds a MetadataWriter interface and an implementation that emits to TMS 
- and a message processor to consume that. It delegates to MetadataAdmin
- adds unit test for the new message type