### PR TITLE
[CDAP-13477] Changes to MMDS and Rules Engine landing pages

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
-import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
+import enableSystemApp from 'services/ServiceEnablerUtilities';
 import T from 'i18n-react';
 import classnames from 'classnames';
 import {objectQuery} from 'services/helpers';
@@ -49,7 +49,7 @@ export default class DataPrepServiceControl extends Component {
 
   enableService() {
     this.setState({loading: true});
-    enableDataPreparationService({
+    enableSystemApp({
       shouldStopService: false,
       artifactName,
       api: MyDataPrepApi,

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import T from 'i18n-react';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
-import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
+import enableSystemApp from 'services/ServiceEnablerUtilities';
 import CardActionFeedback from 'components/CardActionFeedback';
 import ee from 'event-emitter';
 import {i18nPrefix, MIN_DATAPREP_VERSION, artifactName} from 'components/DataPrep';
@@ -51,7 +51,7 @@ export default class UpgradeModal extends Component {
   upgradeClick() {
     this.setState({loading: true});
 
-    enableDataPreparationService({
+    enableSystemApp({
       shouldStopService: true,
       artifactName,
       api: MyDataPrepApi,

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/ExperimentsServiceControl.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/ExperimentsServiceControl.scss
@@ -56,6 +56,7 @@
       li { padding: 10px 0; }
     }
     .action-container {
+      padding-top: 25px;
       padding-bottom: 25px;
 
       .loading-bar { height: 16px; }

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/index.js
@@ -16,9 +16,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
-import {MyArtifactApi} from 'api/artifact';
-import {getCurrentNamespace} from 'services/NamespaceStore';
+import enableSystemApp from 'services/ServiceEnablerUtilities';
 import LoadingSVG from 'components/LoadingSVG';
 import T from 'i18n-react';
 import IconSVG from 'components/IconSVG';
@@ -36,20 +34,14 @@ export default class ExperimentsServiceControl extends Component {
 
   state = {
     loading: false,
-    error: null,
-    artifactNotAvailable: false,
-    showEnableButton: false
+    error: null
   };
-
-  componentDidMount() {
-    this.checkIfMMDSIsAvailable();
-  }
 
   enableMMDS = () => {
     this.setState({
       loading: true
     });
-    enableDataPreparationService({
+    enableSystemApp({
       shouldStopService: false,
       artifactName: MMDSArtifact,
       api: myExperimentsApi,
@@ -65,59 +57,24 @@ export default class ExperimentsServiceControl extends Component {
     );
   };
 
-  checkIfMMDSIsAvailable = () => {
-    let namespace = getCurrentNamespace();
-
-    MyArtifactApi
-      .list({ namespace })
-      .subscribe(
-        (artifacts) => {
-          let isArtifactPresent = artifacts.find(artifact => artifact.name === MMDSArtifact);
-          if (!isArtifactPresent) {
-            this.setState({
-              artifactNotAvailable: true
-            });
-          } else {
-            this.setState({
-              showEnableButton: true
-            });
+  renderEnableBtn = () => {
+    return (
+      <div className="action-container">
+        <button
+          className="btn btn-primary"
+          onClick={this.enableMMDS}
+          disabled={this.state.loading}
+        >
+          {
+            this.state.loading ?
+              <LoadingSVG />
+            :
+              null
           }
-        }
-      );
-  };
-
-  renderAvailableOrEnableBtn = () => {
-    if (!this.state.artifactNotAvailable && !this.state.showEnableButton) {
-      return (<span> {T.translate(`${PREFIX}.checkMessage`)}</span>);
-    }
-    if (this.state.artifactNotAvailable) {
-      return (
-        <div className="action-container">
-          <span className="mail-to-link">
-            {T.translate(`${PREFIX}.contactMessage`)}
-          </span>
-        </div>
-      );
-    }
-    if (this.state.showEnableButton) {
-      return (
-        <div className="action-container">
-          <button
-            className="btn btn-primary"
-            onClick={this.enableMMDS}
-            disabled={this.state.loading}
-          >
-            {
-              this.state.loading ?
-                <LoadingSVG />
-              :
-                null
-            }
-            <span className="btn-label">{T.translate(`${PREFIX}.enableBtnLabel`)}</span>
-          </button>
-        </div>
-      );
-    }
+          <span className="btn-label">{T.translate(`${PREFIX}.enableBtnLabel`)}</span>
+        </button>
+      </div>
+    );
   };
 
   renderError = () => {
@@ -146,6 +103,8 @@ export default class ExperimentsServiceControl extends Component {
         </div>
         <div className="text-container">
           <h2> {T.translate(`${PREFIX}.title`)} </h2>
+          {this.renderEnableBtn()}
+          {this.renderError()}
           <p>
             {T.translate(`${PREFIX}.description`)}
           </p>
@@ -173,10 +132,6 @@ export default class ExperimentsServiceControl extends Component {
               </li>
             </ul>
           </div>
-          {
-            this.renderAvailableOrEnableBtn()
-          }
-          {this.renderError()}
         </div>
       </div>
     );

--- a/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/index.js
@@ -16,8 +16,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
-import {MyArtifactApi} from 'api/artifact';
+import enableSystemApp from 'services/ServiceEnablerUtilities';
 import {MyReportsApi} from 'api/reports';
 import IconSVG from 'components/IconSVG';
 import BtnWithLoading from 'components/BtnWithLoading';
@@ -34,38 +33,7 @@ export default class ReportsServiceControl extends Component {
 
   state = {
     loading: false,
-    error: null,
-    artifactNotAvailable: false,
-    showEnableButton: false
-  };
-
-  componentDidMount() {
-    this.checkIfReportsIsAvailable();
-  }
-
-  checkIfReportsIsAvailable = () => {
-    // The artifact will be in the system namespace, so we are just checking the default namespace
-    // since default namespace will always be there.
-    let params = {
-      namespace: 'default',
-      scope: 'SYSTEM'
-    };
-
-    MyArtifactApi.list(params)
-      .subscribe(
-        (artifacts) => {
-          let isArtifactPresent = artifacts.find(artifact => artifact.name === ReportsArtifact);
-          if (!isArtifactPresent) {
-            this.setState({
-              artifactNotAvailable: true
-            });
-          } else {
-            this.setState({
-              showEnableButton: true
-            });
-          }
-        }
-      );
+    error: null
   };
 
   enableReports = () => {
@@ -73,7 +41,7 @@ export default class ReportsServiceControl extends Component {
       loading: true
     });
 
-    enableDataPreparationService({
+    enableSystemApp({
       shouldStopService: false,
       artifactName: ReportsArtifact,
       api: MyReportsApi,
@@ -89,33 +57,17 @@ export default class ReportsServiceControl extends Component {
     );
   };
 
-  renderAvailableOrEnableBtn = () => {
-    if (!this.state.artifactNotAvailable && !this.state.showEnableButton) {
-      return (
-        <span>{T.translate(`${PREFIX}.checking`)}</span>
-      );
-    }
-    if (this.state.artifactNotAvailable) {
-      return (
-        <div className="action-container">
-          <span className="mail-to-link">
-            {T.translate(`${PREFIX}.contact`)}
-          </span>
-        </div>
-      );
-    }
-    if (this.state.showEnableButton) {
-      return (
-        <div className="action-container">
-          <BtnWithLoading
-            className="btn-primary"
-            label={T.translate(`${PREFIX}.enable`)}
-            loading={this.state.loading}
-            onClick={this.enableReports}
-          />
-        </div>
-      );
-    }
+  renderEnableBtn = () => {
+    return (
+      <div className="action-container">
+        <BtnWithLoading
+          className="btn-primary"
+          label={T.translate(`${PREFIX}.enable`)}
+          loading={this.state.loading}
+          onClick={this.enableReports}
+        />
+      </div>
+    );
   };
 
   renderError = () => {
@@ -142,7 +94,7 @@ export default class ReportsServiceControl extends Component {
       <div className="reports-service-control text-xs-center">
         <Helmet title={T.translate('features.Reports.pageTitle')} />
         <br />
-        {this.renderAvailableOrEnableBtn()}
+        {this.renderEnableBtn()}
         {this.renderError()}
       </div>
     );

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/RulesEngineServiceControl.scss
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/RulesEngineServiceControl.scss
@@ -77,6 +77,12 @@ $icon_color: #cccccc;
         }
       }
     }
+    .action-container {
+      padding-top: 25px;
+      padding-bottom: 25px;
+
+      .loading-bar { height: 16px; }
+    }
     .mail-to-link {
       color: $cdap-orange;
     }

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,18 +15,16 @@
 */
 
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import MyRuleEngineApi from 'api/rulesengine';
-import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
+import enableSystemApp from 'services/ServiceEnablerUtilities';
 import LoadingSVG from 'components/LoadingSVG';
 import T from 'i18n-react';
 import IconSVG from 'components/IconSVG';
-import {MyArtifactApi} from 'api/artifact';
-import NamespaceStore from 'services/NamespaceStore';
 
 require('./RulesEngineServiceControl.scss');
 const PREFIX = 'features.RulesEngine.RulesEngineServiceControl';
+const RulesEngineArtifact = 'dre-service';
 
 export default class RulesEngineServiceControl extends Component {
 
@@ -36,22 +34,16 @@ export default class RulesEngineServiceControl extends Component {
 
   state = {
     loading: false,
-    error: null,
-    rulesEngineNotAvailable: false,
-    showEnableButton: false
+    error: null
   };
-
-  componentDidMount() {
-    this.checkIfRulesEngineIsAvailable();
-  }
 
   enableRulesEngine = () => {
     this.setState({
       loading: true
     });
-    enableDataPreparationService({
+    enableSystemApp({
       shouldStopService: false,
-      artifactName: 'yare-service',
+      artifactName: RulesEngineArtifact,
       api: MyRuleEngineApi,
       i18nPrefix: ''
     })
@@ -65,26 +57,6 @@ export default class RulesEngineServiceControl extends Component {
         }
       );
   }
-
-  checkIfRulesEngineIsAvailable = () => {
-    let {selectedNamespace: namespace} = NamespaceStore.getState();
-    MyArtifactApi
-      .list({ namespace })
-      .subscribe(
-        (artifacts) => {
-          let isYareServicePresent = artifacts.find(artifact => artifact.name === 'yare-service');
-          if (!isYareServicePresent) {
-            this.setState({
-              rulesEngineNotAvailable: true
-            });
-          } else {
-            this.setState({
-              showEnableButton: true
-            });
-          }
-        }
-      );
-  };
 
   renderError = () => {
     if (!this.state.error) {
@@ -103,19 +75,9 @@ export default class RulesEngineServiceControl extends Component {
     );
   }
 
-  renderAvailableOrEnableBtn = () => {
-    if (!this.state.rulesEngineNotAvailable && !this.state.showEnableButton) {
-      return (<span> {T.translate(`${PREFIX}.checkMessage`)}</span>);
-    }
-    if (this.state.rulesEngineNotAvailable) {
-      return (
-        <span className="mail-to-link">
-          {T.translate(`${PREFIX}.contactMessage`)}
-        </span>
-      );
-    }
-    if (this.state.showEnableButton) {
-      return (
+  renderEnableBtn = () => {
+    return (
+      <div className="action-container">
         <button
           className="btn btn-primary"
           onClick={this.enableRulesEngine}
@@ -123,14 +85,14 @@ export default class RulesEngineServiceControl extends Component {
         >
           {
             this.state.loading ?
-              <LoadingSVG height="16px"/>
+              <LoadingSVG />
             :
               null
           }
           <span className="btn-label">{T.translate(`${PREFIX}.enableBtnLabel`)}</span>
         </button>
-      );
-    }
+      </div>
+    );
   };
 
   render() {
@@ -142,6 +104,8 @@ export default class RulesEngineServiceControl extends Component {
         </div>
         <div className="text-container">
           <h2> {T.translate(`${PREFIX}.title`)} </h2>
+          {this.renderEnableBtn()}
+          {this.renderError()}
           <p>
             {T.translate(`${PREFIX}.description`)}
           </p>
@@ -171,10 +135,6 @@ export default class RulesEngineServiceControl extends Component {
               </li>
             </ul>
           </div>
-          {
-            this.renderAvailableOrEnableBtn()
-          }
-          {this.renderError()}
         </div>
       </div>
     );

--- a/cdap-ui/app/cdap/services/ServiceEnablerUtilities.js
+++ b/cdap-ui/app/cdap/services/ServiceEnablerUtilities.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,7 +21,7 @@ import Version from 'services/VersionRange/Version';
 import T from 'i18n-react';
 import {Subject} from 'rxjs/Subject';
 
-export default function enableDataPreparationService({
+export default function enableSystemApp({
   shouldStopService,
   artifactName,
   api,

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1173,8 +1173,6 @@ features:
         b5: Support for tuning custom hyperparameters for algorithms.
         b6: Integrated metrics and visualization providing rich summaries and graphs for model evaluation.
         title: "Some key benefits of MMDS are:"
-      checkMessage: Checking if MMDS is available...
-      contactMessage: "Contact support@cask.co to enable"
       description: "Data Scientists typically build custom tooling for managing their machine learning models and deploying them. Model Management and Distribution Service (MMDS) provides a seamless, automated interface to help users develop, train, test, evaluate and deploy their machine learning models using CDAP."
       enableBtnLabel: Enable MMDS
       errorTitle: Enabling MMDS Failed
@@ -1962,8 +1960,6 @@ features:
       noReports: No reports are available
       selectAReport: Select a report to view
     ReportsServiceControl:
-      checking: Checking if Reports is available
-      contact: contact support@cask.co
       enable: Enable Reports
       unableToStart: Unable to start Reports service
 
@@ -2076,10 +2072,8 @@ features:
         b3: "Fully integrated: The Rules Engine is available as a library to integrate with JBoss, WebLogic, Spring, and SQL tools"
         b4: "Scalable: The Rules Engine is horizontally scalable, i.e. it scales out with your big data environment"
         b5: "Easy governance: The Rules engine provides a centralized repository for policies and transformations"
-        title: "Benefits of the Cask Rules Engine include:"
-      checkMessage: Checking if Rules Engine is available...
-      contactMessage: Contact support@cask.co to enable
-      description: Cask Distributed Rules Engine provides an easy way to create and manage a knowledge base that is executable in your big data environment.
+        title: "Benefits of the Rules Engine include:"
+      description: Business Rules Engine provides an easy way to create and manage a knowledge base that is executable in your big data environment.
                   The intuitive UI allows business analysts to set up business rules and use them within a data pipeline.
       enableBtnLabel: Enable Rules Engine
       errorTitle: Enabling Rules Engine Failed


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13477

Things done in this PR:
- Removes the 'contact to enable' message for both MMDS and Rules Engine, since they're now both open source. Also removed all the relevant code, including functions to check whether MMDS/DRE artifacts are available.
- Moves 'Enable' buttons for both MMDS/DRE to above the description, as described in the JIRA.
- Renames `enableDataPreparationService` to `enableSystemApp` to be more generic, and moves `ServiceEnablerUtilities` to a generic helper directory, instead of having it in `DataPrep` directory