### PR TITLE
CDAP-13925 fix tag value of profile

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -521,7 +521,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
   private void emitProfileMetrics(ProgramRunId programRunId, ProfileId profileId, String metricName) {
     Map<String, String> tags = ImmutableMap.<String, String>builder()
       .put(Constants.Metrics.Tag.PROFILE_SCOPE, profileId.getScope().name())
-      .put(Constants.Metrics.Tag.PROFILE, profileId.getScopedName())
+      .put(Constants.Metrics.Tag.PROFILE, profileId.getProfile())
       .put(Constants.Metrics.Tag.NAMESPACE, programRunId.getNamespace())
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, programRunId.getType().getPrettyName())
       .put(Constants.Metrics.Tag.APP, programRunId.getApplication())

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/profile/ProfileMetricService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/profile/ProfileMetricService.java
@@ -82,7 +82,7 @@ public class ProfileMetricService extends AbstractScheduledService {
                                                      ProgramRunId programRunId, ProfileId profileId) {
     Map<String, String> tags = ImmutableMap.<String, String>builder()
       .put(Constants.Metrics.Tag.PROFILE_SCOPE, profileId.getScope().name())
-      .put(Constants.Metrics.Tag.PROFILE, profileId.getScopedName())
+      .put(Constants.Metrics.Tag.PROFILE, profileId.getProfile())
       .put(Constants.Metrics.Tag.NAMESPACE, programRunId.getNamespace())
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, programRunId.getType().getPrettyName())
       .put(Constants.Metrics.Tag.APP, programRunId.getApplication())

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
@@ -309,7 +309,7 @@ public class ProgramNotificationSubscriberServiceTest {
   private long getMetric(MetricStore metricStore, ProgramRunId programRunId, ProfileId profileId, String metricName) {
     Map<String, String> tags = ImmutableMap.<String, String>builder()
       .put(Constants.Metrics.Tag.PROFILE_SCOPE, profileId.getScope().name())
-      .put(Constants.Metrics.Tag.PROFILE, profileId.getScopedName())
+      .put(Constants.Metrics.Tag.PROFILE, profileId.getProfile())
       .put(Constants.Metrics.Tag.NAMESPACE, programRunId.getNamespace())
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, programRunId.getType().getPrettyName())
       .put(Constants.Metrics.Tag.APP, programRunId.getApplication())

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileMetricServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileMetricServiceTest.java
@@ -76,7 +76,7 @@ public class ProfileMetricServiceTest {
   private long getMetric(MetricStore metricStore, ProgramRunId programRunId, ProfileId profileId, String metricName) {
     Map<String, String> tags = ImmutableMap.<String, String>builder()
       .put(Constants.Metrics.Tag.PROFILE_SCOPE, profileId.getScope().name())
-      .put(Constants.Metrics.Tag.PROFILE, profileId.getScopedName())
+      .put(Constants.Metrics.Tag.PROFILE, profileId.getProfile())
       .put(Constants.Metrics.Tag.NAMESPACE, programRunId.getNamespace())
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, programRunId.getType().getPrettyName())
       .put(Constants.Metrics.Tag.APP, programRunId.getApplication())

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/BasicInfo.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/BasicInfo.scss
@@ -41,6 +41,7 @@ $grey-font-color: $grey-03;
           overflow: hidden;
           text-overflow: ellipsis;
           vertical-align: middle;
+          line-height: 1.4;
         }
 
         .profile-actions-wrapper {

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/index.js
@@ -82,7 +82,7 @@ export default class ProfileAssociations extends Component {
     let extraTags = {
       program: objectQuery(metadata, 'program'),
       programtype: objectQuery(metadata, 'type') || 'Workflow',
-      profile: `${profile.scope}:${profile.name}`,
+      profile: `${profile.name}`,
       app: objectQuery(metadata, 'app'),
       namespace: objectQuery(metadata, 'namespace')
     };

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
@@ -69,7 +69,7 @@ export default class ProfileDetailView extends Component {
     let {namespace} = this.props.match.params;
     let {profile} = this.state;
     let extraTags = {
-      profile: `${profile.scope}:${profile.name}`,
+      profile: `${profile.name}`,
       programtype: 'Workflow'
     };
     fetchAggregateProfileMetrics(namespace, profile, extraTags)

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
@@ -56,7 +56,8 @@ const profiles = (state = DEFAULT_PROFILES_STATE, action = defaultAction) => {
       let {profiles} = state;
       profiles = profiles.map(profile => {
         let metricObj = {runs: '--', minutes: '--'};
-        let profileMetrics = profilesToMetricsMap[profile.name] || {};
+        let profileKey = `${profile.scope.toLowerCase()}:${profile.name}`;
+        let profileMetrics = profilesToMetricsMap[profileKey] || {};
         /*
           We are adding empty oneday and overall metrics AND metrics from backend
           as we are not sure UI will get all metrics from backend. This will give


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13925
Build: https://builds.cask.co/browse/CDAP-RUT1602-1

Fix a tag value when we emit profile metrics, changed the PROFILE tag to use profile name instead of scoped name since we already have a PROFILE_SCOPE tag.

Note that this will require corresponding UI changes to make sure metrics can be correctly retrieved.