### PR TITLE
CDAP-13463 fix pipeline planner when conditions are on branches

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
@@ -97,6 +97,7 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -108,7 +109,6 @@ import java.util.Set;
  */
 public class SmartWorkflow extends AbstractWorkflow {
   public static final String NAME = "DataPipelineWorkflow";
-  public static final String DESCRIPTION = "Data Pipeline Workflow";
   public static final String TRIGGERING_PROPERTIES_MAPPING = "triggering.properties.mapping";
 
   private static final String RESOLVED_PLUGIN_PROPERTIES_MAP = "resolved.plugin.properties.map";
@@ -157,7 +157,7 @@ public class SmartWorkflow extends AbstractWorkflow {
   @Override
   protected void configure() {
     setName(NAME);
-    setDescription(DESCRIPTION);
+    setDescription("Data Pipeline Workflow");
 
     // set the pipeline spec as a property in case somebody like the UI wants to read it
     Map<String, String> properties = new HashMap<>();
@@ -208,6 +208,18 @@ public class SmartWorkflow extends AbstractWorkflow {
       return;
     }
 
+    /*
+       ControlDag is used to flatten the dag that represents connections between phases.
+       Connections between phases represent a happens-before relationship, not the flow of data.
+       As such, phases can be shifted around as long as every happens-before relationship is maintained.
+       The exception is condition phases. Connection from a condition to another phase must be maintained as is.
+
+       Flattening a ControlDag will transform a dag into a special fork-join dag by moving phases around.
+       We therefore cannot blindly flatten the phase connections.
+       However, we validated earlier that condition outputs have a special property, where every stage following a
+       condition can only have a single input. This means we will never need to flatten anything after the first
+       set of conditions. We will only have to flatten what comes before the first set of conditions.
+     */
     dag = new ControlDag(plan.getPhaseConnections());
     boolean dummyNodeAdded = false;
     Map<String, ConditionBranches> conditionBranches = plan.getConditionPhaseBranches();
@@ -215,7 +227,7 @@ public class SmartWorkflow extends AbstractWorkflow {
       // after flattening, there is guaranteed to be just one source
       dag.flatten();
     } else if (!conditionBranches.keySet().containsAll(dag.getSources())) {
-      // Continue only if the conditon node is not the source of the dag, otherwise dag is already in the
+      // Continue only if the condition node is not the source of the dag, otherwise dag is already in the
       // required form
       Set<String> conditions = conditionBranches.keySet();
       // flatten only the part of the dag starting from sources and ending in conditions/sinks.
@@ -228,7 +240,25 @@ public class SmartWorkflow extends AbstractWorkflow {
       Set<String> sinks = new HashSet<>();
 
       // If its a single phase without condition then no need to flatten
-      if (dagNodesWithoutCondition.size() > 1) {
+      if (dagNodesWithoutCondition.size() < 2) {
+        sinks.addAll(dagNodesWithoutCondition);
+      } else {
+        /*
+           Create a subdag from dagNodesWithoutCondition.
+           There are a couple situations where this is not immediately possible. For example:
+
+             source1 --|
+                       |--> condition -- ...
+             source2 --|
+
+           Here, dagNodesWithoutCondition = [source1, source2], which is an invalid dag. Similarly:
+
+             source --> condition -- ...
+
+           Here, dagNodesWithoutCondition = [source], which is also invalid. In order to ensure that we have a
+           valid dag, we just insert a dummy node as the first node in the subdag, adding a connection from the
+           dummy node to all the sources.
+         */
         Dag subDag;
         try {
           subDag = dag.createSubDag(dagNodesWithoutCondition);
@@ -270,8 +300,6 @@ public class SmartWorkflow extends AbstractWorkflow {
           }
         }
         sinks.addAll(cdag.getSinks());
-      } else {
-        sinks.addAll(dagNodesWithoutCondition);
       }
 
       // Add back the existing condition nodes and corresponding conditions
@@ -307,11 +335,12 @@ public class SmartWorkflow extends AbstractWorkflow {
     if (dummyNodeAdded) {
       WorkflowProgramAdder fork = programAdder.fork();
       String dummyNode = dag.getSources().iterator().next();
-      for (String output : dag.getNodeOutputs(dummyNode)) {
-        // need to make sure we don't call also() if this is the final branch
-        if (!addBranchPrograms(output, fork)) {
-          fork = fork.also();
-        }
+      // need to make sure we don't call also() if this is the final branch
+      Iterator<String> outputIter = dag.getNodeOutputs(dummyNode).iterator();
+      addBranchPrograms(outputIter.next(), fork, false);
+      while (outputIter.hasNext()) {
+        fork = fork.also();
+        addBranchPrograms(outputIter.next(), fork, !outputIter.hasNext());
       }
     } else {
       String start = dag.getSources().iterator().next();
@@ -390,7 +419,6 @@ public class SmartWorkflow extends AbstractWorkflow {
       String targetKey = mapping.getTarget() == null ? sourceKey : mapping.getTarget();
       token.put(targetKey, value);
     }
-    return;
   }
 
   @Override
@@ -554,49 +582,62 @@ public class SmartWorkflow extends AbstractWorkflow {
 
   private void addPrograms(String node, WorkflowProgramAdder programAdder) {
     programAdder = addProgram(node, programAdder);
-    Set<String> outputs = dag.getNodeOutputs(node);
-    if (outputs.isEmpty()) {
+    Iterator<String> outputIter = dag.getNodeOutputs(node).iterator();
+    if (!outputIter.hasNext()) {
       return;
     }
+    String output = outputIter.next();
 
     ConditionBranches branches = plan.getConditionPhaseBranches().get(node);
     if (branches != null) {
       // This is condition
-      addCondition(programAdder, branches);
+      addConditionBranches(programAdder, branches);
     } else {
       // if this is a fork
-      if (outputs.size() > 1) {
+      if (outputIter.hasNext()) {
         WorkflowProgramAdder fork = programAdder.fork();
-        for (String output : outputs) {
-          // need to make sure we don't call also() if this is the final branch
-          if (!addBranchPrograms(output, fork)) {
-            fork = fork.also();
-          }
+        addBranchPrograms(output, fork, false);
+
+        while (outputIter.hasNext()) {
+          fork = fork.also();
+          addBranchPrograms(outputIter.next(), fork, !outputIter.hasNext());
         }
       } else {
-        addPrograms(outputs.iterator().next(), programAdder);
+        addPrograms(output, programAdder);
       }
     }
   }
 
-  // returns whether this is the final branch of the fork
-  private boolean addBranchPrograms(String node, WorkflowProgramAdder programAdder) {
+  private void addBranchPrograms(String node, WorkflowProgramAdder programAdder, boolean shouldJoin) {
     // if this is a join node
-    Set<String> inputs = dag.getNodeInputs(node);
     if (dag.getNodeInputs(node).size() > 1) {
       // if we've reached the join from the final branch of the fork
-      if (dag.visit(node) == inputs.size()) {
+      if (shouldJoin) {
         // join the fork and continue on
         addPrograms(node, programAdder.join());
-        return true;
-      } else {
-        return false;
       }
+      return;
     }
 
-    // a flattened control dag guarantees that if this is not a join node, there is exactly one output
-    addProgram(node, programAdder);
-    return addBranchPrograms(dag.getNodeOutputs(node).iterator().next(), programAdder);
+    programAdder = addProgram(node, programAdder);
+    ConditionBranches branches = plan.getConditionPhaseBranches().get(node);
+    if (branches != null) {
+      programAdder = addConditionBranches(programAdder, branches);
+      if (shouldJoin) {
+        programAdder.join();
+      }
+    } else {
+      // if we're already on a branch, we should never have another branch for non-condition programs
+      Set<String> nodeOutputs = dag.getNodeOutputs(node);
+      if (nodeOutputs.size() > 1) {
+        throw new IllegalStateException("Found an unexpected non-condition branch while on another branch. " +
+                                          "This means there is a pipeline planning bug. " +
+                                          "Please contact the CDAP team to open a bug report.");
+      }
+      if (!nodeOutputs.isEmpty()) {
+        addBranchPrograms(dag.getNodeOutputs(node).iterator().next(), programAdder, shouldJoin);
+      }
+    }
   }
 
   private BatchPhaseSpec getPhaseSpec(String programName, PipelinePhase phase) {
@@ -651,7 +692,6 @@ public class SmartWorkflow extends AbstractWorkflow {
       programAdder.addAction(new PipelineAction(batchPhaseSpec));
     } else if (pluginTypes.contains(Condition.PLUGIN_TYPE)) {
       // conditions will be all by themselves in a phase
-      // addCondition(programAdder, phaseName, batchPhaseSpec);
       programAdder = programAdder.condition(new PipelineCondition(batchPhaseSpec));
     } else if (pluginTypes.contains(Constants.SPARK_PROGRAM_PLUGIN_TYPE)) {
       // spark programs will be all by themselves in a phase
@@ -670,7 +710,7 @@ public class SmartWorkflow extends AbstractWorkflow {
     return programAdder;
   }
 
-  private void addCondition(WorkflowProgramAdder conditionAdder, ConditionBranches branches) {
+  private WorkflowProgramAdder addConditionBranches(WorkflowProgramAdder conditionAdder, ConditionBranches branches) {
     // Add all phases on the true branch here
     String trueOutput = branches.getTrueOutput();
     if (trueOutput != null) {
@@ -681,6 +721,6 @@ public class SmartWorkflow extends AbstractWorkflow {
       conditionAdder.otherwise();
       addPrograms(falseOutput, conditionAdder);
     }
-    conditionAdder.end();
+    return conditionAdder.end();
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -118,6 +118,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1083,6 +1084,68 @@ public class DataPipelineTest extends HydratorTestBase {
       Assert.assertEquals("val3", MockAction.readOutput(actionTableDS, "row3", "key3"));
       Assert.assertEquals("val4", MockAction.readOutput(actionTableDS, "row4", "key4"));
     }
+  }
+
+  @Test
+  public void testConditionsOnBranches() throws Exception {
+    /*
+     *                            |-- true --> sink1
+     *          |--> condition1 --|
+     * source --|                 |-- false --> sink2
+     *          |
+     *          |                              |-- true --> sink3
+     *          |-- transform --> condition2 --|
+     *                                         |-- false --> sink4
+     */
+    Schema schema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING))
+    );
+    String sourceName = "branchConditionsSource";
+    String sink1Name = "branchConditionsSink1";
+    String sink2Name = "branchConditionsSink2";
+    String sink3Name = "branchConditionsSink3";
+    String sink4Name = "branchConditionsSink4";
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MockSource.getPlugin(sourceName, schema)))
+      .addStage(new ETLStage("condition1", MockCondition.getPlugin("condition1")))
+      .addStage(new ETLStage("transform", IdentityTransform.getPlugin()))
+      .addStage(new ETLStage("condition2", MockCondition.getPlugin("condition2")))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin(sink1Name)))
+      .addStage(new ETLStage("sink2", MockSink.getPlugin(sink2Name)))
+      .addStage(new ETLStage("sink3", MockSink.getPlugin(sink3Name)))
+      .addStage(new ETLStage("sink4", MockSink.getPlugin(sink4Name)))
+      .addConnection("source", "condition1")
+      .addConnection("source", "transform")
+      .addConnection("condition1", "sink1", true)
+      .addConnection("condition1", "sink2", false)
+      .addConnection("transform", "condition2")
+      .addConnection("condition2", "sink3", true)
+      .addConnection("condition2", "sink4", false)
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT_RANGE, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("branchConditions");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    List<StructuredRecord> records = Collections.singletonList(
+      StructuredRecord.builder(schema).set("name", "samuel").build());
+
+    DataSetManager<Table> inputManager = getDataset(sourceName);
+    MockSource.writeInput(inputManager, records);
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start(ImmutableMap.of("condition1.branch.to.execute", "true",
+                                          "condition2.branch.to.execute", "false"));
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> sink1Manager = getDataset(sink1Name);
+    DataSetManager<Table> sink2Manager = getDataset(sink2Name);
+    DataSetManager<Table> sink3Manager = getDataset(sink3Name);
+    DataSetManager<Table> sink4Manager = getDataset(sink4Name);
+    Assert.assertEquals(records, MockSink.readOutput(sink1Manager));
+    Assert.assertTrue(MockSink.readOutput(sink2Manager).isEmpty());
+    Assert.assertTrue(MockSink.readOutput(sink3Manager).isEmpty());
+    Assert.assertEquals(records, MockSink.readOutput(sink4Manager));
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ControlDag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ControlDag.java
@@ -18,15 +18,12 @@ package co.cask.cdap.etl.planner;
 
 import co.cask.cdap.etl.proto.Connection;
 import com.google.common.base.Joiner;
-import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multiset;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -39,34 +36,13 @@ import java.util.UUID;
  */
 public class ControlDag extends Dag {
   private static final Set<String> EMPTY = ImmutableSet.of();
-  private final Multiset<String> nodeVisits;
 
   public ControlDag(Collection<Connection> connections) {
     super(connections);
-    this.nodeVisits = HashMultiset.create();
   }
 
   public ControlDag(Dag dag) {
     super(dag);
-    this.nodeVisits = HashMultiset.create();
-  }
-
-  /**
-   * Record that this node was visited.
-   *
-   * @param node node that was visited
-   * @return the number of times this node was visited, including the visit from this call
-   */
-  public int visit(String node) {
-    nodeVisits.add(node);
-    return nodeVisits.count(node);
-  }
-
-  /**
-   * Resets the number of times each node was visited back to 0.
-   */
-  public void resetVisitCounts() {
-    nodeVisits.clear();
   }
 
   /**
@@ -82,7 +58,7 @@ public class ControlDag extends Dag {
    *      |           v
    *      |--> n4 --> n6
    *
-   *  There are many ways to turn this a fork-join while still respecting all happens-before relationships,
+   *  There are many ways to turn this into a fork-join while still respecting all happens-before relationships,
    *  but for simplicity we'll use an algorithm that doesn't have any nested forks and will turn the above into:
    *
    *       |--> n2 --|
@@ -301,34 +277,5 @@ public class ControlDag extends Dag {
       name += UUID.randomUUID().toString();
     }
     return name;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-
-    ControlDag that = (ControlDag) o;
-
-    return Objects.equals(nodeVisits, that.nodeVisits);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), nodeVisits);
-  }
-
-  @Override
-  public String toString() {
-    return "ControlDag{" +
-      "nodeVisits=" + nodeVisits +
-      "} " + super.toString();
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -355,6 +355,8 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig,
    * All inputs into a stage have the same schema.
    * ErrorTransforms only have BatchSource, Transform, or BatchAggregator as input stages.
    * AlertPublishers have at least one input and no outputs and don't have SparkSink or BatchSink as input.
+   * Action stages can only be at the start or end of the pipeline.
+   * Condition stages have at most 2 outputs. Each stage on a condition's output branch has at most a single input.
    *
    * Returns the stages in the order they should be configured to ensure that all input stages are configured
    * before their output.

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ConnectorDagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/ConnectorDagTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -869,7 +870,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testSubdagMerge() throws Exception {
+  public void testSubdagMerge() {
     /*
         n1 -----|
                 |-- n4(r) -- n6
@@ -921,7 +922,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testSimpleCondition() throws Exception {
+  public void testSimpleCondition() {
 
     /*
       file - csv - condition - sink1
@@ -936,7 +937,7 @@ public class ConnectorDagTest {
       new Connection("condition", "sink2")
     );
 
-    Set<String> conditions = new HashSet<>(Arrays.asList("condition"));
+    Set<String> conditions = Collections.singleton("condition");
     Set<String> reduceNodes = new HashSet<>();
     Set<String> isolationNodes = new HashSet<>();
     Set<String> multiPortNodes = new HashSet<>();
@@ -956,7 +957,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testSimpleConditionWithReducers() throws Exception {
+  public void testSimpleConditionWithReducers() {
     /*
              |--- n2
         n1 --|
@@ -974,8 +975,8 @@ public class ConnectorDagTest {
       new Connection("condition", "n6")
     );
 
-    Set<String> conditions = new HashSet<>(Arrays.asList("condition"));
-    Set<String> reduceNodes = new HashSet<>(Arrays.asList("n3"));
+    Set<String> conditions = Collections.singleton("condition");
+    Set<String> reduceNodes = Collections.singleton("n3");
     Set<String> isolationNodes = new HashSet<>();
     Set<String> multiPortNodes = new HashSet<>();
     Set<Dag> actual = PipelinePlanner.split(connections, conditions, reduceNodes, isolationNodes, EMPTY_ACTIONS,
@@ -997,7 +998,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testSimpleConditionWithMultipleSources() throws Exception {
+  public void testSimpleConditionWithMultipleSources() {
     /*
              |--- n2
         n1 --|
@@ -1016,8 +1017,8 @@ public class ConnectorDagTest {
       new Connection("n11", "n3")
     );
 
-    Set<String> conditions = new HashSet<>(Arrays.asList("condition"));
-    Set<String> reduceNodes = new HashSet<>(Arrays.asList("n3"));
+    Set<String> conditions = Collections.singleton("condition");
+    Set<String> reduceNodes = Collections.singleton("n3");
     Set<String> isolationNodes = new HashSet<>();
     Set<String> multiPortNodes = new HashSet<>();
     Set<Dag> actual = PipelinePlanner.split(connections, conditions, reduceNodes, isolationNodes, EMPTY_ACTIONS,
@@ -1040,7 +1041,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testConditionDag() throws Exception {
+  public void testConditionDag() {
 
     /*
           file - csv - c1 - t1---agg1--agg2---sink1
@@ -1102,7 +1103,7 @@ public class ConnectorDagTest {
   }
 
   @Test
-  public void testMultipleNonNestedConditions() throws Exception {
+  public void testMultipleNonNestedConditions() {
     /*
        n1-c1-n2-n3-c2-n4
      */

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/DagTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -561,7 +562,7 @@ public class DagTest {
   }
 
   @Test
-  public void testSplitByControlNodes() throws Exception {
+  public void testSplitByControlNodes() {
 
     // In following test cases note that Action nodes are named as (a0, a1...) and condition nodes are named
     // as (c0, c1, ..)
@@ -708,6 +709,38 @@ public class DagTest {
     expectedDags.clear();
     expectedDags.add(dag);
     Assert.assertEquals(expectedDags, actual);
+  }
+
+  @Test
+  public void testConditionsOnBranches() {
+    /*
+                        |--> n2
+              |--> c1 --|
+         n1 --|         |--> n3
+              |
+              |                |--> n5
+              |--> n4 --> c2 --|
+                               |--> n6
+     */
+
+    Dag dag = new Dag(ImmutableSet.of(
+      new Connection("n1", "c1"),
+      new Connection("n1", "n4"),
+      new Connection("c1", "n2"),
+      new Connection("c1", "n3"),
+      new Connection("n4", "c2"),
+      new Connection("c2", "n5"),
+      new Connection("c2", "n6")));
+    Set<Dag> actual = dag.splitByControlNodes(ImmutableSet.of("c1", "c2"), Collections.<String>emptySet());
+
+    Set<Dag> expected = ImmutableSet.of(
+      new Dag(ImmutableSet.of(new Connection("n1", "n4"), new Connection("n1", "c1"), new Connection("n4", "c2"))),
+      new Dag(ImmutableSet.of(new Connection("c1", "n2"))),
+      new Dag(ImmutableSet.of(new Connection("c1", "n3"))),
+      new Dag(ImmutableSet.of(new Connection("c2", "n5"))),
+      new Dag(ImmutableSet.of(new Connection("c2", "n6"))));
+
+    Assert.assertEquals(expected, actual);
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/condition/MockCondition.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/condition/MockCondition.java
@@ -115,8 +115,7 @@ public class MockCondition extends Condition {
   /**
    * Read the value for the specified rowKey and columnKey.
    */
-  public static String readOutput(DataSetManager<Table> tableManager, String rowKey, String columnKey)
-    throws Exception {
+  public static String readOutput(DataSetManager<Table> tableManager, String rowKey, String columnKey) {
     Table table = tableManager.get();
     return Bytes.toString(table.get(Bytes.toBytes(rowKey), Bytes.toBytes(columnKey)));
   }


### PR DESCRIPTION
SmartWorkflow had a bug where it assumed that all programs
on a branch would not fork or be conditions. It is still true
that they won't fork, but it has never been true that they cannot
be conditions. Fixing to handle that scenario, adding unit tests,
and performing general cleanup to fix warnings.