### PR TITLE
CDAP-14091 make dataproc credentials optional

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -35,8 +35,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.security.GeneralSecurityException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +60,12 @@ public class DataProcProvisioner implements Provisioner {
 
   @Override
   public void validateProperties(Map<String, String> properties) {
-    DataProcConf.fromProperties(properties);
+    DataProcConf conf = DataProcConf.fromProperties(properties);
+    try {
+      DataProcClient.fromConf(conf);
+    } catch (IOException | GeneralSecurityException e) {
+      throw new IllegalArgumentException(e.getMessage(), e);
+    }
   }
 
   @Override

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -13,8 +13,7 @@
           "widget-type": "textbox",
           "label": "Project ID",
           "name": "projectId",
-          "required": true,
-          "description": "Google Cloud Project ID, which uniquely identifies your project. You can find it on the Dashboard in the Cloud Platform Console.",
+          "description": "Google Cloud Project ID, which uniquely identifies your project. You can find it on the Dashboard in the Cloud Platform Console. Not required when running on Google Cloud Platform.",
           "widget-attributes": {
             "placeholder": "Specify your GCP Project ID"
           }
@@ -23,10 +22,9 @@
           "widget-type": "securekey-textarea",
           "label": "Service Account Key",
           "name": "accountKey",
-          "required": true,
-          "description": "A service account is a special type of Google account that belongs to your application or a virtual machine (VM), instead of to an individual end user. Paste the contents of the service account key JSON file that you can download from the service accounts section under IAM and admin on the Cloud Console.",
+          "description": "A service account is a special type of Google account that belongs to your application or a virtual machine (VM), instead of to an individual end user. Paste the contents of the service account key JSON file that you can download from the service accounts section under IAM and admin on the Cloud Console. Not required when running on Google Cloud Platform.",
           "widget-attributes": {
-            "placeholder": "Specify the GCP service account to use to run pipelines using this profile"
+            "placeholder": "Specify the GCP service account"
           }
         }
       ]


### PR DESCRIPTION
Changed project id and account key to be optional settings. When
they are not specified, we will try to pick up them up from the
environment, with the assumption that we are running on a compute
engine instance.