### PR TITLE
[CDAP-13792] Simplifies and fixes data parsing function in Ops Dashboard

### DIFF
--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/DataParser.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/DataParser.js
@@ -16,7 +16,7 @@
 
 import moment from 'moment';
 import uniqBy from 'lodash/uniqBy';
-import {ONE_DAY_SECONDS} from 'services/helpers';
+import {DAY_IN_SEC} from 'components/OpsDashboard/store/ActionCreator';
 
 export function parseDashboardData(rawData, startTime, duration, pipeline, customApp) {
   let {
@@ -40,6 +40,8 @@ export function parseDashboardData(rawData, startTime, duration, pipeline, custo
 
     let startTime = getBucket(runInfo.start * 1000);
     let endTime = getBucket(runInfo.end * 1000);
+    let runningTime;
+
 
     if (buckets[startTime]) {
       // add start method
@@ -58,7 +60,7 @@ export function parseDashboardData(rawData, startTime, duration, pipeline, custo
     }
 
     // add status
-    if (endTime && buckets[endTime]) {
+    if (buckets[endTime]) {
       if (runInfo.status === 'COMPLETED') {
         buckets[endTime].successful++;
       } else if (runInfo.status === 'FAILED') {
@@ -67,35 +69,32 @@ export function parseDashboardData(rawData, startTime, duration, pipeline, custo
       buckets[endTime].runsList.push(runInfo);
     }
 
-    // if end time is not present, that means the program is still running
-    let end = runInfo.end * 1000 || Date.now();
-    let start = runInfo.start * 1000;
-
-    let startIndex = timeArray.indexOf(startTime);
-    // if startTime not found, then the program started before the graph
-    // so set start value to start of first bucket
-    if (startIndex === -1) {
-      startIndex = 0;
-      start = parseInt(timeArray[startIndex], 10);
-    }
-
-    let endIndex = timeArray.indexOf(endTime);
-    // if endTime not found, then the program end after the graph
-    if (endIndex === -1) {
-      end = Date.now();
-    }
-
     // add running
-    let duration = end - start;
-    duration = moment.duration(duration).asHours();
-    duration = parseInt(duration, 10);
+    if (runInfo.running) {
+      runningTime = getBucket(runInfo.running * 1000);
+      let startIndex = timeArray.indexOf(runningTime);
+      // if startTime not found, then the program started before the graph
+      // so set start index to first bucket
+      if (startIndex === -1) {
+        startIndex = 0;
+      }
 
-    for (let i = 0; i < duration + 1; i++) {
-      let time = timeArray[startIndex + i];
+      let endIndex = timeArray.indexOf(endTime);
+      // if endTime not found, then the program ended after the graph
+      // or the program is still running, but we shouldn't show it as
+      // running past the bucket of current time
+      if (endIndex === -1) {
+        let currentTimeBucketIndex = timeArray.indexOf(getBucket(Date.now()));
+        endIndex = currentTimeBucketIndex === -1 ? timeArray.length - 1 : currentTimeBucketIndex;
+      }
 
-      if (buckets[time]) {
-        buckets[time].running++;
-        buckets[time].runsList.push(runInfo);
+      for (let i = startIndex; i <= endIndex; i++) {
+        let time = timeArray[i];
+
+        if (buckets[time]) {
+          buckets[time].running++;
+          buckets[time].runsList.push(runInfo);
+        }
       }
     }
   });
@@ -131,11 +130,11 @@ function setBuckets(startTime, duration) {
   let start = startTime * 1000;
 
   // hourly or per 5 minutes
-  let numBuckets = duration === ONE_DAY_SECONDS ? 24 : 12;
+  let numBuckets = duration === DAY_IN_SEC ? 24 : 12;
 
   for (let i = 0; i < numBuckets; i++) {
     let time = moment(start).startOf('hour');
-    if (duration === ONE_DAY_SECONDS) {
+    if (duration === DAY_IN_SEC) {
       time = time.add(i, 'h').format('x');
     } else {
       time = time.add(i*5, 'm').format('x');

--- a/cdap-ui/app/cdap/components/OpsDashboard/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/store/ActionCreator.js
@@ -20,7 +20,15 @@ import moment from 'moment';
 import {parseDashboardData} from 'components/OpsDashboard/RunsGraph/DataParser';
 import DashboardStore, {DashboardActions} from 'components/OpsDashboard/store/DashboardStore';
 
-const DAY_IN_SEC = 24 * 60 * 60;
+// We are subtracting 1 second, as we don't want to get the runs scheduled
+// for the bucket after the rightmost bucket we are showing
+// For example, let's say we're querying from 11am of previous day to 11am today.
+// If there's a pipeline scheduled for 11:00am today, it will show up in the
+// last (current time) bucket. However, this is wrong, since the current bucket
+// will only show runs between 10:00:00 am and 10:59:59 am today. That's why we
+// need to subtract 1 second from the range we are requesting to the backend.
+
+export const DAY_IN_SEC = 24 * 60 * 60 - 1;
 
 export function enableLoading() {
   DashboardStore.dispatch({
@@ -34,7 +42,7 @@ export function getData(start, duration = DAY_IN_SEC, namespaces = DashboardStor
   let state = DashboardStore.getState().dashboard;
 
   if (!start) {
-    start = moment().subtract(23, 'h').format('x');
+    start = moment().startOf('hour').subtract(23, 'h').format('x');
     start = Math.floor(parseInt(start, 10) / 1000);
   }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13792

This PR fixes the issue mentioned in the above JIRA, which is runs scheduled to run in the future show up in historical time buckets in current dashboard. 

This PR also fixes this issue: Currently, we get the `running` time of a run, the `end` time (or current time if end time not available), and then calculate the duration to figure out how many buckets to fill in starting from the `running` time. This is implemented starting at line 89 before the changes.

However, this approach would have a problem in this scenario:
- Run1 starts at 2:50pm, and hasn't ended yet.
- The user opens the Ops Dashboard at 4:10pm.
- When we calculate the `duration` in lines 90 and 91 before the changes, we get 1 as the value. 
- In the `for` loop, we go from 0 to `duration + 1`, so the loop iterates twice. This will fill the bucket from 2pm to 3pm (the starting bucket), and the bucket from 3pm to 4pm.
- However, since the current time is already 4:10pm, the user would expect to see the bucket from 4pm to 5pm being filled as well.

So instead of using the `duration`, if there's no `end` time, I just get the bucket corresponding to the current time, and fill all the buckets from `running` time to current time.