### PR TITLE
CDAP-13817 Improve message processing resiliency

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractNotificationSubscriberService.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.TxConstants;
 
 /**
  * Abstract class that fetches notifications from TMS
@@ -55,7 +56,9 @@ public abstract class AbstractNotificationSubscriberService extends AbstractMess
                                                   MessagingService messagingService,
                                                   DatasetFramework datasetFramework, TransactionSystemClient txClient,
                                                   MetricsCollectionService metricsCollectionService) {
-    super(NamespaceId.SYSTEM.topic(topicName), transactionalFetch, fetchSize, emptyFetchDelayMillis,
+    super(NamespaceId.SYSTEM.topic(topicName), transactionalFetch, fetchSize,
+          cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT),
+          emptyFetchDelayMillis,
           RetryStrategies.fromConfiguration(cConf, "system.notification."),
           metricsCollectionService.getContext(ImmutableMap.of(
             Constants.Metrics.Tag.COMPONENT, Constants.Service.MASTER_SERVICES,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataMessageProcessor.java
@@ -29,13 +29,4 @@ public interface MetadataMessageProcessor {
    */
   void processMessage(MetadataMessage message);
 
-  /**
-   * Determine if processing this message takes a long time
-   *
-   * @param message the message to be processed
-   * @return a boolean variable which indicates if the processing time is long
-   */
-  default boolean isTimeConsumingMessage(MetadataMessage message) {
-    return false;
-  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
@@ -51,6 +51,7 @@ import co.cask.cdap.metadata.profile.ProfileMetadataMessageProcessor;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.codec.OperationTypeAdapter;
+import co.cask.cdap.proto.element.EntityType;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -62,6 +63,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.TxConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,6 +105,7 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
     super(
       NamespaceId.SYSTEM.topic(cConf.get(Constants.Metadata.MESSAGING_TOPIC)),
       true, cConf.getInt(Constants.Metadata.MESSAGING_FETCH_SIZE),
+      cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT),
       cConf.getLong(Constants.Metadata.MESSAGING_POLL_DELAY_MILLIS),
       RetryStrategies.fromConfiguration(cConf, "system.metadata."),
       metricsCollectionService.getContext(ImmutableMap.of(
@@ -182,6 +185,12 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
   }
 
   @Override
+  protected boolean shouldRunInSeparateTx(MetadataMessage message) {
+    EntityType entityType = message.getEntityId().getEntityType();
+    return entityType.equals(EntityType.INSTANCE) || entityType.equals(EntityType.NAMESPACE);
+  }
+
+  @Override
   protected void processMessages(DatasetContext datasetContext,
                                  Iterator<ImmutablePair<String, MetadataMessage>> messages) {
     Map<MetadataMessage.Type, MetadataMessageProcessor> processors = new HashMap<>();
@@ -223,11 +232,6 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
       }
 
       processor.processMessage(message);
-
-      // if this message is time consuming, return to end the transaction to avoid tx timeout
-      if (processor.isTimeConsumingMessage(message)) {
-        return;
-      }
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -52,11 +52,9 @@ import co.cask.cdap.proto.id.WorkflowId;
 import co.cask.cdap.store.NamespaceMDS;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -106,12 +104,6 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
         // This shouldn't happen
         LOG.warn("Unknown message type for profile metadata update. Ignoring the message {}", message);
     }
-  }
-
-  @Override
-  public boolean isTimeConsumingMessage(MetadataMessage message) {
-    EntityType entityType = message.getEntityId().getEntityType();
-    return entityType.equals(EntityType.INSTANCE) || entityType.equals(EntityType.NAMESPACE);
   }
 
   private void updateProfileMetadata(EntityId entityId, MetadataMessage message) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeBoundIterator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeBoundIterator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.common.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.AbstractIterator;
+
+import java.util.Iterator;
+
+/**
+ * An iterator that will act as if there are no more elements if a certain amount of time has passed, or there actually
+ * are no more elements.
+ *
+ * @param <T> type of element in the iterator
+ */
+public class TimeBoundIterator<T> extends AbstractIterator<T> {
+  private final Iterator<T> delegate;
+  private final long timeBoundMillis;
+  private final Stopwatch stopwatch;
+
+  public TimeBoundIterator(Iterator<T> delegate, long timeBoundMillis) {
+    this(delegate, timeBoundMillis, new Stopwatch());
+  }
+
+  @VisibleForTesting
+  TimeBoundIterator(Iterator<T> delegate, long timeBoundMillis, Stopwatch stopwatch) {
+    this.delegate = delegate;
+    this.timeBoundMillis = timeBoundMillis;
+    this.stopwatch = stopwatch;
+    this.stopwatch.start();
+  }
+
+  @Override
+  protected T computeNext() {
+    if (stopwatch.elapsedMillis() < timeBoundMillis && delegate.hasNext()) {
+      return delegate.next();
+    }
+    return endOfData();
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/utils/TimeBoundIteratorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/utils/TimeBoundIteratorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.common.utils;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Ticker;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests {@link TimeBoundIterator}
+ */
+public class TimeBoundIteratorTest {
+
+  @Test
+  public void testTimeBoundNotHit() {
+    SettableTicker ticker = new SettableTicker(0);
+    Stopwatch stopwatch = new Stopwatch(ticker);
+
+    List<Integer> list = new ArrayList<>();
+    list.add(0);
+    list.add(1);
+    list.add(2);
+
+    Iterator<Integer> iter = new TimeBoundIterator<>(list.iterator(), Long.MAX_VALUE, stopwatch);
+    Assert.assertTrue(iter.hasNext());
+    Assert.assertEquals(0, (int) iter.next());
+    Assert.assertTrue(iter.hasNext());
+    Assert.assertEquals(1, (int) iter.next());
+    Assert.assertTrue(iter.hasNext());
+    Assert.assertEquals(2, (int) iter.next());
+    Assert.assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void testTimeBoundImmediatelyHit() {
+    SettableTicker ticker = new SettableTicker(0);
+    Stopwatch stopwatch = new Stopwatch(ticker);
+
+    List<Integer> list = new ArrayList<>();
+    list.add(0);
+    list.add(1);
+    list.add(2);
+
+    Iterator<Integer> iter = new TimeBoundIterator<>(list.iterator(), 10, stopwatch);
+    ticker.millis = 10;
+    Assert.assertFalse(iter.hasNext());
+  }
+
+
+  @Test
+  public void testEarlyStop() {
+    SettableTicker ticker = new SettableTicker(0);
+    Stopwatch stopwatch = new Stopwatch(ticker);
+
+    List<Integer> list = new ArrayList<>();
+    list.add(0);
+    list.add(1);
+    list.add(2);
+
+    Iterator<Integer> iter = new TimeBoundIterator<>(list.iterator(), 10, stopwatch);
+    ticker.millis = 9;
+    Assert.assertTrue(iter.hasNext());
+    Assert.assertEquals(0, (int) iter.next());
+    Assert.assertTrue(iter.hasNext());
+    ticker.millis = 10;
+    Assert.assertEquals(1, (int) iter.next());
+    Assert.assertFalse(iter.hasNext());
+  }
+
+  /**
+   * Ticker for unit tests
+   */
+  private static class SettableTicker extends Ticker {
+    private long millis;
+
+    public SettableTicker(long millis) {
+      this.millis = millis;
+    }
+
+    @Override
+    public long read() {
+      return TimeUnit.MILLISECONDS.toNanos(millis);
+    }
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/subscriber/AbstractMessagingSubscriberService.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/subscriber/AbstractMessagingSubscriberService.java
@@ -32,6 +32,7 @@ import co.cask.cdap.common.logging.Loggers;
 import co.cask.cdap.common.service.AbstractRetryableScheduledService;
 import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.common.utils.ImmutablePair;
+import co.cask.cdap.common.utils.TimeBoundIterator;
 import co.cask.cdap.messaging.data.MessageId;
 import co.cask.cdap.proto.id.TopicId;
 import com.google.common.collect.AbstractIterator;
@@ -62,6 +63,7 @@ public abstract class AbstractMessagingSubscriberService<T> extends AbstractRetr
   private final int fetchSize;
   private final long emptyFetchDelayMillis;
   private final MetricsContext metricsContext;
+  private final int txTimeoutSeconds;
   private boolean messageIdInitialized;
   private String messageId;
 
@@ -71,17 +73,19 @@ public abstract class AbstractMessagingSubscriberService<T> extends AbstractRetr
    * @param topicId the topic to consume from
    * @param transactionalFetch {@code true} to indicate fetching from TMS needs to be performed inside transaction
    * @param fetchSize number of messages to fetch in each batch
+   * @param txTimeoutSeconds transaction timeout in seconds to use when processing messages
    * @param emptyFetchDelayMillis number of milliseconds to sleep after a fetch returns empty result
    * @param retryStrategy the {@link RetryStrategy} to determine retry on failure
    * @param metricsContext the {@link MetricsContext} for emitting metrics about the message consumption.
    */
   protected AbstractMessagingSubscriberService(TopicId topicId, boolean transactionalFetch, int fetchSize,
-                                               long emptyFetchDelayMillis, RetryStrategy retryStrategy,
-                                               MetricsContext metricsContext) {
+                                               int txTimeoutSeconds, long emptyFetchDelayMillis,
+                                               RetryStrategy retryStrategy, MetricsContext metricsContext) {
     super(retryStrategy);
     this.topicId = topicId;
     this.transactionalFetch = transactionalFetch;
     this.fetchSize = fetchSize;
+    this.txTimeoutSeconds = txTimeoutSeconds;
     this.emptyFetchDelayMillis = emptyFetchDelayMillis;
     this.metricsContext = metricsContext;
   }
@@ -135,6 +139,16 @@ public abstract class AbstractMessagingSubscriberService<T> extends AbstractRetr
    * @throws Exception if the decode failed and the given message will be skipped for processing
    */
   protected abstract T decodeMessage(Message message) throws Exception;
+
+  /**
+   * Whether the message should run in its own transaction because it is expected to be an expensive operation.
+   *
+   * @param message the message to process
+   * @return whether the message should be processed in its own transaction
+   */
+  protected boolean shouldRunInSeparateTx(T message) {
+    return false;
+  }
 
   /**
    * Processes the give list of messages. This method will be called from the same transaction as the
@@ -214,8 +228,11 @@ public abstract class AbstractMessagingSubscriberService<T> extends AbstractRetr
     startTime = System.currentTimeMillis();
 
     // Process the notifications and record the message id of where the processing is up to.
+    // 90% of the tx timeout is .9 * 1000 * txTimeoutSeconds = 900 * txTimeoutSeconds
+    long timeBoundMillis = 900L * txTimeoutSeconds;
     MessageTrackingIterator iterator = Transactionals.execute(getTransactional(), context -> {
-      MessageTrackingIterator trackingIterator = new MessageTrackingIterator(messages.iterator());
+      TimeBoundIterator<Message> timeBoundMessages = new TimeBoundIterator<>(messages.iterator(), timeBoundMillis);
+      MessageTrackingIterator trackingIterator = new MessageTrackingIterator(timeBoundMessages);
       processMessages(context, trackingIterator);
       String lastMessageId = trackingIterator.getLastMessageId();
 
@@ -287,28 +304,49 @@ public abstract class AbstractMessagingSubscriberService<T> extends AbstractRetr
     private final Iterator<Message> messages;
     private String lastMessageId;
     private int consumedCount;
+    private boolean shouldEnd;
 
     MessageTrackingIterator(Iterator<Message> messages) {
       this.messages = messages;
+      this.consumedCount = 0;
+      this.shouldEnd = false;
     }
 
     @Override
     protected ImmutablePair<String, T> computeNext() {
+      if (shouldEnd) {
+        return endOfData();
+      }
       // Decode the next message into Notification.
       while (messages.hasNext()) {
-        consumedCount++;
         Message message = messages.next();
-        lastMessageId = message.getId();
 
         try {
           T decoded = decodeMessage(message);
-          LOG.trace("Processing message from topic {} with message id {}: {}", topicId, lastMessageId, decoded);
-          return new ImmutablePair<>(lastMessageId, decoded);
+          if (shouldRunInSeparateTx(decoded)) {
+            // if we should process this message in a separate tx and we've already processed other messages,
+            // pretend we've gone through all messages already. The next time we try to process a batch of messages,
+            // this expensive one will be the first message.
+            if (consumedCount > 0) {
+              LOG.debug("Ending message batch early to process {} in a separate tx", decoded);
+              return endOfData();
+            }
+            // if we should process this message in a separate tx and we haven't processed any messages yet,
+            // remember that we should pretend this iterator only had one element in it
+            shouldEnd = true;
+          }
+          LOG.trace("Processing message from topic {} with message id {}: {}", topicId, message.getId(), decoded);
+          consumedCount++;
+          lastMessageId = message.getId();
+          return new ImmutablePair<>(message.getId(), decoded);
         } catch (Exception e) {
           // This shouldn't happen.
           LOG.warn("Failed to decode message with id {} and payload '{}'. Skipped.",
                    message.getId(), message.getPayloadAsString(), e);
         }
+
+        consumedCount++;
+        lastMessageId = message.getId();
       }
       return endOfData();
     }


### PR DESCRIPTION
Adding a couple improvements to how we process messages read from
TMS. The first improvement is to stop processing messages if we
are past 90% of the tx timeout. The second is an improvement on
an earlier optimization that would stop processing messaging in a
batch after processing an expensive message. That approach would
not help in situations where the expensive message was at the end
of the batch. Changed it so that expensive messages are run in
their own transaction.