### PR TITLE
CDAP-13709 Fix a regression to MapReduce, when adding the Spark application

### DIFF
--- a/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/EMRClient.java
+++ b/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/EMRClient.java
@@ -82,22 +82,19 @@ public class EMRClient implements AutoCloseable {
    */
   public String createCluster(String name) {
     AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard()
-            .withCredentials(emrConf.getCredentialsProvider())
-            .withRegion(emrConf.getRegion())
-            .build();
+      .withCredentials(emrConf.getCredentialsProvider())
+      .withRegion(emrConf.getRegion())
+      .build();
 
     // name the keypair the same thing as the cluster name
     ec2.importKeyPair(new ImportKeyPairRequest(name, emrConf.getPublicKey().getKey()));
-
-    Map<String, String> yarnConf =
-            Collections.singletonMap("yarn.nodemanager.aux-services", "mapreduce_shuffle,spark_shuffle");
 
     RunJobFlowRequest request = new RunJobFlowRequest()
       .withName(name)
       .withApplications(new Application().withName("Spark"))
       .withConfigurations(new Configuration()
-              .withClassification("yarn-site")
-              .withProperties(yarnConf))
+        .withClassification("yarn-site")
+        .withProperties(Collections.singletonMap("yarn.nodemanager.aux-services", "mapreduce_shuffle,spark_shuffle")))
       // all 4.9.x is java 7... which we don't support, so EMR 5.0.0 is our minimum
       .withReleaseLabel("emr-5.0.0")
       .withServiceRole(emrConf.getServiceRole())
@@ -129,9 +126,9 @@ public class EMRClient implements AutoCloseable {
     client.terminateJobFlows(new TerminateJobFlowsRequest().withJobFlowIds(id));
 
     AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard()
-            .withCredentials(emrConf.getCredentialsProvider())
-            .withRegion(emrConf.getRegion())
-            .build();
+      .withCredentials(emrConf.getCredentialsProvider())
+      .withRegion(emrConf.getRegion())
+      .build();
 
     // named the keypair the same thing as the cluster id
     ec2.deleteKeyPair(new DeleteKeyPairRequest().withKeyName(id));
@@ -175,10 +172,10 @@ public class EMRClient implements AutoCloseable {
     List<ClusterSummary> clusters = client.listClusters().getClusters();
 
     List<ClusterSummary> clustersWithSameName = clusters.stream()
-            .filter(clusterSummary -> name.equals(clusterSummary.getName()))
-            .filter(clusterSummary -> UNTERMINATED_STATES.contains(
-                    ClusterState.fromValue(clusterSummary.getStatus().getState())))
-            .collect(Collectors.toList());
+      .filter(clusterSummary -> name.equals(clusterSummary.getName()))
+      .filter(clusterSummary -> UNTERMINATED_STATES.contains(
+              ClusterState.fromValue(clusterSummary.getStatus().getState())))
+      .collect(Collectors.toList());
 
     if (clustersWithSameName.size() == 0) {
       return Optional.empty();

--- a/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/EMRClient.java
+++ b/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/EMRClient.java
@@ -29,6 +29,7 @@ import com.amazonaws.services.elasticmapreduce.model.Cluster;
 import com.amazonaws.services.elasticmapreduce.model.ClusterState;
 import com.amazonaws.services.elasticmapreduce.model.ClusterStatus;
 import com.amazonaws.services.elasticmapreduce.model.ClusterSummary;
+import com.amazonaws.services.elasticmapreduce.model.Configuration;
 import com.amazonaws.services.elasticmapreduce.model.DescribeClusterRequest;
 import com.amazonaws.services.elasticmapreduce.model.JobFlowInstancesConfig;
 import com.amazonaws.services.elasticmapreduce.model.RunJobFlowRequest;
@@ -88,9 +89,15 @@ public class EMRClient implements AutoCloseable {
     // name the keypair the same thing as the cluster name
     ec2.importKeyPair(new ImportKeyPairRequest(name, emrConf.getPublicKey().getKey()));
 
+    Map<String, String> yarnConf =
+            Collections.singletonMap("yarn.nodemanager.aux-services", "mapreduce_shuffle,spark_shuffle");
+
     RunJobFlowRequest request = new RunJobFlowRequest()
       .withName(name)
       .withApplications(new Application().withName("Spark"))
+      .withConfigurations(new Configuration()
+              .withClassification("yarn-site")
+              .withProperties(yarnConf))
       // all 4.9.x is java 7... which we don't support, so EMR 5.0.0 is our minimum
       .withReleaseLabel("emr-5.0.0")
       .withServiceRole(emrConf.getServiceRole())


### PR DESCRIPTION
CDAP-13709 Fix a regression to MapReduce, when adding the Spark application.

When I added the Spark application to the EMR cluster creation, then MapReduce jobs failed due to:
`InvalidAuxServiceException: The auxService:mapreduce_shuffle does not exist`.
Similar to:
https://stackoverflow.com/questions/49796181/aws-emr-invalidauxserviceexception-the-auxservicemapreduce-shuffle-does-not-ex
https://stackoverflow.com/questions/43478985/aws-emr-s3distcp-the-auxservicemapreduce-shuffle-does-not-exist

This fixes it, so that both Spark and MapReduce work on the same cluster.