### PR TITLE
[CDAP-14071] Upgrades datavoyager to make sure it works in react 16 environment

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -100,7 +100,7 @@
     "@babel/polyfill": "^7.0.0-beta.53",
     "body-parser": "1.14.2",
     "bootstrap": "4.0.0-alpha.5",
-    "cask-datavoyager": "2.0.0-alpha.12.6",
+    "cask-datavoyager": "2.0.0-alpha.12.7",
     "cdap-avsc": "4.1.12",
     "classnames": "2.2.5",
     "clipboard": "1.7.1",

--- a/cdap-ui/yarn.lock
+++ b/cdap-ui/yarn.lock
@@ -1925,9 +1925,9 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-cask-datavoyager@2.0.0-alpha.12.6:
-  version "2.0.0-alpha.12.6"
-  resolved "https://registry.yarnpkg.com/cask-datavoyager/-/cask-datavoyager-2.0.0-alpha.12.6.tgz#3bcf81bc05b4c23ca602be613e9031838e7fe118"
+cask-datavoyager@2.0.0-alpha.12.7:
+  version "2.0.0-alpha.12.7"
+  resolved "https://registry.yarnpkg.com/cask-datavoyager/-/cask-datavoyager-2.0.0-alpha.12.7.tgz#d0b14a0776cf8fe6b7e2d6f0208bc661a4eaa4fb"
 
 cdap-avsc@4.1.12:
   version "4.1.12"


### PR DESCRIPTION
Corresponding voyager PR: https://github.com/ajainarayanan/voyager/pull/2

JIRA: https://issues.cask.co/browse/CDAP-14071
Build: https://builds.cask.co/browse/CDAP-UDUT46