### PR TITLE
[CDAP-13706] UI change for getReport and getDetails API endpoints changes

### DIFF
--- a/cdap-ui/app/cdap/api/reports.js
+++ b/cdap-ui/app/cdap/api/reports.js
@@ -22,13 +22,14 @@ let appPath = '/namespaces/system/apps/ReportGenerationApp';
 let programPath = `${appPath}/spark/ReportGenerationSpark`;
 
 let methodsPath = `${programPath}/methods`;
-let basepath = `${methodsPath}/reports/:reportId`;
+let reportsPath = `${methodsPath}/reports`;
+let basepath = `${reportsPath}/:reportId`;
 
 export const MyReportsApi = {
-  list: apiCreator(dataSrc, 'GET', 'REQUEST', `${methodsPath}/reports`),
-  getDetails: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/details`),
-  getReport: apiCreator(dataSrc, 'GET', 'REQUEST', basepath),
-  generateReport: apiCreator(dataSrc, 'POST', 'REQUEST', `${methodsPath}/reports`),
+  list: apiCreator(dataSrc, 'GET', 'REQUEST', reportsPath),
+  getDetails: apiCreator(dataSrc, 'GET', 'REQUEST', `${reportsPath}/download`),
+  getReport: apiCreator(dataSrc, 'GET', 'REQUEST', `${reportsPath}/info`),
+  generateReport: apiCreator(dataSrc, 'POST', 'REQUEST', reportsPath),
   deleteReport: apiCreator(dataSrc, 'DELETE', 'REQUEST', basepath),
   saveReport: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/save`),
 
@@ -38,6 +39,6 @@ export const MyReportsApi = {
   stopService: apiCreator(dataSrc, 'POST', 'REQUEST', `${programPath}/stop`),
   pollServiceStatus: apiCreator(dataSrc, 'GET', 'POLL', `${programPath}/status`, { interval: 2000 }),
   createApp: apiCreator(dataSrc, 'PUT', 'REQUEST', appPath),
-  ping: apiCreator(dataSrc, 'GET', 'REQUEST', `${methodsPath}/reports`),
+  ping: apiCreator(dataSrc, 'GET', 'REQUEST', reportsPath),
   deleteApp: apiCreator(dataSrc, 'DELETE', 'REQUEST', appPath)
 };

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/SaveButton/SaveModal.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/SaveButton/SaveModal.js
@@ -46,14 +46,17 @@ export default class SaveModal extends Component {
       reportId: this.props.reportId
     };
 
+    let detailParams = {
+      'report-id': this.props.reportId
+    };
+
     let body = {
-      name: this.state.name,
-      description: 'test'
+      name: this.state.name
     };
 
     MyReportsApi.saveReport(params, body)
       .subscribe(() => {
-        MyReportsApi.getReport(params)
+        MyReportsApi.getReport(detailParams)
           .subscribe((res) => {
             ReportsStore.dispatch({
               type: ReportsActions.setInfoStatus,

--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/index.js
@@ -57,7 +57,7 @@ class ReportsDetailView extends Component {
 
   fetchStatus = () => {
     let params = {
-      reportId: this.props.match.params.reportId
+      'report-id': this.props.match.params.reportId
     };
 
     MyReportsApi.getReport(params)

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/ActionPopover.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/ActionPopover.js
@@ -48,7 +48,7 @@ export default class ActionPopover extends Component {
 
   cloneCriteria = () => {
     let params = {
-      reportId: this.props.report.id
+      'report-id': this.props.report.id
     };
 
     MyReportsApi.getReport(params)

--- a/cdap-ui/app/cdap/components/Reports/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Reports/store/ActionCreator.js
@@ -186,7 +186,7 @@ export function listReports(id) {
 export function fetchRuns(reportId = ReportsStore.getState().details.reportId) {
   let {runsOffset: offset, runsLimit: limit} = ReportsStore.getState().details;
   let params = {
-    reportId,
+    'report-id': reportId,
     offset,
     limit
   };


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13706

Corresponding backend PR: https://github.com/caskdata/cdap/pull/10190

The API changes are:
- `/reports/[reportId]` -> `/reports/info?report-id=[reportId]`
- `/reports/[reportId]/details` -> `/reports/download?report-id=[reportId]`