### PR TITLE
CDAP-13346 add provisioner polling strategy

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/YarnProvisioner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/YarnProvisioner.java
@@ -18,14 +18,16 @@ package co.cask.cdap.internal.provision;
 
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
+import co.cask.cdap.runtime.spi.provisioner.PollingStrategies;
+import co.cask.cdap.runtime.spi.provisioner.PollingStrategy;
 import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerContext;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
-import co.cask.cdap.runtime.spi.provisioner.RetryableProvisionException;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Default provisioner that doesn't provision a cluster
@@ -67,5 +69,11 @@ public class YarnProvisioner implements Provisioner {
   @Override
   public void deleteCluster(ProvisionerContext context, Cluster cluster) {
     // no-op
+  }
+
+  @Override
+  public PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster) {
+    // shouldn't matter, as we won't ever poll
+    return PollingStrategies.fixedInterval(2, TimeUnit.SECONDS);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
@@ -20,6 +20,8 @@ import co.cask.cdap.proto.provisioner.ProvisionerInfo;
 import co.cask.cdap.proto.provisioner.ProvisionerPropertyValue;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
+import co.cask.cdap.runtime.spi.provisioner.PollingStrategies;
+import co.cask.cdap.runtime.spi.provisioner.PollingStrategy;
 import co.cask.cdap.runtime.spi.provisioner.ProgramRun;
 import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerContext;
@@ -124,6 +126,12 @@ public class MockProvisioner implements Provisioner {
     failIfConfigured(context, FAIL_DELETE);
     failRetryablyEveryN(context);
     waitIfConfigured(context, WAIT_DELETE_MS);
+  }
+
+  @Override
+  public PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster) {
+    // retry immediately in unit tests
+    return PollingStrategies.fixedInterval(0, TimeUnit.MILLISECONDS);
   }
 
   // throws a RetryableProvisionException every other time this is called

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -153,13 +153,12 @@ public class DataProcProvisioner implements Provisioner {
     PollingStrategy strategy = PollingStrategies.fixedInterval(conf.getPollInterval(), TimeUnit.SECONDS);
     switch (cluster.getStatus()) {
       case CREATING:
-        strategy = PollingStrategies.initialDelay(strategy, conf.getPollCreateDelay(),
-                                                  conf.getPollCreateJitter(), TimeUnit.SECONDS);
-        break;
+        return PollingStrategies.initialDelay(strategy, conf.getPollCreateDelay(),
+                                              conf.getPollCreateJitter(), TimeUnit.SECONDS);
       case DELETING:
-        strategy = PollingStrategies.initialDelay(strategy, conf.getPollDeleteDelay(), TimeUnit.SECONDS);
-        break;
+        return PollingStrategies.initialDelay(strategy, conf.getPollDeleteDelay(), TimeUnit.SECONDS);
     }
+    LOG.warn("Received a request to get the polling strategy for unexpected cluster status {}", cluster.getStatus());
     return strategy;
   }
 

--- a/cdap-runtime-ext-dataproc/src/main/resources/gce-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gce-dataproc.json
@@ -220,6 +220,47 @@
           }
         }
       ]
+    },
+    {
+      "label": "Polling Settings",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Create Poll Delay",
+          "name": "pollCreateDelay",
+          "description": "The number of seconds to wait after creating a cluster to begin polling to see if it has been created",
+          "widget-attributes": {
+            "default": "60"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Create Poll Jitter",
+          "name": "pollCreateJitter",
+          "description": "Maximum amount of jitter in seconds to add to the delay for polling for cluster creation",
+          "widget-attributes": {
+            "default": "20"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Delete Poll Delay",
+          "name": "pollDeleteDelay",
+          "description": "The number of seconds to wait after deleting a cluster to begin polling to see if it has been deleted",
+          "widget-attributes": {
+            "default": "30"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Poll Interval",
+          "name": "pollInterval",
+          "description": "The number of seconds to wait in between polls for cluster status during create and delete operations",
+          "widget-attributes": {
+            "default": "2"
+          }
+        }
+      ]
     }
   ]
 }

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/PollingStrategies.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/PollingStrategies.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.runtime.spi.provisioner;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Some common {@link PollingStrategy PollingStrategies}
+ */
+public class PollingStrategies {
+
+  /**
+   * Return a {@link PollingStrategy} that polls at a fixed interval.
+   *
+   * @param duration time to wait in between polls
+   * @param timeUnit time unit of the wait
+   * @return fixed interval polling strategy
+   */
+  public static PollingStrategy fixedInterval(long duration, TimeUnit timeUnit) {
+    return (numPolls, startTime) -> timeUnit.toMillis(duration);
+  }
+
+  /**
+   * A {@link PollingStrategy} that will wait for a specified amount of time before performing the first poll.
+   * Every subsequent poll will be determined by the specified polling strategy.
+   *
+   * @param strategy polling strategy to use after the first poll
+   * @param duration time to wait before the first poll
+   * @param timeUnit time unit of the wait
+   * @return a polling strategy that has an initial delay added in
+   */
+  public static PollingStrategy initialDelay(PollingStrategy strategy, long duration, TimeUnit timeUnit) {
+    return (numPolls, startTime) -> {
+      if (numPolls == 0) {
+        return timeUnit.toMillis(duration);
+      }
+      return strategy.nextPoll(numPolls - 1, startTime);
+    };
+  }
+
+  /**
+   * A {@link PollingStrategy} that will wait for a specified base amount of time plus some random jitter time
+   * before performing the first poll. Every subsequent poll will be determined by the specified polling strategy.
+   *
+   * @param strategy polling strategy to use after the first poll
+   * @param baseDuration wait at least this amount of time before the first poll
+   * @param jitterDuration maximum jitter time to add to the base duration
+   * @param timeUnit time unit of the wait
+   * @return a polling strategy that has a random amount of initial delay added in
+   */
+  public static PollingStrategy initialDelay(PollingStrategy strategy, long baseDuration, long jitterDuration,
+                                             TimeUnit timeUnit) {
+    return (numPolls, startTime) -> {
+      if (numPolls == 0) {
+        return timeUnit.toMillis((long) (baseDuration + Math.random() * jitterDuration));
+      }
+      return strategy.nextPoll(numPolls - 1, startTime);
+    };
+  }
+}

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/PollingStrategy.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/PollingStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.runtime.spi.provisioner;
+
+/**
+ * Defines how CDAP should poll for cluster status while waiting for a cluster to change state.
+ * For example, if it takes at least two minutes to create a cluster,
+ * a provisioner can use a strategy where it first waits two minutes, then polls every ten seconds.
+ * See {@link PollingStrategies} for some common strategies.
+ */
+public interface PollingStrategy {
+
+  /**
+   * Return the number of milliseconds to wait before the next poll, given the time that polling began, and the number
+   * of polls already attempted. Returning 0 or less means the next poll will be tried immediately.
+   *
+   * @param numPolls the number of times the status was polled already. Starts at 0.
+   * @param startTime the timestamp in milliseconds that polling began.
+   * @return the number of milliseconds to wait before the next poll
+   */
+  long nextPoll(int numPolls, long startTime);
+
+}

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
@@ -108,7 +108,8 @@ public interface Provisioner {
   void deleteCluster(ProvisionerContext context, Cluster cluster) throws Exception;
 
   /**
-   * Get the {@link PollingStrategy} to use when polling for cluster creation or deletion.
+   * Get the {@link PollingStrategy} to use when polling for cluster creation or deletion. The cluster status is
+   * guaranteed to be {@link ClusterStatus#CREATING} or {@link ClusterStatus#DELETING}.
    *
    * @param context provisioner context
    * @param cluster the cluster to poll status for

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
@@ -107,4 +107,12 @@ public interface Provisioner {
    */
   void deleteCluster(ProvisionerContext context, Cluster cluster) throws Exception;
 
+  /**
+   * Get the {@link PollingStrategy} to use when polling for cluster creation or deletion.
+   *
+   * @param context provisioner context
+   * @param cluster the cluster to poll status for
+   */
+  PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster);
+
 }


### PR DESCRIPTION
Add a way for provisioners to specify how to poll for cluster
status for each cluster. The SPI includes some default strategies
for polling at a fixed interval and for polling at a fixed interval
after waiting for an initial amount of time. Modified the dataproc
provision to start polling after 30 seconds after deleting a cluster,
and 40 seconds plus a random jitter (max 20 seconds) after creating
a cluster. After the initial delay, it will poll every 2 seconds.

These times can also be overridden in case somebody needs to adjust
them.