### PR TITLE
[CDAP-13694] Fixes System compute profiles count showing 0 when accordion is closed

### DIFF
--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
@@ -25,7 +25,7 @@ import ProfilesStore from 'components/Cloud/Profiles/Store';
 import {importProfile} from 'components/Cloud/Profiles/Store/ActionCreator';
 import {connect, Provider} from 'react-redux';
 import {Label, Input} from 'reactstrap';
-import {getProfiles} from 'components/Cloud/Profiles/Store/ActionCreator';
+import {getProfiles, resetProfiles} from 'components/Cloud/Profiles/Store/ActionCreator';
 require('./SystemProfilesAccordion.scss');
 
 const PREFIX = 'features.Administration.Accordions.SystemProfiles';
@@ -40,6 +40,10 @@ class SystemProfilesAccordion extends Component {
 
   componentDidMount() {
     getProfiles('system');
+  }
+
+  componentWillUnmount() {
+    resetProfiles();
   }
 
   renderLabel() {

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -33,8 +33,7 @@ import {
   getDefaultProfile,
   setDefaultProfile,
   extractProfileName,
-  getProfileNameWithScope,
-  resetProfiles
+  getProfileNameWithScope
 } from 'components/Cloud/Profiles/Store/ActionCreator';
 import {connect, Provider} from 'react-redux';
 import Alert from 'components/Alert';
@@ -130,10 +129,6 @@ class ProfilesListView extends Component {
     getProfiles(this.props.namespace);
     getDefaultProfile(this.props.namespace);
     this.getProvisioners();
-  }
-
-  componentWillUnmount() {
-    resetProfiles();
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13694

The root problem was that when we clicked on a different accordion pane, or closed the System Compute Profiles pane, we unmounted the `ProfilesListView` component, which would reset the profiles store. However, we get the count on the accordion pane label from the store, so the count goes to 0 when the store is reset.

My solution here is to reset the profiles store on mounting instead of unmounting the profiles list view component. We still need to reset the store, as we might see the wrong profiles list when navigating from namespace detail to admin page, and vice versa.