### PR TITLE
CDAP-13709 Surface the icon information/data from the json to the UI.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/DefaultProvisionerConfigProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/DefaultProvisionerConfigProvider.java
@@ -41,7 +41,7 @@ import javax.inject.Inject;
 
 /**
  * Default implementation of the ProvsionerConfigProvider. It expects a json file for from each module dir and
- * expects a "configuration-groups" in the json file
+ * expects a "configuration-groups" in the json file. "icon" and "beta" fields are optional.
  */
 public class DefaultProvisionerConfigProvider implements ProvisionerConfigProvider {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultProvisionerConfigProvider.class);
@@ -80,7 +80,7 @@ public class DefaultProvisionerConfigProvider implements ProvisionerConfigProvid
                                  && provisioners.contains(name.substring(0, name.lastIndexOf('.')));
                              });
         if (jsonFiles.isEmpty()) {
-          LOG.info("Not able to find configuration groups file for module {}", moduleDir);
+          LOG.info("Not able to find JSON config file for module {}", moduleDir);
           continue;
         }
 
@@ -90,7 +90,7 @@ public class DefaultProvisionerConfigProvider implements ProvisionerConfigProvid
           try (Reader reader = Files.newReader(configFile, Charsets.UTF_8)) {
             results.put(provisionerName, GSON.fromJson(new JsonReader(reader), ProvisionerConfig.class));
           } catch (Exception e) {
-            LOG.warn("Exception reading configuration groups file for provisioner {}. Ignoring file.",
+            LOG.warn("Exception reading JSON config file for provisioner {}. Ignoring file.",
                      provisionerName, e);
           }
         }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerConfig.java
@@ -20,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Contains the config for the provisioner
@@ -27,13 +28,29 @@ import java.util.Objects;
 public class ProvisionerConfig {
   @SerializedName("configuration-groups")
   private final List<Object> configurationGroups;
+  @SerializedName("icon")
+  private final Object icon;
+  @SerializedName("beta")
+  private final Boolean beta;
 
-  public ProvisionerConfig(List<Object> configurationGroups) {
+  public ProvisionerConfig(List<Object> configurationGroups, @Nullable Object icon, @Nullable Boolean beta) {
     this.configurationGroups = configurationGroups;
+    this.icon = icon;
+    this.beta = beta;
   }
 
   public List<Object> getConfigurationGroups() {
     return configurationGroups;
+  }
+
+  @Nullable
+  public Object getIcon() {
+    return icon;
+  }
+
+  @Nullable
+  public Boolean isBeta() {
+    return beta;
   }
 
   @Override
@@ -46,11 +63,13 @@ public class ProvisionerConfig {
     }
     ProvisionerConfig that = (ProvisionerConfig) o;
 
-    return Objects.equals(configurationGroups, that.configurationGroups);
+    return Objects.equals(configurationGroups, that.configurationGroups) &&
+      Objects.equals(configurationGroups, that.configurationGroups) &&
+      Objects.equals(beta, that.beta);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(configurationGroups);
+    return Objects.hash(configurationGroups, icon, beta);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
@@ -357,9 +357,10 @@ public class ProvisioningService extends AbstractIdleService {
       ProvisionerSpecification spec = provisionerEntry.getValue().getSpec();
       String provisionerName = provisionerEntry.getKey();
       ProvisionerConfig config = provisionerConfigs.getOrDefault(provisionerName,
-                                                                 new ProvisionerConfig(new ArrayList<>()));
+                                                                 new ProvisionerConfig(new ArrayList<>(), null, null));
       details.put(provisionerName, new ProvisionerDetail(spec.getName(), spec.getLabel(), spec.getDescription(),
-                                                         config.getConfigurationGroups()));
+                                                         config.getConfigurationGroups(), config.getIcon(),
+                                                         config.isBeta()));
     }
     provisionerInfo.set(new ProvisionerInfo(provisioners, details));
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProfileHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProfileHttpHandlerTest.java
@@ -162,7 +162,7 @@ public class ProfileHttpHandlerTest extends AppFabricTestBase {
     // if given some unrelated json, it should return a 400 instead of 500
     ProvisionerSpecification spec = new MockProvisioner().getSpec();
     ProvisionerDetail test = new ProvisionerDetail(spec.getName(), spec.getLabel(), spec.getDescription(),
-                                                   new ArrayList<>());
+                                                   new ArrayList<>(), null, null);
     putProfile(NamespaceId.DEFAULT.profile(test.getName()), test, 400);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProvisionerHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProvisionerHttpHandlerTest.java
@@ -44,7 +44,7 @@ public class ProvisionerHttpHandlerTest extends AppFabricTestBase {
     // in unit test, we only have the mock provisioner currently
     ProvisionerSpecification spec = new MockProvisioner().getSpec();
     ProvisionerDetail expected = new ProvisionerDetail(spec.getName(), spec.getLabel(),
-                                                       spec.getDescription(), new ArrayList<>());
+                                                       spec.getDescription(), new ArrayList<>(), null, null);
     List<ProvisionerDetail> details = listProvisioners();
     Assert.assertEquals(ImmutableList.of(expected), details);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
@@ -132,7 +132,7 @@ public class ProvisioningServiceTest {
 
     ProvisionerSpecification spec = new MockProvisioner().getSpec();
     ProvisionerDetail expected = new ProvisionerDetail(spec.getName(), spec.getLabel(),
-                                                       spec.getDescription(), new ArrayList<>());
+                                                       spec.getDescription(), new ArrayList<>(), null, null);
     Assert.assertEquals(expected, specs.iterator().next());
 
     Assert.assertEquals(expected, provisioningService.getProvisionerDetail(MockProvisioner.NAME));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerDetail.java
@@ -20,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * A class which contains the config of a provisioner
@@ -30,12 +31,19 @@ public class ProvisionerDetail {
   private final String description;
   @SerializedName("configuration-groups")
   private final List<Object> configurationGroups;
+  @SerializedName("icon")
+  private final Object icon;
+  @SerializedName("beta")
+  private final Boolean beta;
 
-  public ProvisionerDetail(String name, String label, String description, List<Object> configurationGroups) {
+  public ProvisionerDetail(String name, String label, String description, List<Object> configurationGroups,
+                           @Nullable Object icon, @Nullable Boolean beta) {
     this.name = name;
     this.label = label;
     this.description = description;
     this.configurationGroups = configurationGroups;
+    this.icon = icon;
+    this.beta = beta;
   }
 
   public String getName() {
@@ -48,10 +56,6 @@ public class ProvisionerDetail {
 
   public String getDescription() {
     return description;
-  }
-
-  public List<Object> getConfigurationGroups() {
-    return configurationGroups;
   }
 
   @Override
@@ -67,11 +71,13 @@ public class ProvisionerDetail {
     return Objects.equals(name, that.name) &&
       Objects.equals(label, that.label) &&
       Objects.equals(description, that.description) &&
-      Objects.equals(configurationGroups, that.configurationGroups);
+      Objects.equals(configurationGroups, that.configurationGroups) &&
+      Objects.equals(icon, that.icon) &&
+      Objects.equals(beta, that.beta);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, label, description, configurationGroups);
+    return Objects.hash(name, label, description, configurationGroups, icon, beta);
   }
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-13376
Otherwise, even if you add an icon to the provisioner's json file (like plugins do - https://github.com/caskdata/hydrator-plugins/pull/745/files), it will not get surfaced to the UI.