### PR TITLE
CDAP-13604 add cross namespace metadata search

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -205,7 +205,7 @@ public abstract class MetadataTestBase extends ClientTestBase {
                                          cursor, showHiddden);
   }
 
-  protected MetadataSearchResponseV2 searchMetadata(NamespaceId namespaceId, String query,
+  protected MetadataSearchResponseV2 searchMetadata(@Nullable NamespaceId namespaceId, String query,
                                                     Set<EntityTypeSimpleName> targets,
                                                     @Nullable String sort, int offset, int limit, int numCursors,
                                                     @Nullable String cursor, boolean showHiddden,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchRequest.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchRequest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -48,7 +49,7 @@ public class SearchRequest {
    * Represents a request for a search for CDAP entities in the specified namespace with the specified search query and
    * an optional set of {@link EntityTypeSimpleName entity types} in the specified {@link MetadataScope}.
    *
-   * @param namespaceId the namespace id to filter the search by
+   * @param namespaceId the namespace id to filter the search by. Null if the search is across all namespaces
    * @param query the search query
    * @param types the types of CDAP entity to be searched. If empty all possible types will be searched
    * @param sortInfo represents sorting information. Use {@link SortInfo#DEFAULT} to return search results without
@@ -64,9 +65,9 @@ public class SearchRequest {
    *                    or not.
    * @param entityScope a set which specifies which scope of entities to display.
    */
-  public SearchRequest(NamespaceId namespaceId, String query, Set<EntityTypeSimpleName> types, SortInfo sortInfo,
-                       int offset, int limit, int numCursors, @Nullable String cursor, boolean showHidden,
-                       Set<EntityScope> entityScope) {
+  public SearchRequest(@Nullable NamespaceId namespaceId, String query, Set<EntityTypeSimpleName> types,
+                       SortInfo sortInfo, int offset, int limit, int numCursors, @Nullable String cursor,
+                       boolean showHidden, Set<EntityScope> entityScope) {
     if (query == null || query.isEmpty()) {
       throw new IllegalArgumentException("query must be specified");
     }
@@ -78,6 +79,9 @@ public class SearchRequest {
     }
     if (numCursors < 0) {
       throw new IllegalArgumentException("numCursors must not be negative");
+    }
+    if (entityScope.isEmpty()) {
+      throw new IllegalArgumentException("entity scope must be specified");
     }
     this.namespaceId = namespaceId;
     this.query = query;
@@ -92,10 +96,17 @@ public class SearchRequest {
   }
 
   /**
-   * @return the namespace to search in
+   * @return the namespace to search in, or empty if this is a cross namespace search.
    */
-  public NamespaceId getNamespaceId() {
-    return namespaceId;
+  public Optional<NamespaceId> getNamespaceId() {
+    return Optional.ofNullable(namespaceId);
+  }
+
+  /**
+   * @return true if the search request is within a namespace, false if it is across namespaces.
+   */
+  public boolean isNamespaced() {
+    return namespaceId != null;
   }
 
   /**
@@ -177,7 +188,7 @@ public class SearchRequest {
    * @return whether the search is done on the system metadata table or user metadata table.
    *   If a scope not defined the scan is performed on both and results are aggregated .
    */
-  public Set<EntityScope> getEntityScope() {
+  public Set<EntityScope> getEntityScopes() {
     return entityScope;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -20,9 +20,6 @@ import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.metadata.dataset.SearchRequest;
-import co.cask.cdap.data2.metadata.dataset.SortInfo;
-import co.cask.cdap.proto.EntityScope;
-import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
 import com.google.common.collect.ImmutableSet;
 
@@ -121,7 +118,7 @@ public class NoOpMetadataStore implements MetadataStore {
   public MetadataSearchResponseV2 search(SearchRequest request) {
     return new MetadataSearchResponseV2(request.getSortInfo().toString(), request.getOffset(), request.getLimit(),
                                         request.getNumCursors(), 0, Collections.emptySet(), Collections.emptyList(),
-                                        request.shouldShowHidden(), request.getEntityScope());
+                                        request.shouldShowHidden(), request.getEntityScopes());
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -51,9 +51,11 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -928,8 +930,9 @@ public class  MetadataDatasetTest {
       Assert.assertEquals(ImmutableList.of(expectedDatasetEntry), searchResults);
     });
     // delete indexes
-    // 6 indexes should have been deleted - flowValue, flowKey:flowValue, datasetValue, datasetKey:datasetValue and
-    // then the types with their name i.e. flow:flow1, dataset:dataset1
+    // 6 indexes should have been deleted
+    //   ns1:flowValue, ns1:flowKey:flowValue, ns1:datasetValue, ns1:datasetKey:datasetValue
+    //   and then the types with their name i.e. ns1:flow:flow1, ns1:dataset:dataset1
     for (int i = 0; i < 6; i++) {
       txnl.execute(() -> Assert.assertEquals(1, dataset.deleteAllIndexes(1)));
     }
@@ -955,36 +958,163 @@ public class  MetadataDatasetTest {
     final String namespaceId = flow1.getValue(MetadataEntity.NAMESPACE);
     txnl.execute(() -> {
       // entry with no special indexes
-      assertSingleIndex(dataset, MetadataDataset.DEFAULT_INDEX_COLUMN, namespaceId, value);
-      assertNoIndexes(dataset, MetadataDataset.ENTITY_NAME_INDEX_COLUMN, namespaceId, value);
-      assertNoIndexes(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN, namespaceId, value);
-      assertNoIndexes(dataset, MetadataDataset.CREATION_TIME_INDEX_COLUMN, namespaceId, value);
-      assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN, namespaceId, value);
+      assertSingleIndex(dataset, MetadataDataset.DEFAULT_INDEX_COLUMN.getColumn(), namespaceId, value);
+      assertNoIndexes(dataset, MetadataDataset.ENTITY_NAME_INDEX_COLUMN.getColumn(), namespaceId, value);
+      assertNoIndexes(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN.getColumn(), namespaceId, value);
+      assertNoIndexes(dataset, MetadataDataset.CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId, value);
+      assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId, value);
       // entry with a schema
-      assertSingleIndex(dataset, MetadataDataset.DEFAULT_INDEX_COLUMN, namespaceId, body);
-      assertNoIndexes(dataset, MetadataDataset.ENTITY_NAME_INDEX_COLUMN, namespaceId, body);
-      assertNoIndexes(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN, namespaceId, body);
-      assertNoIndexes(dataset, MetadataDataset.CREATION_TIME_INDEX_COLUMN, namespaceId, body);
-      assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN, namespaceId, body);
+      assertSingleIndex(dataset, MetadataDataset.DEFAULT_INDEX_COLUMN.getColumn(), namespaceId, body);
+      assertNoIndexes(dataset, MetadataDataset.ENTITY_NAME_INDEX_COLUMN.getColumn(), namespaceId, body);
+      assertNoIndexes(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN.getColumn(), namespaceId, body);
+      assertNoIndexes(dataset, MetadataDataset.CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId, body);
+      assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId, body);
       // entry with entity name
-      assertSingleIndex(dataset, MetadataDataset.DEFAULT_INDEX_COLUMN, namespaceId, name);
-      assertSingleIndex(dataset, MetadataDataset.ENTITY_NAME_INDEX_COLUMN, namespaceId, name);
-      assertNoIndexes(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN, namespaceId, name);
+      assertSingleIndex(dataset, MetadataDataset.DEFAULT_INDEX_COLUMN.getColumn(), namespaceId, name);
+      assertSingleIndex(dataset, MetadataDataset.ENTITY_NAME_INDEX_COLUMN.getColumn(), namespaceId, name);
+      assertNoIndexes(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN.getColumn(), namespaceId, name);
       Indexer indexer = new InvertedValueIndexer();
       String index = Iterables.getOnlyElement(indexer.getIndexes(new MetadataEntry(dataset1, "key", name)));
-      assertSingleIndex(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN, namespaceId, index.toLowerCase());
-      assertNoIndexes(dataset, MetadataDataset.CREATION_TIME_INDEX_COLUMN, namespaceId, name);
-      assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN, namespaceId, name);
+      assertSingleIndex(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN.getColumn(),
+                        namespaceId, index.toLowerCase());
+      assertNoIndexes(dataset, MetadataDataset.CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId, name);
+      assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId, name);
       // entry with creation time
       String time = String.valueOf(creationTime);
-      assertSingleIndex(dataset, MetadataDataset.DEFAULT_INDEX_COLUMN, namespaceId, time);
-      assertNoIndexes(dataset, MetadataDataset.ENTITY_NAME_INDEX_COLUMN, namespaceId, time);
-      assertNoIndexes(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN, namespaceId, time);
-      assertSingleIndex(dataset, MetadataDataset.CREATION_TIME_INDEX_COLUMN, namespaceId, time);
-      assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN, namespaceId, time);
-      assertSingleIndex(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN, namespaceId,
+      assertSingleIndex(dataset, MetadataDataset.DEFAULT_INDEX_COLUMN.getColumn(), namespaceId, time);
+      assertNoIndexes(dataset, MetadataDataset.ENTITY_NAME_INDEX_COLUMN.getColumn(), namespaceId, time);
+      assertNoIndexes(dataset, MetadataDataset.INVERTED_ENTITY_NAME_INDEX_COLUMN.getColumn(), namespaceId, time);
+      assertSingleIndex(dataset, MetadataDataset.CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId, time);
+      assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId, time);
+      assertSingleIndex(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN.getColumn(), namespaceId,
                         String.valueOf(Long.MAX_VALUE - creationTime));
     });
+  }
+
+  @Test
+  public void testCrossNamespaceDefaultSearch() throws Exception {
+    MetadataDataset dataset =
+      getDataset(DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("crossNamespaceDefault"), MetadataScope.SYSTEM);
+    TransactionExecutor txnl = dsFrameworkUtil.newInMemoryTransactionExecutor((TransactionAware) dataset);
+
+    MetadataEntity ns1App = new NamespaceId("ns1").app("a").toMetadataEntity();
+    MetadataEntity ns2App = new NamespaceId("ns2").app("a").toMetadataEntity();
+    txnl.execute(() -> {
+      dataset.setProperty(ns1App, "k1", "v1");
+      dataset.setProperty(ns1App, "k2", "v2");
+      dataset.setProperty(ns2App, "k1", "v1");
+    });
+
+    SearchRequest request1 = new SearchRequest(null, "v1", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                              0, 10, 0, null, false, EnumSet.allOf(EntityScope.class));
+    SearchResults results = txnl.execute(() -> dataset.search(request1));
+    Set<MetadataEntry> actual = new HashSet<>(results.getResults());
+    Set<MetadataEntry> expected = new HashSet<>();
+    expected.add(new MetadataEntry(ns1App, "k1", "v1"));
+    expected.add(new MetadataEntry(ns2App, "k1", "v1"));
+    Assert.assertEquals(expected, actual);
+
+    SearchRequest request2 = new SearchRequest(null, "v2", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                               0, 10, 0, null, false, EnumSet.allOf(EntityScope.class));
+    results = txnl.execute(() -> dataset.search(request2));
+    Assert.assertEquals(Collections.singletonList(new MetadataEntry(ns1App, "k2", "v2")), results.getResults());
+
+    SearchRequest star = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                           0, 10, 0, null, false, EnumSet.allOf(EntityScope.class));
+    results = txnl.execute(() -> dataset.search(star));
+    expected.add(new MetadataEntry(ns1App, "k2", "v2"));
+    Assert.assertEquals(expected, new HashSet<>(results.getResults()));
+  }
+
+  @Test
+  public void testCrossNamespaceSearchPagination() throws Exception {
+    MetadataDataset dataset =
+      getDataset(DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("crossNamespaceDefaultPag"), MetadataScope.SYSTEM);
+    TransactionExecutor txnl = dsFrameworkUtil.newInMemoryTransactionExecutor((TransactionAware) dataset);
+
+    ApplicationId ns1app1 = new NamespaceId("ns1").app("a1");
+    ApplicationId ns1app2 = new NamespaceId("ns1").app("a2");
+    ApplicationId ns1app3 = new NamespaceId("ns1").app("a3");
+    ApplicationId ns2app1 = new NamespaceId("ns2").app("a1");
+    ApplicationId ns2app2 = new NamespaceId("ns2").app("a2");
+    String key = AbstractSystemMetadataWriter.ENTITY_NAME_KEY;
+    txnl.execute(() -> {
+      dataset.setProperty(ns1app1.toMetadataEntity(), key, ns1app1.getApplication());
+      dataset.setProperty(ns1app2.toMetadataEntity(), key, ns1app2.getApplication());
+      dataset.setProperty(ns1app3.toMetadataEntity(), key, ns1app3.getApplication());
+      dataset.setProperty(ns2app1.toMetadataEntity(), key, ns2app1.getApplication());
+      dataset.setProperty(ns2app2.toMetadataEntity(), key, ns2app2.getApplication());
+    });
+
+    MetadataEntry ns1app1Entry = new MetadataEntry(ns1app1.toMetadataEntity(), key, ns1app1.getApplication());
+    MetadataEntry ns1app2Entry = new MetadataEntry(ns1app2.toMetadataEntity(), key, ns1app2.getApplication());
+    MetadataEntry ns1app3Entry = new MetadataEntry(ns1app3.toMetadataEntity(), key, ns1app3.getApplication());
+    MetadataEntry ns2app1Entry = new MetadataEntry(ns2app1.toMetadataEntity(), key, ns2app1.getApplication());
+    MetadataEntry ns2app2Entry = new MetadataEntry(ns2app2.toMetadataEntity(), key, ns2app2.getApplication());
+    SortInfo nameAsc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.ASC);
+    // first, get the full ordered list in one page
+    SearchRequest request1 = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), nameAsc,
+                                               0, 10, 1, null, false, EnumSet.allOf(EntityScope.class));
+    List<MetadataEntry> actual = txnl.execute(() -> dataset.search(request1).getResults());
+    List<MetadataEntry> expected = new ArrayList<>();
+    // sorted by name asc
+    expected.add(ns1app1Entry);
+    expected.add(ns2app1Entry);
+    expected.add(ns1app2Entry);
+    expected.add(ns2app2Entry);
+    expected.add(ns1app3Entry);
+    Assert.assertEquals(expected, actual);
+
+    // now search with 3 pages, 2 results per page
+    SearchRequest request2 = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), nameAsc,
+                                               0, 2, 3, null, false, EnumSet.allOf(EntityScope.class));
+    SearchResults results = txnl.execute(() -> dataset.search(request2));
+    // dataset returns all pages, so results should be in same order
+    Assert.assertEquals(expected, results.getResults());
+
+    // check the cursors
+    List<String> expectedCursors = new ArrayList<>();
+    expectedCursors.add(ns1app2Entry.getValue());
+    expectedCursors.add(ns1app3Entry.getValue());
+    Assert.assertEquals(expectedCursors, results.getCursors());
+
+    // now search for for 2nd and 3rd pages using the cursor
+    SearchRequest request3 = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), nameAsc,
+                                               0, 2, 3, results.getCursors().get(0), false,
+                                               EnumSet.allOf(EntityScope.class));
+    results = txnl.execute(() -> dataset.search(request3));
+    expected.clear();
+    expected.add(ns1app2Entry);
+    expected.add(ns2app2Entry);
+    expected.add(ns1app3Entry);
+    Assert.assertEquals(expected, results.getResults());
+    Assert.assertEquals(Collections.singletonList(ns1app3Entry.getValue()), results.getCursors());
+  }
+
+  @Test
+  public void testCrossNamespaceCustomSearch() throws Exception {
+    MetadataDataset dataset =
+      getDataset(DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("crossNamespaceCustom"), MetadataScope.SYSTEM);
+    TransactionExecutor txnl = dsFrameworkUtil.newInMemoryTransactionExecutor((TransactionAware) dataset);
+
+    String appName = "app";
+    MetadataEntity ns1App = new NamespaceId("ns1").app(appName).toMetadataEntity();
+    MetadataEntity ns2App = new NamespaceId("ns2").app(appName).toMetadataEntity();
+    txnl.execute(() -> {
+      dataset.setProperty(ns2App, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
+      dataset.setProperty(ns1App, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
+    });
+
+    SortInfo nameAsc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.ASC);
+
+    SearchRequest request = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), nameAsc,
+                                              0, 10, 0, null, false, EnumSet.allOf(EntityScope.class));
+    SearchResults results = txnl.execute(() -> dataset.search(request));
+    List<MetadataEntry> actual = results.getResults();
+    List<MetadataEntry> expected = new ArrayList<>();
+    expected.add(new MetadataEntry(ns1App, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName));
+    expected.add(new MetadataEntry(ns2App, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName));
+    Assert.assertEquals(expected, actual);
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStoreTest.java
@@ -57,6 +57,7 @@ import com.google.inject.Injector;
 import com.google.inject.util.Modules;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.runtime.TransactionInMemoryModule;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,6 +67,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +77,7 @@ import java.util.Set;
 /**
  * Tests for {@link MetadataStore}
  */
-public class MetadataStoreTest {
+public class DefaultMetadataStoreTest {
   private static final Map<String, String> EMPTY_PROPERTIES = Collections.emptyMap();
   private static final Set<String> EMPTY_TAGS = Collections.emptySet();
   private static final Map<MetadataScope, Metadata> EMPTY_USER_METADATA =
@@ -183,7 +186,7 @@ public class MetadataStoreTest {
 
   private static CConfiguration cConf;
   private static TransactionManager txManager;
-  private static MetadataStore store;
+  private static DefaultMetadataStore store;
   private static InMemoryAuditPublisher auditPublisher;
 
   @BeforeClass
@@ -210,13 +213,18 @@ public class MetadataStoreTest {
     cConf = injector.getInstance(CConfiguration.class);
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
-    store = injector.getInstance(MetadataStore.class);
+    store = injector.getInstance(DefaultMetadataStore.class);
     auditPublisher = injector.getInstance(InMemoryAuditPublisher.class);
   }
 
   @Before
   public void clearAudit() {
     auditPublisher.popMessages();
+  }
+
+  @After
+  public void cleanupTest() throws Exception {
+    store.deleteAndRecreate();
   }
 
   @Test
@@ -325,6 +333,151 @@ public class MetadataStoreTest {
     Assert.assertEquals(3, response.getTotal());
     actual = Lists.newArrayList(response.getResults());
     Assert.assertTrue(actual.containsAll(expected));
+  }
+
+  @Test
+  public void testCrossNamespaceSearch() {
+    NamespaceId ns1 = new NamespaceId("ns1");
+    NamespaceId ns2 = new NamespaceId("ns2");
+
+    MetadataEntity ns1app1 = ns1.app("a1").toMetadataEntity();
+    MetadataEntity ns1app2 = ns1.app("a2").toMetadataEntity();
+    MetadataEntity ns1app3 = ns1.app("a3").toMetadataEntity();
+    MetadataEntity ns2app1 = ns2.app("a1").toMetadataEntity();
+    MetadataEntity ns2app2 = ns2.app("a2").toMetadataEntity();
+
+    store.setProperty(MetadataScope.USER, ns1app1, "k1", "v1");
+    store.addTags(MetadataScope.USER, ns1app1, Collections.singleton("v1"));
+    Metadata meta = new Metadata(Collections.singletonMap("k1", "v1"), Collections.singleton("v1"));
+    MetadataSearchResultRecordV2 ns1app1Record =
+      new MetadataSearchResultRecordV2(ns1app1, Collections.singletonMap(MetadataScope.USER, meta));
+
+    store.setProperty(MetadataScope.USER, ns1app2, "k1", "v1");
+    store.setProperty(MetadataScope.USER, ns1app2, "k2", "v2");
+    meta = new Metadata(ImmutableMap.of("k1", "v1", "k2", "v2"), Collections.emptySet());
+    MetadataSearchResultRecordV2 ns1app2Record =
+      new MetadataSearchResultRecordV2(ns1app2, Collections.singletonMap(MetadataScope.USER, meta));
+
+    store.setProperty(MetadataScope.USER, ns1app3, "k1", "v1");
+    store.setProperty(MetadataScope.USER, ns1app3, "k3", "v3");
+    meta = new Metadata(ImmutableMap.of("k1", "v1", "k3", "v3"), Collections.emptySet());
+    MetadataSearchResultRecordV2 ns1app3Record =
+      new MetadataSearchResultRecordV2(ns1app3, Collections.singletonMap(MetadataScope.USER, meta));
+
+    store.setProperty(MetadataScope.USER, ns2app1, "k1", "v1");
+    store.setProperty(MetadataScope.USER, ns2app1, "k2", "v2");
+    meta = new Metadata(ImmutableMap.of("k1", "v1", "k2", "v2"), Collections.emptySet());
+    MetadataSearchResultRecordV2 ns2app1Record =
+      new MetadataSearchResultRecordV2(ns2app1, Collections.singletonMap(MetadataScope.USER, meta));
+
+    store.setProperty(MetadataScope.USER, ns2app2, "k1", "v1");
+    store.addTags(MetadataScope.USER, ns2app2, ImmutableSet.of("v2", "v3"));
+    meta = new Metadata(ImmutableMap.of("k1", "v1"), ImmutableSet.of("v2", "v3"));
+    MetadataSearchResultRecordV2 ns2app2Record =
+      new MetadataSearchResultRecordV2(ns2app2, Collections.singletonMap(MetadataScope.USER, meta));
+
+    // everything should match 'v1'
+    SearchRequest request = new SearchRequest(null, "v1", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                              0, 10, 0, null, false, EnumSet.allOf(EntityScope.class));
+    MetadataSearchResponseV2 results = store.search(request);
+    Set<MetadataSearchResultRecordV2> expected = new HashSet<>();
+    expected.add(ns1app1Record);
+    expected.add(ns1app2Record);
+    expected.add(ns1app3Record);
+    expected.add(ns2app1Record);
+    expected.add(ns2app2Record);
+    Assert.assertEquals(expected, results.getResults());
+
+    // ns1app2, ns2app1, and ns2app2 should match 'v2'
+    request = new SearchRequest(null, "v2", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                0, 10, 0, null, false, EnumSet.allOf(EntityScope.class));
+    results = store.search(request);
+    expected.clear();
+    expected.add(ns1app2Record);
+    expected.add(ns2app1Record);
+    expected.add(ns2app2Record);
+    Assert.assertEquals(expected, results.getResults());
+
+    // ns1app3 and ns2app2 should match 'v3'
+    request = new SearchRequest(null, "v3", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                0, 10, 0, null, false, EnumSet.allOf(EntityScope.class));
+    results = store.search(request);
+    expected.clear();
+    expected.add(ns1app3Record);
+    expected.add(ns2app2Record);
+    Assert.assertEquals(expected, results.getResults());
+  }
+
+  @Test
+  public void testCrossNamespacePagination() {
+    NamespaceId ns1 = new NamespaceId("ns1");
+    NamespaceId ns2 = new NamespaceId("ns2");
+
+    MetadataEntity ns1app1 = ns1.app("a1").toMetadataEntity();
+    MetadataEntity ns1app2 = ns1.app("a2").toMetadataEntity();
+    MetadataEntity ns1app3 = ns1.app("a3").toMetadataEntity();
+    MetadataEntity ns2app1 = ns2.app("a1").toMetadataEntity();
+    MetadataEntity ns2app2 = ns2.app("a2").toMetadataEntity();
+
+    Metadata meta = new Metadata(Collections.emptyMap(), Collections.singleton("v1"));
+
+    store.addTags(MetadataScope.USER, ns1app1, Collections.singleton("v1"));
+    store.addTags(MetadataScope.USER, ns1app2, Collections.singleton("v1"));
+    store.addTags(MetadataScope.USER, ns1app3, Collections.singleton("v1"));
+    store.addTags(MetadataScope.USER, ns2app1, Collections.singleton("v1"));
+    store.addTags(MetadataScope.USER, ns2app2, Collections.singleton("v1"));
+
+    // first get everything
+    SearchRequest request = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                              0, 10, 0, null, false, EnumSet.allOf(EntityScope.class));
+    MetadataSearchResponseV2 results = store.search(request);
+    Assert.assertEquals(5, results.getResults().size());
+
+    Iterator<MetadataSearchResultRecordV2> resultIter = results.getResults().iterator();
+
+    MetadataSearchResultRecordV2 result1 = resultIter.next();
+    MetadataSearchResultRecordV2 result2 = resultIter.next();
+    MetadataSearchResultRecordV2 result3 = resultIter.next();
+    MetadataSearchResultRecordV2 result4 = resultIter.next();
+    MetadataSearchResultRecordV2 result5 = resultIter.next();
+
+    // get 4 results (guaranteed to have at least one from each namespace), offset 1
+    request = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                1, 4, 0, null, false, EnumSet.allOf(EntityScope.class));
+    results = store.search(request);
+
+    List<MetadataSearchResultRecordV2> expected = new ArrayList<>();
+    expected.add(result2);
+    expected.add(result3);
+    expected.add(result4);
+    expected.add(result5);
+    List<MetadataSearchResultRecordV2> actual = new ArrayList<>(results.getResults());
+    Assert.assertEquals(expected, actual);
+
+    // get the first four
+    request = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                0, 4, 0, null, false, EnumSet.allOf(EntityScope.class));
+    results = store.search(request);
+    expected.clear();
+    expected.add(result1);
+    expected.add(result2);
+    expected.add(result3);
+    expected.add(result4);
+    actual.clear();
+    actual.addAll(results.getResults());
+    Assert.assertEquals(expected, actual);
+
+    // get middle 3
+    request = new SearchRequest(null, "*", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
+                                1, 3, 0, null, false, EnumSet.allOf(EntityScope.class));
+    results = store.search(request);
+    expected.clear();
+    expected.add(result2);
+    expected.add(result3);
+    expected.add(result4);
+    actual.clear();
+    actual.addAll(results.getResults());
+    Assert.assertEquals(expected, actual);
   }
 
   // Tests pagination for search results queries that do not have indexes stored in sorted order

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -116,7 +116,8 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       endsWith(uriParts, "metadata", "tags") || endsWith(uriParts, "metadata", "tags", null) ||
       endsWith(uriParts, "metadata", "search") ||
       beginsWith(uriParts, "v3", "namespaces", null, "datasets", null, "lineage") ||
-      beginsWith(uriParts, "v3", "namespaces", null, "streams", null, "lineage"))) {
+      beginsWith(uriParts, "v3", "namespaces", null, "streams", null, "lineage") ||
+      beginsWith(uriParts, "v3", "metadata", "search"))) {
       return METADATA_SERVICE;
     } else if (beginsWith(uriParts, "v3", "security", "authorization") ||
       beginsWith(uriParts, "v3", "namespaces", null, "securekeys")) {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathLookupTest.java
@@ -383,6 +383,7 @@ public class RouterPathLookupTest {
                   RouterPathLookup.METADATA_SERVICE);
     // search metadata
     assertRouting("/v3/namespaces/default/metadata/search", RouterPathLookup.METADATA_SERVICE);
+    assertRouting("/v3/metadata/search", RouterPathLookup.METADATA_SERVICE);
     // lineage
     assertRouting("/v3/namespaces/default/////datasets/ds1/lineage", RouterPathLookup.METADATA_SERVICE);
     assertRouting("/v3/namespaces/default/streams/st1/lineage", RouterPathLookup.METADATA_SERVICE);


### PR DESCRIPTION
Cross namespace search is implemented by adding additional index
columns that don't contain prefix the index value with the entity
namespace. When index value 'foo' is written on an entity in
namespace 'ns1', instead of just writing 'ns1:foo' to column 'i',
we will also write 'foo' to column 'xi'.
    
This adds new indexes, and will rely on upgrade to add those new
indexes.
    
Performing some refactoring to the MetadataDataset by introducing
a SearchTerm class that holds a namespace, term, and whether
it is a prefix search. Using the class instead of performing
string manipulation everywhere.