### PR TITLE
CDAP-13601 Added rules for field lineage endpoints in RouterPathLookup.

### DIFF
--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -114,7 +114,9 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       // SecureStoreHandler
       endsWith(uriParts, "metadata", "properties") || endsWith(uriParts, "metadata", "properties", "?") ||
       endsWith(uriParts, "metadata", "tags") || endsWith(uriParts, "metadata", "tags", "?") ||
-      endsWith(uriParts, "metadata", "search") || endsWith(uriParts, "lineage"))) {
+      endsWith(uriParts, "metadata", "search") ||
+      matches(uriParts, "v3", "namespaces", null, "datasets", null, "lineage") ||
+      matches(uriParts, "v3", "namespaces", null, "streams", null, "lineage"))) {
       return METADATA_SERVICE;
     } else if (matches(uriParts, "v3", "security", "authorization") ||
       matches(uriParts, "v3", "namespaces", null, "securekeys")) {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathLookupTest.java
@@ -389,6 +389,12 @@ public class RouterPathLookupTest {
     // get metadata for accesses
     assertRouting("/v3/namespaces/default//apps/WordCount/flows/WordCountFlow/runs/runid/metadata",
                   RouterPathLookup.METADATA_SERVICE);
+
+    // test field lineage path
+    assertRouting("/v3/namespaces/default/datasets/ds1/lineage/fields", RouterPathLookup.METADATA_SERVICE);
+    assertRouting("/v3/namespaces/default/datasets/ds1/lineage/fields/field1", RouterPathLookup.METADATA_SERVICE);
+    assertRouting("/v3/namespaces/default/datasets/ds1/lineage/fields/field1/operations",
+                  RouterPathLookup.METADATA_SERVICE);
   }
 
   @Test


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13601