### PR TITLE
[CDAP-13725] Fixes pipeline detailed view post ingesting data from wrangler

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/CreateDatasetBtn/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/CreateDatasetBtn/index.js
@@ -199,7 +199,7 @@ export default class CreateDatasetBtn extends Component {
       }
       macroMap = Object.assign(macroMap, databaseConfig);
     }
-    return Object.assign({}, macroMap, {
+    macroMap = Object.assign({}, macroMap, {
       datasetName: this.state.datasetName,
       filename: objectQuery(workspaceInfo, 'properties', 'path') || '',
       directives: directives.join('\n'),
@@ -224,6 +224,13 @@ export default class CreateDatasetBtn extends Component {
       bqTable: objectQuery(bigqueryStage, 'plugin', 'properties', 'table') || '',
       bqSchema: objectQuery(bigqueryStage, 'plugin', 'properties', 'schema') || ''
     });
+    var newMacorMap = {};
+    // This is to prevent from passing all the empty properties as payload while starting the pipeline.
+    Object
+      .keys(macroMap)
+      .filter(key => !isEmpty(macroMap[key]))
+      .forEach(key => newMacorMap[key] = macroMap[key]);
+    return newMacorMap;
   }
 
   addMacrosToPipelineConfig(pipelineConfig) {

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
@@ -118,7 +118,7 @@ const DEFAULT_CONFIGURE_OPTIONS = {
 
 };
 
-const getCustomConfigFromProperties = (properties) => {
+const getCustomConfigFromProperties = (properties = {}) => {
   const backendProperties = ['system.spark.spark.streaming.backpressure.enabled', 'system.spark.spark.executor.instances', 'system.spark.spark.master'];
   let customConfig = {};
   Object.keys(properties).forEach(key => {

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
@@ -163,6 +163,9 @@ $border-color: $grey-05;
           .historical-runtimeargs-keyvalues {
             text-align: left;
             padding: 10px 0;
+            height: calc(100% - 65px);
+            overflow-y: auto;
+
             > div {
               display: grid;
               padding: 5px 0;

--- a/cdap-ui/app/hydrator/controllers/detail-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail-ctrl.js
@@ -61,7 +61,7 @@ angular.module(PKG.name + '.feature.hydrator')
       let pipelineDetailStoreState = window.CaskCommon.PipelineDetailStore.getState();
 
       if (!pluginsFetched) {
-        let pluginsToFetchDetailsFor = pipelineDetailStoreState.config.stages.concat(pipelineDetailStoreState.config.postActions);
+        let pluginsToFetchDetailsFor = pipelineDetailStoreState.config.stages.concat(pipelineDetailStoreState.config.postActions || []);
         PipelineAvailablePluginsActions.fetchPluginsForDetails($stateParams.namespace, pluginsToFetchDetailsFor);
         pluginsFetched = true;
       }


### PR DESCRIPTION
**Issue**
- We import/create pipeline config from multiple places
- We don't have a single logic to create the pipeline spec and it varies between places where we generate
- However when we parse the spec in pipeline view we expect some properties to be present
- This issue is caused by the gap in our implementation. We expect the property to be an object but when we generate the pipeline spec it is not specified

**Solution**
- Have fixed the receiving/parsing end to assume defaults if it got undefined/null
- Right solution should be generate the pipeline spec in single place. Didn't do this here as it will be a much large change.

JIRA: https://issues.cask.co/browse/CDAP-13725
Build: https://builds.cask.co/browse/CDAP-URUT9