### PR TITLE
[CDAP-13851] Fixes pipelines/custom apps selections bug, and removes Export button in Reports

### DIFF
--- a/cdap-ui/app/cdap/components/Reports/ReportsDetail/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsDetail/index.js
@@ -117,10 +117,6 @@ class ReportsDetailView extends Component {
 
           <div className="action-button float-xs-right">
             <SaveButton />
-
-            <button className="btn btn-link">
-              {T.translate(`${PREFIX}.export`)}
-            </button>
           </div>
         </div>
 

--- a/cdap-ui/app/cdap/components/Reports/ReportsList/ActionPopover.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsList/ActionPopover.js
@@ -53,6 +53,12 @@ export default class ActionPopover extends Component {
 
     MyReportsApi.getReport(params)
       .subscribe((res) => {
+        // Has to clear current selections, otherwise current selections in the
+        // store will union with the cloned selections
+        ReportsStore.dispatch({
+          type: ReportsActions.clearSelection
+        });
+
         let {request} = res;
 
         let selectedFields = difference(request.fields, DefaultSelection);
@@ -91,7 +97,7 @@ export default class ActionPopover extends Component {
               }
 
               payload.statusSelections = statusSelections;
-            } else if (filter.fieldName === 'artifact') {
+            } else if (filter.fieldName === 'artifactName') {
               if (filter.whitelist) {
                 payload.selections.pipelines = true;
               } else if (filter.blacklist) {

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2072,7 +2072,6 @@ features:
       byTrigger: By trigger
       customApp: custom app
       expiresIn: Expires in
-      export: Export
       generatedTime: Report generated on {time}
       getReportName: "{statusLabel} runs - {startDate} to {endDate}"
       lastStarted: "Newest: {newest}; Oldest: {oldest}"


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13851

The main problem was that the backend changed the property name from `artifact` to `artifactName`. We have this logic in the code that if we don't see a filter for `artifact`, we just check both the `Pipelines` and `Custom apps`. Fixing it to use the right property fixes the problem of the cloned criteria's selections not being applied.

This PR also removes the 'Export' link next to the 'Save Report' button, since report exporting functionality is not coming in 5.0.