### PR TITLE
CDAP-13262 Expose metadata api to plugins

### DIFF
--- a/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContextBase.scala
+++ b/cdap-api-spark-base/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContextBase.scala
@@ -18,14 +18,12 @@ package co.cask.cdap.api.spark
 
 import java.io.IOException
 
-import co.cask.cdap.api.{RuntimeContext, ServiceDiscoverer, TaskLocalizationContext, Transactional, TxRunnable}
 import co.cask.cdap.api.annotation.Beta
 import co.cask.cdap.api.data.batch.Split
 import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.messaging.MessagingContext
-import co.cask.cdap.api.metadata.MetadataReader
-import co.cask.cdap.api.metadata.MetadataWriter
+import co.cask.cdap.api.metadata.{MetadataReader, MetadataWriter}
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo
@@ -33,17 +31,17 @@ import co.cask.cdap.api.security.store.SecureStore
 import co.cask.cdap.api.spark.dynamic.SparkInterpreter
 import co.cask.cdap.api.stream.GenericStreamEventData
 import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
+import co.cask.cdap.api.{RuntimeContext, ServiceDiscoverer, TaskLocalizationContext, Transactional, TxRunnable}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.tephra.TransactionFailureException
 
 import scala.reflect.ClassTag
-
 /**
   * Spark program execution context. User Spark program can interact with CDAP through this context.
   */
 @Beta
-trait SparkExecutionContextBase extends RuntimeContext with Transactional {
+trait SparkExecutionContextBase extends RuntimeContext with Transactional with MetadataReader with MetadataWriter {
 
   /**
     * @return The specification used to configure this Spark job instance.
@@ -98,22 +96,6 @@ trait SparkExecutionContextBase extends RuntimeContext with Transactional {
     * @return A [[co.cask.cdap.api.messaging.MessagingContext]]
     */
   def getMessagingContext: MessagingContext
-
-  /**
-    * Returns a [[co.cask.cdap.api.metadata.MetadataReader]] which can be used to read metadata.
-    * Currently the returned instance can only be used in the Spark driver process.
-    *
-    * @return A [[co.cask.cdap.api.metadata.MetadataReader]]
-    */
-  def getMetadataReader: MetadataReader
-
-  /**
-    * Returns a [[co.cask.cdap.api.metadata.MetadataWriter]] which can be used to emit metadata.
-    * Currently the returned instance can only be used in the Spark driver process.
-    *
-    * @return A [[co.cask.cdap.api.metadata.MetadataWriter]]
-    */
-  def getMetadataWriter: MetadataWriter
 
   /**
     * Returns the [[co.cask.cdap.api.workflow.WorkflowToken]] if the Spark program

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -226,7 +226,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @Nullable @QueryParam("entityScope") String entityScope) throws Exception {
     SearchRequest searchRequest = getValidatedSearchRequest(namespaceId, searchQuery, targets, sort, offset,
                                                             limit, numCursors, cursor, showHidden, entityScope);
-    LOG.trace("Received sesarch request {}", searchRequest);
+    LOG.trace("Received search request {}", searchRequest);
 
     MetadataSearchResponseV2 response = metadataAdmin.search(searchRequest);
     if (showCustom) {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -26,6 +26,9 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.messaging.Message;
 import co.cask.cdap.api.messaging.MessageFetcher;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
@@ -33,6 +36,9 @@ import co.cask.cdap.api.workflow.NodeStatus;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.metadata.MetadataRecordV2;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.data2.metadata.writer.MetadataOperation;
 import co.cask.cdap.datapipeline.mock.NaiveBayesClassifier;
 import co.cask.cdap.datapipeline.mock.NaiveBayesTrainer;
 import co.cask.cdap.datapipeline.mock.SpamMessage;
@@ -78,6 +84,7 @@ import co.cask.cdap.etl.spark.Compat;
 import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
 import co.cask.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
 import co.cask.cdap.internal.schedule.constraint.Constraint;
+import co.cask.cdap.metadata.MetadataAdmin;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ScheduleDetail;
@@ -118,6 +125,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -135,7 +143,7 @@ public class DataPipelineTest extends HydratorTestBase {
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
   private static final ArtifactSummary APP_ARTIFACT_RANGE = new ArtifactSummary("app", "[0.1.0,1.1.0)");
   private static int startCount = 0;
-  
+
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
                                                                        Constants.Security.Store.PROVIDER, "file",
@@ -2760,6 +2768,100 @@ public class DataPipelineTest extends HydratorTestBase {
 
     deleteDatasetInstance(NamespaceId.DEFAULT.dataset("inputTable"));
     deleteDatasetInstance(NamespaceId.DEFAULT.dataset("outputTable"));
+  }
+
+  @Test
+  public void testMetadata() throws Exception {
+    ImmutableSet<String> inputTagsToAdd = ImmutableSet.of("tOne", "tTwo");
+    ImmutableMap<String, String> inputPropToAdd = ImmutableMap.of("kOne", "vOne", "kTwo", "vTwo");
+    MetadataOperation op =
+      new MetadataOperation(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"),
+                            MetadataOperation.Type.PUT, new Metadata(inputPropToAdd,
+                                                                     inputTagsToAdd));
+    Set<MetadataOperation> operations = new HashSet<>(Collections.singletonList(op));
+
+    // run pipeline with the metadata operations which need to be performed
+    runPipelineForMetadata(operations);
+    MetadataAdmin metadataAdmin = getMetadataAdmin();
+    waitForMetadataProcessing(metadataAdmin, 2);
+
+    // verify metadata written by the pipeline
+    Set<MetadataRecordV2> actual =
+      metadataAdmin.getMetadata(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"));
+
+    Assert.assertNotNull(actual);
+    Assert.assertTrue(!actual.isEmpty());
+    for (MetadataRecordV2 actualRecord : actual) {
+      if (actualRecord.getScope() == MetadataScope.USER) {
+        // verify the user properties
+        Assert.assertTrue(!actualRecord.getProperties().isEmpty());
+        Assert.assertTrue(!actualRecord.getTags().isEmpty());
+        Assert.assertEquals(inputPropToAdd, actualRecord.getProperties());
+        Assert.assertEquals(inputTagsToAdd, actualRecord.getTags());
+      }
+    }
+
+    // delete some properties and tag
+    op = new MetadataOperation(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"),
+                                       MetadataOperation.Type.DELETE, new Metadata(ImmutableMap.of("kOne", ""),
+                                                                                ImmutableSet.of("tOne")));
+    operations = new HashSet<>(Collections.singleton(op));
+
+    runPipelineForMetadata(operations);
+
+    waitForMetadataProcessing(metadataAdmin, 1);
+
+    actual = metadataAdmin.getMetadata(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"));
+
+    Assert.assertNotNull(actual);
+    Assert.assertTrue(!actual.isEmpty());
+    for (MetadataRecordV2 actualRecord : actual) {
+      if (actualRecord.getScope() == MetadataScope.USER) {
+        // verify the user properties
+        Assert.assertEquals(1, actualRecord.getProperties().size());
+        Assert.assertEquals(1, actualRecord.getTags().size());
+        Assert.assertTrue(actualRecord.getProperties().containsKey("kTwo"));
+        Assert.assertEquals("vTwo", actualRecord.getProperties().get("kTwo"));
+        Assert.assertEquals("tTwo", actualRecord.getTags().iterator().next());
+      }
+    }
+  }
+
+  private void waitForMetadataProcessing(MetadataAdmin metadataAdmin, int expectedTagSize)
+    throws TimeoutException, InterruptedException, java.util.concurrent.ExecutionException {
+    Tasks.waitFor(true, () -> {
+      Set<MetadataRecordV2> metadataRecordV2s =
+        metadataAdmin.getMetadata(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"));
+      for (MetadataRecordV2 actualRecord : metadataRecordV2s) {
+        if (actualRecord.getScope() == MetadataScope.USER) {
+          return actualRecord.getTags().size() == expectedTagSize;
+        }
+      }
+      return false;
+    }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+  }
+
+  private void runPipelineForMetadata(Set<MetadataOperation> operations) throws Exception {
+    Schema schema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING))
+    );
+    /*
+     * source --> sink
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MockSource.getPlugin("singleInput", schema, operations)))
+      .addStage(new ETLStage("sink", MockSink.getPlugin("singleOutput")))
+      .addConnection("source", "sink")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT_RANGE, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("MetadataTestApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractStageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractStageContext.java
@@ -19,7 +19,9 @@ package co.cask.cdap.etl.common;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.metadata.Metadata;
 import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.StageContext;
 import co.cask.cdap.etl.api.StageMetrics;
@@ -192,51 +194,87 @@ public abstract class AbstractStageContext implements StageContext {
 
   @Override
   public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
-    return null;
+    return CALLER.callUnchecked(() -> getMetadataReader().getMetadata(metadataEntity));
   }
 
   @Override
   public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
-    return null;
+    return CALLER.callUnchecked(() -> getMetadataReader().getMetadata(scope, metadataEntity));
   }
 
   @Override
   public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
-
+    CALLER.callUnchecked((Callable<Void>) () -> {
+      getMetadataWriter().addProperties(metadataEntity, properties);
+      return null;
+    });
   }
 
   @Override
   public void addTags(MetadataEntity metadataEntity, String... tags) {
-
+    CALLER.callUnchecked((Callable<Void>) () -> {
+      getMetadataWriter().addTags(metadataEntity, tags);
+      return null;
+    });
   }
 
   @Override
   public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
-
+    CALLER.callUnchecked((Callable<Void>) () -> {
+      getMetadataWriter().addTags(metadataEntity, tags);
+      return null;
+    });
   }
 
   @Override
   public void removeMetadata(MetadataEntity metadataEntity) {
-
+    CALLER.callUnchecked((Callable<Void>) () -> {
+      getMetadataWriter().removeMetadata(metadataEntity);
+      return null;
+    });
   }
 
   @Override
   public void removeProperties(MetadataEntity metadataEntity) {
-
+    CALLER.callUnchecked((Callable<Void>) () -> {
+      getMetadataWriter().removeProperties(metadataEntity);
+      return null;
+    });
   }
 
   @Override
   public void removeProperties(MetadataEntity metadataEntity, String... keys) {
-
+    CALLER.callUnchecked((Callable<Void>) () -> {
+      getMetadataWriter().removeProperties(metadataEntity, keys);
+      return null;
+    });
   }
 
   @Override
   public void removeTags(MetadataEntity metadataEntity) {
-
+    CALLER.callUnchecked((Callable<Void>) () -> {
+      getMetadataWriter().removeTags(metadataEntity);
+      return null;
+    });
   }
 
   @Override
   public void removeTags(MetadataEntity metadataEntity, String... tags) {
+    CALLER.callUnchecked((Callable<Void>) () -> {
+      getMetadataWriter().removeTags(metadataEntity, tags);
+      return null;
+    });
+  }
 
+  private MetadataReader getMetadataReader() {
+    return pipelineRuntime.getMetadataReader().orElseThrow(this::createMetadataUnsupportedException);
+  }
+
+  private MetadataWriter getMetadataWriter() {
+    return pipelineRuntime.getMetadataWriter().orElseThrow(this::createMetadataUnsupportedException);
+  }
+
+  private UnsupportedOperationException createMetadataUnsupportedException() {
+    return new UnsupportedOperationException("Metadata operation is not supported.");
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractTransformContext.java
@@ -16,9 +16,6 @@
 
 package co.cask.cdap.etl.common;
 
-import co.cask.cdap.api.metadata.Metadata;
-import co.cask.cdap.api.metadata.MetadataEntity;
-import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.TransformContext;
@@ -45,56 +42,6 @@ public abstract class AbstractTransformContext extends AbstractStageContext impl
   @Override
   public <T> Lookup<T> provide(String table, Map<String, String> arguments) {
     return lookup.provide(table, arguments);
-  }
-
-  @Override
-  public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
-    return null;
-  }
-
-  @Override
-  public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) {
-    return null;
-  }
-
-  @Override
-  public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
-
-  }
-
-  @Override
-  public void addTags(MetadataEntity metadataEntity, String... tags) {
-
-  }
-
-  @Override
-  public void addTags(MetadataEntity metadataEntity, Iterable<String> tags) {
-
-  }
-
-  @Override
-  public void removeMetadata(MetadataEntity metadataEntity) {
-
-  }
-
-  @Override
-  public void removeProperties(MetadataEntity metadataEntity) {
-
-  }
-
-  @Override
-  public void removeProperties(MetadataEntity metadataEntity, String... keys) {
-
-  }
-
-  @Override
-  public void removeTags(MetadataEntity metadataEntity) {
-
-  }
-
-  @Override
-  public void removeTags(MetadataEntity metadataEntity, String... tags) {
-
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineRuntime.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineRuntime.java
@@ -20,11 +20,15 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.customaction.CustomActionContext;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import co.cask.cdap.api.metadata.MetadataReader;
+import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.etl.api.StageContext;
+
+import java.util.Optional;
 
 /**
  * Holds common information, services, and contexts required at runtime by plugins. This exists mainly so that we
@@ -39,15 +43,17 @@ public class PipelineRuntime {
   private final Metrics metrics;
   private final PluginContext pluginContext;
   private final ServiceDiscoverer serviceDiscoverer;
+  private final MetadataReader metadataReader;
+  private final MetadataWriter metadataWriter;
 
   public PipelineRuntime(SparkClientContext context) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-         new BasicArguments(context), context.getMetrics(), context, context);
+         new BasicArguments(context), context.getMetrics(), context, context, context, context);
   }
 
   public PipelineRuntime(CustomActionContext context, Metrics metrics) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-         new BasicArguments(context), metrics, context, context);
+         new BasicArguments(context), metrics, context, context, context, context);
   }
 
   public PipelineRuntime(MapReduceTaskContext context, Metrics metrics, BasicArguments arguments) {
@@ -57,16 +63,18 @@ public class PipelineRuntime {
 
   public PipelineRuntime(MapReduceContext context, Metrics metrics) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-         new BasicArguments(context), metrics, context, context);
+         new BasicArguments(context), metrics, context, context, context, context);
   }
 
   public PipelineRuntime(WorkflowContext context, Metrics metrics) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-         new BasicArguments(context.getToken(), context.getRuntimeArguments()), metrics, context, context);
+         new BasicArguments(context.getToken(), context.getRuntimeArguments()), metrics, context, context, context,
+         context);
   }
 
   public PipelineRuntime(String namespace, String pipelineName, long logicalStartTime, BasicArguments arguments,
-                         Metrics metrics, PluginContext pluginContext, ServiceDiscoverer serviceDiscoverer) {
+                         Metrics metrics, PluginContext pluginContext, ServiceDiscoverer serviceDiscoverer,
+                         MetadataReader metadataReader, MetadataWriter metadataWriter) {
     this.namespace = namespace;
     this.pipelineName = pipelineName;
     this.logicalStartTime = logicalStartTime;
@@ -74,6 +82,13 @@ public class PipelineRuntime {
     this.metrics = metrics;
     this.pluginContext = pluginContext;
     this.serviceDiscoverer = serviceDiscoverer;
+    this.metadataReader = metadataReader;
+    this.metadataWriter = metadataWriter;
+  }
+
+  public PipelineRuntime(String namespace, String pipelineName, long logicalStartTime, BasicArguments arguments,
+                         Metrics metrics, PluginContext pluginContext, ServiceDiscoverer serviceDiscoverer) {
+    this(namespace, pipelineName, logicalStartTime, arguments, metrics, pluginContext, serviceDiscoverer, null, null);
   }
 
   public String getNamespace() {
@@ -102,5 +117,25 @@ public class PipelineRuntime {
 
   public ServiceDiscoverer getServiceDiscoverer() {
     return serviceDiscoverer;
+  }
+
+  /**
+   * @return an {@link Optional} of {@link MetadataReader} which is present is metadataReader is not null
+   */
+  public Optional<MetadataReader> getMetadataReader() {
+    if (metadataReader != null) {
+      return Optional.of(metadataReader);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * @return an {@link Optional} of {@link MetadataWriter} which is present is metadataWriter is not null
+   */
+  public Optional<MetadataWriter> getMetadataWriter() {
+    if (metadataWriter != null) {
+      return Optional.of(metadataWriter);
+    }
+    return Optional.empty();
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/SparkPipelineRuntime.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/SparkPipelineRuntime.java
@@ -28,7 +28,7 @@ public class SparkPipelineRuntime extends PipelineRuntime {
 
   public SparkPipelineRuntime(SparkClientContext context) {
     super(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-          new BasicArguments(context), context.getMetrics(), context, context);
+          new BasicArguments(context), context.getMetrics(), context, context, context, context);
   }
 
   public SparkPipelineRuntime(JavaSparkExecutionContext sec) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/PluginFunctionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/PluginFunctionContext.java
@@ -24,8 +24,6 @@ import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.etl.api.StageMetrics;
-import co.cask.cdap.etl.batch.connector.ConnectorSink;
-import co.cask.cdap.etl.batch.connector.ConnectorSource;
 import co.cask.cdap.etl.batch.connector.SingleConnectorSink;
 import co.cask.cdap.etl.batch.connector.SingleConnectorSource;
 import co.cask.cdap.etl.common.BasicArguments;
@@ -40,7 +38,6 @@ import co.cask.cdap.etl.spark.plugin.SparkPipelinePluginContext;
 import co.cask.cdap.etl.spec.StageSpec;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -51,7 +51,7 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
   public DefaultStreamingContext(StageSpec stageSpec, JavaSparkExecutionContext sec, JavaStreamingContext jsc) {
     super(new PipelineRuntime(sec.getNamespace(), sec.getApplicationSpecification().getName(),
                               sec.getLogicalStartTime(), new BasicArguments(sec), sec.getMetrics(),
-                              sec.getPluginContext(), sec.getServiceDiscoverer()), stageSpec);
+                              sec.getPluginContext(), sec.getServiceDiscoverer(), sec, sec), stageSpec);
     this.sec = sec;
     this.jsc = jsc;
     this.admin = sec.getAdmin();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataOperation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/MetadataOperation.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.metadata.writer;
 import co.cask.cdap.api.metadata.Metadata;
 import co.cask.cdap.api.metadata.MetadataEntity;
 
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 import static co.cask.cdap.data2.metadata.writer.MetadataOperation.Type.DELETE;
@@ -99,5 +100,33 @@ public class MetadataOperation {
   @Nullable
   public Metadata getMetadata() {
     return metadata;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MetadataOperation that = (MetadataOperation) o;
+    return Objects.equals(entity, that.entity) &&
+      type == that.type &&
+      Objects.equals(metadata, that.metadata);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entity, type, metadata);
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataOperation{" +
+      "entity=" + entity +
+      ", type=" + type +
+      ", metadata=" + metadata +
+      '}';
   }
 }

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/SparkWikipediaClustering.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/SparkWikipediaClustering.java
@@ -18,13 +18,15 @@ package co.cask.cdap.examples.wikipedia;
 
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.spark.AbstractSpark;
-import org.apache.spark.SparkConf;
 
 /**
  * Spark program that executes in a workflow and analyzes wikipedia data
  */
 public class SparkWikipediaClustering extends AbstractSpark {
   public static final String NAME = SparkWikipediaClustering.class.getSimpleName();
+  static final String CLUSTERING_ALGORITHM = "clusteringAlgorithm";
+  static final String CLUSTERING_ALGORITHM_LDA = "lda";
+  static final String CLUSTERING_ALGORITHM_KMEANS = "kmeans";
 
   private final WikipediaPipelineApp.WikipediaAppConfig appConfig;
 
@@ -34,10 +36,10 @@ public class SparkWikipediaClustering extends AbstractSpark {
 
   @Override
   protected void configure() {
-    if ("lda".equals(appConfig.clusteringAlgorithm)) {
+    if (CLUSTERING_ALGORITHM_LDA.equalsIgnoreCase(appConfig.clusteringAlgorithm)) {
       setDescription("A Spark program that analyzes wikipedia data using Latent Dirichlet Allocation (LDA).");
       setMainClass(ScalaSparkLDA.class);
-    } else if ("kmeans".equals(appConfig.clusteringAlgorithm)) {
+    } else if (CLUSTERING_ALGORITHM_KMEANS.equalsIgnoreCase(appConfig.clusteringAlgorithm)) {
       setDescription("A Spark program that analyzes wikipedia data using K-Means.");
       setMainClass(ScalaSparkKMeans.class);
     } else {

--- a/cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ScalaSparkKMeans.scala
+++ b/cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ScalaSparkKMeans.scala
@@ -16,7 +16,9 @@
 
 package co.cask.cdap.examples.wikipedia
 
+import co.cask.cdap.api.metadata.MetadataEntity
 import co.cask.cdap.api.spark.{SparkExecutionContext, SparkMain}
+import com.google.common.collect.ImmutableMap
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.clustering.KMeans
 import org.apache.spark.mllib.linalg.Vector
@@ -37,6 +39,12 @@ class ScalaSparkKMeans extends SparkMain {
 
     var dataNamespace = sec.getRuntimeArguments.get(WikipediaPipelineApp.NAMESPACE_ARG)
     dataNamespace = if (dataNamespace != null) dataNamespace else sec.getNamespace
+
+    // add the algorithm as the metadata of the output dataset to represent the algorithm used to generate the data
+    // if the property already exists from last run then the algorithm value will be over written
+    sec.addProperties(MetadataEntity.ofDataset(dataNamespace, WikipediaPipelineApp.SPARK_CLUSTERING_OUTPUT_DATASET),
+      ImmutableMap.of(SparkWikipediaClustering.CLUSTERING_ALGORITHM,
+        SparkWikipediaClustering.CLUSTERING_ALGORITHM_KMEANS))
 
     // Pre-process data for LDA
     val (corpus, vocabArray, _) = ClusteringUtils.preProcess(

--- a/cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ScalaSparkLDA.scala
+++ b/cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ScalaSparkLDA.scala
@@ -18,7 +18,9 @@ package co.cask.cdap.examples.wikipedia
 
 import java.util
 
+import co.cask.cdap.api.metadata.MetadataEntity
 import co.cask.cdap.api.spark.{SparkExecutionContext, SparkMain}
+import com.google.common.collect.ImmutableMap
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.clustering.{LDA, LDAModel}
 import org.apache.spark.mllib.linalg.Vector
@@ -40,6 +42,11 @@ class ScalaSparkLDA extends SparkMain {
     val arguments = sec.getRuntimeArguments
     var dataNamespace = sec.getRuntimeArguments.get(WikipediaPipelineApp.NAMESPACE_ARG)
     dataNamespace = if (dataNamespace != null) dataNamespace else sec.getNamespace
+
+    // add the algorithm as the metadata of the output dataset to represent the algorithm used to generate the data
+    // if the property already exists from last run then the algorithm value will be over written
+    sec.addProperties(MetadataEntity.ofDataset(dataNamespace, WikipediaPipelineApp.SPARK_CLUSTERING_OUTPUT_DATASET),
+      ImmutableMap.of(SparkWikipediaClustering.CLUSTERING_ALGORITHM, SparkWikipediaClustering.CLUSTERING_ALGORITHM_LDA))
 
     // Pre-process data for LDA
     val (corpus, vocabArray, _) = ClusteringUtils.preProcess(

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -16,39 +16,31 @@
 
 package co.cask.cdap.app.runtime.spark
 
-import co.cask.cdap.api.Admin
-import co.cask.cdap.api.ServiceDiscoverer
-import co.cask.cdap.api.TxRunnable
+import java.io.IOException
+import java.{lang, util}
+
+import co.cask.cdap.api.{Admin, ServiceDiscoverer, TxRunnable}
 import co.cask.cdap.api.app.ApplicationSpecification
 import co.cask.cdap.api.data.batch.Split
 import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.messaging.MessagingContext
-import co.cask.cdap.api.metadata.{Metadata, MetadataEntity, MetadataReader, MetadataScope}
+import co.cask.cdap.api.metadata.{Metadata, MetadataEntity, MetadataScope}
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.preview.DataTracer
-import co.cask.cdap.api.security.store.SecureStore
-import co.cask.cdap.api.security.store.SecureStoreData
-import co.cask.cdap.api.spark.JavaSparkExecutionContext
-import co.cask.cdap.api.spark.SparkExecutionContext
-import co.cask.cdap.api.spark.SparkSpecification
+import co.cask.cdap.api.schedule.TriggeringScheduleInfo
+import co.cask.cdap.api.security.store.{SecureStore, SecureStoreData}
+import co.cask.cdap.api.spark.{JavaSparkExecutionContext, SparkExecutionContext, SparkSpecification}
 import co.cask.cdap.api.spark.dynamic.SparkInterpreter
-import co.cask.cdap.api.stream.GenericStreamEventData
-import co.cask.cdap.api.stream.StreamEventDecoder
-import co.cask.cdap.api.workflow.WorkflowInfo
-import co.cask.cdap.api.workflow.WorkflowToken
+import co.cask.cdap.api.stream.{GenericStreamEventData, StreamEventDecoder}
+import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
 import co.cask.cdap.data.stream.AbstractStreamInputFormat
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
-import org.apache.spark.api.java.JavaPairRDD
-import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.api.java.{JavaPairRDD, JavaRDD}
 import org.apache.spark.rdd.RDD
 import org.apache.twill.api.RunId
-import java.io.IOException
-import java.{lang, util}
-
-import co.cask.cdap.api.schedule.TriggeringScheduleInfo
 
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
@@ -256,43 +248,43 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
   }
 
   override def getMetadata(metadataEntity: MetadataEntity): util.Map[MetadataScope, Metadata] = {
-    return sec.getMetadataReader.getMetadata(metadataEntity);
+    return sec.getMetadata(metadataEntity);
   }
 
   override def getMetadata(scope: MetadataScope, metadataEntity: MetadataEntity): Metadata = {
-    return sec.getMetadataReader.getMetadata(scope, metadataEntity);
+    return sec.getMetadata(scope, metadataEntity);
   }
 
   override def addProperties(metadataEntity: MetadataEntity, properties: util.Map[String, String]) = {
-    sec.getMetadataWriter.addProperties(metadataEntity, properties);
+    sec.addProperties(metadataEntity, properties);
   }
 
   override def addTags(metadataEntity: MetadataEntity, tags: String*) = {
-    sec.getMetadataWriter.addTags(metadataEntity, tags)
+    sec.addTags(metadataEntity, tags)
   }
 
   override def addTags(metadataEntity: MetadataEntity, tags: lang.Iterable[String]): Unit = {
-    sec.getMetadataWriter.addTags(metadataEntity, tags)
+    sec.addTags(metadataEntity, tags)
   }
 
   override def removeMetadata(metadataEntity: MetadataEntity): Unit = {
-    sec.getMetadataWriter.removeMetadata(metadataEntity)
+    sec.removeMetadata(metadataEntity)
   }
 
   override def removeProperties(metadataEntity: MetadataEntity): Unit = {
-    sec.getMetadataWriter.removeProperties(metadataEntity)
+    sec.removeProperties(metadataEntity)
   }
 
   override def removeProperties(metadataEntity: MetadataEntity, keys: String*): Unit = {
-    sec.getMetadataWriter.removeProperties(metadataEntity, keys:_*)
+    sec.removeProperties(metadataEntity, keys:_*)
   }
 
   override def removeTags(metadataEntity: MetadataEntity): Unit = {
-    sec.getMetadataWriter.removeTags(metadataEntity)
+    sec.removeTags(metadataEntity)
   }
 
   override def removeTags(metadataEntity: MetadataEntity, tags: String*): Unit = {
-    sec.getMetadataWriter.removeTags(metadataEntity, tags:_*)
+    sec.removeTags(metadataEntity, tags:_*)
   }
 }
 

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -16,20 +16,20 @@
 
 package co.cask.cdap.app.runtime.spark
 
+import java.io.{Externalizable, ObjectInput, ObjectOutput}
+import java.{lang, util}
+
 import co.cask.cdap.api.TxRunnable
 import co.cask.cdap.api.data.batch.Split
 import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
+import co.cask.cdap.api.metadata.{Metadata, MetadataEntity, MetadataScope}
 import co.cask.cdap.api.preview.DataTracer
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo
 import co.cask.cdap.api.spark.SparkExecutionContext
 import co.cask.cdap.api.spark.dynamic.SparkInterpreter
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-
-import java.io.Externalizable
-import java.io.ObjectInput
-import java.io.ObjectOutput
 
 import scala.reflect.ClassTag
 
@@ -110,10 +110,6 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
 
   override def getMessagingContext = delegate.getMessagingContext
 
-  override def getMetadataReader = delegate.getMetadataReader
-
-  override def getMetadataWriter = delegate.getMetadataWriter
-
   override def getPluginContext = delegate.getPluginContext
 
   override def getMetrics = delegate.getMetrics
@@ -130,6 +126,46 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
 
   override def writeExternal(out: ObjectOutput) = {
     // no-op
+  }
+
+  override def getMetadata(metadataEntity: MetadataEntity): util.Map[MetadataScope, Metadata] = {
+    return delegate.getMetadata(metadataEntity);
+  }
+
+  override def getMetadata(scope: MetadataScope, metadataEntity: MetadataEntity): Metadata = {
+    return delegate.getMetadata(scope, metadataEntity);
+  }
+
+  override def addProperties(metadataEntity: MetadataEntity, properties: util.Map[String, String]) = {
+    delegate.addProperties(metadataEntity, properties);
+  }
+
+  override def addTags(metadataEntity: MetadataEntity, tags: String*) = {
+    delegate.addTags(metadataEntity, tags:_*)
+  }
+
+  override def addTags(metadataEntity: MetadataEntity, tags: lang.Iterable[String]): Unit = {
+    delegate.addTags(metadataEntity, tags)
+  }
+
+  override def removeMetadata(metadataEntity: MetadataEntity): Unit = {
+    delegate.removeMetadata(metadataEntity)
+  }
+
+  override def removeProperties(metadataEntity: MetadataEntity): Unit = {
+    delegate.removeProperties(metadataEntity)
+  }
+
+  override def removeProperties(metadataEntity: MetadataEntity, keys: String*): Unit = {
+    delegate.removeProperties(metadataEntity, keys:_*)
+  }
+
+  override def removeTags(metadataEntity: MetadataEntity): Unit = {
+    delegate.removeTags(metadataEntity)
+  }
+
+  override def removeTags(metadataEntity: MetadataEntity, tags: String*): Unit = {
+    delegate.removeTags(metadataEntity, tags:_*)
   }
 
   override def getDataTracer(loggerName: String): DataTracer = delegate.getDataTracer(loggerName)

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -36,6 +36,7 @@ import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.preview.PreviewHttpModule;
 import co.cask.cdap.app.preview.PreviewManager;
+import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
@@ -85,8 +86,8 @@ import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.messaging.context.BasicMessagingAdmin;
 import co.cask.cdap.messaging.context.MultiThreadMessagingContext;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
+import co.cask.cdap.metadata.MetadataAdmin;
 import co.cask.cdap.metadata.MetadataReaderWriterModules;
-import co.cask.cdap.metadata.MetadataService;
 import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metadata.MetadataSubscriberService;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
@@ -214,6 +215,7 @@ public class TestBase {
   private static PreviewManager previewManager;
   private static ProvisioningService provisioningService;
   private static MetadataSubscriberService metadataSubscriberService;
+  private static MetadataAdmin metadataAdmin;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -305,6 +307,7 @@ public class TestBase {
     );
 
     metadataSubscriberService = injector.getInstance(MetadataSubscriberService.class);
+    metadataAdmin = injector.getInstance(MetadataAdmin.class);
 
     messagingService = injector.getInstance(MessagingService.class);
     if (messagingService instanceof Service) {
@@ -954,6 +957,13 @@ public class TestBase {
 
   protected static MessagingAdmin getMessagingAdmin(NamespaceId namespace) {
     return new BasicMessagingAdmin(messagingService, namespace);
+  }
+
+  /**
+   * @return {@link MetadataAdmin} to interact with metadata
+   */
+  protected static MetadataAdmin getMetadataAdmin() {
+    return metadataAdmin;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Exposes Metadata API to plugins
- Metadata propagation / processing is the responsibility of the plugin developer
- Added a unit test where metadata operation JSON is passed as plugin config to a mock plugin for testing

## Tasks
- [x] Build: https://builds.cask.co/browse/CDAP-DUT6529-1
- [ ] Testing on multi-node cluster
- [ ] Test on multi-node cluster with spark engine 