### PR TITLE
CDAP-13721 RunId metadata aggregation only for backward compatibility

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHTTPHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHTTPHandler.java
@@ -56,7 +56,7 @@ import javax.ws.rs.QueryParam;
  * HttpHandler for lineage.
  */
 @Path(Constants.Gateway.API_VERSION_3)
-public class LineageHandler extends AbstractHttpHandler {
+public class LineageHTTPHandler extends AbstractHttpHandler {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .create();
@@ -65,7 +65,7 @@ public class LineageHandler extends AbstractHttpHandler {
   private final FieldLineageAdmin fieldLineageAdmin;
 
   @Inject
-  LineageHandler(LineageAdmin lineageAdmin, FieldLineageAdmin fieldLineageAdmin) {
+  LineageHTTPHandler(LineageAdmin lineageAdmin, FieldLineageAdmin fieldLineageAdmin) {
     this.lineageAdmin = lineageAdmin;
     this.fieldLineageAdmin = fieldLineageAdmin;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -106,10 +106,11 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   @Path("/**/metadata")
   public void getMetadata(HttpRequest request, HttpResponder responder,
                           @QueryParam("scope") String scope, @QueryParam("type") String type,
-                          @QueryParam("showCustom") boolean showCustom)
+                          @QueryParam("showCustom") boolean showCustom,
+                          @DefaultValue("true") @QueryParam("aggregateRun") boolean aggregateRun)
     throws BadRequestException {
     MetadataEntity metadataEntity = getMetadataEntityFromPath(request.uri(), type, "/metadata");
-    Set<MetadataRecordV2> metadata = getMetadata(metadataEntity, scope);
+    Set<MetadataRecordV2> metadata = getMetadata(metadataEntity, scope, aggregateRun);
     if (showCustom) {
       // if user has specified to show custom entity resources then no need to make the result compatible
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(metadata, SET_METADATA_RECORD_V2_TYPE));
@@ -412,10 +413,11 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   }
 
   private Set<MetadataRecordV2> getMetadata(MetadataEntity metadataEntity,
-                                          @Nullable String scope) throws BadRequestException {
+                                            @Nullable String scope, boolean aggregateRun) throws BadRequestException {
     // the lineage admin handles the metadata call for program runs so delegate the call to that
     Set<MetadataRecordV2> metadata;
-    if (metadataEntity.getType().equals(MetadataEntity.PROGRAM_RUN)) {
+    if (aggregateRun && metadataEntity.getType().equals(MetadataEntity.PROGRAM_RUN)) {
+      // CDAP-13721 for backward compatibility we need to support metadata aggregation of runId.
       metadata = lineageAdmin.getMetadataForRun(EntityId.fromMetadataEntity(metadataEntity));
     } else {
       if (scope == null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
@@ -39,7 +39,7 @@ public class MetadataServiceModule extends PrivateModule {
 
     CommonHandlers.add(handlerBinder);
     handlerBinder.addBinding().to(MetadataHttpHandler.class);
-    handlerBinder.addBinding().to(LineageHandler.class);
+    handlerBinder.addBinding().to(LineageHTTPHandler.class);
     expose(Key.get(new TypeLiteral<Set<HttpHandler>>() { }, Names.named(Constants.Metadata.HANDLERS_NAME)));
     bind(MetadataAdmin.class).to(DefaultMetadataAdmin.class);
     expose(MetadataAdmin.class);

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ClientTestsSuite.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ClientTestsSuite.java
@@ -32,7 +32,7 @@ import org.junit.runners.Suite;
   ApplicationClientTestRun.class,
   ArtifactClientTestRun.class,
   DatasetClientTestRun.class,
-  LineageTestRun.class,
+  LineageHttpHandlerTestRun.class,
   MetaClientTestRun.class,
   MetadataHttpHandlerTestRun.class,
   MetricsClientTestRun.class,

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/LineageHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/LineageHttpHandlerTestRun.java
@@ -61,8 +61,8 @@ import javax.annotation.Nullable;
  * Tests lineage recording and query.
  */
 @Category(SlowTests.class)
-public class LineageTestRun extends MetadataTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(LineageTestRun.class);
+public class LineageHttpHandlerTestRun extends MetadataTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(LineageHttpHandlerTestRun.class);
 
   @Test
   public void testFlowLineage() throws Exception {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -35,11 +35,11 @@ import co.cask.cdap.client.app.AllProgramsApp;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.id.Id;
 import co.cask.cdap.common.metadata.MetadataRecord;
 import co.cask.cdap.common.metadata.MetadataRecordV2;
-import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
@@ -58,12 +58,11 @@ import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
-import co.cask.cdap.proto.id.ProfileId;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
-import co.cask.cdap.proto.metadata.MetadataSearchResponseV2;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecordV2;
 import co.cask.common.http.HttpRequest;
@@ -103,6 +102,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   private final ApplicationId application = NamespaceId.DEFAULT.app(AppWithDataset.class.getSimpleName());
   private final ArtifactId artifactId = NamespaceId.DEFAULT.artifact(application.getApplication(), "1.0.0");
   private final ProgramId pingService = application.service("PingService");
+  private final ProgramRunId runId = pingService.run(RunIds.generate());
   private final DatasetId myds = NamespaceId.DEFAULT.dataset("myds");
   private final StreamId mystream = NamespaceId.DEFAULT.stream("mystream");
   private final StreamViewId myview = mystream.view("myview");
@@ -156,6 +156,11 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     addProperties(artifactId, null, BadRequestException.class);
     Map<String, String> artifactProperties = ImmutableMap.of("rKey", "rValue", "rK", "rV");
     addProperties(artifactId, artifactProperties);
+    // should fail because we haven't provided any metadata in the request
+    addProperties(runId, null, BadRequestException.class);
+    Map<String, String> runProperties = ImmutableMap.of("runKey", "runValue", "runK", "runV");
+    addProperties(runId, runProperties);
+
     // retrieve properties and verify
     Map<String, String> properties = getProperties(application, MetadataScope.USER);
     Assert.assertEquals(appProperties, properties);
@@ -169,6 +174,8 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertEquals(viewProperties, properties);
     properties = getProperties(artifactId, MetadataScope.USER);
     Assert.assertEquals(artifactProperties, properties);
+    properties = getProperties(runId, MetadataScope.USER);
+    Assert.assertEquals(runProperties, properties);
 
     // test search for application
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(
@@ -270,6 +277,10 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertEquals(ImmutableMap.of("multiword", multiWordValue), getProperties(mystream, MetadataScope.USER));
     removeProperty(myview, "viewK");
     Assert.assertEquals(ImmutableMap.of("viewKey", "viewValue"), getProperties(myview, MetadataScope.USER));
+    removeProperty(runId, "runK");
+    removeProperty(runId, "runKey");
+    Assert.assertTrue(getProperties(runId, MetadataScope.USER).isEmpty());
+
     // cleanup
     removeProperties(myview);
     removeProperties(application);
@@ -277,12 +288,14 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     removeProperties(myds);
     removeProperties(mystream);
     removeProperties(artifactId);
+    removeProperties(runId);
     Assert.assertTrue(getProperties(application, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getProperties(pingService, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getProperties(myds, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getProperties(mystream, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getProperties(myview, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getProperties(artifactId, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getProperties(runId, MetadataScope.USER).isEmpty());
   }
 
   @Test
@@ -298,6 +311,9 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     addTags(pingService, null, BadRequestException.class);
     Set<String> serviceTags = ImmutableSet.of("sTag", "sT");
     addTags(pingService, serviceTags);
+    addTags(runId, null, BadRequestException.class);
+    Set<String> runTags = ImmutableSet.of("runTag", "runT");
+    addTags(runId, runTags);
     addTags(mystream, null, BadRequestException.class);
     Set<String> streamTags = ImmutableSet.of("stTag", "stT", "Wow-WOW1", "WOW_WOW2");
     addTags(mystream, streamTags);
@@ -316,6 +332,9 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     tags = getTags(pingService, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(serviceTags));
     Assert.assertTrue(serviceTags.containsAll(tags));
+    tags = getTags(runId, MetadataScope.USER);
+    Assert.assertTrue(tags.containsAll(runTags));
+    Assert.assertTrue(runTags.containsAll(tags));
     tags = getTags(myds, MetadataScope.USER);
     Assert.assertTrue(tags.containsAll(datasetTags));
     Assert.assertTrue(datasetTags.containsAll(tags));
@@ -375,6 +394,8 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
     removeTags(pingService);
     Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
+    removeTags(runId);
+    Assert.assertTrue(getTags(runId, MetadataScope.USER).isEmpty());
     removeTag(myds, "dT");
     Assert.assertEquals(ImmutableSet.of("dTag"), getTags(myds, MetadataScope.USER));
     removeTag(mystream, "stT");
@@ -390,12 +411,14 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     // cleanup
     removeTags(application);
     removeTags(pingService);
+    removeTags(runId);
     removeTags(myds);
     removeTags(mystream);
     removeTags(myview);
     removeTags(artifactId);
     Assert.assertTrue(getTags(application, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getTags(pingService, MetadataScope.USER).isEmpty());
+    Assert.assertTrue(getTags(runId, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getTags(myds, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getTags(mystream, MetadataScope.USER).isEmpty());
     Assert.assertTrue(getTags(artifactId, MetadataScope.USER).isEmpty());
@@ -410,6 +433,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     // Add some properties and tags
     Map<String, String> appProperties = ImmutableMap.of("aKey", "aValue");
     Map<String, String> serviceProperties = ImmutableMap.of("sKey", "sValue");
+    Map<String, String> runProperties = ImmutableMap.of("runKey", "runValue");
     Map<String, String> datasetProperties = ImmutableMap.of("dKey", "dValue");
     Map<String, String> streamProperties = ImmutableMap.of("stKey", "stValue");
     Map<String, String> viewProperties = ImmutableMap.of("viewKey", "viewValue");
@@ -417,6 +441,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Map<String, String> fieldProperties = ImmutableMap.of("fKey", "fValue");
     Set<String> appTags = ImmutableSet.of("aTag");
     Set<String> serviceTags = ImmutableSet.of("sTag");
+    Set<String> runTags = ImmutableSet.of("runTag");
     Set<String> datasetTags = ImmutableSet.of("dTag");
     Set<String> streamTags = ImmutableSet.of("stTag");
     Set<String> viewTags = ImmutableSet.of("viewTag");
@@ -424,6 +449,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Set<String> fieldTags = ImmutableSet.of("fTag");
     addProperties(application, appProperties);
     addProperties(pingService, serviceProperties);
+    addProperties(runId, runProperties);
     addProperties(myds, datasetProperties);
     addProperties(mystream, streamProperties);
     addProperties(myview, viewProperties);
@@ -431,6 +457,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     addProperties(fieldEntity, fieldProperties);
     addTags(application, appTags);
     addTags(pingService, serviceTags);
+    addTags(runId, runTags);
     addTags(myds, datasetTags);
     addTags(mystream, streamTags);
     addTags(myview, viewTags);
@@ -452,6 +479,16 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertEquals(pingService, metadata.getEntityId());
     Assert.assertEquals(serviceProperties, metadata.getProperties());
     Assert.assertEquals(serviceTags, metadata.getTags());
+    // verify run metadata we specifically call the getMetadata with MetadataEntity and not the EntityId of the run
+    // so that we get the metadata in new behavior where there is no aggregation for runId metadata. For
+    // aggregated version of test see LineageHttpHandlerTest
+    Set<MetadataRecordV2> runMetadataRecords = getMetadata(runId.toMetadataEntity(), MetadataScope.USER);
+    Assert.assertEquals(1, runMetadataRecords.size());
+    MetadataRecordV2 runMetadata = runMetadataRecords.iterator().next();
+    Assert.assertEquals(MetadataScope.USER, runMetadata.getScope());
+    Assert.assertEquals(runId.toMetadataEntity(), runMetadata.getMetadataEntity());
+    Assert.assertEquals(runProperties, runMetadata.getProperties());
+    Assert.assertEquals(runTags, runMetadata.getTags());
     // verify dataset
     metadataRecords = getMetadata(myds, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
@@ -736,15 +773,15 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       removeCreationTime(getProperties(app, MetadataScope.SYSTEM)));
     Assert.assertEquals(ImmutableSet.of(AllProgramsApp.class.getSimpleName()),
                         getTags(app, MetadataScope.SYSTEM));
-    // verify program system metadata, we now have profile as system metadata for workflow
+    // verify program system metadata
     assertProgramSystemMetadata(app.flow(AllProgramsApp.NoOpFlow.NAME), "Realtime",
-                                AllProgramsApp.NoOpFlow.DESCRIPTION, null);
-    assertProgramSystemMetadata(app.worker(AllProgramsApp.NoOpWorker.NAME), "Realtime", null, null);
-    assertProgramSystemMetadata(app.service(AllProgramsApp.NoOpService.NAME), "Realtime", null, null);
-    assertProgramSystemMetadata(app.mr(AllProgramsApp.NoOpMR.NAME), "Batch", null, null);
-    assertProgramSystemMetadata(app.spark(AllProgramsApp.NoOpSpark.NAME), "Batch", null, null);
+                                AllProgramsApp.NoOpFlow.DESCRIPTION);
+    assertProgramSystemMetadata(app.worker(AllProgramsApp.NoOpWorker.NAME), "Realtime", null);
+    assertProgramSystemMetadata(app.service(AllProgramsApp.NoOpService.NAME), "Realtime", null);
+    assertProgramSystemMetadata(app.mr(AllProgramsApp.NoOpMR.NAME), "Batch", null);
+    assertProgramSystemMetadata(app.spark(AllProgramsApp.NoOpSpark.NAME), "Batch", null);
     assertProgramSystemMetadata(app.workflow(AllProgramsApp.NoOpWorkflow.NAME), "Batch",
-                                AllProgramsApp.NoOpWorkflow.DESCRIPTION, ProfileId.NATIVE);
+                                AllProgramsApp.NoOpWorkflow.DESCRIPTION);
 
     // update dataset properties to add the workflow.local.dataset property to it.
     try {
@@ -951,8 +988,8 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
 
     // Search for multiple target types
     Assert.assertEquals(ImmutableSet.of(
-                          new MetadataSearchResultRecord(datasetId),
-                          new MetadataSearchResultRecord(streamId)
+      new MetadataSearchResultRecord(datasetId),
+      new MetadataSearchResultRecord(streamId)
                         ),
                         searchMetadata(namespace, "utag*",
                                        ImmutableSet.of(
@@ -962,8 +999,8 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
                         ));
 
     Assert.assertEquals(ImmutableSet.of(
-                          new MetadataSearchResultRecord(datasetId),
-                          new MetadataSearchResultRecord(appId)
+      new MetadataSearchResultRecord(datasetId),
+      new MetadataSearchResultRecord(appId)
                         ),
                         searchMetadata(namespace, "utag*",
                                        ImmutableSet.of(
@@ -974,15 +1011,15 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
 
     // Search for all target types
     Assert.assertEquals(ImmutableSet.of(
-                          new MetadataSearchResultRecord(datasetId),
-                          new MetadataSearchResultRecord(appId),
-                          new MetadataSearchResultRecord(streamId)
+      new MetadataSearchResultRecord(datasetId),
+      new MetadataSearchResultRecord(appId),
+      new MetadataSearchResultRecord(streamId)
                         ),
                         searchMetadata(namespace, "utag*", EntityTypeSimpleName.ALL));
     Assert.assertEquals(ImmutableSet.of(
-                          new MetadataSearchResultRecord(datasetId),
-                          new MetadataSearchResultRecord(appId),
-                          new MetadataSearchResultRecord(streamId)
+      new MetadataSearchResultRecord(datasetId),
+      new MetadataSearchResultRecord(appId),
+      new MetadataSearchResultRecord(streamId)
                         ),
                         searchMetadata(namespace, "utag*",
                                        ImmutableSet.of(
@@ -1057,45 +1094,6 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   }
 
   @Test
-  public void testCrossNamespaceSearchMetadata() throws Exception {
-    NamespaceId namespace1 = new NamespaceId("ns1");
-    namespaceClient.create(new NamespaceMeta.Builder().setName(namespace1).build());
-    NamespaceId namespace2 = new NamespaceId("ns2");
-    namespaceClient.create(new NamespaceMeta.Builder().setName(namespace2).build());
-
-    try {
-      appClient.deploy(namespace1, createAppJarFile(AllProgramsApp.class));
-      appClient.deploy(namespace2, createAppJarFile(AllProgramsApp.class));
-
-      // Add metadata to app
-      Map<String, String> props = ImmutableMap.of("key1", "value1");
-      Metadata meta = new Metadata(props, Collections.emptySet());
-      ApplicationId app1Id = namespace1.app(AllProgramsApp.NAME);
-      addProperties(app1Id, props);
-
-      ApplicationId app2Id = namespace2.app(AllProgramsApp.NAME);
-      addProperties(app2Id, props);
-
-      MetadataSearchResponseV2 results = searchMetadata(null, "value*", EnumSet.allOf(EntityTypeSimpleName.class),
-                                                        null, 0, 10, 0, null, false, true);
-
-      Map<MetadataEntity, Metadata> expected = new HashMap<>();
-      expected.put(app1Id.toMetadataEntity(), meta);
-      expected.put(app2Id.toMetadataEntity(), meta);
-
-      Map<MetadataEntity, Metadata> actual = new HashMap<>();
-      Assert.assertEquals(2, results.getResults().size());
-      for (MetadataSearchResultRecordV2 record : results.getResults()) {
-        actual.put(record.getMetadataEntity(), record.getMetadata().get(MetadataScope.USER));
-      }
-      Assert.assertEquals(expected, actual);
-    } finally {
-      namespaceClient.delete(namespace1);
-      namespaceClient.delete(namespace2);
-    }
-  }
-
-  @Test
   public void testSearchMetadataDelete() throws Exception {
     NamespaceId namespace = new NamespaceId("ns1");
     namespaceClient.create(new NamespaceMeta.Builder().setName(namespace).build());
@@ -1127,18 +1125,18 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(datasetInstance)),
                         searchMetadata(namespace, "mydataset"));
     Assert.assertEquals(ImmutableSet.of(
-                          new MetadataSearchResultRecord(app),
-                          new MetadataSearchResultRecord(flow),
-                          new MetadataSearchResultRecord(artifact),
-                          new MetadataSearchResultRecord(service)
+      new MetadataSearchResultRecord(app),
+      new MetadataSearchResultRecord(flow),
+      new MetadataSearchResultRecord(artifact),
+      new MetadataSearchResultRecord(service)
                         ),
                         searchMetadata(namespace, "word*"));
     Assert.assertEquals(ImmutableSet.of(
-                          new MetadataSearchResultRecord(app),
-                          new MetadataSearchResultRecord(flow),
-                          new MetadataSearchResultRecord(stream),
-                          new MetadataSearchResultRecord(datasetInstance),
-                          new MetadataSearchResultRecord(view)
+      new MetadataSearchResultRecord(app),
+      new MetadataSearchResultRecord(flow),
+      new MetadataSearchResultRecord(stream),
+      new MetadataSearchResultRecord(datasetInstance),
+      new MetadataSearchResultRecord(view)
                         ),
                         searchMetadata(namespace, "tag1"));
 
@@ -1187,18 +1185,18 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(datasetInstance)),
                         searchMetadata(namespace, "mydataset"));
     Assert.assertEquals(ImmutableSet.of(
-                          new MetadataSearchResultRecord(app),
-                          new MetadataSearchResultRecord(flow),
-                          new MetadataSearchResultRecord(artifact),
-                          new MetadataSearchResultRecord(service)
+      new MetadataSearchResultRecord(app),
+      new MetadataSearchResultRecord(flow),
+      new MetadataSearchResultRecord(artifact),
+      new MetadataSearchResultRecord(service)
                         ),
                         searchMetadata(namespace, "word*"));
     Assert.assertEquals(ImmutableSet.of(
-                          new MetadataSearchResultRecord(app),
-                          new MetadataSearchResultRecord(flow),
-                          new MetadataSearchResultRecord(stream),
-                          new MetadataSearchResultRecord(datasetInstance),
-                          new MetadataSearchResultRecord(view)
+      new MetadataSearchResultRecord(app),
+      new MetadataSearchResultRecord(flow),
+      new MetadataSearchResultRecord(stream),
+      new MetadataSearchResultRecord(datasetInstance),
+      new MetadataSearchResultRecord(view)
                         ),
                         searchMetadata(namespace, "tag1"));
 
@@ -1479,19 +1477,12 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   }
 
   private void assertProgramSystemMetadata(ProgramId programId, String mode,
-                                           @Nullable String description,
-                                           @Nullable ProfileId profileId) throws Exception {
+                                           @Nullable String description) throws Exception {
     ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
       .put(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, programId.getEntityName())
       .put(AbstractSystemMetadataWriter.VERSION_KEY, ApplicationId.DEFAULT_VERSION);
     if (description != null) {
       properties.put(AbstractSystemMetadataWriter.DESCRIPTION_KEY, description);
-    }
-    if (profileId != null) {
-      properties.put("profile", profileId.toString());
-      // need to wait for the profile id to come up since we are updating it asyncly
-      Tasks.waitFor(profileId.toString(), () -> getProperties(programId, MetadataScope.SYSTEM).get("profile"),
-                    10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     }
     Assert.assertEquals(properties.build(), removeCreationTime(getProperties(programId, MetadataScope.SYSTEM)));
     Set<String> expected = ImmutableSet.of(programId.getType().getPrettyName(), mode);
@@ -1762,11 +1753,11 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
 
     ImmutableSet<MetadataSearchResultRecord> expectedExplorableDatasets =
       ImmutableSet.<MetadataSearchResultRecord>builder()
-      .addAll(expectedKvTables)
-      .add(new MetadataSearchResultRecord(datasetInstance4))
-      .add(new MetadataSearchResultRecord(datasetInstance5))
-      .add(new MetadataSearchResultRecord(dsWithSchema))
-      .build();
+        .addAll(expectedKvTables)
+        .add(new MetadataSearchResultRecord(datasetInstance4))
+        .add(new MetadataSearchResultRecord(datasetInstance5))
+        .add(new MetadataSearchResultRecord(dsWithSchema))
+        .build();
     ImmutableSet<MetadataSearchResultRecord> expectedAllDatasets = ImmutableSet.<MetadataSearchResultRecord>builder()
       .addAll(expectedExplorableDatasets)
       .add(new MetadataSearchResultRecord(datasetInstance6))
@@ -1774,10 +1765,10 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       .build();
     ImmutableSet<MetadataSearchResultRecord> expectedExplorables =
       ImmutableSet.<MetadataSearchResultRecord>builder()
-      .addAll(expectedExplorableDatasets)
-      .add(new MetadataSearchResultRecord(streamId))
-      .add(new MetadataSearchResultRecord(mystream))
-      .build();
+        .addAll(expectedExplorableDatasets)
+        .add(new MetadataSearchResultRecord(streamId))
+        .add(new MetadataSearchResultRecord(mystream))
+        .build();
     metadataSearchResultRecords = searchMetadata(NamespaceId.DEFAULT, "explore");
     Assert.assertEquals(expectedExplorables, metadataSearchResultRecords);
     metadataSearchResultRecords = searchMetadata(NamespaceId.DEFAULT, KeyValueTable.class.getName());

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
@@ -244,7 +244,9 @@ public abstract class AbstractMetadataClient {
    */
   public Set<MetadataRecordV2> getMetadata(MetadataEntity metadataEntity, @Nullable MetadataScope scope)
     throws BadRequestException, UnauthenticatedException, IOException, UnauthorizedException {
-    HttpResponse response = getMetadataHelper(metadataEntity, scope, true);
+    // for new getMetadata which takes MetadataEntity we don't want to do any aggregation of metadata for runId
+    // CDAP-13721
+    HttpResponse response = getMetadataHelper(metadataEntity, scope, true, false);
     return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_V2_TYPE);
   }
 
@@ -256,7 +258,9 @@ public abstract class AbstractMetadataClient {
    */
   public Set<MetadataRecord> getMetadata(EntityId entityId, @Nullable MetadataScope scope)
     throws BadRequestException, UnauthenticatedException, IOException, UnauthorizedException {
-    HttpResponse response = getMetadataHelper(entityId.toMetadataEntity(), scope, false);
+    // for old getMetadata which takes EntityId we want to do any aggregation of metadata for runId for backward
+    // compatibility CDAP-13721
+    HttpResponse response = getMetadataHelper(entityId.toMetadataEntity(), scope, false, true);
     return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
   }
 
@@ -271,10 +275,10 @@ public abstract class AbstractMetadataClient {
   }
 
   private HttpResponse getMetadataHelper(MetadataEntity metadataEntity, @Nullable MetadataScope scope,
-                                         boolean includeCustom)
+                                         boolean includeCustom, boolean aggregateRun)
     throws IOException, UnauthenticatedException, BadRequestException {
     String path = String.format("%s/metadata", constructPath(metadataEntity));
-    path = addQueryParas(path, metadataEntity, scope, includeCustom);
+    path = addQueryParams(path, metadataEntity, scope, includeCustom, aggregateRun);
     return makeRequest(path, HttpMethod.GET, null);
   }
 
@@ -339,7 +343,7 @@ public abstract class AbstractMetadataClient {
   public Set<String> getTags(MetadataEntity metadataEntity, @Nullable MetadataScope scope)
     throws BadRequestException, UnauthenticatedException, IOException, UnauthorizedException, NotFoundException {
     String path = String.format("%s/metadata/tags", constructPath(metadataEntity));
-    path = addQueryParas(path, metadataEntity, scope, true);
+    path = addQueryParams(path, metadataEntity, scope, true);
     HttpResponse response = makeRequest(path, HttpMethod.GET, null);
     return GSON.fromJson(response.getResponseBodyAsString(), SET_STRING_TYPE);
   }
@@ -369,7 +373,7 @@ public abstract class AbstractMetadataClient {
   public void addTags(MetadataEntity metadataEntity, Set<String> tags) throws BadRequestException,
     UnauthenticatedException, IOException, UnauthorizedException {
     String path = String.format("%s/metadata/tags", constructPath(metadataEntity));
-    path = addQueryParas(path, metadataEntity, null, false);
+    path = addQueryParams(path, metadataEntity, null, false);
     makeRequest(path, HttpMethod.POST, GSON.toJson(tags));
   }
 
@@ -424,7 +428,7 @@ public abstract class AbstractMetadataClient {
   public Map<String, String> getProperties(MetadataEntity metadataEntity, @Nullable MetadataScope scope)
     throws IOException, UnauthenticatedException, BadRequestException, UnauthorizedException {
     String path = String.format("%s/metadata/properties", constructPath(metadataEntity));
-    path = addQueryParas(path, metadataEntity, scope, false);
+    path = addQueryParams(path, metadataEntity, scope, false);
     HttpResponse response = makeRequest(path, HttpMethod.GET, null);
     return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
   }
@@ -438,7 +442,7 @@ public abstract class AbstractMetadataClient {
   public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties)
     throws IOException, UnauthenticatedException, BadRequestException, UnauthorizedException {
     String path = String.format("%s/metadata/properties", constructPath(metadataEntity));
-    path = addQueryParas(path, metadataEntity, null, false);
+    path = addQueryParams(path, metadataEntity, null, false);
     makeRequest(path, HttpMethod.POST, GSON.toJson(properties));
   }
 
@@ -451,7 +455,7 @@ public abstract class AbstractMetadataClient {
   public void removeProperty(MetadataEntity metadataEntity, String propertyToRemove)
     throws IOException, UnauthenticatedException, BadRequestException, UnauthorizedException {
     String path = String.format("%s/metadata/properties/%s", constructPath(metadataEntity), propertyToRemove);
-    path = addQueryParas(path, metadataEntity, null, false);
+    path = addQueryParams(path, metadataEntity, null, false);
     makeRequest(path, HttpMethod.DELETE, null);
   }
 
@@ -463,7 +467,7 @@ public abstract class AbstractMetadataClient {
   public void removeProperties(MetadataEntity metadataEntity)
     throws IOException, UnauthenticatedException, BadRequestException, UnauthorizedException {
     String path = String.format("%s/metadata/properties", constructPath(metadataEntity));
-    path = addQueryParas(path, metadataEntity, null, false);
+    path = addQueryParams(path, metadataEntity, null, false);
     makeRequest(path, HttpMethod.DELETE, null);
   }
 
@@ -475,7 +479,7 @@ public abstract class AbstractMetadataClient {
   public void removeTag(MetadataEntity metadataEntity, String tagToRemove)
     throws IOException, UnauthenticatedException, BadRequestException, UnauthorizedException {
     String path = String.format("%s/metadata/tags/%s", constructPath(metadataEntity), tagToRemove);
-    path = addQueryParas(path, metadataEntity, null, false);
+    path = addQueryParams(path, metadataEntity, null, false);
     makeRequest(path, HttpMethod.DELETE, null);
   }
 
@@ -487,7 +491,7 @@ public abstract class AbstractMetadataClient {
   public void removeTags(MetadataEntity metadataEntity)
     throws IOException, UnauthenticatedException, BadRequestException, UnauthorizedException {
     String path = String.format("%s/metadata/tags", constructPath(metadataEntity));
-    path = addQueryParas(path, metadataEntity, null, false);
+    path = addQueryParams(path, metadataEntity, null, false);
     makeRequest(path, HttpMethod.DELETE, null);
   }
 
@@ -499,7 +503,7 @@ public abstract class AbstractMetadataClient {
   public void removeMetadata(MetadataEntity metadataEntity) throws IOException, UnauthenticatedException,
     BadRequestException, UnauthorizedException {
     String path = String.format("%s/metadata", constructPath(metadataEntity));
-    path = addQueryParas(path, metadataEntity, null, false);
+    path = addQueryParams(path, metadataEntity, null, false);
     makeRequest(path, HttpMethod.DELETE, null);
   }
 
@@ -536,8 +540,15 @@ public abstract class AbstractMetadataClient {
     return builder.toString();
   }
 
-  private String addQueryParas(String path, MetadataEntity metadataEntity, @Nullable  MetadataScope scope,
-                               boolean showCustom) {
+  private String addQueryParams(String path, MetadataEntity metadataEntity, @Nullable  MetadataScope scope,
+                                boolean showCustom) {
+    // for all other queries except getMetadata called on EntityId we don't want aggregation of metadata for runIds.
+    // CDAP-13721
+    return addQueryParams(path, metadataEntity, scope, showCustom, false);
+  }
+
+  private String addQueryParams(String path, MetadataEntity metadataEntity, @Nullable  MetadataScope scope,
+                                boolean showCustom, boolean aggregateRun) {
     StringBuilder builder = new StringBuilder(path);
     String prefix = "?";
     if (!Iterables.getLast(metadataEntity.getKeys()).equalsIgnoreCase(metadataEntity.getType())) {
@@ -551,6 +562,13 @@ public abstract class AbstractMetadataClient {
       builder.append(prefix);
       builder.append("showCustom=");
       builder.append(true);
+      prefix = "&";
+    }
+    // the default value of aggregateRun is true so in the case it is false we need to include it as query param
+    if (!aggregateRun) {
+      builder.append(prefix);
+      builder.append("aggregateRun=");
+      builder.append(false);
       prefix = "&";
     }
     if (scope == null) {


### PR DESCRIPTION
## Summary
### Background
- Before CDAP 5.0 metadata for RunId behaved differently than all other EntityIds.
- For RunId we only supported getMetadata calls. There was no support for adding tags, properties directly to the runId or retrieving the metadata directly associated with it.
- Before 5.0 the getMetadata on runIds used to aggregate all the metadata associated with all the entities (app, programs, dataset, streams) associated with that run and return that to the caller.
- This API was added years ago and we are not sure what was the use case which it was going to serve.
- As of now, there is no consumer of this API in either CDAP or Tracker so we have decided to deprecate this API and make runIds behave like an other entity in CDAP for consistency unless there is specific use case not to.
### Changes
- This PR introduces a query parameter called `runAggregation` for getMetadata API whose default value is `true` and as the name depicts if this query parameter is not provided by default the getMetadata API will perform aggregation for runId for backward compatibility.
- A user who wishes to retrieve metadata directly associated with the runId (as now tags and properties can be added to runId since runId behaves just like any other entity) can explicitly set this query parameter to false.
- The new behavior can also be used through MetadataClient.getMetadata which takes MetadataEntity (5.0 representation of entities for Metadata) the old EntityId based api behaves in backward compatible mode and does the aggregation. 
- Added unit test in MetadataHttpHandlerTestRun for the new behavior. The old behavior has existing unit tests.

## Misc
- [Issue](https://issues.cask.co/browse/CDAP-13721)
- [ ] Build: https://builds.cask.co/browse/CDAP-RUT1541-1