### PR TITLE
[CDAP-11379][CDAP-13900]Bugfixes in Dataprep

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/index.js
@@ -28,7 +28,8 @@ export default class DataPrepCLI extends Component {
     this.state = {
       directiveInput: '',
       error: null,
-      autoCompleteOpen: false
+      autoCompleteOpen: false,
+      currentWorkspace: null
     };
 
     this.handleDirectiveChange = this.handleDirectiveChange.bind(this);
@@ -38,11 +39,18 @@ export default class DataPrepCLI extends Component {
     this.execute = this.execute.bind(this);
 
     this.sub = DataPrepStore.subscribe(() => {
-      let storeState = DataPrepStore.getState().error;
-
-      this.setState({
-        error: storeState.cliError
-      });
+      let {error, dataprep} = DataPrepStore.getState();
+      let newState = {
+        error: error.cliError
+      };
+      if (dataprep.workspaceId !== this.state.currentWorkspace) {
+        newState = {
+          ...newState,
+          currentWorkspace: dataprep.workspaceId,
+          directiveInput: ''
+        };
+      }
+      this.setState(newState);
     });
   }
 

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/index.js
@@ -295,6 +295,7 @@ export default class DataPrepTable extends Component {
                                 onWarning={this.showWarningMessage.bind(this, index)}
                                 allowSpace={false}
                                 shouldSelect={true}
+                                validCharacterRegex={/^\w+$/}
                               />
                               {
                                 head.showWarning ?

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPositions/CutDirective.js
@@ -125,6 +125,7 @@ export default class CutDirective extends Component {
               className={classnames("form-control mousetrap", CELLHIGHLIGHTCLASSNAME)}
               onChange={this.handleColNameChange}
               value={this.newColName}
+              validCharacterRegex={/^\w+$/}
             />
           </div>
           <div

--- a/cdap-ui/app/cdap/components/TextboxOnValium/index.js
+++ b/cdap-ui/app/cdap/components/TextboxOnValium/index.js
@@ -15,7 +15,7 @@
  */
 
 import PropTypes from 'prop-types';
-
+import isNil from 'lodash/isNil';
 import React, { Component } from 'react';
 export default class TextboxOnValium extends Component {
   constructor(props) {
@@ -42,6 +42,13 @@ export default class TextboxOnValium extends Component {
 
     if (!this.props.allowSpace) {
       textValue = textValue.trim();
+    }
+    if (
+      !isNil(this.props.validCharacterRegex) &&
+      this.props.validCharacterRegex instanceof RegExp &&
+      !this.props.validCharacterRegex.test(textValue)
+    ) {
+      return;
     }
 
     this.setState({
@@ -88,7 +95,8 @@ export default class TextboxOnValium extends Component {
 }
 
 TextboxOnValium.defaultProps = {
-  allowSpace: true
+  allowSpace: true,
+  validCharacterRegex: null
 };
 
 TextboxOnValium.propTypes = {
@@ -97,5 +105,6 @@ TextboxOnValium.propTypes = {
   onWarning: PropTypes.func,
   className: PropTypes.string,
   allowSpace: PropTypes.bool,
-  shouldSelect: PropTypes.bool
+  shouldSelect: PropTypes.bool,
+  validCharacterRegex: PropTypes.object // regex expression
 };


### PR DESCRIPTION
- Fixes dataprep UI to not allow users to enter characters other than characters, numbers and `_` for column names
- Fix dataprep cli to revert to default when switching tabs.

JIRA:
https://issues.cask.co/browse/CDAP-11379
https://issues.cask.co/browse/CDAP-13900

Build: 
https://builds.cask.co/browse/CDAP-UDUT26