### PR TITLE
Bugfix/docs sdk to sandbox

### DIFF
--- a/cdap-docs/developer-manual/source/getting-started/sandbox/docker.rst
+++ b/cdap-docs/developer-manual/source/getting-started/sandbox/docker.rst
@@ -109,7 +109,7 @@ started correctly.
    <debugging-sandbox>`, name it ``cdap-sandbox-debugging``, and set the proxying of ports.
 
 #. CDAP will start automatically once the container starts. CDAP’s software
-   directory is under ``/opt/cdap/sdk``.
+   directory is under ``/opt/cdap/sandbox``.
 
 #. Once CDAP starts, it will instruct you to connect to the CDAP UI with a web browser
    at :cdap-ui:`http://localhost:11011/ <>`.
@@ -184,8 +184,8 @@ Options Starting CDAP Containers
   <https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume>`__.
   However, if you mount a host directory, you must make sure that it exists and that
   permissions are set correctly. You pass such a directory using ``-v
-  /my/own/datadir:/opt/cdap/sdk/my/own/datadir``, which mounts the ``/my/own/datadir`` from the
-  host system as ``/opt/cdap/sdk/my/own/datadir`` in the container.
+  /my/own/datadir:/opt/cdap/sandbox/my/own/datadir``, which mounts the ``/my/own/datadir`` from the
+  host system as ``/opt/cdap/sandbox/my/own/datadir`` in the container.
 
 Controlling the CDAP Instance
 -----------------------------

--- a/cdap-docs/developer-manual/source/getting-started/sandbox/docker.rst
+++ b/cdap-docs/developer-manual/source/getting-started/sandbox/docker.rst
@@ -103,7 +103,7 @@ started correctly.
      :languages: console,shell-session
      :keepslashes:
 
-     $ docker run -it --name cdap-sandbox-debugging -p 11011:11011 -p 11015:11015 caskdata/cdap-sandbox:|release| cdap sandbox start --enable-debug
+     $ docker run -it --name cdap-sandbox-debugging -p 11011:11011 -p 11015:11015 caskdata/cdap-sandbox:|release| cdap sandbox start --enable-debug --foreground
 
    This will start the container (in the foreground, the default), :ref:`enable debugging
    <debugging-sandbox>`, name it ``cdap-sandbox-debugging``, and set the proxying of ports.
@@ -154,17 +154,6 @@ Options Starting CDAP Containers
 
     $ docker run -it --name cdap-cli --rm caskdata/cdap-sandbox cdap cli -u http://${CDAP_HOST}:11015
 
-- Use the CDAP CLI in its own container (*cdap-cli*), against the above *cdap-sandbox* container using container linking:
-
-  .. tabbed-parsed-literal::
-    :tabs: "Linux or Mac OS X",Windows
-    :mapping: linux,windows
-    :dependent: linux-windows
-    :languages: console,shell-session
-    :keepslashes:
-
-    $ docker run -it --link cdap-sandbox:sdk --name cdap-cli --rm caskdata/cdap-sandbox sh -c 'exec cdap cli -u http://${SDK_PORT_11011_TCP_ADDR}:${SDK_PORT_11011_TCP_PORT}'
-
 - Starting the CDAP Sandbox, in the foreground, with ports forwarded:
 
   .. tabbed-parsed-literal::
@@ -174,7 +163,7 @@ Options Starting CDAP Containers
     :languages: console,shell-session
     :keepslashes:
 
-    $ docker run -it -p 11015:11015 -p 11011:11011 --name cdap-sandbox caskdata/cdap-sandbox cdap sandbox start
+    $ docker run -it -p 11015:11015 -p 11011:11011 --name cdap-sandbox caskdata/cdap-sandbox cdap sandbox start --foreground
 
 - Starting the CDAP Sandbox, in the foreground, with ports forwarded, and with debugging enabled:
 
@@ -185,7 +174,7 @@ Options Starting CDAP Containers
     :languages: console,shell-session
     :keepslashes:
 
-    $ docker run -it -p 11015:11015 -p 11011:11011 --name cdap-sandbox caskdata/cdap-sandbox cdap sandbox start --enable-debug
+    $ docker run -it -p 11015:11015 -p 11011:11011 --name cdap-sandbox caskdata/cdap-sandbox cdap sandbox start --enable-debug --foreground
 
 - For information on mounting volumes and sharing data with the container, see the
   examples in Docker's documentation on `data volumes

--- a/cdap-docs/developer-manual/source/getting-started/sandbox/virtual-machine.rst
+++ b/cdap-docs/developer-manual/source/getting-started/sandbox/virtual-machine.rst
@@ -26,7 +26,7 @@ The CDAP Sandbox Virtual Machine is configured with the recommended settings for
 
 It has pre-installed all the software that you need to run and develop CDAP applications:
 
-- The CDAP Sandbox is installed under ``/opt/cdap/sdk``
+- The CDAP Sandbox is installed under ``/opt/cdap/sandbox``
   and will automatically start when the virtual machine starts.
 - A Java JDK is installed.
 - Maven is installed and configured to work for CDAP.
@@ -76,15 +76,15 @@ remove software, the admin user and password are both ``cdap``.
 Starting and Stopping CDAP Sandbox
 ========================================
 
-Use the ``cdap`` script (located in ``/opt/cdap/sdk/bin``) to start and stop the CDAP Sandbox:
+Use the ``cdap`` script (located in ``/opt/cdap/sandbox/bin``) to start and stop the CDAP Sandbox:
 
 .. tabbed-parsed-literal::
    :tabs: "Linux Virtual Machine"
    :independent:
 
-   $ /opt/cdap/sdk/bin/cdap sandbox start
+   $ /opt/cdap/sandbox/bin/cdap sandbox start
      . . .
-   $ /opt/cdap/sdk/bin/cdap sandbox stop
+   $ /opt/cdap/sandbox/bin/cdap sandbox stop
 
 Note that starting CDAP is not necessary if you use the Virtual Machine, as it
 starts the CDAP Sandbox automatically on startup.


### PR DESCRIPTION
- [x] update references to the install path of the vm/docker image to `sandbox`, from `sdk`.
- [x] add `--foreground` flag to docker commands where needed (otherwise container exits)
- [x] remove the linking example as that is [deprecated](https://docs.docker.com/network/links/) 