### PR TITLE
Bump develop for 5.1.0 snapshot

### DIFF
--- a/cdap-api-common/pom.xml
+++ b/cdap-api-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-api-common</artifactId>

--- a/cdap-api-spark/pom.xml
+++ b/cdap-api-spark/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-api-spark</artifactId>

--- a/cdap-api-spark2_2.11/pom.xml
+++ b/cdap-api-spark2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-api-spark2_2.11</artifactId>

--- a/cdap-api/pom.xml
+++ b/cdap-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-api</artifactId>

--- a/cdap-app-fabric-tests/pom.xml
+++ b/cdap-app-fabric-tests/pom.xml
@@ -22,7 +22,7 @@ the License.
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-app-fabric-tests</artifactId>

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-app-fabric</artifactId>

--- a/cdap-app-templates/cdap-data-quality/pom.xml
+++ b/cdap-app-templates/cdap-data-quality/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-app-templates</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-data-quality</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-data-pipeline</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-data-pipeline2_2.11</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-data-streams</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-data-streams2_2.11</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-api-spark</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-api</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl-archetypes</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-data-pipeline-plugins-archetype</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spark.version>1.6.1</spark.version>
-    <cdap.version>5.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>5.1.0-SNAPSHOT</cdap.version>
     <hadoop.version>2.3.0</hadoop.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-archetypes</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-batch</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-core</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-proto</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-etl-tools</artifactId>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hydrator-spark-core</artifactId>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hydrator-spark-core2_2.11</artifactId>

--- a/cdap-app-templates/cdap-etl/hydrator-test/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hydrator-test</artifactId>

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-app-templates</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-app-templates/cdap-program-report/cdap-program-report1_2.10/pom.xml
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report1_2.10/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-program-report</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-app-templates/cdap-program-report/cdap-program-report2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report2_2.11/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-program-report</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-app-templates/cdap-program-report/pom.xml
+++ b/cdap-app-templates/cdap-program-report/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-app-templates</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-app-templates/pom.xml
+++ b/cdap-app-templates/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-app-templates</artifactId>

--- a/cdap-archetypes/cdap-app-archetype/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-archetypes</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-app-archetype</artifactId>

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <app.main.class>${package}.HelloWorld</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>5.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>5.1.0-SNAPSHOT</cdap.version>
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>
     <junit.version>4.11</junit.version>

--- a/cdap-archetypes/cdap-mapreduce-archetype/pom.xml
+++ b/cdap-archetypes/cdap-mapreduce-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-archetypes</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-mapreduce-archetype</artifactId>

--- a/cdap-archetypes/cdap-mapreduce-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-mapreduce-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <app.main.class>${package}.MapReduceApp</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>5.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>5.1.0-SNAPSHOT</cdap.version>
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>
     <junit.version>4.11</junit.version>

--- a/cdap-archetypes/cdap-spark-java-archetype/pom.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-archetypes</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-spark-java-archetype</artifactId>

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
     <app.main.class>${package}.SparkPageRankApp</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <cdap.version>5.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>5.1.0-SNAPSHOT</cdap.version>
     <spark.core.version>1.6.1</spark.core.version>
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>

--- a/cdap-archetypes/cdap-spark-scala-archetype/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-archetypes</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-spark-scala-archetype</artifactId>

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <app.main.class>${package}.SparkKMeansApp</app.main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>5.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>5.1.0-SNAPSHOT</cdap.version>
     <spark.core.version>1.6.1</spark.core.version>
     <slf4j.version>1.7.5</slf4j.version>
     <gson.version>2.2.4</gson.version>

--- a/cdap-archetypes/pom.xml
+++ b/cdap-archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-archetypes</artifactId>

--- a/cdap-cli-tests/pom.xml
+++ b/cdap-cli-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-cli</artifactId>

--- a/cdap-client-tests/pom.xml
+++ b/cdap-client-tests/pom.xml
@@ -22,7 +22,7 @@ the License.
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-client-tests</artifactId>

--- a/cdap-client/pom.xml
+++ b/cdap-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-client</artifactId>

--- a/cdap-common-unit-test/pom.xml
+++ b/cdap-common-unit-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-common-unit-test</artifactId>

--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-common</artifactId>

--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-data-fabric-tests</artifactId>

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-data-fabric</artifactId>

--- a/cdap-distributions/bin/build_docs_bucket.sh
+++ b/cdap-distributions/bin/build_docs_bucket.sh
@@ -44,7 +44,7 @@ TARGET_DIR=${DOCS_HOME}/target
 
 S3_BUCKET=${S3_BUCKET:-docs.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-cdap} # No leading or trailing slashes
-VERSION=${VERSION:-5.0.0-SNAPSHOT}
+VERSION=${VERSION:-5.1.0-SNAPSHOT}
 
 function die() { __code=${2:-1}; echo "[ERROR] ${1}" >&2; exit ${__code}; };
 

--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-distributions</artifactId>

--- a/cdap-distributions/src/hdinsight/pkg/mainTemplate.json
+++ b/cdap-distributions/src/hdinsight/pkg/mainTemplate.json
@@ -50,12 +50,12 @@
       },
       "installScriptActions": [{
         "name": "[concat('cdap-pageblob-configure-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure-5.0.0.sh",
+        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure-5.1.0.sh",
         "roles": ["edgenode"]
       },
       {
         "name": "[concat('cdap-install-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "http://downloads.cask.co/hdinsight/install-5.0.0.sh",
+        "uri": "http://downloads.cask.co/hdinsight/install-5.1.0.sh",
         "roles": ["edgenode"]
       }],
       "uninstallScriptActions": [],

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -1,6 +1,6 @@
 {
   "cdap": {
-    "version": "5.0.0-1"
+    "version": "5.1.0-1"
   },
   "nodejs": {
     "install_method": "binary",

--- a/cdap-docs-gen/pom.xml
+++ b/cdap-docs-gen/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-docs-gen</artifactId>

--- a/cdap-examples/ClicksAndViews/pom.xml
+++ b/cdap-examples/ClicksAndViews/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/CountRandom/pom.xml
+++ b/cdap-examples/CountRandom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/CubeService/pom.xml
+++ b/cdap-examples/CubeService/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cdap-examples</artifactId>
         <groupId>co.cask.cdap</groupId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/DataCleansing/pom.xml
+++ b/cdap-examples/DataCleansing/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/DecisionTreeRegression/pom.xml
+++ b/cdap-examples/DecisionTreeRegression/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/FileSetExample/pom.xml
+++ b/cdap-examples/FileSetExample/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/HelloWorld/pom.xml
+++ b/cdap-examples/HelloWorld/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>cdap-examples</artifactId>
         <groupId>co.cask.cdap</groupId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/LogAnalysis/pom.xml
+++ b/cdap-examples/LogAnalysis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/Purchase/pom.xml
+++ b/cdap-examples/Purchase/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/SpamClassifier/pom.xml
+++ b/cdap-examples/SpamClassifier/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/SparkKMeans/pom.xml
+++ b/cdap-examples/SparkKMeans/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/SparkPageRank/pom.xml
+++ b/cdap-examples/SparkPageRank/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>SparkPageRank</artifactId>

--- a/cdap-examples/SportResults/pom.xml
+++ b/cdap-examples/SportResults/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/StreamConversion/pom.xml
+++ b/cdap-examples/StreamConversion/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/UserProfiles/pom.xml
+++ b/cdap-examples/UserProfiles/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/WebAnalytics/pom.xml
+++ b/cdap-examples/WebAnalytics/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/WikipediaPipeline/pom.xml
+++ b/cdap-examples/WikipediaPipeline/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/WordCount/pom.xml
+++ b/cdap-examples/WordCount/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-examples</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-examples/pom.xml
+++ b/cdap-examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-examples</artifactId>

--- a/cdap-examples/resources/weblog-analytics-config.json
+++ b/cdap-examples/resources/weblog-analytics-config.json
@@ -2,7 +2,7 @@
     "artifact": {
         "name": "cdap-data-pipeline",
         "scope": "SYSTEM",
-        "version": "5.0.0-SNAPSHOT"
+        "version": "5.1.0-SNAPSHOT"
     },
     "config": {
         "source": {

--- a/cdap-examples/resources/weblog-analytics.txt
+++ b/cdap-examples/resources/weblog-analytics.txt
@@ -1,3 +1,3 @@
-create app test cdap-etl-batch 5.0.0-SNAPSHOT system \$CDAP_HOME/examples/resources/weblog-analytics-config.json
+create app test cdap-etl-batch 5.1.0-SNAPSHOT system \$CDAP_HOME/examples/resources/weblog-analytics-config.json
 load stream logEventStream \$CDAP_HOME/examples/resources/accesslog.txt
 start mapreduce test.ETLMapReduce

--- a/cdap-examples/resources/weblog-service.txt
+++ b/cdap-examples/resources/weblog-service.txt
@@ -1,2 +1,2 @@
-deploy app \$CDAP_HOME/examples/CubeService/target/CubeServiceApp-5.0.0-SNAPSHOT.jar
+deploy app \$CDAP_HOME/examples/CubeService/target/CubeServiceApp-5.1.0-SNAPSHOT.jar
 start service CubeServiceApp.CubeService 

--- a/cdap-explore-client/pom.xml
+++ b/cdap-explore-client/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-explore-client</artifactId>

--- a/cdap-explore-jdbc/pom.xml
+++ b/cdap-explore-jdbc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-explore-jdbc</artifactId>

--- a/cdap-explore/pom.xml
+++ b/cdap-explore/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-explore</artifactId>

--- a/cdap-formats/pom.xml
+++ b/cdap-formats/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-gateway/pom.xml
+++ b/cdap-gateway/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-gateway</artifactId>

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-0.96</artifactId>

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-0.98</artifactId>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0-cdh</artifactId>

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0-cdh5.5.0</artifactId>

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0</artifactId>

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.1</artifactId>

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-hbase-compat-base/pom.xml
+++ b/cdap-hbase-compat-base/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-hbase-spi/pom.xml
+++ b/cdap-hbase-spi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-integration-test/pom.xml
+++ b/cdap-integration-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-kafka</artifactId>

--- a/cdap-kms/pom.xml
+++ b/cdap-kms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <properties>
     <hadoop.common.version>2.6.0</hadoop.common.version>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-master</artifactId>

--- a/cdap-notifications-api/pom.xml
+++ b/cdap-notifications-api/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-notifications-api</artifactId>

--- a/cdap-notifications/pom.xml
+++ b/cdap-notifications/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-notifications</artifactId>

--- a/cdap-operational-stats-core/pom.xml
+++ b/cdap-operational-stats-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-proto/pom.xml
+++ b/cdap-proto/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-proto</artifactId>

--- a/cdap-runtime-ext-dataproc/pom.xml
+++ b/cdap-runtime-ext-dataproc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-runtime-spi/pom.xml
+++ b/cdap-runtime-spi/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-security-spi/pom.xml
+++ b/cdap-security-spi/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-security</artifactId>

--- a/cdap-spark-core/pom.xml
+++ b/cdap-spark-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-spark-core</artifactId>

--- a/cdap-spark-core2_2.11/pom.xml
+++ b/cdap-spark-core2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-spark-core2_2.11</artifactId>

--- a/cdap-spark-python/pom.xml
+++ b/cdap-spark-python/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-spi/pom.xml
+++ b/cdap-spi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-spi</artifactId>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-standalone</artifactId>

--- a/cdap-test/pom.xml
+++ b/cdap-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-tms-tests/pom.xml
+++ b/cdap-tms-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-tms-tests</artifactId>

--- a/cdap-tms/pom.xml
+++ b/cdap-tms/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-tms</artifactId>

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdap-ui",
-  "version": "5.0.0-SNAPSHOT",
+  "version": "5.1.0-SNAPSHOT",
   "description": "Front-end for CDAP",
   "license": "Apache-2.0",
   "scripts": {

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-ui</artifactId>

--- a/cdap-ui/server/config/cdap-ui-config.json
+++ b/cdap-ui/server/config/cdap-ui-config.json
@@ -2,7 +2,7 @@
   "tracker": {
     "artifact": {
       "name": "tracker",
-      "version": "0.7.0-SNAPSHOT",
+      "version": "0.8.0-SNAPSHOT",
       "scope": "SYSTEM"
     },
     "appId": "_Tracker",
@@ -12,7 +12,7 @@
   "navigator": {
     "artifact": {
       "name": "navigator",
-      "version": "0.7.1",
+      "version": "0.9.0-SNAPSHOT",
       "scope": "SYSTEM"
     },
     "appId": "_ClouderaNavigator",

--- a/cdap-unit-test-spark2_2.11/pom.xml
+++ b/cdap-unit-test-spark2_2.11/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-unit-test-spark2_2.11</artifactId>

--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-unit-test</artifactId>

--- a/cdap-watchdog-api/pom.xml
+++ b/cdap-watchdog-api/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-watchdog-api</artifactId>

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-watchdog</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>co.cask.cdap</groupId>
   <artifactId>cdap</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Cask Data Application Platform (CDAP)</name>
   <description>Data Application Platform for Hadoop</description>


### PR DESCRIPTION
Bump 5.0.0-SNAPSHOT to 5.1.0-SNAPSHOT, after branching off release branch: [release/5.0](https://github.com/caskdata/cdap/tree/release/5.0).