### PR TITLE
CDAP-13714 add a get cluster status api to provisioner

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
@@ -220,8 +220,9 @@ public class ProvisioningService extends AbstractIdleService {
       }
 
       // the actual task still needs to be run for cleanup to happen, but avoid logging a confusing
-      // message about resuming a task that is in cancelled state.
-      if (provisioningOp.getStatus() != ProvisioningOp.Status.CANCELLED) {
+      // message about resuming a task that is in cancelled state or resuming a task that is completed
+      if (provisioningOp.getStatus() != ProvisioningOp.Status.CANCELLED &&
+        provisioningOp.getStatus() != ProvisioningOp.Status.CREATED) {
         LOG.info("Resuming provisioning task for run {} of type {} in state {}.",
                  provisioningTaskInfo.getProgramRunId(), provisioningTaskInfo.getProvisioningOp().getType(),
                  provisioningTaskInfo.getProvisioningOp().getStatus());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/YarnProvisioner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/YarnProvisioner.java
@@ -48,19 +48,24 @@ public class YarnProvisioner implements Provisioner {
   }
 
   @Override
-  public Cluster createCluster(ProvisionerContext context) throws RetryableProvisionException {
+  public Cluster createCluster(ProvisionerContext context) {
     return new Cluster(context.getProgramRun().getRun(), ClusterStatus.RUNNING,
                        Collections.emptyList(), Collections.emptyMap());
   }
 
   @Override
-  public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) throws RetryableProvisionException {
+  public ClusterStatus getClusterStatus(ProvisionerContext context, Cluster cluster) {
     ClusterStatus status = cluster.getStatus();
-    return new Cluster(cluster, status == ClusterStatus.DELETING ? ClusterStatus.NOT_EXISTS : status);
+    return status == ClusterStatus.DELETING ? ClusterStatus.NOT_EXISTS : status;
   }
 
   @Override
-  public void deleteCluster(ProvisionerContext context, Cluster cluster) throws RetryableProvisionException {
+  public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) {
+    return new Cluster(cluster, getClusterStatus(context, cluster));
+  }
+
+  @Override
+  public void deleteCluster(ProvisionerContext context, Cluster cluster) {
     // no-op
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ClusterInitializeSubtask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ClusterInitializeSubtask.java
@@ -38,7 +38,11 @@ public class ClusterInitializeSubtask extends ProvisioningSubtask {
 
   @Override
   public Cluster execute(Cluster cluster) throws Exception {
-    provisioner.initializeCluster(provisionerContext, cluster);
-    return new Cluster(cluster, ClusterStatus.RUNNING);
+    // get the full details, since many times, information like ip addresses is not available until we're done
+    // polling for status and are ready to initialize. Up until now, the cluster object is what we got from
+    // the original createCluster() call, except with the status updated.
+    Cluster fullClusterDetails = provisioner.getClusterDetail(provisionerContext, cluster);
+    provisioner.initializeCluster(provisionerContext, fullClusterDetails);
+    return new Cluster(fullClusterDetails, ClusterStatus.RUNNING);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ClusterPollSubtask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ClusterPollSubtask.java
@@ -41,11 +41,12 @@ public class ClusterPollSubtask extends ProvisioningSubtask {
 
   @Override
   protected Cluster execute(Cluster cluster) throws Exception {
-    while (cluster.getStatus() == status) {
-      cluster = provisioner.getClusterDetail(provisionerContext, cluster);
+    ClusterStatus currentStatus = status;
+    while (currentStatus == status) {
+      currentStatus = provisioner.getClusterStatus(provisionerContext, cluster);
       // TODO: CDAP-13346 use provisioner specified polling strategy instead of hardcoded sleep
       TimeUnit.SECONDS.sleep(2);
     }
-    return cluster;
+    return new Cluster(cluster, currentStatus);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisioningTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisioningTask.java
@@ -91,10 +91,10 @@ public abstract class ProvisioningTask {
       }
 
       try {
-        LOG.debug("Executing {} subtask {}.", taskInfo.getProvisioningOp().getType(), state);
+        LOG.info("Executing {} subtask {}.", taskInfo.getProvisioningOp().getType(), state);
         taskInfoOptional = Retries.callWithInterruptibleRetries(() -> subtask.execute(taskInfo), retryStrategy,
                                                                 t -> t instanceof RetryableProvisionException);
-        LOG.debug("Completed {} subtask {}.", taskInfo.getProvisioningOp().getType(), state);
+        LOG.info("Completed {} subtask {}.", taskInfo.getProvisioningOp().getType(), state);
       } catch (InterruptedException e) {
         throw e;
       } catch (Exception e) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
@@ -83,13 +83,13 @@ public class MockProvisioner implements Provisioner {
   }
 
   @Override
-  public void initializeCluster(ProvisionerContext context, Cluster cluster) throws Exception {
+  public void initializeCluster(ProvisionerContext context, Cluster cluster) {
     failIfConfigured(context, FAIL_INIT);
-    failRetryablyEveryN(context);
   }
 
   @Override
-  public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) throws RetryableProvisionException {
+  public ClusterStatus getClusterStatus(ProvisionerContext context,
+                                        Cluster cluster) throws RetryableProvisionException {
     failIfConfigured(context, FAIL_GET);
     failRetryablyEveryN(context);
     ClusterStatus status = cluster.getStatus();
@@ -110,7 +110,12 @@ public class MockProvisioner implements Provisioner {
           break;
       }
     }
-    return new Cluster(cluster, newStatus);
+    return newStatus;
+  }
+
+  @Override
+  public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) throws RetryableProvisionException {
+    return new Cluster(cluster, getClusterStatus(context, cluster));
   }
 
   @Override

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.runtime.spi.provisioner.dataproc;
 
-import co.cask.cdap.runtime.spi.SparkCompat;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.Node;
@@ -66,7 +65,6 @@ public class DataProcProvisioner implements Provisioner {
       // if it already exists, it means this is a retry. We can skip actually making the request
       Optional<Cluster> existing = client.getCluster(clusterName);
 
-      SparkCompat sparkCompat = context.getSparkCompat();
       String imageVersion;
       switch (context.getSparkCompat()) {
         case SPARK1_2_10:
@@ -83,6 +81,16 @@ public class DataProcProvisioner implements Provisioner {
       } else {
         return existing.get();
       }
+    }
+  }
+
+  @Override
+  public ClusterStatus getClusterStatus(ProvisionerContext context, Cluster cluster) throws Exception {
+    DataProcConf conf = DataProcConf.fromProperties(context.getProperties());
+    String clusterName = getClusterName(context.getProgramRun());
+
+    try (DataProcClient client = DataProcClient.fromConf(conf)) {
+      return client.getClusterStatus(clusterName);
     }
   }
 

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
@@ -44,6 +44,7 @@ public interface Provisioner {
    * but it must be at least in the processes of being created. Must be implemented in an idempotent way,
    * otherwise there may be resource leaks. This means the implementation must first check if the cluster exists
    * before trying to create it, otherwise multiple clusters may be created for a single program run.
+   * The cluster returned will be passed to subsequent calls.
    *
    * @param context provisioner context
    * @return information about the cluster
@@ -53,8 +54,22 @@ public interface Provisioner {
   Cluster createCluster(ProvisionerContext context) throws Exception;
 
   /**
+   * Get the status of the cluster. If it does not exist, {@link ClusterStatus#NOT_EXISTS} should be returned.
+   * This is used to poll for status after {@link #createCluster(ProvisionerContext)} or
+   * {@link #deleteCluster(ProvisionerContext, Cluster)} is called.
+   *
+   * @param context provisioner context
+   * @param cluster the cluster to get the status of
+   * @return the status of the cluster
+   * @throws RetryableProvisionException if the operation failed, but may succeed on a retry
+   * @throws Exception if the operation failed in a non-retryable fashion
+   */
+  ClusterStatus getClusterStatus(ProvisionerContext context, Cluster cluster) throws Exception;
+
+  /**
    * Get details about the cluster. If the cluster does not exist, a cluster with status
-   * {@link ClusterStatus#NOT_EXISTS} should be returned.
+   * {@link ClusterStatus#NOT_EXISTS} should be returned. This is called after a cluster has been created, but before
+   * it has been initialized.
    *
    * @param context provisioner context
    * @param cluster the cluster to get


### PR DESCRIPTION
The call to get full cluster details is overkill when polling for
a cluster to be deleted or created. Most of the time, getting the
full cluster details will require multiple API calls to the
cloud, which can incur additional costs or be subject to rate
limiting.