### PR TITLE
CDAP-13609 fix metrics processor flaky test

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorService.java
@@ -509,6 +509,11 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
         // the number of metrics being persisted each time
         Deque<MetricValues> metricsCopy = new LinkedList<>();
         Iterator<MetricValues> iterator = metricsFromAllTopics.iterator();
+        // Though the blocking queue(metricsFromAllTopics) has upper bound on its size (which is the "queueSize")
+        // there can be a scenario, as the current thread is removing entries from blocking queue
+        // and adding it to a copy list, other threads are simultaneously adding entries to the queue and
+        // the current list might become very big causing out of memory issues, we avoid this
+        // by making the copy list size also to be limited by the max queue size.
         while (iterator.hasNext() && metricsCopy.size() < queueSize) {
           metricsCopy.add(iterator.next());
           iterator.remove();

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorServiceTest.java
@@ -97,7 +97,16 @@ public class MessagingMetricsProcessorServiceTest extends MetricsProcessorServic
 
       // validate metrics processor metrics
       // 50 counter and 50 gauge metrics are emitted in each iteration above
-      Assert.assertEquals(100, metricStore.getMetricsProcessedByMetricsProcessor());
+      Tasks.waitFor(100L, () -> metricStore.getMetricsProcessedByMetricsProcessor(),
+                    15, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+      // publish a dummy metric
+      // this is to force the metrics processor to publish delay metrics for all the topics
+      publishMessagingMetrics(100, startTime, METRICS_CONTEXT, expected, "", MetricType.GAUGE);
+      // validate the newly published metric
+      Tasks.waitFor(101L, () -> metricStore.getMetricsProcessedByMetricsProcessor(),
+                    15, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
       // in MessagingMetricsProcessorService, before persisting the metrics and topic metas, a copy of the topic metas
       // containing the metrics processor delay metrics is made before making a copy of metric values.
       // Therefore, there can be a very small chance where all metric values are persisted but the corresponding


### PR DESCRIPTION
We make a copy of the topic level metadata (how far have we processed from each topic), before we start dequeuing the metrics from the blocking queue. once we are done dequeuing we persist both the metrics and metadata after that.

This means by design, the topic level metadata information might be slightly behind the metrics processed from TMS. the topic level metadata is updated regularly even when there are no metrics, so the metadata information catches up quickly and is not a concern. However the delay metrics are emitted only when there are metrics available to be persisted and it could be based on the slightly behind topic level metadata.

This is the behavior we were seeing in the flaky test case, all the metrics were processed and the delay metrics were emitted for the slightly behind topic level metadata information due to the race condition and the delay metrics were missing for some of the topics.

Since the delay metrics are for insight into the metrics processor system, this is not a serious concern in production and only an issue in this test case, as a workaround, in the test case, we publish an additional dummy metric after we have ensured the previous metrics were processed, this forces the metrics processor to publish topic level for all the topics.