### PR TITLE
CDAP-13088 Metadata from program and plugin docs [Part 2]

### DIFF
--- a/cdap-docs/developer-manual/source/getting-started/quick-start.rst
+++ b/cdap-docs/developer-manual/source/getting-started/quick-start.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2017 Cask Data, Inc.
+    :copyright: Copyright © 2014-2018 Cask Data, Inc.
 
 .. _quick-start:
 
@@ -20,15 +20,16 @@ Data Pipeline
 =============
 
 CDAP Pipelines is a self-service, reconfigurable, extendable framework to develop, run,
-automate, and operate **data pipelines** on Hadoop. Follow the instructions :ref:`here <cdap-pipelines-getting-started-start>` to build and run your data pipeline.
+automate, and operate **data pipelines** on Hadoop. Follow the instructions
+:ref:`here <cdap-pipelines-getting-started-start>` to build and run your data pipeline.
 
 Data Pipeline Tutorials
 =======================
 
-- :ref: `Use CDAP's data preparation and data pipelines to clean, prepare, and store customer data stored in a MySQL database. <tutorials-campaign>`
+- :ref:`Cleaning and preparing customer data in MySQL <tutorials-campaign>`
 
-- :ref: `Learn how to process XML data using data preparation and data pipelines <tutorials-nytimes>`
+- :ref:`Processing XML data <tutorials-nytimes>`
 
-- :ref: `Use CDAP data pipelines for analyzing and Masking IoT Device Data <tutorials-fitbit>`
+- :ref:`Analyzing and masking IoT device data <tutorials-fitbit>`
 
-- :ref: `Building a Stock Selection Pipeline. <tutorials-stocks>`
+- :ref:`Building a Stock Selection Pipeline. <tutorials-stocks>`

--- a/cdap-docs/developer-manual/source/metadata/index.rst
+++ b/cdap-docs/developer-manual/source/metadata/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015-2017 Cask Data, Inc.
+    :copyright: Copyright © 2015-2018 Cask Data, Inc.
 
 :hide-toc: true
 
@@ -18,9 +18,10 @@ Metadata
     Discovery and Lineage <discovery-lineage>
     Audit Logging <audit-logging>
     CDAP Metadata UI <metadata-ui>
+    Accessing metadata programmatically <programmatic-metadata>
 
 
-*Metadata* is an important capability of CDAP. CDAP Metadata helps show how datasets and
+*Metadata* is an important capability of CDAP. It helps show how datasets and
 programs are related to each other and helps in understanding the impact of a change
 before the change is made.
 
@@ -38,7 +39,7 @@ and governance for every application.
 
 CDAP metadata |---| consisting of **properties** (a list of key-value pairs) or **tags** (a
 list of keys) |---| can be used to annotate artifacts, applications, programs, datasets,
-streams, and views.
+streams, views and custom entities.
 
 Using the CDAP :ref:`Metadata HTTP RESTful API <http-restful-api-metadata>`, you can set,
 retrieve, and delete these metadata annotations.
@@ -77,6 +78,12 @@ object associated with a single entity is limited to 10K bytes in size.
 
 - |metadata-ui|_ lets you see how data is flowing into and out of datasets, streams, and
   stream views.
+
+.. |programmatic-metadata| replace:: **Accessing metadata programmatically:**
+.. _programmatic-metadata: programmatic-metadata.html
+
+- |programmatic-metadata|_ Metadata can be retrieved or updated programmatically from CDAP programs and plugins,
+  primarily for enabling metadata based processing.
 
 
 .. _metadata-navigator-integration:

--- a/cdap-docs/developer-manual/source/metadata/programmatic-metadata.rst
+++ b/cdap-docs/developer-manual/source/metadata/programmatic-metadata.rst
@@ -1,0 +1,103 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2018 Cask Data, Inc.
+
+.. _programmatic-metadata:
+
+===================================
+Accessing metadata programmatically
+===================================
+
+.. highlight:: java
+
+Metadata can be retrieved and updated programmatically in both *programs* and *plugins*.
+
+This feature can be used to perform metadata based processing. For example, suppose you have a dataset which contains
+sensitive information in one of its fields. Your organization also has a policy that requires that all sensitive
+information be masked. You can annotate the field with a tag to represent that it contains sensitive information.
+You can then develop a plugin which reads the metadata of all the fields in the dataset and masks the contents of a
+field, if it is annotated with a particular tag.
+
+*Note*: Currently, reading metadata is not supported in a *program* or a *plugin* running in a *cloud* environment.
+However, metadata can still be added, updated or deleted in this case.
+
+.. _metadata-programs:
+
+Programs
+========
+Metadata can be accessed from *MapReduce*, *Spark*, *Workers* and *Service* through methods from the
+`MetadataReader <../../reference-manual/javadocs/co/cask/cdap/api/metadata/MetadataReader.html>`__ object,
+which are available via the appropriate program context object in your program. The program context object can
+be obtained by invoking the ``getContext()`` method inside the ``initialize`` method of your program.
+
+The following example shows how you can retrieve the metadata of an entity in a *MapReduce* program::
+
+  @Override
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
+
+    // construct the metadata entity
+    MetadataEntity entity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "myNamespace")
+      .appendAsType(MetadataEntity.DATASET, "myDataset").build();
+
+    // get the metadata
+    Map<MetadataScope, Metadata> metadata = context.getMetadata(entity);
+  }
+
+You can also annotate metadata to an entity through methods from the
+`MetadataWriter <../../reference-manual/javadocs/co/cask/cdap/api/metadata/MetadataWriter.html>`__
+object, which are also available through the same program context object as above.
+
+The following example shows how you can annotate metadata to entity in a *MapReduce* program::
+
+  @Override
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
+
+    // construct the metadata entity
+    MetadataEntity entity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "myNamespace")
+      .appendAsType(MetadataEntity.DATASET, "myDataset").build();
+
+    // add a tag
+    context.addTags(entity, "someTag");
+  }
+
+.. _metadata-plugins:
+
+Plugins
+=======
+Metadata can be accessed from a *Plugin* through methods from the
+`MetadataReader <../../reference-manual/javadocs/co/cask/cdap/api/metadata/MetadataReader.html>`__ object,
+which are available via the appropriate context provided to in ``prepareRun`` stage.
+
+The following example shows how you can retrieve the metadata of an entity in a *Plugin*::
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    context.setInput(Input.ofDataset(config.tableName));
+
+    // construct the metadata entity
+    MetadataEntity entity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "myNamespace")
+      .appendAsType(MetadataEntity.DATASET, "myDataset").build();
+
+    // get the metadata
+    Map<MetadataScope, Metadata> metadata = context.getMetadata(entity);
+  }
+
+You can also annotate metadata to an entity through methods from the
+`MetadataWriter <../../reference-manual/javadocs/co/cask/cdap/api/metadata/MetadataWriter.html>`__
+object, which are also available through the same context object as above.
+
+The following example shows how you can annotate metadata to entity in a *Plugin*::
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    context.setInput(Input.ofDataset(config.tableName));
+
+    // construct the metadata entity
+    MetadataEntity entity = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, context.getNamespace())
+      .appendAsType(MetadataEntity.DATASET, config.tableName).build();
+
+    // add a tag
+    context.addTags(entity, "someTag");
+  }


### PR DESCRIPTION
## Metadata 5.0 Docs
### Part 2

- Documents accessing Metadata from Plugin and Pipelines.

Build: https://builds.cask.co/browse/CDAP-DQB412-1

Rendered Page: https://builds.cask.co/artifact/CDAP-DQB412/shared/build-4/Docs-HTML/5.0.0-SNAPSHOT/en/developer-manual/metadata/programmatic-metadata.html