### PR TITLE
[CDAP-13613] Fixes bower registry to be the new one

### DIFF
--- a/cdap-ui/.bowerrc
+++ b/cdap-ui/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "registry": "https://registry.bower.io"
+}

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -151,6 +151,7 @@
                   <exclude>**/*.svg</exclude>
                   <exclude>**/*__mocks__/**</exclude>
                   <exclude>**/bower_components/**</exclude>
+                  <exclude>**/*.bowerrc</exclude>
                   <exclude>**/node_modules/**</exclude>
                   <exclude>**/coverage/**</exclude>
                   <exclude>**/dist/**</exclude>


### PR DESCRIPTION
Same PR as https://github.com/caskdata/cdap/pull/10241 but for develop