### PR TITLE
[CDAP-8546] Fix backend behavior to show right message when appropriate services fail

### DIFF
--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -442,10 +442,6 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
         headers: headers
       }, function (err, response) {
         if (err) {
-          if (err.code === 'ECONNREFUSED') {
-            res.status(404).send(err);
-            return;
-          }
           res.status(500).send(err);
         } else {
           res.status(response.statusCode).send('OK');


### PR DESCRIPTION
- Fix express to NOT send a 404 response when backend sends otherwise for the heartbeat api call. This is causing UI to always show "User interface service is down" when the backend services are down.
- Fixes a minor js error in socket module. We keep throwing error for a "POLL" even after the observable (subject) is unsubscribed during previous response.

JIRA: https://issues.cask.co/browse/CDAP-8546
Build: https://builds.cask.co/browse/CDAP-UDUT40