### PR TITLE
Renamed field lineage table and added it for the upgrade path.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/lineage/field/FieldOperation.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/lineage/field/FieldOperation.java
@@ -22,7 +22,8 @@ import java.util.Objects;
 
 /**
  * Abstract base class to represent a field lineage operation. Each operation has a
- * name and description. Operation typically has input and output fields.
+ * name and description. The name of operation must be unique within all operations
+ * recorded by the same pipeline stage. Operation typically has input and output fields.
  */
 @Beta
 public abstract class FieldOperation {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDataset.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.metadata.lineage.field;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.AbstractDataset;
 import co.cask.cdap.api.dataset.table.Put;
@@ -45,6 +46,7 @@ import com.google.gson.JsonSyntaxException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -100,7 +102,7 @@ public class FieldLineageDataset extends AbstractDataset {
   // ---------------------------------------------------------------------
 
 
-  public static final DatasetId FIELD_LINEAGE_DATASET_ID = NamespaceId.SYSTEM.dataset("fieldLineage");
+  public static final DatasetId FIELD_LINEAGE_DATASET_ID = NamespaceId.SYSTEM.dataset("fieldlineage");
 
   private static final Logger LOG = LoggerFactory.getLogger(FieldLineageDataset.class);
   private static final Gson GSON = new GsonBuilder()
@@ -123,6 +125,16 @@ public class FieldLineageDataset extends AbstractDataset {
   public FieldLineageDataset(String instanceName, Table table) {
     super(instanceName, table);
     this.table = table;
+  }
+
+  /**
+   * Adds datasets and types to the given {@link DatasetFramework}.
+   * Used by the upgrade tool to upgrade Field Lineage Dataset.
+   *
+   * @param framework framework to add types and datasets to
+   */
+  public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
+    framework.addInstance(FieldLineageDataset.class.getName(), FIELD_LINEAGE_DATASET_ID, DatasetProperties.EMPTY);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDatasetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/field/FieldLineageDatasetDefinition.java
@@ -30,15 +30,17 @@ import java.util.Map;
  * {@link DatasetDefinition} for {@link FieldLineageDataset}.
  */
 public class FieldLineageDatasetDefinition extends CompositeDatasetDefinition<FieldLineageDataset> {
+  private static final String FIELD_LINEAGE_INFO_TABLE = "info";
+
   public FieldLineageDatasetDefinition(String name, DatasetDefinition<Table, ? extends DatasetAdmin> tableDefinition) {
-    super(name, "fieldLineage", tableDefinition);
+    super(name, FIELD_LINEAGE_INFO_TABLE, tableDefinition);
   }
 
 
   @Override
   public FieldLineageDataset getDataset(DatasetContext datasetContext, DatasetSpecification spec,
                                         Map<String, String> arguments, ClassLoader classLoader) throws IOException {
-    Table table = getDataset(datasetContext, "fieldLineage", spec, arguments, classLoader);
+    Table table = getDataset(datasetContext, FIELD_LINEAGE_INFO_TABLE, spec, arguments, classLoader);
     return new FieldLineageDataset(spec.getName(), table);
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -50,6 +50,7 @@ import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.metadata.lineage.LineageDataset;
+import co.cask.cdap.data2.metadata.lineage.field.FieldLineageDataset;
 import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
 import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
@@ -486,6 +487,7 @@ public class UpgradeTool {
     if (includeNewDatasets) {
       // Add all new system dataset introduced in the current release in this block. If no new dataset was introduced
       // then leave this block empty but do not remove block so that it can be used in next release if needed
+      FieldLineageDataset.setupDatasets(datasetFramework);
     }
 
     // owner metadata


### PR DESCRIPTION
1. Renamed field lineage table from `cdap_system.fieldLineage.fieldLineage` to `cdap_system.fieldlineage.info`
2. Added field lineage table to the upgrade path, so that if 5.0 is installed and after that HBase is upgraded without the CDAP upgrade, coprocessor of the newly added field linage table also gets upgraded.
3. minor doc change on the `FieldOperation` class to indicate that operation names need to be unique.