### PR TITLE
CDAP-13780 increase default dataset worker threads

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1058,7 +1058,7 @@
 
   <property>
     <name>dataset.service.worker.threads</name>
-    <value>4</value>
+    <value>10</value>
     <description>
       Number of Netty service worker threads for the dataset service
     </description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="2d366307545eb81c47093b80c3d0dab6"
+DEFAULT_XML_MD5_HASH="b9b59596fc54c3b981d444e1a58465cb"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Other services default to 10 worker threads, changing dataset
service to also default to 10.