### PR TITLE
Docs to deprecate streams and flows

### DIFF
--- a/cdap-docs/developer-manual/source/building-blocks/flows-flowlets/index.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/flows-flowlets/index.rst
@@ -8,7 +8,7 @@
 ==================
 Flows and Flowlets
 ==================
-** Flows are deprecated as of release 5.0, use spark streaming as replacement technology. Support for flows will be discontinued in 6.0 release **
+**Flows are deprecated as of release 5.0, use spark streaming as replacement technology. Support for flows will be discontinued in 6.0 release**
    
 
 .. toctree::

--- a/cdap-docs/developer-manual/source/building-blocks/flows-flowlets/index.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/flows-flowlets/index.rst
@@ -27,6 +27,7 @@ Flows and Flowlets
    :hidden:
 
    flows
+** Flows are deprecated as of release 5.0, use spark streaming as replacement technology. Support for flows will be discontinued in 6.0 release **
    
 *Flows* are user-implemented real-time stream processors. They are comprised of one or
 more *Flowlets* that are wired together into a directed acyclic graph or DAG. Flowlets

--- a/cdap-docs/developer-manual/source/building-blocks/flows-flowlets/index.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/flows-flowlets/index.rst
@@ -8,6 +8,8 @@
 ==================
 Flows and Flowlets
 ==================
+** Flows are deprecated as of release 5.0, use spark streaming as replacement technology. Support for flows will be discontinued in 6.0 release **
+   
 
 .. toctree::
    :maxdepth: 1
@@ -27,8 +29,7 @@ Flows and Flowlets
    :hidden:
 
    flows
-** Flows are deprecated as of release 5.0, use spark streaming as replacement technology. Support for flows will be discontinued in 6.0 release **
-   
+
 *Flows* are user-implemented real-time stream processors. They are comprised of one or
 more *Flowlets* that are wired together into a directed acyclic graph or DAG. Flowlets
 pass data between one another; each flowlet is able to perform custom logic and execute

--- a/cdap-docs/developer-manual/source/building-blocks/index.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/index.rst
@@ -15,7 +15,7 @@ Building Blocks
 
     Core Abstractions <core>
     Applications <applications>
-    Streams <streams> 
+    Streams <streams>
     Datasets <datasets/index>
     Views <views>
     Flows and Flowlets <flows-flowlets/index> 

--- a/cdap-docs/developer-manual/source/building-blocks/index.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/index.rst
@@ -15,10 +15,10 @@ Building Blocks
 
     Core Abstractions <core>
     Applications <applications>
-    Streams <streams>
+    Streams <streams> *Streams are deprecated as of release 5.0, use kafka as a replacement technology*
     Datasets <datasets/index>
     Views <views>
-    Flows and Flowlets <flows-flowlets/index>
+    Flows and Flowlets <flows-flowlets/index> *Flows are deprecated as of release 5.0, use spark streaming as a replacement technology*
     MapReduce Programs<mapreduce-programs>
     Plugins <plugins>
     Schedules <schedules>

--- a/cdap-docs/developer-manual/source/building-blocks/index.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/index.rst
@@ -15,10 +15,10 @@ Building Blocks
 
     Core Abstractions <core>
     Applications <applications>
-    Streams <streams> *Streams are deprecated as of release 5.0, use kafka as a replacement technology*
+    Streams <streams> 
     Datasets <datasets/index>
     Views <views>
-    Flows and Flowlets <flows-flowlets/index> *Flows are deprecated as of release 5.0, use spark streaming as a replacement technology*
+    Flows and Flowlets <flows-flowlets/index> 
     MapReduce Programs<mapreduce-programs>
     Plugins <plugins>
     Schedules <schedules>

--- a/cdap-docs/developer-manual/source/building-blocks/streams.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/streams.rst
@@ -7,7 +7,7 @@
 =======
 Streams
 =======
-** Streams are deprecated as of release 5.0, use kafka as a replacement technology. Support for streams will be discontinued in 6.0 release **
+**Streams are deprecated as of release 5.0, use kafka as a replacement technology. Support for streams will be discontinued in 6.0 release**
 
 *Streams* are the primary means of bringing data from external systems into the CDAP in real time.
 They are ordered, time-partitioned sequences of data, usable for real-time collection and consumption of data.

--- a/cdap-docs/developer-manual/source/building-blocks/streams.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/streams.rst
@@ -7,6 +7,7 @@
 =======
 Streams
 =======
+** Streams are deprecated as of release 5.0, use kafka as a replacement technology. Support for streams will be discontinued in 6.0 release **
 
 *Streams* are the primary means of bringing data from external systems into the CDAP in real time.
 They are ordered, time-partitioned sequences of data, usable for real-time collection and consumption of data.

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -35,7 +35,11 @@ Cask Data Application Platform Release Notes
 Deprecated and Removed Features
 -------------------------------
 
-- The Following deprecations have been removed from the `cdap-api` module:
+- Streams are deprecated in this release, use kafka as a replacement technology. Streams will be removed in 6.0 release.
+
+- Flows are deprecated in this release, use spark streaming as a replacement technology. Flows will be removed in 6.0 release.
+
+- The following deprecations have been removed from the `cdap-api` module:
 	- Scheduling workflow using co.cask.cdap.api.schedule.Schedule in AbstractApplication is removed, Use co.cask.cdap.internal.schedule.ScheduleCreationSpec for scheduling workflow.
 	- Adding schedule using co.cask.cdap.api.schedule.Schedule is removed in ApplicationConfigurer, use co.cask.cdap.internal.schedule.ScheduleCreationSpec for adding schedules.
 	- Deprecated methods getStreams, getDatasetModules and getDatasetSpecs have been removed from FlowletDefinition.
@@ -46,7 +50,7 @@ Deprecated and Removed Features
 	- MapReduceTaskContext#getInputName has been removed, use getInputContext instead.
 
 
-- The Following deprecations have been removed from the `cdap-proto` module:
+- The following deprecations have been removed from the `cdap-proto` module:
 	- ApplicationDetail#getArtifactVersion has been removed, use ApplicationDetail#getArtifact instead.
 	- getId() method has been removed in ApplicationRecord, DatasetRecord, ProgramLiveInfo and ProgramRecord.
 	- Id class has been removed.
@@ -55,7 +59,7 @@ Deprecated and Removed Features
 	- Methods for getting ScheduleSpecification toScheduleSpec() and toScheduleSpecs(List<ScheduleDetail> details), have been removed from ScheduleDetail.
 	- Deprecated MetadataRecord class has been removed.
 
-- The Following deprecations have been removed from the `cdap-client` module:
+- The following deprecations have been removed from the `cdap-client` module:
  	- Removed Methods which were using the old co.cask.cdap.proto.Id classes in ApplicationClient, ArtifactClient, ClientConfig, DatsetClient, DatasetModuleClient, DatasetTypeClient, LineageClient, MetricsClient, ProgramClient, ScheduleClient, ServiceClient, StreamClient, StreamViewClient and WorkflowClient.
  	- Removed methods to add, update schedules using ScheduleInstanceConfiguration in ScheduleClient, use methods taking ScheduleDetail as parameter instead.
 


### PR DESCRIPTION
Build: https://builds.cask.co/browse/CDAP-DQB410

Relevant pages: 
- https://builds.cask.co/artifact/CDAP-DQB410/shared/build-4/Docs-HTML/html/developer-manual/building-blocks/streams.html
- https://builds.cask.co/artifact/CDAP-DQB410/shared/build-4/Docs-HTML/html/developer-manual/building-blocks/flows-flowlets/index.html
- https://builds.cask.co/artifact/CDAP-DQB410/shared/build-4/Docs-HTML/html/reference-manual/release-notes.html#deprecated-and-removed-features