### PR TITLE
heartbeat table changes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramStateWriter;
+import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.ImmutablePair;
@@ -42,6 +43,7 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.reporting.ProgramHeartbeatDataset;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import com.google.gson.Gson;
@@ -122,10 +124,12 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
   protected void processMessages(DatasetContext datasetContext,
                                  Iterator<ImmutablePair<String, Notification>> messages) throws Exception {
     AppMetadataStore appMetadataStore = getAppMetadataStore(datasetContext);
+    ProgramHeartbeatDataset heartbeatDataset =
+      ProgramHeartbeatDataset.getOrCreate(datasetContext, datasetFramework, cConf);
     List<Runnable> tasks = new LinkedList<>();
     while (messages.hasNext()) {
       ImmutablePair<String, Notification> messagePair = messages.next();
-      Optional<Runnable> task = processNotification(datasetContext, appMetadataStore,
+      Optional<Runnable> task = processNotification(datasetContext, appMetadataStore, heartbeatDataset,
                                                     messagePair.getFirst().getBytes(StandardCharsets.UTF_8),
                                                     messagePair.getSecond());
       task.ifPresent(tasks::add);
@@ -150,6 +154,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
    *
    * @param datasetContext the {@link DatasetContext} for getting access to dataset instances
    * @param appMetadataStore the {@link AppMetadataStore} for updating app metadata
+   * @param programHeartbeatDataset the {@link ProgramHeartbeatDataset} for writing heart beats and program status
    * @param messageIdBytes the raw message id in the TMS for the notification
    * @param notification the {@link Notification} to process
    * @return an {@link Optional} {@link Runnable} task to run after the transactional processing of the whole
@@ -157,6 +162,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
    * @throws Exception if failed to process the given notification
    */
   private Optional<Runnable> processNotification(DatasetContext datasetContext, AppMetadataStore appMetadataStore,
+                                                 ProgramHeartbeatDataset programHeartbeatDataset,
                                                  byte[] messageIdBytes, Notification notification) throws Exception {
     Map<String, String> properties = notification.getProperties();
     // Required parameters
@@ -193,9 +199,18 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
       }
     }
 
+    if (notification.getNotificationType().equals(Notification.Type.PROGRAM_HEART_BEAT)) {
+      RunRecordMeta runRecordMeta = appMetadataStore.getRun(programRunId);
+      long heartBeatTimeInSeconds =
+        TimeUnit.MILLISECONDS.toSeconds(Long.parseLong(properties.get(ProgramOptionConstants.HEART_BEAT_TIME)));
+      writeToHeartBeatDataset(runRecordMeta, heartBeatTimeInSeconds, datasetContext, programHeartbeatDataset);
+      // we can return after writing to heart beat table
+      return Optional.empty();
+    }
+
     if (programRunStatus != null) {
       handleProgramEvent(programRunId, programRunStatus, notification, messageIdBytes,
-                         appMetadataStore);
+                         appMetadataStore, programHeartbeatDataset, datasetContext);
     }
 
     if (clusterStatus == null) {
@@ -208,7 +223,8 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
 
   private void handleProgramEvent(ProgramRunId programRunId, ProgramRunStatus programRunStatus,
                                   Notification notification, byte[] messageIdBytes,
-                                  AppMetadataStore appMetadataStore) throws Exception {
+                                  AppMetadataStore appMetadataStore, ProgramHeartbeatDataset programHeartbeatDataset,
+                                  DatasetContext datasetContext) throws Exception {
     LOG.trace("Processing program status notification: {}", notification);
     Map<String, String> properties = notification.getProperties();
     String twillRunId = notification.getProperties().get(ProgramOptionConstants.TWILL_RUN_ID);
@@ -235,6 +251,9 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         }
         recordedRunRecord = appMetadataStore.recordProgramStart(programRunId, twillRunId,
                                                                 systemArguments, messageIdBytes);
+        writeToHeartBeatDataset(recordedRunRecord,
+                                RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS), datasetContext,
+                                programHeartbeatDataset);
         break;
       case RUNNING:
         long logicalStartTimeSecs = getTimeSeconds(notification.getProperties(),
@@ -246,6 +265,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         }
         recordedRunRecord =
           appMetadataStore.recordProgramRunning(programRunId, logicalStartTimeSecs, twillRunId, messageIdBytes);
+        writeToHeartBeatDataset(recordedRunRecord, logicalStartTimeSecs, datasetContext, programHeartbeatDataset);
         break;
       case SUSPENDED:
         long suspendTime = getTimeSeconds(notification.getProperties(),
@@ -253,6 +273,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         // since we are adding suspend time recently, there might be old suspended notificications for which time
         // can be -1.
         recordedRunRecord = appMetadataStore.recordProgramSuspend(programRunId, messageIdBytes, suspendTime);
+        writeToHeartBeatDataset(recordedRunRecord, suspendTime, datasetContext, programHeartbeatDataset);
         break;
       case RESUMING:
         long resumeTime = getTimeSeconds(notification.getProperties(),
@@ -260,6 +281,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         // since we are adding suspend time recently, there might be old suspended notificications for which time
         // can be -1.
         recordedRunRecord = appMetadataStore.recordProgramResumed(programRunId, messageIdBytes, resumeTime);
+        writeToHeartBeatDataset(recordedRunRecord, resumeTime, datasetContext, programHeartbeatDataset);
         break;
       case COMPLETED:
       case KILLED:
@@ -270,6 +292,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         }
         recordedRunRecord =
           appMetadataStore.recordProgramStop(programRunId, endTimeSecs, programRunStatus, null, messageIdBytes);
+        writeToHeartBeatDataset(recordedRunRecord, endTimeSecs, datasetContext, programHeartbeatDataset);
         break;
       case FAILED:
         if (endTimeSecs == -1) {
@@ -280,6 +303,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         BasicThrowable cause = decodeBasicThrowable(properties.get(ProgramOptionConstants.PROGRAM_ERROR));
         recordedRunRecord =
           appMetadataStore.recordProgramStop(programRunId, endTimeSecs, programRunStatus, cause, messageIdBytes);
+        writeToHeartBeatDataset(recordedRunRecord, endTimeSecs, datasetContext, programHeartbeatDataset);
         break;
       default:
         // This should not happen
@@ -302,6 +326,17 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
           provisionerNotifier.deprovisioning(programRunId);
         }
       }
+    }
+  }
+
+  /**
+   * write to heart beat dataset if the recordedRunRecord is not null
+   */
+  private void writeToHeartBeatDataset(@Nullable RunRecordMeta recordedRunRecord,
+                                       long timestampInSeconds, DatasetContext datasetContext,
+                                       ProgramHeartbeatDataset programHeartbeatDataset) {
+    if (recordedRunRecord != null) {
+      programHeartbeatDataset.writeRunRecordMeta(recordedRunRecord, timestampInSeconds);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/reporting/ProgramHeartbeatDataset.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/reporting/ProgramHeartbeatDataset.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.reporting;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.dataset.table.TableProperties;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.internal.app.runtime.schedule.TriggeringScheduleInfoAdapter;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Heartbeat Store that writes heart beat messages and program status messages
+ * to program heartbeat table. This is used for efficiently
+ * scanning and returning results for dashboard status queries
+ *
+ * Rowkey for the table is organized in the following format
+ * [namespace][timestamp-in-seconds][program-run-Id]
+ *
+ */
+public class ProgramHeartbeatDataset extends AbstractDataset {
+  private static final Gson GSON = TriggeringScheduleInfoAdapter.addTypeAdapters(new GsonBuilder()).create();
+  private static final byte[] COLUMN_NAME = Bytes.toBytes("status");
+  private static final DatasetId PROGRAM_HEARTBEAT_INSTANCE_ID =
+    NamespaceId.SYSTEM.dataset(Constants.ProgramHeartbeat.TABLE);
+  private final Table table;
+
+  public ProgramHeartbeatDataset(Table table) {
+    super("ignored", table);
+    this.table = table;
+  }
+
+  /**
+   * Static method for creating an instance of {@link ProgramHeartbeatDataset}.
+   */
+  public static ProgramHeartbeatDataset getOrCreate(DatasetContext datasetContext,
+                                                    DatasetFramework datasetFramework, CConfiguration cConfiguration) {
+    try {
+      TableProperties.Builder props = TableProperties.builder();
+      long ttl = cConfiguration.getLong(Constants.ProgramHeartbeat.HEARTBEAT_TABLE_TTL_SECONDS);
+      props.setTTL(ttl);
+      Table table = DatasetsUtil.getOrCreateDataset(datasetContext, datasetFramework, PROGRAM_HEARTBEAT_INSTANCE_ID,
+                                                    Table.class.getName(), props.build());
+      return new ProgramHeartbeatDataset(table);
+    } catch (DatasetManagementException | IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Write {@link RunRecordMeta} to heart beat dataset as value,
+   * with rowKey in format [namespace][timestamp-in-seconds][program-run-Id]
+   *
+   * @param runRecordMeta row value to write
+   * @param timestampInSeconds used for creating rowKey
+   */
+  public void writeRunRecordMeta(RunRecordMeta runRecordMeta, long timestampInSeconds) {
+    byte[] rowKey = createRowKey(timestampInSeconds, runRecordMeta.getProgramRunId());
+    table.put(rowKey, COLUMN_NAME, Bytes.toBytes(GSON.toJson(runRecordMeta)));
+  }
+
+  private byte[] createRowKey(long timestampInSeconds, ProgramRunId programRunId) {
+    MDSKey.Builder builder = new MDSKey.Builder();
+    // add namespace at the beginning
+    builder.add(programRunId.getNamespace());
+    // add timestamp
+    builder.add(timestampInSeconds);
+    // add program runId fields, skip namespace as that is part of row key
+    builder.add(programRunId.getApplication());
+    builder.add(programRunId.getType().name());
+    builder.add(programRunId.getProgram());
+    builder.add(programRunId.getRun());
+
+    return builder.build().getKey();
+  }
+
+  /**
+   * Add namespace and timestamp and return it as the scan key
+   * @return scan key
+   */
+  private byte[] getScanKey(String namespace, long timestamp) {
+    MDSKey.Builder scanKeyBuilder = new MDSKey.Builder();
+    scanKeyBuilder.add(namespace);
+    scanKeyBuilder.add(timestamp);
+    return scanKeyBuilder.build().getKey();
+  }
+
+  /**
+   * Scan the table for the time range for each of the namespace provided
+   * and return collection of latest {@link RunRecordMeta}
+   * we maintain the latest {@link RunRecordMeta} identified by {@link ProgramRunId},
+   * Since there can be more than one RunRecordMeta for the
+   * same runId due to multiple state changes and heart beat messages.
+   *
+   * @param startTimestampInSeconds inclusive start rowKey
+   * @param endTimestampInSeconds exclusive end rowKey
+   * @param namespaces set of namespaces
+   * @return collection of {@link RunRecordMeta}
+   */
+  public Collection<RunRecordMeta> scan(long startTimestampInSeconds, long endTimestampInSeconds,
+                                        Set<String> namespaces) {
+    List<RunRecordMeta> resultRunRecordList = new ArrayList<>();
+    for (String namespace : namespaces) {
+      byte[] startRowKey = getScanKey(namespace, startTimestampInSeconds);
+      byte[] endRowKey = getScanKey(namespace, endTimestampInSeconds);
+      performScanAddToList(startRowKey, endRowKey, resultRunRecordList);
+    }
+    return resultRunRecordList;
+  }
+
+  /**
+   * Scan is executed based on the given startRowKey and endRowKey, for each of the scanned rows, we maintain
+   * the latest {@link RunRecordMeta} identified by its {@link ProgramRunId} in a map. Finally after scan is
+   * complete add the runrecords to the result list
+   *
+   * @param startRowKey byte array used as start row key in scan
+   * @param endRowKey byte array used as end row key in scan
+   * @param runRecordMetas result list to which the run records to be added
+   */
+  private void performScanAddToList(byte[] startRowKey, byte[] endRowKey, List<RunRecordMeta> runRecordMetas) {
+    try (Scanner scanner = table.scan(startRowKey, endRowKey)) {
+      Row row;
+      Map<ProgramRunId, RunRecordMeta> runIdToRunRecordMap = new HashMap<>();
+      while ((row = scanner.next()) != null) {
+        RunRecordMeta runRecordMeta = GSON.fromJson(Bytes.toString(row.getColumns().get(COLUMN_NAME)),
+                                                    RunRecordMeta.class);
+        ProgramRunId runId = getProgramRunIdFromRowKey(row.getRow());
+        runIdToRunRecordMap.put(runId, runRecordMeta);
+      }
+
+      // since the serialized runRecordMeta doesn't have programRunId (transient), we will create and
+      // add the programRunId to RunRecordMeta and add to result list
+
+      runIdToRunRecordMap.entrySet().forEach((entry) -> {
+        RunRecordMeta.Builder builder = RunRecordMeta.builder(entry.getValue());
+        builder.setProgramRunId(entry.getKey());
+        runRecordMetas.add(builder.build());
+      });
+    }
+  }
+
+  /**
+   * Deserialize and return {@link ProgramRunId} from rowKey
+   */
+  private ProgramRunId getProgramRunIdFromRowKey(byte[] rowKey) {
+    MDSKey.Splitter splitter = new MDSKey(rowKey).split();
+    // get namespace
+    String namespace = splitter.getString();
+    // skip timestamp
+    splitter.skipLong();
+    // now read the programRunId fields, create and return ProgramRunId
+    return new ProgramRunId(namespace, splitter.getString(),
+                            ProgramType.valueOf(splitter.getString()),
+                            splitter.getString(), splitter.getString());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/reporting/ProgramHeartbeatService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/reporting/ProgramHeartbeatService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.reporting;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.inject.Inject;
+import org.apache.tephra.RetryStrategies;
+import org.apache.tephra.TransactionSystemClient;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Service to access {@link ProgramHeartbeatDataset} in transaction
+ */
+public class ProgramHeartbeatService {
+  private static final DatasetId PROGRAM_HEARTBEAT_INSTANCE_ID =
+    NamespaceId.SYSTEM.dataset(Constants.ProgramHeartbeat.TABLE);
+
+  private final DatasetFramework datasetFramework;
+  private final Transactional transactional;
+  private final CConfiguration cConfiguration;
+
+  @Inject
+  public ProgramHeartbeatService(DatasetFramework datasetFramework, TransactionSystemClient txClient,
+                                 CConfiguration cConfiguration) {
+    this.datasetFramework = datasetFramework;
+    this.transactional = Transactions.createTransactionalWithRetry(
+      Transactions.createTransactional(new MultiThreadDatasetCache(
+        new SystemDatasetInstantiator(datasetFramework), txClient, PROGRAM_HEARTBEAT_INSTANCE_ID.getParent(),
+        Collections.emptyMap(), null, null)),
+      RetryStrategies.retryOnConflict(20, 100)
+    );
+    this.cConfiguration = cConfiguration;
+  }
+
+  /**
+   * Performs the {@link ProgramHeartbeatDataset#scan(long, long, Set)}
+   * @param startTimestampInSeconds starting timestamp inclusive
+   * @param endTimestampInSeconds ending timestamp exclusive
+   * @param namespaces set of namespaces to scan for the timerange
+   * @return collection of run record meta
+   */
+  public Collection<RunRecordMeta> scan(long startTimestampInSeconds,
+                                        long endTimestampInSeconds, Set<String> namespaces) {
+    return Transactionals.execute(transactional, context -> {
+      ProgramHeartbeatDataset programHeartbeatDataset =
+        ProgramHeartbeatDataset.getOrCreate(context, datasetFramework, cConfiguration);
+      return programHeartbeatDataset.scan(startTimestampInSeconds, endTimestampInSeconds, namespaces);
+    });
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
@@ -16,105 +16,217 @@
 
 package co.cask.cdap.gateway.handlers;
 
-import co.cask.cdap.api.artifact.ArtifactId;
-import co.cask.cdap.api.artifact.ArtifactScope;
-import co.cask.cdap.api.artifact.ArtifactVersion;
+
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.app.store.Store;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.schedule.TriggerInfo;
+import co.cask.cdap.api.schedule.TriggeringScheduleInfo;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.schedule.DefaultTriggeringScheduleInfo;
+import co.cask.cdap.internal.app.runtime.schedule.TriggeringScheduleInfoAdapter;
+import co.cask.cdap.internal.app.runtime.schedule.trigger.DefaultTimeTriggerInfo;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
-import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
-import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.ops.DashboardProgramRunRecord;
+import co.cask.cdap.reporting.ProgramHeartbeatDataset;
 import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import com.google.inject.Injector;
 import org.apache.http.HttpResponse;
+import org.apache.tephra.TransactionExecutor;
+import org.apache.tephra.TransactionExecutorFactory;
+import org.apache.tephra.TransactionFailureException;
+import org.apache.twill.api.RunId;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Tests for {@link OperationsDashboardHttpHandler}
  */
 public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
-  private static final Gson GSON = new Gson();
+  private static final ArtifactId ARTIFACT_ID = NamespaceId.DEFAULT.artifact("testArtifact", "1.0");
+  private static final Gson GSON =
+    TriggeringScheduleInfoAdapter.addTypeAdapters(new GsonBuilder()).create();
   private static final String BASE_PATH = Constants.Gateway.API_VERSION_3;
   private static final Type DASHBOARD_DETAIL_TYPE = new TypeToken<List<DashboardProgramRunRecord>>() { }.getType();
-  private static Store store;
-  private static long sourceId;
+  private static final byte[] SOURCE_ID = Bytes.toBytes("sourceId");
+
+  private static ProgramHeartbeatDataset programHeartbeatDataset;
+  private static TransactionExecutor heartBeatTxnl;
 
   @BeforeClass
-  public static void setup() {
-    store = getInjector().getInstance(DefaultStore.class);
+  public static void setup() throws Exception {
+    Injector injector = getInjector();
+    TransactionExecutorFactory txExecutorFactory =
+      injector.getInstance(TransactionExecutorFactory.class);
+    DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
+    DatasetId heartbeatDataset = NamespaceId.SYSTEM.dataset(Constants.ProgramHeartbeat.TABLE);
+    Table heartbeatTable = DatasetsUtil.getOrCreateDataset(datasetFramework, heartbeatDataset, Table.class.getName(),
+                                                           DatasetProperties.EMPTY, Collections.emptyMap());
+    programHeartbeatDataset = new ProgramHeartbeatDataset(heartbeatTable);
+    heartBeatTxnl = txExecutorFactory.createExecutor(Collections.singleton(programHeartbeatDataset));
+  }
+
+  /**
+   * writes heart beat messages starting from startTime + interval up to endTime, each heartbeat separated by interval
+   */
+  private void setUpProgramHeartBeats(RunRecordMeta runRecordMeta,
+                                      long startTime, long endTime, long interval)
+    throws TransactionFailureException, InterruptedException {
+    for (long time = startTime + interval; time < endTime; time += interval) {
+      writeRunRecordMeta(runRecordMeta, time);
+    }
+  }
+
+  private void writeRunRecordMeta(RunRecordMeta runRecordMeta,
+                                  long timestampInMillis) throws InterruptedException, TransactionFailureException {
+    heartBeatTxnl.execute(() -> {
+      programHeartbeatDataset.writeRunRecordMeta(runRecordMeta, timestampInMillis);
+    });
+  }
+
+  /**
+   * setup and return mock program properties on runrecord builder but use passed namespaceId and runId
+   */
+  private RunRecordMeta.Builder getMockRunRecordMeta(NamespaceId namespaceId, RunId runId) {
+    ProgramId programId = namespaceId.app("someapp").program(ProgramType.SERVICE, "s");
+    RunRecordMeta.Builder runRecordBuilder = RunRecordMeta.builder();
+    runRecordBuilder.setArtifactId(ARTIFACT_ID.toApiArtifactId());
+    runRecordBuilder.setPrincipal("userA");
+    runRecordBuilder.setProgramRunId(programId.run(runId));
+    runRecordBuilder.setSourceId(SOURCE_ID);
+    runRecordBuilder.setStartTime(RunIds.getTime(runId, TimeUnit.SECONDS));
+    return runRecordBuilder;
   }
 
   @Test
-  public void testDashboardDetail() throws Exception {
-    ProgramId programId1 = new ProgramId("ns1", "app", ProgramType.WORKFLOW, "program");
-    ArtifactId artifactId = new ArtifactId("ns1", new ArtifactVersion("1.0.0"), ArtifactScope.USER);
-    // a path to get ops dashboard results between time 100 and 100 + 1440 = 1540 from namesapce "ns1" and "ns2"
-    String opsDashboardQueryPath = BASE_PATH + "/dashboard?start=100&duration=1440&namespace=ns1&namespace=ns2";
-    // run1 will not be included in the query results since it stops before the query start time 100
-    ProgramRunId run1 = programId1.run(RunIds.generate(TimeUnit.SECONDS.toMillis(10)));
-    writeCompletedRunRecord(run1, artifactId, 50);
-    // run2 will be included in the query results since it starts before query end time
-    // and stops after query start time
-    ProgramRunId run2 = programId1.run(RunIds.generate(TimeUnit.SECONDS.toMillis(60)));
-    writeCompletedRunRecord(run2, artifactId, 110);
-    ProgramId programId2 = new ProgramId("ns2", "app", ProgramType.WORKFLOW, "program");
-    // run3 will be included in the query results since it starts before query end time
-    // and stops after query start time
-    ProgramRunId run3 = programId2.run(RunIds.generate(TimeUnit.SECONDS.toMillis(120)));
-    writeCompletedRunRecord(run3, artifactId, 200);
-    // run4 will be included in the query results since it starts before query end time
-    // and stops after query start time
-    ProgramRunId run4 = programId2.run(RunIds.generate(TimeUnit.SECONDS.toMillis(60)));
-    writeCompletedRunRecord(run4, artifactId, 2200);
-    // run5 will be included in the query results since it starts before query end time
-    // and stops after query start time
-    ProgramRunId run5 = programId2.run(RunIds.generate(TimeUnit.SECONDS.toMillis(60)));
-    store.setProvisioning(run5, Collections.emptyMap(), Collections.emptyMap(),
-                          Bytes.toBytes(++sourceId), artifactId);
-    store.setStart(run5, "twillId", Collections.emptyMap(), Bytes.toBytes(++sourceId));
-    // run6 will not be included in the query results since it starts after query end time
-    ProgramRunId run6 = programId2.run(RunIds.generate(TimeUnit.SECONDS.toMillis(2000)));
-    writeCompletedRunRecord(run6, artifactId, 2200);
+  public void testDashboardWithNamespaceFiltering() throws Exception {
+    long startTime1 = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    RunId runId1 = RunIds.generate();
+    NamespaceId ns1 = new NamespaceId("ns1");
+    RunRecordMeta.Builder metaBuilder = getMockRunRecordMeta(ns1, runId1);
+    metaBuilder.setRunTime(startTime1);
+    metaBuilder.setStatus(ProgramRunStatus.RUNNING);
+    RunRecordMeta meta = metaBuilder.build();
+    writeRunRecordMeta(meta, startTime1);
 
-    ProgramId programId3 = new ProgramId("ns3", "app", ProgramType.WORKFLOW, "program");
-    // run7 will not be included in the query results since it does not belong the namespaces in the query
-    ProgramRunId run7 = programId3.run(RunIds.generate(TimeUnit.SECONDS.toMillis(120)));
-    writeCompletedRunRecord(run7, artifactId, 200);
+    // write heart beat messages for 10 minutes (every minute) for this program run.
+    long endTime = startTime1 + TimeUnit.MINUTES.toSeconds(10);
+    long interval = TimeUnit.MINUTES.toSeconds(1);
+    setUpProgramHeartBeats(meta, startTime1, endTime, interval);
+
+    // write end notification message
+    metaBuilder.setStopTime(endTime);
+    metaBuilder.setStatus(ProgramRunStatus.COMPLETED);
+    meta = metaBuilder.build();
+    writeRunRecordMeta(meta, endTime);
+
+    long startTime2 = startTime1 + TimeUnit.MINUTES.toSeconds(5);
+    NamespaceId ns2 = new NamespaceId("ns2");
+    RunId runId2 = RunIds.generate();
+    RunRecordMeta.Builder metaBuilder2 = getMockRunRecordMeta(ns2, runId2);
+    metaBuilder2.setRunTime(startTime2);
+    metaBuilder2.setStatus(ProgramRunStatus.RUNNING);
+    RunRecordMeta meta2 = metaBuilder2.build();
+    writeRunRecordMeta(meta2, startTime2);
+
+    // write heart beat messages for 5 minutes (every minute) for this program run.
+    // this program doesnt have endTime for this testOp
+    setUpProgramHeartBeats(meta2, startTime2, endTime, interval);
+
+    String opsDashboardQueryPath =
+      String.format("%s/dashboard?start=%s&duration=%s&namespace=%s&namespace=%s", BASE_PATH,
+                    String.valueOf(startTime1), String.valueOf(endTime), ns1.getNamespace(), ns2.getNamespace());
     // get ops dashboard query results
     HttpResponse response = doGet(opsDashboardQueryPath);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     String content = new String(ByteStreams.toByteArray(response.getEntity().getContent()), Charsets.UTF_8);
     List<DashboardProgramRunRecord> dashboardDetail = GSON.fromJson(content, DASHBOARD_DETAIL_TYPE);
-    // assert the result contains 4 entries and run2, run3, run4, and run5 are there
-    Assert.assertEquals(4, dashboardDetail.size());
-    Set<String> runs = dashboardDetail.stream().map(DashboardProgramRunRecord::getRun).collect(Collectors.toSet());
-    Assert.assertEquals(ImmutableSet.of(run2.getRun(), run3.getRun(), run4.getRun(), run5.getRun()), runs);
+    // assert the result contains 2 entries
+    Assert.assertEquals(2, dashboardDetail.size());
+    Set<DashboardProgramRunRecord> expected =
+      ImmutableSet.of(OperationsDashboardHttpHandler.runRecordToDashboardRecord(meta),
+                      OperationsDashboardHttpHandler.runRecordToDashboardRecord(meta2));
+    Assert.assertEquals(expected.size(), dashboardDetail.size());
+    Assert.assertTrue(dashboardDetail.containsAll(expected));
+
+    // for the same time range query only in namespace ns1 to ensure filtering works fine
+    opsDashboardQueryPath =
+      String.format("%s/dashboard?start=%s&duration=%s&namespace=%s", BASE_PATH,
+                    String.valueOf(startTime1), String.valueOf(endTime), ns2.getNamespace());
+
+    // get ops dashboard query results
+    response = doGet(opsDashboardQueryPath);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    content = new String(ByteStreams.toByteArray(response.getEntity().getContent()), Charsets.UTF_8);
+    dashboardDetail = GSON.fromJson(content, DASHBOARD_DETAIL_TYPE);
+    // assert the result contains 1 entry
+    Assert.assertEquals(1, dashboardDetail.size());
+    Assert.assertEquals(OperationsDashboardHttpHandler.runRecordToDashboardRecord(meta2),
+                        dashboardDetail.iterator().next());
   }
 
-  private void writeCompletedRunRecord(ProgramRunId runId, ArtifactId artifactId, long endTime) {
-    store.setProvisioning(runId, Collections.emptyMap(), Collections.emptyMap(),
-                          Bytes.toBytes(++sourceId), artifactId);
-    store.setProvisioned(runId, 0, Bytes.toBytes(++sourceId));
-    store.setStart(runId, null, Collections.emptyMap(), Bytes.toBytes(++sourceId));
-    store.setRunning(runId, endTime - 1, null, Bytes.toBytes(++sourceId));
-    store.setStop(runId, endTime, ProgramRunStatus.COMPLETED, Bytes.toBytes(++sourceId));
+  @Test
+  public void testDashboardReadWithScheduledRuns() throws Exception {
+    long startTime1 = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    RunId runId1 = RunIds.generate();
+    NamespaceId ns3 = new NamespaceId("ns3");
+    List<TriggerInfo> triggerInfos = new ArrayList<>();
+    triggerInfos.add(new DefaultTimeTriggerInfo("*/5 * * * *", startTime1));
+    TriggeringScheduleInfo triggeringScheduleInfo =
+      new DefaultTriggeringScheduleInfo("test", "test", triggerInfos, new HashMap<>());
+    RunRecordMeta.Builder metaBuilder = getMockRunRecordMeta(ns3, runId1);
+    metaBuilder.setRunTime(startTime1);
+    metaBuilder.setStatus(ProgramRunStatus.RUNNING);
+    Map<String, String> systemArgs =
+      ImmutableMap.of(ProgramOptionConstants.TRIGGERING_SCHEDULE_INFO, GSON.toJson(triggeringScheduleInfo));
+    metaBuilder.setSystemArgs(systemArgs);
+    RunRecordMeta meta = metaBuilder.build();
+    writeRunRecordMeta(meta, startTime1);
+
+    // write heart beat messages for 10 minutes (every minute) for this program run.
+    long endTime = startTime1 + TimeUnit.MINUTES.toSeconds(5);
+    long interval = TimeUnit.MINUTES.toSeconds(1);
+    setUpProgramHeartBeats(meta, startTime1, endTime, interval);
+
+    String opsDashboardQueryPath =
+      String.format("%s/dashboard?start=%s&duration=%s&namespace=%s", BASE_PATH,
+                    String.valueOf(startTime1), String.valueOf(endTime), ns3.getNamespace());
+
+    // get ops dashboard query results
+    HttpResponse response = doGet(opsDashboardQueryPath);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    String content = new String(ByteStreams.toByteArray(response.getEntity().getContent()), Charsets.UTF_8);
+    List<DashboardProgramRunRecord> dashboardDetail = GSON.fromJson(content, DASHBOARD_DETAIL_TYPE);
+    // assert the result contains 1 entry
+    Assert.assertEquals(1, dashboardDetail.size());
+    Assert.assertEquals(OperationsDashboardHttpHandler.runRecordToDashboardRecord(meta),
+                        dashboardDetail.iterator().next());
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/reporting/ProgramHeartBeatDatasetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/reporting/ProgramHeartBeatDatasetTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.reporting;
+
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import org.apache.tephra.TransactionExecutor;
+import org.apache.tephra.TransactionFailureException;
+import org.apache.twill.api.RunId;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class ProgramHeartBeatDatasetTest {
+  private static DatasetFramework datasetFramework;
+  private static TransactionExecutorFactory txExecutorFactory;
+  private static final ArtifactId ARTIFACT_ID = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+  private static final byte[] SOURCE_ID = Bytes.toBytes("sourceId");
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Injector injector = AppFabricTestHelper.getInjector();
+    AppFabricTestHelper.ensureNamespaceExists(NamespaceId.DEFAULT);
+    datasetFramework = injector.getInstance(DatasetFramework.class);
+    txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
+  }
+
+  @Test
+  public void testWritingScanningHeartBeats() throws Exception {
+    ProgramHeartbeatDataset programHeartbeatDataset = getHeartBeatStore("testBeats");
+    TransactionExecutor txnl = txExecutorFactory.createExecutor(Collections.singleton(programHeartbeatDataset));
+
+    //  write program status "running" for program 1 starting at x
+    long startTime1 = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    RunId runId = RunIds.generate();
+    RunRecordMeta.Builder metaBuilder =
+      getMockRunRecordMeta(NamespaceId.DEFAULT, runId);
+    metaBuilder.setRunTime(startTime1);
+    metaBuilder.setStatus(ProgramRunStatus.RUNNING);
+    RunRecordMeta meta = metaBuilder.build();
+    txnl.execute(() -> {
+      programHeartbeatDataset.writeRunRecordMeta(meta, startTime1);
+    });
+
+    // write heart beat messages for 10 minutes (every minute) for this program run.
+    long endTime = startTime1 + TimeUnit.MINUTES.toSeconds(10);
+    long interval = TimeUnit.MINUTES.toSeconds(1);
+    setUpProgramHeartBeats(meta, startTime1, endTime, interval, txnl, programHeartbeatDataset);
+
+
+    //  write program status "running" for program 2 starting at x + 5
+    long startTime2 = startTime1 + TimeUnit.MINUTES.toSeconds(5);
+    RunId runId2 = RunIds.generate();
+    RunRecordMeta.Builder metaBuilder2 = getMockRunRecordMeta(NamespaceId.DEFAULT, runId2);
+    metaBuilder2.setRunTime(startTime2);
+    metaBuilder2.setStatus(ProgramRunStatus.RUNNING);
+    RunRecordMeta meta2 = metaBuilder2.build();
+    txnl.execute(() -> {
+      programHeartbeatDataset.writeRunRecordMeta(meta2, startTime2);
+    });
+
+    // write heart beat messages for 5 minutes (every minute) for this program run.
+    setUpProgramHeartBeats(meta2, startTime2, endTime, interval, txnl, programHeartbeatDataset);
+
+    // program run1 runtime -> x     : x + 10
+    // program run2 runtime -> x + 5 : x + 10
+    txnl.execute(() -> {
+      // end row key is exclusive, scanning from x : x + 5 should only return run1
+      Collection<RunRecordMeta> result =
+        programHeartbeatDataset.scan(startTime1, startTime2, ImmutableSet.of(NamespaceId.DEFAULT.getNamespace()));
+
+      Assert.assertEquals(1 , result.size());
+      Assert.assertEquals(meta, result.iterator().next());
+      // scanning from x : x + 10, should return both
+      Set<RunRecordMeta> expected = ImmutableSet.of(meta, meta2);
+      result = programHeartbeatDataset.scan(startTime1, endTime,
+                                            ImmutableSet.of(NamespaceId.DEFAULT.getNamespace()));
+      Assert.assertEquals(expected.size() , result.size());
+      Assert.assertTrue(result.containsAll(expected));
+
+      // scanning from x + 5 : x + 10, should return both
+      result = programHeartbeatDataset.scan(startTime2, endTime,
+                                            ImmutableSet.of(NamespaceId.DEFAULT.getNamespace()));
+      Assert.assertEquals(expected.size() , result.size());
+      Assert.assertTrue(result.containsAll(expected));
+    });
+  }
+
+  /**
+   * setup and return mock program properties on runrecord builder but use passed namespaceId and runId
+   */
+  private RunRecordMeta.Builder getMockRunRecordMeta(NamespaceId namespaceId, RunId runId) {
+    ProgramId programId = namespaceId.app("someapp").program(ProgramType.SERVICE, "s");
+    RunRecordMeta.Builder runRecordBuilder = RunRecordMeta.builder();
+    runRecordBuilder.setArtifactId(ARTIFACT_ID);
+    runRecordBuilder.setPrincipal("userA");
+    runRecordBuilder.setProgramRunId(programId.run(runId));
+    runRecordBuilder.setSourceId(SOURCE_ID);
+    runRecordBuilder.setStartTime(RunIds.getTime(runId, TimeUnit.SECONDS));
+    return runRecordBuilder;
+  }
+
+  /**
+   * writes heart beat messages starting from startTime + interval up to endTime, each heartbeat separated by interval
+   */
+  private void setUpProgramHeartBeats(RunRecordMeta runRecordMeta,
+                                      long startTime, long endTime, long interval,
+                                      TransactionExecutor txnl, ProgramHeartbeatDataset programHeartbeatDataset)
+    throws InterruptedException, TransactionFailureException {
+    txnl.execute(() -> {
+      for (long time = startTime + interval; time < endTime; time += interval) {
+        programHeartbeatDataset.writeRunRecordMeta(runRecordMeta, time);
+      }
+    });
+  }
+
+  @Test
+  public void testScanningProgramStatus() throws Exception {
+    // p1 : x           ->    x + 5
+    // scanning from x -> x + 4 -> return one record with status running
+    // scanning from x -> x + 5min + 1s -> return one record with status killed
+
+    ProgramHeartbeatDataset programHeartbeatDataset = getHeartBeatStore("testStatusChange");
+    TransactionExecutor txnl = txExecutorFactory.createExecutor(Collections.singleton(programHeartbeatDataset));
+
+    //  write program status "running" for program 1 starting at x
+    long startTime1 = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    RunId runId = RunIds.generate();
+    RunRecordMeta.Builder metaRunningBuilder = getMockRunRecordMeta(NamespaceId.DEFAULT, runId);
+    metaRunningBuilder.setStatus(ProgramRunStatus.RUNNING);
+    metaRunningBuilder.setRunTime(startTime1);
+    RunRecordMeta metaRunning = metaRunningBuilder.build();
+    txnl.execute(() -> {
+      programHeartbeatDataset.writeRunRecordMeta(metaRunning, startTime1);
+    });
+
+    // write heart beat messages for 10 minutes (every minute) for this program run.
+    long heartBeatEndTime = startTime1 + TimeUnit.MINUTES.toSeconds(4);
+    long interval = TimeUnit.MINUTES.toSeconds(1);
+    setUpProgramHeartBeats(metaRunning, startTime1, heartBeatEndTime, interval, txnl, programHeartbeatDataset);
+
+    long programEndTime = startTime1 + TimeUnit.MINUTES.toSeconds(5);
+
+    RunRecordMeta.Builder metaKilledBuilder = getMockRunRecordMeta(NamespaceId.DEFAULT, runId);
+    metaKilledBuilder.setStatus(ProgramRunStatus.KILLED);
+    metaKilledBuilder.setStopTime(programEndTime);
+    RunRecordMeta metaKilled = metaKilledBuilder.build();
+    txnl.execute(() -> {
+      programHeartbeatDataset.writeRunRecordMeta(metaKilled, programEndTime);
+    });
+
+    // perform scan checks
+    txnl.execute(() -> {
+      // end row key is exclusive, scanning from x : x + 5 should only return run1
+      Collection<RunRecordMeta> runRecordMetaList =
+        programHeartbeatDataset.scan(startTime1, heartBeatEndTime, ImmutableSet.of(NamespaceId.DEFAULT.getNamespace()));
+      Assert.assertEquals(1 , runRecordMetaList.size());
+      Assert.assertEquals(ProgramRunStatus.RUNNING, runRecordMetaList.iterator().next().getStatus());
+      Assert.assertEquals(metaRunning, runRecordMetaList.iterator().next());
+      // scanning from x : x + (5 min + 1s), should return run1 with status KILLED
+      runRecordMetaList = programHeartbeatDataset.scan(startTime1, programEndTime + 1,
+                                                       ImmutableSet.of(NamespaceId.DEFAULT.getNamespace()));
+      Assert.assertEquals(1 , runRecordMetaList.size());
+      Assert.assertEquals(metaKilled, runRecordMetaList.iterator().next());
+    });
+  }
+
+  private ProgramHeartbeatDataset getHeartBeatStore(String tableName) throws Exception {
+    DatasetId storeTable = NamespaceId.SYSTEM.dataset(tableName);
+    datasetFramework.addInstance(Table.class.getName(), storeTable, DatasetProperties.EMPTY);
+    Table table = datasetFramework.getDataset(storeTable, ImmutableMap.of(), null);
+    Assert.assertNotNull(table);
+    return new ProgramHeartbeatDataset(table);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -350,6 +350,7 @@ public final class Constants {
   public static final class ProgramHeartbeat {
     public static final String TABLE = "program.heartbeat";
     public static final String HEARTBEAT_INTERVAL_SECONDS = "program.heartbeat.interval.seconds";
+    public static final String HEARTBEAT_TABLE_TTL_SECONDS = "program.heartbeat.table.ttl.seconds";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3694,7 +3694,15 @@
     <name>program.heartbeat.interval.seconds</name>
     <value>1800</value>
     <description>
-      Interval of heartbeat sent from program while its running, default 30 minutes.
+      Interval of heartbeat sent from program while its running, default 30 minutes
+    </description>
+  </property>
+
+  <property>
+    <name>program.heartbeat.table.ttl.seconds</name>
+    <value>2592000</value>
+    <description>
+      TTL duration for program heartbeat table, by default 30 days
     </description>
   </property>
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ops/DashboardProgramRunRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ops/DashboardProgramRunRecord.java
@@ -22,6 +22,7 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.id.ProgramRunId;
 
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -40,6 +41,10 @@ public class DashboardProgramRunRecord {
   @Nullable
   private final Long running;
   @Nullable
+  private final Long suspend;
+  @Nullable
+  private final Long resume;
+  @Nullable
   private final Long end;
   private final ProgramRunStatus status;
 
@@ -48,13 +53,15 @@ public class DashboardProgramRunRecord {
     this(runId.getNamespace(), ArtifactSummary.from(artifactId),
          new ApplicationNameVersion(runId.getApplication(), runId.getVersion()),
          runId.getType().name(), runId.getProgram(), runId.getRun(), user, startMethod,
-         runRecord.getStartTs(), runRecord.getRunTs(), runRecord.getStopTs(), runRecord.getStatus());
+         runRecord.getStartTs(), runRecord.getRunTs(), runRecord.getSuspendTs(), runRecord.getResumeTs(),
+         runRecord.getStopTs(), runRecord.getStatus());
   }
 
   public DashboardProgramRunRecord(String namespace, ArtifactSummary artifact, ApplicationNameVersion application,
                                    String type, String program, String run,
                                    String user, String startMethod, long start,
-                                   @Nullable Long running, @Nullable Long end, ProgramRunStatus status) {
+                                   @Nullable Long running, @Nullable Long suspend, @Nullable Long resume,
+                                   @Nullable Long end, ProgramRunStatus status) {
     this.namespace = namespace;
     this.artifact = artifact;
     this.application = application;
@@ -65,6 +72,8 @@ public class DashboardProgramRunRecord {
     this.startMethod = startMethod;
     this.start = start;
     this.running = running;
+    this.suspend = suspend;
+    this.resume = resume;
     this.end = end;
     this.status = status;
   }
@@ -115,6 +124,24 @@ public class DashboardProgramRunRecord {
   }
 
   /**
+   * @return the time in seconds when the program was last suspended, or {@code null} if the program run was not
+   * suspended
+   */
+  @Nullable
+  public Long getSuspend() {
+    return suspend;
+  }
+
+  /**
+   * @return the time in seconds when the program was last resumed from suspended state,
+   * or {@code null} if the program run was never suspended or never resumed from suspended state.
+   */
+  @Nullable
+  public Long getResume() {
+    return resume;
+  }
+
+  /**
    * @return the time in seconds when the program run stopped, or {@code null} if the program run has not stopped yet.
    */
   @Nullable
@@ -151,5 +178,55 @@ public class DashboardProgramRunRecord {
     public String getVersion() {
       return version;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ApplicationNameVersion that = (ApplicationNameVersion) o;
+      return Objects.equals(this.getName(), that.getName()) &&
+        Objects.equals(this.getVersion(), that.getVersion());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, version);
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, artifact, application, type, program, run, user,
+                        startMethod, start, running, suspend, resume, end, status);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DashboardProgramRunRecord that = (DashboardProgramRunRecord) o;
+    return Objects.equals(this.getNamespace(), that.getNamespace()) &&
+      Objects.equals(this.getArtifact(), that.getArtifact()) &&
+      Objects.equals(this.getApplication(), that.getApplication()) &&
+      Objects.equals(this.getType(), that.getType()) &&
+      Objects.equals(this.getProgram(), that.getProgram()) &&
+      Objects.equals(this.getRun(), that.getRun()) &&
+      Objects.equals(this.getUser(), that.getUser()) &&
+      Objects.equals(this.getStartMethod(), that.getStartMethod()) &&
+      Objects.equals(this.getStart(), that.getStart()) &&
+      Objects.equals(this.getRunning(), that.getRunning()) &&
+      Objects.equals(this.getSuspend(), that.getSuspend()) &&
+      Objects.equals(this.getResume(), that.getResume()) &&
+      Objects.equals(this.getEnd(), that.getEnd()) &&
+      Objects.equals(this.getStatus(), that.getStatus());
   }
 }


### PR DESCRIPTION
Part 2 of https://issues.cask.co/browse/CDAP-13352

Reading the heart beat messages in Subscriber service and writing both heartbeat and program status run records to heartBeat dataset. 

OperationDashboardHandler changes to read from the heart beat dataset for queries and related test cases.