### PR TITLE
CDAP-13742 fix report list size inconsistency when reports are expired

### DIFF
--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/util/Constants.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/util/Constants.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.report.util;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Constants used by the report generation app and file schema.
  */
@@ -96,5 +98,13 @@ public final class Constants {
       public static final String SUSPENDED = "SUSPENDED";
       public static final String RESUMING = "RESUMING";
     }
+  }
+  /**
+   * Constants related to report generation and expiration
+   */
+  public static final class Report {
+    // report files will expire after 48 hours after they are generated
+    public static final String DEFAULT_REPORT_EXPIRY_TIME_SECONDS = String.valueOf(TimeUnit.DAYS.toSeconds(2));
+    public static final String REPORT_EXPIRY_TIME_SECONDS = "report.expiry.duration.seconds";
   }
 }


### PR DESCRIPTION
we skip reports which has past the expiry time. however when we return the reportList response, we are also including the expired reports for the total (count of reports) field. this fixes that bug and also adds a test case to check expiration changes.

