### PR TITLE
CDAP-13593 No need to start/stop SystemArtifactLoader service when running preview.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,7 +32,6 @@ import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.internal.app.deploy.ProgramTerminator;
 import co.cask.cdap.internal.app.runtime.AbstractListener;
-import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.services.ApplicationLifecycleService;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.ProgramNotificationSubscriberService;
@@ -87,7 +86,6 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
   private final DatasetService datasetService;
   private final LogAppenderInitializer logAppenderInitializer;
   private final ApplicationLifecycleService applicationLifecycleService;
-  private final SystemArtifactLoader systemArtifactLoader;
   private final ProgramRuntimeService programRuntimeService;
   private final ProgramLifecycleService programLifecycleService;
   private final PreviewStore previewStore;
@@ -108,7 +106,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
   DefaultPreviewRunner(MessagingService messagingService, DatasetService datasetService,
                        LogAppenderInitializer logAppenderInitializer,
                        ApplicationLifecycleService applicationLifecycleService,
-                       SystemArtifactLoader systemArtifactLoader, ProgramRuntimeService programRuntimeService,
+                       ProgramRuntimeService programRuntimeService,
                        ProgramLifecycleService programLifecycleService,
                        PreviewStore previewStore, DataTracerFactory dataTracerFactory,
                        NamespaceAdmin namespaceAdmin, ProgramStore programStore,
@@ -118,7 +116,6 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     this.datasetService = datasetService;
     this.logAppenderInitializer = logAppenderInitializer;
     this.applicationLifecycleService = applicationLifecycleService;
-    this.systemArtifactLoader = systemArtifactLoader;
     this.programRuntimeService = programRuntimeService;
     this.programLifecycleService = programLifecycleService;
     this.previewStore = previewStore;
@@ -263,7 +260,6 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
                                                                        Constants.Service.PREVIEW_HTTP));
     Futures.allAsList(
       applicationLifecycleService.start(),
-      systemArtifactLoader.start(),
       programRuntimeService.start(),
       metricsCollectionService.start(),
       programNotificationSubscriberService.start()
@@ -285,7 +281,6 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     }
     programRuntimeService.stopAndWait();
     applicationLifecycleService.stopAndWait();
-    systemArtifactLoader.stopAndWait();
     logAppenderInitializer.close();
     metricsCollectionService.stopAndWait();
     programNotificationSubscriberService.stopAndWait();


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13593

Since we already share the ArtifactManager instance with the real space, no need to start/stop SystemArtifactLoader while running preview. If timing of stopping the SystemArtifactLoader matches with it performing transaction, transaction manager dies with the following snippet of exception - 

```java
2018-06-26 00:00:22,650 - ERROR [Endure-Service-:o.a.t.TransactionManager@743] - Aborting transaction manager due to: Error appending to transaction log
java.nio.channels.ClosedByInterruptException: null
        at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202) ~[na:1.8.0_151]
        at sun.nio.ch.FileChannelImpl.position(FileChannelImpl.java:269) ~[na:1.8.0_151]
        at org.apache.tephra.persist.LocalFileTransactionLog$LogWriter.getPosition(LocalFileTransactionLog.java:75) ~[org.apache.tephra.tephra-core-0.13.0-incubating.jar:0.13.0-incubating]
        at 
...
at co.cask.cdap.internal.app.runtime.artifact.ArtifactStore.getArtifacts(ArtifactStore.java:256) [na:na]
        at co.cask.cdap.internal.app.runtime.artifact.DefaultArtifactRepository.createParentClassLoader(DefaultArtifactRepository.java:531) [na:na]
        at co.cask.cdap.internal.app.runtime.artifact.DefaultArtifactRepository.addArtifact(DefaultArtifactRepository.java:263) [na:na]
        at co.cask.cdap.internal.app.runtime.artifact.DefaultArtifactRepository.addSystemArtifact(DefaultArtifactRepository.java:453) [na:na]
        at co.cask.cdap.internal.app.runtime.artifact.DefaultArtifactRepository.addSystemArtifacts(DefaultArtifactRepository.java:396) [na:na]
```
Verified that preview runs fine and no exception is seen in the log related to the loading artifact.
