### PR TITLE
CDAP-13673 use fileset instead of partitioned fileset for connectors

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
@@ -20,8 +20,7 @@ import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.app.ApplicationConfigurer;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
-import co.cask.cdap.api.dataset.lib.PartitionFilter;
-import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.lineage.field.Operation;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.metrics.Metrics;
@@ -497,9 +496,8 @@ public class SmartWorkflow extends AbstractWorkflow {
     for (Map.Entry<String, AlertPublisher> alertPublisherEntry : alertPublishers.entrySet()) {
       String name = alertPublisherEntry.getKey();
       AlertPublisher alertPublisher = alertPublisherEntry.getValue();
-      PartitionedFileSet alertConnector = workflowContext.getDataset(name);
-      try (CloseableIterator<Alert> alerts =
-             new AlertReader(alertConnector.getPartitions(PartitionFilter.ALWAYS_MATCH))) {
+      FileSet alertConnector = workflowContext.getDataset(name);
+      try (CloseableIterator<Alert> alerts = new AlertReader(alertConnector)) {
         if (!alerts.hasNext()) {
           continue;
         }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/connector/ConnectorSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/connector/ConnectorSink.java
@@ -17,10 +17,10 @@
 package co.cask.cdap.etl.batch.connector;
 
 import co.cask.cdap.api.data.batch.Output;
-import co.cask.cdap.api.dataset.lib.PartitionKey;
-import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.FileSetArguments;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.common.Constants;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
 
@@ -53,10 +53,9 @@ public abstract class ConnectorSink<T> extends BatchSink<T, NullWritable, Text> 
   }
 
   @Override
-  public void prepareRun(BatchSinkContext context) throws Exception {
+  public void prepareRun(BatchSinkContext context) {
     Map<String, String> arguments = new HashMap<>();
-    PartitionKey outputPartition = PartitionKey.builder().addStringField("phase", phaseName).build();
-    PartitionedFileSetArguments.setOutputPartitionKey(arguments, outputPartition);
+    FileSetArguments.setOutputPath(arguments, Constants.Connector.DATA_DIR + "/" + phaseName);
     context.addOutput(Output.ofDataset(datasetName, arguments));
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
@@ -54,6 +54,7 @@ public final class Constants {
     public static final String TYPE = "type";
     public static final String SOURCE_TYPE = "source";
     public static final String SINK_TYPE = "sink";
+    public static final String DATA_DIR = "data";
   }
 
   /**

--- a/cdap-common/src/test/java/co/cask/cdap/common/io/LocationsTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/io/LocationsTest.java
@@ -35,7 +35,57 @@ public class LocationsTest {
   private static final String TEST_PATH = "some/test/path";
 
   @Test
-  public void absolutePathTests() throws IOException {
+  public void testParentHDFS() {
+    Configuration conf = new Configuration();
+    conf.set("fs.defaultFS", "hdfs://1.2.3.4:8020");
+    LocationFactory locationFactory = new FileContextLocationFactory(conf, "abc");
+    Location location = locationFactory.create("def");
+    Assert.assertEquals("def", location.getName());
+    location = Locations.getParent(location);
+    Assert.assertNotNull(location);
+    Assert.assertEquals("abc", location.getName());
+    location = Locations.getParent(location);
+    Assert.assertNotNull(location);
+    Assert.assertTrue(Locations.isRoot(location));
+    Assert.assertTrue(location.getName().isEmpty());
+    Assert.assertNull(Locations.getParent(location));
+  }
+
+  @Test
+  public void testRootParentFile() {
+    Configuration conf = new Configuration();
+    conf.set("fs.defaultFS", "file:///");
+    LocationFactory locationFactory = new FileContextLocationFactory(conf, "abc");
+    Location location = locationFactory.create("def");
+    Assert.assertEquals("def", location.getName());
+    location = Locations.getParent(location);
+    Assert.assertNotNull(location);
+    Assert.assertEquals("abc", location.getName());
+    location = Locations.getParent(location);
+    Assert.assertNotNull(location);
+    Assert.assertTrue(Locations.isRoot(location));
+    Assert.assertTrue(location.getName().isEmpty());
+    Assert.assertNull(Locations.getParent(location));
+  }
+
+  @Test
+  public void testRootParentLocal() throws IOException {
+    LocationFactory locationFactory = new LocalLocationFactory(new File(File.separator));
+    Location location = locationFactory.create("abc");
+    location = location.append("def");
+    Assert.assertEquals("def", location.getName());
+    location = Locations.getParent(location);
+    Assert.assertNotNull(location);
+    Assert.assertEquals("abc", location.getName());
+    location = Locations.getParent(location);
+    Assert.assertNotNull(location);
+    Assert.assertTrue(Locations.isRoot(location));
+    Assert.assertTrue(location.getName().isEmpty());
+    Assert.assertNull(Locations.getParent(location));
+  }
+
+  @Test
+  public void absolutePathTests() {
     // Test HDFS:
     Configuration conf = new Configuration();
     conf.set("fs.defaultFS", "hdfs://1.2.3.4:8020/");

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetAdmin.java
@@ -94,10 +94,10 @@ public class FileSetAdmin implements DatasetAdmin, Updatable {
       }
 
       // we can't simply mkdirs() the base location, because we need to set the group id on
-      // every directory we create. Thus find the first ancestor of the base that does not exist:
+      // every directory we create. Thus find the first ancestor of the base that does not exist
       Location ancestor = baseLocation;
       Location firstDirToCreate = null;
-      while (ancestor != null && !ancestor.exists()) {
+      while (ancestor != null && (Locations.isRoot(ancestor) || !ancestor.exists())) {
         firstDirToCreate = ancestor;
         ancestor = Locations.getParent(ancestor);
       }


### PR DESCRIPTION
Changing to use fileset to remove the usage of a Table. This will
allow pipelines that use connectors to work in cloud environments

Also fixing a bug in FileSetAdmin and Locations, where it would
recursively check for parents of the fileset location. In cloud
environments, this would go all the way up to the root location
and result in an exception because there would be no path in the
location URI. Instead, changing FileSetAdmin to stop the recursive
parent lookup when it gets to one level above the root directory.