### PR TITLE
(CDAP-13653) Fix to support Spark 2.3

### DIFF
--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -174,8 +174,7 @@ public final class SparkRuntimeContextProvider {
       ProgramOptions programOptions = contextConfig.getProgramOptions();
 
       // Should be yarn only and only for executor node, not the driver node.
-      Preconditions.checkState(!contextConfig.isLocal(programOptions)
-                                 && Boolean.parseBoolean(System.getenv("SPARK_YARN_MODE")),
+      Preconditions.checkState(!contextConfig.isLocal(programOptions),
                                "SparkContextProvider.getSparkContext should only be called in Spark executor process.");
 
       // Create the program


### PR DESCRIPTION
- Remove check for the SPARK_YARN_MODE env variable
  - It is removed in Spark 2.3 (SPARK-22372)
- Remove incompatible lz4 library