### PR TITLE
CDAP-13708

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2340,7 +2340,7 @@
     <name>app.program.runtime.monitor.polltime.ms</name>
     <value>2000</value>
     <description>
-      Polling time in millis to poll updates from a runtime
+      Polling time in milliseconds to poll updates from a runtime
     </description>
   </property>
 
@@ -2348,7 +2348,7 @@
     <name>app.program.runtime.monitor.batch.limit</name>
     <value>1000</value>
     <description>
-      Number of events to fetch from a runtime in each poll call.
+      Number of events to fetch from a runtime in each poll call
     </description>
   </property>
 
@@ -2356,7 +2356,7 @@
     <name>app.program.runtime.monitor.topics.configs</name>
     <value>audit.topic,data.event.topic,metadata.messaging.topic,metrics.topic.prefix:${metrics.messaging.topic.num},program.status.event.topic</value>
     <description>
-      A comma-separated list of topics config to be monitored by runtime monitor.
+      A comma-separated list of topic config to be monitored by runtime monitor
     </description>
     <final>true</final>
   </property>
@@ -2373,7 +2373,7 @@
     <name>app.program.runtime.monitor.server.port</name>
     <value>443</value>
     <description>
-      CDAP Runtime monitor server bind port
+      CDAP Runtime monitor server port
     </description>
   </property>
 
@@ -3678,7 +3678,7 @@
     <name>program.heartbeat.interval.seconds</name>
     <value>1800</value>
     <description>
-      Interval of heartbeat sent from program while its running, default 30 minutes
+      Interval of heartbeat sent from program while it's running, default 30 minutes
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="9c2f70f9103808bd36cb512770f0ee85"
+DEFAULT_XML_MD5_HASH="38e8321d98bc04fddaaede3c7b110758"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
This includes changes to the description requested in caskdata/cm_csd#193

Most of this is cosmetic but the property `app.program.runtime.monitor.server.port` needs to be reviewed. It was updated in the following PR and we need to validate that it's a server port over a bind port. 
https://github.com/caskdata/cdap/commit/f1b4096e9bef740937e6b0b17be93aa1e3715aff#diff-d2f273e30d51501da90e3f8cea5929e0R2375