### PR TITLE
CDAP-14102:Bind http services to localhost in sandbox

### DIFF
--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -454,6 +454,8 @@ public class StandaloneMain {
     cConf.set(Constants.CFG_DATA_INMEMORY_PERSISTENCE, Constants.InMemoryPersistenceType.LEVELDB.name());
 
     // configure all services except for router and auth to bind to 127.0.0.1
+    // For details see: https://issues.cask.co/browse/CDAP-7992. Router and auth bind addresses are configured by
+    // cdap-site.xml and are not overridden here.
     String localhost = InetAddress.getLoopbackAddress().getHostAddress();
     cConf.set(Constants.Service.MASTER_SERVICES_BIND_ADDRESS, localhost);
     cConf.set(Constants.Transaction.Container.ADDRESS, localhost);
@@ -465,6 +467,7 @@ public class StandaloneMain {
     cConf.set(Constants.Explore.SERVER_ADDRESS, localhost);
     cConf.set(Constants.Metadata.SERVICE_BIND_ADDRESS, localhost);
     cConf.set(Constants.Preview.ADDRESS, localhost);
+    cConf.set(Constants.RemoteSystemOpService.SERVICE_BIND_ADDRESS, localhost);
 
     return ImmutableList.of(
       new ConfigModule(cConf, hConf),

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -204,9 +204,11 @@
     </description>
   </property>
 
+  <!-- Bind to 127.0.0.1 (localhost) to protect from xss vulnerabilities while running in sandbox.
+  This must be changed if access to router is needed from a machine other than local machine. See CDAP-14102 -->
   <property>
     <name>router.bind.address</name>
-    <value>0.0.0.0</value>
+    <value>127.0.0.1</value>
     <description>
       CDAP Router service bind address
     </description>
@@ -252,6 +254,25 @@
       The 'file' provider is only used in the sandbox. In distributed environments, this should
       be set to 'kms', presuming your cluster has been configured to use KMS. The 'file' provider
       will not work in distributed environments.
+    </description>
+  </property>
+
+  <!-- Override default 0.0.0.0 to 127.0.0.1 (localhost) to protect from xss vulnerabilities while
+  running in sandbox. These must be changed if access is needed from a machine other than local machine.
+  See CDAP-14102 -->
+  <property>
+    <name>dashboard.bind.address</name>
+    <value>127.0.0.1</value>
+    <description>
+      CDAP UI bind address
+    </description>
+  </property>
+
+  <property>
+    <name>security.auth.server.bind.address</name>
+    <value>127.0.0.1</value>
+    <description>
+      CDAP Authentication service bind address
     </description>
   </property>
 

--- a/cdap-ui/server/config/development/cdap.json
+++ b/cdap-ui/server/config/development/cdap.json
@@ -1,6 +1,6 @@
 {
   "router.ssl.bind.port": "10443",
-  "dashboard.bind.address": "0.0.0.0",
+  "dashboard.bind.address": "127.0.0.1",
   "router.ssl.server.port": "10443",
   "router.server.port": "11015",
   "dashboard.ssl.bind.port": "9443",


### PR DESCRIPTION
### Summary of Change
- For CDAP sandbox we bind all the http servers to 127.0.0.1 loopback address so the sandbox is only accessible from the machine which it runs.

### Future work
- This fix does not solves the real problem. In distributed we bind to `0.0.0.0` to be able be available to all the known addresses of the machines.
- If CDAP is running in sandbox mode and needs to be made accessible to outside world then the binding will need to be changed.

Issue: https://issues.cask.co/browse/CDAP-14102