### PR TITLE
CDAP-13614 avoid a guaranteed NPE when task state is not found

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
@@ -297,7 +297,7 @@ public class ProvisioningService extends AbstractIdleService {
     ProvisioningTaskInfo existing =
       provisionerDataset.getTaskInfo(new ProvisioningTaskKey(programRunId, ProvisioningOp.Type.PROVISION));
     if (existing == null) {
-      runWithProgramLogging(programRunId, existing.getProgramOptions().getArguments().asMap(),
+      runWithProgramLogging(programRunId, Collections.emptyMap(),
                             () -> LOG.error("No task state found while deprovisioning the cluster. "
                                               + "The cluster will be marked as orphaned."));
 


### PR DESCRIPTION
We don't expect the task state to be missing, but will fix that
in a follow up PR.