### PR TITLE
CDAP-13849 Improved error message when Dataproc Provisioner can not connect to the remote host

### DIFF
--- a/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisioner.java
+++ b/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisioner.java
@@ -31,9 +31,12 @@ import co.cask.cdap.runtime.spi.ssh.SSHKeyPair;
 import co.cask.cdap.runtime.spi.ssh.SSHSession;
 import com.amazonaws.services.elasticmapreduce.model.ClusterSummary;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.net.ConnectException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -107,10 +110,25 @@ public class ElasticMapReduceProvisioner implements Provisioner {
   @Override
   public void initializeCluster(ProvisionerContext context, Cluster cluster) throws Exception {
     // Start the ZK server
-    try (SSHSession session = context.getSSHContext().createSSHSession(getMasterExternalIp(cluster))) {
+    try (SSHSession session = createSSHSession(context, getMasterExternalIp(cluster))) {
       LOG.debug("Starting zookeeper server.");
       String output = session.executeAndWait("sudo zookeeper-server start");
       LOG.debug("Zookeeper server started: {}", output);
+    }
+  }
+
+  private SSHSession createSSHSession(ProvisionerContext provisionerContext, String host) throws IOException {
+    try {
+      return provisionerContext.getSSHContext().createSSHSession(host);
+    } catch (IOException ioe) {
+      if (Throwables.getRootCause(ioe) instanceof ConnectException) {
+        throw new IOException(String.format(
+                "Failed to connect to host %s. Ensure that the the provisioner property for \"Additional Master" +
+                        " Security Group\" has been configured with an EC2 Security Group that has inbound rules" +
+                        " allowing ssh and https (ports 22 and 443).", host),
+                ioe);
+      }
+      throw ioe;
     }
   }
 

--- a/cdap-runtime-ext-emr/src/main/resources/aws-emr.json
+++ b/cdap-runtime-ext-emr/src/main/resources/aws-emr.json
@@ -79,10 +79,10 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Additional EMR managed security group for the master instance",
+          "label": "Additional Master Security Group",
           "name": "additionalMasterSecurityGroup",
           "required": true,
-          "description": "An additional EMR managed security group that will be applied to the master instance. For more information, refer to https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-man-sec-groups.html.",
+          "description": "An additional EMR managed security group that will be applied to the master instance. It must have an inbound rule that allows ssh and https (ports 22 and 443). For more information, refer to https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-man-sec-groups.html.",
           "widget-attributes": {
             "placeholder": "Specify your EMR managed security group"
           }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-13849
Improved error message when Dataproc/EMR Provisioner can not connect to the remote host.