### PR TITLE
CDAP-13894 fix for sandbox metrics

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -634,7 +634,11 @@ public final class Constants {
     public static final String TIME_SERIES_TABLE_ROLL_TIME = "metrics.data.table.ts.rollTime";
 
     // Key prefix for retention seconds. The actual key is suffixed by the table resolution.
-    public static final String RETENTION_SECONDS = "metrics.data.table.retention.resolution";
+    public static final String RETENTION_SECONDS = "metrics.data.table.retention.resolution.";
+    public static final int SECOND_RESOLUTION = 1;
+    public static final int MINUTE_RESOLUTION = 60;
+    public static final int HOUR_RESOLUTION = 3600;
+    public static final String RETENTION_SECONDS_SUFFIX = ".seconds";
 
     public static final String TOPIC_PREFIX = "metrics.topic.prefix";
     // legacy name, we no longer use Kafka for metrics, we use TMS
@@ -651,8 +655,6 @@ public final class Constants {
     public static final String METRICS_TABLE_HBASE_SPLIT_POLICY = "metrics.table.hbase.split.policy";
 
     public static final int DEFAULT_TIME_SERIES_TABLE_ROLL_TIME = 3600;
-
-    public static final long DEFAULT_RETENTION_HOURS = 2;
 
     public static final String MESSAGING_TOPIC_NUM = "metrics.messaging.topic.num";
 

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricStore.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricStore.java
@@ -53,9 +53,15 @@ public interface MetricStore {
 
   /**
    * Deletes all metric data before given timestamp. Used for applying TTL policy.
+   *
    * @param timestamp time up to which to delete metrics data, in ms since epoch
    */
   void deleteBefore(long timestamp) throws Exception;
+
+  /**
+   * Deletes all metric data in the resolution tables based on their ttl setting based on the current timestamp.
+   */
+  void deleteTTLExpired() throws Exception;
 
   /**
    * Deletes all metric data specified by the {@link MetricDeleteQuery}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -70,12 +70,14 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
     String v3TableName = cConf.get(Constants.Metrics.METRICS_TABLE_PREFIX,
                                    Constants.Metrics.DEFAULT_METRIC_V3_TABLE_PREFIX) + ".ts." + resolution;
 
-    int ttl = cConf.getInt(Constants.Metrics.RETENTION_SECONDS + "." + resolution + ".seconds", -1);
-
     TableProperties.Builder props = TableProperties.builder();
     // don't add TTL for MAX_RESOLUTION table. CDAP-1626
-    if (ttl > 0 && resolution != Integer.MAX_VALUE) {
-      props.setTTL(ttl);
+    if (resolution != Integer.MAX_VALUE) {
+      int ttl = cConf.getInt(Constants.Metrics.RETENTION_SECONDS + resolution +
+                               Constants.Metrics.RETENTION_SECONDS_SUFFIX);
+      if (ttl > 0) {
+        props.setTTL(ttl);
+      }
     }
     // for efficient counters
     props.setReadlessIncrementSupport(true);
@@ -156,9 +158,9 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
    */
   public static void setupDatasets(DefaultMetricDatasetFactory factory) {
     // adding all fact tables
-    factory.getOrCreateFactTable(1);
-    factory.getOrCreateFactTable(60);
-    factory.getOrCreateFactTable(3600);
+    factory.getOrCreateFactTable(Constants.Metrics.SECOND_RESOLUTION);
+    factory.getOrCreateFactTable(Constants.Metrics.MINUTE_RESOLUTION);
+    factory.getOrCreateFactTable(Constants.Metrics.HOUR_RESOLUTION);
     factory.getOrCreateFactTable(Integer.MAX_VALUE);
 
     // adding kafka consumer meta

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorServiceTest.java
@@ -138,12 +138,12 @@ public class MessagingMetricsProcessorServiceTest extends MetricsProcessorServic
 
     @Override
     public void setMetricsContext(MetricsContext metricsContext) {
-
+      // no-op
     }
 
     @Override
     public void add(MetricValues metricValues) throws Exception {
-
+      // no-op
     }
 
     @Override
@@ -201,12 +201,17 @@ public class MessagingMetricsProcessorServiceTest extends MetricsProcessorServic
 
     @Override
     public void deleteBefore(long timestamp) throws Exception {
+      // no-op
+    }
 
+    @Override
+    public void deleteTTLExpired() throws Exception {
+      // no-op
     }
 
     @Override
     public void delete(MetricDeleteQuery query) throws Exception {
-
+      // no-op
     }
 
     @Override


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13894
Build: https://builds.cask.co/browse/CDAP-DUT6576

Fix for the metrics clean up for sandbox. We have different configurations for different resolution table retention. But when we do clean up, we only get the configuration for second resolution table, which by default is 2 hours. We then try to delete all the metrics before this timestamp for all resolution tables. 
The fix is to get all the configs and try to delete from the metrics table using the correct timestamp.