### PR TITLE
CDAP-13260 Support CLI for metadata entity and tests

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -18,7 +18,9 @@ package co.cask.cdap.cli;
 
 import co.cask.cdap.StandaloneTester;
 import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.cli.command.NamespaceCommandUtils;
+import co.cask.cdap.cli.command.metadata.MetadataCommandHelper;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.DatasetTypeClient;
@@ -848,6 +850,7 @@ public class CLIMainTest extends CLITestBase {
     testCommandOutputContains(cli, String.format("get metadata-properties %s", FAKE_DS_ID), "dsKey,dsValue");
     testCommandOutputContains(cli, String.format("add metadata-tags %s 'streamTag1 streamTag2'", FAKE_STREAM_ID),
                               "Successfully added metadata tags");
+
     output = getCommandOutput(cli, String.format("get metadata-tags %s", FAKE_STREAM_ID));
     lines = Arrays.asList(output.split("\\r?\\n"));
     Assert.assertTrue(lines.contains("streamTag1") && lines.contains("streamTag2"));
@@ -894,6 +897,58 @@ public class CLIMainTest extends CLITestBase {
     lines = Arrays.asList(output.split("\\r?\\n"));
     expected = ImmutableList.of("Entity", FAKE_WORKFLOW_ID.toString());
     Assert.assertTrue(lines.containsAll(expected) && expected.containsAll(lines));
+
+    MetadataEntity fieldEntity =
+      MetadataEntity.builder(FAKE_DS_ID.toMetadataEntity()).appendAsType("field", "empName").build();
+
+    testCommandOutputContains(cli, String.format("add metadata-tags %s 'fieldTag1 fieldTag2 fieldTag3'",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)),
+                              "Successfully added metadata tags");
+    output = getCommandOutput(cli, String.format("get metadata-tags %s",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)));
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    Assert.assertTrue(lines.contains("fieldTag1") && lines.contains("fieldTag2") && lines.contains("fieldTag3"));
+    testCommandOutputContains(cli, String.format("add metadata-properties %s fieldKey=fieldValue",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)),
+                              "Successfully added metadata properties");
+    testCommandOutputContains(cli, String.format("get metadata-properties %s",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)),
+                              "fieldKey,fieldValue");
+
+    // test that retrieving metadata for EntityId is returned in old format
+    testCommandOutputContains(cli, String.format("get metadata %s", FAKE_STREAM_ID), FAKE_STREAM_ID.toString());
+    // test get metadata for custom entity and verify that return is in new format
+    testCommandOutputContains(cli, String.format("get metadata %s", MetadataCommandHelper.toCliString(fieldEntity)),
+                              fieldEntity.toString());
+
+    // test remove
+    testCommandOutputContains(cli, String.format("remove metadata-tag %s 'fieldTag3'",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)),
+                              "Successfully removed metadata tag");
+    output = getCommandOutput(cli, String.format("get metadata-tags %s",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)));
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    // should not contain the removed tag
+    Assert.assertTrue(lines.contains("fieldTag1") && lines.contains("fieldTag2") && !lines.contains("fieldTag3"));
+    testCommandOutputContains(cli, String.format("remove metadata-tags %s",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)),
+                              "Successfully removed metadata tags");
+    output = getCommandOutput(cli, String.format("get metadata-tags %s",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)));
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    // should not contain any tags except the header added by cli
+    Assert.assertTrue(lines.size() == 1 && lines.contains("tags"));
+
+    testCommandOutputContains(cli, String.format("remove metadata-properties %s",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)),
+                              "Successfully removed metadata properties");
+
+    // test remove properties
+    output = getCommandOutput(cli, String.format("get metadata-properties %s",
+                                                 MetadataCommandHelper.toCliString(fieldEntity)));
+    lines = Arrays.asList(output.split("\\r?\\n"));
+    // should not contain any properties except the header added by cli
+    Assert.assertTrue(lines.size() == 1 && lines.contains("key,value"));
   }
 
   private static File createAppJarFile(Class<?> cls) throws IOException {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
 
@@ -42,9 +42,10 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
     Map<String, String> properties = parseMap(arguments.get("properties"), "<properties>");
-    client.addProperties(entity, properties);
+    client.addProperties(metadataEntity, properties);
     output.println("Successfully added metadata properties");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataTagsCommand.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -43,9 +43,10 @@ public class AddMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
     Set<String> tags = ImmutableSet.copyOf(parseList(arguments.get("tags")));
-    client.addTags(entity, tags);
+    client.addTags(metadataEntity, tags);
     output.println("Successfully added metadata tags");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
@@ -16,13 +16,13 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -49,10 +49,11 @@ public class GetMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
     String scope = arguments.getOptional(ArgumentName.METADATA_SCOPE.toString());
-    Map<String, String> properties = scope == null ? client.getProperties(entity) :
-      client.getProperties(entity, MetadataScope.valueOf(scope.toUpperCase()));
+    Map<String, String> properties = scope == null ? client.getProperties(metadataEntity) :
+      client.getProperties(metadataEntity, MetadataScope.valueOf(scope.toUpperCase()));
 
     Table table = Table.builder()
       .setHeader("key", "value")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
@@ -16,13 +16,13 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -49,10 +49,11 @@ public class GetMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
     String scope = arguments.getOptional(ArgumentName.METADATA_SCOPE.toString());
-    Set<String> tags = scope == null ? client.getTags(entity) :
-      client.getTags(entity, MetadataScope.valueOf(scope.toUpperCase()));
+    Set<String> tags = scope == null ? client.getTags(metadataEntity) :
+      client.getTags(metadataEntity, MetadataScope.valueOf(scope.toUpperCase()));
 
     Table table = Table.builder()
       .setHeader("tags")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/MetadataCommandHelper.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/MetadataCommandHelper.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License
+ */
+package co.cask.cdap.cli.command.metadata;
+
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.proto.id.EntityId;
+
+/**
+ * Helper for CLI to convert string representation of {@link EntityId} used in metadata CLI command
+ * to/from {@link MetadataEntity}
+ */
+public class MetadataCommandHelper {
+  private static final String METADATA_ENTITY_KV_SEPARATOR = "=";
+  private static final String METADATA_ENTITY_PARTS_SEPARATOR = ",";
+  private static final String METADATA_ENTITY_TYPE = "type";
+
+  /**
+   * Returns a CLI friendly representation of MetadataEntity.
+   * For a dataset ds1 in ns1 the EntityId representation will be
+   * <pre>dataset:ns1.ds1</pre>
+   * It's equivalent MetadataEntity representation will be
+   * <pre>MetadataEntity{details={namespace=ns1, dataset=ds1}, type='dataset'}</pre>
+   * The CLI friendly representation will be
+   * <pre>namespace=ns1,dataset=ds1,type=dataset</pre>
+   *
+   * Note: It is not necessary to give a type, if a type is not provided the
+   * last key-value pair's key in the hierarchy will be considered as the type.
+   */
+  public static String toCliString(MetadataEntity metadataEntity) {
+    StringBuilder builder = new StringBuilder();
+    for (MetadataEntity.KeyValue keyValue : metadataEntity) {
+      builder.append(keyValue.getKey());
+      builder.append(METADATA_ENTITY_KV_SEPARATOR);
+      builder.append(keyValue.getValue());
+      builder.append(METADATA_ENTITY_PARTS_SEPARATOR);
+    }
+    builder.append(METADATA_ENTITY_TYPE);
+    builder.append(METADATA_ENTITY_KV_SEPARATOR);
+    builder.append(metadataEntity.getType());
+    return builder.toString();
+  }
+
+  /**
+   * Converts a CLI friendly string representation of MetadataEntity to MetadataEntity. For more details see
+   * documentation for {@link #toCliString(MetadataEntity)}
+   *
+   * @param cliString the cli friendly string representation
+   * @return {@link MetadataEntity}
+   */
+  public static MetadataEntity toMetadataEntity(String cliString) {
+    MetadataEntity metadataEntity;
+    try {
+      // For backward compatibility we support entityId.toString representation from CLI for metadata for example
+      // dataset representation look likes dataset:namespaceName.datasetName. Try to parse it as CDAP entity if it
+      // fails then take the representation to be MetadataEntity which was introduced in CDAP 5.0
+      metadataEntity = EntityId.fromString(cliString).toMetadataEntity();
+    } catch (IllegalArgumentException e) {
+      metadataEntity = fromCliString(cliString);
+    }
+    return metadataEntity;
+  }
+
+  private static MetadataEntity fromCliString(String cliString) {
+    String[] keyValues = cliString.split(METADATA_ENTITY_PARTS_SEPARATOR);
+    int lastKeyValueIndex = keyValues.length - 1;
+    MetadataEntity.Builder builder = MetadataEntity.builder();
+
+    String customType = null;
+    if (getKeyValue(keyValues[lastKeyValueIndex])[0].equalsIgnoreCase(METADATA_ENTITY_TYPE)) {
+      // if a type is specified then store it to call appendAsType later
+      customType = getKeyValue(keyValues[lastKeyValueIndex])[1];
+      lastKeyValueIndex -= 1;
+    }
+
+    for (int i = 0; i <= lastKeyValueIndex; i++) {
+      String[] part = getKeyValue(keyValues[i]);
+      if (part[0].equals(customType)) {
+        builder.appendAsType(part[0], part[1]);
+      } else {
+        builder.append(part[0], part[1]);
+      }
+    }
+    return builder.build();
+  }
+
+  private static String[] getKeyValue(String keyValue) {
+    String[] keyValuePair = keyValue.split(METADATA_ENTITY_KV_SEPARATOR);
+    if (keyValuePair.length != 2 || keyValuePair[0].isEmpty() || keyValuePair[1].isEmpty()) {
+      throw new IllegalArgumentException(String.format("%s is an invalid key-value.", keyValue));
+    }
+    return keyValuePair;
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataCommand.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
 
@@ -41,8 +41,9 @@ public class RemoveMetadataCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    client.removeMetadata(entity);
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
+    client.removeMetadata(metadataEntity);
     output.println("Successfully removed metadata");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertiesCommand.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
 
@@ -41,8 +41,9 @@ public class RemoveMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    client.removeProperties(entity);
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
+    client.removeProperties(metadataEntity);
     output.println("Successfully removed metadata properties");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertyCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertyCommand.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
 
@@ -41,9 +41,10 @@ public class RemoveMetadataPropertyCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
     String property = arguments.get("property");
-    client.removeProperty(entity, property);
+    client.removeProperty(metadataEntity, property);
     output.println("Successfully removed metadata property");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagCommand.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
 
@@ -41,9 +41,10 @@ public class RemoveMetadataTagCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
     String tag = arguments.get("tag");
-    client.removeTag(entity, tag);
+    client.removeTag(metadataEntity, tag);
     output.println("Successfully removed metadata tag");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagsCommand.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.cli.command.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.MetadataClient;
-import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
 
@@ -41,8 +41,9 @@ public class RemoveMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    client.removeTags(entity);
+    MetadataEntity metadataEntity =
+      MetadataCommandHelper.toMetadataEntity(arguments.get(ArgumentName.ENTITY.toString()));
+    client.removeTags(metadataEntity);
     output.println("Successfully removed metadata tags");
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
@@ -420,6 +420,15 @@ public abstract class AbstractMetadataClient {
   }
 
   /**
+   * @param metadataEntity the {@link MetadataEntity} for which to retrieve the metadata properties
+   * @return The metadata properties for the entity.
+   */
+  public Map<String, String> getProperties(MetadataEntity metadataEntity)
+    throws UnauthenticatedException, BadRequestException, IOException, UnauthorizedException {
+    return getProperties(metadataEntity, null);
+  }
+
+  /**
    * Return the properties for the {@link MetadataEntity} in the given scope
    * @param metadataEntity whose properties is needed
    * @param scope the scope of properties


### PR DESCRIPTION
## Summary
- Add support for specifying MetadataEntity (custom entities) from CLI for metadata command. 
- For backward compatibility the [EntityId string representation which the metadata command currently uses in CLI](https://docs.cask.co/cdap/4.3.4/en/reference-manual/cli-api.html#metadata-and-lineage) is still supported. 
- get metadata command which displays a metadata record containing entity details operate in two different mode.
    - Backward compatible mode: If get metadata command is called with an EntityId representation then the display results will be MetadataRecord (containing entityId representation) for backward compatibility
    - Custom Entity mode: If get metadata is called for a custom entity then we assume user knows the format change and the displayed result is MetadataRecordV2 (containing MetadataEntity)

## Misc
- [Issue](https://issues.cask.co/browse/CDAP-13260)
- [Previously closed PR](https://github.com/caskdata/cdap/pull/10136)
- Build: https://builds.cask.co/browse/CDAP-RUT1530-1
