### PR TITLE
[CDAP-14105] Do not correct run records in unit tests

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -88,6 +88,7 @@ import co.cask.cdap.internal.app.runtime.workflow.WorkflowStateWriter;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.app.services.DistributedRunRecordCorrectorService;
 import co.cask.cdap.internal.app.services.LocalRunRecordCorrectorService;
+import co.cask.cdap.internal.app.services.NoopRunRecordCorrectorService;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.RunRecordCorrectorService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
@@ -171,7 +172,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new AbstractModule() {
                              @Override
                              protected void configure() {
-                               bind(RunRecordCorrectorService.class).to(LocalRunRecordCorrectorService.class)
+                               bind(RunRecordCorrectorService.class).to(NoopRunRecordCorrectorService.class)
                                  .in(Scopes.SINGLETON);
                                bind(TimeSchedulerService.class).to(LocalTimeSchedulerService.class)
                                  .in(Scopes.SINGLETON);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/NoopRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/NoopRunRecordCorrectorService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.runtime.ProgramStateWriter;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import com.google.inject.Inject;
+
+/**
+ * A run record corrector that does not correct run records at all.
+ * Note that this still runs the local dataset deleter that is started by its base class.
+ */
+public class NoopRunRecordCorrectorService extends RunRecordCorrectorService {
+
+  @Inject
+  NoopRunRecordCorrectorService(CConfiguration cConf, Store store, ProgramStateWriter programStateWriter,
+                                ProgramRuntimeService runtimeService, NamespaceAdmin namespaceAdmin,
+                                DatasetFramework datasetFramework) {
+    super(cConf, store, programStateWriter, runtimeService, namespaceAdmin, datasetFramework);
+  }
+}


### PR DESCRIPTION
It is not needed and causes frequent test (=build) failures.

See https://issues.cask.co/browse/CDAP-14105 for explanation.