### PR TITLE
CDAP-13261 Support emiting metadata to TMS from programs (Part 2)

### DIFF
--- a/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContextBase.java
+++ b/cdap-api-spark-base/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContextBase.java
@@ -30,6 +30,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -56,7 +57,7 @@ import javax.annotation.Nullable;
 @Beta
 public abstract class JavaSparkExecutionContextBase implements SchedulableProgramContext, RuntimeContext, Transactional,
                                                                WorkflowInfoProvider,
-                                                               SecureStore, MetadataReader {
+                                                               SecureStore, MetadataReader, MetadataWriter {
 
   /**
    * @return The specification used to configure this {@link Spark} job instance.

--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContextBase.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContextBase.scala
@@ -25,6 +25,7 @@ import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.messaging.MessagingContext
 import co.cask.cdap.api.metadata.MetadataReader
+import co.cask.cdap.api.metadata.MetadataWriter
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo
@@ -105,6 +106,14 @@ trait SparkExecutionContextBase extends RuntimeContext with Transactional {
     * @return A [[co.cask.cdap.api.metadata.MetadataReader]]
     */
   def getMetadataReader: MetadataReader
+
+  /**
+    * Returns a [[co.cask.cdap.api.metadata.MetadataWriter]] which can be used to emit metadata.
+    * Currently the returned instance can only be used in the Spark driver process.
+    *
+    * @return A [[co.cask.cdap.api.metadata.MetadataWriter]]
+    */
+  def getMetadataWriter: MetadataWriter
 
   /**
     * Returns the [[co.cask.cdap.api.workflow.WorkflowToken]] if the Spark program

--- a/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionContext.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
@@ -32,7 +33,8 @@ import co.cask.cdap.api.workflow.WorkflowInfoProvider;
  * Represents runtime context of the {@link CustomAction} in the Workflow.
  */
 public interface CustomActionContext extends SchedulableProgramContext, RuntimeContext, DatasetContext, Transactional,
-  WorkflowInfoProvider, PluginContext, SecureStore, ServiceDiscoverer, MessagingContext, MetadataReader {
+  WorkflowInfoProvider, PluginContext, SecureStore, ServiceDiscoverer, MessagingContext, MetadataReader,
+  MetadataWriter {
 
   /**
    * Return the specification of the custom action.

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
@@ -22,13 +22,14 @@ import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.security.store.SecureStore;
 
 /**
  * This interface represents the Flowlet context.
  */
 public interface FlowletContext extends RuntimeContext, DatasetContext, ServiceDiscoverer,
-  SecureStore, Transactional, MessagingContext, MetadataReader {
+  SecureStore, Transactional, MessagingContext, MetadataReader, MetadataWriter {
   /**
    * @return Number of instances of this flowlet.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.lineage.field.LineageRecorder;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
@@ -38,7 +39,7 @@ import co.cask.cdap.api.workflow.WorkflowInfoProvider;
  */
 public interface MapReduceContext extends SchedulableProgramContext, RuntimeContext, DatasetContext, ServiceDiscoverer,
   Transactional, PluginContext, ClientLocalizationContext, WorkflowInfoProvider, SecureStore, MessagingContext,
-  MetadataReader, LineageRecorder {
+  LineageRecorder, MetadataReader, MetadataWriter {
 
   /**
    * @return The specification used to configure this {@link MapReduce} job instance.

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.artifact.ArtifactManager;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -31,7 +32,7 @@ import co.cask.cdap.api.security.store.SecureStore;
  * {@link HttpServiceHandlerSpecification} and the runtime arguments passed by the user.
  */
 public interface HttpServiceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, MessagingContext,
-  PluginContext, SecureStore, Transactional, ArtifactManager, MetadataReader {
+  PluginContext, SecureStore, Transactional, ArtifactManager, MetadataReader, MetadataWriter {
 
   /**
    * @return the specification bound to this HttpServiceContext

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkClientContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkClientContext.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.lineage.field.LineageRecorder;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -43,7 +44,7 @@ import java.net.URI;
 @Beta
 public interface SparkClientContext extends SchedulableProgramContext, RuntimeContext, DatasetContext,
   ClientLocalizationContext, Transactional, ServiceDiscoverer, PluginContext, WorkflowInfoProvider,
-  SecureStore, MessagingContext, MetadataReader, LineageRecorder {
+  SecureStore, MessagingContext, LineageRecorder, MetadataReader, MetadataWriter {
 
   /**
    * @return The specification used to configure this {@link Spark} job instance.

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -30,7 +31,7 @@ import co.cask.cdap.api.security.store.SecureStore;
  * Context for {@link Worker}.
  */
 public interface WorkerContext extends RuntimeContext, ServiceDiscoverer, StreamWriter, MessagingContext,
-  DatasetContext, PluginContext, Transactional, SecureStore, MetadataReader {
+  DatasetContext, PluginContext, Transactional, SecureStore, MetadataReader, MetadataWriter {
 
   /**
    * Returns the specification used to configure {@link Worker} bounded to this context.

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.lineage.field.LineageRecorder;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -36,7 +37,7 @@ import java.util.Map;
  * available to {@link Condition}.
  */
 public interface WorkflowContext extends SchedulableProgramContext, RuntimeContext, Transactional, MessagingContext,
-  ServiceDiscoverer, DatasetContext, PluginContext, SecureStore, MetadataReader, LineageRecorder {
+  ServiceDiscoverer, DatasetContext, PluginContext, SecureStore, LineageRecorder, MetadataReader, MetadataWriter {
 
   WorkflowSpecification getWorkflowSpecification();
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -38,6 +38,7 @@ import co.cask.cdap.common.lang.WeakReferenceDelegatorClassLoader;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.SystemArguments;
@@ -108,10 +109,11 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
                         @Nullable PluginInstantiator pluginInstantiator,
                         SecureStore secureStore,
                         SecureStoreManager secureStoreManager,
-                        MessagingService messagingService, MetadataReader metadataReader) {
+                        MessagingService messagingService, MetadataReader metadataReader,
+                        MetadataPublisher metadataPublisher) {
     super(program, programOptions, cConf, spec.getDataSets(), dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
-          messagingService, pluginInstantiator, metadataReader);
+          messagingService, pluginInstantiator, metadataReader, metadataPublisher);
 
     this.workflowProgramInfo = workflowProgramInfo;
     this.loggingContext = createLoggingContext(program.getId(), getRunId(), workflowProgramInfo);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -45,6 +45,7 @@ import co.cask.cdap.common.lang.WeakReferenceDelegatorClassLoader;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.DefaultTaskLocalizationContext;
 import co.cask.cdap.internal.app.runtime.SystemArguments;
@@ -137,11 +138,11 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                             AuthorizationEnforcer authorizationEnforcer,
                             AuthenticationContext authenticationContext,
                             MessagingService messagingService, MapReduceClassLoader mapReduceClassLoader,
-                            MetadataReader metadataReader) {
+                            MetadataReader metadataReader, MetadataPublisher metadataPublisher) {
     super(program, programOptions, cConf, ImmutableSet.of(), dsFramework, txClient, discoveryServiceClient,
           true, metricsCollectionService, createMetricsTags(programOptions,
                                                             taskId, type, workflowProgramInfo), secureStore,
-          secureStoreManager, messagingService, pluginInstantiator, metadataReader);
+          secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher);
     this.cConf = cConf;
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -333,17 +333,57 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
 
   @Override
   public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) throws MetadataException {
-  return delegate.getMetadata(metadataEntity);
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
   }
 
   @Override
   public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) throws MetadataException {
-    return delegate.getMetadata(scope, metadataEntity);
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
   }
 
   @Override
   public void record(Collection<? extends Operation> operations) {
     throw new UnsupportedOperationException("Recording field lineage operations is not supported in " +
-            "                                 MapReduce task-level context");
+                                              "                                 MapReduce task-level context");
+  }
+
+  @Override
+  public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, String... tags) {
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
+  }
+
+  @Override
+  public void removeMetadata(MetadataEntity metadataEntity) {
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity) {
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity, String... keys) {
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity) {
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity, String... tags) {
+    throw new UnsupportedOperationException("Metadata operations are not supported from tasks.");
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -36,6 +36,7 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.ProgramContextAware;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.BasicProgramContext;
@@ -96,6 +97,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MessagingService messagingService;
   private final MetadataReader metadataReader;
   private final FieldLineageWriter fieldLineageWriter;
+  private final MetadataPublisher metadataPublisher;
 
   @Inject
   public MapReduceProgramRunner(Injector injector, CConfiguration cConf, Configuration hConf,
@@ -109,7 +111,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                 AuthorizationEnforcer authorizationEnforcer,
                                 AuthenticationContext authenticationContext,
                                 MessagingService messagingService, MetadataReader metadataReader,
-                                FieldLineageWriter fieldLineageWriter) {
+                                MetadataPublisher metadataPublisher, FieldLineageWriter fieldLineageWriter) {
     super(cConf);
     this.injector = injector;
     this.cConf = cConf;
@@ -126,6 +128,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.authenticationContext = authenticationContext;
     this.messagingService = messagingService;
     this.metadataReader = metadataReader;
+    this.metadataPublisher = metadataPublisher;
     this.fieldLineageWriter = fieldLineageWriter;
   }
 
@@ -176,7 +179,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
         new BasicMapReduceContext(program, options, cConf, spec, workflowInfo, discoveryServiceClient,
                                   metricsCollectionService, txSystemClient, programDatasetFramework, streamAdmin,
                                   getPluginArchive(options), pluginInstantiator, secureStore, secureStoreManager,
-                                  messagingService, metadataReader);
+                                  messagingService, metadataReader, metadataPublisher);
       closeables.add(context);
 
       Reflections.visit(mapReduce, mapReduce.getClass(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -30,6 +30,7 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data.ProgramContextAware;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.BasicProgramContext;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
@@ -179,6 +180,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
     // Multiple instances of BasicMapReduceTaskContext can share the same program.
     final AtomicReference<Program> programRef = new AtomicReference<>();
     final MetadataReader metadataReader = injector.getInstance(MetadataReader.class);
+    final MetadataPublisher metadataPublisher = injector.getInstance(MetadataPublisher.class);
 
     return new CacheLoader<ContextCacheKey, BasicMapReduceTaskContext>() {
       @Override
@@ -249,7 +251,8 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           spec, workflowInfo, discoveryServiceClient, metricsCollectionService, txClient,
           transaction, programDatasetFramework, classLoader.getPluginInstantiator(),
           contextConfig.getLocalizedResources(), secureStore, secureStoreManager,
-          authorizationEnforcer, authenticationContext, messagingService, mapReduceClassLoader, metadataReader
+          authorizationEnforcer, authenticationContext, messagingService, mapReduceClassLoader, metadataReader,
+          metadataPublisher
         );
       }
     };

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
@@ -28,6 +28,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
@@ -55,12 +56,13 @@ public class BasicCustomActionContext extends AbstractContext implements CustomA
                                   DiscoveryServiceClient discoveryServiceClient,
                                   @Nullable PluginInstantiator pluginInstantiator,
                                   SecureStore secureStore, SecureStoreManager secureStoreManager,
-                                  MessagingService messagingService, MetadataReader metadataReader) {
+                                  MessagingService messagingService, MetadataReader metadataReader,
+                                  MetadataPublisher metadataPublisher) {
 
     super(workflow, programOptions, cConf, customActionSpecification.getDatasets(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, workflowProgramInfo.updateMetricsTags(new HashMap<String, String>()), secureStore,
-          secureStoreManager, messagingService, pluginInstantiator, metadataReader);
+          secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher);
 
     this.customActionSpecification = customActionSpecification;
     this.workflowProgramInfo = workflowProgramInfo;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
@@ -30,6 +30,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.logging.context.FlowletLoggingContext;
 import co.cask.cdap.messaging.MessagingService;
@@ -70,12 +71,12 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
                       SecureStore secureStore,
                       SecureStoreManager secureStoreManager,
                       MessagingService messagingService,
-                      MetadataReader metadataReader,
+                      MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                       CConfiguration cConf) {
     super(program, programOptions, cConf, datasets, dsFramework, txClient, discoveryServiceClient, false,
           metricsService, ImmutableMap.of(Constants.Metrics.Tag.FLOWLET, flowletId.getFlowlet(),
                                           Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
-          secureStore, secureStoreManager, messagingService, null, metadataReader);
+          secureStore, secureStoreManager, messagingService, null, metadataReader, metadataPublisher);
 
     this.flowletId = flowletId;
     this.groupId = FlowUtils.generateConsumerGroupId(program.getId(), flowletId.getFlowlet());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -59,6 +59,7 @@ import co.cask.cdap.data.ProgramContextAware;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.data.stream.StreamPropertyListener;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.ConsumerGroupConfig;
 import co.cask.cdap.data2.queue.DequeueStrategy;
@@ -149,6 +150,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
   private final SecureStoreManager secureStoreManager;
   private final MessagingService messageService;
   private final MetadataReader metadataReader;
+  private final MetadataPublisher metadataPublisher;
 
   @Inject
   public FlowletProgramRunner(CConfiguration cConfiguration,
@@ -164,7 +166,8 @@ public final class FlowletProgramRunner implements ProgramRunner {
                               UsageWriter usageWriter,
                               SecureStore secureStore,
                               SecureStoreManager secureStoreManager,
-                              MessagingService messagingService, MetadataReader metadataReader) {
+                              MessagingService messagingService, MetadataReader metadataReader,
+                              MetadataPublisher metadataPublisher) {
     this.cConf = cConfiguration;
     this.schemaGenerator = schemaGenerator;
     this.datumWriterFactory = datumWriterFactory;
@@ -180,6 +183,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
     this.secureStoreManager = secureStoreManager;
     this.messageService = messagingService;
     this.metadataReader = metadataReader;
+    this.metadataPublisher = metadataPublisher;
   }
 
   @SuppressWarnings("unchecked")
@@ -232,7 +236,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
                                                flowletDef.getDatasets(), flowletDef.getFlowletSpec(),
                                                metricsCollectionService, discoveryServiceClient, txClient,
                                                dsFramework, secureStore, secureStoreManager, messageService,
-                                               metadataReader, cConf);
+                                               metadataReader, metadataPublisher, cConf);
 
       // Creates tx related objects
       DataFabricFacade dataFabricFacade =

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -31,6 +31,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data.ProgramContextAware;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.BasicProgramContext;
 import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
@@ -71,6 +72,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MessagingService messagingService;
   private final ArtifactManagerFactory artifactManagerFactory;
   private final MetadataReader metadataReader;
+  private final MetadataPublisher metadataPublisher;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -79,7 +81,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               SecureStore secureStore, SecureStoreManager secureStoreManager,
                               MessagingService messagingService,
                               ArtifactManagerFactory artifactManagerFactory,
-                              MetadataReader metadataReader) {
+                              MetadataReader metadataReader, MetadataPublisher metadataPublisher) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -91,6 +93,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.messagingService = messagingService;
     this.artifactManagerFactory = artifactManagerFactory;
     this.metadataReader = metadataReader;
+    this.metadataPublisher = metadataPublisher;
   }
 
   @Override
@@ -131,7 +134,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           metricsCollectionService, datasetFramework,
                                                           txClient, discoveryServiceClient,
                                                           pluginInstantiator, secureStore, secureStoreManager,
-                                                          messagingService, artifactManager, metadataReader);
+                                                          messagingService, artifactManager, metadataReader,
+                                                          metadataPublisher);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton((Closeable) pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -30,6 +30,7 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.messaging.MessagingService;
@@ -78,11 +79,12 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
                                  TransactionSystemClient txClient, @Nullable PluginInstantiator pluginInstantiator,
                                  SecureStore secureStore, SecureStoreManager secureStoreManager,
                                  MessagingService messagingService,
-                                 ArtifactManager artifactManager, MetadataReader metadataReader) {
+                                 ArtifactManager artifactManager, MetadataReader metadataReader,
+                                 MetadataPublisher metadataPublisher) {
     super(program, programOptions, cConf, spec == null ? Collections.emptySet() : spec.getDatasets(),
           dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(spec, instanceId),
-          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher);
     this.spec = spec;
     this.instanceId = instanceId;
     this.instanceCount = instanceCount;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.id.Id;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.logging.context.WorkerLoggingContext;
@@ -69,11 +70,12 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
                      @Nullable PluginInstantiator pluginInstantiator,
                      SecureStore secureStore,
                      SecureStoreManager secureStoreManager,
-                     MessagingService messagingService, MetadataReader metadataReader) {
+                     MessagingService messagingService, MetadataReader metadataReader,
+                     MetadataPublisher metadataPublisher) {
     super(program, programOptions, cConf, spec.getDatasets(),
           datasetFramework, transactionSystemClient, discoveryServiceClient, true,
           metricsCollectionService, ImmutableMap.of(Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
-          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher);
 
     this.specification = spec;
     this.instanceId = instanceId;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -31,6 +31,7 @@ import co.cask.cdap.app.stream.StreamWriterFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data.ProgramContextAware;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.BasicProgramContext;
 import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
@@ -67,13 +68,15 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final SecureStoreManager secureStoreManager;
   private final MessagingService messagingService;
   private final MetadataReader metadataReader;
+  private final MetadataPublisher metadataPublisher;
 
   @Inject
   public WorkerProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                              DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
                              TransactionSystemClient txClient, StreamWriterFactory streamWriterFactory,
                              SecureStore secureStore, SecureStoreManager secureStoreManager,
-                             MessagingService messagingService, MetadataReader metadataReader) {
+                             MessagingService messagingService, MetadataReader metadataReader,
+                             MetadataPublisher metadataPublisher) {
     super(cConf);
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
@@ -85,6 +88,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.secureStoreManager = secureStoreManager;
     this.messagingService = messagingService;
     this.metadataReader = metadataReader;
+    this.metadataPublisher = metadataPublisher;
   }
 
   @Override
@@ -127,7 +131,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           metricsCollectionService, datasetFramework, txClient,
                                                           discoveryServiceClient, streamWriterFactory,
                                                           pluginInstantiator, secureStore, secureStoreManager,
-                                                          messagingService, metadataReader);
+                                                          messagingService, metadataReader, metadataPublisher);
 
       WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -31,6 +31,7 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -64,12 +65,12 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
                        @Nullable PluginInstantiator pluginInstantiator,
                        SecureStore secureStore, SecureStoreManager secureStoreManager,
                        MessagingService messagingService, @Nullable ConditionSpecification conditionSpecification,
-                       MetadataReader metadataReader) {
+                       MetadataReader metadataReader, MetadataPublisher metadataPublisher) {
     super(program, programOptions, cConf, new HashSet(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, Collections.singletonMap(Constants.Metrics.Tag.WORKFLOW_RUN_ID,
                                                              ProgramRunners.getRunId(programOptions).getId()),
-          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher);
     this.workflowSpec = workflowSpec;
     this.conditionSpecification = conditionSpecification;
     this.token = token;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data.ProgramContextAware;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.BasicProgramContext;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
@@ -68,7 +69,9 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final CConfiguration cConf;
   private final ProgramStateWriter programStateWriter;
   private final MetadataReader metadataReader;
+  private final MetadataPublisher metadataPublisher;
   private final FieldLineageWriter fieldLineageWriter;
+
 
   @Inject
   public WorkflowProgramRunner(ProgramRunnerFactory programRunnerFactory,
@@ -77,7 +80,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                WorkflowStateWriter workflowStateWriter, CConfiguration cConf, SecureStore secureStore,
                                SecureStoreManager secureStoreManager, MessagingService messagingService,
                                ProgramStateWriter programStateWriter, MetadataReader metadataReader,
-                               FieldLineageWriter fieldLineageWriter) {
+                               MetadataPublisher metadataPublisher, FieldLineageWriter fieldLineageWriter) {
     super(cConf);
     this.programRunnerFactory = programRunnerFactory;
     this.metricsCollectionService = metricsCollectionService;
@@ -91,6 +94,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.cConf = cConf;
     this.programStateWriter = programStateWriter;
     this.metadataReader = metadataReader;
+    this.metadataPublisher = metadataPublisher;
     this.fieldLineageWriter = fieldLineageWriter;
   }
 
@@ -127,7 +131,8 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                  metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                  txClient, workflowStateWriter, cConf, pluginInstantiator,
                                                  secureStore, secureStoreManager, messagingService,
-                                                 programStateWriter, metadataReader, fieldLineageWriter);
+                                                 programStateWriter, metadataReader, metadataPublisher,
+                                                 fieldLineageWriter);
 
       // Controller needs to be created before starting the driver so that the state change of the driver
       // service can be fully captured by the controller.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -37,6 +37,7 @@ import co.cask.cdap.common.lang.InstantiatorFactory;
 import co.cask.cdap.common.lang.PropertyFieldSetter;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
 import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
@@ -81,7 +82,8 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                            @Nullable PluginInstantiator pluginInstantiator,
                            SecureStore secureStore, SecureStoreManager secureStoreManager,
                            MessagingService messagingService,
-                           ArtifactManager artifactManager, MetadataReader metadataReader) {
+                           ArtifactManager artifactManager, MetadataReader metadataReader,
+                           MetadataPublisher metadataPublisher) {
     super(host, program, programOptions, instanceId, serviceAnnouncer, TransactionControl.IMPLICIT);
 
     this.cConf = cConf;
@@ -90,7 +92,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
     this.contextFactory = createContextFactory(program, programOptions, instanceId, this.instanceCount,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
-                                               messagingService, artifactManager, metadataReader);
+                                               messagingService, artifactManager, metadataReader, metadataPublisher);
     this.context = contextFactory.create(null);
   }
 
@@ -141,11 +143,12 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                               SecureStoreManager secureStoreManager,
                                                               MessagingService messagingService,
                                                               ArtifactManager artifactManager,
-                                                              MetadataReader metadataReader) {
+                                                              MetadataReader metadataReader,
+                                                              MetadataPublisher metadataPublisher) {
     return spec -> new BasicHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
-                                               messagingService, artifactManager, metadataReader);
+                                               messagingService, artifactManager, metadataReader, metadataPublisher);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataReaderWriterModules.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataReaderWriterModules.java
@@ -20,6 +20,8 @@ import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.common.metadata.AbstractMetadataClient;
 import co.cask.cdap.common.runtime.RuntimeModule;
+import co.cask.cdap.data2.metadata.writer.MessagingMetadataPublisher;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 
@@ -35,6 +37,7 @@ public class MetadataReaderWriterModules extends RuntimeModule {
       @Override
       protected void configure() {
         bind(MetadataReader.class).to(DefaultMetadataReader.class);
+        bind(MetadataPublisher.class).to(MessagingMetadataPublisher.class);
       }
     };
   }
@@ -45,6 +48,7 @@ public class MetadataReaderWriterModules extends RuntimeModule {
       @Override
       protected void configure() {
         bind(MetadataReader.class).to(DefaultMetadataReader.class);
+        bind(MetadataPublisher.class).to(MessagingMetadataPublisher.class);
       }
     };
   }
@@ -60,6 +64,7 @@ public class MetadataReaderWriterModules extends RuntimeModule {
         bind(AbstractMetadataClient.class).to(RemoteMetadataClient.class);
         // TODO: Bind to cloud implementation in cloud mode. How to check cdap is in cloud mode?
         bind(MetadataReader.class).to(RemoteMetadataReader.class);
+        bind(MetadataPublisher.class).to(MessagingMetadataPublisher.class);
       }
     };
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
@@ -213,6 +213,8 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
         }
       });
 
+      // look like intellij doesn't understand return from closures and consider it as function return.
+      // noinspection ConstantConditions
       if (processor == null) {
         LOG.warn("Unsupported metadata message type {}. Message ignored.", message.getType());
         continue;
@@ -334,10 +336,10 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
       switch (message.getType()) {
         case WORKFLOW_TOKEN:
           appMetadataStore.setWorkflowToken(programRunId, message.getPayload(GSON, BasicWorkflowToken.class));
-        break;
+          break;
         case WORKFLOW_STATE:
           appMetadataStore.addWorkflowNodeState(programRunId, message.getPayload(GSON, WorkflowNodeStateDetail.class));
-        break;
+          break;
         default:
           // This shouldn't happen
           LOG.warn("Unknown message type for workflow state information. Ignoring the message {}", message);
@@ -352,39 +354,49 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
   private class MetadataOperationProcessor implements MetadataMessageProcessor {
 
     @Override
-    public void processMessage(MetadataMessage message)  {
+    public void processMessage(MetadataMessage message) {
       MetadataOperation operation = message.getPayload(GSON, MetadataOperation.class);
       Metadata metadata = operation.getMetadata();
       MetadataEntity entity = operation.getEntity();
-
+      LOG.trace("Received {} for entity {}: {}", operation, entity, metadata);
       // TODO: Authorize that the operation is allowed. Currently MetadataMessage does not carry user info
       switch (operation.getType()) {
         case PUT: {
-          LOG.trace("Received PUT for entity {}: {}", entity, metadata);
           try {
-            if (metadata.getProperties() != null && !metadata.getProperties().isEmpty()) {
+            if (metadata != null && metadata.getProperties() != null && !metadata.getProperties().isEmpty()) {
               metadataAdmin.addProperties(entity, metadata.getProperties());
             }
-            if (metadata.getTags() != null && !metadata.getTags().isEmpty()) {
+            if (metadata != null && metadata.getTags() != null && !metadata.getTags().isEmpty()) {
               Set<String> toAdd = metadata.getTags();
               metadataAdmin.addTags(entity, toAdd);
-
             }
           } catch (InvalidMetadataException e) {
-            LOG.warn("Ignoring invalid metadata operation from TMS: {}", GSON.toJson(message.getRawPayload()), e);
+            LOG.warn("Ignoring invalid metadata operation {} from TMS: {}", operation,
+                     GSON.toJson(message.getRawPayload()), e);
           }
           break;
         }
         case DELETE: {
-          LOG.trace("Received DELETE for entity {}: {}", entity, metadata);
-          if (metadata.getProperties() != null && !metadata.getProperties().isEmpty()) {
+          if (metadata != null && metadata.getProperties() != null && !metadata.getProperties().isEmpty()) {
             Set<String> toRemove = metadata.getProperties().keySet();
             metadataAdmin.removeProperties(entity, toRemove);
           }
-          if (metadata.getTags() != null && !metadata.getTags().isEmpty()) {
+          if (metadata != null && metadata.getTags() != null && !metadata.getTags().isEmpty()) {
             Set<String> toRemove = metadata.getTags();
             metadataAdmin.removeTags(entity, toRemove);
           }
+          break;
+        }
+        case DELETE_ALL: {
+          metadataAdmin.removeMetadata(entity);
+          break;
+        }
+        case DELETE_ALL_PROPERTIES: {
+          metadataAdmin.removeProperties(entity);
+          break;
+        }
+        case DELETE_ALL_TAGS: {
+          metadataAdmin.removeTags(entity);
           break;
         }
         default:

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -859,5 +859,45 @@ public class HttpHandlerGeneratorTest {
     public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
       return null;
     }
+
+    @Override
+    public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addTags(MetadataEntity metadataEntity, String... tags) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeMetadata(MetadataEntity metadataEntity) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeProperties(MetadataEntity metadataEntity) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeProperties(MetadataEntity metadataEntity, String... keys) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeTags(MetadataEntity metadataEntity) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeTags(MetadataEntity metadataEntity, String... tags) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataOperation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataOperation.java
@@ -19,16 +19,30 @@ package co.cask.cdap.data2.metadata.writer;
 import co.cask.cdap.api.metadata.Metadata;
 import co.cask.cdap.api.metadata.MetadataEntity;
 
+import javax.annotation.Nullable;
+
+import static co.cask.cdap.data2.metadata.writer.MetadataOperation.Type.DELETE;
+import static co.cask.cdap.data2.metadata.writer.MetadataOperation.Type.PUT;
+
 /**
- * Represents a meta data operation - either a put or a delete - for an entity.
+ * Represents a meta data operation for an entity.
  * <ul>
- *   <li>
- *     For a put, the metadata to be added is given as a {@link Metadata} object.
- *   </li><li>
- *     For a delete, the {@link Metadata} contains the tags to be deleted, and an
- *     entry in the properties for each property to be deleted (the values are
- *     ignored).
- *   </li>
+ * <li>
+ * For a {@link Type#PUT}, the metadata to be added is given as a {@link Metadata} object.
+ * </li><li>
+ * For a {@link Type#DELETE}, the {@link Metadata} contains the tags to be deleted, and an
+ * entry in the properties for each property to be deleted (the values are
+ * ignored).
+ * </li>
+ * <li>
+ * For {@link Type#DELETE_ALL} all of the properties and tags will be deleted
+ * </li>
+ * <li>
+ * For {@link Type#DELETE_ALL_TAGS} all of the tags will be deleted
+ * </li>
+ * <li>
+ * For {@link Type#DELETE_ALL_PROPERTIES} all of the properties will be deleted
+ * </li>
  * </ul>
  */
 public class MetadataOperation {
@@ -36,31 +50,53 @@ public class MetadataOperation {
   /**
    * Type of the operation:
    * <ul><li>
-   *   PUT for adding metadata;
+   * {@link Type#PUT} for adding metadata;
    * </li><li>
-   *   DELETE for removing metadata.
+   * {@link Type#DELETE} for removing metadata.
+   * </li><li>
+   * {@link Type#DELETE_ALL} to delete all metadata (properties and tags)
+   * </li><li>
+   * {@link Type#DELETE_ALL_PROPERTIES} to delete all properties
+   * </li><li>
+   * {@link Type#DELETE_ALL_TAGS} to delete all tags
    * </li></ul>
    */
-  public enum Type { PUT, DELETE }
+  public enum Type {
+    PUT, DELETE, DELETE_ALL, DELETE_ALL_PROPERTIES, DELETE_ALL_TAGS
+  }
 
   private final MetadataEntity entity;
   private final Type type;
+  @Nullable
   private final Metadata metadata;
 
-  public MetadataOperation(MetadataEntity entity, Type type, Metadata metadata) {
+  public MetadataOperation(MetadataEntity entity, Type type, @Nullable Metadata metadata) {
+    if (metadata == null && (type == PUT || type == DELETE)) {
+      throw new IllegalArgumentException("Metadata cannot be null");
+    }
     this.entity = entity;
     this.type = type;
     this.metadata = metadata;
   }
 
+  /**
+   * @return the {@link MetadataEntity} on which this operation is performed
+   */
   public MetadataEntity getEntity() {
     return entity;
   }
 
+  /**
+   * @return the {@link Type} of operation
+   */
   public Type getType() {
     return type;
   }
 
+  /**
+   * @return return the {@link Metadata} for {@link Type#PUT} and {@link Type#DELETE} and null for other operations
+   */
+  @Nullable
   public Metadata getMetadata() {
     return metadata;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataPublisher.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataPublisher.java
@@ -16,28 +16,19 @@
 
 package co.cask.cdap.data2.metadata.writer;
 
-import co.cask.cdap.api.metadata.MetadataEntity;
-import co.cask.cdap.proto.id.ProgramRunId;
-import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nullable;
+  import co.cask.cdap.api.metadata.MetadataEntity;
+  import co.cask.cdap.proto.id.ProgramRunId;
 
 /**
- * Record metadata for entities.
+ * Publishes {@link MetadataOperation} for {@link MetadataEntity}
  */
-public interface MetadataWriter {
+public interface MetadataPublisher {
 
   /**
-   * Add metadata for an entity.
+   * Publishes the {@link MetadataOperation} from the given {@link ProgramRunId}
+   *
+   * @param run the {@link ProgramRunId}
+   * @param metadataOperation the {@link MetadataOperation}
    */
-  void add(ProgramRunId run, MetadataEntity entity,
-           @Nullable Map<String, String> propertiesToAdd,
-           @Nullable Set<String> tagsToAdd);
-
-  /**
-   * Delete metadata for an entity.
-   */
-  void remove(ProgramRunId run, MetadataEntity entity,
-              @Nullable Set<String> propertiesToDelete,
-              @Nullable Set<String> tagsToDelete);
+  void publish(ProgramRunId run, MetadataOperation metadataOperation);
 }

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
@@ -417,4 +417,44 @@ final class BasicSparkClientContext implements SparkClientContext {
   public void record(Collection<? extends Operation> operations) {
     sparkRuntimeContext.record(operations);
   }
+
+  @Override
+  public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
+    sparkRuntimeContext.addProperties(metadataEntity, properties);
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, String... tags) {
+    sparkRuntimeContext.addTags(metadataEntity, tags);
+  }
+
+  @Override
+  public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
+    sparkRuntimeContext.addTags(metadataEntity, tags);
+  }
+
+  @Override
+  public void removeMetadata(MetadataEntity metadataEntity) {
+    sparkRuntimeContext.removeMetadata(metadataEntity);
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity) {
+    sparkRuntimeContext.removeProperties(metadataEntity);
+  }
+
+  @Override
+  public void removeProperties(MetadataEntity metadataEntity, String... keys) {
+    sparkRuntimeContext.removeProperties(metadataEntity, keys);
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity) {
+    sparkRuntimeContext.removeTags(metadataEntity);
+  }
+
+  @Override
+  public void removeTags(MetadataEntity metadataEntity, String... tags) {
+    sparkRuntimeContext.removeTags(metadataEntity, tags);
+  }
 }

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -39,6 +39,7 @@ import co.cask.cdap.common.lang.InstantiatorFactory;
 import co.cask.cdap.data.ProgramContextAware;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.BasicProgramContext;
@@ -106,6 +107,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
   private final PluginFinder pluginFinder;
   private final MetadataReader metadataReader;
   private final FieldLineageWriter fieldLineageWriter;
+  private final MetadataPublisher metadataPublisher;
 
   @Inject
   SparkProgramRunner(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
@@ -115,7 +117,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                      SecureStore secureStore, SecureStoreManager secureStoreManager,
                      AuthorizationEnforcer authorizationEnforcer, AuthenticationContext authenticationContext,
                      MessagingService messagingService, ServiceAnnouncer serviceAnnouncer,
-                     PluginFinder pluginFinder, MetadataReader metadataReader,
+                     PluginFinder pluginFinder, MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                      FieldLineageWriter fieldLineageWriter) {
     super(cConf);
     this.cConf = cConf;
@@ -135,6 +137,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
     this.pluginFinder = pluginFinder;
     this.metadataReader = metadataReader;
     this.fieldLineageWriter = fieldLineageWriter;
+    this.metadataPublisher = metadataPublisher;
   }
 
   @Override
@@ -184,7 +187,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                                                                    pluginInstantiator, secureStore, secureStoreManager,
                                                                    authorizationEnforcer, authenticationContext,
                                                                    messagingService, serviceAnnouncer, pluginFinder,
-                                                                   locationFactory, metadataReader);
+                                                                   locationFactory, metadataReader, metadataPublisher);
       closeables.addFirst(runtimeContext);
 
       Spark spark;

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.WeakReferenceDelegatorClassLoader;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.artifact.PluginFinder;
@@ -94,10 +95,10 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
                       AuthenticationContext authenticationContext,
                       MessagingService messagingService, ServiceAnnouncer serviceAnnouncer,
                       PluginFinder pluginFinder, LocationFactory locationFactory,
-                      MetadataReader metadataReader) {
+                      MetadataReader metadataReader, MetadataPublisher metadataPublisher) {
     super(program, programOptions, cConf, getSparkSpecification(program).getDatasets(), datasetFramework, txClient,
           discoveryServiceClient, true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
-          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher);
     this.cConf = cConf;
     this.hConf = hConf;
     this.hostname = hostname;

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -40,6 +40,7 @@ import co.cask.cdap.common.service.ServiceDiscoverable;
 import co.cask.cdap.data.ProgramContextAware;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.BasicProgramContext;
 import co.cask.cdap.internal.app.runtime.ProgramClassLoader;
@@ -259,7 +260,8 @@ public final class SparkRuntimeContextProvider {
         serviceAnnouncer,
         injector.getInstance(PluginFinder.class),
         injector.getInstance(LocationFactory.class),
-        injector.getInstance(MetadataReader.class)
+        injector.getInstance(MetadataReader.class),
+        injector.getInstance(MetadataPublisher.class)
       );
       LoggingContextAccessor.setLoggingContext(sparkRuntimeContext.getLoggingContext());
       return sparkRuntimeContext;

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
@@ -16,46 +16,40 @@
 
 package co.cask.cdap.app.runtime.spark
 
+import java.io.{Closeable, File, IOException}
+import java.net.{URI, URL}
+import java.util
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
 import co.cask.cdap.api._
 import co.cask.cdap.api.app.ApplicationSpecification
-import co.cask.cdap.api.data.batch.BatchWritable
-import co.cask.cdap.api.data.batch.DatasetOutputCommitter
-import co.cask.cdap.api.data.batch.OutputFormatProvider
-import co.cask.cdap.api.data.batch.Split
+import co.cask.cdap.api.data.batch.{BatchWritable, DatasetOutputCommitter, OutputFormatProvider, Split}
 import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.dataset.Dataset
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.messaging.MessagingContext
-import co.cask.cdap.api.metadata.MetadataReader
+import co.cask.cdap.api.metadata.{MetadataReader, MetadataWriter}
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.preview.DataTracer
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo
 import co.cask.cdap.api.security.store.SecureStore
-import co.cask.cdap.api.spark.JavaSparkExecutionContext
-import co.cask.cdap.api.spark.SparkExecutionContext
-import co.cask.cdap.api.spark.SparkSpecification
+import co.cask.cdap.api.spark.{JavaSparkExecutionContext, SparkExecutionContext, SparkSpecification}
 import co.cask.cdap.api.spark.dynamic.SparkInterpreter
 import co.cask.cdap.api.stream.GenericStreamEventData
-import co.cask.cdap.api.workflow.WorkflowInfo
-import co.cask.cdap.api.workflow.WorkflowToken
+import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
 import co.cask.cdap.app.runtime.spark.SparkTransactional.TransactionType
 import co.cask.cdap.app.runtime.spark.data.DatasetRDD
-import co.cask.cdap.app.runtime.spark.dynamic.AbstractSparkCompiler
-import co.cask.cdap.app.runtime.spark.dynamic.SparkClassFileHandler
-import co.cask.cdap.app.runtime.spark.dynamic.SparkCompilerCleanupManager
-import co.cask.cdap.app.runtime.spark.dynamic.URLAdder
+import co.cask.cdap.app.runtime.spark.dynamic.{AbstractSparkCompiler, SparkClassFileHandler, SparkCompilerCleanupManager, URLAdder}
 import co.cask.cdap.app.runtime.spark.preview.SparkDataTracer
-import co.cask.cdap.app.runtime.spark.service.DefaultSparkHttpServiceContext
-import co.cask.cdap.app.runtime.spark.service.SparkHttpServiceServer
+import co.cask.cdap.app.runtime.spark.service.{DefaultSparkHttpServiceContext, SparkHttpServiceServer}
 import co.cask.cdap.app.runtime.spark.stream.SparkStreamInputFormat
-import co.cask.cdap.common.conf.ConfigurationUtil
-import co.cask.cdap.common.conf.Constants
+import co.cask.cdap.common.conf.{ConfigurationUtil, Constants}
 import co.cask.cdap.common.id.Id
 import co.cask.cdap.common.utils.DirUtils
 import co.cask.cdap.data.LineageDatasetContext
-import co.cask.cdap.data.stream.AbstractStreamInputFormat
-import co.cask.cdap.data.stream.StreamUtils
+import co.cask.cdap.data.stream.{AbstractStreamInputFormat, StreamUtils}
 import co.cask.cdap.data2.metadata.lineage.AccessType
 import co.cask.cdap.internal.app.runtime.DefaultTaskLocalizationContext
 import co.cask.cdap.proto.id.StreamId
@@ -63,25 +57,13 @@ import co.cask.cdap.proto.security.Action
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapreduce.MRJobConfig
-import org.apache.spark.SparkContext
-import org.apache.spark.TaskContext
+import org.apache.spark.{SparkContext, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler._
 import org.apache.tephra.TransactionAware
 import org.apache.twill.api.RunId
 import org.slf4j.LoggerFactory
-
-import java.io.Closeable
-import java.io.File
-import java.io.IOException
-import java.net.URI
-import java.net.URL
-import java.util
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -225,6 +207,8 @@ abstract class AbstractSparkExecutionContext(sparkClassLoader: SparkClassLoader,
   override def getMessagingContext: MessagingContext = runtimeContext
 
   override def getMetadataReader: MetadataReader = runtimeContext
+
+  override def getMetadataWriter: MetadataWriter = runtimeContext
 
   override def getPluginContext: PluginContext = new SparkPluginContext(runtimeContext)
 

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -46,7 +46,7 @@ import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd.RDD
 import org.apache.twill.api.RunId
 import java.io.IOException
-import java.util
+import java.{lang, util}
 
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo
 
@@ -261,6 +261,38 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
 
   override def getMetadata(scope: MetadataScope, metadataEntity: MetadataEntity): Metadata = {
     return sec.getMetadataReader.getMetadata(scope, metadataEntity);
+  }
+
+  override def addProperties(metadataEntity: MetadataEntity, properties: util.Map[String, String]) = {
+    sec.getMetadataWriter.addProperties(metadataEntity, properties);
+  }
+
+  override def addTags(metadataEntity: MetadataEntity, tags: String*) = {
+    sec.getMetadataWriter.addTags(metadataEntity, tags)
+  }
+
+  override def addTags(metadataEntity: MetadataEntity, tags: lang.Iterable[String]): Unit = {
+    sec.getMetadataWriter.addTags(metadataEntity, tags)
+  }
+
+  override def removeMetadata(metadataEntity: MetadataEntity): Unit = {
+    sec.getMetadataWriter.removeMetadata(metadataEntity)
+  }
+
+  override def removeProperties(metadataEntity: MetadataEntity): Unit = {
+    sec.getMetadataWriter.removeProperties(metadataEntity)
+  }
+
+  override def removeProperties(metadataEntity: MetadataEntity, keys: String*): Unit = {
+    sec.getMetadataWriter.removeProperties(metadataEntity, keys:_*)
+  }
+
+  override def removeTags(metadataEntity: MetadataEntity): Unit = {
+    sec.getMetadataWriter.removeTags(metadataEntity)
+  }
+
+  override def removeTags(metadataEntity: MetadataEntity, tags: String*): Unit = {
+    sec.getMetadataWriter.removeTags(metadataEntity, tags:_*)
   }
 }
 

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -112,6 +112,8 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
 
   override def getMetadataReader = delegate.getMetadataReader
 
+  override def getMetadataWriter = delegate.getMetadataWriter
+
   override def getPluginContext = delegate.getPluginContext
 
   override def getMetrics = delegate.getMetrics

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -88,6 +88,7 @@ import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
 import co.cask.cdap.metadata.MetadataReaderWriterModules;
 import co.cask.cdap.metadata.MetadataService;
 import co.cask.cdap.metadata.MetadataServiceModule;
+import co.cask.cdap.metadata.MetadataSubscriberService;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.metrics.query.MetricsQueryService;
@@ -212,6 +213,7 @@ public class TestBase {
   private static MessagingContext messagingContext;
   private static PreviewManager previewManager;
   private static ProvisioningService provisioningService;
+  private static MetadataSubscriberService metadataSubscriberService;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -302,6 +304,8 @@ public class TestBase {
       }
     );
 
+    metadataSubscriberService = injector.getInstance(MetadataSubscriberService.class);
+
     messagingService = injector.getInstance(MessagingService.class);
     if (messagingService instanceof Service) {
       ((Service) messagingService).startAndWait();
@@ -376,6 +380,7 @@ public class TestBase {
     previewManager = injector.getInstance(PreviewManager.class);
     provisioningService = injector.getInstance(ProvisioningService.class);
     provisioningService.startAndWait();
+    metadataSubscriberService.startAndWait();
   }
 
   private static TestManager getTestManager() {
@@ -527,6 +532,7 @@ public class TestBase {
       ((Service) messagingService).stopAndWait();
     }
     provisioningService.stopAndWait();
+    metadataSubscriberService.stopAndWait();
   }
 
   protected MetricsManager getMetricsManager() {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithMetadataPrograms.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithMetadataPrograms.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.metadata.Metadata;
 import co.cask.cdap.api.metadata.MetadataEntity;
-import co.cask.cdap.api.metadata.MetadataException;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.service.BasicService;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
@@ -28,11 +27,19 @@ import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.UnauthenticatedException;
+import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
@@ -43,22 +50,27 @@ public class AppWithMetadataPrograms extends AbstractApplication {
   public static final String APP_NAME = "AppWithMetadataPrograms";
   static final String METADATA_SERVICE_NAME = "MetadataService";
   static final String METADATA_SERVICE_DATASET = "MetadataServiceDataset";
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Gson GSON = new Gson();
 
   @Override
   public void configure() {
     setName(APP_NAME);
     addService(new BasicService(METADATA_SERVICE_NAME, new MetadataHandler()));
+    createDataset(METADATA_SERVICE_DATASET, KeyValueTable.class);
   }
 
   public static final class MetadataHandler extends AbstractHttpServiceHandler {
+
+    /************************************************ GET ************************************************************/
     @GET
     @Path("metadata/{dataset}")
-    public void ping(HttpServiceRequest request, HttpServiceResponder responder,
-                     @PathParam("dataset") String dataset) {
+    public void getMetadata(HttpServiceRequest request, HttpServiceResponder responder,
+                            @PathParam("dataset") String dataset) {
       Map<MetadataScope, Metadata> metadata = null;
       try {
         metadata = getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
-      } catch (MetadataException e) {
+      } catch (Exception e) {
         if (e.getCause() instanceof UnauthorizedException) {
           responder.sendStatus(((UnauthorizedException) e.getCause()).getStatusCode());
         } else if (e.getCause() instanceof UnauthenticatedException) {
@@ -72,9 +84,136 @@ public class AppWithMetadataPrograms extends AbstractApplication {
       responder.sendJson(HttpResponseStatus.OK.code(), metadata);
     }
 
-    @Override
-    protected void configure() {
-      createDataset(METADATA_SERVICE_DATASET, KeyValueTable.class);
+    /************************************************* PUT ***********************************************************/
+    @PUT
+    @Path("metadata/{dataset}/tags")
+    public void addTag(HttpServiceRequest request, HttpServiceResponder responder,
+                       @PathParam("dataset") String dataset) {
+      String tag = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      getContext().addTags(MetadataEntity.ofDataset(getContext().getNamespace(), dataset), tag);
+      // wait till change is recorded to store
+      try {
+        Tasks.waitFor(true, () -> {
+          Map<MetadataScope, Metadata> metadata2 =
+            getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+          return metadata2.get(MetadataScope.USER).getTags().contains(tag);
+        }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+      }
+      responder.sendStatus(HttpResponseStatus.OK.code());
+    }
+
+    @PUT
+    @Path("metadata/{dataset}/properties")
+    public void addProperties(HttpServiceRequest request, HttpServiceResponder responder,
+                              @PathParam("dataset") String dataset) {
+      String body = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      Map<String, String> properties = GSON.fromJson(body, MAP_STRING_STRING_TYPE);
+      getContext().addProperties(MetadataEntity.ofDataset(getContext().getNamespace(), dataset), properties);
+      // wait till change is recorded to store
+      try {
+        Tasks.waitFor(true, () -> {
+          Map<MetadataScope, Metadata> metadata2 =
+            getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+          return metadata2.get(MetadataScope.USER).getProperties().keySet().containsAll(properties.keySet());
+        }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+      }
+      responder.sendStatus(HttpResponseStatus.OK.code());
+    }
+
+    /************************************************ DELETE *********************************************************/
+    @DELETE
+    @Path("metadata/{dataset}/tags/{tag}")
+    public void removeTag(HttpServiceRequest request, HttpServiceResponder responder,
+                          @PathParam("dataset") String dataset, @PathParam("tag") String tag) {
+      getContext().removeTags(MetadataEntity.ofDataset(getContext().getNamespace(), dataset), tag);
+      // wait till change is recorded to store
+      try {
+        Tasks.waitFor(true, () -> {
+          Map<MetadataScope, Metadata> metadata2 =
+            getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+          return !metadata2.get(MetadataScope.USER).getTags().contains(tag);
+        }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+      }
+      responder.sendStatus(HttpResponseStatus.OK.code());
+    }
+
+    @DELETE
+    @Path("metadata/{dataset}/tags")
+    public void removeAllTags(HttpServiceRequest request, HttpServiceResponder responder,
+                              @PathParam("dataset") String dataset) {
+      getContext().removeTags(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+      // wait till change is recorded to store
+      try {
+        Tasks.waitFor(true, () -> {
+          Map<MetadataScope, Metadata> metadata2 =
+            getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+          return metadata2.get(MetadataScope.USER).getTags().isEmpty();
+        }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+      }
+      responder.sendStatus(HttpResponseStatus.OK.code());
+    }
+
+    @DELETE
+    @Path("metadata/{dataset}/properties/{key}")
+    public void removeProperty(HttpServiceRequest request, HttpServiceResponder responder,
+                               @PathParam("dataset") String dataset, @PathParam("key") String key) {
+      getContext().removeProperties(MetadataEntity.ofDataset(getContext().getNamespace(), dataset), key);
+      // wait till change is recorded to store
+      try {
+        Tasks.waitFor(true, () -> {
+          Map<MetadataScope, Metadata> metadata2 =
+            getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+          return !metadata2.get(MetadataScope.USER).getProperties().containsKey(key);
+        }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+      }
+      responder.sendStatus(HttpResponseStatus.OK.code());
+    }
+
+    @DELETE
+    @Path("metadata/{dataset}/properties")
+    public void removeAllProperties(HttpServiceRequest request, HttpServiceResponder responder,
+                                    @PathParam("dataset") String dataset) {
+      getContext().removeProperties(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+      // wait till change is recorded to store
+      try {
+        Tasks.waitFor(true, () -> {
+          Map<MetadataScope, Metadata> metadata2 =
+            getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+          return metadata2.get(MetadataScope.USER).getProperties().isEmpty();
+        }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+      }
+      responder.sendStatus(HttpResponseStatus.OK.code());
+    }
+
+    @DELETE
+    @Path("metadata/{dataset}")
+    public void removeMetadata(HttpServiceRequest request, HttpServiceResponder responder,
+                               @PathParam("dataset") String dataset) {
+      getContext().removeMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+      // wait till change is recorded to store
+      try {
+        Tasks.waitFor(true, () -> {
+          Map<MetadataScope, Metadata> metadata2 =
+            getContext().getMetadata(MetadataEntity.ofDataset(getContext().getNamespace(), dataset));
+          return metadata2.get(MetadataScope.USER).getProperties().isEmpty() && metadata2.get(MetadataScope.USER)
+            .getTags().isEmpty();
+        }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+      }
+      responder.sendStatus(HttpResponseStatus.OK.code());
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds support for emitting metadata from CDAP programs
- Metadata messages are emitted to TMS which is later consumed by a  subscriber which stores it in Hbase.
- Extended the existing unit test where a `service` reads/emit metadata changes.

## Tasks:
- [x] Build: https://builds.cask.co/browse/CDAP-DUT6523-2
- [x] Integration Tests:
- [x] Test on multinode cluster
- [ ] Test behavior inside spark's closures 
- [ ] Test in cloud