### PR TITLE
CDAP-13651 Fix secure key listing doc

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/security.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/security.rst
@@ -391,8 +391,8 @@ with the secure keys in the namespace returned as a JSON string map of string-st
 in the response body (shown here pretty-printed)::
 
   {
-    secure-key-id-1: data-1,
-    secure-key-id-2: data-2,
+    secure-key-id-1: secure key description,
+    secure-key-id-2: secure key description,
     ...
   }
 
@@ -401,8 +401,8 @@ in the response body (shown here pretty-printed)::
 such as (depending on what was stored)::
 
   {
-    "securekey": "securedata",
-    "password": "passw0rd",
+    "securekey": "secure key description",
+    "password": "password description",
     ...
   }
 


### PR DESCRIPTION
### [Issue](https://issues.cask.co/browse/CDAP-13651)

Secure key listing return the key with it's description and not the value of the key. 

For example if the following secure keys were added through PUT

> curl -X PUT \
  http://localhost:11015/v3/namespaces/default/securekeys/key1 \
  -d '{
  "description": "desc1",
  "data": "k1",
  "properties": {
    "<property-key>": "pk1"
  }
}'

and 

> curl -X PUT \
  http://localhost:11015/v3/namespaces/default/securekeys/key2 \
  -d '{
  "description": "desc2",
  "data": "k2",
  "properties": {
    "<property-key>": "pk2"
  }
}'

Then a list returns

> {
    "key1": "desc1",
    "key2": "desc2"
}

Build: https://builds.cask.co/browse/CDAP-DQB415-1