### PR TITLE
CDAP-13858 always use scoped name for profile metadata

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -222,7 +222,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
   private void setProfileMetadata(NamespacedEntityId entityId, ProfileId profileId) {
     // if we are able to get profile from preferences or schedule properties, use it
     // otherwise default profile will be used
-    metadataDataset.setProperty(entityId.toMetadataEntity(), PROFILE_METADATA_KEY, profileId.toString());
+    metadataDataset.setProperty(entityId.toMetadataEntity(), PROFILE_METADATA_KEY, profileId.getScopedName());
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileMetadataTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileMetadataTest.java
@@ -84,11 +84,11 @@ public class ProfileMetadataTest extends AppFabricTestBase {
     ProgramId programId = defaultAppId.workflow(AppWithSchedule.WORKFLOW_NAME);
 
     // Verify the workflow and schedule has been updated to native profile
-    Tasks.waitFor(ProfileId.NATIVE.toString(), () -> getMetadataProperties(programId).get("profile"),
+    Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(ProfileId.NATIVE.toString(), () -> getMetadataProperties(scheduleId1).get("profile"),
+    Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(ProfileId.NATIVE.toString(), () -> getMetadataProperties(scheduleId2).get("profile"),
+    Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(scheduleId2).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
 
@@ -97,11 +97,11 @@ public class ProfileMetadataTest extends AppFabricTestBase {
                    Collections.singletonMap(SystemArguments.PROFILE_NAME, "USER:MyProfile"), 200);
 
     // Verify the workflow and schedule has been updated to my profile
-    Tasks.waitFor(myProfile.toString(), () -> getMetadataProperties(programId).get("profile"),
+    Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(myProfile.toString(), () -> getMetadataProperties(scheduleId1).get("profile"),
+    Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(myProfile.toString(), () -> getMetadataProperties(scheduleId2).get("profile"),
+    Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(scheduleId2).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
     // set it at app level through preferences
@@ -109,33 +109,33 @@ public class ProfileMetadataTest extends AppFabricTestBase {
                    Collections.singletonMap(SystemArguments.PROFILE_NAME, "USER:MyProfile2"), 200);
 
     // Verify the workflow and schedule has been updated to my profile 2
-    Tasks.waitFor(myProfile2.toString(), () -> getMetadataProperties(programId).get("profile"),
+    Tasks.waitFor(myProfile2.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(myProfile2.toString(), () -> getMetadataProperties(scheduleId1).get("profile"),
+    Tasks.waitFor(myProfile2.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(myProfile2.toString(), () -> getMetadataProperties(scheduleId2).get("profile"),
+    Tasks.waitFor(myProfile2.getScopedName(), () -> getMetadataProperties(scheduleId2).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
     // delete app level pref, metadata should point to ns level
     deletePreferences(getPreferenceURI(TEST_NAMESPACE1, defaultAppId.getApplication()), 200);
 
     // Verify the workflow and schedule has been updated to my profile
-    Tasks.waitFor(myProfile.toString(), () -> getMetadataProperties(programId).get("profile"),
+    Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(myProfile.toString(), () -> getMetadataProperties(scheduleId1).get("profile"),
+    Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(myProfile.toString(), () -> getMetadataProperties(scheduleId2).get("profile"),
+    Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(scheduleId2).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
     // delete at ns level should let the program use native profile since no profile is set at instance level
     deletePreferences(getPreferenceURI(TEST_NAMESPACE1), 200);
 
     // Verify the workflow and schedule has been updated to native profile
-    Tasks.waitFor(ProfileId.NATIVE.toString(), () -> getMetadataProperties(programId).get("profile"),
+    Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(ProfileId.NATIVE.toString(), () -> getMetadataProperties(scheduleId1).get("profile"),
+    Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    Tasks.waitFor(ProfileId.NATIVE.toString(), () -> getMetadataProperties(scheduleId2).get("profile"),
+    Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(scheduleId2).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
     deleteApp(defaultAppId, 200);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataSubscriberServiceTest.java
@@ -440,10 +440,12 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
 
     try {
       // Verify the workflow profile metadata is updated to default profile
-      Tasks.waitFor(ProfileId.NATIVE.toString(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(ProfileId.NATIVE.getScopedName(),
+                    () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
       // Verify the schedule profile metadata is updated to default profile
-      Tasks.waitFor(ProfileId.NATIVE.toString(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(ProfileId.NATIVE.getScopedName(),
+                    () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
 
@@ -452,10 +454,10 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
                                        Collections.singletonMap(SystemArguments.PROFILE_NAME, "USER:MyProfile"));
 
       // Verify the workflow profile metadata is updated to my profile
-      Tasks.waitFor(myProfile.toString(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile.getScopedName(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
       // Verify the schedule profile metadata is updated to my profile
-      Tasks.waitFor(myProfile.toString(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile.getScopedName(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
       // set app level to use my profile 2
@@ -467,40 +469,42 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
                                                                 ProfileId.NATIVE.getScopedName()));
 
       // Verify the workflow profile metadata is updated to MyProfile2 which is at app level
-      Tasks.waitFor(myProfile2.toString(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile2.getScopedName(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
       // Verify the schedule profile metadata is updated to MyProfile2 which is at app level
-      Tasks.waitFor(myProfile2.toString(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile2.getScopedName(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
       // remove the preferences at instance level, should not affect the metadata
       preferencesService.deleteProperties();
 
       // Verify the workflow profile metadata is updated to default profile
-      Tasks.waitFor(myProfile2.toString(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile2.getScopedName(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
       // Verify the schedule profile metadata is updated to default profile
-      Tasks.waitFor(myProfile2.toString(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile2.getScopedName(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
       // remove app level pref should let the programs/schedules use ns level pref
       preferencesService.deleteProperties(appId);
 
       // Verify the workflow profile metadata is updated to MyProfile
-      Tasks.waitFor(myProfile.toString(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile.getScopedName(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
       // Verify the schedule profile metadata is updated to MyProfile
-      Tasks.waitFor(myProfile.toString(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile.getScopedName(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
       // remove ns level pref so no pref is there
       preferencesService.deleteProperties(NamespaceId.DEFAULT);
 
       // Verify the workflow profile metadata is updated to default profile
-      Tasks.waitFor(ProfileId.NATIVE.toString(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(ProfileId.NATIVE.getScopedName(),
+                    () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
       // Verify the schedule profile metadata is updated to default profile
-      Tasks.waitFor(ProfileId.NATIVE.toString(), () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(ProfileId.NATIVE.getScopedName(),
+                    () -> mds.getProperties(scheduleId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     } finally {
       // stop and clean up the store
@@ -552,14 +556,15 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
 
     try {
       // Verify the workflow profile metadata is updated to my profile
-      Tasks.waitFor(myProfile.toString(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(myProfile.getScopedName(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
       // Set the property without profile is a replacement of the preference, so it is same as deletion of the profile
       preferencesService.setProperties(NamespaceId.DEFAULT, Collections.emptyMap());
 
       // Verify the workflow profile metadata is updated to default profile
-      Tasks.waitFor(ProfileId.NATIVE.toString(), () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
+      Tasks.waitFor(ProfileId.NATIVE.getScopedName(),
+                    () -> mds.getProperties(workflowId.toMetadataEntity()).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     } finally {
       // stop and clean up the store
@@ -610,8 +615,9 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
 
     // need to put metadata on workflow since we currently only set or delete workflow metadata
     mds.setProperties(MetadataScope.SYSTEM, workflowId.toMetadataEntity(),
-                      Collections.singletonMap("profile", ProfileId.NATIVE.toString()));
-    Assert.assertEquals(ProfileId.NATIVE.toString(), mds.getProperties(workflowId.toMetadataEntity()).get("profile"));
+                      Collections.singletonMap("profile", ProfileId.NATIVE.getScopedName()));
+    Assert.assertEquals(ProfileId.NATIVE.getScopedName(),
+                        mds.getProperties(workflowId.toMetadataEntity()).get("profile"));
 
     // get the subsciber service and start it
     MetadataSubscriberService metadataSubscriberService = injector.getInstance(MetadataSubscriberService.class);

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -1528,9 +1528,9 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       properties.put(AbstractSystemMetadataWriter.DESCRIPTION_KEY, description);
     }
     if (profileId != null) {
-      properties.put("profile", profileId.toString());
+      properties.put("profile", profileId.getScopedName());
       // need to wait for the profile id to come up since we are updating it asyncly
-      Tasks.waitFor(profileId.toString(), () -> getProperties(programId, MetadataScope.SYSTEM).get("profile"),
+      Tasks.waitFor(profileId.getScopedName(), () -> getProperties(programId, MetadataScope.SYSTEM).get("profile"),
                     10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     }
     Assert.assertEquals(properties.build(), removeCreationTime(getProperties(programId, MetadataScope.SYSTEM)));

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/ActionCreator.js
@@ -241,11 +241,16 @@ export const getProfiles = (namespace) => {
             });
           });
         profiles.forEach(profile => {
-          MySearchApi
-            .search({
-              namespace,
-              query: `profile:${namespace}.${profile.name}`
-            })
+          let {scope} = profile;
+          scope = scope.toLowerCase();
+          let profileName = `profile:${scope}:${profile.name}`;
+          let apiObservable$;
+          if (namespace === 'system') {
+            apiObservable$ = MySearchApi.searchSystem({ query: profileName });
+          } else {
+            apiObservable$ = MySearchApi.search({ namespace, query: profileName });
+          }
+          apiObservable$
             .subscribe(res => updateScheduleAndTriggersToStore(profile.name, res.results));
         });
       },


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13858
Build: https://builds.cask.co/browse/CDAP-RUT1589

We should always use scoped name for profile, so that for association, metadata and metrics, we can use consistent name to query.