### PR TITLE
update current workflow status API

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -1562,7 +1562,9 @@ For workflows, you can retrieve:
 
 - the information about the currently running node(s) in the workflow::
 
-    GET /v3/namespaces/<namespace-id>/apps/<app-id>/workflows/<workflow-id>/runs/<run-id>/current
+    GET /v3/namespaces/<namespace-id>/apps/<app-id>/workflows/<workflow-id>/runs/<run-id>/nodes/state
+
+More information about workflow endpoint can be found at :ref:`Workflows <http-restful-api-workflow>`
 
 - the schedules defined for a workflow (using the parameter ``schedules``)::
 


### PR DESCRIPTION
we removed workflow current REST API in https://github.com/caskdata/cdap/pull/9890,

Update to the docs to use the appropriate API to get the current workflow information.