### PR TITLE
Bind UI to localhost

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3650,7 +3650,7 @@
 
   <property>
     <name>dashboard.bind.address</name>
-    <value>0.0.0.0</value>
+    <value>127.0.0.1</value>
     <description>
       CDAP UI bind address
     </description>


### PR DESCRIPTION
- Bind  UI to localhost rather to avoid xss vulnerability.

- Tested on local machine.

