### PR TITLE
CDAP-13514 add profile deletion restrictions

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -495,7 +495,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @param namespaceId the {@link NamespaceId} under which all application should be deleted
    * @throws Exception
    */
-  public void removeAll(final NamespaceId namespaceId) throws Exception {
+  public void removeAll(NamespaceId namespaceId) throws Exception {
     Map<ProgramRunId, RunRecordMeta> runningPrograms = store.getActiveRuns(namespaceId);
     List<ApplicationSpecification> allSpecs = new ArrayList<>(store.getAllApplications(namespaceId));
     Map<ApplicationId, ApplicationSpecification> apps = new HashMap<>();
@@ -530,7 +530,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @param appId the {@link ApplicationId} of the application to be removed
    * @throws Exception
    */
-  public void removeApplication(final ApplicationId appId) throws Exception {
+  public void removeApplication(ApplicationId appId) throws Exception {
     // enforce ADMIN privileges on the app
     authorizationEnforcer.enforce(appId, authenticationContext.getPrincipal(), Action.ADMIN);
     ensureNoRunningPrograms(appId);
@@ -563,7 +563,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @param appId the id of the application to find running programs for
    * @throws CannotBeDeletedException : the application cannot be deleted because of running programs
    */
-  private void ensureNoRunningPrograms(final ApplicationId appId) throws CannotBeDeletedException {
+  private void ensureNoRunningPrograms(ApplicationId appId) throws CannotBeDeletedException {
     //Check if all are stopped.
     Map<ProgramRunId, RunRecordMeta> runningPrograms = store.getActiveRuns(appId);
 
@@ -702,7 +702,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @param spec the spec of the application to delete
    * @throws Exception
    */
-  private void deleteApp(final ApplicationId appId, ApplicationSpecification spec) throws Exception {
+  private void deleteApp(ApplicationId appId, ApplicationSpecification spec) throws Exception {
     //Delete the schedules
     scheduler.deleteSchedules(appId);
     for (WorkflowSpecification workflowSpec : spec.getWorkflows().values()) {
@@ -749,7 +749,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @param appId the id of the application to delete
    * @param spec the spec of the application to delete
    */
-  private void deleteAppVersion(final ApplicationId appId, ApplicationSpecification spec) {
+  private void deleteAppVersion(ApplicationId appId, ApplicationSpecification spec) {
     //Delete the schedules
     scheduler.deleteSchedules(appId);
     for (WorkflowSpecification workflowSpec : spec.getWorkflows().values()) {
@@ -809,7 +809,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   /**
    * Filter the {@link ApplicationDetail} by only returning the visible entities
    */
-  private ApplicationDetail filterApplicationDetail(final ApplicationId appId,
+  private ApplicationDetail filterApplicationDetail(ApplicationId appId,
                                                     ApplicationDetail applicationDetail) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     List<ProgramRecord> filteredPrograms =

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -896,6 +896,14 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return getRuns(programRunIds, Integer.MAX_VALUE);
   }
 
+  /**
+   * Get active runs in the given set of namespaces that satisfies a filter, active runs means program run with status
+   * STARTING, PENDING, RUNNING or SUSPENDED.
+   *
+   * @param namespaces set of namespaces
+   * @param filter filter to filter run record
+   * @return map of run id to run record meta
+   */
   public Map<ProgramRunId, RunRecordMeta> getActiveRuns(Set<NamespaceId> namespaces, Predicate<RunRecordMeta> filter) {
     return namespaces.stream().flatMap(namespaceId -> {
       MDSKey key = getNamespaceKeyBuilder(TYPE_RUN_RECORD_STARTING, namespaceId).build();
@@ -910,6 +918,31 @@ public class AppMetadataStore extends MetadataStoreDataset {
     }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
+  /**
+   * Get active runs in all namespaces with a filter, active runs means program run with status STARTING, PENDING,
+   * RUNNING or SUSPENDED.
+   *
+   * @param filter filter to filter run record
+   * @return map of run id to run record meta
+   */
+  public Map<ProgramRunId, RunRecordMeta> getActiveRuns(Predicate<RunRecordMeta> filter) {
+    MDSKey key = getNamespaceKeyBuilder(TYPE_RUN_RECORD_STARTING, null).build();
+    Map<ProgramRunId, RunRecordMeta> activeRuns = getProgramRunIdMap(listKV(key, null, RunRecordMeta.class,
+                                                                            Integer.MAX_VALUE, filter));
+    key = getNamespaceKeyBuilder(TYPE_RUN_RECORD_STARTED, null).build();
+    activeRuns.putAll(getProgramRunIdMap(listKV(key, null, RunRecordMeta.class, Integer.MAX_VALUE, filter)));
+    key = getNamespaceKeyBuilder(TYPE_RUN_RECORD_SUSPENDED, null).build();
+    activeRuns.putAll(getProgramRunIdMap(listKV(key, null, RunRecordMeta.class, Integer.MAX_VALUE, filter)));
+    return activeRuns;
+  }
+
+  /**
+   * Get active runs in the given namespace, active runs means program run with status STARTING, PENDING,
+   * RUNNING or SUSPENDED.
+   *
+   * @param namespaceId given namespace
+   * @return map of run id to run record meta
+   */
   public Map<ProgramRunId, RunRecordMeta> getActiveRuns(NamespaceId namespaceId) {
     // TODO CDAP-12361 should consolidate these methods and get rid of duplicate / unnecessary methods.
     Predicate<RunRecordMeta> timePredicate = getTimeRangePredicate(0, Long.MAX_VALUE);
@@ -924,6 +957,13 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return activeRuns;
   }
 
+  /**
+   * Get active runs in the given application, active runs means program run with status STARTING, PENDING,
+   * RUNNING or SUSPENDED.
+   *
+   * @param applicationId given app
+   * @return map of run id to run record meta
+   */
   public Map<ProgramRunId, RunRecordMeta> getActiveRuns(ApplicationId applicationId) {
     Predicate<RunRecordMeta> timePredicate = getTimeRangePredicate(0, Long.MAX_VALUE);
     MDSKey key = getApplicationKeyBuilder(TYPE_RUN_RECORD_STARTING, applicationId).build();
@@ -937,6 +977,13 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return activeRuns;
   }
 
+  /**
+   * Get active runs in the given program, active runs means program run with status STARTING, PENDING,
+   * RUNNING or SUSPENDED.
+   *
+   * @param programId given program
+   * @return map of run id to run record meta
+   */
   public Map<ProgramRunId, RunRecordMeta> getActiveRuns(ProgramId programId) {
     Predicate<RunRecordMeta> timePredicate = getTimeRangePredicate(0, Long.MAX_VALUE);
     MDSKey key = getProgramKeyBuilder(TYPE_RUN_RECORD_STARTING, programId).build();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
@@ -46,7 +46,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 /**
- * Handy dataset to be used for managing metadata
+ * Handy dataset to be used for managing metadata.
  */
 public class MetadataStoreDataset extends AbstractDataset {
   /**
@@ -85,6 +85,12 @@ public class MetadataStoreDataset extends AbstractDataset {
     return gson.fromJson(Bytes.toString(serialized), typeOfT);
   }
 
+  /**
+   * Check whether the value is there in the row and default COLUMN
+   *
+   * @param id the mds key for the row
+   * @return a boolean which indicates the value exists or not
+   */
   public boolean exists(MDSKey id) {
     Row row = table.get(id.getKey());
     if (row.isEmpty()) {
@@ -95,6 +101,13 @@ public class MetadataStoreDataset extends AbstractDataset {
     return value != null;
   }
 
+  /**
+   * Get the value at the row and default COLUMN, of type T
+   *
+   * @param id the mds key for the row
+   * @param typeOfT the type of the result
+   * @return the deserialized value of the result, null if not exist
+   */
   @Nullable
   public <T> T get(MDSKey id, Type typeOfT) {
     Row row = table.get(id.getKey());
@@ -110,7 +123,13 @@ public class MetadataStoreDataset extends AbstractDataset {
     return deserialize(id, value, typeOfT);
   }
 
-  // returns first that matches
+  /**
+   * Get the first element in the row and default COLUMN, of type T
+   *
+   * @param id the mds key for the row
+   * @param typeOfT the type of the result
+   * @return the deserialized value of the result, null if not exist
+   */
   @Nullable
   public <T> T getFirst(MDSKey id, Type typeOfT) {
     try {
@@ -132,7 +151,13 @@ public class MetadataStoreDataset extends AbstractDataset {
     }
   }
 
-  // Get all non-null values with the given ids
+  /**
+   * Get all non-null values with the given ids for default COLUMN
+   *
+   * @param ids set of the mds keys
+   * @param typeOfT the type of the result
+   * @return a list of the deserialized value of the result
+   */
   public <T> List<T> get(Set<MDSKey> ids, Type typeOfT) {
     List<T> resultList = new ArrayList<>();
     List<Get> getList = new ArrayList<>();
@@ -156,38 +181,93 @@ public class MetadataStoreDataset extends AbstractDataset {
     return resultList;
   }
 
-  // lists all that has same first id parts
+  /**
+   * Lists all that has same first id parts for default COLUMN
+   *
+   * @param id prefix row key
+   * @param typeOfT the type of the result
+   * @return a list of the deserialized value of the result
+   */
   public <T> List<T> list(MDSKey id, Type typeOfT) {
     return list(id, typeOfT, Integer.MAX_VALUE);
   }
 
-  // lists all that has same first id parts, with a limit
+  /**
+   * Lists all that has same first id parts for default COLUMN, with a limit
+   *
+   * @param id prefix row key
+   * @param typeOfT the type of the result
+   * @param limit limit number of result
+   * @return a list of the deserialized value of the result
+   */
   public <T> List<T> list(MDSKey id, Type typeOfT, int limit) {
     return list(id, null, typeOfT, limit, x -> true);
   }
 
-  // lists all that has first id parts in range of startId and stopId
+  /**
+   * Lists all that has first id parts in range of startId and stopId for default COLUMN
+   *
+   * @param startId start row key
+   * @param stopId stop row key
+   * @param typeOfT the type of the result
+   * @param limit limit number of result
+   * @param filter filter for the result
+   * @return a list of the deserialized value of the result
+   */
   public <T> List<T> list(MDSKey startId, @Nullable MDSKey stopId, Type typeOfT, int limit,
                           Predicate<T> filter) {
     return Lists.newArrayList(listKV(startId, stopId, typeOfT, limit, filter).values());
   }
 
-  // returns mapping of all that has same first id parts
+  /**
+   * Returns mapping of all that has same first id parts for default COLUMN
+   *
+   * @param id prefix row key
+   * @param typeOfT the type of the result
+   * @return map of row key to result
+   */
   public <T> Map<MDSKey, T> listKV(MDSKey id, Type typeOfT) {
     return listKV(id, typeOfT, Integer.MAX_VALUE);
   }
 
-  // returns mapping of  all that has same first id parts, with a limit
+  /**
+   * Returns mapping of all that has same first id parts for default COLUMN, with a limit
+   *
+   * @param id prefix row key
+   * @param typeOfT the type of the result
+   * @param limit limit of the result
+   * @return map of row key to result
+   */
   public <T> Map<MDSKey, T> listKV(MDSKey id, Type typeOfT, int limit) {
     return listKV(id, null, typeOfT, limit, x -> true);
   }
 
-  // returns mapping of all that has first id parts in range of startId and stopId
+  /**
+   * returns mapping of all that has first id parts in range of startId and stopId for default COLUMN
+   *
+   * @param startId start row key
+   * @param stopId stop row key
+   * @param typeOfT the type of the result
+   * @param limit limit number of result
+   * @param filter filter for the result
+   * @return map of row key to result
+   */
   public <T> Map<MDSKey, T> listKV(MDSKey startId, @Nullable MDSKey stopId, Type typeOfT, int limit,
                                    Predicate<T> filter) {
     return listKV(startId, stopId, typeOfT, limit, null, filter);
   }
 
+  /**
+   * returns mapping of all that has first id parts in range of startId and stopId for default COLUMN
+   *
+   * @param startId start row key
+   * @param stopId stop row key
+   * @param typeOfT the type of the result
+   * @param limit limit number of result
+   * @param keyFilter filter of the key
+   * @param valueFilter filter for the result
+   * @return map of row key to result
+   */
   public <T> Map<MDSKey, T> listKV(MDSKey startId, @Nullable MDSKey stopId, Type typeOfT, int limit,
                                    Predicate<MDSKey> keyFilter, Predicate<T> valueFilter) {
     byte[] startKey = startId.getKey();
@@ -195,6 +275,146 @@ public class MetadataStoreDataset extends AbstractDataset {
 
     Scan scan = new Scan(startKey, stopKey);
     return listKV(scan, typeOfT, limit, keyFilter, valueFilter);
+  }
+
+  /**
+   * Returns mapping of all that match the given keySet provided they pass the combinedFilter predicate
+   * for default COLUMN
+   *
+   * @param keySet row key set
+   * @param typeOfT the type of the result
+   * @param limit limit number of result
+   * @param combinedFilter filter for key
+   * @return map of row key to result
+   */
+  public <T> Map<MDSKey, T> listKV(Set<MDSKey> keySet, Type typeOfT, int limit,
+                                   @Nullable Predicate<KeyValue<T>> combinedFilter) {
+    // Sort fuzzy keys
+    List<MDSKey> sortedKeys = Lists.newArrayList(keySet);
+    Collections.sort(sortedKeys);
+
+    // Scan using fuzzy filter
+    byte[] startKey = sortedKeys.get(0).getKey();
+    byte[] stopKey = Bytes.stopKeyForPrefix(sortedKeys.get(sortedKeys.size() - 1).getKey());
+
+    List<ImmutablePair<byte [], byte []>> fuzzyKeys = new ArrayList<>();
+    for (MDSKey key : sortedKeys) {
+      fuzzyKeys.add(getFuzzyKeyFor(key));
+    }
+
+    Scan scan = new Scan(startKey, stopKey, new FuzzyRowFilter(fuzzyKeys));
+    return listCombinedFilterKV(scan, typeOfT, limit, combinedFilter);
+  }
+
+  /**
+   * Returns mapping of all that match the given keySet for default COLUMN
+   *
+   * @param keySet row key set
+   * @param typeOfT the type of the result
+   * @param limit limit of the result
+   * @return map of row key to result
+   */
+  public <T> Map<MDSKey, T> listKV(Set<MDSKey> keySet, Type typeOfT, int limit) {
+    return listKV(keySet, typeOfT, limit, x -> true);
+  }
+
+  /**
+   * Run a scan on MDS for default COLUMN
+   *
+   * @param startId  scan start key
+   * @param stopId   scan stop key
+   * @param typeOfT  type of value
+   * @param function function to process each element returned from scan.
+   *                 If function.apply returns false then the scan is stopped.
+   *                 Also, function.apply should not return null.
+   * @param <T>      type of value
+   */
+  public <T> void scan(MDSKey startId, @Nullable MDSKey stopId, Type typeOfT, Function<KeyValue<T>, Boolean> function) {
+    byte[] startKey = startId.getKey();
+    byte[] stopKey = stopId == null ? Bytes.stopKeyForPrefix(startKey) : stopId.getKey();
+
+    try (Scanner scan = table.scan(startKey, stopKey)) {
+      Row next;
+      while ((next = scan.next()) != null) {
+        byte[] columnValue = next.get(COLUMN);
+        if (columnValue == null) {
+          continue;
+        }
+        MDSKey key = new MDSKey(next.getRow());
+        T value = deserialize(key, columnValue, typeOfT);
+
+        //noinspection ConstantConditions
+        if (!function.apply(new KeyValue<>(key, value))) {
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * Delete all values in the given prefix row key
+   *
+   * @param id prefix row key
+   */
+  public void deleteAll(MDSKey id) {
+    deleteAll(id, x -> true);
+  }
+
+  /**
+   * Delete all values in the given prefix row key which satisfies the predicate
+   *
+   * @param id prefix row key
+   */
+  public void deleteAll(MDSKey id, @Nullable Predicate<MDSKey> filter) {
+    byte[] prefix = id.getKey();
+    byte[] stopKey = Bytes.stopKeyForPrefix(prefix);
+
+    try {
+      try (Scanner scan = table.scan(prefix, stopKey)) {
+        Row next;
+        while ((next = scan.next()) != null) {
+          String columnValue = next.getString(COLUMN);
+          if (columnValue == null) {
+            continue;
+          }
+
+          MDSKey key = new MDSKey(next.getRow());
+          if (filter != null && !filter.test(key)) {
+            continue;
+          }
+          table.delete(new Delete(next.getRow()).add(COLUMN));
+        }
+      }
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Delete all values in the given row key
+   *
+   * @param id row key to delete
+   */
+  public void delete(MDSKey id) {
+    try {
+      table.delete(id.getKey(), COLUMN);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Put the value with the given row key and default COLUMN
+   *
+   * @param id row key
+   * @param value the value to put
+   */
+  public <T> void write(MDSKey id, T value) {
+    try {
+      table.put(new Put(id.getKey()).add(COLUMN, serialize(value)));
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   private <T> Map<MDSKey, T> listCombinedFilterKV(Scan runScan, Type typeOfT, int limit,
@@ -274,64 +494,6 @@ public class MetadataStoreDataset extends AbstractDataset {
     return new ImmutablePair<>(Bytes.concat(keyBytes, new byte[1]), infoBytes);
   }
 
-  // returns mapping of all that match the given keySet provided they pass the combinedFilter predicate
-  public <T> Map<MDSKey, T> listKV(Set<MDSKey> keySet, Type typeOfT, int limit,
-                                   @Nullable Predicate<KeyValue<T>> combinedFilter) {
-    // Sort fuzzy keys
-    List<MDSKey> sortedKeys = Lists.newArrayList(keySet);
-    Collections.sort(sortedKeys);
-
-    // Scan using fuzzy filter
-    byte[] startKey = sortedKeys.get(0).getKey();
-    byte[] stopKey = Bytes.stopKeyForPrefix(sortedKeys.get(sortedKeys.size() - 1).getKey());
-
-    List<ImmutablePair<byte [], byte []>> fuzzyKeys = new ArrayList<>();
-    for (MDSKey key : sortedKeys) {
-      fuzzyKeys.add(getFuzzyKeyFor(key));
-    }
-
-    Scan scan = new Scan(startKey, stopKey, new FuzzyRowFilter(fuzzyKeys));
-    return listCombinedFilterKV(scan, typeOfT, limit, combinedFilter);
-  }
-
-  // returns mapping of all that match the given keySet
-  public <T> Map<MDSKey, T> listKV(Set<MDSKey> keySet, Type typeOfT, int limit) {
-    return listKV(keySet, typeOfT, limit, x -> true);
-  }
-
-  /**
-   * Run a scan on MDS.
-   *
-   * @param startId  scan start key
-   * @param stopId   scan stop key
-   * @param typeOfT  type of value
-   * @param function function to process each element returned from scan.
-   *                 If function.apply returns false then the scan is stopped.
-   *                 Also, function.apply should not return null.
-   * @param <T>      type of value
-   */
-  public <T> void scan(MDSKey startId, @Nullable MDSKey stopId, Type typeOfT, Function<KeyValue<T>, Boolean> function) {
-    byte[] startKey = startId.getKey();
-    byte[] stopKey = stopId == null ? Bytes.stopKeyForPrefix(startKey) : stopId.getKey();
-
-    try (Scanner scan = table.scan(startKey, stopKey)) {
-      Row next;
-      while ((next = scan.next()) != null) {
-        byte[] columnValue = next.get(COLUMN);
-        if (columnValue == null) {
-          continue;
-        }
-        MDSKey key = new MDSKey(next.getRow());
-        T value = deserialize(key, columnValue, typeOfT);
-
-        //noinspection ConstantConditions
-        if (!function.apply(new KeyValue<>(key, value))) {
-          break;
-        }
-      }
-    }
-  }
-
   /**
    * Output value of a scan.
    *
@@ -352,51 +514,6 @@ public class MetadataStoreDataset extends AbstractDataset {
 
     public T getValue() {
       return value;
-    }
-  }
-
-  public void deleteAll(MDSKey id) {
-    deleteAll(id, x -> true);
-  }
-
-  public void deleteAll(MDSKey id, @Nullable Predicate<MDSKey> filter) {
-    byte[] prefix = id.getKey();
-    byte[] stopKey = Bytes.stopKeyForPrefix(prefix);
-
-    try {
-      try (Scanner scan = table.scan(prefix, stopKey)) {
-        Row next;
-        while ((next = scan.next()) != null) {
-          String columnValue = next.getString(COLUMN);
-          if (columnValue == null) {
-            continue;
-          }
-
-          MDSKey key = new MDSKey(next.getRow());
-          if (filter != null && !filter.test(key)) {
-            continue;
-          }
-          table.delete(new Delete(next.getRow()).add(COLUMN));
-        }
-      }
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  public void delete(MDSKey id) {
-    try {
-      table.delete(id.getKey(), COLUMN);
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  public <T> void write(MDSKey id, T value) {
-    try {
-      table.put(new Put(id.getKey()).add(COLUMN, serialize(value)));
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
     }
   }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13514
Build: https://builds.cask.co/browse/CDAP-DUT6532
Adding restrictions to profile deletion, now a profile can only be deleted when: 
1. It is DISABLED,
2. No entity has assignment with it
3. No active program runs using it
Majority changes is to let MetadataStoreDataset be able to read, write based on the passed in column name. Also rearranged some method orders so that public method comes before private methods.
