### PR TITLE
CDAP-13594 Ignore the received field lineage message if any errors while persisting it to the field lineage dataset.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
@@ -279,8 +279,20 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
 
     @Override
     public void processMessage(MetadataMessage message) {
-      FieldLineageInfo info = message.getPayload(GSON, FieldLineageInfo.class);
+      if (!(message.getEntityId() instanceof ProgramRunId)) {
+        LOG.warn("Missing program run id from the field lineage information. Ignoring the message {}", message);
+        return;
+      }
+
       ProgramRunId programRunId = (ProgramRunId) message.getEntityId();
+      FieldLineageInfo info;
+      try {
+        info = message.getPayload(GSON, FieldLineageInfo.class);
+      } catch (Throwable t) {
+        LOG.warn("Error while deserializing the field lineage information message received from TMS. Ignoring : {}",
+                 message, t);
+        return;
+      }
       fieldLineageDataset.addFieldLineageInfo(programRunId, info);
     }
   }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13594
Skip the message received from TMS for field lineage if any errors while persisting it to the dataset to avoid getting stuck into the error loop.