### PR TITLE
remove deprecated sdk commands

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -83,7 +83,6 @@ case ${1} in
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   version) shift; cdap_version_command ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
-  sdk) shift; echo "[WARN] sdk commands are deprecated, please use sandbox commands instead.">&2; cdap_sdk ${@}; __ret=${?} ;;
   sandbox) shift; cdap_sdk ${@}; __ret=${?} ;;
   setup) shift; cdap_setup ${@}; __ret=${?} ;;
   debug) shift; cdap_debug ${@}; __ret=${?} ;;

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -54,36 +54,12 @@ cd "%CDAP_HOME%"
 
 REM Process command line
 IF "%1" == "cli" GOTO CLI
-IF "%1" == "sdk" ( 
-ECHO [WARN] sdk commands are deprecated, please use sandbox commands instead. 
-GOTO SDK )
 IF "%1" == "sandbox" GOTO SDK 
 IF "%1" == "tx-debugger" GOTO TX_DEBUGGER
 IF "%1" == "apply-pack" GOTO APPLY_PACK
 IF "%1" == "version" GOTO VERSION
-REM Process deprecated SDK arguments
-IF "%1" == "start" GOTO SDK_DEPRECATED
-IF "%1" == "stop" GOTO SDK_DEPRECATED
-IF "%1" == "restart" GOTO SDK_DEPRECATED
-IF "%1" == "status" GOTO SDK_DEPRECATED
-IF "%1" == "reset" GOTO SDK_DEPRECATED
 REM Everything else gets usage
 GOTO USAGE
-
-:SDK_DEPRECATED
-REM Process deprecated SDK arguments
-ECHO:
-ECHO [WARN] %0 is deprecated and will be removed in CDAP 5.0. Please use 'cdap sandbox' for the CDAP command line.
-ECHO:
-ECHO   cdap sandbox %*
-ECHO:
-ECHO:
-IF "%1" == "start" GOTO SDK_START
-IF "%1" == "stop" GOTO SDK_STOP
-IF "%1" == "restart" GOTO SDK_RESTART
-IF "%1" == "status" GOTO SDK_STATUS
-IF "%1" == "reset" GOTO SDK_RESET
-GOTO SDK_USAGE
 
 :SDK
 REM Process SDK arguments


### PR DESCRIPTION
- [x] removes the deprecated ``cdap sdk`` commands from the init scripts.  Previously, it would throw up a deprecation notice instructing you to use ``cdap sandbox`` instead.  Now, the ``cdap`` script will show usage

fixes https://issues.cask.co/browse/CDAP-12584

![screen shot 2018-07-16 at 4 17 31 pm](https://user-images.githubusercontent.com/1816517/42788324-c863e256-8913-11e8-9de7-d533b1156a0e.png)

