### PR TITLE
CDAP-13723: Make error message for metadata user friendly

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/InvalidMetadataException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/InvalidMetadataException.java
@@ -16,7 +16,6 @@
 package co.cask.cdap.common;
 
 import co.cask.cdap.api.metadata.MetadataEntity;
-import co.cask.cdap.proto.id.NamespacedEntityId;
 
 /**
  * Base exception for Metadata validation.
@@ -25,13 +24,8 @@ public class InvalidMetadataException extends BadRequestException {
 
   private final MetadataEntity metadataEntity;
 
-  public InvalidMetadataException(NamespacedEntityId targetId, String message) {
-    super("Unable to set metadata for " + targetId + " with error: " + message);
-    this.metadataEntity = targetId.toMetadataEntity();
-  }
-
   public InvalidMetadataException(MetadataEntity metadataEntity, String message) {
-    super("Unable to set metadata for " + metadataEntity + " with error: " + message);
+    super("Unable to set metadata for " + metadataEntity.getDescription() + " failed due to error: " + message);
     this.metadataEntity = metadataEntity;
   }
 

--- a/cdap-common/src/test/java/co/cask/cdap/common/InvalidMetadataExceptionTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/InvalidMetadataExceptionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common;
+
+
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.NamespaceId;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for {@link InvalidMetadataException}
+ */
+public class InvalidMetadataExceptionTest {
+
+  @Test
+  public void testMesssages() {
+    // test dataset
+    InvalidMetadataException invalidMetadataException =
+      new InvalidMetadataException(NamespaceId.DEFAULT.dataset("ds").toMetadataEntity(), "error");
+    String expectedMessage = "Unable to set metadata for dataset: ds " +
+      "which exists in namespace: default failed due to error: error";
+    Assert.assertEquals(expectedMessage, invalidMetadataException.getMessage());
+
+    // test view
+    invalidMetadataException =
+      new InvalidMetadataException(NamespaceId.DEFAULT.stream("st").view("v").toMetadataEntity(), "error");
+    expectedMessage =
+      "Unable to set metadata for view: v of stream: st which exists in namespace: default failed due to error: error";
+    Assert.assertEquals(expectedMessage, invalidMetadataException.getMessage());
+
+    // test program
+    invalidMetadataException =
+      new InvalidMetadataException(NamespaceId.DEFAULT.app("app").program(ProgramType.FLOW, "myflow")
+                                     .toMetadataEntity(), "error");
+    expectedMessage = "Unable to set metadata for flow: myflow in application: app of version: -SNAPSHOT deployed in " +
+      "namespace: default failed due to error: error";
+    Assert.assertEquals(expectedMessage, invalidMetadataException.getMessage());
+
+    // test flowlet
+    invalidMetadataException =
+      new InvalidMetadataException(NamespaceId.DEFAULT.app("app").program(ProgramType.FLOW, "flow1")
+                                     .flowlet("flowlet1").toMetadataEntity(), "error");
+    expectedMessage = "Unable to set metadata for flowlet: flowlet1 of flow: flow1 in application: app of " +
+      "version: -SNAPSHOT deployed in namespace: default failed due to error: error";
+    Assert.assertEquals(expectedMessage, invalidMetadataException.getMessage());
+
+    // test custom entity
+    MetadataEntity customEntity = MetadataEntity.builder(NamespaceId.DEFAULT.dataset("ds").toMetadataEntity())
+      .appendAsType("field", "empName").build();
+    invalidMetadataException = new InvalidMetadataException(customEntity, "error");
+    expectedMessage = "Unable to set metadata for namespace=default,dataset=ds,field=empNam of type 'field' " +
+      "failed due to error: error";
+    Assert.assertEquals(expectedMessage, invalidMetadataException.getMessage());
+  }
+}


### PR DESCRIPTION
## Summary
- In CDAP 5.0 we introduced MetadataEntity which internally uses a LinkedHashMap to store the key-value pair for resource. For example a dataset looks like this:
MetadataEntity{details={namespace="ns1", dataset="ds1"}, type="dataset"}  this shows up in UI to user if a metadata calls fails as the error message.
- This PR makes the representation which is show to user for MetadataEntity more friendly.
    1. For EntityId (i.e. CDAP Entities) we will show user helpful descriptive messages for example
    > Unable to set metadata for application <app-name> in namespace <ns-name>  : xxxxxx should 
       not exceed 50 characters.
 
    2. For custom entities we show the list of hierarchical key-values and not the implementation details such as the data structure representation etc.


## Misc
[Issue](https://issues.cask.co/browse/CDAP-13723)
Build: https://builds.cask.co/browse/CDAP-RUT1534-1