### PR TITLE
CDAP-13623 fix flaky service test

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1074,10 +1074,10 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     startProgram(service1, 404);
     startProgram(service2);
 
+    waitState(service2, RUNNING);
+
     Tasks.waitFor(200, () -> getServiceAvailability(service2).getStatusLine().getStatusCode(),
                   2, TimeUnit.SECONDS, 10, TimeUnit.MILLISECONDS);
-
-    waitState(service2, RUNNING);
 
     // verify instances
     try {


### PR DESCRIPTION
Fix the test to wait for the service to be running before checking
that it is available.