### PR TITLE
[CDAP-14129] Do not start DataPrep in tests

### DIFF
--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -107,8 +107,9 @@ import java.util.List;
  */
 public class StandaloneMain {
 
-  // A special key in the CConfiguration to disable UI. It's mainly used for unit-tests that start Standalone.
+  // Special keys in the CConfiguration to disable stuff. It's mainly used for unit-tests that start Standalone.
   public static final String DISABLE_UI = "standalone.disable.ui";
+  public static final String DISABLE_DATAPREP = "standalone.disable.dataprep";
 
   private static final Logger LOG = LoggerFactory.getLogger(StandaloneMain.class);
 
@@ -125,6 +126,7 @@ public class StandaloneMain {
   private final MetadataService metadataService;
   private final boolean securityEnabled;
   private final boolean sslEnabled;
+  private final boolean dataPrepEnabled;
   private final CConfiguration cConf;
   private final DatasetService datasetService;
   private final ExploreClient exploreClient;
@@ -182,6 +184,8 @@ public class StandaloneMain {
 
     exploreClient = injector.getInstance(ExploreClient.class);
     metadataService = injector.getInstance(MetadataService.class);
+
+    dataPrepEnabled = !cConf.getBoolean(DISABLE_DATAPREP, false);
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -260,7 +264,9 @@ public class StandaloneMain {
     }
     metadataService.startAndWait();
 
-    wranglerAppCreationService.startAndWait();
+    if (dataPrepEnabled) {
+      wranglerAppCreationService.startAndWait();
+    }
 
     operationalStatsService.startAndWait();
 
@@ -284,7 +290,9 @@ public class StandaloneMain {
         userInterfaceService.stopAndWait();
       }
 
-      wranglerAppCreationService.stopAndWait();
+      if (dataPrepEnabled) {
+        wranglerAppCreationService.stopAndWait();
+      }
 
       //  shut down router to stop all incoming traffic
       router.stopAndWait();

--- a/cdap-standalone/src/main/java/co/cask/cdap/WranglerAppCreationService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/WranglerAppCreationService.java
@@ -38,7 +38,7 @@ public class WranglerAppCreationService extends AbstractAppCreationService {
   private static final ProgramId WRANGLER_SERVICEID = WRANGLER_APPID.service("service");
 
   private static final Map<ProgramId, Map<String, String>> PROGRAM_ID_MAP =
-    ImmutableMap.<ProgramId, Map<String, String>>of(WRANGLER_SERVICEID, ImmutableMap.<String, String>of());
+    ImmutableMap.of(WRANGLER_SERVICEID, ImmutableMap.of());
 
 
   @Inject

--- a/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
+++ b/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
@@ -78,6 +78,7 @@ public class StandaloneTester extends ExternalResource {
     cConf.setBoolean(Constants.Explore.EXPLORE_ENABLED, true);
     cConf.setBoolean(Constants.Explore.START_ON_DEMAND, false);
     cConf.setBoolean(StandaloneMain.DISABLE_UI, true);
+    cConf.setBoolean(StandaloneMain.DISABLE_DATAPREP, true);
     cConf.setBoolean(Constants.Audit.ENABLED, false);
 
     for (int i = 0; i < configs.length; i += 2) {


### PR DESCRIPTION
- adds a configuration for standalone, whether to start DataPrep; and disables it for tests.
- fix in AbstractAppCreationService to actually not start the program during shutdown
