### PR TITLE
CDAP-13521 fix profile property override

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -297,7 +297,8 @@ public class ProgramLifecycleService {
              programId.getProgram());
     ProfileId profileId =
       SystemArguments.getProfileIdFromArgs(programId.getNamespaceId(), userArgs).orElse(ProfileId.NATIVE);
-    Profile profile = profileService.getProfile(profileId);
+    Map<String, String> profileProperties = SystemArguments.getProfileProperties(userArgs);
+    Profile profile = profileService.getProfile(profileId, profileProperties);
     if (profile.getStatus() == ProfileStatus.DISABLED) {
       throw new ProfileConflictException(String.format("Profile %s in namespace %s is disabled. It cannot be " +
                                                          "used to start the program %s",
@@ -308,12 +309,9 @@ public class ProgramLifecycleService {
     if (spec == null) {
       throw new NotFoundException(String.format("Provisioner '%s' not found.", profile.getProvisioner().getName()));
     }
-    // add profile properties to the system arguments
-    Map<String, String> systemArgs = new HashMap<>();
-    systemArgs.putAll(sysArgs);
     // get and add any user overrides for profile properties
-    systemArgs.putAll(SystemArguments.getProfileProperties(userArgs));
-    // add the rest of the profile properties to system properties
+    Map<String, String> systemArgs = new HashMap<>(sysArgs);
+    // add profile properties to the system arguments
     SystemArguments.addProfileArgs(systemArgs, profile);
 
     // Set the ClusterMode. If it is NATIVE profile, then it is ON_PREMISE, otherwise is ISOLATED

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProfileHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProfileHttpHandlerTest.java
@@ -26,7 +26,6 @@ import co.cask.cdap.proto.provisioner.ProvisionerInfo;
 import co.cask.cdap.proto.provisioner.ProvisionerPropertyValue;
 import co.cask.cdap.runtime.spi.profile.ProfileStatus;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,8 +40,8 @@ import java.util.Set;
  * Unit tests for profile http handler
  */
 public class ProfileHttpHandlerTest extends AppFabricTestBase {
-  private static final List<ProvisionerPropertyValue> PROPERTY_SUMMARIES =
-    ImmutableList.<ProvisionerPropertyValue>builder()
+  private static final Set<ProvisionerPropertyValue> PROPERTY_SUMMARIES =
+    ImmutableSet.<ProvisionerPropertyValue>builder()
       .add(new ProvisionerPropertyValue("1st property", "1st value", false))
       .add(new ProvisionerPropertyValue("2nd property", "2nd value", true))
       .add(new ProvisionerPropertyValue("3rd property", "3rd value", false))
@@ -162,7 +161,7 @@ public class ProfileHttpHandlerTest extends AppFabricTestBase {
     // Get the profile, it should not contain the null value, the property should be an empty list
     Profile actual = getProfile(NamespaceId.DEFAULT.profile(profile.getName()), 200).get();
     Assert.assertNotNull(actual);
-    Assert.assertEquals(Collections.EMPTY_LIST, actual.getProvisioner().getProperties());
+    Assert.assertEquals(Collections.EMPTY_SET, actual.getProvisioner().getProperties());
 
     disableProfile(NamespaceId.DEFAULT.profile(profile.getName()), 200);
     deleteProfile(NamespaceId.DEFAULT.profile(profile.getName()), 200);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/profile/Profile.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/profile/Profile.java
@@ -100,4 +100,15 @@ public class Profile {
   public int hashCode() {
     return Objects.hash(name, description, scope, provisioner);
   }
+
+  @Override
+  public String toString() {
+    return "Profile{" +
+      "name='" + name + '\'' +
+      ", description='" + description + '\'' +
+      ", scope=" + scope +
+      ", status=" + status +
+      ", provisioner=" + provisioner +
+      '}';
+  }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerInfo.java
@@ -19,6 +19,7 @@ package co.cask.cdap.proto.provisioner;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -26,19 +27,19 @@ import java.util.stream.Collectors;
  */
 public class ProvisionerInfo {
   private final String name;
-  private final Collection<ProvisionerPropertyValue> properties;
+  private final Set<ProvisionerPropertyValue> properties;
 
   public ProvisionerInfo(String name, Collection<ProvisionerPropertyValue> properties) {
     this.name = name;
-    this.properties = Collections.unmodifiableList(
-      properties.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+    this.properties = Collections.unmodifiableSet(
+      properties.stream().filter(Objects::nonNull).collect(Collectors.toSet()));
   }
 
   public String getName() {
     return name;
   }
 
-  public Collection<ProvisionerPropertyValue> getProperties() {
+  public Set<ProvisionerPropertyValue> getProperties() {
     return properties;
   }
 
@@ -60,5 +61,13 @@ public class ProvisionerInfo {
   @Override
   public int hashCode() {
     return Objects.hash(name, properties);
+  }
+
+  @Override
+  public String toString() {
+    return "ProvisionerInfo{" +
+      "name='" + name + '\'' +
+      ", properties=" + properties +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerPropertyValue.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerPropertyValue.java
@@ -65,4 +65,13 @@ public class ProvisionerPropertyValue {
   public int hashCode() {
     return Objects.hash(name, value, isEditable);
   }
+
+  @Override
+  public String toString() {
+    return "ProvisionerPropertyValue{" +
+      "name='" + name + '\'' +
+      ", value='" + value + '\'' +
+      ", isEditable=" + isEditable +
+      '}';
+  }
 }


### PR DESCRIPTION
Fixed a bug where profile properties provided at runtime were not
correctly overriding whatever currently exists in the profile.
In addition, properties not set in the profile were being ignored
completely.

Added a method to ProfileService to do the property overrides and
added a unit test for it.