### PR TITLE
CDAP-13260 Metadata Rest APIs update and custom entity [Part 1]

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/metadata.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metadata.rst
@@ -55,9 +55,10 @@ Metadata Properties
 
 Annotating Properties
 ---------------------
-To annotate user metadata properties for an application, dataset, or stream, submit an HTTP POST request::
+To annotate user metadata properties for an application, dataset, or other entities including custom entities,
+submit an HTTP POST request::
 
-  POST /v3/namespaces/<namespace-id>/<entity-type>/<entity-id>/metadata/properties
+  POST /v3/namespaces/<namespace-id>/<entity-details>/metadata/properties
 
 or, for a particular program of a specific application::
 
@@ -70,6 +71,10 @@ or, for a particular version of an artifact::
 or, for a particular view of a stream::
 
   POST /v3/namespaces/<namespace-id>/streams/<stream-id>/views/<view-id>/metadata/properties
+
+or, for a custom entity like field of a dataset::
+
+    POST /v3/namespaces/<namespace-id>/datasets/<dataset-id>/field/<field-name>/metadata/properties
 
 .. highlight:: json-ellipsis
 
@@ -84,8 +89,8 @@ request body::
 
 .. highlight:: console
 
-If the entity requested is found, new keys will be added and existing keys will be
-updated. Existing keys not in the properties map will not be deleted.
+New property keys will be added and existing keys will be updated.
+Existing keys not in the properties map will not be deleted.
 
 .. list-table::
    :widths: 20 80
@@ -95,10 +100,8 @@ updated. Existing keys not in the properties map will not be deleted.
      - Description
    * - ``namespace-id``
      - Namespace ID
-   * - ``entity-type``
-     - One of ``apps``, ``datasets``, or ``streams``
-   * - ``entity-id``
-     - Name of the entity
+   * - ``entity-details``
+     - :ref:`Hierarchical key-value representation of the entity <metadata_custom_entities>`
    * - ``app-id``
      - Name of the application
    * - ``program-type``
@@ -113,6 +116,10 @@ updated. Existing keys not in the properties map will not be deleted.
      - Name of the stream
    * - ``view-id``
      - Name of the stream view
+   * - ``dataset-id``
+     - Name of the dataset
+   * - ``field-name``
+     - Name of the field
 
 .. rubric:: HTTP Responses
 
@@ -124,8 +131,6 @@ updated. Existing keys not in the properties map will not be deleted.
      - Description
    * - ``200 OK``
      - The properties were set
-   * - ``404 NOT FOUND``
-     - The entity or program for which properties are being set was not found
 
 **Note**: When using this API, properties can be added to the metadata of the specified entity
 only in the *user* scope.
@@ -133,9 +138,10 @@ only in the *user* scope.
 
 Retrieving Properties
 ---------------------
-To retrieve user metadata properties for an application, dataset, or stream, submit an HTTP GET request::
+To retrieve user metadata properties for an application, dataset, or other entities including custom entities,
+submit an HTTP GET request::
 
-  GET /v3/namespaces/<namespace-id>/<entity-type>/<entity-id>/metadata/properties[?scope=<scope>]
+  GET /v3/namespaces/<namespace-id>/<entity-details>/metadata/properties[?scope=<scope>]
 
 or, for a particular program of a specific application::
 
@@ -148,6 +154,10 @@ or, for a particular version of an artifact::
 or, for a particular view of a stream::
 
   GET /v3/namespaces/<namespace-id>/streams/<stream-id>/views/<view-id>/metadata/properties[?scope=<scope>]
+
+or, for a custom entity like field of a dataset::
+
+  GET /v3/namespaces/<namespace-id>/datasets/<dataset-id>/field/<field-name>/metadata/properties[?scope=<scope>]
 
 .. highlight:: json-ellipsis
 
@@ -170,10 +180,8 @@ in the response body (pretty-printed)::
      - Description
    * - ``namespace-id``
      - Namespace ID
-   * - ``entity-type``
-     - One of ``apps``, ``datasets``, or ``streams``
-   * - ``entity-id``
-     - Name of the entity
+   * - ``entity-details``
+     - :ref:`Hierarchical key-value representation of the entity <metadata_custom_entities>`
    * - ``app-id``
      - Name of the application
    * - ``program-type``
@@ -188,6 +196,10 @@ in the response body (pretty-printed)::
      - Name of the stream
    * - ``view-id``
      - Name of the stream view
+   * - ``dataset-id``
+     - Name of the dataset
+   * - ``field-name``
+     - Name of the field
    * - ``scope``
      - Optional scope filter. If not specified, properties in the ``user`` and
        ``system`` scopes are returned. Otherwise, only properties in the specified scope are returned.
@@ -201,17 +213,15 @@ in the response body (pretty-printed)::
    * - Status Codes
      - Description
    * - ``200 OK``
-     - The properties requested were returned as a JSON string in the body of the response
-   * - ``404 NOT FOUND``
-     - The entity or program for which properties are being retrieved was not found
+     - The properties requested were returned as a JSON string in the body of the response which can be empty if there are no properties associated with the entity, or the entity does not exist
 
 
 Deleting Properties
 -------------------
-To delete **all** user metadata properties for an application, dataset, or stream, submit an
-HTTP DELETE request::
+To delete **all** user metadata properties for an application, dataset, or other entities including custom entities,
+submit an HTTP DELETE request::
 
-  DELETE /v3/namespaces/<namespace-id>/<entity-type>/<entity-id>/metadata/properties
+  DELETE /v3/namespaces/<namespace-id>/<entity-details>/metadata/properties
 
 or, for all user metadata properties of a particular program of a specific application::
 
@@ -242,6 +252,10 @@ or, for a particular view of a stream::
 
   DELETE /v3/namespaces/<namespace-id>/streams/<stream-id>/views/<view-id>/metadata/properties/<key>
 
+or, for a custom entity like field of a dataset::
+
+    DELETE /v3/namespaces/<namespace-id>/datasets/<dataset-id>/field/<field-name>/metadata/properties/<key>
+
 .. list-table::
    :widths: 20 80
    :header-rows: 1
@@ -250,10 +264,8 @@ or, for a particular view of a stream::
      - Description
    * - ``namespace-id``
      - Namespace ID
-   * - ``entity-type``
-     - One of ``apps``, ``datasets``, or ``streams``
-   * - ``entity-id``
-     - Name of the entity
+   * - ``entity-details``
+     - :ref:`Hierarchical key-value representation of the entity <metadata_custom_entities>`
    * - ``app-id``
      - Name of the application
    * - ``program-type``
@@ -268,6 +280,10 @@ or, for a particular view of a stream::
      - Name of the stream
    * - ``view-id``
      - Name of the stream view
+   * - ``dataset-id``
+     - Name of the dataset
+   * - ``field-name``
+     - Name of the field
    * - ``key``
      - Metadata property key
 
@@ -281,9 +297,7 @@ or, for a particular view of a stream::
      - Description
    * - ``200 OK``
      - The method was successfully called, and the properties were deleted, or in the case of a
-       specific key, were either deleted or the key was not present
-   * - ``404 NOT FOUND``
-     - The entity or program for which properties are being deleted was not found
+       specific key, were either deleted or the key was not present, or the entity itself was not present
 
 **Note**: When using this API, only properties in the *user* scope can be deleted.
 
@@ -294,9 +308,10 @@ Metadata Tags
 
 Adding Tags
 -----------
-To add user metadata tags for an application, dataset, or stream, submit an HTTP POST request::
+To add user metadata tags for an application, dataset, or other entities including custom entities,
+submit an HTTP POST request::
 
-  POST /v3/namespaces/<namespace-id>/<entity-type>/<entity-id>/metadata/tags
+  POST /v3/namespaces/<namespace-id>/<entity-details>/metadata/tags
 
 or, for a particular program of a specific application::
 
@@ -310,6 +325,10 @@ or, for a particular view of a stream::
 
   POST /v3/namespaces/<namespace-id>/streams/<stream-id>/views/<view-id>/metadata/tags
 
+or, for a custom entity like field of a dataset::
+
+  POST /v3/namespaces/<namespace-id>/datasets/<dataset-id>/field/<field-name>/metadata/tags
+
 with the metadata tags, as a list of strings, passed in the JSON request body::
 
   ["tag1", "tag2"]
@@ -322,10 +341,8 @@ with the metadata tags, as a list of strings, passed in the JSON request body::
      - Description
    * - ``namespace-id``
      - Namespace ID
-   * - ``entity-type``
-     - One of ``apps``, ``datasets``, or ``streams``
-   * - ``entity-id``
-     - Name of the entity
+   * - ``entity-details``
+     - :ref:`Hierarchical key-value representation of the entity <metadata_custom_entities>`
    * - ``app-id``
      - Name of the application
    * - ``program-type``
@@ -340,6 +357,10 @@ with the metadata tags, as a list of strings, passed in the JSON request body::
      - Name of the stream
    * - ``view-id``
      - Name of the stream view
+   * - ``dataset-id``
+     - Name of the dataset
+   * - ``field-name``
+     - Name of the field
 
 .. rubric:: HTTP Responses
 
@@ -351,29 +372,32 @@ with the metadata tags, as a list of strings, passed in the JSON request body::
      - Description
    * - ``200 OK``
      - The tags were set
-   * - ``404 NOT FOUND``
-     - The entity or program for which tags are being set was not found
 
 **Note**: When using this API, tags can be added to the metadata of the specified entity only in the user scope.
 
 
 Retrieving Tags
 ---------------
-To retrieve user metadata tags for an application, dataset, or stream, submit an HTTP GET request::
+To retrieve user metadata tags for an application, dataset, or other entities including custom entities,
+submit an HTTP GET request::
 
-  GET /v3/namespaces/<namespace-id>/<entity-type>/<entity-id>/metadata/tags[?scope=<scope>
+  GET /v3/namespaces/<namespace-id>/<entity-details>/metadata/tags[?scope=<scope>]
 
 or, for a particular program of a specific application::
 
-  GET /v3/namespaces/<namespace-id>/apps/<app-id>/<program-type>/<program-id>/metadata/tags[?scope=<scope>
+  GET /v3/namespaces/<namespace-id>/apps/<app-id>/<program-type>/<program-id>/metadata/tags[?scope=<scope>]
 
 or, for a particular version of an artifact::
 
-  GET /v3/namespaces/<namespace-id>/artifacts/<artifact-id>/versions/<artifact-version>/metadata/tags[?scope=<scope>
+  GET /v3/namespaces/<namespace-id>/artifacts/<artifact-id>/versions/<artifact-version>/metadata/tags[?scope=<scope>]
 
 or, for a particular view of a stream::
 
-  GET /v3/namespaces/<namespace-id>/streams/<stream-id>/views/<view-id>/metadata/tags[?scope=<scope>
+  GET /v3/namespaces/<namespace-id>/streams/<stream-id>/views/<view-id>/metadata/tags[?scope=<scope>]
+
+or, for a custom entity like field of a dataset::
+
+  GET /v3/namespaces/<namespace-id>/dataset/<dataset-id>/field/<field-name>/metadata/tags[?scope=<scope>]
 
 with the metadata tags returned as a JSON string in the return body::
 
@@ -387,10 +411,8 @@ with the metadata tags returned as a JSON string in the return body::
      - Description
    * - ``namespace-id``
      - Namespace ID
-   * - ``entity-type``
-     - One of ``apps``, ``datasets``, or ``streams``
-   * - ``entity-id``
-     - Name of the entity
+   * - ``entity-details``
+     - :ref:`Hierarchical key-value representation of the entity <metadata_custom_entities>`
    * - ``app-id``
      - Name of the application
    * - ``program-type``
@@ -405,6 +427,10 @@ with the metadata tags returned as a JSON string in the return body::
      - Name of the stream
    * - ``view-id``
      - Name of the stream view
+   * - ``dataset-id``
+     - Name of the dataset
+   * - ``field-name``
+     - Name of the field
    * - ``scope``
      - Optional scope filter. If not specified, properties in the ``user`` and
        ``system`` scopes are returned. Otherwise, only properties in the specified scope are returned.
@@ -418,17 +444,15 @@ with the metadata tags returned as a JSON string in the return body::
    * - Status Codes
      - Description
    * - ``200 OK``
-     - The properties requested were returned as a JSON string in the body of the response
-   * - ``404 NOT FOUND``
-     - The entity or program for which properties are being retrieved was not found
+     - The tags requested were returned as a JSON string in the body of the response which can be empty if there are no tags associated with the entity or entity does not exist
 
 
 Removing Tags
 -------------
-To delete all user metadata tags for an application, dataset, or stream, submit an
+To delete all user metadata tags for an application, dataset, or other entities including custom entities, submit an
 HTTP DELETE request::
 
-  DELETE /v3/namespaces/<namespace-id>/<entity-type>/<entity-id>/metadata/tags
+  DELETE /v3/namespaces/<namespace-id>/<entity-details>/metadata/tags
 
 or, for all user metadata tags of a particular program of a specific application::
 
@@ -459,6 +483,10 @@ or, for a particular view of a stream::
 
   DELETE /v3/namespaces/<namespace-id>/streams/<stream-id>/views/<view-id>/metadata/tags/<tag>
 
+or, for a custom entity like field of a dataset::
+
+  DELETE /v3/namespaces/<namespace-id>/datasets/<dataset-id>/field/<field-name>/metadata/tags/<tag>
+
 .. list-table::
    :widths: 20 80
    :header-rows: 1
@@ -467,10 +495,8 @@ or, for a particular view of a stream::
      - Description
    * - ``namespace-id``
      - Namespace ID
-   * - ``entity-type``
-     - One of ``apps``, ``datasets``, or ``streams``
-   * - ``entity-id``
-     - Name of the entity
+   * - ``entity-details``
+     - :ref:`Hierarchical key-value representation of the entity <metadata_custom_entities>`
    * - ``app-id``
      - Name of the application
    * - ``program-type``
@@ -485,6 +511,10 @@ or, for a particular view of a stream::
      - Name of the stream
    * - ``view-id``
      - Name of the stream view
+   * - ``dataset-id``
+     - Name of the dataset
+   * - ``field-name``
+     - Name of the field
    * - ``tag``
      - Metadata tag
 
@@ -498,9 +528,7 @@ or, for a particular view of a stream::
      - Description
    * - ``200 OK``
      - The method was successfully called, and the tags were deleted, or in the case of a
-       specific tag, was either deleted or the tag was not present
-   * - ``404 NOT FOUND``
-     - The entity or program for which tags are being deleted was not found
+       specific tag, was either deleted or the tag was not present, or the entity itself was not present
 
 **Note**: When using this API, only tags in the user scope can be deleted.
 
@@ -528,7 +556,7 @@ metadata property or metadata tag, submit an HTTP GET request::
      - Restricts the search to either all or specified entity types: ``all``, ``artifact``, ``app``, ``dataset``,
        ``program``, ``stream``, ``view``
    * - ``option``
-     - Options for controlling cursors, limits, offsets, the inclusion of hidden entities, and sorting:
+     - Options for controlling cursors, limits, offsets, the inclusion of hidden and custom entities, and sorting:
 
        .. list-table::
           :widths: 20 80
@@ -556,6 +584,9 @@ metadata property or metadata tag, submit an HTTP GET request::
           * - ``showHidden``
             - By default, metadata search hides entities whose name starts with an ``_`` (underscore) from the search
               results. Set this to ``true`` to include these hidden entities in search results. Default is ``false``.
+          * - ``showCustom``
+            - By default, metadata search hides custom entities from the search results for backward compatibility.
+              Set this to ``true`` to include these custom entities in search results. Default is ``false``.
           * - ``entityScope``
             - The scope of entities for the metadata search. By default, all entities will be returned. Set this to
               ``USER`` to include only user entities; set this to ``SYSTEM`` to include only system entities.
@@ -1542,8 +1573,8 @@ Following is a sample response::
 
 .. _http-restful-api-metadata-run:
 
-Retrieving Metadata for a Program Run
-=====================================
+Retrieving Metadata for a Program Run (Deprecated)
+==================================================
 At every run of a program, the metadata associated with the program, the application it is part of, and any datasets
 and streams used by the program run are recorded. To retrieve the metadata for a program run, submit an HTTP GET request::
 
@@ -1635,3 +1666,47 @@ with the metadata returned as a JSON string in the return body::
      - The properties requested were returned as a JSON string in the body of the response
    * - ``404 NOT FOUND``
      - The entity, program, or run for which properties are being requested was not found
+
+**Note**: The Metadata aggregation of program, application, stream and dataset associated with a program is
+deprecated. Program runs are treated like any other entity to which metadata can be associated directly.
+To retrieve the direct metadata of program run please refer to
+:ref:`Metadata Properties <http-restful-api-metadata-properties>` and
+:ref:`Metadata Tags <http-restful-api-metadata-tags>`. An additional query parameter ``aggregateRun`` must be set to
+``false`` while operating with metadata directly associated with program runs.
+
+.. _metadata_custom_entities:
+
+Metadata for Custom Entities
+============================
+
+Metadata can also be associated with custom entities. In CDAP Entities are separated into two kinds:
+
+- CDAP Entities: These are system defined entities that have special meaning in CDAP. ``Namespace``, ``Stream``, ``Application``, ``Dataset`` etc. are example of CDAP Entities.
+
+- Custom Entities: These are user defined entities that represent a resource that exists in CDAP.
+
+Custom Entities are represented as a hierarchical key-value pair and can optionally have a explicitly defined type.
+
+If a type is not specified then the last key in the hierarchy is considered as the type.
+
+In REST APIs, custom entities are represented as hierarchical key-value pairs. If the last key in the hierarchy is
+not a type, the type is specified as a query parameter.
+
+For example, to add tags to a custom file entity in a dataset::
+
+  POST /v3/namespaces/<namespace-id>/datasets/<dataset-id>/file/<file-name>/metadata/tags
+
+In the example above, the custom entity is a single key-value pair where ``file`` is the key and ``<file-name>``
+is the value.
+
+To add tags to a custom jar entity in a namespace::
+
+  POST /v3/namespaces/<namespace-id>/jar/<jar-id>/versions/<jar-version>/metadata/tags[?type=jar]
+
+In the example above, the custom entity consists of two key-value pairs. The first has key ``jar`` and value
+``<jar-id>``. The second has key ``versions`` and value ``<jar-version>``. We pass the jar as the type to specify
+the type of the entity since the last key in the hierarchy is not the type in this case.
+
+In both examples, the metadata tags are passed as a JSON list of strings in the request body::
+
+  ["tag1", "tag2"]


### PR DESCRIPTION
## Metadata 5.0 Docs
### Part 1

- Updates to existing rest API to show example of field metadata specifically
- Updates to search api to document `showCustom`
- Added a new sub section on custom entity

Build: https://builds.cask.co/browse/CDAP-DQB408-2

Rendered Page: https://builds.cask.co/artifact/CDAP-DQB408/shared/build-2/Docs-HTML/html/reference-manual/http-restful-api/metadata.html