### PR TITLE
CDAP-13741 fix : write to heart beat table on completed status

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -301,7 +301,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         }
         recordedRunRecord =
           appMetadataStore.recordProgramStop(programRunId, endTimeSecs, programRunStatus, null, messageIdBytes);
-
+        writeToHeartBeatDataset(recordedRunRecord, endTimeSecs, datasetContext, programHeartbeatDataset);
         if (recordedRunRecord != null) {
           runnable = getEmitMetricsRunnable(programRunId, recordedRunRecord,
                                             Constants.Metrics.Program.PROGRAM_COMPLETED_RUNS);


### PR DESCRIPTION
New code introduced as part of https://github.com/caskdata/cdap/pull/10272, skipped writing to heart beat table on completed run status. 

This fixes that and added test coverage for completed status. 