### PR TITLE
CDAP-13254 - Adding Metadata Dataset Migration Service

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataEntity.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataEntity.java
@@ -75,6 +75,7 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
   public static final String ARTIFACT = "artifact";
   public static final String VERSION = "version";
   public static final String DATASET = "dataset";
+  public static final String DATASET_INSTANCE = "DatasetInstance";
   public static final String STREAM = "stream";
   public static final String VIEW = "stream_view";
   public static final String TYPE = "type";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataMigrator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataMigrator.java
@@ -19,14 +19,16 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.data.DatasetContext;
-import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LogSamplers;
 import co.cask.cdap.common.logging.Loggers;
+import co.cask.cdap.common.service.AbstractRetryableScheduledService;
+import co.cask.cdap.common.service.RetryStrategies;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -37,38 +39,35 @@ import co.cask.cdap.data2.metadata.dataset.MetadataEntries;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import org.apache.tephra.TransactionSystemClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Metadata Migrator to migrate metadata from V1 metadata tables to V2 metadata tables.
  * Migration happens on business table as well as system table. It only migrates value and history rows.
  * Indexes will be automatically generated for every write on V2 metadata table.
  */
-class MetadataMigrator extends AbstractExecutionThreadService {
+class MetadataMigrator extends AbstractRetryableScheduledService {
   private static final Logger LOG = LoggerFactory.getLogger(MetadataMigrator.class);
   // For outage, only log once per 60 seconds per message.
   private static final Logger OUTAGE_LOG = Loggers.sampling(LOG, LogSamplers.perMessage(
     () -> LogSamplers.limitRate(60000)));
-  private static final Map<DatasetId, DatasetId> DATASET_IDS = ImmutableMap.of(
-    NamespaceId.SYSTEM.dataset("system.metadata"), NamespaceId.SYSTEM.dataset("v2.system.metadata"),
-    NamespaceId.SYSTEM.dataset("business.metadata"), NamespaceId.SYSTEM.dataset("v2.business.metadata"));
+  private static final Queue<KeyValue<DatasetId, DatasetId>> DATASETS = new LinkedList<>();
 
   private final DatasetFramework dsFramework;
   private final Transactional transactional;
   private final int batchSize;
-  private volatile Thread runThread;
-  private volatile boolean stopped;
 
   MetadataMigrator(CConfiguration cConf, DatasetFramework dsFramework, TransactionSystemClient txClient) {
+    // exponentially retry in case of failure to migrate
+    super(RetryStrategies.exponentialDelay(1, 60, TimeUnit.SECONDS));
     this.dsFramework = dsFramework;
     this.batchSize = cConf.getInt(Constants.Metadata.MIGRATOR_BATCH_SIZE);
     this.transactional = Transactions.createTransactionalWithRetry(
@@ -77,65 +76,60 @@ class MetadataMigrator extends AbstractExecutionThreadService {
                                                                    Collections.emptyMap(), null, null)),
       org.apache.tephra.RetryStrategies.retryOnConflict(20, 100)
     );
+    DATASETS.add(new KeyValue<>(NamespaceId.SYSTEM.dataset("system.metadata"),
+                                NamespaceId.SYSTEM.dataset("v2.system.metadata")));
+
+    DATASETS.add(new KeyValue<>(NamespaceId.SYSTEM.dataset("business.metadata"),
+                                NamespaceId.SYSTEM.dataset("v2.business.metadata")));
   }
 
   @Override
-  protected void startUp() throws Exception {
+  protected void doStartUp() throws Exception {
     LOG.info("Starting Metadata Migrator Service.");
   }
 
   @Override
-  public void run() {
-    runThread = Thread.currentThread();
-
-    try {
-      for (Map.Entry<DatasetId, DatasetId> datasetIdEntry : DATASET_IDS.entrySet()) {
-        // assume we already have v1 metadata table instance
-        AtomicBoolean hasV1Instance = new AtomicBoolean(true);
-
-        while (!stopped && hasV1Instance.get()) {
-          try {
-            if (!dsFramework.hasInstance(datasetIdEntry.getKey())) {
-              hasV1Instance.set(false);
-              break;
-            }
-            // This thread migrates metadata in batches. It does following operations in a single transaction:
-            // 1.) Scan V1 metadata table for value and history rows in batch of batchSize.
-            // 2.) Write scanned MetadataEntries to V2 table.
-            // 3.) Delete successfully written metadata entries from V1 table.
-            Transactionals.execute(transactional, context -> {
-              MetadataDataset v1 = getMetadataDataset(context, datasetIdEntry.getKey());
-              MetadataDataset v2 = getMetadataDataset(context, datasetIdEntry.getValue());
-
-              // All the metadata entries are written using setProperty because it does not modify the MetadataEntry
-              // keys
-              MetadataEntries entries = v1.scanFromV1Table(batchSize);
-
-              if (entries.getEntries().isEmpty()) {
-                // All the value and history rows have been migrated so stop this thread and drop V1 MetadataDataset
-                dropV1MetadataDataset(datasetIdEntry.getKey());
-                LOG.debug("Migration for dataset {} is complete. This dataset is dropped.", datasetIdEntry.getKey());
-                hasV1Instance.set(false);
-                return;
-              }
-
-              v2.writeUpgradedRows(entries.getEntries());
-              // We do not need to keep checkpoints. Instead, we will just delete scanned rows from metadata dataset
-              v1.deleteRows(entries.getRows());
-            });
-          } catch (Exception e) {
-            OUTAGE_LOG.error("Exception while migrating metadata from {} to {}, will be retried. ",
-                             datasetIdEntry.getKey(), datasetIdEntry.getValue(), e);
-            Thread.sleep(1000);
-          }
-        }
-      }
-    } catch (InterruptedException e) {
-      // Interruption means stopping the service
+  public long runTask() throws Exception {
+    if (DATASETS.isEmpty()) {
+      stop();
     }
 
-    // Clear the interrupt flag
-    Thread.interrupted();
+    KeyValue<DatasetId, DatasetId> datasetIdEntry = DATASETS.peek();
+    if (!dsFramework.hasInstance(datasetIdEntry.getKey())) {
+      DATASETS.poll();
+      return 0;
+    }
+
+    // This thread migrates metadata in batches. It does following operations in a single transaction:
+    // 1.) Scan V1 metadata table for value and history rows in batch of batchSize.
+    // 2.) Write scanned MetadataEntries to V2 table.
+    // 3.) Delete successfully written metadata entries from V1 table.
+    Boolean dropV1Table = Transactionals.execute(transactional, context -> {
+      MetadataDataset v1 = getMetadataDataset(context, datasetIdEntry.getKey());
+      MetadataDataset v2 = getMetadataDataset(context, datasetIdEntry.getValue());
+
+      // All the metadata entries are written using setProperty because it does not modify the MetadataEntry
+      // keys
+      MetadataEntries entries = v1.scanFromV1Table(batchSize);
+
+      if (entries.getEntries().isEmpty()) {
+        // All the value and history rows have been migrated so stop this thread and drop V1 MetadataDataset
+        return true;
+      }
+
+      v2.writeUpgradedRows(entries.getEntries());
+      // We do not need to keep checkpoints. Instead, we will just delete scanned rows from metadata dataset
+      v1.deleteRows(entries.getRows());
+      return false;
+    });
+
+    if (dropV1Table) {
+      dsFramework.deleteInstance(datasetIdEntry.getKey());
+      LOG.debug("Migration for dataset {} is complete. This dataset is dropped.", datasetIdEntry.getKey());
+    }
+
+    // Immediately migrate next batch to finish migration faster.
+    return 0;
   }
 
   @Override
@@ -144,23 +138,8 @@ class MetadataMigrator extends AbstractExecutionThreadService {
   }
 
   @Override
-  protected void triggerShutdown() {
-    stopped = true;
-    if (runThread != null) {
-      runThread.interrupt();
-    }
-  }
-
-  @Override
-  protected void shutDown() throws Exception {
+  protected void doShutdown() throws Exception {
     LOG.info("Stopping Metadata Migrator Service.");
-  }
-
-  private void dropV1MetadataDataset(DatasetId datasetId) throws DatasetManagementException, IOException {
-    DatasetAdmin admin = dsFramework.getAdmin(datasetId, null);
-    if (admin != null) {
-      admin.drop();
-    }
   }
 
   private MetadataDataset getMetadataDataset(DatasetContext context, DatasetId datasetId)

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataMigrator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataMigrator.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.logging.LogSamplers;
+import co.cask.cdap.common.logging.Loggers;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.MetadataDatasetDefinition;
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import org.apache.tephra.TransactionSystemClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Metadata Migrator to migrate metadata from V1 metadata tables to V2 metadata tables.
+ * Migration happens on business table as well as system table. It only migrates value and history rows.
+ * Indexes will be automatically generated for every write on V2 metadata table.
+ */
+class MetadataMigrator extends AbstractExecutionThreadService {
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataMigrator.class);
+  // For outage, only log once per 60 seconds per message.
+  private static final Logger OUTAGE_LOG = Loggers.sampling(LOG, LogSamplers.perMessage(
+    () -> LogSamplers.limitRate(60000)));
+  private static final List<DatasetId> DATASET_IDS = ImmutableList.of(NamespaceId.SYSTEM.dataset("system.metadata"),
+                                                                      NamespaceId.SYSTEM.dataset("v2.system.metadata"),
+                                                                      NamespaceId.SYSTEM.dataset("business.metadata"),
+                                                                      NamespaceId.SYSTEM.dataset("v2.business.metadata")
+  );
+
+  private final DatasetFramework dsFramework;
+  private final Transactional transactional;
+  private final int batchSize;
+  private volatile Thread runThread;
+  private volatile boolean stopped;
+  private volatile boolean hasV1Instance;
+
+  MetadataMigrator(CConfiguration cConf, DatasetFramework dsFramework, TransactionSystemClient txClient) {
+    this.dsFramework = dsFramework;
+    this.batchSize = cConf.getInt(Constants.Metadata.MIGRATOR_BATCH_SIZE);
+    this.transactional = Transactions.createTransactionalWithRetry(
+      Transactions.createTransactional(new MultiThreadDatasetCache(new SystemDatasetInstantiator(dsFramework),
+                                                                   txClient, NamespaceId.SYSTEM,
+                                                                   Collections.emptyMap(), null, null)),
+      org.apache.tephra.RetryStrategies.retryOnConflict(20, 100)
+    );
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting Metadata Migrator Service.");
+  }
+
+  @Override
+  public void run() {
+    runThread = Thread.currentThread();
+
+    try {
+      for (int i = 0; i < DATASET_IDS.size(); i = i + 2) {
+        // assume we already have v1 metadata table instance
+        hasV1Instance = true;
+
+        while (!stopped && hasV1Instance) {
+          try {
+            final int index = i;
+            // This thread migrates metadata in batches. It does following operations in a single transaction:
+            // 1.) Scan V1 metadata table for value and history rows in batch of batchSize.
+            // 2.) Write scanned MetadataEntries to V2 table.
+            // 3.) Delete successfully written metadata entries from V1 table.
+            Transactionals.execute(transactional, context -> {
+              if (!dsFramework.hasInstance(DATASET_IDS.get(index))) {
+                hasV1Instance = false;
+                return;
+              }
+
+              MetadataDataset v1 = getMetadataDataset(context, DATASET_IDS.get(index));
+              MetadataDataset v2 = getMetadataDataset(context, DATASET_IDS.get(index + 1));
+
+              // All the metadata entries are written using setProperty because it does not modify the MetadataEntry
+              // keys
+              List<KeyValue<Long, MetadataEntry>> entries = v1.scanOrDeleteFromV1Table(batchSize, false);
+
+              if (entries.isEmpty()) {
+                // All the value and history rows have been migrated so stop this thread and drop V1 MetadataDataset
+                dropV1MetadataDataset(index);
+                LOG.debug("Migration for dataset {} is complete. This dataset is dropped.", DATASET_IDS.get(index));
+                return;
+              }
+
+              v2.writeUpgradedRow(entries);
+              // We do not need to keep checkpoints. Instead, we will just delete scanned rows from metadata dataset
+              v1.scanOrDeleteFromV1Table(entries.size(), true);
+            });
+          } catch (Exception e) {
+            OUTAGE_LOG.error("Exception while migrating metadata from {} to {}, will be retried. ", DATASET_IDS.get(i),
+                             DATASET_IDS.get(i + 1), e);
+            Thread.sleep(1000);
+          }
+        }
+      }
+    } catch (InterruptedException e) {
+      // Interruption means stopping the service
+    }
+
+    // Clear the interrupt flag
+    Thread.interrupted();
+  }
+
+  @Override
+  protected String getServiceName() {
+    return "metadata-migrator-service";
+  }
+
+  @Override
+  protected void triggerShutdown() {
+    stopped = true;
+    if (runThread != null) {
+      runThread.interrupt();
+    }
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping Metadata Migrator Service.");
+  }
+
+  private void dropV1MetadataDataset(int index) throws DatasetManagementException, IOException {
+    DatasetAdmin admin = dsFramework.getAdmin(DATASET_IDS.get(index), null);
+    if (admin != null) {
+      admin.drop();
+      hasV1Instance = false;
+    }
+  }
+
+  private MetadataDataset getMetadataDataset(DatasetContext context, DatasetId datasetId)
+    throws IOException, DatasetManagementException {
+    MetadataScope scope = datasetId.getDataset().contains("business") ? MetadataScope.USER : MetadataScope.SYSTEM;
+    return DatasetsUtil.getOrCreateDataset(context, dsFramework, datasetId, MetadataDataset.class.getName(),
+                                           DatasetProperties.builder().add(MetadataDatasetDefinition.SCOPE_KEY,
+                                                                           scope.name()).build());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataService.java
@@ -49,7 +49,6 @@ public class MetadataService extends AbstractIdleService {
   private final MetricsCollectionService metricsCollectionService;
   private final DiscoveryService discoveryService;
   private final Set<HttpHandler> handlers;
-  private final Integer instanceId;
   private final MetadataMigrator metadataMigrator;
 
   private NettyHttpService httpService;
@@ -59,13 +58,11 @@ public class MetadataService extends AbstractIdleService {
   MetadataService(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                   DiscoveryService discoveryService,
                   @Named(Constants.Metadata.HANDLERS_NAME) Set<HttpHandler> handlers,
-                  DatasetFramework dsFramework, TransactionSystemClient txClient,
-                  @Named(Constants.DatasetOpsExecutor.INSTANCE_ID) Integer instanceId) {
+                  DatasetFramework dsFramework, TransactionSystemClient txClient) {
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
     this.discoveryService = discoveryService;
     this.handlers = handlers;
-    this.instanceId = instanceId;
     this.metadataMigrator = new MetadataMigrator(cConf, dsFramework, txClient);
   }
 
@@ -85,8 +82,8 @@ public class MetadataService extends AbstractIdleService {
 
     httpService.start();
 
-    // Start migration only on the first instance of Dataset Ops Executor.
-    if (instanceId == 0) {
+    // Only first instance will run the migration thread.
+    if (Boolean.valueOf(cConf.get(Constants.Dataset.Executor.IS_UPGRADE_NEEDED, "false"))) {
       metadataMigrator.start();
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
@@ -24,7 +24,6 @@ import com.google.inject.PrivateModule;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
-import org.apache.twill.api.TwillContext;
 
 import java.util.Set;
 
@@ -32,20 +31,9 @@ import java.util.Set;
  * Guice module for metadata service.
  */
 public class MetadataServiceModule extends PrivateModule {
-  private final Integer instanceId;
-
-  public MetadataServiceModule(TwillContext twillContext) {
-    this.instanceId = twillContext.getInstanceId();
-  }
-
-  public MetadataServiceModule() {
-    this.instanceId = 0;
-  }
 
   @Override
   protected void configure() {
-    bind(Integer.class).annotatedWith(Names.named(Constants.DatasetOpsExecutor.INSTANCE_ID))
-      .toInstance(instanceId);
     Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
       binder(), HttpHandler.class, Names.named(Constants.Metadata.HANDLERS_NAME));
 
@@ -55,7 +43,5 @@ public class MetadataServiceModule extends PrivateModule {
     expose(Key.get(new TypeLiteral<Set<HttpHandler>>() { }, Names.named(Constants.Metadata.HANDLERS_NAME)));
     bind(MetadataAdmin.class).to(DefaultMetadataAdmin.class);
     expose(MetadataAdmin.class);
-    bind(MetadataService.class);
-    expose(MetadataService.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
@@ -24,6 +24,7 @@ import com.google.inject.PrivateModule;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
+import org.apache.twill.api.TwillContext;
 
 import java.util.Set;
 
@@ -31,9 +32,16 @@ import java.util.Set;
  * Guice module for metadata service.
  */
 public class MetadataServiceModule extends PrivateModule {
+  private final Integer instanceId;
+
+  public MetadataServiceModule(TwillContext twillContext) {
+    this.instanceId = twillContext.getInstanceId();
+  }
 
   @Override
   protected void configure() {
+    bind(Integer.class).annotatedWith(Names.named(Constants.DatasetOpsExecutor.INSTANCE_ID))
+      .toInstance(instanceId);
     Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
       binder(), HttpHandler.class, Names.named(Constants.Metadata.HANDLERS_NAME));
 
@@ -43,5 +51,7 @@ public class MetadataServiceModule extends PrivateModule {
     expose(Key.get(new TypeLiteral<Set<HttpHandler>>() { }, Names.named(Constants.Metadata.HANDLERS_NAME)));
     bind(MetadataAdmin.class).to(DefaultMetadataAdmin.class);
     expose(MetadataAdmin.class);
+    bind(MetadataService.class);
+    expose(MetadataService.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -36,6 +36,10 @@ public class MetadataServiceModule extends PrivateModule {
 
   public MetadataServiceModule(TwillContext twillContext) {
     this.instanceId = twillContext.getInstanceId();
+  }
+
+  public MetadataServiceModule() {
+    this.instanceId = 0;
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.test.MockTwillContext;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -95,7 +96,7 @@ public class DefaultPreviewManagerTest {
       new StreamAdminModules().getInMemoryModules(),
       new StreamServiceRuntimeModule().getInMemoryModules(),
       new NamespaceStoreModule().getStandaloneModules(),
-      new MetadataServiceModule(),
+      new MetadataServiceModule(new MockTwillContext()),
       new MetadataReaderWriterModules().getInMemoryModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getStandaloneModules(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -28,7 +28,6 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
-import co.cask.cdap.common.test.MockTwillContext;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -96,7 +95,7 @@ public class DefaultPreviewManagerTest {
       new StreamAdminModules().getInMemoryModules(),
       new StreamServiceRuntimeModule().getInMemoryModules(),
       new NamespaceStoreModule().getStandaloneModules(),
-      new MetadataServiceModule(new MockTwillContext()),
+      new MetadataServiceModule(),
       new MetadataReaderWriterModules().getInMemoryModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getStandaloneModules(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.test.MockTwillContext;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -108,7 +109,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new StreamAdminModules().getInMemoryModules());
     install(new StreamServiceRuntimeModule().getInMemoryModules());
     install(new NamespaceStoreModule().getStandaloneModules());
-    install(new MetadataServiceModule());
+    install(new MetadataServiceModule(new MockTwillContext()));
     install(new AuthorizationModule());
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreModules().getInMemoryModules());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -27,7 +27,6 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
-import co.cask.cdap.common.test.MockTwillContext;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -109,7 +108,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new StreamAdminModules().getInMemoryModules());
     install(new StreamServiceRuntimeModule().getInMemoryModules());
     install(new NamespaceStoreModule().getStandaloneModules());
-    install(new MetadataServiceModule(new MockTwillContext()));
+    install(new MetadataServiceModule());
     install(new AuthorizationModule());
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreModules().getInMemoryModules());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataMigratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataMigratorTest.java
@@ -42,6 +42,7 @@ import co.cask.cdap.data2.metadata.dataset.MetadataDatasetDefinition;
 import co.cask.cdap.data2.metadata.dataset.MetadataEntries;
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
 import co.cask.cdap.data2.metadata.dataset.MetadataV1;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
@@ -153,7 +154,7 @@ public class MetadataMigratorTest {
     MetadataMigrator migrator = new MetadataMigrator(cConf, datasetFramework, transactionSystemClient);
     migrator.start();
 
-    // Wait for migrator to finish before reading v2 tables
+    // Wait for migrator to finish before reading v2 tablesf
     Tasks.waitFor(true, () -> migrator.state().equals(Service.State.TERMINATED), 5, TimeUnit.MINUTES);
 
     Transactionals.execute(transactional, context -> {
@@ -226,10 +227,12 @@ public class MetadataMigratorTest {
   }
 
   private void assertIndex(MetadataDataset v2System) throws Exception {
-    List<MetadataEntry> entries = v2System.search(app1.getNamespace(), "avalue1",
-                                                  ImmutableSet.of(EntityTypeSimpleName.ALL),
-                                                  SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null,
-                                                  false, EnumSet.of(EntityScope.USER)).getResults();
+    SearchRequest sr = new SearchRequest(new NamespaceId("ns1"), "avalue1",
+                                              ImmutableSet.of(EntityTypeSimpleName.ALL), SortInfo.DEFAULT, 0,
+                                              Integer.MAX_VALUE, 1, null, false, EnumSet.of(EntityScope.USER));
+
+
+    List<MetadataEntry> entries = v2System.search(sr).getResults();
 
     for (MetadataEntry entry : entries) {
       Assert.assertEquals("avalue1", entry.getValue());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataMigratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataMigratorTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.metadata.dataset.MdsHistoryKey;
+import co.cask.cdap.data2.metadata.dataset.MdsKey;
+import co.cask.cdap.data2.metadata.dataset.Metadata;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.MetadataDatasetDefinition;
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.MetadataV1;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.internal.guice.AppFabricTestModule;
+import co.cask.cdap.proto.EntityScope;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Service;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.tephra.RetryStrategies;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TransactionSystemClient;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for Metadata Migrator Service.
+ */
+public class MetadataMigratorTest {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
+    .create();
+
+  private final ApplicationId app1 = new ApplicationId("ns1", "app1");
+  private final ProgramId flow1 = new ProgramId("ns1", "app1", ProgramType.FLOW, "flow1");
+  private final DatasetId dataset1 = new DatasetId("ns1", "ds1");
+  private final StreamId stream1 = new StreamId("ns1", "s1");
+  private final StreamViewId view1 = new StreamViewId(stream1.getNamespace(), stream1.getStream(), "v1");
+  private final ArtifactId artifact1 = new ArtifactId("ns1", "a1", "1.0.0");
+
+  private static CConfiguration cConf;
+  private TransactionManager txManager;
+  private TransactionSystemClient transactionSystemClient;
+  private DatasetService datasetService;
+  private DatasetFramework datasetFramework;
+  private Transactional transactional;
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @Before
+  public void init() throws Exception {
+    cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.set(Constants.Metadata.MIGRATOR_BATCH_SIZE, "5");
+
+    Injector injector = Guice.createInjector(new AppFabricTestModule(cConf));
+
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+    transactionSystemClient = injector.getInstance(TransactionSystemClient.class);
+
+    datasetService = injector.getInstance(DatasetService.class);
+    datasetService.startAndWait();
+    datasetFramework = injector.getInstance(DatasetFramework.class);
+
+    this.transactional = Transactions.createTransactionalWithRetry(
+      Transactions.createTransactional(new MultiThreadDatasetCache(
+        new SystemDatasetInstantiator(datasetFramework), transactionSystemClient,
+        NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)),
+      RetryStrategies.retryOnConflict(20, 100)
+    );
+
+  }
+
+  @After
+  public void stop() {
+    datasetService.stopAndWait();
+    txManager.stopAndWait();
+  }
+
+  /**
+   * Tests data migration from V1 MetadataDataset to V2 MetadataDataset.
+   */
+  @Test
+  public void testMetadataMigration() throws Exception {
+    DatasetId v1SystemDatasetId = NamespaceId.SYSTEM.dataset("system.metadata");
+    DatasetId v1BusinessDatasetId = NamespaceId.SYSTEM.dataset("business.metadata");
+    DatasetId v2SystemDatasetId = NamespaceId.SYSTEM.dataset("v2.system.metadata");
+    DatasetId v2BusinessDatasetId = NamespaceId.SYSTEM.dataset("v2.business.metadata");
+
+    generateMetadata(v1SystemDatasetId);
+    generateMetadata(v1BusinessDatasetId);
+
+    MetadataMigrator migrator = new MetadataMigrator(cConf, datasetFramework, transactionSystemClient);
+    migrator.start();
+
+    // Wait for migrator to finish before reading v2 tables
+    Tasks.waitFor(true, () -> migrator.state().equals(Service.State.TERMINATED), 5, TimeUnit.MINUTES);
+
+    Transactionals.execute(transactional, context -> {
+      MetadataDataset v2System = getMetadataDataset(context, v2SystemDatasetId);
+      MetadataDataset v2Business = getMetadataDataset(context, v2BusinessDatasetId);
+
+      assertProperties(v2System, v2Business);
+      assertHistory(v2System, v2Business);
+      assertIndex(v2System);
+      assertIndex(v2Business);
+    });
+  }
+
+  /**
+   * Tests batch scanning and deletes on V1 MetadataDataset.
+   */
+  @Test
+  public void testScanOrDelete() throws Exception {
+    DatasetId v1SystemDatasetId = NamespaceId.SYSTEM.dataset("system.metadata");
+    DatasetId v1BusinessDatasetId = NamespaceId.SYSTEM.dataset("business.metadata");
+
+    generateMetadata(v1SystemDatasetId);
+    generateMetadata(v1BusinessDatasetId);
+
+    Transactionals.execute(transactional, context -> {
+      MetadataDataset v1System = getMetadataDataset(context, v1SystemDatasetId);
+      int total = 0;
+      int scanCount;
+      int deleteCount;
+      do {
+        scanCount = v1System.scanOrDeleteFromV1Table(2, false).size();
+        deleteCount = v1System.scanOrDeleteFromV1Table(2, true).size();
+        Assert.assertEquals(scanCount, deleteCount);
+        total = total + scanCount;
+      } while (scanCount != 0);
+
+      Assert.assertEquals(13, total);
+    });
+  }
+
+  private void assertProperties(MetadataDataset v2System, MetadataDataset v2Business) {
+    Assert.assertEquals("avalue11", v2System.getProperties(app1.toMetadataEntity()).get("akey1"));
+    Assert.assertEquals("avalue2", v2System.getProperties(flow1.toMetadataEntity()).get("akey2"));
+    Assert.assertEquals("avalue3", v2System.getProperties(dataset1.toMetadataEntity()).get("akey3"));
+    Assert.assertEquals("avalue4", v2System.getProperties(stream1.toMetadataEntity()).get("akey4"));
+    Assert.assertEquals("avalue5", v2System.getProperties(view1.toMetadataEntity()).get("akey5"));
+    Assert.assertEquals("avalue6", v2System.getProperties(artifact1.toMetadataEntity()).get("akey6"));
+
+    Assert.assertEquals("avalue11", v2Business.getProperties(app1.toMetadataEntity()).get("akey1"));
+    Assert.assertEquals("avalue2", v2Business.getProperties(flow1.toMetadataEntity()).get("akey2"));
+    Assert.assertEquals("avalue3", v2Business.getProperties(dataset1.toMetadataEntity()).get("akey3"));
+    Assert.assertEquals("avalue4", v2Business.getProperties(stream1.toMetadataEntity()).get("akey4"));
+    Assert.assertEquals("avalue5", v2Business.getProperties(view1.toMetadataEntity()).get("akey5"));
+    Assert.assertEquals("avalue6", v2Business.getProperties(artifact1.toMetadataEntity()).get("akey6"));
+  }
+
+  private void assertHistory(MetadataDataset v2System, MetadataDataset v2Business) {
+    verifyhistory(v2System, app1.toMetadataEntity());
+    verifyhistory(v2System, flow1.toMetadataEntity());
+    verifyhistory(v2System, dataset1.toMetadataEntity());
+    verifyhistory(v2System, stream1.toMetadataEntity());
+    verifyhistory(v2System, view1.toMetadataEntity());
+    verifyhistory(v2System, artifact1.toMetadataEntity());
+
+    verifyhistory(v2Business, app1.toMetadataEntity());
+    verifyhistory(v2Business, flow1.toMetadataEntity());
+    verifyhistory(v2Business, dataset1.toMetadataEntity());
+    verifyhistory(v2Business, stream1.toMetadataEntity());
+    verifyhistory(v2Business, view1.toMetadataEntity());
+    verifyhistory(v2Business, artifact1.toMetadataEntity());
+  }
+
+  private void assertIndex(MetadataDataset v2System) throws Exception {
+    List<MetadataEntry> entries = v2System.search(app1.getNamespace(), "avalue1",
+                                                  ImmutableSet.of(EntityTypeSimpleName.ALL),
+                                                  SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null,
+                                                  false, EnumSet.of(EntityScope.USER)).getResults();
+
+    for (MetadataEntry entry : entries) {
+      Assert.assertEquals("avalue1", entry.getValue());
+    }
+  }
+
+  private void verifyhistory(MetadataDataset v2System, MetadataEntity entity) {
+    for (Metadata metadata : v2System.getSnapshotBeforeTime(ImmutableSet.of(entity), System.currentTimeMillis())) {
+      Assert.assertEquals(1, metadata.getProperties().size());
+    }
+  }
+
+  private void generateMetadata(DatasetId datasetId) throws Exception {
+    // Set some properties
+    write(datasetId, app1, "akey1", "avalue1");
+    write(datasetId, flow1, "akey2", "avalue2");
+    write(datasetId, dataset1, "akey3", "avalue3");
+    write(datasetId, stream1, "akey4", "avalue4");
+    write(datasetId, view1, "akey5", "avalue5");
+    write(datasetId, artifact1, "akey6", "avalue6");
+    write(datasetId, app1, "akey1", "avalue11");
+  }
+
+  private void write(DatasetId datasetId, NamespacedEntityId targetId, String key, String value) throws Exception {
+    Put valuePut = createValuePut(targetId, key, value);
+    Put historyPut = createHistoryPut(targetId);
+
+    Transactionals.execute(transactional, context -> {
+      // Create metadata dataset to access underlying indexed table
+      getMetadataDataset(context, datasetId);
+
+      getIndexedTable(context, datasetId).put(valuePut);
+      getIndexedTable(context, datasetId).put(historyPut);
+    }, Exception.class);
+  }
+
+  private Put createValuePut(NamespacedEntityId targetId, String key, String value) {
+    MDSKey mdsValueKey = MdsKey.getMDSValueKey(targetId, key);
+    Put put = new Put(mdsValueKey.getKey());
+
+    // add the metadata value
+    byte[] valueRowPrefix = {'v'};
+    put.add(valueRowPrefix, Bytes.toBytes(value));
+    return put;
+  }
+
+  private Put createHistoryPut(NamespacedEntityId targetId) {
+    MetadataV1 metadataV1 = getMetadataV1(targetId);
+    byte[] row = MdsHistoryKey.getMdsKey(targetId, System.currentTimeMillis()).getKey();
+    Put put = new Put(row);
+    put.add(Bytes.toBytes("h"), Bytes.toBytes(GSON.toJson(metadataV1)));
+    return put;
+  }
+
+  private MetadataV1 getMetadataV1(NamespacedEntityId targetId) {
+    Map<String, String> properties = ImmutableMap.of("pk1", "pv1", "pk2", "pv2");
+    Set<String> tags = ImmutableSet.of("tag1, tag2");
+    return new MetadataV1(targetId, properties, tags);
+  }
+
+  /**
+   * Gets underlying Indexed Table.
+   */
+  private IndexedTable getIndexedTable(DatasetContext context, DatasetId datasetId) throws Exception {
+    String prefix = datasetId.getDataset().contains("business") ? "business" : "system";
+    return DatasetsUtil.getOrCreateDataset(context, datasetFramework,
+                                           NamespaceId.SYSTEM.dataset(prefix + ".metadata.metadata_index"),
+                                           IndexedTable.class.getName(),
+                                           DatasetProperties.builder()
+                                             .add(IndexedTable.INDEX_COLUMNS_CONF_KEY, "i,n,in,c,ic").build());
+  }
+
+  /**
+   * Gets metadata table.
+   */
+  private MetadataDataset getMetadataDataset(DatasetContext context, DatasetId datasetId) throws Exception {
+    MetadataScope scope = datasetId.getDataset().contains("business") ? MetadataScope.USER : MetadataScope.SYSTEM;
+
+    return DatasetsUtil.getOrCreateDataset(context, datasetFramework, datasetId, MetadataDataset.class.getName(),
+                                           DatasetProperties.builder()
+                                             .add(MetadataDatasetDefinition.SCOPE_KEY, scope.name()).build());
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -478,6 +478,8 @@ public final class Constants {
       public static final String MAX_INSTANCES = "dataset.executor.max.instances";
 
       public static final String SERVICE_DESCRIPTION = "Service to perform dataset operations.";
+
+      public static final String IS_UPGRADE_NEEDED = "dataset.upgrade.needed";
     }
 
     /**
@@ -493,13 +495,6 @@ public final class Constants {
       public static final String DISTMODE_METRICS_TABLE = "dataset.extensions.distributed.mode.metrics.table";
       public static final String DISTMODE_QUEUE_TABLE = "dataset.extensions.distributed.mode.queue.table";
     }
-  }
-
-  /**
-   * Dataset Ops executor constants.
-   */
-  public static final class DatasetOpsExecutor {
-    public static final String INSTANCE_ID = "ops.executor.instance.id";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -496,6 +496,13 @@ public final class Constants {
   }
 
   /**
+   * Dataset Ops executor constants.
+   */
+  public static final class DatasetOpsExecutor {
+    public static final String INSTANCE_ID = "ops.executor.instance.id";
+  }
+
+  /**
    * Stream configurations and constants.
    */
   public static final class Stream {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1299,7 +1299,7 @@ public final class Constants {
   }
 
   /**
-   * Constants for metadata service
+   * Constants for metadata service and metadata migrator
    */
   public static final class Metadata {
     public static final String SERVICE_DESCRIPTION = "Service to perform metadata operations.";
@@ -1313,6 +1313,8 @@ public final class Constants {
     public static final String MESSAGING_TOPIC = "metadata.messaging.topic";
     public static final String MESSAGING_FETCH_SIZE = "metadata.messaging.fetch.size";
     public static final String MESSAGING_POLL_DELAY_MILLIS = "metadata.messaging.poll.delay.millis";
+
+    public static final String MIGRATOR_BATCH_SIZE = "metadata.upgrade.migration.batch.size";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2056,6 +2056,14 @@
     </description>
   </property>
 
+  <property>
+    <name>metadata.upgrade.migration.batch.size</name>
+    <value>1000</value>
+    <description>
+      Number of metadata value or history rows to be migrated to v2 metadata table in a batch
+    </description>
+  </property>
+
   <!-- Metrics Configuration -->
 
   <property>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/EntityIdKeyHelper.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/EntityIdKeyHelper.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.dataset2.lib.table;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
@@ -140,7 +141,7 @@ public final class EntityIdKeyHelper {
       String name = keySplitter.getString();
       String version = keySplitter.getString();
       return new ArtifactId(namespaceId, name, version);
-    } else if (type.equals(TYPE_MAP.get(DatasetId.class))) {
+    } else if (type.equals(TYPE_MAP.get(DatasetId.class)) || type.equals(MetadataEntity.DATASET_INSTANCE)) {
       String namespaceId = keySplitter.getString();
       String instanceId  = keySplitter.getString();
       return new DatasetId(namespaceId, instanceId);
@@ -163,8 +164,20 @@ public final class EntityIdKeyHelper {
     throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
   }
 
-  public static String getTargetType(NamespacedEntityId namespacedEntityId) {
+  private static String getTargetType(NamespacedEntityId namespacedEntityId) {
     return TYPE_MAP.get(namespacedEntityId.getClass());
+  }
+
+  /**
+   * To get entity type in v1 format. We need this method because in 5.0 we are renaming Dataset
+   * serialization from DatasetInstance to Dataset.
+   *
+   * @param namespacedEntityId entity for which type is needed
+   * @return v1 type of the entity
+   */
+  public static String getV1TargetType(NamespacedEntityId namespacedEntityId) {
+    String type = TYPE_MAP.get(namespacedEntityId.getClass());
+    return type.equals(MetadataEntity.DATASET) ? MetadataEntity.DATASET_INSTANCE : type;
   }
 
   private EntityIdKeyHelper() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
@@ -16,10 +16,16 @@
 
 package co.cask.cdap.data2.metadata.dataset;
 
-import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.proto.id.NamespacedEntityId;
+
+import static co.cask.cdap.api.metadata.MetadataEntity.APPLICATION;
+import static co.cask.cdap.api.metadata.MetadataEntity.ARTIFACT;
+import static co.cask.cdap.api.metadata.MetadataEntity.DATASET;
+import static co.cask.cdap.api.metadata.MetadataEntity.PROGRAM;
+import static co.cask.cdap.api.metadata.MetadataEntity.STREAM;
+import static co.cask.cdap.api.metadata.MetadataEntity.VIEW;
 
 /**
  * Key class to get v1 metadata history key information
@@ -47,30 +53,30 @@ public final class MdsHistoryKey {
     keySplitter.skipBytes();
 
     switch (type) {
-      case MetadataEntity.PROGRAM:
+      case PROGRAM:
         keySplitter.skipString();
         keySplitter.skipString();
         keySplitter.skipString();
         keySplitter.skipString();
         break;
-      case MetadataEntity.APPLICATION:
+      case APPLICATION:
         keySplitter.skipString();
         keySplitter.skipString();
         break;
-      case MetadataEntity.DATASET:
+      case DATASET:
         keySplitter.skipString();
         keySplitter.skipString();
         break;
-      case MetadataEntity.STREAM:
+      case STREAM:
         keySplitter.skipString();
         keySplitter.skipString();
         break;
-      case MetadataEntity.VIEW:
+      case VIEW:
         keySplitter.skipString();
         keySplitter.skipString();
         keySplitter.skipString();
         break;
-      case MetadataEntity.ARTIFACT:
+      case ARTIFACT:
         keySplitter.skipString();
         keySplitter.skipString();
         keySplitter.skipString();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
@@ -23,6 +23,7 @@ import co.cask.cdap.proto.id.NamespacedEntityId;
 import static co.cask.cdap.api.metadata.MetadataEntity.APPLICATION;
 import static co.cask.cdap.api.metadata.MetadataEntity.ARTIFACT;
 import static co.cask.cdap.api.metadata.MetadataEntity.DATASET;
+import static co.cask.cdap.api.metadata.MetadataEntity.DATASET_INSTANCE;
 import static co.cask.cdap.api.metadata.MetadataEntity.PROGRAM;
 import static co.cask.cdap.api.metadata.MetadataEntity.STREAM;
 import static co.cask.cdap.api.metadata.MetadataEntity.VIEW;
@@ -60,22 +61,13 @@ public final class MdsHistoryKey {
         keySplitter.skipString();
         break;
       case APPLICATION:
-        keySplitter.skipString();
-        keySplitter.skipString();
-        break;
       case DATASET:
-        keySplitter.skipString();
-        keySplitter.skipString();
-        break;
+      case DATASET_INSTANCE:
       case STREAM:
         keySplitter.skipString();
         keySplitter.skipString();
         break;
       case VIEW:
-        keySplitter.skipString();
-        keySplitter.skipString();
-        keySplitter.skipString();
-        break;
       case ARTIFACT:
         keySplitter.skipString();
         keySplitter.skipString();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Key class to get v1 metadata history key information
+ */
+public final class MdsHistoryKey {
+  private static final byte[] ROW_PREFIX = {'h'};
+
+  public static MDSKey getMdsKey(NamespacedEntityId targetId, long time) {
+    MDSKey.Builder builder = new MDSKey.Builder();
+    builder.add(ROW_PREFIX);
+    EntityIdKeyHelper.addTargetIdToKey(builder, targetId);
+    builder.add(invertTime(time));
+    return builder.build();
+  }
+
+  static byte[] getHistoryRowPrefix() {
+    MDSKey key = new MDSKey.Builder().add(ROW_PREFIX).build();
+    return key.getKey();
+  }
+
+  private static long invertTime(long time) {
+    return Long.MAX_VALUE - time;
+  }
+
+  static long getHistoryTime(byte[] rowKey) {
+    return ByteBuffer.wrap(rowKey).getLong(rowKey.length - 8);
+  }
+
+  private MdsHistoryKey() {
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
@@ -16,15 +16,10 @@
 
 package co.cask.cdap.data2.metadata.dataset;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
-import co.cask.cdap.proto.id.ApplicationId;
-import co.cask.cdap.proto.id.ArtifactId;
-import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
-import co.cask.cdap.proto.id.ProgramId;
-import co.cask.cdap.proto.id.StreamId;
-import co.cask.cdap.proto.id.StreamViewId;
 
 /**
  * Key class to get v1 metadata history key information
@@ -51,33 +46,37 @@ public final class MdsHistoryKey {
     // Skip rowType
     keySplitter.skipBytes();
 
-    // Skip targetId
-    if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ProgramId.class))) {
-      keySplitter.skipString();
-      keySplitter.skipString();
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ApplicationId.class))) {
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(DatasetId.class))) {
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamId.class))) {
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamViewId.class))) {
-      // skip namespace, stream, view
-      keySplitter.skipString();
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ArtifactId.class))) {
-      // skip namespace, name, version
-      keySplitter.skipString();
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else {
-      throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
+    switch (type) {
+      case MetadataEntity.PROGRAM:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      case MetadataEntity.APPLICATION:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      case MetadataEntity.DATASET:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      case MetadataEntity.STREAM:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      case MetadataEntity.VIEW:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      case MetadataEntity.ARTIFACT:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      default:
+        throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
     }
 
     return Long.MAX_VALUE - keySplitter.getLong();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
+
+import javax.annotation.Nullable;
+
+/**
+ * Key class to get v1 metadata key information
+ */
+public final class MdsKey {
+  private static final byte[] VALUE_ROW_PREFIX = {'v'}; // value row prefix to store metadata value
+  private static final byte[] INDEX_ROW_PREFIX = {'i'}; // index row prefix used for metadata search
+
+  static String getMetadataKey(String type, byte[] rowKey) {
+    MDSKey.Splitter keySplitter = new MDSKey(rowKey).split();
+    // The rowkey is
+    // [rowPrefix][targetType][targetId][key] for value rows and
+    // [rowPrefix][targetType][targetId][key][index] for value index rows
+    // so skip the first few strings.
+
+    // Skip rowType
+    keySplitter.skipBytes();
+
+    // Skip targetType
+    keySplitter.skipString();
+
+    // Skip targetId
+    if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ProgramId.class))) {
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ApplicationId.class))) {
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(DatasetId.class))) {
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamId.class))) {
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamViewId.class))) {
+      // skip namespace, stream, view
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ArtifactId.class))) {
+      // skip namespace, name, version
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else {
+      throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
+    }
+    return keySplitter.getString();
+  }
+
+  static String getTargetType(byte[] rowKey) {
+    MDSKey.Splitter keySplitter = new MDSKey(rowKey).split();
+    // The rowkey is
+    // [rowPrefix][targetType][targetId][key] for value rows and
+    // [rowPrefix][targetType][targetId][key][index] for value index rows
+    keySplitter.getBytes();
+    return keySplitter.getString();
+  }
+
+  /**
+   * Creates a key for metadata value row in the format:
+   * [{@link #VALUE_ROW_PREFIX}][targetType][targetId][key] for value index rows
+   */
+  public static MDSKey getMDSValueKey(NamespacedEntityId targetId, @Nullable String key) {
+    MDSKey.Builder builder = getMDSKeyPrefix(targetId, VALUE_ROW_PREFIX);
+    if (key != null) {
+      builder.add(key);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Creates a key for metadata index row in the format:
+   * [{@link #INDEX_ROW_PREFIX}][targetType][targetId][key][index] for value index rows
+   */
+  static MDSKey getMDSIndexKey(NamespacedEntityId targetId, String key, @Nullable String index) {
+    MDSKey.Builder builder = getMDSKeyPrefix(targetId, INDEX_ROW_PREFIX);
+    builder.add(key);
+    if (index != null) {
+      builder.add(index);
+    }
+    return builder.build();
+  }
+
+  static NamespacedEntityId getNamespacedIdFromKey(String type, byte[] rowKey) {
+    MDSKey.Splitter keySplitter = new MDSKey(rowKey).split();
+
+    // The rowkey is
+    // [rowPrefix][targetType][targetId][key] for value rows and
+    // [rowPrefix][targetType][targetId][key][index] for value index rows
+    // so skip the first two.
+    keySplitter.skipBytes();
+    keySplitter.skipString();
+    return EntityIdKeyHelper.getTargetIdIdFromKey(keySplitter, type);
+  }
+
+  static String getNamespaceId(MDSKey key) {
+    MDSKey.Splitter keySplitter = key.split();
+
+    // The rowkey is
+    // [rowPrefix][targetType][targetId][key] for value rows and
+    // [rowPrefix][targetType][targetId][key][index] for value index rows
+    // so skip the first two.
+    keySplitter.skipBytes();
+    keySplitter.skipString();
+    // We are getting the first part of [targetId] which always be the namespace id.
+    return keySplitter.getString();
+  }
+
+  static byte[] getValueRowPrefix() {
+    MDSKey key = new MDSKey.Builder().add(VALUE_ROW_PREFIX).build();
+    return key.getKey();
+  }
+
+  static byte[] getIndexRowPrefix() {
+    MDSKey key = new MDSKey.Builder().add(INDEX_ROW_PREFIX).build();
+    return key.getKey();
+  }
+
+  private static MDSKey.Builder getMDSKeyPrefix(NamespacedEntityId targetId, byte[] rowPrefix) {
+    String targetType = EntityIdKeyHelper.getTargetType(targetId);
+    MDSKey.Builder builder = new MDSKey.Builder();
+    builder.add(rowPrefix);
+    builder.add(targetType);
+    EntityIdKeyHelper.addTargetIdToKey(builder, targetId);
+    return builder;
+  }
+
+  private MdsKey() {
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.metadata.dataset;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -57,7 +58,8 @@ public final class MdsKey {
     } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ApplicationId.class))) {
       keySplitter.skipString();
       keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(DatasetId.class))) {
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(DatasetId.class))
+      || type.equals(MetadataEntity.DATASET_INSTANCE)) {
       keySplitter.skipString();
       keySplitter.skipString();
     } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamId.class))) {
@@ -149,7 +151,7 @@ public final class MdsKey {
   }
 
   private static MDSKey.Builder getMDSKeyPrefix(NamespacedEntityId targetId, byte[] rowPrefix) {
-    String targetType = EntityIdKeyHelper.getTargetType(targetId);
+    String targetType = EntityIdKeyHelper.getV1TargetType(targetId);
     MDSKey.Builder builder = new MDSKey.Builder();
     builder.add(rowPrefix);
     builder.add(targetType);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
@@ -16,18 +16,19 @@
 
 package co.cask.cdap.data2.metadata.dataset;
 
-import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
-import co.cask.cdap.proto.id.ApplicationId;
-import co.cask.cdap.proto.id.ArtifactId;
-import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
-import co.cask.cdap.proto.id.ProgramId;
-import co.cask.cdap.proto.id.StreamId;
-import co.cask.cdap.proto.id.StreamViewId;
 
 import javax.annotation.Nullable;
+
+import static co.cask.cdap.api.metadata.MetadataEntity.APPLICATION;
+import static co.cask.cdap.api.metadata.MetadataEntity.ARTIFACT;
+import static co.cask.cdap.api.metadata.MetadataEntity.DATASET;
+import static co.cask.cdap.api.metadata.MetadataEntity.DATASET_INSTANCE;
+import static co.cask.cdap.api.metadata.MetadataEntity.PROGRAM;
+import static co.cask.cdap.api.metadata.MetadataEntity.STREAM;
+import static co.cask.cdap.api.metadata.MetadataEntity.VIEW;
 
 /**
  * Key class to get v1 metadata key information
@@ -49,35 +50,30 @@ public final class MdsKey {
     // Skip targetType
     keySplitter.skipString();
 
-    // Skip targetId
-    if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ProgramId.class))) {
-      keySplitter.skipString();
-      keySplitter.skipString();
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ApplicationId.class))) {
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(DatasetId.class))
-      || type.equals(MetadataEntity.DATASET_INSTANCE)) {
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamId.class))) {
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamViewId.class))) {
-      // skip namespace, stream, view
-      keySplitter.skipString();
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ArtifactId.class))) {
-      // skip namespace, name, version
-      keySplitter.skipString();
-      keySplitter.skipString();
-      keySplitter.skipString();
-    } else {
-      throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
+    switch (type) {
+      case PROGRAM:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      case APPLICATION:
+      case DATASET:
+      case DATASET_INSTANCE:
+      case STREAM:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      case VIEW:
+      case ARTIFACT:
+        keySplitter.skipString();
+        keySplitter.skipString();
+        keySplitter.skipString();
+        break;
+      default:
+        throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
     }
+
     return keySplitter.getString();
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.utils.ImmutablePair;
+import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.metadata.indexer.DefaultValueIndexer;
@@ -900,16 +901,13 @@ public class MetadataDataset extends AbstractDataset {
    * @param metadataEntity target id for which metadata needs snapshotting
    */
   private void writeHistory(MetadataEntity metadataEntity) {
-    writeHistory(metadataEntity, -1);
+    writeHistory(metadataEntity, System.currentTimeMillis());
   }
 
   private void writeHistory(MetadataEntity metadataEntity, long time) {
     Map<String, String> properties = getProperties(metadataEntity);
     Set<String> tags = getTags(metadataEntity);
     Metadata metadata = new Metadata(metadataEntity, properties, tags);
-    if (time < 0) {
-      time = System.currentTimeMillis();
-    }
     byte[] row = MetadataHistoryKey.getMDSKey(metadataEntity, time).getKey();
     indexedTable.put(row, Bytes.toBytes(HISTORY_COLUMN), Bytes.toBytes(GSON.toJson(metadata)));
   }
@@ -1146,52 +1144,48 @@ public class MetadataDataset extends AbstractDataset {
   }
 
   /**
-   * Starts scanning/deleting of V1 table value row keys in batches. If there are no more value row keys available,
+   * Starts scanning of V1 table value row keys in batches. If there are no more value row keys available,
    * it will scan history rows. If there are no value/history rows, it returns empty list.
    *
    * @param limit  Batch size for scan/delete.
-   * @param delete Determines if operation to perform is scan or delete.
-   * @return List of {@link KeyValue} where key is timestamp for history row other wise it is null,
-   * value is {@link MetadataEntry}
+   * @return metadata entries with list of {@link KeyValue} where key is timestamp for history row other wise
+   * it is null, value is {@link MetadataEntry} and list of rowkeys to be deleted.
    */
-  public List<KeyValue<Long, MetadataEntry>> scanOrDeleteFromV1Table(int limit, boolean delete) {
+  public MetadataEntries scanFromV1Table(int limit) {
+    MetadataEntries scannedEntries = new MetadataEntries(new LinkedList<>(), new LinkedList<>());
+
     // Try to scan value rows first
     byte[] rowPrefix = MdsKey.getValueRowPrefix();
     byte[] stopRowKey = Bytes.stopKeyForPrefix(rowPrefix);
 
-    List<KeyValue<Long, MetadataEntry>> entries = scanOrDelete(rowPrefix, stopRowKey, limit, delete,
-                                                               this::convertFromV1Value);
+    scan(rowPrefix, stopRowKey, limit, scannedEntries, this::convertFromV1Value);
 
     // Scan History rows if all the Value rows are scanned
-    if (entries.size() < limit) {
+    if (scannedEntries.getEntries().size() < limit) {
       rowPrefix = MdsHistoryKey.getHistoryRowPrefix();
       stopRowKey = Bytes.stopKeyForPrefix(rowPrefix);
-      entries.addAll(scanOrDelete(rowPrefix, stopRowKey, limit - entries.size(), delete, this::convertFromV1History));
+
+      limit = limit - scannedEntries.getEntries().size();
+      scan(rowPrefix, stopRowKey, limit, scannedEntries, this::convertFromV1History);
     }
 
-    return entries;
+    return scannedEntries;
   }
 
-  private List<KeyValue<Long, MetadataEntry>> scanOrDelete(byte[] rowPrefix, byte[] stopRowKey,
-                                                           int limit, boolean delete,
-                                                           Function<Row, KeyValue<Long, MetadataEntry>> function) {
-    List<KeyValue<Long, MetadataEntry>> entries = new LinkedList<>();
+  private void scan(byte[] rowPrefix, byte[] stopRowKey, int limit, MetadataEntries entries,
+                    Function<Row, KeyValue<Long, MetadataEntry>> function) {
     try (Scanner scan = indexedTable.scan(rowPrefix, stopRowKey)) {
       Row row;
       while ((row = scan.next()) != null && limit > 0) {
         KeyValue<Long, MetadataEntry> entry = function.apply(row);
 
         if (entry != null) {
-          entries.add(entry);
+          entries.getEntries().add(entry);
+          entries.getRows().add(row.getRow());
           limit--;
-        }
-
-        if (delete) {
-          indexedTable.delete(new Delete(row.getRow()));
         }
       }
     }
-    return entries;
   }
 
   /**
@@ -1222,11 +1216,13 @@ public class MetadataDataset extends AbstractDataset {
   @Nullable
   private KeyValue<Long, MetadataEntry> convertFromV1History(Row row) {
     byte[] rowKey = row.getRow();
-    long historyTime = MdsHistoryKey.getHistoryTime(rowKey);
+    // History rows does not store entity type in the key. So to get the entity, we will read the value, deserialize it.
+    // However, in v2 tables, we are going to add type in the history row key.
     MetadataV1 metadata = GSON.fromJson(row.getString(HISTORY_COLUMN), MetadataV1.class);
     if (metadata == null) {
       return null;
     }
+    long historyTime = MdsHistoryKey.extractTime(rowKey, EntityIdKeyHelper.getTargetType(metadata.getEntityId()));
     // For history we do not care about key and value for MetadataEntry as we are not going to extract that
     // information for upgrade
     return new KeyValue<>(historyTime, new MetadataEntry(metadata.getEntityId(), "", ""));
@@ -1237,15 +1233,26 @@ public class MetadataDataset extends AbstractDataset {
    *
    * @param entries list of entries to be written.
    */
-  public void writeUpgradedRow(List<KeyValue<Long, MetadataEntry>> entries) {
+  public void writeUpgradedRows(List<KeyValue<Long, MetadataEntry>> entries) {
     for (KeyValue<Long, MetadataEntry> kv : entries) {
       MetadataEntry entry = kv.getValue();
       if (kv.getKey() == null) {
         writeWithoutHistory(entry.getMetadataEntity(), entry,
                             getIndexersForKey(entry.getMetadataEntity(), entry.getKey()));
       } else {
-        writeHistory(entry.getMetadataEntity());
+        writeHistory(entry.getMetadataEntity(), kv.getKey());
       }
+    }
+  }
+
+  /**
+   * Deletes rows from underlying index table.
+   *
+   * @param rowsToDelete row keys to be deleted.
+   */
+  public void deleteRows(List<byte[]> rowsToDelete) {
+    for (byte[] row : rowsToDelete) {
+      indexedTable.delete(new Delete(row));
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.metadata.dataset;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.lib.AbstractDataset;
 import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.table.Delete;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
@@ -76,6 +77,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -524,6 +526,7 @@ public class MetadataDataset extends AbstractDataset {
     removeMetadata(metadataEntity, TAGS_KEY::equals);
   }
 
+
   /**
    * Returns the snapshot of the metadata for entities on or before the given time.
    * @param metadataEntitys entity ids
@@ -820,6 +823,11 @@ public class MetadataDataset extends AbstractDataset {
   }
 
   private void write(MetadataEntity metadataEntity, MetadataEntry entry, Set<Indexer> indexers) {
+    writeWithoutHistory(metadataEntity, entry, indexers);
+    writeHistory(metadataEntity);
+  }
+
+  private void writeWithoutHistory(MetadataEntity metadataEntity, MetadataEntry entry, Set<Indexer> indexers) {
     String key = entry.getKey();
     MDSKey mdsValueKey = MetadataKey.createValueRowKey(metadataEntity, key);
     Put put = new Put(mdsValueKey.getKey());
@@ -828,7 +836,6 @@ public class MetadataDataset extends AbstractDataset {
     put.add(Bytes.toBytes(VALUE_COLUMN), Bytes.toBytes(entry.getValue()));
     indexedTable.put(put);
     storeIndexes(metadataEntity, key, indexers, entry);
-    writeHistory(metadataEntity);
   }
 
   /**
@@ -893,10 +900,17 @@ public class MetadataDataset extends AbstractDataset {
    * @param metadataEntity target id for which metadata needs snapshotting
    */
   private void writeHistory(MetadataEntity metadataEntity) {
+    writeHistory(metadataEntity, -1);
+  }
+
+  private void writeHistory(MetadataEntity metadataEntity, long time) {
     Map<String, String> properties = getProperties(metadataEntity);
     Set<String> tags = getTags(metadataEntity);
     Metadata metadata = new Metadata(metadataEntity, properties, tags);
-    byte[] row = MetadataHistoryKey.getMDSKey(metadataEntity, System.currentTimeMillis()).getKey();
+    if (time < 0) {
+      time = System.currentTimeMillis();
+    }
+    byte[] row = MetadataHistoryKey.getMDSKey(metadataEntity, time).getKey();
     indexedTable.put(row, Bytes.toBytes(HISTORY_COLUMN), Bytes.toBytes(GSON.toJson(metadata)));
   }
 
@@ -1085,7 +1099,7 @@ public class MetadataDataset extends AbstractDataset {
      * If the term is a [key]:[value] search, any whitespace around the ':' separator will be removed.
      * For example, 'foo : bar' will be changed to 'foo:bar'.
      * If it is a prefix search, the part before the ending '*' will be used taken as the term.
-     *
+     * <p>
      * For example, given raw term ' State : BETA* ', the result will be a prefix search where term = 'state:beta'.
      *
      * @param rawTerm the raw search term
@@ -1101,12 +1115,12 @@ public class MetadataDataset extends AbstractDataset {
      * For example, 'foo : bar' will be changed to 'foo:bar'.
      * If it is a prefix search, the part before the ending '*' will be used taken as the term.
      * If it is a namespace search, the namespace will be prefixed to the term.
-     *
+     * <p>
      * For example, given namespace 'ns1' and raw term ' State : BETA* ', the result will be a
      * prefix search where term = 'ns1:state:beta'.
      *
      * @param namespaceId the namespace id if it is a within-namespace search, or null if it is cross namespace
-     * @param rawTerm the raw search term
+     * @param rawTerm     the raw search term
      */
     static SearchTerm from(@Nullable NamespaceId namespaceId, String rawTerm) {
       String formattedTerm = rawTerm.trim().toLowerCase();
@@ -1127,6 +1141,111 @@ public class MetadataDataset extends AbstractDataset {
       }
 
       return new SearchTerm(namespaceId, formattedTerm, isPrefix);
+    }
+
+  }
+
+  /**
+   * Starts scanning/deleting of V1 table value row keys in batches. If there are no more value row keys available,
+   * it will scan history rows. If there are no value/history rows, it returns empty list.
+   *
+   * @param limit  Batch size for scan/delete.
+   * @param delete Determines if operation to perform is scan or delete.
+   * @return List of {@link KeyValue} where key is timestamp for history row other wise it is null,
+   * value is {@link MetadataEntry}
+   */
+  public List<KeyValue<Long, MetadataEntry>> scanOrDeleteFromV1Table(int limit, boolean delete) {
+    // Try to scan value rows first
+    byte[] rowPrefix = MdsKey.getValueRowPrefix();
+    byte[] stopRowKey = Bytes.stopKeyForPrefix(rowPrefix);
+
+    List<KeyValue<Long, MetadataEntry>> entries = scanOrDelete(rowPrefix, stopRowKey, limit, delete,
+                                                               this::convertFromV1Value);
+
+    // Scan History rows if all the Value rows are scanned
+    if (entries.size() < limit) {
+      rowPrefix = MdsHistoryKey.getHistoryRowPrefix();
+      stopRowKey = Bytes.stopKeyForPrefix(rowPrefix);
+      entries.addAll(scanOrDelete(rowPrefix, stopRowKey, limit - entries.size(), delete, this::convertFromV1History));
+    }
+
+    return entries;
+  }
+
+  private List<KeyValue<Long, MetadataEntry>> scanOrDelete(byte[] rowPrefix, byte[] stopRowKey,
+                                                           int limit, boolean delete,
+                                                           Function<Row, KeyValue<Long, MetadataEntry>> function) {
+    List<KeyValue<Long, MetadataEntry>> entries = new LinkedList<>();
+    try (Scanner scan = indexedTable.scan(rowPrefix, stopRowKey)) {
+      Row row;
+      while ((row = scan.next()) != null && limit > 0) {
+        KeyValue<Long, MetadataEntry> entry = function.apply(row);
+
+        if (entry != null) {
+          entries.add(entry);
+          limit--;
+        }
+
+        if (delete) {
+          indexedTable.delete(new Delete(row.getRow()));
+        }
+      }
+    }
+    return entries;
+  }
+
+  /**
+   * Deserializes value row key to get metadata entry.
+   *
+   * @param row value row.
+   * @return {@link KeyValue} key is null, value is {@link MetadataEntry}.
+   */
+  @Nullable
+  private KeyValue<Long, MetadataEntry> convertFromV1Value(Row row) {
+    byte[] rowKey = row.getRow();
+    String targetType = MdsKey.getTargetType(rowKey);
+    NamespacedEntityId namespacedEntityId = MdsKey.getNamespacedIdFromKey(targetType, rowKey);
+    String key = MdsKey.getMetadataKey(targetType, rowKey);
+    byte[] value = row.get(VALUE_COLUMN);
+    if (key == null || value == null) {
+      return null;
+    }
+    return new KeyValue<>(null, new MetadataEntry(namespacedEntityId, key, Bytes.toString(value)));
+  }
+
+  /**
+   * Deserializes history row key to get timestamp and metadata entry.
+   *
+   * @param row history row.
+   * @return {@link KeyValue} key is timestamp from history key, value is {@link MetadataEntry}.
+   */
+  @Nullable
+  private KeyValue<Long, MetadataEntry> convertFromV1History(Row row) {
+    byte[] rowKey = row.getRow();
+    long historyTime = MdsHistoryKey.getHistoryTime(rowKey);
+    MetadataV1 metadata = GSON.fromJson(row.getString(HISTORY_COLUMN), MetadataV1.class);
+    if (metadata == null) {
+      return null;
+    }
+    // For history we do not care about key and value for MetadataEntry as we are not going to extract that
+    // information for upgrade
+    return new KeyValue<>(historyTime, new MetadataEntry(metadata.getEntityId(), "", ""));
+  }
+
+  /**
+   * Writes entries to V2 MetadataTable.
+   *
+   * @param entries list of entries to be written.
+   */
+  public void writeUpgradedRow(List<KeyValue<Long, MetadataEntry>> entries) {
+    for (KeyValue<Long, MetadataEntry> kv : entries) {
+      MetadataEntry entry = kv.getValue();
+      if (kv.getKey() == null) {
+        writeWithoutHistory(entry.getMetadataEntity(), entry,
+                            getIndexersForKey(entry.getMetadataEntity(), entry.getKey()));
+      } else {
+        writeHistory(entry.getMetadataEntity());
+      }
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -1222,7 +1222,7 @@ public class MetadataDataset extends AbstractDataset {
     if (metadata == null) {
       return null;
     }
-    long historyTime = MdsHistoryKey.extractTime(rowKey, EntityIdKeyHelper.getTargetType(metadata.getEntityId()));
+    long historyTime = MdsHistoryKey.extractTime(rowKey, EntityIdKeyHelper.getV1TargetType(metadata.getEntityId()));
     // For history we do not care about key and value for MetadataEntry as we are not going to extract that
     // information for upgrade
     return new KeyValue<>(historyTime, new MetadataEntry(metadata.getEntityId(), "", ""));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntries.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntries.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.api.dataset.lib.KeyValue;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Holds information needed for metadata migration
+ */
+public class MetadataEntries {
+  private final List<KeyValue<Long, MetadataEntry>> entries;
+  private final List<byte[]> rows;
+
+  public MetadataEntries(List<KeyValue<Long, MetadataEntry>> entries, List<byte[]> rows) {
+    this.entries = entries;
+    this.rows = rows;
+  }
+
+  public List<KeyValue<Long, MetadataEntry>> getEntries() {
+    return entries;
+  }
+
+  public List<byte[]> getRows() {
+    return rows;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MetadataEntries that = (MetadataEntries) o;
+
+    return Objects.equals(entries, that.entries) && Objects.equals(rows, that.rows);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entries, rows);
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataEntries{" +
+      "entries=" + entries +
+      ", rows=" + rows +
+      '}';
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Cask Data, Inc.
+ * Copyright 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataHistoryKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataHistoryKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,6 +27,7 @@ class MetadataHistoryKey {
   private static final byte[] ROW_PREFIX = {'h'};
 
   static MDSKey getMDSKey(MetadataEntity targetId, long time) {
+    // [rowPrefix][targetType][targetId][time]
     MDSKey.Builder builder = getKeyPart(targetId);
     builder.add(invertTime(time));
     return builder.build();
@@ -48,6 +49,7 @@ class MetadataHistoryKey {
   private static MDSKey.Builder getKeyPart(MetadataEntity metadataEntity) {
     MDSKey.Builder builder = new MDSKey.Builder();
     builder.add(ROW_PREFIX);
+    builder.add(metadataEntity.getType());
     for (MetadataEntity.KeyValue keyValue : metadataEntity) {
       builder.add(keyValue.getKey());
       builder.add(keyValue.getValue());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataV1.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2018 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,25 +14,34 @@
  * the License.
  */
 
-package co.cask.cdap.api.metadata;
+package co.cask.cdap.data2.metadata.dataset;
 
-import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents metadata (properties and tags) of an entity.
+ * Metadata v1 record. We need to copy this because we do not store entity type information in metadata history key.
+ * So we will use this class to deserialize the value for v1 history row and get the entity type.
  */
-@Beta
-public class Metadata {
+public class MetadataV1 {
+  private final NamespacedEntityId namespacedEntityId;
   private final Map<String, String> properties;
   private final Set<String> tags;
 
-  public Metadata(Map<String, String> properties, Set<String> tags) {
+  /**
+   * Returns an empty {@link Metadata}
+   */
+  public MetadataV1(NamespacedEntityId namespacedEntityId, Map<String, String> properties, Set<String> tags) {
+    this.namespacedEntityId = namespacedEntityId;
     this.properties = properties;
     this.tags = tags;
+  }
+
+  public NamespacedEntityId getEntityId() {
+    return namespacedEntityId;
   }
 
   public Map<String, String> getProperties() {
@@ -48,23 +57,27 @@ public class Metadata {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof Metadata)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Metadata that = (Metadata) o;
-    return Objects.equals(properties, that.properties) &&
+
+    MetadataV1 that = (MetadataV1) o;
+
+    return Objects.equals(namespacedEntityId, that.namespacedEntityId) &&
+      Objects.equals(properties, that.properties) &&
       Objects.equals(tags, that.tags);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(properties, tags);
+    return Objects.hash(namespacedEntityId, properties, tags);
   }
 
   @Override
   public String toString() {
-    return "Metadata{" +
-      "properties=" + properties +
+    return "MetadataV1{" +
+      "namespacedEntityId=" + namespacedEntityId +
+      ", properties=" + properties +
       ", tags=" + tags +
       '}';
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/DefaultOwnerStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/DefaultOwnerStore.java
@@ -149,7 +149,9 @@ public class DefaultOwnerStore extends OwnerStore {
   }
 
   private static byte[] createRowKey(NamespacedEntityId targetId) {
-    String targetType = EntityIdKeyHelper.getTargetType(targetId);
+    // We are not going to upgrade owner.meta table in 5.0, when we upgrade this table,
+    // we should call  EntityIdKeyHelper#getTargetType()
+    String targetType = EntityIdKeyHelper.getV1TargetType(targetId);
     MDSKey.Builder builder = new MDSKey.Builder();
     builder.add(OWNER_PREFIX);
     builder.add(targetType);

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="de25b240bb01cfce5cea90048473c83d"
+DEFAULT_XML_MD5_HASH="2be2c02e655eddfb458ebcdeb530c3ca"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -89,7 +89,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
 
     String txClientId = String.format("cdap.service.%s.%d", Constants.Service.DATASET_EXECUTOR,
                                       context.getInstanceId());
-    injector = createInjector(cConf, hConf, txClientId);
+    injector = createInjector(cConf, hConf, txClientId, context);
 
     injector.getInstance(LogAppenderInitializer.class).initialize();
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
@@ -99,7 +99,8 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
   }
 
   @VisibleForTesting
-  static Injector createInjector(CConfiguration cConf, Configuration hConf, String txClientId) {
+  static Injector createInjector(CConfiguration cConf, Configuration hConf, String txClientId,
+                                 TwillContext twillContext) {
     return Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new IOModule(), new ZKClientModule(),
@@ -115,7 +116,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new LoggingModules().getDistributedModules(),
       new ExploreClientModule(),
       new NamespaceClientRuntimeModule().getDistributedModules(),
-      new MetadataServiceModule(),
+      new MetadataServiceModule(twillContext),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
       new NotificationFeedClientModule(),

--- a/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TwillRunnableTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TwillRunnableTest.java
@@ -40,7 +40,8 @@ public class TwillRunnableTest {
   @Test
   public void testDatasetOpExecutorTwillRunnableInjector() throws Exception {
     Injector injector = DatasetOpExecutorServerTwillRunnable.createInjector(CConfiguration.create(),
-                                                                            HBaseConfiguration.create(), "");
+                                                                            HBaseConfiguration.create(), "",
+                                                                            new MockTwillContext());
     Store store = injector.getInstance(Store.class);
     Assert.assertNotNull(store);
     NamespaceQueryAdmin namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);

--- a/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TwillRunnableTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TwillRunnableTest.java
@@ -40,8 +40,7 @@ public class TwillRunnableTest {
   @Test
   public void testDatasetOpExecutorTwillRunnableInjector() throws Exception {
     Injector injector = DatasetOpExecutorServerTwillRunnable.createInjector(CConfiguration.create(),
-                                                                            HBaseConfiguration.create(), "",
-                                                                            new MockTwillContext());
+                                                                            HBaseConfiguration.create(), "");
     Store store = injector.getInstance(Store.class);
     Assert.assertNotNull(store);
     NamespaceQueryAdmin namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2017 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
TL;DR:

Implemented MetadataMigrator Service to migrate metadata to V2 tables. In a single transaction, below steps are followed for data migration:
1.) Scan value and history rows from v1 table in batches
2.) Write the rows in new format to v2 table
3.) Delete all the written rows from v1 tables.

Remaining Tasks: 

- Currently testing on the cluster. 
- Handling Queries (Will open separate PR for it).