### PR TITLE
[CDAP-13767] [CDAP-13890] Fixes surfacing profile information for historical runs in pipelines

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/SecureKeyTextarea/index.js
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SecureKeyTextarea/index.js
@@ -22,8 +22,7 @@ import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import {objectQuery} from 'services/helpers';
-import {SECURE_KEY_PREFIX, SECURE_KEY_SUFFIX} from 'services/global-constants';
-
+import {SECURE_KEY_PREFIX, SECURE_KEY_SUFFIX, SYSTEM_NAMESPACE} from 'services/global-constants';
 require('./SecureKeyTextarea.scss');
 
 const PREFIX = 'features.AbstractWidget.SecureKeyTextarea';
@@ -42,7 +41,7 @@ export default class SecureKeyTextarea extends Component {
   componentWillMount() {
     const namespace = objectQuery(this.props, 'extraConfig', 'namespace') || getCurrentNamespace();
 
-    if (namespace === 'system') { return; }
+    if (namespace === SYSTEM_NAMESPACE) { return; }
 
     const params = {
       namespace

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
@@ -26,6 +26,7 @@ import {importProfile} from 'components/Cloud/Profiles/Store/ActionCreator';
 import {connect, Provider} from 'react-redux';
 import {Label, Input} from 'reactstrap';
 import {getProfiles, resetProfiles} from 'components/Cloud/Profiles/Store/ActionCreator';
+import {SYSTEM_NAMESPACE} from 'services/global-constants';
 require('./SystemProfilesAccordion.scss');
 
 const PREFIX = 'features.Administration.Accordions.SystemProfiles';
@@ -39,7 +40,7 @@ class SystemProfilesAccordion extends Component {
   }
 
   componentDidMount() {
-    getProfiles('system');
+    getProfiles(SYSTEM_NAMESPACE);
   }
 
   componentWillUnmount() {
@@ -96,12 +97,12 @@ class SystemProfilesAccordion extends Component {
               type="file"
               accept='.json'
               id="import-profile"
-              onChange={importProfile.bind(this, 'system')}
+              onChange={importProfile.bind(this, SYSTEM_NAMESPACE)}
               onClick={(e) => e.target.value = null}
             />
           </Label>
         </div>
-        <ProfilesListView namespace='system' />
+        <ProfilesListView namespace={SYSTEM_NAMESPACE} />
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/AppDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/index.js
@@ -38,6 +38,7 @@ import Helmet from 'react-helmet';
 import OverviewHeader from 'components/Overview/OverviewHeader';
 import {MyMetadataApi} from 'api/metadata';
 import EntityType from 'services/metadata-parser/EntityType';
+import {SCOPES} from 'services/global-constants';
 require('./AppDetailedView.scss');
 
 export default class AppDetailedView extends Component {
@@ -77,7 +78,7 @@ export default class AppDetailedView extends Component {
         namespace,
         entityType: 'apps',
         entityId: appId,
-        scope: 'SYSTEM'
+        scope: SCOPES.SYSTEM
       };
       MyMetadataApi
         .getProperties(metadataParams)

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/ProvisionerSelection/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/ProvisionerSelection/index.js
@@ -27,6 +27,7 @@ import {ADMIN_CONFIG_ACCORDIONS} from 'components/Administration/AdminConfigTabC
 import EntityTopPanel from 'components/EntityTopPanel';
 import ExperimentalBanner from 'components/ExperimentalBanner';
 import IconSVG from 'components/IconSVG';
+import {SYSTEM_NAMESPACE} from 'services/global-constants';
 
 require('./ProvisionerSelection.scss');
 
@@ -43,7 +44,7 @@ class ProfileCreateProvisionerSelection extends Component {
   };
 
   state = {
-    isSystem: objectQuery(this.props.match, 'params', 'namespace') === 'system'
+    isSystem: objectQuery(this.props.match, 'params', 'namespace') === SYSTEM_NAMESPACE
   };
 
   componentDidMount() {

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -41,6 +41,7 @@ import uuidV4 from 'uuid/v4';
 import CreateProfileStore from 'components/Cloud/Profiles/CreateView/CreateProfileStore';
 import {highlightNewProfile} from 'components/Cloud/Profiles/Store/ActionCreator';
 import T from 'i18n-react';
+import {SCOPES, SYSTEM_NAMESPACE} from 'services/global-constants';
 
 const PREFIX = 'features.Cloud.Profiles.CreateView';
 
@@ -61,7 +62,7 @@ class ProfileCreateView extends Component {
     redirectToNamespace: false,
     redirectToAdmin: false,
     creatingProfile: false,
-    isSystem: objectQuery(this.props.match, 'params', 'namespace') === 'system',
+    isSystem: objectQuery(this.props.match, 'params', 'namespace') === SYSTEM_NAMESPACE,
     selectedProvisioner: objectQuery(this.props.match, 'params', 'provisionerId')
   };
 
@@ -125,7 +126,7 @@ class ProfileCreateView extends Component {
             });
           }
 
-          let profilePrefix = this.state.isSystem ? 'SYSTEM' : 'USER';
+          let profilePrefix = this.state.isSystem ? SCOPES.SYSTEM : SCOPES.USER;
           name = `${profilePrefix}:${name}`;
           highlightNewProfile(name);
         },
@@ -198,7 +199,7 @@ class ProfileCreateView extends Component {
   renderGroup = (group) => {
     let {properties} = CreateProfileStore.getState();
     const extraConfig = {
-      namespace: this.state.isSystem ? 'system' : getCurrentNamespace()
+      namespace: this.state.isSystem ? SYSTEM_NAMESPACE : getCurrentNamespace()
     };
 
     return (

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle.js
@@ -23,7 +23,7 @@ import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
 import {extractProfileName} from 'components/Cloud/Profiles/Store/ActionCreator';
 import {MyCloudApi} from 'api/cloud';
 import T from 'i18n-react';
-import {CLOUD} from 'services/global-constants';
+import {CLOUD, SYSTEM_NAMESPACE} from 'services/global-constants';
 
 const PREFIX = 'features.Cloud.Profiles';
 
@@ -58,7 +58,7 @@ export default class ProfileStatusToggle extends Component {
     const profile = this.props.profile;
     const action = PROFILE_STATUSES[profile.status] === 'enabled' ? 'disable' : 'enable';
     let apiObservable$;
-    if (this.props.namespace === 'system') {
+    if (this.props.namespace === SYSTEM_NAMESPACE) {
       apiObservable$ = MyCloudApi.toggleSystemProfileStatus({
         profile: profile.name,
         action

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/BasicInfo/index.js
@@ -27,7 +27,7 @@ import ActionsPopover from 'components/Cloud/Profiles/ActionsPopover';
 import isEqual from 'lodash/isEqual';
 import {getProvisionerLabel, extractProfileName, getNodeHours} from 'components/Cloud/Profiles/Store/ActionCreator';
 import ProfileStatusToggle from 'components/Cloud/Profiles/DetailView/Content/BasicInfo/ProfileStatusToggle';
-import {CLOUD} from 'services/global-constants';
+import {CLOUD, SYSTEM_NAMESPACE} from 'services/global-constants';
 import {humanReadableDate} from 'services/helpers';
 import CopyableId from 'components/CopyableID';
 
@@ -193,7 +193,7 @@ export default class ProfileDetailViewBasicInfo extends Component {
       pathname: '/administration/configuration',
       state: { accordionToExpand: ADMIN_CONFIG_ACCORDIONS.systemProfiles }
     } : `/ns/${getCurrentNamespace()}/details`;
-    let namespace = this.props.isSystem ? 'system' : getCurrentNamespace();
+    let namespace = this.props.isSystem ? SYSTEM_NAMESPACE : getCurrentNamespace();
     const isNativeProfile = profile.name === extractProfileName(CLOUD.DEFAULT_PROFILE_NAME);
 
     const actionsElem = () => {

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/index.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {MySearchApi} from 'api/search';
 import {isNilOrEmpty, humanReadableDuration, objectQuery} from 'services/helpers';
-import {GLOBALS} from 'services/global-constants';
+import {GLOBALS, SYSTEM_NAMESPACE} from 'services/global-constants';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import {
@@ -117,10 +117,9 @@ export default class ProfileAssociations extends Component {
   componentDidMount() {
     let {namespace, profile} = this.props;
     let {scope} = profile;
-    scope = scope.toLowerCase();
     let profileName = `profile:${scope}:${profile.name}`;
     let apiObservable$;
-    if (namespace === 'system') {
+    if (namespace === SYSTEM_NAMESPACE) {
       apiObservable$ = MySearchApi.searchSystem({
         query: profileName
       });

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
@@ -26,6 +26,7 @@ import {getCurrentNamespace} from 'services/NamespaceStore';
 import {getProvisionersMap} from 'components/Cloud/Profiles/Store/Provisioners';
 import {ONEDAYMETRICKEY, OVERALLMETRICKEY, fetchAggregateProfileMetrics} from 'components/Cloud/Profiles/Store/ActionCreator';
 import T from 'i18n-react';
+import {SYSTEM_NAMESPACE} from 'services/global-constants';
 
 const PREFIX = 'features.Cloud.Profiles.DetailView';
 require('./DetailView.scss');
@@ -44,7 +45,7 @@ export default class ProfileDetailView extends Component {
     provisioners: [],
     loading: true,
     error: null,
-    isSystem: objectQuery(this.props.match, 'params', 'namespace') === 'system'
+    isSystem: objectQuery(this.props.match, 'params', 'namespace') === SYSTEM_NAMESPACE
   };
 
   static propTypes = {
@@ -89,7 +90,7 @@ export default class ProfileDetailView extends Component {
   getProfile = () => {
     let {namespace, profileId} = this.props.match.params;
     let apiObservable$;
-    if (namespace === 'system') {
+    if (namespace === SYSTEM_NAMESPACE) {
       apiObservable$ = MyCloudApi.getSystemProfile({ profile: profileId });
     } else {
       apiObservable$ = MyCloudApi.get({ namespace, profile: profileId });

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/ListView/index.js
@@ -42,9 +42,10 @@ import uuidV4 from 'uuid/v4';
 import ActionsPopover from 'components/Cloud/Profiles/ActionsPopover';
 import isEqual from 'lodash/isEqual';
 import {getProvisionersMap} from 'components/Cloud/Profiles/Store/Provisioners';
-import {CLOUD} from 'services/global-constants';
+import {CLOUD, SYSTEM_NAMESPACE} from 'services/global-constants';
 import {preventPropagation} from 'services/helpers';
 import findIndex from 'lodash/findIndex';
+import {SCOPES} from 'services/global-constants';
 require('./ListView.scss');
 
 const PREFIX = 'features.Cloud.Profiles';
@@ -181,7 +182,7 @@ class ProfilesListView extends Component {
   };
 
   deleteProfile = (profile) => {
-    let namespace = profile.scope === 'SYSTEM' ? 'system' : this.props.namespace;
+    let namespace = profile.scope === SCOPES.SYSTEM ? SYSTEM_NAMESPACE : this.props.namespace;
 
     deleteProfile(namespace, profile.name, this.props.namespace)
       .subscribe(() => {
@@ -211,7 +212,7 @@ class ProfilesListView extends Component {
       return (
         <div className="text-xs-center">
           {
-            this.props.namespace === 'system' ?
+            this.props.namespace === SYSTEM_NAMESPACE ?
               (
                 <span>
                   {T.translate(`${PREFIX}.ListView.noProfilesSystem`)}
@@ -311,7 +312,7 @@ class ProfilesListView extends Component {
   }
 
   renderProfilerow = (profile) => {
-    let namespace = profile.scope === 'SYSTEM' ? 'system' : this.props.namespace;
+    let namespace = profile.scope === SCOPES.SYSTEM ? SYSTEM_NAMESPACE : this.props.namespace;
     let provisionerName = profile.provisioner.name;
     profile.provisioner.label = this.state.provisionersMap[provisionerName] || provisionerName;
     let profileStatus = PROFILE_STATUSES[profile.status];

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Preview/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Preview/index.js
@@ -28,6 +28,7 @@ import {
 import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
 import {humanReadableDate} from 'services/helpers';
 import T from 'i18n-react';
+import {SCOPES, SYSTEM_NAMESPACE} from 'services/global-constants';
 require('./Preview.scss');
 
 export default class ProfilePreview extends Component {
@@ -56,7 +57,7 @@ export default class ProfilePreview extends Component {
   getProfileDetails() {
     let namespace = getCurrentNamespace();
     let apiObservable$;
-    if (this.props.profileScope === 'system') {
+    if (this.props.profileScope === SCOPES.SYSTEM) {
       apiObservable$ = MyCloudApi.getSystemProfile({ profile: this.props.profileName});
     } else {
       apiObservable$ = MyCloudApi.get({
@@ -122,7 +123,7 @@ export default class ProfilePreview extends Component {
         </div>
       );
     }
-    let profileNamespace = this.state.profileDetails.scope === 'SYSTEM' ? 'system' : getCurrentNamespace();
+    let profileNamespace = this.state.profileDetails.scope === SCOPES.SYSTEM ? SYSTEM_NAMESPACE : getCurrentNamespace();
     let profileDetailsLink = `${location.protocol}//${location.host}/cdap/ns/${profileNamespace}/profiles/details/${this.props.profileName}`;
     let profileProvisionerLabel = getProvisionerLabel(this.state.profileDetails, this.state.provisioners);
     const profileStatus = PROFILE_STATUSES[this.state.profileDetails.status];

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/index.js
@@ -41,7 +41,6 @@ const PROFILE_STATUSES = {
   DISABLED: 'disabled'
 };
 
-
 const profiles = (state = DEFAULT_PROFILES_STATE, action = defaultAction) => {
   switch (action.type) {
     case PROFILES_ACTIONS.SET_PROFILES:
@@ -56,7 +55,7 @@ const profiles = (state = DEFAULT_PROFILES_STATE, action = defaultAction) => {
       let {profiles} = state;
       profiles = profiles.map(profile => {
         let metricObj = {runs: '--', minutes: '--'};
-        let profileKey = `${profile.scope.toLowerCase()}:${profile.name}`;
+        let profileKey = `${profile.scope}:${profile.name}`;
         let profileMetrics = profilesToMetricsMap[profileKey] || {};
         /*
           We are adding empty oneday and overall metrics AND metrics from backend

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/PipelineConfigHelper.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/PipelineConfigHelper.js
@@ -25,6 +25,7 @@ import {findHighestVersion} from 'services/VersionRange/VersionUtilities';
 import T from 'i18n-react';
 import {Subject} from 'rxjs/Subject';
 import find from 'lodash/find';
+import {SCOPES} from 'services/global-constants';
 
 const PREFIX = 'features.DataPrep.PipelineError';
 
@@ -72,7 +73,7 @@ function findWranglerArtifacts(artifacts, pluginVersion) {
   let returnArtifact = filteredArtifacts[0];
 
   if (filteredArtifacts.length > 1) {
-    returnArtifact.scope = 'USER';
+    returnArtifact.scope = SCOPES.USER;
   }
 
   return returnArtifact;
@@ -422,13 +423,13 @@ function constructProperties(workspaceInfo, pluginVersion) {
       let batchArtifact = {
         name: 'cdap-data-pipeline',
         version: highestBatchArtifactVersion,
-        scope: 'SYSTEM'
+        scope: SCOPES.SYSTEM
       };
 
       let realtimeArtifact = {
         name: 'cdap-data-streams',
         version: highestRealtimeArtifactVersion,
-        scope: 'SYSTEM'
+        scope: SCOPES.SYSTEM
       };
 
       let wranglerArtifact;

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
@@ -36,6 +36,7 @@ import Helmet from 'react-helmet';
 import queryString from 'query-string';
 import {Route, Switch} from 'react-router-dom';
 import FieldLevelLineage from 'components/FieldLevelLineage';
+import {SCOPES} from 'services/global-constants';
 require('./DatasetDetailedView.scss');
 
 export default class DatasetDetailedView extends Component {
@@ -116,7 +117,7 @@ export default class DatasetDetailedView extends Component {
         namespace,
         entityType: 'datasets',
         entityId: datasetId,
-        scope: 'SYSTEM'
+        scope: SCOPES.SYSTEM
       };
 
       MyMetadataApi.getProperties(metadataParams)

--- a/cdap-ui/app/cdap/components/EntityListView/JustAddedSection/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/JustAddedSection/index.js
@@ -31,6 +31,7 @@ import SearchStore from 'components/EntityListView/SearchStore';
 import {JUSTADDED_THRESHOLD_TIME} from 'components/EntityListView/SearchStore/SearchConstants';
 import isNil from 'lodash/isNil';
 import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStoreActions';
+import {SCOPES} from 'services/global-constants';
 require('./JustAddedSection.scss');
 
 export default class JustAddedSection extends Component {
@@ -116,7 +117,7 @@ export default class JustAddedSection extends Component {
         return res.results
           .map(parseMetadata)
           .filter((entity) => {
-            let creationTime = objectQuery(entity, 'metadata', 'metadata', 'SYSTEM', 'properties', 'creation-time');
+            let creationTime = objectQuery(entity, 'metadata', 'metadata', SCOPES.SYSTEM, 'properties', 'creation-time');
 
             creationTime = parseInt(creationTime, 10);
             let thresholdTime = Date.now() - JUSTADDED_THRESHOLD_TIME;

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/PredictionDatasetExploreModal/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/PredictionDatasetExploreModal/index.js
@@ -23,6 +23,7 @@ import {isNilOrEmpty} from 'services/helpers';
 import ExploreTablesStore from 'services/ExploreTables/ExploreTablesStore';
 import {fetchTables} from 'services/ExploreTables/ActionCreator';
 import uuidV4 from 'uuid/v4';
+import {SCOPES} from 'services/global-constants';
 require('./PredictionDatasetExploreModal.scss');
 
 export default class PredictionDatasetExploreModal extends Component {
@@ -57,7 +58,7 @@ export default class PredictionDatasetExploreModal extends Component {
         namespace: getCurrentNamespace(),
         entityType: 'datasets',
         entityId: this.state.predictionDataset,
-        scope: 'SYSTEM'
+        scope: SCOPES.SYSTEM
       })
       .subscribe(
         (datasetDetails) => {

--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -27,6 +27,7 @@ import ConfirmationModal from 'components/ConfirmationModal';
 import {Tooltip} from 'reactstrap';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
+import {SCOPES} from 'services/global-constants';
 import T from 'i18n-react';
 
 export default class DeleteAction extends Component {
@@ -43,7 +44,7 @@ export default class DeleteAction extends Component {
       tooltipOpen: false,
       errorMessage: '',
       extendedMessage: '',
-      disabled: this.props.entity.type === 'artifact' && this.props.entity.scope === 'SYSTEM'
+      disabled: this.props.entity.type === 'artifact' && this.props.entity.scope === SCOPES.SYSTEM
     };
     this.eventEmitter = ee(ee);
   }
@@ -159,7 +160,7 @@ DeleteAction.propTypes = {
     id: PropTypes.string.isRequired,
     uniqueId: PropTypes.string,
     version: PropTypes.string,
-    scope: PropTypes.oneOf(['SYSTEM', 'USER']),
+    scope: PropTypes.oneOf([SCOPES.SYSTEM, SCOPES.USER]),
     type: PropTypes.oneOf(['application', 'artifact', 'dataset', 'stream']).isRequired
   }),
   onSuccess: PropTypes.func

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
@@ -26,6 +26,7 @@ import {contructUrl, insertAt, removeAt, humanReadableDate} from 'services/helpe
 import {UncontrolledTooltip} from 'components/UncontrolledComponents';
 require('./ExploreModal.scss');
 import NamespaceStore from 'services/NamespaceStore';
+import {SCOPES} from 'services/global-constants';
 import T from 'i18n-react';
 
 const PREFIX = 'features.FastAction.Explore';
@@ -494,7 +495,7 @@ ExploreModal.propTypes = {
   entity: PropTypes.shape({
     id: PropTypes.string.isRequired,
     version: PropTypes.string,
-    scope: PropTypes.oneOf(['SYSTEM', 'USER']),
+    scope: PropTypes.oneOf([SCOPES.SYSTEM, SCOPES.USER]),
     type: PropTypes.oneOf(['application', 'artifact', 'dataset', 'stream']).isRequired,
     databaseName: PropTypes.string,
     tableName: PropTypes.string

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
@@ -26,6 +26,7 @@ import {objectQuery} from 'services/helpers';
 import myExploreApi from 'api/explore';
 import NamespaceStore from 'services/NamespaceStore';
 import classnames from 'classnames';
+import {SCOPES} from 'services/global-constants';
 require('./ExploreAction.scss');
 
 export default class ExploreAction extends Component {
@@ -34,7 +35,7 @@ export default class ExploreAction extends Component {
       id: PropTypes.string.isRequired,
       version: PropTypes.string,
       uniqueId: PropTypes.string,
-      scope: PropTypes.oneOf(['SYSTEM', 'USER']),
+      scope: PropTypes.oneOf([SCOPES.SYSTEM, SCOPES.USER]),
       type: PropTypes.oneOf(['application', 'artifact', 'dataset', 'stream']).isRequired,
     }),
     opened: PropTypes.bool,

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -31,9 +31,10 @@ import KeyValueStoreActions from 'components/KeyValuePairs/KeyValueStoreActions'
 import NamespaceStore from 'services/NamespaceStore';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
+import {SCOPES} from 'services/global-constants';
 
 export const PREFERENCES_LEVEL = {
-  SYSTEM: 'SYSTEM',
+  SYSTEM: SCOPES.SYSTEM,
   NAMESPACE: 'NAMESPACE'
 };
 
@@ -289,7 +290,7 @@ export default class SetPreferenceModal extends Component {
       if (this.props.entity) {
         entity = this.props.entity.id;
         entityWithType = `${this.props.entity.type} "${entity}"`;
-        tooltipID = `${this.props.entity.uniqueId}-title`;
+        tooltipID = `setpreference-modaltitle-${this.props.entity.uniqueId}`;
         if (this.props.entity.type === 'application') {
           description = T.translate(`${PREFIX}.DescriptionLabel.app`);
         } else {

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
@@ -82,7 +82,7 @@ export default class SetPreferenceAction extends Component {
       {'fa-lg': this.props.setAtLevel === PREFERENCES_LEVEL.NAMESPACE},
       {'text-success': this.state.preferencesSaved}
     );
-    let tooltipID = `${this.namespace}-setpreferences`;
+    let tooltipID = `setpreferences-${this.namespace}`;
     if (this.props.entity) {
       tooltipID = `setpreferences-${this.props.entity.uniqueId}`;
     }

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -31,6 +31,7 @@ import getLastSelectedNamespace from 'services/get-last-selected-namespace';
 import NavLinkWrapper from 'components/NavLinkWrapper';
 import ControlCenterDropdown from 'components/Header/ControlCenterDropdown';
 import {objectQuery} from 'services/helpers';
+import {SYSTEM_NAMESPACE} from 'services/global-constants';
 
 require('./Header.scss');
 
@@ -68,7 +69,7 @@ export default class Header extends Component {
     this.nsSubscription = NamespaceStore.subscribe(() => {
       let selectedNamespace = getLastSelectedNamespace();
       let {namespaces} = NamespaceStore.getState();
-      if (selectedNamespace === 'system') {
+      if (selectedNamespace === SYSTEM_NAMESPACE) {
         selectedNamespace = objectQuery(namespaces, 0, 'name');
       }
       if (selectedNamespace !== this.state.currentNamespace) {

--- a/cdap-ui/app/cdap/components/Overview/AppOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/AppOverview/index.js
@@ -31,6 +31,7 @@ import T from 'i18n-react';
 import FastActionToMessage from 'services/fast-action-message-helper';
 import capitalize from 'lodash/capitalize';
 import EntityType from 'services/metadata-parser/EntityType';
+import {SCOPES} from 'services/global-constants';
 
 export default class AppOverview extends Component {
   constructor(props) {
@@ -71,7 +72,7 @@ export default class AppOverview extends Component {
       namespace,
       entityType: 'apps',
       entityId,
-      scope: 'SYSTEM'
+      scope: SCOPES.SYSTEM
     };
 
     if (entityId) {

--- a/cdap-ui/app/cdap/components/Overview/DatasetOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/DatasetOverview/index.js
@@ -29,6 +29,7 @@ import isNil from 'lodash/isNil';
 import T from 'i18n-react';
 import FastActionToMessage from 'services/fast-action-message-helper';
 import capitalize from 'lodash/capitalize';
+import {SCOPES} from 'services/global-constants';
 
 export default class DatasetOverview extends Component {
   constructor(props) {
@@ -70,7 +71,7 @@ export default class DatasetOverview extends Component {
         namespace,
         entityType: 'datasets',
         entityId: this.props.entity.id,
-        scope: 'SYSTEM'
+        scope: SCOPES.SYSTEM
       };
 
       MyMetadataApi.getProperties(metadataParams)

--- a/cdap-ui/app/cdap/components/Overview/StreamOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/StreamOverview/index.js
@@ -29,6 +29,7 @@ import isNil from 'lodash/isNil';
 import T from 'i18n-react';
 import FastActionToMessage from 'services/fast-action-message-helper';
 import capitalize from 'lodash/capitalize';
+import {SCOPES} from 'services/global-constants';
 
 export default class StreamOverview extends Component {
   constructor(props) {
@@ -72,7 +73,7 @@ export default class StreamOverview extends Component {
         namespace,
         entityType: 'streams',
         entityId: this.props.entity.id,
-        scope: 'SYSTEM'
+        scope: SCOPES.SYSTEM
       };
 
       MyMetadataApi.getProperties(metadataParams)

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/index.js
@@ -31,7 +31,7 @@ import {getCustomizationMap} from 'components/PipelineConfigurations/Store/Actio
 import {getProvisionersMap} from 'components/Cloud/Profiles/Store/Provisioners';
 import {PROFILE_STATUSES} from 'components/Cloud/Profiles/Store';
 import {extractProfileName, getProfileNameWithScope} from 'components/Cloud/Profiles/Store/ActionCreator';
-import {CLOUD} from 'services/global-constants';
+import {CLOUD, SCOPES, SYSTEM_NAMESPACE} from 'services/global-constants';
 import T from 'i18n-react';
 
 const PREFIX = 'features.PipelineDetails.ProfilesListView';
@@ -173,7 +173,7 @@ export default class ProfilesListViewInPipeline extends Component {
   };
 
   renderProfileRow = (profile) => {
-    let profileNamespace = profile.scope === 'SYSTEM' ? 'system' : getCurrentNamespace();
+    let profileNamespace = profile.scope === SCOPES.SYSTEM ? SYSTEM_NAMESPACE : getCurrentNamespace();
     let profileDetailsLink = `${location.protocol}//${location.host}/cdap/ns/${profileNamespace}/profiles/details/${profile.name}`;
     let profileName = getProfileNameWithScope(profile.name, profile.scope);
     let selectedProfile = this.state.selectedProfile || '';

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunComputeProfile/index.js
@@ -27,6 +27,8 @@ import ProfilesStore from 'components/Cloud/Profiles/Store';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import {CLOUD} from 'services/global-constants';
 import T from 'i18n-react';
+import isObject from 'lodash/isObject';
+import {SCOPES, SYSTEM_NAMESPACE} from 'services/global-constants';
 
 const PREFIX = 'features.PipelineDetails.RunLevel.RunComputeProfile';
 
@@ -125,7 +127,7 @@ class RunLevelComputeProfile extends Component {
               <ProfilePreview
                 profileLabel={this.getProfileLabel()}
                 profileName={extractProfileName(this.props.profileName)}
-                profileScope={this.props.profileName.indexOf('SYSTEM:') !== -1 ? 'system' : 'user'}
+                profileScope={this.props.profileName.indexOf(`${SCOPES.SYSTEM}:`) !== -1 ? SCOPES.SYSTEM : SCOPES.USER}
               />
             </Popover>
         }
@@ -150,18 +152,18 @@ function ProfileWrappedRunLevelComputeProfile({...restProps}) {
   );
 }
 
-const getProfileName = (runProperties) => {
-  let runtimeArgs;
-  try {
-    runtimeArgs = JSON.parse(runProperties);
-  } catch (e) {
+const getProfileName = (profileObj) => {
+  if (isNilOrEmpty(profileObj) || !isObject(profileObj)) {
     return null;
   }
-  return runtimeArgs[CLOUD.PROFILE_NAME_PREFERENCE_PROPERTY] || null;
+  if (profileObj.namespace === SYSTEM_NAMESPACE) {
+    return `SYSTEM:${profileObj.profileName}`;
+  }
+  return `USER:${profileObj.profileName}`;
 };
 const mapStateToProps = (state) => {
   return {
-    profileName: getProfileName(objectQuery(state, 'currentRun', 'properties', 'runtimeArgs'))
+    profileName: getProfileName(objectQuery(state, 'currentRun', 'profile'))
   };
 };
 

--- a/cdap-ui/app/cdap/components/PropertiesEditor/EditProperty/index.js
+++ b/cdap-ui/app/cdap/components/PropertiesEditor/EditProperty/index.js
@@ -21,6 +21,7 @@ import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
 import CardActionFeedback from 'components/CardActionFeedback';
 import {MyMetadataApi} from 'api/metadata';
 import NamespaceStore from 'services/NamespaceStore';
+import {SCOPES} from 'services/global-constants';
 import T from 'i18n-react';
 
 export default class EditProperty extends Component {
@@ -55,7 +56,7 @@ export default class EditProperty extends Component {
       namespace,
       entityType: this.props.entityType,
       entityId: this.props.entityId,
-      scope: 'USER'
+      scope: SCOPES.USER
     };
 
     let requestBody = {};

--- a/cdap-ui/app/cdap/components/PropertiesEditor/index.js
+++ b/cdap-ui/app/cdap/components/PropertiesEditor/index.js
@@ -26,6 +26,7 @@ import T from 'i18n-react';
 import DeleteConfirmation from 'components/PropertiesEditor/DeleteConfirmation';
 import EditProperty from 'components/PropertiesEditor/EditProperty';
 import classnames from 'classnames';
+import {SCOPES} from 'services/global-constants';
 
 require('./PropertiesEditor.scss');
 
@@ -61,8 +62,8 @@ export default class PropertiesEditor extends Component {
       entityId: this.props.entityId
     };
 
-    let systemParams = Object.assign({}, baseRequestObject, { scope: 'SYSTEM' });
-    let userParams = Object.assign({}, baseRequestObject, { scope: 'USER' });
+    let systemParams = Object.assign({}, baseRequestObject, { scope: SCOPES.SYSTEM });
+    let userParams = Object.assign({}, baseRequestObject, { scope: SCOPES.USER });
 
     MyMetadataApi.getProperties(systemParams)
       .map(convertObjToArr)
@@ -83,7 +84,7 @@ export default class PropertiesEditor extends Component {
       namespace,
       entityType: this.props.entityType,
       entityId: this.props.entityId,
-      scope: 'USER'
+      scope: SCOPES.USER
     };
 
     MyMetadataApi.getProperties(params)

--- a/cdap-ui/app/cdap/components/StreamDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/index.js
@@ -34,6 +34,7 @@ import BreadCrumb from 'components/BreadCrumb';
 import PlusButton from 'components/PlusButton';
 import Helmet from 'react-helmet';
 import queryString from 'query-string';
+import {SCOPES} from 'services/global-constants';
 
 require('./StreamDetailedView.scss');
 
@@ -115,7 +116,7 @@ export default class StreamDetailedView extends Component {
         namespace,
         entityType: 'streams',
         entityId: streamId,
-        scope: 'SYSTEM'
+        scope: SCOPES.SYSTEM
       };
 
       MyMetadataApi.getProperties(metadataParams)

--- a/cdap-ui/app/cdap/components/Tags/Tag/index.js
+++ b/cdap-ui/app/cdap/components/Tags/Tag/index.js
@@ -20,6 +20,7 @@ import React, { Component } from 'react';
 import SpotlightModal from 'components/SpotlightSearch/SpotlightModal';
 import classnames from 'classnames';
 import IconSVG from 'components/IconSVG';
+import {SCOPES} from 'services/global-constants';
 
 require('./Tag.scss');
 
@@ -47,8 +48,8 @@ export default class Tag extends Component {
 
   render() {
     let tagClasses = classnames("btn btn-secondary tag-btn", {
-      "system-tag": this.props.scope === 'SYSTEM',
-      "user-tag": this.props.scope === 'USER'
+      "system-tag": this.props.scope === SCOPES.SYSTEM,
+      "user-tag": this.props.scope === SCOPES.USER
     });
     return (
       <span className={tagClasses}>
@@ -58,7 +59,7 @@ export default class Tag extends Component {
         >
           <span>{this.props.value}</span>
           {
-            this.props.scope === 'USER' ?
+            this.props.scope === SCOPES.USER ?
               <IconSVG
                 name="icon-close"
                 onClick={this.props.onDelete}

--- a/cdap-ui/app/cdap/components/Tags/index.js
+++ b/cdap-ui/app/cdap/components/Tags/index.js
@@ -28,6 +28,7 @@ import IconSVG from 'components/IconSVG';
 import Popover from 'components/Popover';
 require('./Tags.scss');
 import T from 'i18n-react';
+import {SCOPES} from 'services/global-constants';
 
 const PREFIX = 'features.Tags';
 
@@ -65,8 +66,8 @@ export default class Tags extends Component {
     Mousetrap.bind('return', this.addTag);
     Mousetrap.bind('escape', this.closeInputFieldIfEmpty);
 
-    let systemParams = Object.assign({}, this.params, { scope: 'SYSTEM' });
-    let userParams = Object.assign({}, this.params, { scope: 'USER' });
+    let systemParams = Object.assign({}, this.params, { scope: SCOPES.SYSTEM });
+    let userParams = Object.assign({}, this.params, { scope: SCOPES.USER });
 
     this.setState({
       loading: true
@@ -127,7 +128,7 @@ export default class Tags extends Component {
   };
 
   fetchUserTags() {
-    let params = Object.assign({}, this.params, { scope: 'USER' });
+    let params = Object.assign({}, this.params, { scope: SCOPES.USER });
 
     let fetchTagsSubscription = MyMetadataApi
       .getTags(params)
@@ -220,7 +221,7 @@ export default class Tags extends Component {
             return (
               <Tag
                 value={tag}
-                scope='SYSTEM'
+                scope={SCOPES.SYSTEM}
                 isNativeLink={this.props.isNativeLink}
                 key={tag}
               />
@@ -240,7 +241,7 @@ export default class Tags extends Component {
               <Tag
                 value={tag}
                 onDelete={this.deleteTag.bind(this, tag)}
-                scope='USER'
+                scope={SCOPES.USER}
                 isNativeLink={this.props.isNativeLink}
                 key={tag}
               />

--- a/cdap-ui/app/cdap/services/NamespaceStore/index.js
+++ b/cdap-ui/app/cdap/services/NamespaceStore/index.js
@@ -17,6 +17,7 @@
 import {combineReducers, createStore} from 'redux';
 import NamespaceActions from './NamespaceActions';
 import {composeEnhancers, objectQuery, isNilOrEmpty} from 'services/helpers';
+import {SYSTEM_NAMESPACE} from 'services/global-constants';
 
 const defaultAction = {
   action : '',
@@ -41,14 +42,14 @@ const username = (state = '', action = defaultAction) => {
 const selectedNamespace = (state = '', action = defaultAction) => {
   switch (action.type) {
     case NamespaceActions.selectNamespace: {
-      if (action.payload.selectedNamespace === 'system') {
+      if (action.payload.selectedNamespace === SYSTEM_NAMESPACE) {
         return localStorage.getItem('CurrentNamespace');
       }
       return action.payload.selectedNamespace;
     }
     case NamespaceActions.updateNamespaces: {
       let previouslyAccessedNs = localStorage.getItem('CurrentNamespace');
-      if (isNilOrEmpty(state) || state === 'system') {
+      if (isNilOrEmpty(state) || state === SYSTEM_NAMESPACE) {
         return !isNilOrEmpty(previouslyAccessedNs) ? previouslyAccessedNs : objectQuery(action.payload, 'namespaces', 0, 'name');
       }
       return state;

--- a/cdap-ui/app/cdap/services/ServiceEnablerUtilities.js
+++ b/cdap-ui/app/cdap/services/ServiceEnablerUtilities.js
@@ -20,6 +20,7 @@ import {MyArtifactApi} from 'api/artifact';
 import Version from 'services/VersionRange/Version';
 import T from 'i18n-react';
 import {Subject} from 'rxjs/Subject';
+import {SCOPES} from 'services/global-constants';
 
 export default function enableSystemApp({
   shouldStopService,
@@ -83,7 +84,7 @@ export default function enableSystemApp({
           // when there are two artifacts with the same version;
           // USER and SYSTEM scope. In that case, take the USER scope
           highestVersionArtifact = highestVersionArtifact[0];
-          highestVersionArtifact.scope = 'USER';
+          highestVersionArtifact.scope = SCOPES.USER;
         } else {
           highestVersionArtifact = highestVersionArtifact[0];
         }

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -271,6 +271,13 @@ const CLOUD = {
   PROFILE_PROPERTIES_PREFERENCE: 'system.profile.properties'
 };
 
+const SCOPES = {
+  SYSTEM: 'SYSTEM',
+  USER: 'USER'
+};
+
+const SYSTEM_NAMESPACE = 'system';
+
 export {
   NUMBER_TYPES,
   GLOBALS,
@@ -278,5 +285,7 @@ export {
   PROGRAM_STATUSES,
   SECURE_KEY_PREFIX,
   SECURE_KEY_SUFFIX,
-  CLOUD
+  CLOUD,
+  SCOPES,
+  SYSTEM_NAMESPACE
 };

--- a/cdap-ui/app/cdap/services/metadata-parser/index.js
+++ b/cdap-ui/app/cdap/services/metadata-parser/index.js
@@ -17,7 +17,7 @@
 import EntityIconMap from 'services/entity-icon-map';
 import intersection from 'lodash/intersection';
 import EntityType from 'services/metadata-parser/EntityType';
-import {GLOBALS} from 'services/global-constants';
+import {GLOBALS, SCOPES, SYSTEM_NAMESPACE} from 'services/global-constants';
 import {objectQuery} from 'services/helpers';
 
 export function parseMetadata(entity) {
@@ -74,7 +74,7 @@ function entityIsApp(entity) {
 }
 
 function entityIsPipeline(entity) {
-  return intersection(GLOBALS.etlPipelineTypes, objectQuery(entity, 'metadata', 'SYSTEM', 'tags')).length > 0;
+  return intersection(GLOBALS.etlPipelineTypes, objectQuery(entity, 'metadata', SCOPES.SYSTEM, 'tags')).length > 0;
 }
 
 function createArtifactObj(entity) {
@@ -83,7 +83,7 @@ function createArtifactObj(entity) {
     type: entity.entityId.entity.toLowerCase(),
     version: entity.entityId.version,
     metadata: entity,
-    scope: entity.entityId.namespace.toLowerCase() === 'system' ? 'SYSTEM' : 'USER',
+    scope: entity.entityId.namespace.toLowerCase() === SYSTEM_NAMESPACE ? SCOPES.SYSTEM : SCOPES.USER,
     icon: EntityIconMap['artifact']
   };
 }


### PR DESCRIPTION
- Fixes the way we use profile information from the run record. Backend now adds a profile object to run record and UI should use that as source of truth for profile info for historical runs
- Fixes IDs used in `FasAction` components to start with a alphabet instead of number (which uuidV4 generates randomly)
- Fixes all references of `'system'` namespace to use a constant instead of hardcoding the value in multiple places
- Fixes all references of `'USER'` and `'SYSTEM'` scopes to use a constant instead of hardcode values in multiple place.


JIRA: 
https://issues.cask.co/browse/CDAP-13767
https://issues.cask.co/browse/CDAP-13890

Build:
https://builds.cask.co/browse/CDAP-UDUT28

**Note:**
The reasoning for extracting the string to constant was we were using those string in a inconsistent way. Some places we used lower case some place upper case, someplace we changed to lower case before passing to a child component and upper cased it in the child 😑 