### PR TITLE
Creating a PartitionedFileSet dataset without the appropriate properties (partitioning) should return a 400

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -121,6 +121,8 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (DatasetAlreadyExistsException e) {
       responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
+    } catch (IllegalArgumentException e) {
+      responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     } catch (DatasetTypeNotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());
     } catch (HandlerException e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
@@ -101,7 +101,7 @@ public class DatasetAdminOpHTTPHandler extends AbstractHttpHandler {
       DatasetId instanceId = new DatasetId(namespaceId, name);
       DatasetSpecification spec = datasetAdminService.createOrUpdate(instanceId, typeMeta, props, null);
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(spec));
-    } catch (BadRequestException e) {
+    } catch (BadRequestException | IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     } catch (Exception e) {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
@@ -88,7 +88,7 @@ public class PartitionedFileSetDefinition
   @Override
   public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
     Partitioning partitioning = PartitionedFileSetProperties.getPartitioning(properties.getProperties());
-    Preconditions.checkNotNull(partitioning, "Properties do not contain partitioning");
+    Preconditions.checkArgument(partitioning != null, "Properties do not contain partitioning");
     // define the columns for indexing on the partitionsTable
     DatasetProperties indexedTableProperties = DatasetProperties.builder()
       .addAll(properties.getProperties())


### PR DESCRIPTION
Creating a PartitionedFileSet dataset without the appropriate properties (partitioning) should return a 400.