### PR TITLE
CDAP-13371 add versions endpoint to get client versions

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/VersionHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/VersionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,51 +16,56 @@
 
 package co.cask.cdap.gateway.handlers;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.gateway.handlers.util.VersionHelper;
+import co.cask.cdap.proto.ClientVersion;
 import co.cask.cdap.proto.Version;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
-import com.google.common.io.Resources;
 import com.google.gson.Gson;
+import com.google.inject.Inject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 /**
  * Handles version requests.
  */
+@Path(Constants.Gateway.API_VERSION_3)
 public class VersionHandler extends AbstractHttpHandler {
 
-  private static final Logger LOG = LoggerFactory.getLogger(VersionHandler.class);
   private static final Gson GSON = new Gson();
 
-  private final String version;
+  private final List<ClientVersion> versions;
 
-  public VersionHandler() {
-    this.version = determineVersion();
+  @Inject
+  public VersionHandler(CConfiguration cConf) {
+    this.versions = determineVersions(cConf);
   }
 
-  @Path(Constants.Gateway.API_VERSION_3 + "/version")
+  @Path("/version")
   @GET
   public void version(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder) {
-    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(new Version(version)));
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(new Version(versions.get(0).getVersion())));
   }
 
-  private String determineVersion() {
-    try {
-      String version = Resources.toString(Resources.getResource("VERSION"), StandardCharsets.UTF_8);
-      if (!version.equals("${project.version}")) {
-        return version.trim();
-      }
-    } catch (IOException e) {
-      LOG.warn("Failed to determine current version", e);
-    }
-    return "unknown";
+  @Path("/versions")
+  @GET
+  public void versions(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder) {
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(versions));
+  }
+
+  private List<ClientVersion> determineVersions(CConfiguration cConf) {
+    List<ClientVersion> versions = new ArrayList<>();
+    versions.add(VersionHelper.getCDAPVersion());
+    versions.add(VersionHelper.getSparkVersion(cConf));
+    versions.add(VersionHelper.getZooKeeperVersion());
+    versions.add(VersionHelper.getHadoopVersion());
+    return versions;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/VersionHelper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/VersionHelper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.util;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.internal.app.spark.SparkCompatReader;
+import co.cask.cdap.proto.ClientVersion;
+import com.google.common.io.Resources;
+import org.apache.hadoop.util.VersionInfo;
+import org.apache.zookeeper.version.Info;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Util class to determine version of clients CDAP is using
+ */
+public class VersionHelper {
+  private static final Logger LOG = LoggerFactory.getLogger(VersionHelper.class);
+
+  private VersionHelper() {
+  }
+
+  public static ClientVersion getCDAPVersion() {
+    try {
+      String version = Resources.toString(Resources.getResource("VERSION"), StandardCharsets.UTF_8);
+      if (!version.equals("${project.version}")) {
+        return new ClientVersion("cdap", version.trim());
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to determine current version", e);
+    }
+    return new ClientVersion("cdap", "unknown");
+  }
+
+  public static ClientVersion getHadoopVersion() {
+    return new ClientVersion("hadoop", VersionInfo.getVersion());
+  }
+
+  public static ClientVersion getZooKeeperVersion() {
+    return new ClientVersion("zookeeper",
+                             String.format("%d.%d.%d.%d", Info.MAJOR, Info.MINOR, Info.MICRO, Info.REVISION));
+  }
+
+  public static ClientVersion getSparkVersion(CConfiguration cConf) {
+    return new ClientVersion("sparkcompat", SparkCompatReader.get(cConf).getCompat());
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ClientVersions.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ClientVersions.java
@@ -18,9 +18,8 @@ package co.cask.cdap.data.runtime.main;
 
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.util.hbase.HBaseVersion;
-import org.apache.hadoop.util.VersionInfo;
+import co.cask.cdap.gateway.handlers.util.VersionHelper;
 import org.apache.kafka.clients.KafkaClient;
-import org.apache.zookeeper.version.Info;
 
 import java.net.URL;
 import java.util.regex.Matcher;
@@ -47,7 +46,7 @@ public class ClientVersions {
 
 
   public static String getHadoopVersion() {
-    return VersionInfo.getVersion();
+    return VersionHelper.getHadoopVersion().getVersion();
   }
 
   public static String getHBaseVersion() {
@@ -55,7 +54,7 @@ public class ClientVersions {
   }
 
   public static String getZooKeeperVersion() {
-    return String.format("%d.%d.%d.%d", Info.MAJOR, Info.MINOR, Info.MICRO, Info.REVISION);
+    return VersionHelper.getZooKeeperVersion().getVersion();
   }
 
   public static String getKafkaVersion() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ClientVersion.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ClientVersion.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto;
+
+/**
+ * Represents the client version.
+ */
+public class ClientVersion extends Version {
+  private final String name;
+
+  public ClientVersion(String name, String version) {
+    super(version);
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13371
Build: https://builds.cask.co/browse/CDAP-RUT1549-1

Adding a new /v3/versions endpoint to return the client versions of CDAP so that the UI can use it to get the sparkcompat version. Based on that, it can disallow enabling of MMDS and Ops dashboard since these apps are not compatible with spark 1.