### PR TITLE
CDAP-13088 - Adding support for rest api while metadata upgrade is in…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataMigrator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataMigrator.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.logging.LogSamplers;
+import co.cask.cdap.common.logging.Loggers;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.MetadataDatasetDefinition;
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import org.apache.tephra.TransactionSystemClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Metadata Migrator to migrate metadata from V1 metadata tables to V2 metadata tables.
+ * Migration happens on business table as well as system table. It only migrates value and history rows.
+ * Indexes will be automatically generated for every write on V2 metadata table.
+ */
+class MetadataMigrator extends AbstractExecutionThreadService {
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataMigrator.class);
+  // For outage, only log once per 60 seconds per message.
+  private static final Logger OUTAGE_LOG = Loggers.sampling(LOG, LogSamplers.perMessage(
+    () -> LogSamplers.limitRate(60000)));
+  private static final List<DatasetId> DATASET_IDS = ImmutableList.of(NamespaceId.SYSTEM.dataset("system.metadata"),
+                                                                      NamespaceId.SYSTEM.dataset("v2.system.metadata"),
+                                                                      NamespaceId.SYSTEM.dataset("business.metadata"),
+                                                                      NamespaceId.SYSTEM.dataset("v2.business.metadata")
+  );
+
+  private final DatasetFramework dsFramework;
+  private final Transactional transactional;
+  private final int batchSize;
+  private volatile Thread runThread;
+  private volatile boolean stopped;
+  private volatile boolean hasV1Instance;
+
+  MetadataMigrator(CConfiguration cConf, DatasetFramework dsFramework, TransactionSystemClient txClient) {
+    this.dsFramework = dsFramework;
+    this.batchSize = cConf.getInt(Constants.Metadata.MIGRATOR_BATCH_SIZE);
+    this.transactional = Transactions.createTransactionalWithRetry(
+      Transactions.createTransactional(new MultiThreadDatasetCache(new SystemDatasetInstantiator(dsFramework),
+                                                                   txClient, NamespaceId.SYSTEM,
+                                                                   Collections.emptyMap(), null, null)),
+      org.apache.tephra.RetryStrategies.retryOnConflict(20, 100)
+    );
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting Metadata Migrator Service.");
+  }
+
+  @Override
+  public void run() {
+    runThread = Thread.currentThread();
+
+    try {
+      for (int i = 0; i < DATASET_IDS.size(); i = i + 2) {
+        // assume we already have v1 metadata table instance
+        hasV1Instance = true;
+
+        while (!stopped && hasV1Instance) {
+          try {
+            final int index = i;
+            // This thread migrates metadata in batches. It does following operations in a single transaction:
+            // 1.) Scan V1 metadata table for value and history rows in batch of batchSize.
+            // 2.) Write scanned MetadataEntries to V2 table.
+            // 3.) Delete successfully written metadata entries from V1 table.
+            Transactionals.execute(transactional, context -> {
+              if (!dsFramework.hasInstance(DATASET_IDS.get(index))) {
+                hasV1Instance = false;
+                return;
+              }
+
+              MetadataDataset v1 = getMetadataDataset(context, DATASET_IDS.get(index));
+              MetadataDataset v2 = getMetadataDataset(context, DATASET_IDS.get(index + 1));
+
+              // All the metadata entries are written using setProperty because it does not modify the MetadataEntry
+              // keys
+              List<KeyValue<Long, MetadataEntry>> entries = v1.scanOrDeleteFromV1Table(batchSize, false);
+
+              if (entries.isEmpty()) {
+                // All the value and history rows have been migrated so stop this thread and drop V1 MetadataDataset
+                dropV1MetadataDataset(index);
+                LOG.debug("Migration for dataset {} is complete. This dataset is dropped.", DATASET_IDS.get(index));
+                return;
+              }
+
+              v2.writeUpgradedRow(entries);
+              // We do not need to keep checkpoints. Instead, we will just delete scanned rows from metadata dataset
+              v1.scanOrDeleteFromV1Table(entries.size(), true);
+            });
+          } catch (Exception e) {
+            OUTAGE_LOG.error("Exception while migrating metadata from {} to {}, will be retried. ", DATASET_IDS.get(i),
+                             DATASET_IDS.get(i + 1), e);
+            Thread.sleep(1000);
+          }
+        }
+      }
+    } catch (InterruptedException e) {
+      // Interruption means stopping the service
+    }
+
+    // Clear the interrupt flag
+    Thread.interrupted();
+  }
+
+  @Override
+  protected String getServiceName() {
+    return "metadata-migrator-service";
+  }
+
+  @Override
+  protected void triggerShutdown() {
+    stopped = true;
+    if (runThread != null) {
+      runThread.interrupt();
+    }
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping Metadata Migrator Service.");
+  }
+
+  private void dropV1MetadataDataset(int index) throws DatasetManagementException, IOException {
+    DatasetAdmin admin = dsFramework.getAdmin(DATASET_IDS.get(index), null);
+    if (admin != null) {
+      admin.drop();
+      hasV1Instance = false;
+    }
+  }
+
+  private MetadataDataset getMetadataDataset(DatasetContext context, DatasetId datasetId)
+    throws IOException, DatasetManagementException {
+    MetadataScope scope = datasetId.getDataset().contains("business") ? MetadataScope.USER : MetadataScope.SYSTEM;
+    return DatasetsUtil.getOrCreateDataset(context, dsFramework, datasetId, MetadataDataset.class.getName(),
+                                           DatasetProperties.builder().add(MetadataDatasetDefinition.SCOPE_KEY,
+                                                                           scope.name()).build());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataService.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.metadata;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.HttpExceptionHandler;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.ResolvingDiscoverable;
@@ -74,6 +75,7 @@ public class MetadataService extends AbstractIdleService {
     LOG.info("Starting Metadata Service");
     httpService = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.METADATA_SERVICE)
       .setHttpHandlers(handlers)
+      .setExceptionHandler(new HttpExceptionHandler())
       .setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                                                                 Constants.Service.METADATA_SERVICE)))
       .setHost(cConf.get(Constants.Metadata.SERVICE_BIND_ADDRESS))

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
@@ -24,6 +24,7 @@ import com.google.inject.PrivateModule;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
+import org.apache.twill.api.TwillContext;
 
 import java.util.Set;
 
@@ -31,9 +32,16 @@ import java.util.Set;
  * Guice module for metadata service.
  */
 public class MetadataServiceModule extends PrivateModule {
+  private final Integer instanceId;
+
+  public MetadataServiceModule(TwillContext twillContext) {
+    this.instanceId = twillContext.getInstanceId();
+  }
 
   @Override
   protected void configure() {
+    bind(Integer.class).annotatedWith(Names.named(Constants.DatasetOpsExecutor.INSTANCE_ID))
+      .toInstance(instanceId);
     Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
       binder(), HttpHandler.class, Names.named(Constants.Metadata.HANDLERS_NAME));
 
@@ -43,5 +51,7 @@ public class MetadataServiceModule extends PrivateModule {
     expose(Key.get(new TypeLiteral<Set<HttpHandler>>() { }, Names.named(Constants.Metadata.HANDLERS_NAME)));
     bind(MetadataAdmin.class).to(DefaultMetadataAdmin.class);
     expose(MetadataAdmin.class);
+    bind(MetadataService.class);
+    expose(MetadataService.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -36,6 +36,10 @@ public class MetadataServiceModule extends PrivateModule {
 
   public MetadataServiceModule(TwillContext twillContext) {
     this.instanceId = twillContext.getInstanceId();
+  }
+
+  public MetadataServiceModule() {
+    this.instanceId = 0;
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.test.MockTwillContext;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -94,7 +95,7 @@ public class DefaultPreviewManagerTest {
       new StreamAdminModules().getInMemoryModules(),
       new StreamServiceRuntimeModule().getInMemoryModules(),
       new NamespaceStoreModule().getStandaloneModules(),
-      new MetadataServiceModule(),
+      new MetadataServiceModule(new MockTwillContext()),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getStandaloneModules(),
       new SecureStoreModules().getInMemoryModules(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.test.MockTwillContext;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -107,7 +108,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new StreamAdminModules().getInMemoryModules());
     install(new StreamServiceRuntimeModule().getInMemoryModules());
     install(new NamespaceStoreModule().getStandaloneModules());
-    install(new MetadataServiceModule());
+    install(new MetadataServiceModule(new MockTwillContext()));
     install(new AuthorizationModule());
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreModules().getInMemoryModules());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataMigratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataMigratorTest.java
@@ -127,7 +127,6 @@ public class MetadataMigratorTest {
         NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)),
       RetryStrategies.retryOnConflict(20, 100)
     );
-
   }
 
   @After
@@ -165,6 +164,10 @@ public class MetadataMigratorTest {
       assertIndex(v2System);
       assertIndex(v2Business);
     });
+
+    if (datasetFramework.hasInstance(v1SystemDatasetId) || datasetFramework.hasInstance(v1BusinessDatasetId)) {
+      throw new Exception("V1 metadata table was not deleted by Metadata Migrator.");
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataMigratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataMigratorTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.metadata.dataset.MdsHistoryKey;
+import co.cask.cdap.data2.metadata.dataset.MdsKey;
+import co.cask.cdap.data2.metadata.dataset.Metadata;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.MetadataDatasetDefinition;
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.MetadataV1;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.internal.guice.AppFabricTestModule;
+import co.cask.cdap.proto.EntityScope;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Service;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.tephra.RetryStrategies;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TransactionSystemClient;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for Metadata Migrator Service.
+ */
+public class MetadataMigratorTest {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
+    .create();
+
+  private final ApplicationId app1 = new ApplicationId("ns1", "app1");
+  private final ProgramId flow1 = new ProgramId("ns1", "app1", ProgramType.FLOW, "flow1");
+  private final DatasetId dataset1 = new DatasetId("ns1", "ds1");
+  private final StreamId stream1 = new StreamId("ns1", "s1");
+  private final StreamViewId view1 = new StreamViewId(stream1.getNamespace(), stream1.getStream(), "v1");
+  private final ArtifactId artifact1 = new ArtifactId("ns1", "a1", "1.0.0");
+
+  private static CConfiguration cConf;
+  private TransactionManager txManager;
+  private TransactionSystemClient transactionSystemClient;
+  private DatasetService datasetService;
+  private DatasetFramework datasetFramework;
+  private Transactional transactional;
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @Before
+  public void init() throws Exception {
+    cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.set(Constants.Metadata.MIGRATOR_BATCH_SIZE, "5");
+
+    Injector injector = Guice.createInjector(new AppFabricTestModule(cConf));
+
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+    transactionSystemClient = injector.getInstance(TransactionSystemClient.class);
+
+    datasetService = injector.getInstance(DatasetService.class);
+    datasetService.startAndWait();
+    datasetFramework = injector.getInstance(DatasetFramework.class);
+
+    this.transactional = Transactions.createTransactionalWithRetry(
+      Transactions.createTransactional(new MultiThreadDatasetCache(
+        new SystemDatasetInstantiator(datasetFramework), transactionSystemClient,
+        NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)),
+      RetryStrategies.retryOnConflict(20, 100)
+    );
+
+  }
+
+  @After
+  public void stop() {
+    datasetService.stopAndWait();
+    txManager.stopAndWait();
+  }
+
+  /**
+   * Tests data migration from V1 MetadataDataset to V2 MetadataDataset.
+   */
+  @Test
+  public void testMetadataMigration() throws Exception {
+    DatasetId v1SystemDatasetId = NamespaceId.SYSTEM.dataset("system.metadata");
+    DatasetId v1BusinessDatasetId = NamespaceId.SYSTEM.dataset("business.metadata");
+    DatasetId v2SystemDatasetId = NamespaceId.SYSTEM.dataset("v2.system.metadata");
+    DatasetId v2BusinessDatasetId = NamespaceId.SYSTEM.dataset("v2.business.metadata");
+
+    generateMetadata(v1SystemDatasetId);
+    generateMetadata(v1BusinessDatasetId);
+
+    MetadataMigrator migrator = new MetadataMigrator(cConf, datasetFramework, transactionSystemClient);
+    migrator.start();
+
+    // Wait for migrator to finish before reading v2 tables
+    Tasks.waitFor(true, () -> migrator.state().equals(Service.State.TERMINATED), 5, TimeUnit.MINUTES);
+
+    Transactionals.execute(transactional, context -> {
+      MetadataDataset v2System = getMetadataDataset(context, v2SystemDatasetId);
+      MetadataDataset v2Business = getMetadataDataset(context, v2BusinessDatasetId);
+
+      assertProperties(v2System, v2Business);
+      assertHistory(v2System, v2Business);
+      assertIndex(v2System);
+      assertIndex(v2Business);
+    });
+  }
+
+  /**
+   * Tests batch scanning and deletes on V1 MetadataDataset.
+   */
+  @Test
+  public void testScanOrDelete() throws Exception {
+    DatasetId v1SystemDatasetId = NamespaceId.SYSTEM.dataset("system.metadata");
+    DatasetId v1BusinessDatasetId = NamespaceId.SYSTEM.dataset("business.metadata");
+
+    generateMetadata(v1SystemDatasetId);
+    generateMetadata(v1BusinessDatasetId);
+
+    Transactionals.execute(transactional, context -> {
+      MetadataDataset v1System = getMetadataDataset(context, v1SystemDatasetId);
+      int total = 0;
+      int scanCount;
+      int deleteCount;
+      do {
+        scanCount = v1System.scanOrDeleteFromV1Table(2, false).size();
+        deleteCount = v1System.scanOrDeleteFromV1Table(2, true).size();
+        Assert.assertEquals(scanCount, deleteCount);
+        total = total + scanCount;
+      } while (scanCount != 0);
+
+      Assert.assertEquals(13, total);
+    });
+  }
+
+  private void assertProperties(MetadataDataset v2System, MetadataDataset v2Business) {
+    Assert.assertEquals("avalue11", v2System.getProperties(app1.toMetadataEntity()).get("akey1"));
+    Assert.assertEquals("avalue2", v2System.getProperties(flow1.toMetadataEntity()).get("akey2"));
+    Assert.assertEquals("avalue3", v2System.getProperties(dataset1.toMetadataEntity()).get("akey3"));
+    Assert.assertEquals("avalue4", v2System.getProperties(stream1.toMetadataEntity()).get("akey4"));
+    Assert.assertEquals("avalue5", v2System.getProperties(view1.toMetadataEntity()).get("akey5"));
+    Assert.assertEquals("avalue6", v2System.getProperties(artifact1.toMetadataEntity()).get("akey6"));
+
+    Assert.assertEquals("avalue11", v2Business.getProperties(app1.toMetadataEntity()).get("akey1"));
+    Assert.assertEquals("avalue2", v2Business.getProperties(flow1.toMetadataEntity()).get("akey2"));
+    Assert.assertEquals("avalue3", v2Business.getProperties(dataset1.toMetadataEntity()).get("akey3"));
+    Assert.assertEquals("avalue4", v2Business.getProperties(stream1.toMetadataEntity()).get("akey4"));
+    Assert.assertEquals("avalue5", v2Business.getProperties(view1.toMetadataEntity()).get("akey5"));
+    Assert.assertEquals("avalue6", v2Business.getProperties(artifact1.toMetadataEntity()).get("akey6"));
+  }
+
+  private void assertHistory(MetadataDataset v2System, MetadataDataset v2Business) {
+    verifyhistory(v2System, app1.toMetadataEntity());
+    verifyhistory(v2System, flow1.toMetadataEntity());
+    verifyhistory(v2System, dataset1.toMetadataEntity());
+    verifyhistory(v2System, stream1.toMetadataEntity());
+    verifyhistory(v2System, view1.toMetadataEntity());
+    verifyhistory(v2System, artifact1.toMetadataEntity());
+
+    verifyhistory(v2Business, app1.toMetadataEntity());
+    verifyhistory(v2Business, flow1.toMetadataEntity());
+    verifyhistory(v2Business, dataset1.toMetadataEntity());
+    verifyhistory(v2Business, stream1.toMetadataEntity());
+    verifyhistory(v2Business, view1.toMetadataEntity());
+    verifyhistory(v2Business, artifact1.toMetadataEntity());
+  }
+
+  private void assertIndex(MetadataDataset v2System) throws Exception {
+    List<MetadataEntry> entries = v2System.search(app1.getNamespace(), "avalue1",
+                                                  ImmutableSet.of(EntityTypeSimpleName.ALL),
+                                                  SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null,
+                                                  false, EnumSet.of(EntityScope.USER)).getResults();
+
+    for (MetadataEntry entry : entries) {
+      Assert.assertEquals("avalue1", entry.getValue());
+    }
+  }
+
+  private void verifyhistory(MetadataDataset v2System, MetadataEntity entity) {
+    for (Metadata metadata : v2System.getSnapshotBeforeTime(ImmutableSet.of(entity), System.currentTimeMillis())) {
+      Assert.assertEquals(1, metadata.getProperties().size());
+    }
+  }
+
+  private void generateMetadata(DatasetId datasetId) throws Exception {
+    // Set some properties
+    write(datasetId, app1, "akey1", "avalue1");
+    write(datasetId, flow1, "akey2", "avalue2");
+    write(datasetId, dataset1, "akey3", "avalue3");
+    write(datasetId, stream1, "akey4", "avalue4");
+    write(datasetId, view1, "akey5", "avalue5");
+    write(datasetId, artifact1, "akey6", "avalue6");
+    write(datasetId, app1, "akey1", "avalue11");
+  }
+
+  private void write(DatasetId datasetId, NamespacedEntityId targetId, String key, String value) throws Exception {
+    Put valuePut = createValuePut(targetId, key, value);
+    Put historyPut = createHistoryPut(targetId);
+
+    Transactionals.execute(transactional, context -> {
+      // Create metadata dataset to access underlying indexed table
+      getMetadataDataset(context, datasetId);
+
+      getIndexedTable(context, datasetId).put(valuePut);
+      getIndexedTable(context, datasetId).put(historyPut);
+    }, Exception.class);
+  }
+
+  private Put createValuePut(NamespacedEntityId targetId, String key, String value) {
+    MDSKey mdsValueKey = MdsKey.getMDSValueKey(targetId, key);
+    Put put = new Put(mdsValueKey.getKey());
+
+    // add the metadata value
+    byte[] valueRowPrefix = {'v'};
+    put.add(valueRowPrefix, Bytes.toBytes(value));
+    return put;
+  }
+
+  private Put createHistoryPut(NamespacedEntityId targetId) {
+    MetadataV1 metadataV1 = getMetadataV1(targetId);
+    byte[] row = MdsHistoryKey.getMdsKey(targetId, System.currentTimeMillis()).getKey();
+    Put put = new Put(row);
+    put.add(Bytes.toBytes("h"), Bytes.toBytes(GSON.toJson(metadataV1)));
+    return put;
+  }
+
+  private MetadataV1 getMetadataV1(NamespacedEntityId targetId) {
+    Map<String, String> properties = ImmutableMap.of("pk1", "pv1", "pk2", "pv2");
+    Set<String> tags = ImmutableSet.of("tag1, tag2");
+    return new MetadataV1(targetId, properties, tags);
+  }
+
+  /**
+   * Gets underlying Indexed Table.
+   */
+  private IndexedTable getIndexedTable(DatasetContext context, DatasetId datasetId) throws Exception {
+    String prefix = datasetId.getDataset().contains("business") ? "business" : "system";
+    return DatasetsUtil.getOrCreateDataset(context, datasetFramework,
+                                           NamespaceId.SYSTEM.dataset(prefix + ".metadata.metadata_index"),
+                                           IndexedTable.class.getName(),
+                                           DatasetProperties.builder()
+                                             .add(IndexedTable.INDEX_COLUMNS_CONF_KEY, "i,n,in,c,ic").build());
+  }
+
+  /**
+   * Gets metadata table.
+   */
+  private MetadataDataset getMetadataDataset(DatasetContext context, DatasetId datasetId) throws Exception {
+    MetadataScope scope = datasetId.getDataset().contains("business") ? MetadataScope.USER : MetadataScope.SYSTEM;
+
+    return DatasetsUtil.getOrCreateDataset(context, datasetFramework, datasetId, MetadataDataset.class.getName(),
+                                           DatasetProperties.builder()
+                                             .add(MetadataDatasetDefinition.SCOPE_KEY, scope.name()).build());
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1272,7 +1272,7 @@ public final class Constants {
   }
 
   /**
-   * Constants for metadata service
+   * Constants for metadata service and metadata migrator
    */
   public static final class Metadata {
     public static final String SERVICE_DESCRIPTION = "Service to perform metadata operations.";
@@ -1286,6 +1286,8 @@ public final class Constants {
     public static final String MESSAGING_TOPIC = "metadata.messaging.topic";
     public static final String MESSAGING_FETCH_SIZE = "metadata.messaging.fetch.size";
     public static final String MESSAGING_POLL_DELAY_MILLIS = "metadata.messaging.poll.delay.millis";
+
+    public static final String MIGRATOR_BATCH_SIZE = "metadata.upgrade.migration.batch.size";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -490,6 +490,13 @@ public final class Constants {
   }
 
   /**
+   * Dataset Ops executor constants.
+   */
+  public static final class DatasetOpsExecutor {
+    public static final String INSTANCE_ID = "ops.executor.instance.id";
+  }
+
+  /**
    * Stream configurations and constants.
    */
   public static final class Stream {

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2040,6 +2040,14 @@
     </description>
   </property>
 
+  <property>
+    <name>metadata.upgrade.migration.batch.size</name>
+    <value>1000</value>
+    <description>
+      Number of metadata value or history rows to be migrated to v2 metadata table in a batch
+    </description>
+  </property>
+
   <!-- Metrics Configuration -->
 
   <property>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Key class to get v1 metadata history key information
+ */
+public final class MdsHistoryKey {
+  private static final byte[] ROW_PREFIX = {'h'};
+
+  public static MDSKey getMdsKey(NamespacedEntityId targetId, long time) {
+    MDSKey.Builder builder = new MDSKey.Builder();
+    builder.add(ROW_PREFIX);
+    EntityIdKeyHelper.addTargetIdToKey(builder, targetId);
+    builder.add(invertTime(time));
+    return builder.build();
+  }
+
+  static byte[] getHistoryRowPrefix() {
+    MDSKey key = new MDSKey.Builder().add(ROW_PREFIX).build();
+    return key.getKey();
+  }
+
+  private static long invertTime(long time) {
+    return Long.MAX_VALUE - time;
+  }
+
+  static long getHistoryTime(byte[] rowKey) {
+    return ByteBuffer.wrap(rowKey).getLong(rowKey.length - 8);
+  }
+
+  private MdsHistoryKey() {
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
+
+import javax.annotation.Nullable;
+
+/**
+ * Key class to get v1 metadata key information
+ */
+public final class MdsKey {
+  private static final byte[] VALUE_ROW_PREFIX = {'v'}; // value row prefix to store metadata value
+  private static final byte[] INDEX_ROW_PREFIX = {'i'}; // index row prefix used for metadata search
+
+  static String getMetadataKey(String type, byte[] rowKey) {
+    MDSKey.Splitter keySplitter = new MDSKey(rowKey).split();
+    // The rowkey is
+    // [rowPrefix][targetType][targetId][key] for value rows and
+    // [rowPrefix][targetType][targetId][key][index] for value index rows
+    // so skip the first few strings.
+
+    // Skip rowType
+    keySplitter.skipBytes();
+
+    // Skip targetType
+    keySplitter.skipString();
+
+    // Skip targetId
+    if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ProgramId.class))) {
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ApplicationId.class))) {
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(DatasetId.class))) {
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamId.class))) {
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(StreamViewId.class))) {
+      // skip namespace, stream, view
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else if (type.equals(EntityIdKeyHelper.TYPE_MAP.get(ArtifactId.class))) {
+      // skip namespace, name, version
+      keySplitter.skipString();
+      keySplitter.skipString();
+      keySplitter.skipString();
+    } else {
+      throw new IllegalArgumentException("Illegal Type " + type + " of metadata source.");
+    }
+    return keySplitter.getString();
+  }
+
+  static String getTargetType(byte[] rowKey) {
+    MDSKey.Splitter keySplitter = new MDSKey(rowKey).split();
+    // The rowkey is
+    // [rowPrefix][targetType][targetId][key] for value rows and
+    // [rowPrefix][targetType][targetId][key][index] for value index rows
+    keySplitter.getBytes();
+    return keySplitter.getString();
+  }
+
+  /**
+   * Creates a key for metadata value row in the format:
+   * [{@link #VALUE_ROW_PREFIX}][targetType][targetId][key] for value index rows
+   */
+  public static MDSKey getMDSValueKey(NamespacedEntityId targetId, @Nullable String key) {
+    MDSKey.Builder builder = getMDSKeyPrefix(targetId, VALUE_ROW_PREFIX);
+    if (key != null) {
+      builder.add(key);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Creates a key for metadata index row in the format:
+   * [{@link #INDEX_ROW_PREFIX}][targetType][targetId][key][index] for value index rows
+   */
+  static MDSKey getMDSIndexKey(NamespacedEntityId targetId, String key, @Nullable String index) {
+    MDSKey.Builder builder = getMDSKeyPrefix(targetId, INDEX_ROW_PREFIX);
+    builder.add(key);
+    if (index != null) {
+      builder.add(index);
+    }
+    return builder.build();
+  }
+
+  static NamespacedEntityId getNamespacedIdFromKey(String type, byte[] rowKey) {
+    MDSKey.Splitter keySplitter = new MDSKey(rowKey).split();
+
+    // The rowkey is
+    // [rowPrefix][targetType][targetId][key] for value rows and
+    // [rowPrefix][targetType][targetId][key][index] for value index rows
+    // so skip the first two.
+    keySplitter.skipBytes();
+    keySplitter.skipString();
+    return EntityIdKeyHelper.getTargetIdIdFromKey(keySplitter, type);
+  }
+
+  static String getNamespaceId(MDSKey key) {
+    MDSKey.Splitter keySplitter = key.split();
+
+    // The rowkey is
+    // [rowPrefix][targetType][targetId][key] for value rows and
+    // [rowPrefix][targetType][targetId][key][index] for value index rows
+    // so skip the first two.
+    keySplitter.skipBytes();
+    keySplitter.skipString();
+    // We are getting the first part of [targetId] which always be the namespace id.
+    return keySplitter.getString();
+  }
+
+  static byte[] getValueRowPrefix() {
+    MDSKey key = new MDSKey.Builder().add(VALUE_ROW_PREFIX).build();
+    return key.getKey();
+  }
+
+  static byte[] getIndexRowPrefix() {
+    MDSKey key = new MDSKey.Builder().add(INDEX_ROW_PREFIX).build();
+    return key.getKey();
+  }
+
+  private static MDSKey.Builder getMDSKeyPrefix(NamespacedEntityId targetId, byte[] rowPrefix) {
+    String targetType = EntityIdKeyHelper.getTargetType(targetId);
+    MDSKey.Builder builder = new MDSKey.Builder();
+    builder.add(rowPrefix);
+    builder.add(targetType);
+    EntityIdKeyHelper.addTargetIdToKey(builder, targetId);
+    return builder;
+  }
+
+  private MdsKey() {
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntries.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntries.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.api.dataset.lib.KeyValue;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Holds information needed for metadata migration
+ */
+public class MetadataEntries {
+  private final List<KeyValue<Long, MetadataEntry>> entries;
+  private final List<byte[]> rows;
+
+  public MetadataEntries(List<KeyValue<Long, MetadataEntry>> entries, List<byte[]> rows) {
+    this.entries = entries;
+    this.rows = rows;
+  }
+
+  public List<KeyValue<Long, MetadataEntry>> getEntries() {
+    return entries;
+  }
+
+  public List<byte[]> getRows() {
+    return rows;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MetadataEntries that = (MetadataEntries) o;
+
+    return Objects.equals(entries, that.entries) && Objects.equals(rows, that.rows);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entries, rows);
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataEntries{" +
+      "entries=" + entries +
+      ", rows=" + rows +
+      '}';
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Cask Data, Inc.
+ * Copyright 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataHistoryKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataHistoryKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,6 +27,7 @@ class MetadataHistoryKey {
   private static final byte[] ROW_PREFIX = {'h'};
 
   static MDSKey getMDSKey(MetadataEntity targetId, long time) {
+    // [rowPrefix][targetType][targetId][time]
     MDSKey.Builder builder = getKeyPart(targetId);
     builder.add(invertTime(time));
     return builder.build();
@@ -48,6 +49,7 @@ class MetadataHistoryKey {
   private static MDSKey.Builder getKeyPart(MetadataEntity metadataEntity) {
     MDSKey.Builder builder = new MDSKey.Builder();
     builder.add(ROW_PREFIX);
+    builder.add(metadataEntity.getType());
     for (MetadataEntity.KeyValue keyValue : metadataEntity) {
       builder.add(keyValue.getKey());
       builder.add(keyValue.getValue());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataV1.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2018 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,25 +14,34 @@
  * the License.
  */
 
-package co.cask.cdap.api.metadata;
+package co.cask.cdap.data2.metadata.dataset;
 
-import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents metadata (properties and tags) of an entity.
+ * Metadata v1 record. We need to copy this because we do not store entity type information in metadata history key.
+ * So we will use this class to deserialize the value for v1 history row and get the entity type.
  */
-@Beta
-public class Metadata {
+public class MetadataV1 {
+  private final NamespacedEntityId namespacedEntityId;
   private final Map<String, String> properties;
   private final Set<String> tags;
 
-  public Metadata(Map<String, String> properties, Set<String> tags) {
+  /**
+   * Returns an empty {@link Metadata}
+   */
+  public MetadataV1(NamespacedEntityId namespacedEntityId, Map<String, String> properties, Set<String> tags) {
+    this.namespacedEntityId = namespacedEntityId;
     this.properties = properties;
     this.tags = tags;
+  }
+
+  public NamespacedEntityId getEntityId() {
+    return namespacedEntityId;
   }
 
   public Map<String, String> getProperties() {
@@ -48,23 +57,27 @@ public class Metadata {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof Metadata)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Metadata that = (Metadata) o;
-    return Objects.equals(properties, that.properties) &&
+
+    MetadataV1 that = (MetadataV1) o;
+
+    return Objects.equals(namespacedEntityId, that.namespacedEntityId) &&
+      Objects.equals(properties, that.properties) &&
       Objects.equals(tags, that.tags);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(properties, tags);
+    return Objects.hash(namespacedEntityId, properties, tags);
   }
 
   @Override
   public String toString() {
-    return "Metadata{" +
-      "properties=" + properties +
+    return "MetadataV1{" +
+      "namespacedEntityId=" + namespacedEntityId +
+      ", properties=" + properties +
       ", tags=" + tags +
       '}';
   }

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="54af3020050a16faf325627a1f84ff6c"
+DEFAULT_XML_MD5_HASH="23357f420660f53f9ba563ac3e41f8a5"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -89,7 +89,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
 
     String txClientId = String.format("cdap.service.%s.%d", Constants.Service.DATASET_EXECUTOR,
                                       context.getInstanceId());
-    injector = createInjector(cConf, hConf, txClientId);
+    injector = createInjector(cConf, hConf, txClientId, context);
 
     injector.getInstance(LogAppenderInitializer.class).initialize();
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
@@ -99,7 +99,8 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
   }
 
   @VisibleForTesting
-  static Injector createInjector(CConfiguration cConf, Configuration hConf, String txClientId) {
+  static Injector createInjector(CConfiguration cConf, Configuration hConf, String txClientId,
+                                 TwillContext twillContext) {
     return Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new IOModule(), new ZKClientModule(),
@@ -115,7 +116,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new LoggingModules().getDistributedModules(),
       new ExploreClientModule(),
       new NamespaceClientRuntimeModule().getDistributedModules(),
-      new MetadataServiceModule(),
+      new MetadataServiceModule(twillContext),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
       new NotificationFeedClientModule(),

--- a/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TwillRunnableTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TwillRunnableTest.java
@@ -40,7 +40,8 @@ public class TwillRunnableTest {
   @Test
   public void testDatasetOpExecutorTwillRunnableInjector() throws Exception {
     Injector injector = DatasetOpExecutorServerTwillRunnable.createInjector(CConfiguration.create(),
-                                                                            HBaseConfiguration.create(), "");
+                                                                            HBaseConfiguration.create(), "",
+                                                                            new MockTwillContext());
     Store store = injector.getInstance(Store.class);
     Assert.assertNotNull(store);
     NamespaceQueryAdmin namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2017 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
… progress
Depends on https://github.com/caskdata/cdap/pull/10256

**TL;DR**
V1 table is read only, meaning none of the writes are written to v1 table while migration is in progress. All the reads are directed to V2 table only. 

Writes to V1 Table - throws a RuntimeException
Writes to V2 Table - if the entity is not present in v1, it passes, else throws RuntimeException
Reads from Table - Reads will always get redirected to V1 tables

Currently testing on cluster.