### PR TITLE
CDAP-13934 Add delegation tokens upon launching of 'master.services'.

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -117,6 +117,7 @@ import org.apache.twill.internal.ServiceListenerAdapter;
 import org.apache.twill.internal.zookeeper.LeaderElection;
 import org.apache.twill.internal.zookeeper.ReentrantDistributedLock;
 import org.apache.twill.kafka.client.KafkaClientService;
+import org.apache.twill.yarn.YarnSecureStore;
 import org.apache.twill.zookeeper.ZKClient;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.apache.twill.zookeeper.ZKOperations;
@@ -929,6 +930,11 @@ public class MasterServiceMain extends DaemonMain {
 
           // Add HBase dependencies
           preparer.withDependencies(injector.getInstance(HBaseTableUtil.class).getClass());
+
+          // Add secure tokens
+          if (User.isHBaseSecurityEnabled(hConf) || UserGroupInformation.isSecurityEnabled()) {
+            preparer.addSecureStore(YarnSecureStore.create(secureStoreRenewer.createCredentials()));
+          }
 
           // add hadoop classpath to application classpath and exclude hadoop classes from bundle jar.
           List<String> yarnAppClassPath = Arrays.asList(


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-13934
Add delegation tokens upon launching of 'master.services' yarn application. This is effectively undoing the removal of the same code from https://github.com/caskdata/cdap/commit/4fb922d734f0469da06814ab2712ebb2d6454765#diff-ef64c290689c73ddd269891673e5281fL921.

https://builds.cask.co/browse/CDAP-RUT1603-2