### PR TITLE
cdap-13851 bugfix for blacklist filtering

### DIFF
--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/scala/co/cask/cdap/report/ReportGenerationHelper.scala
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/scala/co/cask/cdap/report/ReportGenerationHelper.scala
@@ -302,9 +302,14 @@ object ReportGenerationHelper {
           }
           case valueFilter: ValueFilter[_] => {
             val whitelist = valueFilter.getWhitelist
-            newFilterCol &&= fieldCol.isin(whitelist.stream().collect(Collectors.toList()): _*)
             val blacklist = valueFilter.getBlacklist
-            newFilterCol &&= !fieldCol.isin(blacklist.stream().collect(Collectors.toList()): _*)
+            // only either of whitelist or blacklist can be non empty,
+            // and a value filter will have one of them non empty
+            if (whitelist.size() > 0) {
+              newFilterCol &&= fieldCol.isin(whitelist.stream().collect(Collectors.toList()): _*)
+            } else if (blacklist.size() > 0) {
+              newFilterCol &&= !fieldCol.isin(blacklist.stream().collect(Collectors.toList()): _*)
+            }
             // cast filter.getFieldName to Any to avoid ambiguous method reference error
             LOG.debug("Added ValueFilter {} for field {}", valueFilter, filter.getFieldName: Any)
           }


### PR DESCRIPTION
While filtering on values, only whitelist or blacklist can be non empty, hence while constructing the filter, its important to add only either whitelist or blacklist filter. However currently we were adding both, like below.
```
(
	(
	   isnotnull(artifactName) && artifactName IN ()
	) 
	&& NOT artifactName IN (cdap-data-streams,cdap-data-pipeline)
)
```
the above condition with blacklist filter wouldn't match for any records as the 2nd filter for checking in empty list will always be false. causing the issue with filtering by custom pipelines, as that uses blacklisting of data-pipeline and data-streams artifacts.

code change is to add only the required filter and have test coverage for this.