### PR TITLE
[CDAP-13677] Shows error message from backend when enabling system apps fails

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/DataPrepServiceControl.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/DataPrepServiceControl.scss
@@ -75,7 +75,6 @@ $border-shadow-color: #cccccc;
     width: 80%;
   }
   .dataprep-service-control-error {
-    margin-top: 20px;
     p {
       line-height: 1.8;
     }

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/ExperimentsServiceControl.scss
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/ExperimentsServiceControl.scss
@@ -81,8 +81,7 @@
       }
     }
   }
-  .exepriments-service-control-error {
-    margin-top: 20px;
+  .experiments-service-control-error {
     .icon-svg {
       margin-right: 5px;
     }

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/index.js
@@ -20,6 +20,7 @@ import enableSystemApp from 'services/ServiceEnablerUtilities';
 import LoadingSVG from 'components/LoadingSVG';
 import T from 'i18n-react';
 import IconSVG from 'components/IconSVG';
+import isObject from 'lodash/isObject';
 import {myExperimentsApi} from 'api/experiments';
 import {isSpark2Available} from 'services/CDAPComponentsVersions';
 require('./ExperimentsServiceControl.scss');
@@ -46,7 +47,8 @@ export default class ExperimentsServiceControl extends Component {
     loading: false,
     disabled: false,
     checkingForSpark2: true,
-    error: null
+    error: null,
+    extendedError: null
   };
 
   enableMMDS = () => {
@@ -57,12 +59,17 @@ export default class ExperimentsServiceControl extends Component {
       shouldStopService: false,
       artifactName: MMDSArtifact,
       api: myExperimentsApi,
-      i18nPrefix: ''
+      i18nPrefix: PREFIX
     }).subscribe(
       this.props.onServiceStart,
-      () => {
+      (err) => {
+        let extendedMessage = isObject(err.extendedMessage) ?
+          err.extendedMessage.response || err.extendedMessage.message
+        :
+          err.extendedMessage;
         this.setState({
-          error: T.translate(`${PREFIX}.errorMessage`),
+          error: err.error,
+          extendedError: extendedMessage,
           loading: false
         });
       }
@@ -118,10 +125,10 @@ export default class ExperimentsServiceControl extends Component {
       <div className="experiments-service-control-error">
         <h5 className="text-danger">
           <IconSVG name="icon-exclamation-triangle" />
-          <span>{T.translate(`${PREFIX}.errorTitle`)}</span>
+          <span>{this.state.error}</span>
         </h5>
         <p className="text-danger">
-          {this.state.error}
+          {this.state.extendedError}
         </p>
       </div>
     );

--- a/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/ReportsServiceControl.scss
+++ b/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/ReportsServiceControl.scss
@@ -79,7 +79,6 @@
     }
   }
   .reports-service-control-error {
-    margin-top: 20px;
     .icon-svg {
       margin-right: 5px;
     }

--- a/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/index.js
@@ -22,6 +22,7 @@ import IconSVG from 'components/IconSVG';
 import BtnWithLoading from 'components/BtnWithLoading';
 import T from 'i18n-react';
 import {isSpark2Available} from 'services/CDAPComponentsVersions';
+import isObject from 'lodash/isObject';
 import Helmet from 'react-helmet';
 
 require('./ReportsServiceControl.scss');
@@ -38,7 +39,8 @@ export default class ReportsServiceControl extends Component {
     loading: false,
     disabled: false,
     checkingForSpark2: true,
-    error: null
+    error: null,
+    extendedError: null
   };
 
   componentDidMount() {
@@ -60,12 +62,17 @@ export default class ReportsServiceControl extends Component {
       shouldStopService: false,
       artifactName: ReportsArtifact,
       api: MyReportsApi,
-      i18nPrefix: ''
+      i18nPrefix: PREFIX
     }).subscribe(
       this.props.onServiceStart,
-      () => {
+      (err) => {
+        let extendedMessage = isObject(err.extendedMessage) ?
+          err.extendedMessage.response || err.extendedMessage.message
+        :
+          err.extendedMessage;
         this.setState({
-          error: 'Unable to start Report service',
+          error: err.error,
+          extendedError: extendedMessage,
           loading: false
         });
       }
@@ -114,10 +121,10 @@ export default class ReportsServiceControl extends Component {
       <div className="reports-service-control-error">
         <h5 className="text-danger">
           <IconSVG name="icon-exclamation-triangle" />
-          <span>{T.translate(`${PREFIX}.unableToStart`)}</span>
+          <span>{this.state.error}</span>
         </h5>
         <p className="text-danger">
-          {this.state.error}
+          {this.state.extendedError}
         </p>
       </div>
     );

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/RulesEngineServiceControl.scss
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/RulesEngineServiceControl.scss
@@ -98,7 +98,6 @@ $icon_color: #cccccc;
     }
   }
   .rules-engine-service-control-error {
-    margin-top: 20px;
     .icon-svg {
       margin-right: 5px;
     }

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
@@ -34,7 +34,8 @@ export default class RulesEngineServiceControl extends Component {
 
   state = {
     loading: false,
-    error: null
+    error: null,
+    extendedError: null
   };
 
   enableRulesEngine = () => {
@@ -45,13 +46,14 @@ export default class RulesEngineServiceControl extends Component {
       shouldStopService: false,
       artifactName: RulesEngineArtifact,
       api: MyRuleEngineApi,
-      i18nPrefix: ''
+      i18nPrefix: PREFIX
     })
       .subscribe(
         this.props.onServiceStart,
-        () => {
+        (err) => {
           this.setState({
-            error: T.translate(`${PREFIX}.errorMessage`),
+            error: err.error,
+            extendedError: err.extendedMessage,
             loading: false
           });
         }
@@ -66,10 +68,10 @@ export default class RulesEngineServiceControl extends Component {
       <div className="rules-engine-service-control-error">
         <h5 className="text-danger">
           <IconSVG name="icon-exclamation-triangle" />
-          <span>{T.translate(`${PREFIX}.errorTitle`)}</span>
+          <span>{this.state.error}</span>
         </h5>
         <p className="text-danger">
-          {this.state.error}
+          {this.state.extendedError}
         </p>
       </div>
     );

--- a/cdap-ui/app/cdap/services/ServiceEnablerUtilities.js
+++ b/cdap-ui/app/cdap/services/ServiceEnablerUtilities.js
@@ -47,7 +47,8 @@ export default function enableSystemApp({
 
         if (appArtifact.length === 0) {
           observer.error({
-            error: T.translate('features.ServiceEnableUtility.serviceNotFound', {artifactName})
+            error: T.translate(`${i18nPrefix}.errorTitle`),
+            extendedMessage: T.translate('features.ServiceEnableUtility.serviceNotFound', {artifactName})
           });
           return;
         }
@@ -116,7 +117,7 @@ export default function enableSystemApp({
         startService(observer);
       }, (err) => {
         observer.error({
-          error: 'Failed to enable data preparation',
+          error: T.translate(`${i18nPrefix}.errorTitle`),
           extendedMessage: err.data || err
         });
       });
@@ -130,7 +131,7 @@ export default function enableSystemApp({
         pollServiceStatus(observer);
       }, (err) => {
         observer.error({
-          error: 'Failed to enable data preparation',
+          error: T.translate(`${i18nPrefix}.errorTitle`),
           extendedMessage: err.data || err
         });
       });
@@ -147,7 +148,7 @@ export default function enableSystemApp({
         }
       }, (err) => {
         observer.error({
-          error: 'Failed to enable data preparation',
+          error: T.translate(`${i18nPrefix}.errorTitle`),
           extendedMessage: err.data || err
         });
       });
@@ -169,7 +170,7 @@ export default function enableSystemApp({
           }
 
           observer.error({
-            error: 'Error while communicating with Data Preparation Service',
+            error: T.translate(`${i18nPrefix}.errorCommunicating`),
             extendedMessage: err.data || err
           });
         });
@@ -186,7 +187,7 @@ export default function enableSystemApp({
         pollStopServiceStatus(observer);
       }, (err) => {
         observer.error({
-          error: 'Failed to stop Data Preparation service',
+          error: T.translate(`${i18nPrefix}.failedToStop`),
           extendedMessage: err.data || err
         });
       });
@@ -205,7 +206,7 @@ export default function enableSystemApp({
         }
       }, (err) => {
         observer.error({
-          error: 'Failed to stop Data Preparation service',
+          error: T.translate(`${i18nPrefix}.failedToStop`),
           extendedMessage: err.data || err
         });
       });

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -354,6 +354,9 @@ features:
     btnLabel: Enable Data Preparation
     btnLoadingLabel: "Enabling..."
     description: CDAP Data Preparation provides an easy and interactive way to visualize, transform, and cleanse data. It allows the user to view data from a local source, a cluster or a database, and derive new schemas and operationalize the data preparation with a few clicks.
+    errorCommunicating: Error while communicating with Data Preparation service
+    errorTitle: Enabling Data Preparation failed
+    failedToStop: Failed to stop Data Preparation service
     list:
       1: Easy and interactive way to work with messy data
       2: Apply transformations using a variety of operations on various data types
@@ -1257,7 +1260,6 @@ features:
         1: "{context} experiment"
         _: "{context} experiments"
       numModels: No of models
-
     ServiceControl:
       Benefits:
         b1: Intuitive Web UI for building, training, testing and evaluating machine learning models.
@@ -1269,9 +1271,10 @@ features:
         title: "Some key benefits of MMDS are:"
       description: "Data scientists typically build custom tooling for managing their machine learning models and deploying them. Model Management and Distribution Service (MMDS) provides a seamless, automated interface to help users develop, train, test, evaluate and deploy their machine learning models using CDAP."
       enableBtnLabel: Enable MMDS
+      environmentCheckMessage: Checking for environment before enabling Analytics
+      errorCommunicating: Error while communicating with MMDS service
       errorTitle: Enabling MMDS failed
       errorMessage: Please check logs for more information
-      environmentCheckMessage: Checking for environment before enabling Analytics
       serviceDisabledMessage: Please upgrade to Spark 2.0 or later to use Analytics
       title: Welcome to Model Management and Distribution Service
 
@@ -2112,9 +2115,10 @@ features:
       description: "Reports help users generate historical analysis of programs and pipelines running in their data infrastructure. The primary goal of these reports is to help decision makers and administrators make informed business decisions about resource utilization, capacity planning, and onboarding new processes."
       enable: Enable Reports
       environmentCheckMessage: Checking for environment before enabling Reports
+      errorCommunicating: Error while communicating with Reports service
+      errorTitle: Enabling Reports failed
       serviceDisabledMessage: Please upgrade to Spark 2.0 or later to use Reports
       title: Welcome to Reports
-      unableToStart: Unable to start Reports service
 
   Resource-Center:
     Application:
@@ -2229,8 +2233,8 @@ features:
       description: Business Rules Engine provides an easy way to create and manage a knowledge base that is executable in your big data environment.
                   The intuitive UI allows business analysts to set up business rules and use them within a data pipeline.
       enableBtnLabel: Enable Rules Engine
+      errorCommunicating: Error while communicating with Rules Engine service
       errorTitle: Enabling Rules Engine failed
-      errorMessage: Please check logs for more information
       title: Welcome to Rules Engine Management
     RulesList:
       dropContainerText: Add a rule by dragging and dropping from the Rules tab


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13677

The issue mentioned in the JIRA was because we had duplicate hard-coded text in the Reports service control page. However, the real solution is not to fix the text, but to actually surface the errors from the backend. We are already doing this in Data Prep service control, but not the others. 

Besides surfacing the errors from the backend, we'll also show a generic error message across all the service control pages (`Enabling [systemApp] failed`).