### PR TITLE
CDAP-13817 double time out for metadata subscriber service if a tx ti…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/Transactionals.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Transactionals.java
@@ -111,6 +111,26 @@ public final class Transactionals {
   }
 
   /**
+   * Executes the given {@link TxCallable} using the given {@link Transactional} with a given timeout in seconds.
+   * @param transactional the {@link Transactional} to use for transactional execution.
+   * @param timeout the timeout in seconds for transactional execution
+   * @param callable the {@link TxCallable} to be executed inside a transaction
+   * @param <V> type of the result
+   * @return value returned by the given {@link TxCallable}.
+   * @throws  RuntimeException if failed to execute the given {@link TxRunnable} in a transaction.
+   * If the TransactionFailureException has a cause in it, the cause is propagated.
+   */
+  public static <V> V execute(Transactional transactional, int timeout, TxCallable<V> callable) {
+    AtomicReference<V> result = new AtomicReference<>();
+    try {
+      transactional.execute(timeout, context -> result.set(callable.call(context)));
+    } catch (TransactionFailureException e) {
+      throw propagate(e);
+    }
+    return result.get();
+  }
+
+  /**
    * Executes the given {@link TxCallable} using the given {@link Transactional}.
    *
    * @param transactional the {@link Transactional} to use for transactional execution.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractNotificationSubscriberService.java
@@ -58,6 +58,7 @@ public abstract class AbstractNotificationSubscriberService extends AbstractMess
                                                   MetricsCollectionService metricsCollectionService) {
     super(NamespaceId.SYSTEM.topic(topicName), transactionalFetch, fetchSize,
           cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT),
+          cConf.getInt(TxConstants.Manager.CFG_TX_MAX_TIMEOUT),
           emptyFetchDelayMillis,
           RetryStrategies.fromConfiguration(cConf, "system.notification."),
           metricsCollectionService.getContext(ImmutableMap.of(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
@@ -106,6 +106,7 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
       NamespaceId.SYSTEM.topic(cConf.get(Constants.Metadata.MESSAGING_TOPIC)),
       true, cConf.getInt(Constants.Metadata.MESSAGING_FETCH_SIZE),
       cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT),
+      cConf.getInt(TxConstants.Manager.CFG_TX_MAX_TIMEOUT),
       cConf.getLong(Constants.Metadata.MESSAGING_POLL_DELAY_MILLIS),
       RetryStrategies.fromConfiguration(cConf, "system.metadata."),
       metricsCollectionService.getContext(ImmutableMap.of(


### PR DESCRIPTION
…mes out

JIRA: https://issues.cask.co/browse/CDAP-13817
Build: https://builds.cask.co/browse/CDAP-RUT1573

Add a new retry strategy for time out and let the MetadataSubcriberService use it for the retry strategy. I tried to add a unit test for the strategy, but our transaction.execute(timeout, runnable) method does not work with time out less than 30 seconds. It works for any time > 30 seconds. So I cannot include a unit test in the pr. Currently doing manual testing on sandbox and cluster