### PR TITLE
[CDAP-13652] Adds UI restriction on how long user can go back in Ops Dashboard

### DIFF
--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsGraph.scss
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/RunsGraph.scss
@@ -106,6 +106,11 @@ $chart-subtitle-font-color: $grey-03;
       top: 50%;
       transform: translateY(-50%);
       cursor: pointer;
+
+      &.disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
     }
 
     .arrow-left { left: 5px; }
@@ -182,5 +187,13 @@ $chart-subtitle-font-color: $grey-03;
   .axis-last-updated {
     text-anchor: end;
     font-size: 11px;
+  }
+}
+
+.tooltip {
+  .tooltip-inner {
+    &.disabled-arrow-tooltip {
+      text-align: left;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/index.js
@@ -26,7 +26,8 @@ import {next, prev} from 'components/OpsDashboard/store/ActionCreator';
 import RunsTable from 'components/OpsDashboard/RunsGraph/RunsTable';
 import {DashboardActions} from 'components/OpsDashboard/store/DashboardStore';
 import classnames from 'classnames';
-import {getData, setLast24Hours} from 'components/OpsDashboard/store/ActionCreator';
+import {getData, setLast24Hours, setIs7DaysAgo} from 'components/OpsDashboard/store/ActionCreator';
+import {UncontrolledTooltip} from 'components/UncontrolledComponents';
 import T from 'i18n-react';
 
 const PREFIX = 'features.OpsDashboard.RunsGraph';
@@ -44,6 +45,7 @@ class RunsGraphView extends Component {
     viewByOption: PropTypes.string,
     changeDisplay: PropTypes.func,
     isLast24Hours: PropTypes.bool,
+    is7DaysAgo: PropTypes.bool,
     namespacesPick: PropTypes.array
   };
 
@@ -81,6 +83,7 @@ class RunsGraphView extends Component {
 
   last24Hour = () => {
     setLast24Hours(true);
+    setIs7DaysAgo(false);
     getData();
 
   };
@@ -92,6 +95,23 @@ class RunsGraphView extends Component {
     renderGraph('#runs-graph', width, GRAPH_HEIGHT, props.data, props.viewByOption);
   }
 
+  renderDisabledArrowToolitp(showTooltip, arrowId) {
+    if (!showTooltip) {
+      return null;
+    }
+
+    return (
+      <UncontrolledTooltip
+        placement="right"
+        delay={0}
+        target={arrowId}
+        className="disabled-arrow-tooltip"
+      >
+        {T.translate(`${PREFIX}.disabledArrowTooltip`)}
+      </UncontrolledTooltip>
+    );
+  }
+
   render() {
     const chart = (
       <div id={RUNS_GRAPH_CONTAINER}>
@@ -100,6 +120,7 @@ class RunsGraphView extends Component {
     );
 
     const table = <RunsTable />;
+    const arrowLeftId = "runs-graph-arrow-left";
 
     return (
       <div className="runs-graph-container">
@@ -121,7 +142,7 @@ class RunsGraphView extends Component {
             <div className="time-picker">
               <div
                 className={classnames({
-                  'active': this.props.isLast24Hours
+                  "active": this.props.isLast24Hours
                 })}
                 onClick={!this.props.isLast24Hours && this.last24Hour}
               >
@@ -131,8 +152,8 @@ class RunsGraphView extends Component {
 
             <div className="display-type">
               <span
-                className={classnames('option', {
-                  'active': this.props.displayType === 'chart'
+                className={classnames("option", {
+                  "active": this.props.displayType === 'chart'
                 })}
                 onClick={this.props.changeDisplay.bind(this, 'chart')}
               >
@@ -140,8 +161,8 @@ class RunsGraphView extends Component {
               </span>
               <span className="separator">|</span>
               <span
-                className={classnames('option', {
-                  'active': this.props.displayType === 'table'
+                className={classnames("option", {
+                  "active": this.props.displayType === 'table'
                 })}
                 onClick={this.props.changeDisplay.bind(this, 'table')}
               >
@@ -155,8 +176,11 @@ class RunsGraphView extends Component {
           {this.props.displayType === 'chart' ? chart : table}
 
           <div
-            className="navigation arrow-left"
-            onClick={prev}
+            className={classnames("navigation arrow-left", {
+              "disabled": this.props.is7DaysAgo
+            })}
+            onClick={!this.props.is7DaysAgo && prev}
+            id={arrowLeftId}
           >
             <IconSVG name="icon-chevron-left" />
           </div>
@@ -166,6 +190,7 @@ class RunsGraphView extends Component {
           >
             <IconSVG name="icon-chevron-right" />
           </div>
+          {this.renderDisabledArrowToolitp(this.props.is7DaysAgo, arrowLeftId)}
         </div>
 
         {this.props.displayType === 'chart' ? <Legends /> : null}
@@ -181,6 +206,7 @@ const mapStateToProps = (state) => {
     displayType: state.dashboard.displayType,
     viewByOption: state.dashboard.viewByOption,
     isLast24Hours: state.dashboard.isLast24Hours,
+    is7DaysAgo: state.dashboard.is7DaysAgo,
     namespacesPick: state.namespaces.namespacesPick
   };
 };

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsList/RunsList.scss
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsList/RunsList.scss
@@ -29,6 +29,16 @@
     }
   }
 
+  .list-view {
+    .no-runs {
+      margin-top: 30px;
+
+      .icon-exclamation-triangle {
+        margin-right: 5px;
+      }
+    }
+  }
+
   .grid-wrapper {
     $global-header: 50px;
     $header: 70px;

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsList/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsList/index.js
@@ -111,9 +111,10 @@ function renderGrid(data) {
   if (data.length === 0) {
     return (
       <div className="list-view">
-        <h3 className="text-xs-center">
-          {T.translate(`${PREFIX}.noRuns`)}
-        </h3>
+        <h5 className="text-xs-center no-runs">
+          <IconSVG name="icon-exclamation-triangle" />
+          <span>{T.translate(`${PREFIX}.noRuns`)}</span>
+        </h5>
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/OpsDashboard/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/store/ActionCreator.js
@@ -83,6 +83,7 @@ export function next() {
   start = Math.round(parseInt(start, 10) / 1000);
 
   setLast24Hours(false);
+  setIs7DaysAgo(false);
   getData(start, state.duration);
 }
 
@@ -98,6 +99,13 @@ export function prev() {
   }
 
   start = Math.round(parseInt(start, 10) / 1000);
+
+  const sevenDaysAgo = get7DaysFromCurrentTime();
+
+  if (start < sevenDaysAgo) {
+    start = sevenDaysAgo;
+    setIs7DaysAgo(true);
+  }
 
   setLast24Hours(false);
   getData(start, state.duration);
@@ -116,4 +124,18 @@ export function setLast24Hours(value) {
       isLast24Hours: value
     }
   });
+}
+
+export function setIs7DaysAgo(value) {
+  DashboardStore.dispatch({
+    type: DashboardActions.setIs7DaysAgo,
+    payload: {
+      is7DaysAgo: value
+    }
+  });
+}
+
+function get7DaysFromCurrentTime() {
+  const sevenDaysAgo = moment().subtract(7, 'day').format('x');
+  return Math.floor(parseInt(sevenDaysAgo, 10) / 1000);
 }

--- a/cdap-ui/app/cdap/components/OpsDashboard/store/DashboardStore.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/store/DashboardStore.js
@@ -28,6 +28,7 @@ const DashboardActions = {
   changeDisplayType: 'DASHBOARD_CHANGE_DISPLAY_TYPE',
   changeViewByOption: 'DASHBOARD_CHANGE_VIEW_BY_OPTION',
   setLast24Hours: 'DASHBOARD_SET_LAST_24_HOURS',
+  setIs7DaysAgo: 'DASHBOARD_SET_IS_7_DAYS_AGO',
   reset: 'DASHBOARD_RESET'
 };
 
@@ -49,7 +50,8 @@ const defaultInitialState = {
   customApp: true,
   displayType: 'chart',
   viewByOption: ViewByOptions.runStatus,
-  isLast24Hours: true
+  isLast24Hours: true,
+  is7DaysAgo: false
 };
 
 const namespacesInitialState = {
@@ -106,6 +108,11 @@ const dashboard = (state = defaultInitialState, action = defaultAction) => {
       return {
         ...state,
         isLast24Hours: action.payload.isLast24Hours
+      };
+    case DashboardActions.setIs7DaysAgo:
+      return {
+        ...state,
+        is7DaysAgo: action.payload.is7DaysAgo
       };
     case DashboardActions.reset:
       return defaultInitialState;

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1441,6 +1441,7 @@ features:
     pageTitle: CDAP | Dashboard
     RunsGraph:
       chart: Chart
+      disabledArrowTooltip: The runs timelime is only available for the past 7 days
       header: Runs timeline
       last24Hours: Last 24 hours
       Legends:
@@ -1479,7 +1480,7 @@ features:
       name: Name
       namespace: Namespace
       noData: No data
-      noRuns: No runs
+      noRuns: No runs in the selected time bucket
       start: Started
       startMethod: Start method
       status: Status


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13652

After this change, the user can click on the left arrow in Ops Dashboard to see historical runs up to 7 days from current time. After that, the arrow will be disabled.

