### PR TITLE
CDAP-13681 - Use log sampler in metrics processor

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorService.java
@@ -481,6 +481,8 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
           long timeSpent = endTime - startTime;
           return Math.max(0L, metricsProcessIntervalMillis - timeSpent);
         }
+      } catch (ServiceUnavailableException e) {
+        LOG.trace("Could not fetch metrics. Will be retried in next iteration.", e);
       } catch (Exception e) {
         LOG.warn("Failed to process metrics. Will be retried in next iteration.", e);
       }


### PR DESCRIPTION
Use log sampler to avoid master log flooding. 
Build: https://builds.cask.co/browse/CDAP-RUT1513-1