### PR TITLE
CDAP-13147 documentation on operations dashboard and reporting

### DIFF
--- a/cdap-docs/admin-manual/source/operations/index.rst
+++ b/cdap-docs/admin-manual/source/operations/index.rst
@@ -15,6 +15,7 @@ Operations
    
     Logging and Monitoring <logging>
     Metrics <metrics>
+    Dashboard and Reports <operations-dashboard>
     Preferences and Runtime Arguments <preferences>
     Scaling Instances <scaling-instances>
     Resource Guarantees in YARN <resource-guarantees>
@@ -38,6 +39,10 @@ Operations
 
 - |metrics|_ CDAP collects **metrics about the application’s behavior and performance**.
 
+.. |operations-dashboard| replace:: **Dashboard and Reports:**
+.. _operations-dashboard: operations-dashboard.html
+
+- |operations-dashboard|_ Real-time dashboard and reports for program run statistics.
 
 .. |preferences| replace:: **Preferences and Runtime Arguments:**
 .. _preferences: preferences.html

--- a/cdap-docs/admin-manual/source/operations/operations-dashboard.rst
+++ b/cdap-docs/admin-manual/source/operations/operations-dashboard.rst
@@ -1,0 +1,74 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
+
+.. _operations-dashboard:
+
+======================
+Dashboard and Reports
+======================
+
+**Dashboard** is a real-time interactive interface that visualizes program run statistics,
+over any 24-hour window in the last week or, for a more detailed view, over any 1-hour window.
+
+**Reports** provide comprehensive insights into program runs. You can generate a report to view
+statistics about program runs within a given time range such as 24 hours or one week. A Spark batch
+job will process the program runs and generate the requested report.
+
+Dashboard and reports both support monitoring **across namespaces**, allowing you to view dashboard and generate report statistics across multiple namespaces.
+
+Dashboard
+=========
+
+The **Dashboard** was introduced in CDAP 5.0 to offer a holistic operational view of all pipelines and
+application programs running in a CDAP instance. It addresses these common operational needs:
+
+  - CDAP System status
+      - Filter and view pipelines and/or custom programs that are currently running
+      - View pipelines and/or custom programs that have been submitted but are not yet running in the cluster
+      - Slice and dice by namespace, program-status and start-method.
+
+  - Predicting future resource usage
+      - View program and pipeline runs scheduled in the future to predict and proactively manage resource usage.
+
+**Note** : Dashboard UI offers both charting and tabular view of the program runs status in the 24-hour window.
+
+Limitation
+----------
+  - Only the program runs that were started in or after CDAP-5.0 will be processed and displayed on dashboard.
+
+Reports
+=======
+Reports is a tool for administrators to take a historical look at their applications'
+program runs, and performance, optionally filtered by criteria such as program type or final run status.
+
+Reports must be enabled before you can use it, This deploys the **cdap-program-report** application to system namespace
+and starts a Spark service, This service enables you to generate, list, view, save and delete reports.
+
+Once you have enabled the reports and you are in reports page, you can request a report by providing the following
+
+  - Filter, you can specify the filters you are interested in such as program-type (pipeline, custom-program) or program run status
+  - Add additional namespaces to monitor and include in the report, by default report will be generated for programs in current namespace.
+  - Specify the column fields you want to be included in the report content such as namespace, start-time, start-method, etc.
+  - Select a time range.
+  - Generate the report.
+
+Once you request a report, the Spark service launches a Spark job to process the program run statistics
+in a scalable way and generate the report summary and report details, this could take a few minutes before the report is ready to be viewed.
+
+Reports contain two components: a summary and a program runs table. They provide, for example, this information:
+
+  - Tabular view of program runs that matche your request filters, with selected column fields.
+  - In multi-tenant deployments, a summary and detailed report of pipelines run by each user
+  - Minimum, maximum and average duration of program runs that match the report request filters
+  - Summary of runs grouped by namespace, application type, start method and user.
+
+By default, reports expire 2 days after their creation time, unless they are explicitly saved.
+
+Limitations
+-----------
+  - Reports is **not** supported on clusters with Spark version lower than 2.1.
+  - Only the program runs that were started in or after CDAP-5.0 will be processed and included in the reports, program runs from earlier CDAP version will be skipped.
+
+More information about using the dashboard can be found at :ref:`Dashboard REST API <http-restful-api-dashboard>`
+and Reports application's usage can be found at :ref:`Reports REST API <http-restful-api-reports>` in the REST API documentation.

--- a/cdap-docs/reference-manual/source/http-restful-api/dashboard.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/dashboard.rst
@@ -1,0 +1,99 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :description: HTTP RESTful Interface to the Cask Data Application Platform
+    :copyright: Copyright © 2018 Cask Data, Inc.
+
+.. _http-restful-api-dashboard:
+
+==========================
+Dashboard HTTP RESTful API
+==========================
+.. topic::  **Note:**
+
+    Dashboard is currently a **beta** feature of CDAP |release|, and is subject to change without notice.
+
+The CDAP Dashboard HTTP API is used to retrieve real time dashboard details.
+
+.. Base URL explanation
+.. --------------------
+.. include:: base-url.txt
+
+
+Dashboard HTTP REST API
+=======================
+
+Dashboard endpoint to query the dashboard for the programs that ran in a time range and programs schedules that will run in the future.
+
+.. highlight:: console
+
+::
+
+  GET /v3/dashboard?start=<query-start-time>&duration=<query-duration>&namespace=<namespaces>
+
+.. list-table::
+ :widths: 20 80
+ :header-rows: 1
+
+ * - Query Parameter
+   - Description
+ * - ``start``
+   - Query start time in seconds
+ * - ``duration``
+   - Duration in seconds, query end time is inferred as startTime + duration in seconds
+ * - ``namespace``
+   - Set of namespaces, used for filtering by namespace, only programs that ran in this namespace or schedules that will be run in this namespace will be returned.
+
+For the given query timerange, for the time between start time and the current-time, the response will
+return historical runs which were either started, running or reached end state (stopped/killed/failed) in that time window.
+
+For the future time range, time range after current time till the end time,
+The response will return all the programs that are scheduled to run in that time window.
+If a program is scheduled to be run multiple times in the query time range, then all of those will be returned.
+
+Example response for dashboard API query:
+
+.. highlight:: json
+
+::
+
+ [
+    // completed program run
+    {
+        "application": {
+            "name": "HDFSPipeline",
+            "version": "1.0-SNAPSHOT"
+        },
+        "artifact": {
+            "name": "cdap-data-pipeline",
+            "scope": "SYSTEM",
+            "version": "5.0.0-SNAPSHOT"
+        },
+        "end": 1532483112,
+        "namespace": "default",
+        "program": "phase-1",
+        "run": "5b89e259-8fac-11e8-bba1-acde48001122",
+        "running": 1532483108,
+        "start": 1532483106,
+        "startMethod": "SCHEDULED",
+        "status": "COMPLETED",
+        "type": "SPARK"
+    },
+    ....
+    // scheduled program run in future
+    {
+        "application": {
+            "name": "testPipeline",
+            "version": "1.1-SNAPSHOT"
+        },
+        "artifact": {
+            "name": "cdap-data-pipeline",
+            "scope": "SYSTEM",
+            "version": "5.0.0-SNAPSHOT"
+        },
+        "namespace": "default",
+        "program": "DataPipelineWorkflow",
+        "start": 1532487600,
+        "startMethod": "SCHEDULED",
+        "type": "WORKFLOW"
+    }
+ ]

--- a/cdap-docs/reference-manual/source/http-restful-api/index.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/index.rst
@@ -26,8 +26,10 @@ CDAP HTTP RESTful API v3
     Metrics <metrics>
     Monitor <monitor>
     Namespace <namespace>
+    Dashboard <dashboard>
     Preferences <preferences>
     Query <query>
+    Reports <reports>
     Route Config <routeconfig>
     Security <security>
     Service <service>
@@ -84,6 +86,8 @@ data isolation. This is an inital step towards introducing `multi-tenancy
 - :doc:`Logging: <logging>` retrieving application logs
 - :doc:`Metrics: <metrics>` retrieving metrics for system and user applications (user-defined metrics)
 - :doc:`Monitor: <monitor>` checking the status of various system and custom CDAP services
+- :doc:`Dashboard: <dashboard>` check in real time status of past program runs and predict future resource usage
+- :doc:`Reports: <reports>` generate reports to understand and monitor program runs and their performance
 
 
 .. rubric:: Alphabetical List of APIs
@@ -105,8 +109,10 @@ data isolation. This is an inital step towards introducing `multi-tenancy
 - :doc:`Metrics: <metrics>` retrieving metrics for system and user applications (user-defined metrics)
 - :doc:`Monitor: <monitor>` checking the status of various system and custom CDAP services
 - :doc:`Namespace: <namespace>` creating and managing namespaces
+- :doc:`Dashboard: <dashboard>` check in real time status of past program runs and predict future resource usage
 - :doc:`Preferences: <preferences>` setting, retrieving, and deleting preferences
 - :doc:`Query: <query>` sending ad-hoc queries to CDAP datasets
+- :doc:`Reports: <reports>` generate reports to understand and monitor program runs and their performance
 - :doc:`Route Config: <query>` create, fetch, and delete route configurations (*route
   configs*) which allocate requests between different versions of a service
 - :doc:`Security: <security>` granting, revoking, and listing privileges, as well as adding, retrieving,

--- a/cdap-docs/reference-manual/source/http-restful-api/reports.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/reports.rst
@@ -1,0 +1,441 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :description: HTTP RESTful Interface to the Cask Data Application Platform
+    :copyright: Copyright © 2018 Cask Data, Inc.
+
+.. _http-restful-api-reports:
+
+==========================
+Reports HTTP RESTful API
+==========================
+.. topic::  **Note:**
+
+    Reports is currently a **beta** feature of CDAP |release|, and is subject to change without notice.
+
+Overview
+========
+
+Reports provides administrators and developers a way to generate comprehensive report of program runs,
+specify filters based on various options such as namespaces, program status and type of program,
+within a given time range such as 24 hours or one week or a custom time range. You can also specify the columns
+that you would like to include in the generated report.
+
+Reports are backed by the ReportGenerationApp system application, which is a Spark service (named ReportGenerationSpark)
+with endpoints to generate, list, view, download, share, save or delete reports.
+
+.. Base URL explanation
+.. --------------------
+.. include:: base-url.txt
+
+
+Reports HTTP REST API
+=======================
+
+Generating Reports
+-------------------
+.. highlight:: console
+
+::
+
+ POST:
+ /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports
+
+With Request Json provided as part of the request body.
+
+
+
+Request Json with explanation of JSON fields.
+
+.. highlight:: console
+
+::
+
+ {
+   "name":<Name of the report>,
+   "start":<start-time-in-seconds>,
+   "end":<end-time-in-seconds>,
+
+   "fields":[
+      <include-this-field-1-in-report>,
+       <...>,
+      <include-this-field-N-in-report>
+   ],
+
+   "filters":[
+      {
+         // value filter
+         "fieldName":<name-of-the-field-to-filter-on>,
+         "whitelist":[
+            <acceptable-value-1>,
+            <..>
+            <acceptable-value-N>
+         ]
+      },
+      {
+         // value filter
+         "fieldName":<name-of-the-field-to-filter-on>,
+         "blacklist":[
+            <non-acceptable-value-1>,
+            <...>
+            <non-acceptable-value-N>
+         ]
+      },
+      {
+         // range filter
+         "fieldName":"<name-of-the-field-to-filter-on>",
+         "range":{
+            "min":<minimum-allowed-value>
+            "max":<maximum-allowed-value>
+         }
+      }
+   ],
+   "sort":[
+      {
+         "order":"ASCENDING (or) DESCENDING",
+         "fieldName":"<name-of-the-field-to-sort-by>"
+      }
+   ]
+ }
+
+Example request Json
+
+.. highlight:: json
+
+::
+
+ {
+   "name":"Failed, Stopped, Running, Succeeded runs - Jul 23, 2018 00:00am to Jul 24, 2018 21:00pm",
+   "start":1532329200,
+   "end":1532491200,
+   "fields":[
+      "artifactName",
+      "applicationName",
+      "program",
+      "programType",
+      "namespace",
+      "status",
+      "start",
+      "end"
+   ],
+   "filters":[
+      {
+         "fieldName":"status",
+         "whitelist":[
+            "FAILED",
+            "STOPPED",
+            "RUNNING",
+            "COMPLETED",
+            "KILLED"
+         ]
+      },
+      {
+         "fieldName":"namespace",
+         "whitelist":[
+            "default"
+         ]
+      }
+   ]
+ }
+
+On submitting this request, the backend asynchronously launches a spark job to process and generate the report.
+The immediate response contains the report id.
+
+.. highlight:: json
+
+::
+
+ {
+    "id": <report-id>
+ }
+
+You can use this report-id to check the status of the report, if it is running, completed or failed using the `info` endpoint
+and download completed reports to get information using `download` endpoint.
+
+**Note** : Currently sort cannot be performed on more than one field.
+
+Listing Reports
+---------------
+
+.. highlight:: console
+
+::
+
+ GET :
+ /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports
+
+.. list-table::
+ :header-rows: 1
+ :widths: 30 70
+
+ * - Query Param
+   - Description
+ * - offset
+   - offset to read reports from
+ * - limit
+   - limit on the number of reports to return
+
+Response Json with explanation for fields
+
+.. highlight:: console
+
+::
+
+ {
+   "offset":<offset>,
+   "limit":<limit>,
+   "total":<total-reports-size-returned>,
+   "reports":[
+      {
+         "id":<report-id>,
+         "name":<report-name>,
+         "created":<creation-time-seconds>,
+         "expiry":<report-expiry-time-seconds>,
+         "status":<report-status>
+      },
+      ...
+   ]
+ }
+
+Example Response JSON
+
+.. highlight:: json
+
+::
+
+ {
+   "offset":0,
+   "limit":20,
+   "total":7,
+   "reports":[
+      {
+         "id":"18a782b5-8fd4-11e8-ae71-acde48001122",
+         "name":"Failed, Succeeded, Running, Stopped runs - Jul 24, 2018 22:29pm to Jul 24, 2018 23:29pm",
+         "created":1532500174,
+         "expiry":1532672986,
+         "status":"COMPLETED"
+      },
+      ...
+      {
+         "id":"09ec25f4-8fd4-11e8-9d5d-acde48001122",
+         "name":"Failed, Succeeded, Running, Stopped runs - Jul 24, 2018 22:29pm to Jul 24, 2018 23:29pm",
+         "created":1532500149,
+         "expiry":1532672965,
+         "status":"COMPLETED"
+      }
+   ]
+ }
+
+Sharing Reports
+---------------
+
+On Authentication enabled clusters, reports are isolated by logged-in users who generated the reports,
+If you wish, you can generate an encrypted share-id for your report, that can be used by others to access the report.
+
+.. highlight:: console
+
+::
+
+ POST /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports/<report-id>/share
+
+Response JSON:
+
+.. highlight:: json
+
+::
+
+ {
+    "shareId":<share-id>
+ }
+
+
+Viewing Report Status
+----------------------
+
+The info endpoint can be used to get the report status and summary for a report.
+It can be queried either by providing the report-id or by providing a share-id through query param.
+
+.. highlight:: console
+
+::
+
+ GET using Report-Id : /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports/info?report-id=<report-id>
+ GET using Share-Id : /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports/info?share-id=<share-id>
+
+.. highlight:: json
+
+::
+
+ {
+   "request":{
+      <report-generation-request>
+   },
+   "summary":{
+      "namespaces":[
+         {
+            "namespace":"<namespace>",
+            "runs":<runs-in-report-for-the-namespace>
+         },
+         ...
+      ],
+      "start":<start-time-seconds>,
+      "end":<end-time-seconds>,
+      "artifacts":[
+         {
+            "name":<artifactName>,
+            "version":<artifactVersion>,
+            "scope":<artifactScope,
+            "runs":<runs-in-report-belonging-to-the-artifact>
+         },
+         ...
+      ],
+      "durations":{
+         "min":<minimum-duration-of-runs-in-seconds>,
+         "max":<max-duration-of-runs-in-seconds>,
+         "average":<average-duration-of-runs-in-seconds>
+      },
+      "starts":{
+         "oldest":<earliest-started-program-time>,
+         "newest":<latest-started-program-time>
+      },
+      "owners":[
+         {
+            "user":<userName>,
+            "runs":<runs-started-by-this-user>
+         },
+         ...
+      ],
+      "startMethods":[
+         {
+            "method":"MANUAL/SCHEDULED/TRIGGERED",
+            "runs":<runs-started-by-this-start-method>
+         },
+         ...
+      ],
+      "recordCount":<total-records-in-report>,
+      "creationTimeMillis":<time-when-report-was-created>,
+      "expirationTimeMillis":<time-when-report-will-be-expired>
+   },
+   "name":<name-of-the-report>,
+   "created":<report-creation-time-seconds>,
+   "expiry":<report-expiry-time-seconds>,
+   "status":<report-status>
+ }
+
+For reports that are currently running, the response does not contain a report summary
+
+.. highlight:: json
+
+::
+
+ {
+   "request":{
+      <report-generation-request>
+   },
+   "name":<name-of-the-report>,
+   "created":<creation-time>,
+   "status":"RUNNING"
+ }
+
+For failed reports, the response contains the error information.
+
+.. highlight:: json
+
+::
+
+ {
+   "request":{
+      <report-generation-request>
+   },
+   "error" : <error-message>,
+   "name":<name-of-the-report>,
+   "created":<creation-time>,
+   "status":"FAILED"
+ }
+
+Downloading Report contents
+----------------------------
+
+The download endpoint can be used to download the report contents.
+You can either provide a report id or a share id through a query parameter.
+
+.. highlight:: console
+
+::
+
+ GET using report-id : /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports/download?report-id=<report-id>
+ GET using share-id : /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports/download?share-id=<share-id>
+
+.. highlight:: json
+
+::
+
+ {
+   "offset":<offset>,
+   "limit":<limit-of-records-to-return>,
+   "total":<total-number-of-records-in-report>,
+   "details":[
+      {
+         "field1":<value>,
+         ...
+         "fieldN":<value>
+      },
+    ...
+   ]
+ }
+
+Example JSON response
+
+.. highlight:: json
+
+::
+
+ {
+   "offset":0,
+   "limit":20,
+   "total":25,
+   "details":[
+      {
+         "duration":21,
+         "program":"DataPipelineWorkflow",
+         "programType":"Workflow",
+         "applicationName":"testPipeline",
+         "artifactName":"cdap-data-pipeline",
+         "status":"COMPLETED",
+         "end":1532499023,
+         "start":1532499002,
+         "namespace":"default"
+      },
+      ...
+   ]
+ }
+
+Saving Reports
+--------------
+By default reports expire after 2 weeks, however they can be saved by using the following REST endpoint,
+
+.. highlight:: console
+
+::
+
+ POST : /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports/<report-id>/save
+
+with request body containing the name and description for saving the report
+
+.. highlight:: json
+
+::
+
+ {
+   "name" : <report-name>,
+   "description" : <description-for-report>
+ }
+
+Deleting Reports
+----------------
+Unneeded reports (whether generated or failed) can be deleted by making a call to the following endpoint
+
+.. highlight:: console
+
+::
+
+ DELETE : /v3/namespaces/system/apps/ReportGenerationApp/spark/ReportGenerationSpark/methods/reports/<report-id>


### PR DESCRIPTION
Docs quick build : https://builds.cask.co/browse/CDAP-DQB419-9

Quick Links to documentation pages from build 

Overview page : https://builds.cask.co/artifact/CDAP-DQB419/shared/build-9/Docs-HTML/html/admin-manual/operations/operations-dashboard.html

Reporting REST API : https://builds.cask.co/artifact/CDAP-DQB419/shared/build-9/Docs-HTML/html/reference-manual/http-restful-api/reporting.html

Dashboard REST API page : https://builds.cask.co/artifact/CDAP-DQB419/shared/build-9/Docs-HTML/html/reference-manual/http-restful-api/operations.html

TODO : Will add section on limitation (reporting only on spark2, etc)
Edit : updated links to latest build