### PR TITLE
CDAP-13800 fix - read from current time for future schedules

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandler.java
@@ -114,7 +114,7 @@ public class OperationsDashboardHttpHandler extends AbstractAppFabricHttpHandler
     // if the end time is in the future, also add scheduled program runs to the result
     long currentTimeInSeconds = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
     // if start time in query is earlier than current time, use currentTime as start when querying future schedules
-    long scheduleStartTimeSeconds = startTimeSecs > currentTimeInSeconds  ? startTimeSecs : currentTimeInSeconds;
+    long scheduleStartTimeSeconds = startTimeSecs > currentTimeInSeconds ? startTimeSecs : currentTimeInSeconds;
     if (endTimeSecs > currentTimeInSeconds) {
       // end time is exclusive
       result.addAll(getAllScheduledRuns(namespaceIds, scheduleStartTimeSeconds, endTimeSecs + 1));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -303,8 +303,7 @@ public final class TimeScheduler {
    * @param program program to fetch the next runtime.
    * @param programType type of program.
    * @param startTimeSecs the start of the time range in seconds (inclusive, i.e. scheduled time larger or
-   *                      equal to the start will be returned) If this is earlier than the current time,
-   *                      only scheduled runs later than the current time will be returned.
+   *                      equal to the start will be returned)
    * @param endTimeSecs the end of the time range in seconds (exclusive, i.e. scheduled time smaller than the end
    *                    will be returned)
    * @return list of scheduled runtimes for the program. Empty list if there are no schedules

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeSchedulerService.java
@@ -111,8 +111,7 @@ public interface TimeSchedulerService extends Service {
    * @param program program to fetch the next runtime.
    * @param programType type of program.
    * @param startTimeSecs the start of the time range in seconds (inclusive, i.e. scheduled time larger or
-   *                      equal to the start will be returned) If this is earlier than the current time,
-   *                      only scheduled runs later than the current time will be returned.
+   *                      equal to the start will be returned)
    * @param endTimeSecs the end of the time range in seconds (exclusive, i.e. scheduled time smaller than the end
    *                    will be returned)
    * @return list of scheduled runtimes for the program. Empty list if there are no schedules


### PR DESCRIPTION
`Quartz.Trigger#getFireTimeAfter(time)` does not provide any API guarantee that if the parameter `time `is earlier than system current time, it will provide always provide scheduled time after current time.

However we had this incorrect assumption  that it will return schedules after current time and due to that SDK was returning scheduled runs for older time range before current time. 

This fixes that, in dashboard handler, if current time is later than the start time in query, we will use current time as the starting time range when looking for future schedules.

we had coverage in the test case, however quartz doesn't provide the schedules in the past for those queries (strange),  however in SDK we noticed issues as documented in the JIRA. 
