### PR TITLE
CDAP-13634 use AppSpecAdapter to correctly serialize AppSpec

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/profile/AdminEventPublisher.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/profile/AdminEventPublisher.java
@@ -27,7 +27,9 @@ import co.cask.cdap.common.service.Retries;
 import co.cask.cdap.common.service.RetryStrategies;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.metadata.writer.MetadataMessage;
+import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramSchedule;
+import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -36,6 +38,7 @@ import co.cask.cdap.proto.id.ScheduleId;
 import co.cask.cdap.proto.id.TopicId;
 import com.google.common.base.Throwables;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonNull;
 
 import java.io.IOException;
@@ -46,7 +49,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class AdminEventPublisher {
 
-  private static final Gson GSON = new Gson();
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(
+    new GsonBuilder().registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())).create();
 
   private final TopicId topic;
   private final RetryStrategy retryStrategy;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileMetadataTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileMetadataTest.java
@@ -147,7 +147,7 @@ public class ProfileMetadataTest extends AppFabricTestBase {
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(false, () -> getMetadataProperties(scheduleId2).containsKey("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    
+
     disableProfile(myProfile, 200);
     disableProfile(myProfile2, 200);
     deleteProfile(myProfile, 200);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13634
Build: https://builds.cask.co/browse/CDAP-DUT6522-3

The app specification of the tracker app has some schema in it and we didn't use the correct Gson to serialize it. When we deserialize it, we get NPE for some schema fields. We need to use the correct Adaptor to serialize the app spec