### PR TITLE
CDAP-13867 fix to include program schedule while writing to RunMetaFi…

### DIFF
--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/main/MessageUtil.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/main/MessageUtil.java
@@ -148,7 +148,7 @@ public final class MessageUtil {
         if (principal != null) {
           principal = new KerberosName(principal).getShortName();
         }
-        ProgramStartInfo programStartInfo = new ProgramStartInfo(userArguments, artifactId, principal);
+        ProgramStartInfo programStartInfo = new ProgramStartInfo(userArguments, artifactId, principal, systemArguments);
         programRunInfo.setStartInfo(programStartInfo);
         break;
       case Constants.Notification.Status.RUNNING:

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/main/ProgramRunInfoSerializer.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/main/ProgramRunInfoSerializer.java
@@ -37,7 +37,10 @@ public class ProgramRunInfoSerializer {
     Schema.Field.of(Constants.RUNTIME_ARGUMENTS, Schema.mapOf(Schema.of(Schema.Type.STRING),
                                                               Schema.of(Schema.Type.STRING))
     ),
-    Schema.Field.of(Constants.ARTIFACT_ID, ARTIFACT_INFO));
+    Schema.Field.of(Constants.ARTIFACT_ID, ARTIFACT_INFO),
+    Schema.Field.of(Constants.SYSTEM_ARGUMENTS, Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                             Schema.of(Schema.Type.STRING))
+    ));
 
   private static final String SCHEMA_STRING = Schema.recordOf(
     "ReportRecord",
@@ -74,6 +77,7 @@ public class ProgramRunInfoSerializer {
       artifactRecord.put(Constants.ARTIFACT_VERSION, artifactId.getVersion().toString());
       artifactRecord.put(Constants.ARTIFACT_SCOPE, artifactId.getScope().toString());
       startInfoRecord.put(Constants.ARTIFACT_ID, artifactRecord);
+      startInfoRecord.put(Constants.SYSTEM_ARGUMENTS, runInfo.getProgramSartInfo().getSystemArguments());
     }
     GenericData.Record record = new GenericData.Record(SCHEMA);
     record.put(Constants.NAMESPACE, runInfo.getNamespace());

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/main/ProgramStartInfo.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/main/ProgramStartInfo.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.report.main;
 
 import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.schedule.TriggeringScheduleInfo;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -27,11 +28,14 @@ public class ProgramStartInfo {
   private Map<String, String> runtimeArguments;
   private ArtifactId artifactId;
   private String principal;
+  private Map<String, String> systemArguments;
 
-  public ProgramStartInfo(Map<String, String> arguments, ArtifactId artifactId, String principal) {
+  public ProgramStartInfo(Map<String, String> arguments, ArtifactId artifactId, String principal,
+                          Map<String, String> systemArguments) {
     this.runtimeArguments = arguments;
     this.artifactId = artifactId;
     this.principal = principal;
+    this.systemArguments = systemArguments;
   }
 
   public Map<String, String> getRuntimeArguments() {
@@ -40,6 +44,13 @@ public class ProgramStartInfo {
 
   public ArtifactId getArtifactId() {
     return artifactId;
+  }
+
+  /**
+   * Get the system arguemnts map
+   */
+  public Map<String, String> getSystemArguments() {
+    return systemArguments;
   }
 
   /**

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/util/Constants.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/util/Constants.java
@@ -59,6 +59,7 @@ public final class Constants {
   public static final String USER = "user";
   public static final String START_METHOD = "startMethod";
   public static final String RUNTIME_ARGUMENTS = "runtimeArgs";
+  public static final String SYSTEM_ARGUMENTS = "systemArgs";
   public static final String NUM_LOG_WARNINGS = "numLogWarnings";
   public static final String NUM_LOG_ERRORS = "numLogErrors";
   public static final String NUM_RECORDS_OUT = "numRecordsOut";

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/scala/co/cask/cdap/report/util/ProgramStartMethodHelper.scala
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/scala/co/cask/cdap/report/util/ProgramStartMethodHelper.scala
@@ -34,9 +34,9 @@ object ProgramStartMethodHelper {
     *         was started manually, scheduled by time, or triggered by certain condition such as new dataset partition
     *         and program status.
     */
-  def getStartMethod(runtimeArgs: Option[scala.collection.Map[String, String]]): ProgramRunStartMethod = {
-    if (runtimeArgs.isEmpty) return ProgramRunStartMethod.MANUAL
-    val scheduleInfoJson = runtimeArgs.get.get(Constants.Notification.SCHEDULE_INFO_KEY)
+  def getStartMethod(systemArgs: Option[scala.collection.Map[String, String]]): ProgramRunStartMethod = {
+    if (systemArgs.isEmpty) return ProgramRunStartMethod.MANUAL
+    val scheduleInfoJson = systemArgs.get.get(Constants.Notification.SCHEDULE_INFO_KEY)
     if (scheduleInfoJson.isEmpty) return ProgramRunStartMethod.MANUAL
     val scheduleInfo: TriggeringScheduleInfo = GSON.fromJson(scheduleInfoJson.get, classOf[TriggeringScheduleInfo])
     val triggers = scheduleInfo.getTriggerInfos

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/test/java/co/cask/cdap/report/ReportGenerationAppTest.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/test/java/co/cask/cdap/report/ReportGenerationAppTest.java
@@ -493,9 +493,10 @@ public class ReportGenerationAppTest extends TestBase {
       "\"run\":\"randomRunId\",\"entity\": \"PROGRAM\",\"program\": \"wf\",\"programStatus\": \"KILLED\"," +
       "\"type\": \"PROGRAM_STATUS\"}]}";
     ProgramStartInfo startInfo =
-      new ProgramStartInfo(ImmutableMap.of(Constants.Notification.SCHEDULE_INFO_KEY, scheduleInfo),
+      new ProgramStartInfo(ImmutableMap.of(),
                            new ArtifactId(TEST_ARTIFACT_NAME,
-                                          new ArtifactVersion("1.0.0"), ArtifactScope.USER), USER_ALICE);
+                                          new ArtifactVersion("1.0.0"), ArtifactScope.USER), USER_ALICE,
+                           ImmutableMap.of(Constants.Notification.SCHEDULE_INFO_KEY, scheduleInfo));
     long delay = TimeUnit.MINUTES.toMillis(5);
     int mockMessageId = 0;
     for (String namespace : ImmutableList.of("default", "ns1", "ns2")) {

--- a/cdap-app-templates/cdap-program-report/cdap-program-report1_2.10/src/main/scala/co/cask/cdap/report/ReportAggregationFunction.scala
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report1_2.10/src/main/scala/co/cask/cdap/report/ReportAggregationFunction.scala
@@ -210,7 +210,8 @@ class ReportAggregationFunction extends UserDefinedAggregateFunction {
     val artifactInfo = startInfo.map(_.getAs[Row](Constants.ARTIFACT_ID))
     val duration = end.flatMap(e => start.map(e - _))
     val runtimeArgs = startInfo.map(_.getAs[Map[String, String]](Constants.RUNTIME_ARGUMENTS))
-    val startMethod = ProgramStartMethodHelper.getStartMethod(runtimeArgs).name()
+    val systemArgs = startInfo.map(_.getAs[Map[String, String]](Constants.SYSTEM_ARGUMENTS))
+    val startMethod = ProgramStartMethodHelper.getStartMethod(systemArgs).name()
     Row(bufferRow.getAs[String](Constants.NAMESPACE),
       artifactInfo.map(_.getAs[String](Constants.ARTIFACT_NAME)).orNull,
       artifactInfo.map(_.getAs[String](Constants.ARTIFACT_SCOPE)).orNull,
@@ -239,6 +240,8 @@ object ReportAggregationFunction {
     .add(Constants.USER, StringType, true)
     .add(Constants.RUNTIME_ARGUMENTS, MapType(StringType, StringType), false)
     .add(Constants.ARTIFACT_ID, ARTIFACT_SCHEMA, false)
+    .add(Constants.SYSTEM_ARGUMENTS, MapType(StringType, StringType), false)
+
   val STATUS_TIME_SCHEMA: StructType = new StructType()
     .add(Constants.STATUS, StringType, false)
     .add(Constants.TIME, LongType)

--- a/cdap-app-templates/cdap-program-report/cdap-program-report2_2.11/src/main/scala/co/cask/cdap/report/RecordAggregator.scala
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report2_2.11/src/main/scala/co/cask/cdap/report/RecordAggregator.scala
@@ -55,6 +55,6 @@ class RecordAggregator extends Aggregator[Row, RecordBuilder, Record] {
     val artifact: Row = startInfoRow.getAs[Row](Constants.ARTIFACT_ID)
     StartInfo(startInfoRow.getAs(Constants.USER), startInfoRow.getAs(Constants.RUNTIME_ARGUMENTS),
       artifact.getAs(Constants.ARTIFACT_NAME), artifact.getAs(Constants.ARTIFACT_VERSION),
-      artifact.getAs(Constants.ARTIFACT_SCOPE))
+      artifact.getAs(Constants.ARTIFACT_SCOPE), startInfoRow.getAs(Constants.SYSTEM_ARGUMENTS))
   }
 }

--- a/cdap-app-templates/cdap-program-report/cdap-program-report2_2.11/src/main/scala/co/cask/cdap/report/RecordBuilder.scala
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report2_2.11/src/main/scala/co/cask/cdap/report/RecordBuilder.scala
@@ -75,7 +75,8 @@ case class RecordBuilder(namespace: String, applicationName: String, application
       .reduceOption(Math.min(_, _)) // avoid compilation error with Math.min(_, _) instead of Math.min
     val duration = end.flatMap(e => start.map(e - _))
     val runtimeArgs = startInfo.map(_.runtimeArgs)
-    val startMethod = ProgramStartMethodHelper.getStartMethod(runtimeArgs).name()
+    val systemArgs = startInfo.map(_.systemArgs)
+    val startMethod = ProgramStartMethodHelper.getStartMethod(systemArgs).name()
     Record(namespace,
       startInfo.map(_.artifactName), startInfo.map(_.artifactVersion), startInfo.map(_.artifactScope),
       applicationName, applicationVersion,
@@ -94,10 +95,13 @@ case class RecordBuilder(namespace: String, applicationName: String, application
 case class StartInfo(user: String,
                      // Use scala.collection.Map to avoid compilation error in Janino generated code
                      runtimeArgs: scala.collection.Map[String, String],
-                     artifactName: String,  artifactVersion: String, artifactScope: String) {
+                     artifactName: String,  artifactVersion: String, artifactScope: String,
+                     systemArgs: scala.collection.Map[String, String]) {
   def this(user: String, runtimeArgs: java.util.Map[String, String],
-           artifactName: String, artifactVersion: String, artifactScope: String) =
-    this(user, mapAsScalaMap(runtimeArgs).toMap, artifactName, artifactVersion, artifactScope)
+           artifactName: String, artifactVersion: String, artifactScope: String,
+           systemArgs: java.util.Map[String, String]) =
+    this(user, mapAsScalaMap(runtimeArgs).toMap, artifactName, artifactVersion, artifactScope,
+      mapAsScalaMap(systemArgs).toMap)
   def getRuntimeArgsAsJavaMap(): java.util.Map[String, String] = runtimeArgs
 }
 


### PR DESCRIPTION
…leSet and reading it correspondingly in spark app

Summary 

Report Generation Spark job, assumes that the triggeringScheduleInfo necessary to figure out the startMethod is available as part of runtime arguments.

However this is user runtime arguments and the triggeringScheduleInfo is present in system arguments.

Due to this missing information the startMethod will always be "manual" even for scheduled runs.

added triggeringScheduleInfo to program start info  and made appropriate change to read this triggeringScheduleInfo from the programStartInfo rather than runtime arguments in the spark job.

The test case has coverage for scheduled runs, however it passes that information through runtime arguments and the code path in unit test doesn't cover reading from TMS and writing to RunMetaFileset. 