### PR TITLE
Moves dataprep service control error text to be under the right prefix

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
@@ -20,9 +20,9 @@ import React, { Component } from 'react';
 import enableSystemApp from 'services/ServiceEnablerUtilities';
 import T from 'i18n-react';
 import classnames from 'classnames';
-import {objectQuery} from 'services/helpers';
 import MyDataPrepApi from 'api/dataprep';
 import {i18nPrefix, MIN_DATAPREP_VERSION, artifactName} from 'components/DataPrep';
+import isObject from 'lodash/isObject';
 
 require('./DataPrepServiceControl.scss');
 
@@ -59,9 +59,13 @@ export default class DataPrepServiceControl extends Component {
       .subscribe(() => {
         this.props.onServiceStart();
       }, (err) => {
+        let extendedMessage = isObject(err.extendedMessage) ?
+          err.extendedMessage.response || err.extendedMessage.message
+        :
+          err.extendedMessage;
         this.setState({
           error: err.error,
-          extendedMessage: objectQuery(err, 'extendedMessage', 'response'),
+          extendedMessage,
           loading: false
         });
       });
@@ -112,6 +116,7 @@ export default class DataPrepServiceControl extends Component {
                   }
                 </button>
               </div>
+              {this.renderError()}
               <p>
                 {T.translate(`${PREFIX}.description`)}
               </p>
@@ -121,7 +126,6 @@ export default class DataPrepServiceControl extends Component {
                 <li>{T.translate(`${PREFIX}.list.3`)}</li>
                 <li>{T.translate(`${PREFIX}.list.4`)}</li>
               </ul>
-              {this.renderError()}
             </div>
           </div>
         </div>

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
@@ -24,6 +24,7 @@ import CardActionFeedback from 'components/CardActionFeedback';
 import ee from 'event-emitter';
 import {i18nPrefix, MIN_DATAPREP_VERSION, artifactName} from 'components/DataPrep';
 import MyDataPrepApi from 'api/dataprep';
+import isObject from 'lodash/isObject';
 
 const PREFIX = `features.DataPrep.TopPanel.UpgradeModal`;
 
@@ -61,10 +62,14 @@ export default class UpgradeModal extends Component {
       .subscribe(() => {
         this.eventEmitter.emit('REFRESH_DATAPREP');
       }, (err) => {
+        let extendedMessage = isObject(err.extendedMessage) ?
+          err.extendedMessage.response || err.extendedMessage.message
+        :
+          err.extendedMessage;
         this.setState({
           loading: false,
           error: err.error,
-          extendedMessage: err.extendedMessage
+          extendedMessage
         });
       });
   }

--- a/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/RulesEngineServiceControl/index.js
@@ -21,6 +21,7 @@ import enableSystemApp from 'services/ServiceEnablerUtilities';
 import LoadingSVG from 'components/LoadingSVG';
 import T from 'i18n-react';
 import IconSVG from 'components/IconSVG';
+import isObject from 'lodash/isObject';
 
 require('./RulesEngineServiceControl.scss');
 const PREFIX = 'features.RulesEngine.RulesEngineServiceControl';
@@ -51,9 +52,13 @@ export default class RulesEngineServiceControl extends Component {
       .subscribe(
         this.props.onServiceStart,
         (err) => {
+          let extendedMessage = isObject(err.extendedMessage) ?
+            err.extendedMessage.response || err.extendedMessage.message
+          :
+            err.extendedMessage;
           this.setState({
             error: err.error,
-            extendedError: err.extendedMessage,
+            extendedError: extendedMessage,
             loading: false
           });
         }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -354,9 +354,6 @@ features:
     btnLabel: Enable Data Preparation
     btnLoadingLabel: "Enabling..."
     description: CDAP Data Preparation provides an easy and interactive way to visualize, transform, and cleanse data. It allows the user to view data from a local source, a cluster or a database, and derive new schemas and operationalize the data preparation with a few clicks.
-    errorCommunicating: Error while communicating with Data Preparation service
-    errorTitle: Enabling Data Preparation failed
-    failedToStop: Failed to stop Data Preparation service
     list:
       1: Easy and interactive way to work with messy data
       2: Apply transformations using a variety of operations on various data types
@@ -1003,6 +1000,9 @@ features:
       upload: Local File Upload
       viewSchemaBtnLabel: View Schema
     Upgrade:
+      errorCommunicating: Error while communicating with Data Preparation service
+      errorTitle: Enabling Data Preparation failed
+      failedToStop: Failed to stop Data Preparation service
       minimumVersionError: "Data Preparation requires wrangler-service artifact version {minimumVersion} or above. Version {highestVersion} found. Please install the latest wrangler-service from Hub."
     WorkspaceTabs:
       DeleteModal:


### PR DESCRIPTION
Both `DataPrepServiceControl` and `UpgradeModal` passes the same `i18nPrefix` to `enableSystemApp()` call, and the latter will use this prefix to display the appropriate error message. 

Both use the prefix `'features.DataPrep.Upgrade`, however I had incorrectly put the text under `features.DataPrepServiceControl` instead.