### PR TITLE
[CDAP-13663] fix issue where input fields with the same origin will get highlighted

### DIFF
--- a/cdap-ui/app/cdap/components/FieldLevelLineage/OperationsModal/OperationsTable.js
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/OperationsModal/OperationsTable.js
@@ -24,18 +24,24 @@ export default class OperationsTable extends Component {
   };
 
   state = {
-    activeId: null
+    activeOrigin: null,
+    activeField: {}
   };
 
   componentWillReceiveProps() {
     this.setState({
-      activeId: null
+      activeOrigin: null,
+      activeField: {}
     });
   }
 
-  handleInputClick(id) {
+  handleInputClick(field, operation) {
     this.setState({
-      activeId: id
+      activeOrigin: field.origin,
+      activeField: {
+        operation: operation.name,
+        name: field.name
+      }
     });
   }
 
@@ -58,11 +64,16 @@ export default class OperationsTable extends Component {
     if (!fields) { return '--'; }
 
     return fields.map((field, i) => {
+      const activeField = this.state.activeField;
+      const isSelected = activeField.operation === operation.name &&
+                          activeField.name === field.name &&
+                          this.state.activeOrigin === field.origin;
+
       return (
         <span>
           <span
-            className={classnames('input-field', { 'selected': this.state.activeId === field.origin })}
-            onClick={this.handleInputClick.bind(this, field.origin)}
+            className={classnames('input-field', { 'selected': isSelected })}
+            onClick={this.handleInputClick.bind(this, field, operation)}
           >
             {field.name}
           </span>
@@ -103,7 +114,7 @@ export default class OperationsTable extends Component {
             return (
               <div
                 key={operation.id}
-                className={classnames('grid-row', {'active': operation.name === this.state.activeId})}
+                className={classnames('grid-row', {'active': operation.name === this.state.activeOrigin})}
               >
                 <div>{ i + 1 }</div>
                 <div>{ this.renderInput(operation) }</div>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13663
Build: https://builds.cask.co/browse/CDAP-URUT15

To enforce uniqueness of the input field, we are checking for 3 things:
1. ID of the operation (this will target the row the input field is selected)
2. Name of the field
3. Origin of the field (input fields may have the same name, but different origin)


