### PR TITLE
CDAP-13290 use avro for storing reports output

### DIFF
--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/ReportGenerationSpark.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/ReportGenerationSpark.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.spark.AbstractExtendedSpark;
 import co.cask.cdap.api.spark.service.AbstractSparkHttpServiceHandler;
 import co.cask.cdap.api.spark.service.SparkHttpServiceContext;
 import co.cask.cdap.api.spark.service.SparkHttpServiceHandler;
+import co.cask.cdap.report.main.ProgramRunInfoSerializer;
 import co.cask.cdap.report.main.SparkPersistRunRecordMain;
 import co.cask.cdap.report.proto.Filter;
 import co.cask.cdap.report.proto.FilterDeserializer;
@@ -48,6 +49,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.sql.SQLContext;
 import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.Location;
@@ -680,27 +684,26 @@ public class ReportGenerationSpark extends AbstractExtendedSpark {
           return;
       }
       List<String> reportRecords = new ArrayList<>();
-      long lineCount = 0;
+      long recordCount = 0;
       Location reportDir = reportIdDir.append(LocationName.REPORT_DIR);
       // TODO: [CDAP-13290] reports should be in avro format instead of json text;
       // TODO: [CDAP-13291] need to support reading multiple report files
-      Optional<Location> reportFile = reportDir.list().stream().filter(l -> l.getName().endsWith(".json")).findFirst();
+      Optional<Location> reportFile = reportDir.list().stream().filter(l -> l.getName().endsWith(".avro")).findFirst();
       // TODO: [CDAP-13292] use cache to store content of the reports
       // Read the report file and add lines starting from the position of offset to the result until the result reaches
       // the limit
       if (reportFile.isPresent()) {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(reportFile.get().getInputStream(),
-                                                                          StandardCharsets.UTF_8))) {
-          String line;
-          while ((line = br.readLine()) != null) {
-            // skip lines before the offset
-            if (lineCount++ < offset) {
-              continue;
-            }
-            if (reportRecords.size() == limit) {
-              break;
-            }
-            reportRecords.add(line);
+        Location reportFileLocation = reportFile.get();
+        DataFileStream<GenericRecord> dataFileStream =
+          new DataFileStream<>(reportFileLocation.getInputStream(), new GenericDatumReader<>());
+        while (dataFileStream.hasNext()) {
+          GenericRecord record = dataFileStream.next();
+          if (recordCount++ < offset) {
+            continue;
+          }
+          reportRecords.add(record.toString());
+          if (reportRecords.size() >= limit) {
+            break;
           }
         }
       }

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/scala/co/cask/cdap/report/ReportGenerationHelper.scala
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/scala/co/cask/cdap/report/ReportGenerationHelper.scala
@@ -130,9 +130,11 @@ object ReportGenerationHelper {
     // Writing the DataFrame to JSON files requires a non-existing directory to write report files.
     // Create a non-existing directory location with name ReportSparkHandler.REPORT_DIR
     val reportDir = reportIdDir.append(Constants.LocationName.REPORT_DIR).toURI.toString
-    // TODO: [CDAP-13290] output reports as avro instead of json text files
     // TODO: [CDAP-13291] improve how the number of partitions is configured
-    resultDf.coalesce(1).write.option("timestampFormat", "yyyy/MM/dd HH:mm:ss ZZ").json(reportDir)
+    // by default spart sql uses snappy compression codec, set it to uncompressed
+    sql.setConf("spark.sql.avro.compression.codec", "uncompressed")
+    resultDf.coalesce(1).write.option("timestampFormat",
+      "yyyy/MM/dd HH:mm:ss ZZ").format("com.databricks.spark.avro").save(reportDir)
     val count = resultDf.count
     // Create a _COUNT file and write the total number of report records in it
     writeToFile(count.toString, Constants.LocationName.COUNT_FILE, reportIdDir)


### PR DESCRIPTION
use AVRO format instead of writing the reports in JSON format. 
Since spark sql avro uses snappy for compression which requires additional dependencies, we set disable compression.
related changes in handler while reading the reports.