### PR TITLE
[CDAP-13761] fix available plugins map key generation

### DIFF
--- a/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
+++ b/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
@@ -87,7 +87,7 @@ class PipelineAvailablePluginsActions {
         pluginInfo: stage.plugin
       };
 
-      pluginsList.push(pluginInfo.info);
+      pluginsList.push(pluginInfo);
     });
 
     this._fetchInfo(availablePluginsMap, namespace, pluginsList);
@@ -145,15 +145,17 @@ class PipelineAvailablePluginsActions {
   }
 
   _fetchInfo(availablePluginsMap, namespace, plugins) {
-    this.api.fetchAllPluginsProperties({ namespace }, plugins)
+    const reqBody = plugins.map((plugin) => plugin.info);
+
+    this.api.fetchAllPluginsProperties({ namespace }, reqBody)
       .$promise
       .then((res) => {
-        res.forEach((plugin) => {
+        res.forEach((plugin, index) => {
           let pluginProperties = Object.keys(plugin.properties);
           if (pluginProperties.length === 0) { return; }
 
           let pluginKey = pluginProperties[0].split('.')[1];
-          let key = `${pluginKey}-${plugin.name}-${plugin.version}-${plugin.scope}`;
+          let key = plugins[index].key;
 
           availablePluginsMap[key].doc = plugin.properties[`doc.${pluginKey}`];
 
@@ -209,7 +211,7 @@ class PipelineAvailablePluginsActions {
           pluginInfo: plugin
         };
 
-        plugins.push(pluginInfo.info);
+        plugins.push(pluginInfo);
       });
     });
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13761

Root cause:
When we initialized the `availablePluginsMap`, we use the version from the plugin list (which in the case of omniture pipeline, it's using version range) to generate the key. When we get the response from the backend, the backend resolved the version to the latest, so when we try to recreate the key to add the info to the `availablePluginsMap`, the key is not found.