### PR TITLE
[CDAP-13676][CDAP-13691] Fixes File Browser linking to wrong path

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -30,7 +30,7 @@ import {
   listBigQueryTables,
   reset as resetDataPrepBrowserStore,
 } from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
-import {Route, NavLink, Redirect, Switch} from 'react-router-dom';
+import {Route, Redirect, Switch} from 'react-router-dom';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import T from 'i18n-react';
 import LoadingSVG from 'components/LoadingSVG';
@@ -48,6 +48,7 @@ import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import queryString from 'query-string';
 import Version from 'services/VersionRange/Version';
 import { MIN_DATAPREP_VERSION } from 'components/DataPrep';
+import NavLinkWrapper from 'components/NavLinkWrapper';
 
 require('./DataPrepConnections.scss');
 const PREFIX = 'features.DataPrepConnections';
@@ -58,32 +59,6 @@ const RouteToHDFS = () => {
   return (
     <Redirect to={`/ns/${namespace}/connections/browser`} />
   );
-};
-const NavLinkWrapper = ({children, to, singleWorkspaceMode, ...attributes}) => {
-  if (singleWorkspaceMode) {
-    return (
-      <a
-        href={to}
-        {...attributes}
-      >
-        {children}
-      </a>
-    );
-  }
-  return (
-    <NavLink
-      to={to}
-      {...attributes}
-    >
-      {children}
-    </NavLink>
-  );
-};
-
-NavLinkWrapper.propTypes = {
-  children: PropTypes.node,
-  to: PropTypes.string,
-  singleWorkspaceMode: PropTypes.bool
 };
 
 export default class DataPrepConnections extends Component {
@@ -318,7 +293,7 @@ export default class DataPrepConnections extends Component {
                 activeClassName="active"
                 className="menu-item-expanded-list"
                 onClick={this.handlePropagation.bind(this, database)}
-                singleWorkspaceMode={this.props.singleWorkspaceMode}
+                isNativeLink={this.props.singleWorkspaceMode}
               >
                 {database.name}
               </NavLinkWrapper>
@@ -352,7 +327,7 @@ export default class DataPrepConnections extends Component {
                 activeClassName="active"
                 className="menu-item-expanded-list"
                 onClick={this.handlePropagation.bind(this, {...kafka, name: 'kafka'})}
-                singleWorkspaceMode={this.props.singleWorkspaceMode}
+                isNativeLink={this.props.singleWorkspaceMode}
               >
                 {kafka.name}
               </NavLinkWrapper>
@@ -386,7 +361,7 @@ export default class DataPrepConnections extends Component {
                 activeClassName="active"
                 className="menu-item-expanded-list"
                 onClick={this.handlePropagation.bind(this, {...s3, name: s3.type.toLowerCase()})}
-                singleWorkspaceMode={this.props.singleWorkspaceMode}
+                isNativeLink={this.props.singleWorkspaceMode}
               >
                 {s3.name}
               </NavLinkWrapper>
@@ -420,7 +395,7 @@ export default class DataPrepConnections extends Component {
                 activeClassName="active"
                 className="menu-item-expanded-list"
                 onClick={this.handlePropagation.bind(this, {...gcs, name: gcs.type.toLowerCase()})}
-                singleWorkspaceMode={this.props.singleWorkspaceMode}
+                isNativeLink={this.props.singleWorkspaceMode}
               >
                 {gcs.name}
               </NavLinkWrapper>
@@ -454,7 +429,7 @@ export default class DataPrepConnections extends Component {
                 activeClassName="active"
                 className="menu-item-expanded-list"
                 onClick={this.handlePropagation.bind(this, {...bq, name: bq.type.toLowerCase()})}
-                singleWorkspaceMode={this.props.singleWorkspaceMode}
+                isNativeLink={this.props.singleWorkspaceMode}
               >
                 {bq.name}
               </NavLinkWrapper>
@@ -499,7 +474,7 @@ export default class DataPrepConnections extends Component {
               to={`${baseLinkPath}/upload`}
               activeClassName="active"
               onClick={this.handlePropagation.bind(this, {type: 'upload'})}
-              singleWorkspaceMode={this.props.singleWorkspaceMode}
+              isNativeLink={this.props.singleWorkspaceMode}
             >
               <span className="fa fa-fw">
                 <IconSVG name="icon-upload" />
@@ -516,7 +491,7 @@ export default class DataPrepConnections extends Component {
               to={`${baseLinkPath}/browser`}
               activeClassName="active"
               onClick={this.handlePropagation.bind(this, {type: 'file'})}
-              singleWorkspaceMode={this.props.singleWorkspaceMode}
+              isNativeLink={this.props.singleWorkspaceMode}
             >
               <span className="fa fa-fw">
                 <IconSVG name="icon-hdfs" />

--- a/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
@@ -18,42 +18,15 @@ import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
 import uuidV4 from 'uuid/v4';
-import {Link} from 'react-router-dom';
 import classnames from 'classnames';
 import {UncontrolledDropdown} from 'components/UncontrolledComponents';
 import { DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 import {preventPropagation} from 'services/helpers';
+import NavLinkWrapper from 'components/NavLinkWrapper';
 
 require('./FilePath.scss');
 
 const VIEW_LIMIT = 3;
-
-const LinkWrapper = ({enableRouting, children, to, ...attributes}) => {
-  if (enableRouting) {
-    return (
-      <Link
-        to={to}
-        {...attributes}
-      >
-        {children}
-      </Link>
-    );
-  }
-  return (
-    <a
-      href={to}
-      {...attributes}
-    >
-      {children}
-    </a>
-  );
-};
-
-LinkWrapper.propTypes = {
-  enableRouting: PropTypes.string,
-  children: PropTypes.node,
-  to: PropTypes.string
-};
 
 export default class FilePath extends Component {
   constructor(props) {
@@ -77,11 +50,14 @@ export default class FilePath extends Component {
       .filter((directory) => {
         return directory.length > 0;
       });
-
+    let bspath = this.props.baseStatePath;
+    if (bspath[bspath.length - 1] !== '/') {
+      bspath = `${bspath}/`;
+    }
     let paths = [{
       id: uuidV4(),
       name: 'Root',
-      link: `${this.props.baseStatePath}/`
+      link: bspath
     }];
 
     splitPath.forEach((value, index) => {
@@ -130,15 +106,16 @@ export default class FilePath extends Component {
                   <DropdownItem
                     key={i}
                     title={path.name}
+                    tag="div"
                   >
-                    <LinkWrapper
+                    <NavLinkWrapper
                       key={path.id}
                       to={path.link}
                       onClick={this.handlePropagation.bind(this, path.link)}
-                      enableRouting={this.props.enableRouting}
+                      isNativeLink={!this.props.enableRouting}
                     >
                       {path.name}
-                    </LinkWrapper>
+                    </NavLinkWrapper>
                   </DropdownItem>
                 );
               })
@@ -155,18 +132,18 @@ export default class FilePath extends Component {
         {
           links.map((path, index) => {
             return (
-              <LinkWrapper
+              <NavLinkWrapper
                 key={path.id}
                 to={path.link}
                 className={classnames({'active-directory': index === links.length - 1})}
                 onClick={this.handlePropagation.bind(this, path.link)}
-                enableRouting={this.props.enableRouting}
+                isNativeLink={!this.props.enableRouting}
               >
                 <span>{path.name}</span>
                 {
                   index !== links.length - 1 ? <span className="path-divider">/</span> : null
                 }
-              </LinkWrapper>
+              </NavLinkWrapper>
             );
           })
         }

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -38,6 +38,7 @@ require('./FileBrowser.scss');
 
 const BASEPATH = '/';
 const PREFIX = 'features.FileBrowser';
+const trimSuffixSlash = (path) => path.replace(/\/\//, '/');
 
 export default class FileBrowser extends Component {
 
@@ -141,6 +142,7 @@ export default class FileBrowser extends Component {
   }
 
   goToPath = (path) => {
+    path = trimSuffixSlash(path);
     this.setState({
       loading: true,
       path
@@ -294,7 +296,7 @@ export default class FileBrowser extends Component {
         </div>
         <div className="col-xs-1">
           <span title={row.displaySize}>
-            {row.displaySize}
+            {row.directory ? '--' : row.displaySize}
           </span>
         </div>
         <div className="col-xs-2">
@@ -334,6 +336,7 @@ export default class FileBrowser extends Component {
     }
 
     let linkPath = `${this.state.statePath}${content.path}`;
+    linkPath = trimSuffixSlash(linkPath);
     return (
       <Link
         to={linkPath}


### PR DESCRIPTION
- Fixes trailing slash in the file browser during navigation to cause UI to render a backend error.
- Removes local version of `NavLinkWrapper` from components to be replaced with the common one.

JIRA:
https://issues.cask.co/browse/CDAP-13676
https://issues.cask.co/browse/CDAP-13691
Build: https://builds.cask.co/browse/CDAP-UDUT27