### PR TITLE
[CDAP-13359] Allows users to set default profile from system/namespace level in UI

### DIFF
--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/index.js
@@ -21,7 +21,6 @@ import NamespacesAccordion from 'components/Administration/AdminConfigTabContent
 import SystemProfilesAccordion from 'components/Administration/AdminConfigTabContent/SystemProfilesAccordion';
 import SystemPrefsAccordion from 'components/Administration/AdminConfigTabContent/SystemPrefsAccordion';
 import {MyNamespaceApi} from 'api/namespace';
-import {MyPreferenceApi} from 'api/preference';
 import {Link} from 'react-router-dom';
 import T from 'i18n-react';
 
@@ -36,9 +35,7 @@ export const ADMIN_CONFIG_ACCORDIONS = {
 export default class AdminConfigTabContent extends Component {
   state = {
     namespaces: 0,
-    systemPrefs: 0,
     namespacesCountLoading: true,
-    systemPrefsCountLoading: true,
     expandedAccordion: this.props.accordionToExpand || ADMIN_CONFIG_ACCORDIONS.namespaces
   };
 
@@ -64,7 +61,6 @@ export default class AdminConfigTabContent extends Component {
 
   componentDidMount() {
     this.getNamespaces();
-    this.getSystemPrefs();
   }
 
   getNamespaces() {
@@ -75,20 +71,6 @@ export default class AdminConfigTabContent extends Component {
           this.setState({
             namespaces: res,
             namespacesCountLoading: false
-          });
-        },
-        (err) => console.log(err)
-      );
-  }
-
-  getSystemPrefs() {
-    MyPreferenceApi
-      .getSystemPreferences()
-      .subscribe(
-        (res) => {
-          this.setState({
-            systemPrefs: res,
-            systemPrefsCountLoading: false
           });
         },
         (err) => console.log(err)
@@ -118,8 +100,6 @@ export default class AdminConfigTabContent extends Component {
           onExpand={this.expandAccordion.bind(this, ADMIN_CONFIG_ACCORDIONS.systemProfiles)}
         />
         <SystemPrefsAccordion
-          prefs={this.state.systemPrefs}
-          loading={this.state.systemPrefsCountLoading}
           expanded={this.state.expandedAccordion === ADMIN_CONFIG_ACCORDIONS.systemPrefs}
           onExpand={this.expandAccordion.bind(this, ADMIN_CONFIG_ACCORDIONS.systemPrefs)}
         />

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -39,6 +39,7 @@ import {
 import CreateProfileBtn from 'components/Cloud/Profiles/CreateView/CreateProfileBtn';
 import uuidV4 from 'uuid/v4';
 import CreateProfileStore from 'components/Cloud/Profiles/CreateView/CreateProfileStore';
+import {highlightNewProfile} from 'components/Cloud/Profiles/Store/ActionCreator';
 
 require('./CreateView.scss');
 
@@ -114,6 +115,10 @@ class ProfileCreateView extends Component {
               redirectToNamespace: true
             });
           }
+
+          let profilePrefix = this.state.isSystem ? 'SYSTEM' : 'USER';
+          name = `${profilePrefix}:${name}`;
+          highlightNewProfile(name);
         },
         err => {
           this.setState({

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle.js
@@ -20,9 +20,10 @@ import ConfirmationModal from 'components/ConfirmationModal';
 import ToggleSwitch from 'components/ToggleSwitch';
 import Alert from 'components/Alert';
 import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
+import {extractProfileName} from 'components/Cloud/Profiles/Store/ActionCreator';
 import {MyCloudApi} from 'api/cloud';
-import {extractProfileName, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
 import T from 'i18n-react';
+import {CLOUD} from 'services/global-constants';
 
 const PREFIX = 'features.Cloud.Profiles';
 
@@ -144,9 +145,9 @@ export default class ProfileStatusToggle extends Component {
 
   render() {
     const profile = this.props.profile;
-    const profileIsDefault = profile.name === extractProfileName(DEFAULT_PROFILE_NAME);
+    const isNativeProfile = profile.name === extractProfileName(CLOUD.DEFAULT_PROFILE_NAME);
 
-    if (profileIsDefault) {
+    if (isNativeProfile) {
       return null;
     }
 

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
@@ -25,9 +25,9 @@ import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import ActionsPopover from 'components/Cloud/Profiles/ActionsPopover';
 import isEqual from 'lodash/isEqual';
-import {getProvisionerLabel} from 'components/Cloud/Profiles/Store/ActionCreator';
+import {getProvisionerLabel, extractProfileName} from 'components/Cloud/Profiles/Store/ActionCreator';
 import ProfileStatusToggle from 'components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle';
-import {extractProfileName, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
+import {CLOUD} from 'services/global-constants';
 
 require('./BasicInfo.scss');
 
@@ -151,8 +151,8 @@ export default class ProfileDetailViewBasicInfo extends Component {
     );
   }
 
-  renderDivider(profileIsDefault) {
-    if (profileIsDefault) {
+  renderDivider(isNativeProfile) {
+    if (isNativeProfile) {
       return null;
     }
     return <span className="divider"></span>;
@@ -165,7 +165,7 @@ export default class ProfileDetailViewBasicInfo extends Component {
       state: { accordionToExpand: ADMIN_CONFIG_ACCORDIONS.systemProfiles }
     } : `/ns/${getCurrentNamespace()}/details`;
     let namespace = this.props.isSystem ? 'system' : getCurrentNamespace();
-    const profileIsDefault = profile.name === extractProfileName(DEFAULT_PROFILE_NAME);
+    const isNativeProfile = profile.name === extractProfileName(CLOUD.DEFAULT_PROFILE_NAME);
 
     const actionsElem = () => {
       return (
@@ -188,7 +188,7 @@ export default class ProfileDetailViewBasicInfo extends Component {
               namespace={namespace}
               toggleProfileStatusCallback={this.props.toggleProfileStatusCallback}
             />
-            {this.renderDivider(profileIsDefault)}
+            {this.renderDivider(isNativeProfile)}
             <ActionsPopover
               target={actionsElem}
               namespace={namespace}

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/ListView.scss
@@ -26,7 +26,7 @@ $disabled-color: $red-02;
   .grid.grid-container {
     max-height: none;
     .grid-row {
-      grid-template-columns: 20px 1.5fr 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 30px;
+      grid-template-columns: 70px 1.5fr 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 30px;
 
       .sortable-header {
         cursor: pointer;
@@ -44,7 +44,7 @@ $disabled-color: $red-02;
         border: 0;
         padding: 0;
         color: $grey-05;
-        grid-template-columns: 20px 1.5fr 1.5fr 1fr 1fr 1fr 2fr 0fr 1fr 1fr 1fr 30px;
+        grid-template-columns: 70px 1.5fr 1.5fr 1fr 1fr 1fr 2fr 0fr 1fr 1fr 1fr 30px;
 
         .sub-title {
           border-bottom: 2px solid gray;
@@ -74,17 +74,51 @@ $disabled-color: $red-02;
 
         &.native-profile {
           cursor: not-allowed;
+
+          .default-star {
+            cursor: pointer;
+          }
+
+          .profile-actions-popover {
+            cursor: not-allowed;
+
+            &:hover {
+              .icon-cog-empty {
+                stroke: $grey-04;
+              }
+            }
+          }
         }
 
         &:last-child {
-          border-bottom: 0;
+          &:not(.highlighted) {
+            border-bottom: 0;
+          }
         }
 
         &:hover {
-          .profile-actions-popover {
-            .icon-cog-empty {
-              stroke: $blue-03;
+          &:not(.native-profile) {
+            .profile-actions-popover {
+              .icon-cog-empty {
+                stroke: $blue-03;
+              }
             }
+          }
+
+          .default-star {
+            .not-default-profile {
+              display: inline-block;
+            }
+          }
+        }
+
+        .default-star {
+          .default-profile {
+            color: $orange-01;
+          }
+
+          .not-default-profile {
+            display: none;
           }
         }
 

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
@@ -19,6 +19,8 @@ import {defaultAction, composeEnhancers} from 'services/helpers';
 
 const PROFILES_ACTIONS = {
   SET_PROFILES: 'SET_PROFILES',
+  SET_DEFAULT_PROFILE: 'SET_DEFAULT_PROFILE',
+  SET_NEW_PROFILE: 'SET_NEW_PROFILE',
   SET_LOADING: 'SET_LOADING',
   SET_ERROR: 'SET_ERROR',
   RESET: 'RESET'
@@ -26,6 +28,8 @@ const PROFILES_ACTIONS = {
 
 const DEFAULT_PROFILES_STATE = {
   profiles: [],
+  defaultProfile: null,
+  newProfile: "",
   loading: false,
   error: null,
 };
@@ -35,6 +39,7 @@ const PROFILE_STATUSES = {
   DISABLED: 'disabled'
 };
 
+
 const profiles = (state = DEFAULT_PROFILES_STATE, action = defaultAction) => {
   switch (action.type) {
     case PROFILES_ACTIONS.SET_PROFILES:
@@ -43,6 +48,16 @@ const profiles = (state = DEFAULT_PROFILES_STATE, action = defaultAction) => {
         profiles: action.payload.profiles,
         error: null,
         loading: false
+      };
+    case PROFILES_ACTIONS.SET_DEFAULT_PROFILE:
+      return {
+        ...state,
+        defaultProfile: action.payload.defaultProfile
+      };
+    case PROFILES_ACTIONS.SET_NEW_PROFILE:
+      return {
+        ...state,
+        newProfile: action.payload.newProfile
       };
     case PROFILES_ACTIONS.SET_LOADING:
       return {

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ComputeTabContent/index.js
@@ -16,10 +16,11 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import ProfilesListViewInPipeline, {PROFILE_NAME_PREFERENCE_PROPERTY, PROFILE_PROPERTIES_PREFERENCE} from 'components/PipelineDetails/ProfilesListView';
+import ProfilesListViewInPipeline from 'components/PipelineDetails/ProfilesListView';
 import PipelineConfigurationsStore, {ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
 import {connect} from 'react-redux';
 import {objectQuery, convertKeyValuePairsToMap, convertMapToKeyValuePairs} from 'services/helpers';
+import {CLOUD} from 'services/global-constants';
 
 class ComputeTabContent extends Component {
 
@@ -31,11 +32,11 @@ class ComputeTabContent extends Component {
     let {runtimeArgs} = PipelineConfigurationsStore.getState();
     let pairs = [...runtimeArgs.pairs];
     let runtimeObj = convertKeyValuePairsToMap(pairs, true);
-    let existingProfile = runtimeObj[PROFILE_NAME_PREFERENCE_PROPERTY];
+    let existingProfile = runtimeObj[CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY];
     if (!existingProfile) {
-      runtimeObj[PROFILE_NAME_PREFERENCE_PROPERTY] = profileName;
+      runtimeObj[CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY] = profileName;
       Object.keys(customizations).forEach(profileProp => {
-        let key = `${PROFILE_PROPERTIES_PREFERENCE}.${profileProp}`;
+        let key = `${CLOUD.PROFILE_PROPERTIES_PREFERENCE}.${profileProp}`;
         runtimeObj[key] = customizations[profileProp];
       });
     } else {
@@ -43,14 +44,14 @@ class ComputeTabContent extends Component {
         // If the profile is not the same remove any
         // customizations applied to the previous profile.
         Object.keys(runtimeObj).forEach(runtimearg => {
-          if (runtimearg.indexOf(PROFILE_PROPERTIES_PREFERENCE) !== -1) {
+          if (runtimearg.indexOf(CLOUD.PROFILE_PROPERTIES_PREFERENCE) !== -1) {
             delete runtimeObj[runtimearg];
           }
         });
       }
-      runtimeObj[PROFILE_NAME_PREFERENCE_PROPERTY] = profileName;
+      runtimeObj[CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY] = profileName;
       Object.keys(customizations).forEach(profileProperty => {
-        let key = `${PROFILE_PROPERTIES_PREFERENCE}.${profileProperty}`;
+        let key = `${CLOUD.PROFILE_PROPERTIES_PREFERENCE}.${profileProperty}`;
         runtimeObj[key] = customizations[profileProperty];
       });
     }
@@ -82,11 +83,11 @@ class ComputeTabContent extends Component {
 }
 
 const mapStateToProps = (state) => {
-  let selectedProfile = state.runtimeArgs.pairs.find(pair => pair.key === PROFILE_NAME_PREFERENCE_PROPERTY);
-  let profileCustomizations = state.runtimeArgs.pairs.filter(pair => pair.key.indexOf(PROFILE_PROPERTIES_PREFERENCE) !== -1);
+  let selectedProfile = state.runtimeArgs.pairs.find(pair => pair.key === CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY);
+  let profileCustomizations = state.runtimeArgs.pairs.filter(pair => pair.key.indexOf(CLOUD.PROFILE_PROPERTIES_PREFERENCE) !== -1);
   let customizationsMap = {};
   profileCustomizations.forEach(customProp => {
-    let propName = customProp.key.replace(`${PROFILE_PROPERTIES_PREFERENCE}.`, '');
+    let propName = customProp.key.replace(`${CLOUD.PROFILE_PROPERTIES_PREFERENCE}.`, '');
     customizationsMap[propName] = customProp.value;
   });
   let selectedProfileObj = {

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -24,19 +24,19 @@ import {MyPipelineApi} from 'api/pipeline';
 import {MyProgramApi} from 'api/program';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import {MyPreferenceApi} from 'api/preference';
-import {PROFILE_NAME_PREFERENCE_PROPERTY, PROFILE_PROPERTIES_PREFERENCE} from 'components/PipelineDetails/ProfilesListView';
 import {objectQuery} from 'services/helpers';
 import uuidV4 from 'uuid/v4';
 import uniqBy from 'lodash/uniqBy';
 import cloneDeep from 'lodash/cloneDeep';
+import {CLOUD} from 'services/global-constants';
 
 
-// Filter certain preferences from being shown in the run time arguments 
+// Filter certain preferences from being shown in the run time arguments
 // They are being represented in other places (like selected compute profile).
 const getFilteredRuntimeArgs = (runtimeArgs) => {
   const RUNTIME_ARGS_TO_SKIP_DURING_DISPLAY = [
-    PROFILE_NAME_PREFERENCE_PROPERTY,
-    PROFILE_PROPERTIES_PREFERENCE,
+    CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY,
+    CLOUD.PROFILE_PROPERTIES_PREFERENCE,
     'logical.start.time'
   ];
   let {resolvedMacros} = PipelineConfigurationsStore.getState();
@@ -74,7 +74,7 @@ const updateRunTimeArgs = (rtArgs) => {
   let {runtimeArgs} = PipelineConfigurationsStore.getState();
   let modifiedRuntimeArgs = {};
   let excludedPairs = [...runtimeArgs.pairs];
-  const preferencesToFilter = [PROFILE_NAME_PREFERENCE_PROPERTY, PROFILE_PROPERTIES_PREFERENCE];
+  const preferencesToFilter = [CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY, CLOUD.PROFILE_PROPERTIES_PREFERENCE];
   const shouldExcludeProperty = (property) => preferencesToFilter.filter(prefProp => property.indexOf(prefProp) !== -1).length;
   excludedPairs = excludedPairs.filter(pair => shouldExcludeProperty(pair.key));
   modifiedRuntimeArgs.pairs = rtArgs.pairs.concat(excludedPairs);
@@ -258,8 +258,8 @@ const scheduleOrSuspendPipeline = (scheduleApi) => {
 const getCustomizationMap = (properties) => {
   let profileCustomizations = {};
   Object.keys(properties).forEach(prop => {
-    if (prop.indexOf(PROFILE_PROPERTIES_PREFERENCE) !== -1) {
-      let propName = prop.replace(`${PROFILE_PROPERTIES_PREFERENCE}.`, '');
+    if (prop.indexOf(CLOUD.PROFILE_PROPERTIES_PREFERENCE) !== -1) {
+      let propName = prop.replace(`${CLOUD.PROFILE_PROPERTIES_PREFERENCE}.`, '');
       profileCustomizations[propName] = properties[prop];
     }
   });
@@ -303,7 +303,7 @@ const fetchAndUpdateRuntimeArgs = () => {
     // profile for a pipeline until the user choose something else. This is populated from
     // resolved app level preference which will provide preferences from namespace.
     const isProfileProperty = (property) => (
-      [PROFILE_NAME_PREFERENCE_PROPERTY, PROFILE_PROPERTIES_PREFERENCE]
+      [CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY, CLOUD.PROFILE_PROPERTIES_PREFERENCE]
         .filter(profilePrefix => property.indexOf(profilePrefix) !== -1)
         .length
     );

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
@@ -21,7 +21,7 @@ import Accordion, {AccordionContent, AccordionTitle, AccordionPane} from 'compon
 import {MyCloudApi} from 'api/cloud';
 import AbstractWidget from 'components/AbstractWidget';
 import uuidV4 from 'uuid/v4';
-import {extractProfileName} from 'components/PipelineDetails/ProfilesListView';
+import {extractProfileName} from 'components/Cloud/Profiles/Store/ActionCreator';
 import IconSVG from 'components/IconSVG';
 import cloneDeep from 'lodash/cloneDeep';
 

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/index.js
@@ -18,6 +18,7 @@ import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
 import Popover from 'components/Popover';
 import  ProfileCustomizeContent from 'components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent';
+import {getProfileNameWithScope} from 'components/Cloud/Profiles/Store/ActionCreator';
 require('./ProfileCustomizePopover.scss');
 
 export default class ProfileCustomizePopover extends PureComponent {
@@ -51,7 +52,7 @@ export default class ProfileCustomizePopover extends PureComponent {
 
   render() {
     let {name, provisioner, scope} = this.props.profile;
-    let profileName = scope === 'SYSTEM' ? `system:${name}` : `user:${name}`;
+    let profileName = getProfileNameWithScope(name, scope);
     let customizeLink = () => (<div className="btn-link">Customize</div>);
     return (
       <Popover

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
@@ -67,6 +67,8 @@ $enabled-color: $green-02;
       }
     }
     .grid-header {
+      z-index: 1;
+
       .grid-row {
         background: $grey-07;
       }
@@ -88,6 +90,11 @@ $enabled-color: $green-02;
           height: 100%;
           display: flex;
           align-items: center;
+        }
+
+        .icon-star {
+          color: $orange-01;
+          margin-right: 5px;
         }
       }
     }

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/index.js
@@ -18,11 +18,12 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import {objectQuery, preventPropagation} from 'services/helpers';
-import {PROFILE_NAME_PREFERENCE_PROPERTY, extractProfileName, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
 import IconSVG from 'components/IconSVG';
 import ProfilePreview from 'components/Cloud/Profiles/Preview';
 import Popover from 'components/Popover';
 import classnames from 'classnames';
+import {extractProfileName} from 'components/Cloud/Profiles/Store/ActionCreator';
+import {CLOUD} from 'services/global-constants';
 
 require('./RunComputeProfile.scss');
 
@@ -35,7 +36,7 @@ class RunLevelComputeProfile extends Component {
     const ProfileLabel = () => {
       return (
         <div className={classnames("profile-preview-label", {
-          'disabled': this.props.profileName === DEFAULT_PROFILE_NAME
+          'disabled': this.props.profileName === CLOUD.DEFAULT_PROFILE_NAME
         })}>
           {
           !this.props.profileName ?
@@ -50,7 +51,7 @@ class RunLevelComputeProfile extends Component {
           :
             <div
               onClick={(e) => {
-                if (this.props.profileName === DEFAULT_PROFILE_NAME) {
+                if (this.props.profileName === CLOUD.DEFAULT_PROFILE_NAME) {
                   preventPropagation(e);
                   return false;
                 }
@@ -82,7 +83,7 @@ class RunLevelComputeProfile extends Component {
             >
               <ProfilePreview
                 profileName={extractProfileName(this.props.profileName)}
-                profileScope={this.props.profileName.indexOf('system:') !== -1 ? 'system' : 'user'}
+                profileScope={this.props.profileName.indexOf('SYSTEM:') !== -1 ? 'system' : 'user'}
               />
             </Popover>
         }
@@ -98,11 +99,11 @@ const getProfileName = (runProperties) => {
   } catch (e) {
     return null;
   }
-  return runtimeArgs[PROFILE_NAME_PREFERENCE_PROPERTY] || null;
+  return runtimeArgs[CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY] || null;
 };
 const mapStateToProps = (state) => {
   return {
-    profileName: getProfileName(objectQuery(state, 'currentRun', 'properties', 'runtimeArgs')) || DEFAULT_PROFILE_NAME
+    profileName: getProfileName(objectQuery(state, 'currentRun', 'properties', 'runtimeArgs')) || CLOUD.DEFAULT_PROFILE_NAME
   };
 };
 

--- a/cdap-ui/app/cdap/components/PipelineDetails/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/store/ActionCreator.js
@@ -248,7 +248,6 @@ const setUserRuntimeArguments = (argsMap) => {
   });
 };
 
-
 const setMacrosAndUserRuntimeArguments = (macrosMap, argsMap) => {
   PipelineDetailStore.dispatch({
     type: ACTIONS.SET_MACROS_AND_USER_RUNTIME_ARGUMENTS,

--- a/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
@@ -21,11 +21,12 @@ import {Dropdown, DropdownToggle, DropdownMenu} from 'reactstrap';
 import {setSelectedProfile} from 'components/PipelineScheduler/Store/ActionCreator';
 import {connect} from 'react-redux';
 import StatusMapper from 'services/StatusMapper';
-import ProfilesListView, {extractProfileName, isSystemProfile} from 'components/PipelineDetails/ProfilesListView';
+import ProfilesListView from 'components/PipelineDetails/ProfilesListView';
 import {MyCloudApi} from 'api/cloud';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import {getProvisionersMap} from 'components/Cloud/Profiles/Store/Provisioners';
 import {preventPropagation} from 'services/helpers';
+import {extractProfileName, isSystemProfile} from 'components/Cloud/Profiles/Store/ActionCreator';
 require('./ProfilesForSchedule.scss');
 
 export const PROFILES_DROPDOWN_DOM_CLASS = 'profiles-list-dropdown';

--- a/cdap-ui/app/cdap/components/PipelineScheduler/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/Store/index.js
@@ -33,8 +33,8 @@ import {
 import {createStore} from 'redux';
 import range from 'lodash/range';
 import {HYDRATOR_DEFAULT_VALUES} from 'services/global-constants';
-import {PROFILE_NAME_PREFERENCE_PROPERTY, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
 import {getCustomizationMap} from 'components/PipelineConfigurations/Store/ActionCreator';
+import {CLOUD} from 'services/global-constants';
 
 const INTERVAL_OPTIONS = {
   '5MIN': 'Every 5 min',
@@ -100,7 +100,7 @@ const DEFAULT_SCHEDULE_OPTIONS = {
   maxConcurrentRuns: MAX_CONCURRENT_RUNS_OPTIONS[0],
   scheduleView: Object.values(SCHEDULE_VIEWS)[0],
   profiles: {
-    selectedProfile: DEFAULT_PROFILE_NAME,
+    selectedProfile: CLOUD.DEFAULT_PROFILE_NAME,
     profileCustomizations: {}
   },
   currentBackendSchedule: null,
@@ -218,7 +218,7 @@ const schedule = (state = DEFAULT_SCHEDULE_OPTIONS, action = defaultAction) => {
       };
     case ACTIONS.SET_CURRENT_BACKEND_SCHEDULE: {
       let {currentBackendSchedule} = action.payload;
-      let profileFromBackend = objectQuery(currentBackendSchedule, 'properties', PROFILE_NAME_PREFERENCE_PROPERTY);
+      let profileFromBackend = objectQuery(currentBackendSchedule, 'properties', CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY);
       let profileCustomizations = getCustomizationMap(objectQuery(currentBackendSchedule, 'properties') || {});
       let constraintFromBackend = (currentBackendSchedule.constraints || []).find(constraint => {
         return constraint.type === 'CONCURRENCY';
@@ -231,7 +231,7 @@ const schedule = (state = DEFAULT_SCHEDULE_OPTIONS, action = defaultAction) => {
         cron: cronFromBackend,
         maxConcurrentRuns: maxConcurrencyFromBackend,
         profiles: {
-          selectedProfile: profileFromBackend || DEFAULT_PROFILE_NAME,
+          selectedProfile: profileFromBackend || CLOUD.DEFAULT_PROFILE_NAME,
           profileCustomizations
         }
       };

--- a/cdap-ui/app/cdap/components/PipelineScheduler/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/index.js
@@ -40,8 +40,7 @@ import {Observable} from 'rxjs/Observable';
 import {PROFILES_DROPDOWN_DOM_CLASS} from 'components/PipelineScheduler/ProfilesForSchedule';
 import {MyScheduleApi} from 'api/schedule';
 import T from 'i18n-react';
-import {PROFILE_NAME_PREFERENCE_PROPERTY, PROFILE_PROPERTIES_PREFERENCE} from 'components/PipelineDetails/ProfilesListView';
-import {GLOBALS} from 'services/global-constants';
+import {GLOBALS, CLOUD} from 'services/global-constants';
 import isEmpty from 'lodash/isEmpty';
 
 const PREFIX = 'features.PipelineScheduler';
@@ -79,7 +78,7 @@ export default class PipelineScheduler extends Component {
         return constraint.type === 'CONCURRENCY';
       }) || {};
       let profileNameFromBackend = objectQuery(
-        state, 'currentBackendSchedule', 'properties', PROFILE_NAME_PREFERENCE_PROPERTY
+        state, 'currentBackendSchedule', 'properties', CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY
       ) || null;
       if (
         currentCron !== objectQuery(currentBackendSchedule, 'trigger', 'cronExpression') ||
@@ -200,13 +199,13 @@ export default class PipelineScheduler extends Component {
     if (profiles.selectedProfile) {
       scheduleProperties = {
         ...scheduleProperties,
-        [PROFILE_NAME_PREFERENCE_PROPERTY]: profiles.selectedProfile
+        [CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY]: profiles.selectedProfile
       };
     }
     if (!isEmpty(profiles.profileCustomizations)) {
       let profileCustomizations = {};
       Object.keys(profiles.profileCustomizations).forEach(profileProp => {
-        profileCustomizations[`${PROFILE_PROPERTIES_PREFERENCE}.${profileProp}`] = profiles.profileCustomizations[profileProp];
+        profileCustomizations[`${CLOUD.PROFILE_PROPERTIES_PREFERENCE}.${profileProp}`] = profiles.profileCustomizations[profileProp];
       });
       scheduleProperties = {
         ...scheduleProperties,

--- a/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/ScheduleRuntimeArgs/index.js
@@ -31,8 +31,8 @@ import classnames from 'classnames';
 import {objectQuery} from 'services/helpers';
 import {Provider} from 'react-redux';
 import isNil from 'lodash/isNil';
-import {PROFILE_NAME_PREFERENCE_PROPERTY, PROFILE_PROPERTIES_PREFERENCE} from 'components/PipelineDetails/ProfilesListView';
 import {getCustomizationMap} from 'components/PipelineConfigurations/Store/ActionCreator';
+import {CLOUD} from 'services/global-constants';
 
 require('./ScheduleRuntimeArgs.scss');
 require('./Tabs/ScheduleRuntimeTabStyling.scss');
@@ -111,7 +111,7 @@ export default class ScheduleRuntimeArgs extends Component {
 
       let profileCustomizations = getCustomizationMap(scheduleInfo.properties);
 
-      setSelectedProfile(scheduleInfo.properties[PROFILE_NAME_PREFERENCE_PROPERTY], profileCustomizations);
+      setSelectedProfile(scheduleInfo.properties[CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY], profileCustomizations);
       bulkSetArgMapping(argsArray);
     }
   }
@@ -129,10 +129,10 @@ export default class ScheduleRuntimeArgs extends Component {
     if (selectedProfile.name) {
       let {name, profileCustomizations = {}} = selectedProfile;
       let customProperties = Object.keys(profileCustomizations);
-      config[PROFILE_NAME_PREFERENCE_PROPERTY] = name;
+      config[CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY] = name;
       if (customProperties.length) {
         customProperties.forEach(prop => {
-          config[`${PROFILE_PROPERTIES_PREFERENCE}.${prop}`] = profileCustomizations[prop];
+          config[`${CLOUD.PROFILE_PROPERTIES_PREFERENCE}.${prop}`] = profileCustomizations[prop];
         });
       }
     }

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -239,6 +239,7 @@ const HYDRATOR_DEFAULT_VALUES = {
   backpressure: true,
   numExecutors: 1
 };
+
 const PROGRAM_STATUSES = {
   DEPLOYED: 'DEPLOYED',
   SUBMITTING: 'SUBMITTING',
@@ -263,11 +264,18 @@ const PROGRAM_STATUSES = {
 const SECURE_KEY_PREFIX = '${secure(';
 const SECURE_KEY_SUFFIX = ')}';
 
+const CLOUD = {
+  DEFAULT_PROFILE_NAME: 'SYSTEM:native',
+  PROFILE_NAME_PREFERENCE_PROPERTY: 'system.profile.name',
+  PROFILE_PROPERTIES_PREFERENCE: 'system.profile.properties'
+};
+
 export {
   NUMBER_TYPES,
   GLOBALS,
   HYDRATOR_DEFAULT_VALUES,
   PROGRAM_STATUSES,
   SECURE_KEY_PREFIX,
-  SECURE_KEY_SUFFIX
+  SECURE_KEY_SUFFIX,
+  CLOUD
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -268,6 +268,7 @@ features:
       ListView:
         assosciations: Assosciations
         createOne: "creating one"
+        default: Default
         importError: Unable to import profile
         noProfiles: "No compute profiles have been defined in this namespace. Start by "
         noProfilesSystem: "No compute profiles have been defined in the system. Start by "


### PR DESCRIPTION
Main JIRA: https://issues.cask.co/browse/CDAP-13359

Things done in this PR:

- Moves cloud constants like `DEFAULT_PROFILE_NAME`, `PROFILE_NAME_PREFERENCE_PROPERTY` to `global-constants.js`. Before, they were in `PipelineDetails/ProfilesListView` component, and other components requiring these constants would have to include the entire ProfilesListView component.
- Adds an orange star icon next to the default profile in profiles list view. This is taken from the `system.profile.name` preference in preferences. Without this preference in the instance level, the default profile is the profile named `native`. Without this preference in the namespace level, there's no default profile.
- The default profile can be changed by hovering over another profile, and clicking on the star next to that profile name (similar to how we select default namespace).
- Modifies `SystemPrefsAccordion` in admin page to get new prefs on expanding, since the user might change system preferences by selecting another profile as default
- Shows error message if user tries to set a disabled profile as default, or if they try to delete an enabled profile (JIRA: https://issues.cask.co/browse/CDAP-13563)
- Highlights newly added and imported profile in profiles list view (JIRA: https://issues.cask.co/browse/CDAP-13564)
- Changes `user:` and `system:` profile prefixes to `USER:` and `SYSTEM:` respectively, to be in accordance with new changes in backend