### PR TITLE
Fix docs build

### DIFF
--- a/cdap-docs/developer-manual/build.sh
+++ b/cdap-docs/developer-manual/build.sh
@@ -73,7 +73,7 @@ function download_includes() {
   download_readme_file_and_test ${includes_dir} ${ingest_url} cf2d8cac45b4be267adbb0e8ecdc88a4 cdap-flume
   download_readme_file_and_test ${includes_dir} ${ingest_url} a852e493aff54ffd726368691f248d80 cdap-stream-clients/java
   download_readme_file_and_test ${includes_dir} ${ingest_url} da242d9be7051417bd5ff73b3dc5edc2 cdap-stream-clients/python
-  download_readme_file_and_test ${includes_dir} ${ingest_url} b798091f24f6ecfe05d614f1dd1f7a03 cdap-stream-clients/ruby
+  download_readme_file_and_test ${includes_dir} ${ingest_url} 4475514acbba0a5f32a61d5c13c30fdb cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"
 


### PR DESCRIPTION
Fixing the following failure 
```

19-Jul-2018 22:21:54 | WARNING: cdap-stream-clients-ruby.rst has changed! Compare files and update hash!
-- | --
19-Jul-2018 22:21:54 | file: /var/bamboo/xml-data/build-dir/CDAP-DBT33-BCD/cdap/cdap-docs/developer-manual/target/_includes/cdap-stream-clients-ruby.rst
19-Jul-2018 22:21:54 | Old MD5 Hash: b798091f24f6ecfe05d614f1dd1f7a03 New MD5 Hash: 4475514acbba0a5f32a61d5c13c30fdb
```
