### PR TITLE
fix sorting to determine current docs version

### DIFF
--- a/cdap-distributions/bin/docs_bucket_current_develop.sh
+++ b/cdap-distributions/bin/docs_bucket_current_develop.sh
@@ -19,7 +19,7 @@ S3_BUCKET=${S3_BUCKET:-docs.cask.co}
 
 # Get Docs versions
 echo "Getting Docs version from local directory: ${LOCAL_DIR}"
-__local=${VERSION:-$(ls -1F ${LOCAL_DIR}/ | sort -rn | grep '/$' | tail -n 1 | sed -e 's:/$::')}
+__local=${VERSION:-$(ls -1F ${LOCAL_DIR}/ | sort -rn | grep '/$' | head -n 1 | sed -e 's:/$::')}
 echo "Getting Docs versions from remote: ${S3_BUCKET}/${LOCAL_DIR}"
 __current=$(curl -sL http://s3.amazonaws.com/${S3_BUCKET}/${LOCAL_DIR}/version)
 __develop=$(curl -sL http://s3.amazonaws.com/${S3_BUCKET}/${LOCAL_DIR}/development)


### PR DESCRIPTION
This fixes the docs logic for determining current version.

Note that in https://github.com/caskdata/cdap/pull/8617, the description didn't match the code that was checked in.  This PR corrects it.

```
$ ls -1 cdap/
4.3.4
5.0.0

$ ls -1F cdap/ | grep '/$' | sort -rn | tail -n 1 | sed -e 's:/$::'
4.3.4

$ ls -1F cdap/ | grep '/$' | sort -rn | head -n 1 | sed -e 's:/$::'
5.0.0
```