### PR TITLE
CDAP-13625 tag dataproc clusters with the cdap version

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/DefaultProvisionerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/DefaultProvisionerContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.provision;
 
+import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.runtime.spi.SparkCompat;
 import co.cask.cdap.runtime.spi.provisioner.ProgramRun;
@@ -35,6 +36,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   private final Map<String, String> properties;
   private final SSHContext sshContext;
   private final SparkCompat sparkCompat;
+  private final String cdapVersion;
 
   public DefaultProvisionerContext(ProgramRunId programRunId, Map<String, String> properties,
                                    SparkCompat sparkCompat, @Nullable SSHContext sshContext) {
@@ -43,6 +45,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
     this.properties = Collections.unmodifiableMap(properties);
     this.sshContext = sshContext;
     this.sparkCompat = sparkCompat;
+    this.cdapVersion = ProjectInfo.getVersion().toString();
   }
 
   @Override
@@ -66,5 +69,10 @@ public class DefaultProvisionerContext implements ProvisionerContext {
       throw new UnsupportedOperationException("SSH is not supported");
     }
     return sshContext;
+  }
+
+  @Override
+  public String getCDAPVersion() {
+    return cdapVersion;
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcClient.java
@@ -87,13 +87,14 @@ public class DataProcClient implements AutoCloseable {
    *
    * @param name the name of the cluster to create
    * @param imageVersion the image version for the cluster
+   * @param labels labels to set on the cluster
    * @return the response for issuing the create
    * @throws InterruptedException if the thread was interrupted while waiting for the initial request to complete
    * @throws AlreadyExistsException if the cluster already exists
    * @throws IOException if there was an I/O error talking to Google Compute APIs
    * @throws RetryableProvisionException if there was a non 4xx error code returned
    */
-  public OperationSnapshot createCluster(String name, String imageVersion)
+  public OperationSnapshot createCluster(String name, String imageVersion, Map<String, String> labels)
     throws RetryableProvisionException, InterruptedException, IOException {
 
     try {
@@ -114,6 +115,7 @@ public class DataProcClient implements AutoCloseable {
 
       Cluster cluster = com.google.cloud.dataproc.v1.Cluster.newBuilder()
         .setClusterName(name)
+        .putAllLabels(labels)
         .setConfig(ClusterConfig.newBuilder()
                      .setMasterConfig(InstanceGroupConfig.newBuilder()
                                         .setNumInstances(conf.getMasterNumNodes())

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -77,8 +77,13 @@ public class DataProcProvisioner implements Provisioner {
           imageVersion = "1.2";
           break;
       }
+
+      // dataproc only allows label values to be lowercase letters, numbers, or dashes
+      String cdapVersion = context.getCDAPVersion().toLowerCase();
+      cdapVersion = cdapVersion.replaceAll("\\.", "_");
+      Map<String, String> labels = Collections.singletonMap("cdap-version", cdapVersion);
       if (!existing.isPresent()) {
-        client.createCluster(clusterName, imageVersion);
+        client.createCluster(clusterName, imageVersion, labels);
         return new Cluster(clusterName, ClusterStatus.CREATING, Collections.emptyList(), Collections.emptyMap());
       } else {
         return existing.get();

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcTool.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcTool.java
@@ -28,6 +28,7 @@ import org.apache.commons.cli.Options;
 import java.io.File;
 import java.io.FileReader;
 import java.io.Reader;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -100,7 +101,7 @@ public class DataProcTool {
     String name = commandLine.getOptionValue('n');
     try (DataProcClient client = DataProcClient.fromConf(conf)) {
       if ("provision".equals(command)) {
-        client.createCluster(name, imageVersion);
+        client.createCluster(name, imageVersion, Collections.emptyMap());
       } else if ("details".equals(command)) {
         Optional<Cluster> cluster = client.getCluster(name);
         if (cluster.isPresent()) {

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/ProvisionerContext.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/ProvisionerContext.java
@@ -47,5 +47,13 @@ public interface ProvisionerContext {
    */
   SSHContext getSSHContext();
 
+  /**
+   * @return {@link SparkCompat} used by CDAP
+   */
   SparkCompat getSparkCompat();
+
+  /**
+   * @return the CDAP version
+   */
+  String getCDAPVersion();
 }


### PR DESCRIPTION
When creating a dataproc cluster, add a label with the cdap version.
This will allow users to track which clusters were created by CDAP.