### PR TITLE
CDAP-14044 use prefix to delete metrics

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeDeleteQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeDeleteQuery.java
@@ -21,9 +21,10 @@ import co.cask.cdap.api.annotation.Beta;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import java.util.function.Predicate;
 
 /**
  * Defines a query for deleting data in {@link Cube}.
@@ -35,6 +36,7 @@ public class CubeDeleteQuery {
   private final int resolution;
   private final Collection<String> measureNames;
   private final Map<String, String> dimensionValues;
+  private final Predicate<List<String>> tagPredicate;
 
   /**
    * Creates instance of {@link CubeDeleteQuery} that defines selection of data to delete from {@link Cube}.
@@ -43,42 +45,17 @@ public class CubeDeleteQuery {
    * @param resolution resolution of the aggregations to delete from
    * @param dimensionValues dimension name, dimension value pairs that define the data selection
    * @param measureNames name of the measures to delete, {@code null} means delete all
+   * @param tagPredicate predicate to decide how to match the aggregation group to the given tags
    */
   public CubeDeleteQuery(long startTs, long endTs, int resolution,
-                         Map<String, String> dimensionValues, Collection<String> measureNames) {
+                         Map<String, String> dimensionValues, Collection<String> measureNames,
+                         Predicate<List<String>> tagPredicate) {
     this.startTs = startTs;
     this.endTs = endTs;
     this.resolution = resolution;
     this.measureNames = Collections.unmodifiableCollection(new ArrayList<>(measureNames));
-    this.dimensionValues = Collections.unmodifiableMap(new HashMap<>(dimensionValues));
-  }
-
-
-  /**
-   * Creates instance of {@link CubeDeleteQuery} that defines selection of data to delete from {@link Cube}.
-   * @param startTs start time of the data selection, in seconds since epoch
-   * @param endTs end time of the data selection, in seconds since epoch
-   * @param resolution resolution of the aggregations to delete from
-   * @param dimensionValues dimension name, dimension value pairs that define the data selection
-   * @param measureName name of the measure to delete, {@code null} means delete all
-   */
-  public CubeDeleteQuery(long startTs, long endTs, int resolution,
-                         Map<String, String> dimensionValues, @Nullable String measureName) {
-
-    this(startTs, endTs, resolution, dimensionValues,
-         measureName == null ? Collections.<String>emptyList() : Collections.singletonList(measureName));
-  }
-
-  /**
-   * Creates instance of {@link CubeDeleteQuery} that defines selection of data to delete from {@link Cube}.
-   * @param startTs start time of the data selection, in seconds since epoch
-   * @param endTs end time of the data selection, in seconds since epoch
-   * @param resolution resolution of the aggregations to delete from
-   * @param dimensionValues dimension name, dimension value pairs that define the data selection
-   */
-  public CubeDeleteQuery(long startTs, long endTs, int resolution,
-                         Map<String, String> dimensionValues) {
-    this(startTs, endTs, resolution, dimensionValues, (String) null);
+    this.dimensionValues = Collections.unmodifiableMap(new LinkedHashMap<>(dimensionValues));
+    this.tagPredicate = tagPredicate;
   }
 
   public long getStartTs() {
@@ -99,6 +76,10 @@ public class CubeDeleteQuery {
 
   public Map<String, String> getDimensionValues() {
     return dimensionValues;
+  }
+
+  public Predicate<List<String>> getTagPredicate() {
+    return tagPredicate;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -35,12 +35,13 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.scheduler.Scheduler;
 import co.cask.cdap.security.impersonation.Impersonator;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -113,11 +114,12 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
     LOG.debug("Deleting metrics for application {}", applicationId);
     for (String flow : flows) {
       long endTs = System.currentTimeMillis() / 1000;
-      Map<String, String> tags = Maps.newHashMap();
+      Map<String, String> tags = new LinkedHashMap<>();
       tags.put(Constants.Metrics.Tag.NAMESPACE, applicationId.getNamespace());
       tags.put(Constants.Metrics.Tag.APP, applicationId.getApplication());
       tags.put(Constants.Metrics.Tag.FLOW, flow);
-      MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, Collections.<String>emptyList(), tags);
+      MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, Collections.emptySet(), tags,
+                                                            new ArrayList<>(tags.keySet()));
       metricStore.delete(deleteQuery);
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractNamespaceResourceDeleter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractNamespaceResourceDeleter.java
@@ -35,7 +35,9 @@ import co.cask.cdap.security.impersonation.Impersonator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -136,9 +138,10 @@ public abstract class AbstractNamespaceResourceDeleter implements NamespaceResou
 
   private void deleteMetrics(NamespaceId namespaceId) throws Exception {
     long endTs = System.currentTimeMillis() / 1000;
-    Map<String, String> tags = new HashMap<>();
+    Map<String, String> tags = new LinkedHashMap<>();
     tags.put(Constants.Metrics.Tag.NAMESPACE, namespaceId.getNamespace());
-    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, tags);
+    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, Collections.emptySet(), tags,
+                                                          new ArrayList<>(tags.keySet()));
     metricStore.delete(deleteQuery);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
@@ -30,7 +30,6 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.queue.QueueSpecification;
 import co.cask.cdap.app.queue.QueueSpecificationGenerator;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.id.Id;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data2.queue.ConsumerGroupConfig;
 import co.cask.cdap.data2.queue.DequeueStrategy;
@@ -76,9 +75,11 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -382,7 +383,7 @@ public final class FlowUtils {
     Preconditions.checkArgument(namespace != null || appId == null, "Namespace may only be null if AppId is null");
     Preconditions.checkArgument(appId != null || flowId == null, "AppId may only be null if FlowId is null");
     Collection<String> names = Collections.singleton("system.queue.pending");
-    Map<String, String> tags = Maps.newHashMap();
+    Map<String, String> tags = new LinkedHashMap<>();
     if (namespace != null) {
       tags.put(Constants.Metrics.Tag.NAMESPACE, namespace);
       if (appId != null) {
@@ -395,7 +396,7 @@ public final class FlowUtils {
     LOG.info("Deleting 'system.queue.pending' metric for context {}", tags);
     // we must delete up to the current time - let's round up to the next second.
     long nextSecond = System.currentTimeMillis() / 1000 + 1;
-    metricStore.delete(new MetricDeleteQuery(0L, nextSecond, names, tags));
+    metricStore.delete(new MetricDeleteQuery(0L, nextSecond, names, tags, new ArrayList<>(tags.keySet())));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -90,7 +90,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
@@ -101,8 +100,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -618,11 +619,12 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   private void deleteMetrics(ApplicationId applicationId) throws Exception {
     ApplicationSpecification spec = this.store.getApplication(applicationId);
     long endTs = System.currentTimeMillis() / 1000;
-    Map<String, String> tags = Maps.newHashMap();
+    Map<String, String> tags = new LinkedHashMap<>();
     tags.put(Constants.Metrics.Tag.NAMESPACE, applicationId.getNamespace());
     // add or replace application name in the tagMap
     tags.put(Constants.Metrics.Tag.APP, spec.getName());
-    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, tags);
+    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, Collections.emptySet(), tags,
+                                                          new ArrayList<>(tags.keySet()));
     metricStore.delete(deleteQuery);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/DefaultCube.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/DefaultCube.java
@@ -228,7 +228,7 @@ public class DefaultCube implements Cube, MeteredDataset {
     // find all the aggregations that match the dimensionValues in the query and
     // use the dimension values of the aggregation to delete entries in all the fact-tables.
     for (Aggregation agg : aggregations.values()) {
-      if (agg.getDimensionNames().containsAll(query.getDimensionValues().keySet())) {
+      if (query.getTagPredicate().test(agg.getDimensionNames())) {
         dimensionValues.clear();
         for (String dimensionName : agg.getDimensionNames()) {
           dimensionValues.add(new DimensionValue(dimensionName, query.getDimensionValues().get(dimensionName)));

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.metrics.MapReduceMetrics;
 import co.cask.cdap.app.metrics.ProgramUserMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.MetricQueryResult;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
@@ -38,7 +39,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -479,8 +483,13 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
         "&metric=system.reads&interpolate=linear&start=" + start + "&end="
         + end, 4, 1000);
 
+    Map<String, String> deleteTags = new LinkedHashMap<>();
+    deleteTags.put(Constants.Metrics.Tag.NAMESPACE, "interspace");
+    deleteTags.put(Constants.Metrics.Tag.APP, "WordCount1");
+    deleteTags.put(Constants.Metrics.Tag.FLOW, "WordCounter");
     // delete the added metrics for testing interpolator
-    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(start, end, sliceBy);
+    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(start, end, Collections.emptySet(),
+                                                          deleteTags, new ArrayList<>(deleteTags.keySet()));
     metricStore.delete(deleteQuery);
   }
 
@@ -551,8 +560,13 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
         "&metric=system.reads&resolution=auto&start=" + (start - 1) + "&end="
         + (start + 36000), 3, 6);
 
+    Map<String, String> deleteTags = new LinkedHashMap<>();
+    deleteTags.put(Constants.Metrics.Tag.NAMESPACE, "resolutions");
+    deleteTags.put(Constants.Metrics.Tag.APP, "WordCount1");
+    deleteTags.put(Constants.Metrics.Tag.FLOW, "WordCounter");
     // delete the added metrics for testing auto resolutions
-    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(start, (start + 36000), sliceBy);
+    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(start, (start + 36000), Collections.emptySet(), deleteTags,
+                                                          new ArrayList<>(deleteTags.keySet()));
     metricStore.delete(deleteQuery);
   }
 

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricDeleteQuery.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricDeleteQuery.java
@@ -18,33 +18,41 @@ package co.cask.cdap.api.metrics;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Query that specifies parameters to delete entries from {@link MetricStore}.
  */
 public class MetricDeleteQuery {
-
   private final long startTs;
   private final long endTs;
   private final Collection<String> metricNames;
   private final Map<String, String> sliceByTagValues;
+  private final Predicate<List<String>> tagPredicate;
 
+  /**
+   * Creates instance of {@link MetricDeleteQuery} that defines selection of data to delete from the metric store.
+   *
+   * @param startTs start time of the data selection, in seconds since epoch
+   * @param endTs end time of the data selection, in seconds since epoch
+   * @param metricNames ame of the metric names to delete, empty collection means delete all
+   * @param sliceByTagValues the key value pair of the tag and value
+   * @param aggregationTags list of tags for the metric aggregation group, the order must be same as the prefix of the
+   *                        aggregation groups we defined in {@link MetricStore}
+   */
   public MetricDeleteQuery(long startTs, long endTs, Collection<String> metricNames,
-                           Map<String, String> sliceByTagValues) {
+                           Map<String, String> sliceByTagValues, List<String> aggregationTags) {
     this.startTs = startTs;
     this.endTs = endTs;
     this.metricNames = metricNames;
-    this.sliceByTagValues = Maps.newHashMap(sliceByTagValues);
-  }
-
-  public MetricDeleteQuery(long startTs, long endTs,
-                           Map<String, String> sliceByTagValues) {
-    this(startTs, endTs, ImmutableList.<String>of(), sliceByTagValues);
+    this.sliceByTagValues = new LinkedHashMap<>(sliceByTagValues);
+    this.tagPredicate = aggregates -> Collections.indexOfSubList(aggregates, aggregationTags) == 0;
   }
 
   public long getStartTs() {
@@ -61,6 +69,10 @@ public class MetricDeleteQuery {
 
   public Map<String, String> getSliceByTags() {
     return sliceByTagValues;
+  }
+
+  public Predicate<List<String>> getTagPredicate() {
+    return tagPredicate;
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricQueryParser.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricQueryParser.java
@@ -19,7 +19,6 @@ import co.cask.cdap.api.dataset.lib.cube.AggregationFunction;
 import co.cask.cdap.api.dataset.lib.cube.Interpolator;
 import co.cask.cdap.api.dataset.lib.cube.Interpolators;
 import co.cask.cdap.api.metrics.MetricDataQuery;
-import co.cask.cdap.api.metrics.MetricDeleteQuery;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.id.Id;
 import co.cask.cdap.common.utils.TimeMathParser;
@@ -144,18 +143,6 @@ final class MetricQueryParser {
     // +8 for "/metrics"
     int startPos = Constants.Gateway.API_VERSION_3.length() + 8;
     return path.substring(startPos, path.length());
-  }
-
-  static MetricDeleteQuery parseDelete(URI requestURI, String metricPrefix) throws MetricsPathException {
-    MetricDataQueryBuilder builder = new MetricDataQueryBuilder();
-    parseContext(requestURI.getPath(), builder);
-    builder.setStartTs(0);
-    builder.setEndTs(Integer.MAX_VALUE - 1);
-    builder.setMetricName(metricPrefix);
-
-    MetricDataQuery query = builder.build();
-    return new MetricDeleteQuery(query.getStartTs(), query.getEndTs(),
-                                 query.getMetrics().keySet(), query.getSliceByTags());
   }
 
   static MetricDataQuery parse(URI requestURI) throws MetricsPathException {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
@@ -360,7 +360,8 @@ public class DefaultMetricStore implements MetricStore {
   @Override
   public void deleteAll() throws Exception {
     // this will delete all aggregates metrics data
-    delete(new MetricDeleteQuery(0, System.currentTimeMillis() / 1000, Collections.emptyMap()));
+    delete(new MetricDeleteQuery(0, System.currentTimeMillis() / 1000, Collections.emptySet(),
+                                 Collections.emptyMap(), Collections.emptyList()));
     // this will delete all timeseries data
     deleteBefore(System.currentTimeMillis() / 1000);
   }
@@ -369,7 +370,7 @@ public class DefaultMetricStore implements MetricStore {
     // note: delete query currently usually executed synchronously,
     //       so we only attempt to delete totals, to avoid timeout
     return new CubeDeleteQuery(query.getStartTs(), query.getEndTs(), TOTALS_RESOLUTION,
-                               query.getSliceByTags(), query.getMetricNames());
+                               query.getSliceByTags(), query.getMetricNames(), query.getTagPredicate());
   }
 
   @Override
@@ -421,7 +422,8 @@ public class DefaultMetricStore implements MetricStore {
   }
 
   private void deleteMetricsBeforeTimestamp(long timestamp, int resolution) {
-    CubeDeleteQuery query = new CubeDeleteQuery(0, timestamp, resolution, Collections.emptyMap());
+    CubeDeleteQuery query = new CubeDeleteQuery(0, timestamp, resolution, Collections.emptyMap(),
+                                                Collections.emptySet(), strings -> true);
     cube.get().delete(query);
   }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14044
Build: https://builds.cask.co/browse/CDAP-DUT6580-1

When we delete the metric, we use an wildcard match to delete, which means if an aggregation group contains the entity, all the metrics gets removed. This is not a correct behavior, for example, if I have an aggregation group contains {ns, app, program, dataset} for metrics that each program writes to the dataset, and I have another aggregation group contains {ns, dataset, app, program} for metrics about dataset operations. If the app is deleted, the metrics for both aggregation groups will get deleted. This is not an expected behavior because the second aggregation group is supposed to be associated with the dataset. App deletion should not affect it.

To fix this, we should not do a wildcard match when we delete the metrics. Instead, we should use the prefix match of the aggregation group because the prefix actually identifies what this metrics is about. To delete an app, we only delete metrics with {ns, app} as a prefix of the aggregation group. For profile metrics, the prefix will be {profilescope, profile, namespace}, so the profile metrics will not be deleted upon an app deletion.