### PR TITLE
[CDAP-13799] fix error with collapsing runs list by run id

### DIFF
--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/DataParser.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/DataParser.js
@@ -15,8 +15,8 @@
  */
 
 import moment from 'moment';
-import uniqBy from 'lodash/uniqBy';
 import {DAY_IN_SEC} from 'components/OpsDashboard/store/ActionCreator';
+import uniqWith from 'lodash/uniqWith';
 
 export function parseDashboardData(rawData, startTime, duration, pipeline, customApp) {
   let {
@@ -100,7 +100,9 @@ export function parseDashboardData(rawData, startTime, duration, pipeline, custo
   });
 
   timeArray.forEach((time) => {
-    buckets[time].runsList = uniqBy(buckets[time].runsList, 'run');
+    buckets[time].runsList = uniqWith(buckets[time].runsList, (a, b) => {
+      return (a.run && b.run) && (a.run === b.run);
+    });
   });
 
   let data = Object.keys(buckets).map((time) => {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13799


Fix:
- Before we are just checking for the uniqueness of the runId. However for future scheduled runs, the runId does not exist, so all of the record gets collapsed. So the fix is to check for existence for the runId first, then check if the runId is the same.