### PR TITLE
CDAP-13297 implement program stop during provisioning

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -482,16 +482,24 @@ public class AppMetadataStore extends MetadataStoreDataset {
     ProgramRunClusterStatus clusterStatus = existing.getCluster().getStatus();
     delete(existing);
     key.add(getInvertedTsKeyPart(existing.getStartTs())).add(programRunId.getRun()).build();
+    ProgramRunStatus programStatus = existing.getStatus();
 
-    // if the previous state was provisioning, that means we've transitioned here from a failure
-    ProgramRunStatus newStatus = clusterStatus == ProgramRunClusterStatus.PROVISIONING ?
-      ProgramRunStatus.FAILED : existing.getStatus();
+    // if the previous state was provisioning, that means we've transitioned here from a failure or from a stop
+    // if we've transitioned here from a stop, the program run status will be killed. This is because the deprovisioning
+    // message is sent by the subscriber that processed the killed message.
+    // if we've transitioned here from a failure, the program run status will be pending,
+    // which needs to be transitioned to failed. In this case, the provisioning service sent the message.
+    // TODO: (CDAP-13539) state transitions should be computed in a single place and not in the storage layer
+    ProgramRunStatus newProgramStatus = existing.getStatus();
+    if (clusterStatus == ProgramRunClusterStatus.PROVISIONING && programStatus == ProgramRunStatus.PENDING) {
+      newProgramStatus = ProgramRunStatus.FAILED;
+    }
     ProgramRunCluster cluster = new ProgramRunCluster(ProgramRunClusterStatus.DEPROVISIONING, null,
                                                       existing.getCluster().getNumNodes());
     RunRecordMeta meta = RunRecordMeta.builder(existing)
       .setCluster(cluster)
       .setSourceId(sourceId)
-      .setStatus(newStatus)
+      .setStatus(newProgramStatus)
       .build();
     write(key.build(), meta);
     LOG.trace("Recorded {} for program {}", ProgramRunClusterStatus.DEPROVISIONING, programRunId);
@@ -798,7 +806,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
    */
   @Nullable
   public RunRecordMeta recordProgramStop(ProgramRunId programRunId, long stopTs, ProgramRunStatus runStatus,
-                                            @Nullable BasicThrowable failureCause, byte[] sourceId) {
+                                         @Nullable BasicThrowable failureCause, byte[] sourceId) {
     MDSKey.Builder builder = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent());
     return recordProgramStop(programRunId, stopTs, runStatus, failureCause, builder, sourceId);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningOp.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningOp.java
@@ -48,7 +48,8 @@ public class ProvisioningOp {
     POLLING_DELETE,
     DELETED,
     FAILED,
-    ORPHANED
+    ORPHANED,
+    CANCELLED
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/DeprovisionTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/DeprovisionTask.java
@@ -114,6 +114,7 @@ public class DeprovisionTask extends ProvisioningTask {
     // end states
     subtasks.put(ProvisioningOp.Status.ORPHANED, EndSubtask.INSTANCE);
     subtasks.put(ProvisioningOp.Status.DELETED, EndSubtask.INSTANCE);
+    subtasks.put(ProvisioningOp.Status.CANCELLED, EndSubtask.INSTANCE);
 
     return subtasks;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisionTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisionTask.java
@@ -90,6 +90,7 @@ public class ProvisionTask extends ProvisioningTask {
     subtasks.put(ProvisioningOp.Status.INITIALIZING, createInitializeSubtask());
     subtasks.put(ProvisioningOp.Status.FAILED, EndSubtask.INSTANCE);
     subtasks.put(ProvisioningOp.Status.CREATED, EndSubtask.INSTANCE);
+    subtasks.put(ProvisioningOp.Status.CANCELLED, EndSubtask.INSTANCE);
 
     return subtasks;
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
@@ -76,7 +76,7 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
   private static DatasetFramework datasetFramework;
 
   @BeforeClass
-  public static void setup() throws Exception {
+  public static void setup() {
     store = getInjector().getInstance(DefaultStore.class);
     cConf = getInjector().getInstance(CConfiguration.class);
     programStateWriter = getInjector().getInstance(ProgramStateWriter.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
@@ -65,7 +65,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Test for Provisioning Service.
@@ -127,37 +129,37 @@ public class ProvisioningServiceTest {
   }
 
   @Test
-  public void testNoErrors() {
+  public void testNoErrors() throws Exception {
     ProvisionerInfo provisionerInfo = new MockProvisioner.PropertyBuilder().build();
-    ProgramRunId runId = testProvision(ProvisioningOp.Status.CREATED, provisionerInfo);
-    testDeprovision(runId, ProvisioningOp.Status.DELETED);
+    TaskFields taskFields = testProvision(ProvisioningOp.Status.CREATED, provisionerInfo);
+    testDeprovision(taskFields.programRunId, ProvisioningOp.Status.DELETED);
   }
 
   @Test
-  public void testRetryableFailures() {
+  public void testRetryableFailures() throws Exception {
     // will throw a retryable exception every other method call
     ProvisionerInfo provisionerInfo = new MockProvisioner.PropertyBuilder().failRetryablyEveryN(2).build();
-    ProgramRunId runId = testProvision(ProvisioningOp.Status.CREATED, provisionerInfo);
-    testDeprovision(runId, ProvisioningOp.Status.DELETED);
+    TaskFields taskFields = testProvision(ProvisioningOp.Status.CREATED, provisionerInfo);
+    testDeprovision(taskFields.programRunId, ProvisioningOp.Status.DELETED);
   }
 
   @Test
-  public void testProvisionCreateFailure() {
+  public void testProvisionCreateFailure() throws Exception {
     testProvision(ProvisioningOp.Status.FAILED, new MockProvisioner.PropertyBuilder().failCreate().build());
   }
 
   @Test
-  public void testProvisionPollFailure() {
+  public void testProvisionPollFailure() throws Exception {
     testProvision(ProvisioningOp.Status.FAILED, new MockProvisioner.PropertyBuilder().failGet().build());
   }
 
   @Test
-  public void testProvisionInitFailure() {
+  public void testProvisionInitFailure() throws Exception {
     testProvision(ProvisioningOp.Status.FAILED, new MockProvisioner.PropertyBuilder().failInit().build());
   }
 
   @Test
-  public void testProvisionCreateRetry() {
+  public void testProvisionCreateRetry() throws Exception {
     // simulates cluster create, then when polling, cluster status goes to a state that requires
     // that the cluster be deleted, and create retried
     testProvision(ProvisioningOp.Status.CREATED,
@@ -178,10 +180,10 @@ public class ProvisioningServiceTest {
   }
 
   @Test
-  public void testDeprovisionFailure() {
-    ProgramRunId runId = testProvision(ProvisioningOp.Status.CREATED,
-                                       new MockProvisioner.PropertyBuilder().failDelete().build());
-    testDeprovision(runId, ProvisioningOp.Status.FAILED);
+  public void testDeprovisionFailure() throws Exception {
+    TaskFields taskFields = testProvision(ProvisioningOp.Status.CREATED,
+                                          new MockProvisioner.PropertyBuilder().failDelete().build());
+    testDeprovision(taskFields.programRunId, ProvisioningOp.Status.FAILED);
   }
 
   @Test
@@ -211,7 +213,54 @@ public class ProvisioningServiceTest {
     }), 20, TimeUnit.SECONDS);
   }
 
-  private ProgramRunId testProvision(ProvisioningOp.Status expectedState, ProvisionerInfo provisionerInfo) {
+  @Test
+  public void testCancelProvision() {
+    ProvisionerInfo provisionerInfo = new MockProvisioner.PropertyBuilder().waitCreate(1, TimeUnit.MINUTES).build();
+    TaskFields taskFields = createTaskInfo(provisionerInfo);
+
+    Runnable task = Transactionals.execute(transactional, dsContext -> {
+      ProvisionRequest provisionRequest = new ProvisionRequest(taskFields.programRunId, taskFields.programOptions,
+                                                               taskFields.programDescriptor, "Bob");
+      return provisioningService.provision(provisionRequest, dsContext);
+    });
+
+    task.run();
+    Assert.assertTrue(provisioningService.cancelProvisionTask(taskFields.programRunId).isPresent());
+
+    // check that the state of the task is cancelled
+    ProvisioningTaskKey taskKey = new ProvisioningTaskKey(taskFields.programRunId, ProvisioningOp.Type.PROVISION);
+    ProvisioningOp.Status actualState = Transactionals.execute(transactional, dsContext -> {
+      ProvisionerDataset provisionerDataset = ProvisionerDataset.get(dsContext, datasetFramework);
+      ProvisioningTaskInfo provisioningTaskInfo = provisionerDataset.getTaskInfo(taskKey);
+      return provisioningTaskInfo == null ? null : provisioningTaskInfo.getProvisioningOp().getStatus();
+    });
+    Assert.assertEquals(ProvisioningOp.Status.CANCELLED, actualState);
+  }
+
+  @Test
+  public void testCancelDeprovision() throws Exception {
+    ProvisionerInfo provisionerInfo = new MockProvisioner.PropertyBuilder().waitDelete(1, TimeUnit.MINUTES).build();
+    TaskFields taskFields = testProvision(ProvisioningOp.Status.CREATED, provisionerInfo);
+
+    Runnable task = Transactionals.execute(transactional, dsContext -> {
+      return provisioningService.deprovision(taskFields.programRunId, dsContext);
+    });
+
+    task.run();
+    Assert.assertTrue(provisioningService.cancelDeprovisionTask(taskFields.programRunId).isPresent());
+
+    // check that the state of the task is cancelled
+    ProvisioningTaskKey taskKey = new ProvisioningTaskKey(taskFields.programRunId, ProvisioningOp.Type.DEPROVISION);
+    ProvisioningOp.Status actualState = Transactionals.execute(transactional, dsContext -> {
+      ProvisionerDataset provisionerDataset = ProvisionerDataset.get(dsContext, datasetFramework);
+      ProvisioningTaskInfo provisioningTaskInfo = provisionerDataset.getTaskInfo(taskKey);
+      return provisioningTaskInfo == null ? null : provisioningTaskInfo.getProvisioningOp().getStatus();
+    });
+    Assert.assertEquals(ProvisioningOp.Status.CANCELLED, actualState);
+  }
+
+  private TaskFields testProvision(ProvisioningOp.Status expectedState, ProvisionerInfo provisionerInfo)
+    throws InterruptedException, ExecutionException, TimeoutException {
     TaskFields taskFields = createTaskInfo(provisionerInfo);
 
     Runnable task = Transactionals.execute(transactional, dsContext -> {
@@ -222,28 +271,27 @@ public class ProvisioningServiceTest {
     task.run();
 
     ProvisioningTaskKey taskKey = new ProvisioningTaskKey(taskFields.programRunId, ProvisioningOp.Type.PROVISION);
-    ProvisioningOp.Status actualState = Transactionals.execute(transactional, dsContext -> {
+    Tasks.waitFor(expectedState, () -> Transactionals.execute(transactional, dsContext -> {
       ProvisionerDataset provisionerDataset = ProvisionerDataset.get(dsContext, datasetFramework);
       ProvisioningTaskInfo provisioningTaskInfo = provisionerDataset.getTaskInfo(taskKey);
       return provisioningTaskInfo == null ? null : provisioningTaskInfo.getProvisioningOp().getStatus();
-    });
-    Assert.assertEquals(expectedState, actualState);
-    return taskFields.programRunId;
+    }), 60, TimeUnit.SECONDS);
+    return taskFields;
   }
 
-  private void testDeprovision(ProgramRunId programRunId, ProvisioningOp.Status expectedState) {
+  private void testDeprovision(ProgramRunId programRunId, ProvisioningOp.Status expectedState)
+    throws InterruptedException, ExecutionException, TimeoutException {
     Runnable task = Transactionals.execute(transactional, dsContext -> {
       return provisioningService.deprovision(programRunId, dsContext, t -> { });
     });
     task.run();
 
     ProvisioningTaskKey taskKey = new ProvisioningTaskKey(programRunId, ProvisioningOp.Type.DEPROVISION);
-    ProvisioningOp.Status actualState = Transactionals.execute(transactional, dsContext -> {
+    Tasks.waitFor(expectedState, () -> Transactionals.execute(transactional, dsContext -> {
       ProvisionerDataset provisionerDataset = ProvisionerDataset.get(dsContext, datasetFramework);
       ProvisioningTaskInfo provisioningTaskInfo = provisionerDataset.getTaskInfo(taskKey);
       return provisioningTaskInfo == null ? null : provisioningTaskInfo.getProvisioningOp().getStatus();
-    });
-    Assert.assertEquals(expectedState, actualState);
+    }), 60, TimeUnit.SECONDS);
   }
 
   private TaskFields createTaskInfo(ProvisionerInfo provisionerInfo) {


### PR DESCRIPTION
Allow a provision task to be stopped. If a program run is stopped
while it is provisioning a cluster, the run will be marked
as failed and the cluster will be deprovisioned.

Refactored the ProvisioningService so that the tasks all run using
the executor service within the service in order that they can be
tracked by the service and later cancelled by a client. As part of
this refactoring, callers no longer need to submit the tasks using
their own executor services.

Also fixed a bug in the run record corrector where it could
incorrectly identify a run in the pending state as a run that
needs to be corrected because there is not yet any information
in the program runtime service about it.