### PR TITLE
[CDAP-13562] Don't switch to default profile when previously selected profile is disabled

### DIFF
--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle.js
@@ -110,7 +110,6 @@ export default class ProfileStatusToggle extends Component {
         toggleModal={this.toggleDisableModal}
         confirmationText={confirmationText}
         confirmButtonText={T.translate(`${PREFIX}.DetailView.disableYes`)}
-        cancelButtonText={T.translate(`${PREFIX}.DetailView.disableNo`)}
         confirmFn={this.toggleProfileStatus}
         cancelFn={this.toggleDisableModal}
         isOpen={this.state.disableModalOpen}

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/index.js
@@ -22,6 +22,7 @@ import {
   schedulePipeline,
   updatePreferences
 } from 'components/PipelineConfigurations/Store/ActionCreator';
+import {setRunError} from 'components/PipelineDetails/store/ActionCreator';
 import ConfigModelessSaveBtn from 'components/PipelineConfigurations/ConfigurationsContent/ConfigModelessActionButtons/ConfigModelessSaveBtn';
 import {Observable} from 'rxjs/Observable';
 
@@ -70,9 +71,11 @@ export default class ConfigModelessActionButtons extends Component {
     )
       .subscribe(() => {
         actionFn();
+        this.setState({
+          [loadingState]: false
+        });
       }, (err) => {
-        console.log(err);
-      }, () => {
+        setRunError(err.response || err);
         this.setState({
           [loadingState]: false
         });

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfilesListViewInPipeline.scss
@@ -84,6 +84,11 @@ $enabled-color: $green-02;
             text-decoration: underline;
           }
         }
+        > div {
+          height: 100%;
+          display: flex;
+          align-items: center;
+        }
       }
     }
     &.disabled {

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
@@ -102,19 +102,6 @@ export default class ProfilesListViewInPipeline extends Component {
           let selectedProfile = this.state.selectedProfile || preferences[PROFILE_NAME_PREFERENCE_PROPERTY] || DEFAULT_PROFILE_NAME;
           let selectedProfileName = extractProfileName(selectedProfile);
 
-          // If currently selected profile has been disabled, then select 'default'
-          // profile, but only if the profiles list view is not disabled
-          if (!this.props.disabled) {
-            let selectedProfileIsDisabled = allProfiles.some(profile => {
-              return profile.name === selectedProfileName
-                && PROFILE_STATUSES[profile.status] === 'disabled';
-            });
-            if (selectedProfileIsDisabled) {
-              selectedProfile = DEFAULT_PROFILE_NAME;
-              selectedProfileName = extractProfileName(selectedProfile);
-            }
-          }
-
           // This is to surface the selected profile to the top
           // instead of hiding somewhere in the bottom.
           let sortedProfiles = [];
@@ -154,7 +141,7 @@ export default class ProfilesListViewInPipeline extends Component {
       selectedProfile: profileName
     });
     if (this.props.onProfileSelect) {
-      this.props.onProfileSelect(profileName, customizations, true, e);
+      this.props.onProfileSelect(profileName, customizations, e);
     }
   };
 

--- a/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/ProfilesForSchedule/index.js
@@ -21,12 +21,11 @@ import {Dropdown, DropdownToggle, DropdownMenu} from 'reactstrap';
 import {setSelectedProfile} from 'components/PipelineScheduler/Store/ActionCreator';
 import {connect} from 'react-redux';
 import StatusMapper from 'services/StatusMapper';
-import ProfilesListView, {extractProfileName, isSystemProfile, DEFAULT_PROFILE_NAME} from 'components/PipelineDetails/ProfilesListView';
+import ProfilesListView, {extractProfileName, isSystemProfile} from 'components/PipelineDetails/ProfilesListView';
 import {MyCloudApi} from 'api/cloud';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import {getProvisionersMap} from 'components/Cloud/Profiles/Store/Provisioners';
 import {preventPropagation} from 'services/helpers';
-import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
 require('./ProfilesForSchedule.scss');
 
 export const PROFILES_DROPDOWN_DOM_CLASS = 'profiles-list-dropdown';
@@ -97,11 +96,9 @@ class ProfilesForSchedule extends Component {
     });
   }
 
-  setSelectedProfile = (selectedProfile, profileCustomizations = {}, toggleDropdown = true, e) => {
+  setSelectedProfile = (selectedProfile, profileCustomizations = {}, e) => {
     setSelectedProfile(selectedProfile, profileCustomizations);
-    if (toggleDropdown) {
-      this.toggleProfileDropdown(e);
-    }
+    this.toggleProfileDropdown(e);
   };
 
   renderProfilesTable = () => {
@@ -125,18 +122,9 @@ class ProfilesForSchedule extends Component {
 
   renderProfilesDropdown = () => {
     let isScheduled = this.props.scheduleStatus === StatusMapper.statusMap['SCHEDULED'];
-    let provisionerLabel, selectedProfile;
+    let provisionerLabel;
     if (this.state.selectedProfile) {
       let {profileDetails = {}} = this.state;
-      if (profileDetails.status
-          && PROFILE_STATUSES[profileDetails.status] === 'disabled'
-          && !isScheduled
-          && this.state.selectedProfile !== DEFAULT_PROFILE_NAME) {
-        selectedProfile = DEFAULT_PROFILE_NAME;
-        this.setSelectedProfile(DEFAULT_PROFILE_NAME, {}, false);
-      } else {
-        selectedProfile = this.state.selectedProfile;
-      }
       let {provisioner = {}} = profileDetails;
       let {name: provisionerName} = provisioner;
       provisionerLabel = this.state.provisionersMap[provisionerName] || provisionerName;
@@ -158,9 +146,9 @@ class ProfilesForSchedule extends Component {
               <span>
                 {
                   provisionerLabel ?
-                    `${extractProfileName(selectedProfile)} (${provisionerLabel})`
+                    `${extractProfileName(this.state.selectedProfile)} (${provisionerLabel})`
                   :
-                    `${extractProfileName(selectedProfile)}`
+                    `${extractProfileName(this.state.selectedProfile)}`
                 }
               </span>
             :

--- a/cdap-ui/app/cdap/components/PipelineScheduler/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/index.js
@@ -29,7 +29,8 @@ import ViewContainer from 'components/PipelineScheduler/ViewContainer';
 import {
   setSchedule,
   setMaxConcurrentRuns,
-  setOptionalProperty
+  setOptionalProperty,
+  setRunError
 } from 'components/PipelineDetails/store/ActionCreator';
 import IconSVG from 'components/IconSVG';
 import {getCurrentNamespace} from 'services/NamespaceStore';
@@ -242,7 +243,7 @@ export default class PipelineScheduler extends Component {
           }
         },
         err => {
-          console.log('Failed to update schedule', err);
+          setRunError(err.response || err);
           this.setState({
             [savingState]: false
           });

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -255,11 +255,10 @@ features:
         totalRuns: Total runs
       DetailView:
         creation: Creation date and time
-        disableConfirmation: Are you sure you want to disable the profile *_{profile}_*? The pipelines currently using this profile will start using the *_native_* profile.
+        disableConfirmation: Are you sure you want to disable the profile *_{profile}_*? Any programs or pipelines using this profile will fail to start.
         disableError: There was a problem disabling the profile
-        disableNo: No, keep the profile enabled
         disableTitle: Disable profile
-        disableYes: Yes, disable profile
+        disableYes: Disable
         enableError: "There was a problem enabling the profile: {message}"
         hideDetails: Hide Details
         noProperties: No properties available for this profile


### PR DESCRIPTION
Builds: https://builds.cask.co/browse/CDAP-UDUT18

In https://github.com/caskdata/cdap/pull/10225, I added a change where the UI would automatically switch selection to default profile, if the profile that user previously selected was disabled. 

However, there was feedback that this was confusing, so this PR reverts this change. Now, the profile selection will remain the same even when the profile is disabled, and the user will see an error message when they try to run a pipeline without changing to another profile.