### PR TITLE
CDAP-13604 cleanup around the MetadataDataset

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.EntityScope;
@@ -142,15 +143,8 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   }
 
   @Override
-  public MetadataSearchResponseV2 search(String namespaceId, String searchQuery,
-                                         Set<EntityTypeSimpleName> types,
-                                         SortInfo sortInfo, int offset, int limit,
-                                         int numCursors, String cursor, boolean showHidden,
-                                         Set<EntityScope> entityScope) throws Exception {
-    return filterAuthorizedSearchResult(
-      metadataStore.search(namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor, showHidden,
-                           entityScope)
-    );
+  public MetadataSearchResponseV2 search(SearchRequest searchRequest) throws Exception {
+    return filterAuthorizedSearchResult(metadataStore.search(searchRequest));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.InvalidMetadataException;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
@@ -138,24 +139,8 @@ public interface MetadataAdmin {
    * Executes a search for CDAP entities in the specified namespace with the specified search query and
    * an optional set of {@link EntityTypeSimpleName entity types} in the specified {@link MetadataScope}.
    *
-   * @param namespaceId the namespace id to filter the search by
-   * @param searchQuery the search query
-   * @param types the types of CDAP entity to be searched. If empty all possible types will be searched
-   * @param sortInfo represents sorting information. Use {@link SortInfo#DEFAULT} to return search results without
-   *                 sorting (which implies that the sort order is by relevance to the search query)
-   * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
-   * @param limit the number of results to return, starting from #offset. To return all, pass {@link Integer#MAX_VALUE}
-   * @param numCursors the number of cursors to return in the response. A cursor identifies the first index of the
-   *                   next page for pagination purposes. Defaults to {@code 0}
-   * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
-   *               #sortInfo is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
-   *               the cursor. If {@code null}, the first row is used as the cursor
-   * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
-   *                    or not.
-   * @param entityScope a set which specifies which scope of entities to display.
+   * @param request the search request
    * @return the {@link MetadataSearchResponseV2} containing search results for the specified search query and filters
    */
-  MetadataSearchResponseV2 search(String namespaceId, String searchQuery, Set<EntityTypeSimpleName> types,
-                                  SortInfo sortInfo, int offset, int limit, int numCursors,
-                                  String cursor, boolean showHidden, Set<EntityScope> entityScope) throws Exception;
+  MetadataSearchResponseV2 search(SearchRequest request) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -26,12 +26,14 @@ import co.cask.cdap.common.metadata.MetadataRecord;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.common.security.AuditDetail;
 import co.cask.cdap.common.security.AuditPolicy;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
@@ -50,6 +52,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -224,29 +227,52 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @QueryParam("showHidden") @DefaultValue("false") boolean showHidden,
                              @QueryParam("showCustom") boolean showCustom,
                              @Nullable @QueryParam("entityScope") String entityScope) throws Exception {
-    if (searchQuery == null || searchQuery.isEmpty()) {
-      throw new BadRequestException("query is not specified");
-    }
-    Set<EntityTypeSimpleName> types = Collections.emptySet();
-    if (targets != null) {
-      types = targets.stream().map(STRING_TO_TARGET_TYPE).collect(Collectors.toSet());
-    }
-    SortInfo sortInfo = SortInfo.of(URLDecoder.decode(sort, "UTF-8"));
-    if (SortInfo.DEFAULT.equals(sortInfo)) {
-      if (!(cursor.isEmpty()) || 0 != numCursors) {
-        throw new BadRequestException("Cursors are not supported when sort info is not specified.");
-      }
-    }
+    SearchRequest searchRequest = getValidatedSearchRequest(namespaceId, searchQuery, targets, sort, offset,
+                                                            limit, numCursors, cursor, showHidden, entityScope);
 
-    MetadataSearchResponseV2 response =
-      metadataAdmin.search(namespaceId, URLDecoder.decode(searchQuery, "UTF-8"), types,
-                           sortInfo, offset, limit, numCursors, cursor, showHidden, validateEntityScope(entityScope));
+    MetadataSearchResponseV2 response = metadataAdmin.search(searchRequest);
     if (showCustom) {
       // if user has specified to show custom entity/resource then there is no need to filter them
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(response, MetadataSearchResponseV2.class));
     } else {
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(MetadataCompat.makeCompatible(response),
                                                             MetadataSearchResponse.class));
+    }
+  }
+
+  private SearchRequest getValidatedSearchRequest(String namespace, String searchQuery, List<String> targets,
+                                                  String sort, int offset, int limit, int numCursors, String cursor,
+                                                  boolean showHidden, String entityScope)
+    throws BadRequestException, UnsupportedEncodingException {
+
+    if (searchQuery == null || searchQuery.isEmpty()) {
+      throw new BadRequestException("query is not specified");
+    }
+
+    Set<EntityTypeSimpleName> types = Collections.emptySet();
+    if (targets != null) {
+      types = targets.stream().map(STRING_TO_TARGET_TYPE).collect(Collectors.toSet());
+    }
+
+    SortInfo sortInfo = SortInfo.of(URLDecoder.decode(sort, StandardCharsets.UTF_8.name()));
+    if (SortInfo.DEFAULT.equals(sortInfo)) {
+      if (!(cursor.isEmpty()) || 0 != numCursors) {
+        throw new BadRequestException("Cursors are not supported when sort info is not specified.");
+      }
+    }
+
+    NamespaceId namespaceId;
+    try {
+      namespaceId = new NamespaceId(namespace);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+
+    try {
+      return new SearchRequest(namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors,
+                               cursor, showHidden, validateEntityScope(entityScope));
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage());
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.id.Id;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.test.AppJarHelper;
 import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.services.AppFabricServer;
@@ -148,15 +149,13 @@ public class MetadataAdminAuthorizationTest {
 
     AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, AllProgramsApp.class, "{}", cConf);
     EnumSet<EntityTypeSimpleName> types = EnumSet.allOf(EntityTypeSimpleName.class);
-    Assert.assertFalse(
-      metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
-                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false,
-                           EnumSet.allOf(EntityScope.class)).getResults().isEmpty());
+    SearchRequest searchRequest =
+      new SearchRequest(NamespaceId.DEFAULT, "*", types, SortInfo.DEFAULT, 0,
+                        Integer.MAX_VALUE, 0, null, false, EnumSet.allOf(EntityScope.class));
+
+    Assert.assertFalse(metadataAdmin.search(searchRequest).getResults().isEmpty());
     SecurityRequestContext.setUserId("bob");
-    Assert.assertTrue(
-      metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
-                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false,
-                           EnumSet.allOf(EntityScope.class)).getResults().isEmpty());
+    Assert.assertTrue(metadataAdmin.search(searchRequest).getResults().isEmpty());
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchRequest.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchRequest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.proto.EntityScope;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
+import co.cask.cdap.proto.id.NamespaceId;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * A Metadata search request.
+ */
+public class SearchRequest {
+  private final NamespaceId namespace;
+  private final String query;
+  private final Set<EntityTypeSimpleName> types;
+  private final SortInfo sortInfo;
+  private final int offset;
+  private final int limit;
+  private final int numCursors;
+  @Nullable
+  private final String cursor;
+  private final boolean showHidden;
+  private final Set<EntityScope> entityScope;
+
+  public SearchRequest(NamespaceId namespace, String query, Set<EntityTypeSimpleName> types, SortInfo sortInfo,
+                       int offset, int limit, int numCursors, @Nullable String cursor, boolean showHidden,
+                       Set<EntityScope> entityScope) {
+    if (offset < 0) {
+      throw new IllegalArgumentException("offset must not be negative");
+    }
+    if (limit < 0) {
+      throw new IllegalArgumentException("limit must not be negative");
+    }
+    this.namespace = namespace;
+    this.query = query;
+    this.types = Collections.unmodifiableSet(new HashSet<>(types));
+    this.sortInfo = sortInfo;
+    this.numCursors = numCursors;
+    this.cursor = cursor;
+    this.showHidden = showHidden;
+    this.entityScope = Collections.unmodifiableSet(new HashSet<>(entityScope));
+    this.offset = offset;
+    this.limit = limit;
+  }
+
+  /**
+   * @return the namespace to search in
+   */
+  public NamespaceId getNamespace() {
+    return namespace;
+  }
+
+  /**
+   * The search query can be of two form: [key]:[value] or just [value] and can have '*' at the end for a prefix search.
+   *
+   * @return the search query
+   */
+  public String getQuery() {
+    return query;
+  }
+
+  /**
+   * The types of entities to restrict the search to. If empty, all types should be searched.
+   *
+   * @return the types of entities to restrict the search to
+   */
+  public Set<EntityTypeSimpleName> getTypes() {
+    return types;
+  }
+
+  /**
+   * @return how to sort the results
+   */
+  public SortInfo getSortInfo() {
+    return sortInfo;
+  }
+
+  /**
+   * The offset to start with in the search results. {@code 0} means results should be returned from the beginning.
+   * Only applies when {@link #getSortInfo()} is not {@link SortInfo#DEFAULT}.
+   *
+   * @return the offset to start the results at
+   */
+  public int getOffset() {
+    return offset;
+  }
+
+  /**
+   * The max number of results to return, starting from {@link #getOffset()}. Only applies when {@link #getSortInfo()}
+   * is not {@link SortInfo#DEFAULT}.
+   *
+   * @return the maximum number of results to return
+   */
+  public int getLimit() {
+    return limit;
+  }
+
+  /**
+   * The number of cursors to return in the response. A cursor identifies the first index of the next page for
+   * pagination purposes. Only applies when {@link #getSortInfo()} is not {@link SortInfo#DEFAULT}.
+   *
+   * @return number of cursors to return in the response
+   */
+  public int getNumCursors() {
+    return numCursors;
+  }
+
+  /**
+   * The cursor that acts as the starting index for the request page. This is only applicable when
+   * {@link #getSortInfo()} is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
+   * the cursor. If not present, the first row is used as the cursor.
+   *
+   * @return the cursor for search results, or null if there is no cursor
+   */
+  @Nullable
+  public String getCursor() {
+    return cursor;
+  }
+
+  /**
+   * @return whether to display hidden entities (entities whose name start with '_').
+   */
+  public boolean shouldShowHidden() {
+    return showHidden;
+  }
+
+  /**
+   * @return scope of entities to display
+   */
+  public Set<EntityScope> getEntityScope() {
+    return entityScope;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SearchRequest that = (SearchRequest) o;
+    return offset == that.offset &&
+      limit == that.limit &&
+      numCursors == that.numCursors &&
+      showHidden == that.showHidden &&
+      Objects.equals(namespace, that.namespace) &&
+      Objects.equals(query, that.query) &&
+      Objects.equals(types, that.types) &&
+      Objects.equals(sortInfo, that.sortInfo) &&
+      Objects.equals(cursor, that.cursor) &&
+      Objects.equals(entityScope, that.entityScope);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, query, types, sortInfo, offset, limit, numCursors, cursor, showHidden, entityScope);
+  }
+
+  @Override
+  public String toString() {
+    return "SearchRequest{" +
+      "namespace=" + namespace +
+      ", query='" + query + '\'' +
+      ", types=" + types +
+      ", sortInfo=" + sortInfo +
+      ", offset=" + offset +
+      ", limit=" + limit +
+      ", numCursors=" + numCursors +
+      ", cursor='" + cursor + '\'' +
+      ", showHidden=" + showHidden +
+      ", entityScope=" + entityScope +
+      '}';
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexer.java
@@ -26,12 +26,29 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
- * Default {@link Indexer} for {@link MetadataEntry}
+ * Default {@link Indexer} for {@link MetadataEntry}.
  */
 public class DefaultValueIndexer implements Indexer {
   private static final Pattern VALUE_SPLIT_PATTERN = Pattern.compile("[-_:,\\s]+");
   private static final Pattern TAGS_SEPARATOR_PATTERN = Pattern.compile("[,\\s]+");
 
+  /**
+   * Generates a set of tokens based on the metadata values. Splits values on whitespace, '-', '_', ':', and ',' to
+   * generate multiple tokens. Also generates an additional token that has the metadata key prefixed to it.
+   *
+   * For example, when given property 'owner'='foo bar', six tokens will be generated:
+   *
+   * 'foo bar', 'foo', 'bar', 'owner:foo bar', 'owner:foo', and 'owner:bar'.
+   *
+   * If 'tags'='foo,bar baz' is given, six tokens will be generated:
+   *
+   * 'foo', 'bar', 'baz', 'tags:foo', 'tags:bar', 'tags:baz'
+   *
+   * TODO: (CDAP-13629) be consistent with properties and tags on the 'foo bar' case.
+   *
+   * @param entry the {@link MetadataEntry} for which indexes needs to be created
+   * @return split and prefixed index values
+   */
   @Override
   public Set<String> getIndexes(MetadataEntry entry) {
     Set<String> valueIndexes = new HashSet<>();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
@@ -166,28 +167,10 @@ public interface MetadataStore {
    * Search the Metadata Dataset for the specified target types in both {@link MetadataScope#USER} and
    * {@link MetadataScope#SYSTEM}.
    *
-   * @param namespaceId the namespace to search in
-   * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value]
-   * @param types the {@link EntityTypeSimpleName} to restrict the search to, if empty all types are searched
-   * @param sortInfo represents sorting information. Use {@link SortInfo#DEFAULT} to return search results without
-   *                 sorting (which implies that the sort order is by relevance to the search query)
-   * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
-   * @param limit the number of results to return, starting from #offset. To return all, pass {@link Integer#MAX_VALUE}
-   * @param numCursors the number of cursors to return in the response. A cursor identifies the first index of the
-   *                   next page for pagination purposes. Defaults to {@code 0}
-   * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
-   *               #sortInfo is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
-   *               the cursor. If {@code null}, the first row is used as the cursor
-   * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
-   *                    or not.
-   * @param entityScope a set which specifies which scope of entities to display.
+   * @param request the {@link SearchRequest}
    * @return the {@link MetadataSearchResponseV2} containing search results for the specified search query and filters
    */
-  MetadataSearchResponseV2 search(String namespaceId, String searchQuery,
-                                  Set<EntityTypeSimpleName> types,
-                                  SortInfo sortInfo, int offset, int limit,
-                                  int numCursors, String cursor, boolean showHidden,
-                                  Set<EntityScope> entityScope);
+  MetadataSearchResponseV2 search(SearchRequest request);
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in the specified

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -19,6 +19,7 @@ import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.common.service.RetryStrategy;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
@@ -117,13 +118,10 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public MetadataSearchResponseV2 search(String namespaceId, String searchQuery,
-                                         Set<EntityTypeSimpleName> types,
-                                         SortInfo sort, int offset, int limit, int numCursors, String cursor,
-                                         boolean showHidden, Set<EntityScope> entityScope) {
-    return new MetadataSearchResponseV2(sort.toString(), offset, limit, numCursors, 0,
-                                        Collections.emptySet(),
-                                        Collections.emptyList(), showHidden, entityScope);
+  public MetadataSearchResponseV2 search(SearchRequest request) {
+    return new MetadataSearchResponseV2(request.getSortInfo().toString(), request.getOffset(), request.getLimit(),
+                                        request.getNumCursors(), 0, Collections.emptySet(), Collections.emptyList(),
+                                        request.shouldShowHidden(), request.getEntityScope());
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.data2.metadata.indexer;
+
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.proto.id.NamespaceId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tests for {@link DefaultValueIndexer}.
+ */
+public class DefaultValueIndexerTest {
+  private static final Indexer indexer = new DefaultValueIndexer();
+
+  @Test
+  public void testSimpleProperty() {
+    MetadataEntry entry = new MetadataEntry(NamespaceId.DEFAULT.app("a"), "key", "val");
+    Set<String> expected = new HashSet<>();
+    expected.add("val");
+    expected.add("key:val");
+    Assert.assertEquals(expected, indexer.getIndexes(entry));
+  }
+
+  @Test
+  public void testSingleSplitProperty() {
+    MetadataEntry entry = new MetadataEntry(NamespaceId.DEFAULT.app("a"), "key", "foo bar");
+    Set<String> expected = new HashSet<>();
+    // CDAP-13629 - seems odd 'foo bar' is generated here, but not for a single tag 'foo bar'
+    expected.add("foo bar");
+    expected.add("foo");
+    expected.add("bar");
+    expected.add("key:foo bar");
+    expected.add("key:foo");
+    expected.add("key:bar");
+    Assert.assertEquals(expected, indexer.getIndexes(entry));
+  }
+
+  @Test
+  public void testSingleSimpleTags() {
+    MetadataEntry entry = new MetadataEntry(NamespaceId.DEFAULT.app("a"), MetadataDataset.TAGS_KEY, "tag");
+    Set<String> expected = new HashSet<>();
+    expected.add("tag");
+    expected.add(MetadataDataset.TAGS_KEY + ":tag");
+    Assert.assertEquals(expected, indexer.getIndexes(entry));
+  }
+
+  @Test
+  public void testSingleSplitTags() {
+    MetadataEntry entry = new MetadataEntry(NamespaceId.DEFAULT.app("a"), MetadataDataset.TAGS_KEY, "foo bar");
+    Set<String> expected = new HashSet<>();
+    expected.add("foo");
+    expected.add("bar");
+    expected.add(MetadataDataset.TAGS_KEY + ":foo");
+    expected.add(MetadataDataset.TAGS_KEY + ":bar");
+    Assert.assertEquals(expected, indexer.getIndexes(entry));
+  }
+
+  @Test
+  public void testMultipleTags() {
+    MetadataEntry entry = new MetadataEntry(NamespaceId.DEFAULT.app("a"), MetadataDataset.TAGS_KEY, "t1,t2,t3");
+    Set<String> expected = new HashSet<>();
+    expected.add("t1");
+    expected.add("t2");
+    expected.add("t3");
+    expected.add(MetadataDataset.TAGS_KEY + ":t1");
+    expected.add(MetadataDataset.TAGS_KEY + ":t2");
+    expected.add(MetadataDataset.TAGS_KEY + ":t3");
+    Assert.assertEquals(expected, indexer.getIndexes(entry));
+  }
+
+  @Test
+  public void testMultipleSplitTags() {
+    MetadataEntry entry = new MetadataEntry(NamespaceId.DEFAULT.app("a"), MetadataDataset.TAGS_KEY, "foo,bar baz");
+    Set<String> expected = new HashSet<>();
+    expected.add("foo");
+    expected.add("bar");
+    expected.add("baz");
+    expected.add(MetadataDataset.TAGS_KEY + ":foo");
+    expected.add(MetadataDataset.TAGS_KEY + ":bar");
+    expected.add(MetadataDataset.TAGS_KEY + ":baz");
+    Assert.assertEquals(expected, indexer.getIndexes(entry));
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -29,6 +29,7 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.audit.InMemoryAuditPublisher;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.ProgramType;
@@ -434,9 +435,10 @@ public class MetadataStoreTest {
   private MetadataSearchResponseV2 search(String ns, String searchQuery,
                                           int offset, int limit, int numCursors, boolean showHidden,
                                           SortInfo sortInfo) {
-    return store.search(
-      ns, searchQuery, EnumSet.allOf(EntityTypeSimpleName.class),
-      sortInfo, offset, limit, numCursors, "", showHidden, EnumSet.allOf(EntityScope.class));
+    SearchRequest request =
+      new SearchRequest(new NamespaceId(ns), searchQuery, EnumSet.allOf(EntityTypeSimpleName.class), sortInfo, offset,
+                        limit, numCursors, "", showHidden, EnumSet.allOf(EntityScope.class));
+    return store.search(request);
   }
 
   private void generateMetadataUpdates() {


### PR DESCRIPTION
Added javadocs to the MetadataDataset.

Moved search arguments into a SearchRequest class so that we can
pass around a single object instead of ten arguments everywhere.
This also allows us to perform basic validation on every request
in a single place, early on in a request, instead of waiting until
we get down to the dataset.

Also added some unit tests for DefaultValueIndexer