### PR TITLE
Changes UI theme back to default

### DIFF
--- a/cdap-ui/server/config/ui-settings.json
+++ b/cdap-ui/server/config/ui-settings.json
@@ -1,5 +1,5 @@
 {
   "standalone.website.sdk.download": "true",
   "ui.debug.enabled": "false",
-  "ui.theme": "light"
+  "ui.theme": "default"
 }


### PR DESCRIPTION
Had `ui.theme` value as `light` as I was experimenting in https://github.com/caskdata/cdap/pull/10492, but we should change it back to `default` to show what we had before (e.g. black navbar instead of blue).