### PR TITLE
update nodeJS version used in Docker

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -208,10 +208,10 @@
         },
         "nodejs": {
           "install_method": "binary",
-          "version": "4.5.0",
+          "version": "8.7.0",
           "binary": {
             "checksum": {
-              "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+              "linux_x64": "115c7bd133170fd7a1bf408b2e293021e4b5a80a66a4962829ce5d362ce43762"
             }
           }
         },

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -7,10 +7,10 @@
   },
   "nodejs": {
     "install_method": "binary",
-    "version": "4.5.0",
+    "version": "8.7.0",
     "binary": {
       "checksum": {
-        "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+        "linux_x64": "115c7bd133170fd7a1bf408b2e293021e4b5a80a66a4962829ce5d362ce43762"
       }
     }
   },

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -4,10 +4,10 @@
   },
   "nodejs": {
     "install_method": "binary",
-    "version": "4.5.0",
+    "version": "8.7.0",
     "binary": {
       "checksum": {
-        "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+        "linux_x64": "115c7bd133170fd7a1bf408b2e293021e4b5a80a66a4962829ce5d362ce43762"
       }
     }
   },


### PR DESCRIPTION
Update the version of nodejs installed in the Docker image. The old version silently fails to start the UI. There will be a followup PR that checks the version of nodejs and warns the user. https://issues.cask.co/browse/CDAP-14137

The checksum was pulled from here
https://nodejs.org/download/release/v8.7.0/SHASUMS256.txt

This was built and tested locally. 
```
root@3119d22b2bab:/opt/cdap/sandbox/bin# node -v
v8.7.0
root@3119d22b2bab:/opt/cdap/sandbox/bin# netstat -antp | grep LISTEN
tcp        0      0 0.0.0.0:11011           0.0.0.0:*               LISTEN      301/node
```