### PR TITLE
[CDAP-13686] Fixes prediction dataset name + prediction dataset btn in models list view

### DIFF
--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/DetailedViewModelsTable.scss
@@ -58,7 +58,8 @@
     .grid-header,
     .grid-body {
       .grid-row {
-        grid-template-columns: 20px 1fr 1fr 2fr 1fr 1fr 1fr 1fr 20px;
+        grid-template-columns: 20px 2fr 1fr 2fr 1fr 1fr 1fr 1fr 20px;
+        white-space: nowrap;
         &:hover {
           [class*="icon-"] {
             color: $blue-03;
@@ -69,16 +70,20 @@
     .grid-body {
       .grid-row {
         &.opened {
-          grid-template-columns: 20px 1fr 1fr 1fr 1fr 20px;
+          grid-template-columns: 1fr;
           background: $grey-08;
           border-bottom: 3px solid $grey-04;
           border-top: 0;
           align-items: start;
           cursor: auto;
-          > div {
+          .content-wrapper {
+            display: grid;
+            grid-template-columns: 20px 1fr 1fr 1fr 1fr 20px;
             white-space: nowrap;
             text-overflow: ellipsis;
             height: 100%;
+          }
+          > div {
             strong {
               display: block;
             }
@@ -87,6 +92,9 @@
             }
             > div {
               padding: 5px 0;
+              > div:nth-child(2) {
+                padding-top: 10px;
+              }
             }
           }
           .collapsable-wrapper {
@@ -119,9 +127,13 @@
           .model-action-btns {
             display: flex;
             align-items: center;
-            margin-top: 10px;
+            flex-wrap: wrap;
+            margin-left: 20px;
+            margin-top: 0;
+            padding: 0;
+            padding-left: 10px;
             .add-model-to-pipeline {
-              margin-right: 5px;
+              margin: 5px 5px 5px 0;
             }
           }
         }

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ModelsTable/index.js
@@ -239,66 +239,68 @@ const renderModelDetails = (model, newlyTrainingModel, experimentId) => {
   modelTrainingLogsUrl = constructModelTrainingLogs(model, experimentId);
   return (
     <div {...props}>
-      <div />
-      <div>
+      <div className="content-wrapper">
+        <div />
         <div>
-          <strong>Model Description</strong>
-          <div>{model.description || '--'}</div>
-        </div>
-        <div>
-          <strong> Directives ({directivesCount}) </strong>
           <div>
-            <CollapsibleWrapper
-              content={directivesCount ? `${directives[0]}...` : '--'}
-              popoverContent={renderDirectivesTables.bind(null, directives)}
-              alwaysShowViewLink={true}
-            />
+            <strong>Model Description</strong>
+            <div>{model.description || '--'}</div>
+          </div>
+          <div>
+            <strong> Directives ({directivesCount}) </strong>
+            <div>
+              <CollapsibleWrapper
+                content={directivesCount ? `${directives[0]}...` : '--'}
+                popoverContent={renderDirectivesTables.bind(null, directives)}
+                alwaysShowViewLink={true}
+              />
+            </div>
           </div>
         </div>
-        <div className="model-action-btns">
+        <div>
+          <div>
+            <strong>Features ({featuresCount}) </strong>
+            <div>
+              <CollapsibleWrapper
+                content={featuresCount ? model.features.join(',') : '--'}
+                popoverContent={renderFeaturesTable.bind(null, model.features)}
+              />
+            </div>
+          </div>
+        </div>
+        <div>
+          <div>
+            <strong> Created on</strong>
+            <div>{humanReadableDate(model.createtime, true)}</div>
+          </div>
+        </div>
+        <div>
+          <div>
+            <strong> Model ID </strong>
+            <CopyableID
+              id={model.id}
+              label="Copy To Clipboard"
+              placement="left"
+            />
+          </div>
+          {
+            splitId ?
+              <div>
+                <strong>Model Training Logs </strong>
+                <a href={modelTrainingLogsUrl} target="_blank"> Logs </a>
+              </div>
+            :
+              null
+          }
+        </div>
+      </div>
+      <div className="model-action-btns">
           <AddModelToPipelineBtn
             modelName={model.name}
             modelId={model.id}
           />
           <PredictionDatasetExploreModal predictionDataset={model.predictionsDataset} />
         </div>
-      </div>
-      <div>
-        <div>
-          <strong>Features ({featuresCount}) </strong>
-          <div>
-            <CollapsibleWrapper
-              content={featuresCount ? model.features.join(',') : '--'}
-              popoverContent={renderFeaturesTable.bind(null, model.features)}
-            />
-          </div>
-        </div>
-      </div>
-      <div>
-        <div>
-          <strong> Created on</strong>
-          <div>{humanReadableDate(model.createtime, true)}</div>
-        </div>
-      </div>
-      <div>
-        <div>
-          <strong> Model ID </strong>
-          <CopyableID
-            id={model.id}
-            label="Copy To Clipboard"
-            placement="left"
-          />
-        </div>
-        {
-          splitId ?
-            <div>
-              <strong>Model Training Logs </strong>
-              <a href={modelTrainingLogsUrl} target="_blank"> Logs </a>
-            </div>
-          :
-            null
-        }
-      </div>
     </div>
   );
 };

--- a/cdap-ui/app/cdap/components/Experiments/store/CreateExperimentActionCreator.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/CreateExperimentActionCreator.js
@@ -352,10 +352,12 @@ function trainModel() {
   let {experiments_create, model_create} = createExperimentStore.getState();
   let {name: experimentId} = experiments_create;
   let {modelId, name: modelName} = model_create;
+  let formattedExperimentName = experimentId.replace(/[^\w]/g, '');
+  let formattedModelName = modelName.replace(/[^\w]/g, '');
   let postBody = {
     algorithm: model_create.algorithm.name,
     hyperparameters: model_create.algorithm.hyperparameters,
-    predictionsDataset: `${experimentId}_${modelName}_dataset`
+    predictionsDataset: `${formattedExperimentName}_${formattedModelName}_dataset`
   };
   return myExperimentsApi
     .trainModel({


### PR DESCRIPTION
- Fixes prediction dataset name to be free of spaces and other special characters to be able to successfully create a dataset post model training
- Fixes scoring pipeline & prediction dataset buttons to align properly based on browser size.

JIRA: 
- https://issues.cask.co/browse/CDAP-13686
- https://issues.cask.co/browse/CDAP-13692

Build:
https://builds.cask.co/browse/CDAP-URUT12