### PR TITLE
CDAP-13614 fix bug with multiple deprovisioning notifications

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -428,8 +428,13 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
           }
         });
       case DEPROVISIONING:
-        appMetadataStore.recordProgramDeprovisioning(programRunId, messageIdBytes);
-        return Optional.of(provisioningService.deprovision(programRunId, datasetContext));
+        RunRecordMeta recordedMeta = appMetadataStore.recordProgramDeprovisioning(programRunId, messageIdBytes);
+        // If we skipped recording the run status, that means this was a duplicate message,
+        // or an invalid state transition. In both cases, we should not try to deprovision the cluster.
+        if (recordedMeta != null) {
+          return Optional.of(provisioningService.deprovision(programRunId, datasetContext));
+        }
+        break;
       case DEPROVISIONED:
         appMetadataStore.recordProgramDeprovisioned(programRunId, endTs, messageIdBytes);
         break;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -879,6 +879,11 @@ public class AppMetadataStore extends MetadataStoreDataset {
                 nextProgramState, nextClusterState);
       return false;
     }
+    // sometimes we expect duplicate messages. For example, multiple KILLED messages are sent, one by the CDAP master
+    // and one by the program. In these cases, we don't need to write, but we don't want to log a warning
+    if (existing.getStatus() == nextProgramState && existing.getCluster().getStatus() == nextClusterState) {
+      return false;
+    }
     if (!existing.getStatus().canTransitionTo(nextProgramState)) {
       LOG.warn("Ignoring unexpected transition of program run {} from run state {} to {}.",
                existing.getProgramRunId(), existing.getStatus(), nextProgramState);


### PR DESCRIPTION
The root cause was that we were double writing run state if the
multiple run state messages were sent. When a program is killed,
the CDAP master sends a killed message and so does the program.
Both of these would trigger a deprovisioning message, and the
second message would cause errors because a deprovisioning task
had already run.

Fixing by avoiding the run state double write.