### PR TITLE
[CDAP-14134] Reads theme file once when starting up node server, instead of every time user uses UI

### DIFF
--- a/cdap-ui/server/config/parser.js
+++ b/cdap-ui/server/config/parser.js
@@ -35,7 +35,20 @@ var log = log4js.getLogger('default');
 function extractUISettings() {
   try {
     if (require.resolve('./ui-settings.json')) {
-      return require('./ui-settings.json') || {};
+      const uiSettings = require('./ui-settings.json') || {};
+      const uiThemeName = uiSettings['ui.theme'] || 'default';
+      const uiThemePath = `./themes/${uiThemeName}.json`;
+      let uiThemeConfig = {};
+      try {
+        if (require.resolve(uiThemePath)) {
+          uiThemeConfig = require(uiThemePath);
+          log.info(`UI using ${uiThemeName} theme`);
+        }
+      } catch (err) {
+        // The error can either be file doesn't exist, or file contains invalid json
+        log.info(err.toString());
+      }
+      return {uiSettings, uiThemeConfig};
     }
   } catch(e) {
     log.info('Unable to find UI settings json file.');

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -48,7 +48,7 @@ var express = require('express'),
 
 var log = log4js.getLogger('default');
 
-function makeApp (authAddress, cdapConfig, uiSettings) {
+function makeApp (authAddress, cdapConfig, {uiSettings, uiThemeConfig}) {
 
   var app = express();
 
@@ -114,26 +114,11 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
   });
 
   app.get('/ui-theme.js', function (req, res) {
-    let uiThemeName = uiSettings['ui.theme'] || 'default';
-    let path = `${__dirname}/config/themes/${uiThemeName}.json`;
-    try {
-      let file = fs.readFileSync(path, 'utf8');
-      try {
-        let fileConfig = JSON.parse(file);
-        res.header({
-          'Content-Type': 'text/javascript',
-          'Cache-Control': 'no-store, must-revalidate'
-        });
-        res.send(`window.CDAP_UI_THEME = ${JSON.stringify(fileConfig)};`);
-      } catch (err) {
-        log.debug(`Invalid ${uiThemeName}.json file in server/config/themes directory: ${err}`);
-        res.end();
-      }
-    } catch (e) {
-      log.debug(`File ${uiThemeName}.json doesn't exist in server/config/themes directory: ${e}`);
-      res.end();
-    }
-
+    res.header({
+      'Content-Type': 'text/javascript',
+      'Cache-Control': 'no-store, must-revalidate'
+    });
+    res.send(`window.CDAP_UI_THEME = ${JSON.stringify(uiThemeConfig)};`);
   });
 
   app.post('/downloadQuery', function(req, res) {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14134
Build: https://builds.cask.co/browse/CDAP-UDUT48

Currently we read the theme file in the callback function of `GET /ui-theme.js`, which is called every time an user opens up UI in a browser. Instead of doing this, we can just read the file once when Node.js server is starting up, and save the contents of the file in memory. In the callback function mentioned above, we can just access the contents of the file directly.