### PR TITLE
[CDAP-13740] Fix pipeline metrics to show graphs 

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
@@ -28,6 +28,7 @@ $border-color: $grey-05;
   color: $grey-02;
   position: absolute;
   margin-left: 20px;
+  background-color: $grey-08;
 
   .run-info-container {
     display: inline-block;

--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/PipelineNodeMetricsGraph.js
@@ -93,7 +93,7 @@ export default class PipelineNodeMetricsGraph extends Component {
     totalRecordsIn: null,
     totalRecordsOut: null,
     totalRecordsError: null,
-    totalRecordsOutPorts: null,
+    totalRecordsOutPorts: {},
     processTimeMetrics: {},
     resolution: 'hours',
     aggregate: false,


### PR DESCRIPTION
- Fixes the initial state of total records to output ports map to have the right value.
- Fixes the run level section to not have a transparent background to prevent users from seeing pipeline from within the gap 😑 (Related JIRA: https://issues.cask.co/browse/CDAP-13751. Not fully fixed yet.)

JIRA: https://issues.cask.co/browse/CDAP-13740
Build: https://builds.cask.co/browse/CDAP-URUT18-1