### PR TITLE
CDAP-14062 fix report generation app failure to read report before it…

### DIFF
--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/ReportGenerationSpark.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/ReportGenerationSpark.java
@@ -738,6 +738,10 @@ public class ReportGenerationSpark extends AbstractExtendedSpark {
         if (totalRecords > 0) {
           long recordCount = 0;
           Location reportDir = reportIdDir.append(LocationName.REPORT_DIR);
+          if (!reportDir.exists() || reportDir.list().size() < 1) {
+            responder.sendError(404, String.format("Content files not found for report %s", idMessage));
+            return;
+          }
           // TODO: [CDAP-13291] need to support reading multiple report files
           Optional<Location> reportFile =
             reportDir.list().stream().filter(l -> l.getName().endsWith(".avro")).findFirst();

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/main/SparkPersistRunRecordMain.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/main/SparkPersistRunRecordMain.java
@@ -55,15 +55,19 @@ public class SparkPersistRunRecordMain implements JavaSparkMain {
     }
     Location reportFileSetLocation = getDatasetBaseLocationWithRetry(sec, ReportGenerationApp.REPORT_FILESET);
     createSecurityKeyFile(reportFileSetLocation);
-    tmsSubscriber = new TMSSubscriber(sec.getMessagingContext().getMessageFetcher(),
-                                      getDatasetBaseLocationWithRetry(sec, ReportGenerationApp.RUN_META_FILESET),
-                                      sec.getRuntimeArguments(), sec.getMetrics());
-    tmsSubscriber.start();
-    try {
-      tmsSubscriber.join();
-    } catch (InterruptedException ie) {
-      tmsSubscriber.requestStop();
-      tmsSubscriber.interrupt();
+    // enabled by default, configuration to help disable this thread in unit tests
+    if (!Boolean.parseBoolean(
+      sec.getRuntimeArguments().getOrDefault(Constants.DISABLE_TMS_SUBSCRIBER_THREAD, "false"))) {
+      tmsSubscriber = new TMSSubscriber(sec.getMessagingContext().getMessageFetcher(),
+                                        getDatasetBaseLocationWithRetry(sec, ReportGenerationApp.RUN_META_FILESET),
+                                        sec.getRuntimeArguments(), sec.getMetrics());
+      tmsSubscriber.start();
+      try {
+        tmsSubscriber.join();
+      } catch (InterruptedException ie) {
+        tmsSubscriber.requestStop();
+        tmsSubscriber.interrupt();
+      }
     }
   }
 

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/util/Constants.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/main/java/co/cask/cdap/report/util/Constants.java
@@ -115,4 +115,6 @@ public final class Constants {
     public static final String DEFAULT_REPORT_EXPIRY_TIME_SECONDS = String.valueOf(TimeUnit.DAYS.toSeconds(2));
     public static final String REPORT_EXPIRY_TIME_SECONDS = "report.expiry.duration.seconds";
   }
+
+  public static final String DISABLE_TMS_SUBSCRIBER_THREAD = "disable.tms.subscriber.thread";
 }

--- a/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/test/java/co/cask/cdap/report/ReportGenerationAppTest.java
+++ b/cdap-app-templates/cdap-program-report/cdap-program-report-base/src/test/java/co/cask/cdap/report/ReportGenerationAppTest.java
@@ -128,10 +128,18 @@ public class ReportGenerationAppTest extends TestBase {
 
   @Test
   public void testGenerateReport() throws Exception {
+    Map<String, String> runTimeArguments = new HashMap<>();
+    // disable tms subscriber thread as the RunMetaFileSet avro files are written directly by the test case
+    // if the tms subscriber thread is enabled, in order to find the latest message id to start fetching from,
+    // we read the latest RunMetaFileSet avro file's content
+    // whereas the derived message_id will be invalid in TMS as these runs aren't in TMS,
+    // in order to avoid the exception we disable the tms subscriber thread for the test case
+    runTimeArguments.put(Constants.DISABLE_TMS_SUBSCRIBER_THREAD, "true");
+
     Long currentTimeMillis = System.currentTimeMillis();
     DatasetId metaFileset = createAndInitializeDataset(NamespaceId.DEFAULT, currentTimeMillis);
 
-    SparkManager sparkManager = deployAndStartReportingApplication(NamespaceId.DEFAULT, new HashMap<>());
+    SparkManager sparkManager = deployAndStartReportingApplication(NamespaceId.DEFAULT, runTimeArguments);
     URL url = sparkManager.getServiceURL(1, TimeUnit.MINUTES);
     Assert.assertNotNull(url);
     URL reportURL = url.toURI().resolve("reports/").toURL();
@@ -318,6 +326,7 @@ public class ReportGenerationAppTest extends TestBase {
     Map<String, String> runTimeArguments = new HashMap<>();
     // set report expiration time to be 10 seconds
     runTimeArguments.put(Constants.Report.REPORT_EXPIRY_TIME_SECONDS, "1");
+    runTimeArguments.put(Constants.DISABLE_TMS_SUBSCRIBER_THREAD, "true");
     SparkManager sparkManager = deployAndStartReportingApplication(testNamespace, runTimeArguments);
 
     URL url = sparkManager.getServiceURL(1, TimeUnit.MINUTES);


### PR DESCRIPTION
…s written

1) disabling TMS Subscriber thread in reports app test case, as running the thread in test case will cause exception when reading from TMS, which is unnecessary and can be misleading. 
2) write summary to file after the report's contents are written out. we read summary file in order to find out if the report generation completed or failed etc, if the summary for the report is successful, we read the report contents. hence its important to write the summary to file after the report's contents are written out.
3) if report's contents files aren't available, handler should gracefully return not found error code instead of trying to read and cause internal server error.