### PR TITLE
CDAP-13372 fix owner store upgrade

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -484,9 +484,10 @@ public class UpgradeTool {
     if (includeNewDatasets) {
       // Add all new system dataset introduced in the current release in this block. If no new dataset was introduced
       // then leave this block empty but do not remove block so that it can be used in next release if needed
-      // owner meta
-      DefaultOwnerStore.setupDatasets(datasetFramework);
     }
+
+    // owner metadata
+    DefaultOwnerStore.setupDatasets(datasetFramework);
     // metadata and lineage
     DefaultMetadataStore.setupDatasets(datasetFramework);
     LineageDataset.setupDatasets(datasetFramework);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13372
Build: https://builds.cask.co/browse/CDAP-RUT1525-1

We introduced owner store in patch 4.1. So it should get moved of the if-block for new datasets, otherwise the upgrade tool will not upgrade it.