### PR TITLE
(CDAP-13653) (4.3) Fix to support Spark 2.3

### DIFF
--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -152,7 +152,7 @@ public final class SparkRuntimeContextProvider {
       SparkRuntimeContextConfig contextConfig = new SparkRuntimeContextConfig(hConf);
 
       // Should be yarn only and only for executor node, not the driver node.
-      Preconditions.checkState(!contextConfig.isLocal() && Boolean.parseBoolean(System.getenv("SPARK_YARN_MODE")),
+      Preconditions.checkState(!contextConfig.isLocal(),
                                "SparkContextProvider.getSparkContext should only be called in Spark executor process.");
 
       // Create the program


### PR DESCRIPTION
- Remove check for the SPARK_YARN_MODE env variable
  - It is removed in Spark 2.3 (SPARK-22372)
- Remove incompatible lz4 library