### PR TITLE
CDAP-13678 Support artifact/application metadata in backward compatib…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataEntity.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metadata/MetadataEntity.java
@@ -73,6 +73,7 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
   public static final String NAMESPACE = "namespace";
   public static final String APPLICATION = "application";
   public static final String ARTIFACT = "artifact";
+  // version is used by artifact and application and their children which includes programs, flowlet, runs and schedules
   public static final String VERSION = "version";
   public static final String DATASET = "dataset";
   public static final String STREAM = "stream";
@@ -203,12 +204,14 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
           }
         }
         throw new IllegalArgumentException(String.format("Failed to build MetadataEntity of type '%s' from '%s'. " +
-                                                           "Type '%s is a CDAP entity type and must follow one of " +
+                                                           "Type '%s' is a CDAP entity type and must follow one of " +
                                                            "the following key hierarchies '%s'." +
                                                            "If you want to represent a CDAP Entity please follow the " +
                                                            "correct hierarchy. If you are trying to represent a " +
-                                                           "custom resource please use a different type name.",
-                                                         type, parts, type, Arrays.toString(validSequences)));
+                                                           "custom resource please use a different type name. " +
+                                                           "Note: if a type name is not specified the last key is " +
+                                                           "considered as the type.",
+                                                         type, parts, type, Arrays.deepToString(validSequences)));
       }
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.metadata.MetadataEntity;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test helper methods in {@link MetadataHttpHandler}. For handler test please see MetadataHttpHandlerTestRun
+ */
+public class MetadataHttpHandlerTest {
+
+  @Test
+  public void testMakeBackwardCompatible() {
+    MetadataEntity.Builder entity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .append(MetadataEntity.APPLICATION, "app")
+      .append(MetadataEntity.VERSION, "ver");
+
+    MetadataEntity.Builder actual = MetadataHttpHandler.makeBackwardCompatible(entity);
+    MetadataEntity expected = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.APPLICATION, "app")
+      .append(MetadataEntity.VERSION, "ver").build();
+    Assert.assertEquals(expected, actual.build());
+
+    entity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .append(MetadataEntity.ARTIFACT, "art")
+      .append(MetadataEntity.VERSION, "ver");
+
+    actual = MetadataHttpHandler.makeBackwardCompatible(entity);
+    expected = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.ARTIFACT, "art")
+      .append(MetadataEntity.VERSION, "ver").build();
+    Assert.assertEquals(expected, actual.build());
+
+    // apps can have no version information
+    entity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .append(MetadataEntity.APPLICATION, "app");
+    actual = MetadataHttpHandler.makeBackwardCompatible(entity);
+    expected = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.APPLICATION, "app").build();
+    Assert.assertEquals(expected, actual.build());
+  }
+}

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -86,7 +86,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -185,7 +185,8 @@ public abstract class EntityId {
       // application so append it
       extractedParts.add(new MetadataEntity.KeyValue(MetadataEntity.VERSION, version));
     }
-    if (entityType == EntityType.PROGRAM || entityType == EntityType.SCHEDULE) {
+    if (entityType == EntityType.PROGRAM || entityType == EntityType.SCHEDULE || entityType == EntityType.PROGRAM_RUN
+      || entityType == EntityType.FLOWLET) {
       // if the entity is program or schedule then add the version information at its correct position i.e. 2
       // (namespace, application, version) if the version information is not present
       if (!metadataEntity.containsKey(MetadataEntity.VERSION)) {


### PR DESCRIPTION
…le format too

## Summary:
- In https://github.com/caskdata/cdap/pull/10039 while addressing [CDAP-13260](https://issues.cask.co/browse/CDAP-13260) we refactored MetadataHttpHandlers to support custom MetadataEntity and also in the process cleaned up the Handler class.
- In that change we introduced ability to specify type for the MetadataEntity as a [query parameter](https://github.com/caskdata/cdap/pull/10039/files#diff-d3978c7a620a859bcd5abd847ff1a3f3R106) which needs to be set if the last key-value pair key is not the type of the MetadataEntity. 
- This is used for application/artifact which has version as last part even though the type is application/artifact. So now a user can access metadata like this: 

>  curl http://localhost:11015/v3/namespaces/default/apps/PurchaseHistory/versions/-SNAPSHOT/metadata?type="application"

Before 5.0 the above rest call was 
>  curl http://localhost:11015/v3/namespaces/default/apps/PurchaseHistory/versions/-SNAPSHOT/metadata

where the type did not need to be specified explicitly . The need to specify the type is explicitly is needed to support custom MetadataEntity whose type are middle key in hierarchy. 

- This PR introduces the change to support the rest endpoints without the specific query parameters    for artifact and application to maintain backward compatibility.

## Misc
[Issue](https://issues.cask.co/browse/CDAP-13678)
Build: https://builds.cask.co/browse/CDAP-RUT1519-1
