### PR TITLE
CDAP-14099 Allow configuring of the maximum number of open files per LevelDB table.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1230,6 +1230,10 @@ public final class Constants {
   public static final String CFG_DATA_LEVELDB_BLOCKSIZE = "data.local.storage.blocksize";
   public static final String CFG_DATA_LEVELDB_CACHESIZE = "data.local.storage.cachesize";
   public static final String CFG_DATA_LEVELDB_FSYNC = "data.local.storage.fsync";
+  public static final String CFG_DATA_LEVELDB_USER_TABLE_MAX_OPEN_FILES =
+          "data.local.storage.user.table.max.open.files";
+  public static final String CFG_DATA_LEVELDB_SYSTEM_TABLE_MAX_OPEN_FILES =
+          "data.local.storage.system.table.max.open.files";
 
   /**
    * Defaults for Data Fabric.
@@ -1246,7 +1250,7 @@ public final class Constants {
   public static final String DEFAULT_LOG_COLLECTION_ROOT = "data/logs";
 
   /**
-   * Used for upgrade and backwards compatability
+   * Used for upgrade and backwards compatibility
    */
   public static final String DEVELOPER_ACCOUNT = "developer";
   public static final String APP_META_UPGRADE_TIMEOUT_SECS = "app.meta.upgrade.timeout.secs";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -679,6 +679,22 @@
   </property>
 
   <property>
+    <name>data.local.storage.user.table.max.open.files</name>
+    <value>100</value>
+    <description>
+      Maximum number of open files per user table.
+    </description>
+  </property>
+
+  <property>
+    <name>data.local.storage.system.table.max.open.files</name>
+    <value>500</value>
+    <description>
+      Maximum number of open files per system table.
+    </description>
+  </property>
+
+  <property>
     <name>data.event.topic</name>
     <value>dataevent</value>
     <description>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -682,7 +682,7 @@
     <name>data.local.storage.user.table.max.open.files</name>
     <value>100</value>
     <description>
-      Maximum number of open files per user table.
+      Maximum number of open file descriptors per user table to be used when in CDAP Local Sandbox.
     </description>
   </property>
 
@@ -690,7 +690,7 @@
     <name>data.local.storage.system.table.max.open.files</name>
     <value>500</value>
     <description>
-      Maximum number of open files per system table.
+      Maximum number of open file descriptors per system table to be used when in CDAP Local Sandbox.
     </description>
   </property>
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTable.java
@@ -49,7 +49,7 @@ public class LevelDBTable extends BufferingTable {
 
   public LevelDBTable(DatasetContext datasetContext, String tableName,
                       LevelDBTableService service, CConfiguration cConf,
-                      DatasetSpecification spec) throws IOException {
+                      DatasetSpecification spec) {
     super(PrefixedNamespaces.namespace(cConf, datasetContext.getNamespaceId(), tableName),
           false, spec.getProperties());
     this.core = new LevelDBTableCore(getTableName(), service);
@@ -156,7 +156,7 @@ public class LevelDBTable extends BufferingTable {
     };
   }
 
-  // Helper methods to help operate on the Scanner with authroization
+  // Helper methods to help operate on the Scanner with authorization
 
   @ReadOnly
   private Row next(Scanner scanner) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -54,7 +54,7 @@ public class LevelDBTableCore {
   private static final Scanner EMPTY_SCANNER = createEmptyScanner();
 
   // this represents deleted values
-  protected static final byte[] DELETE_MARKER = { };
+  private static final byte[] DELETE_MARKER = { };
 
   // we use the empty column family for all data
   private static final byte[] DATA_COLFAM = { };
@@ -72,13 +72,13 @@ public class LevelDBTableCore {
   // empty immutable row's column->value map constant
   // Using ImmutableSortedMap instead of Maps.unmodifiableNavigableMap to avoid conflicts with
   // Hadoop, which uses an older version of guava without that method.
-  static final NavigableMap<byte[], byte[]> EMPTY_ROW_MAP =
+  private static final NavigableMap<byte[], byte[]> EMPTY_ROW_MAP =
     ImmutableSortedMap.<byte[], byte[]>orderedBy(Bytes.BYTES_COMPARATOR).build();
 
   private final String tableName;
   private final LevelDBTableService service;
 
-  public LevelDBTableCore(String tableName, LevelDBTableService service) throws IOException {
+  public LevelDBTableCore(String tableName, LevelDBTableService service) {
     this.tableName = tableName;
     this.service = service;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
@@ -26,7 +26,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -44,6 +43,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.iq80.leveldb.impl.Iq80DBFactory.factory;
@@ -55,7 +55,7 @@ import static org.iq80.leveldb.impl.Iq80DBFactory.factory;
 public class LevelDBTableService implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(LevelDBTableService.class);
-  private final ConcurrentMap<String, DB> tables = Maps.newConcurrentMap();
+  private final ConcurrentMap<String, DB> tables = new ConcurrentHashMap<>();;
 
   private String tablePrefix;
   private int blockSize;
@@ -100,8 +100,12 @@ public class LevelDBTableService implements AutoCloseable {
     userTablesMaxOpenFiles = config.getInt(Constants.CFG_DATA_LEVELDB_USER_TABLE_MAX_OPEN_FILES);
     systemTablesMaxOpenFiles = config.getInt(Constants.CFG_DATA_LEVELDB_SYSTEM_TABLE_MAX_OPEN_FILES);
     // sanity checks to fail fast
-    Preconditions.checkArgument(userTablesMaxOpenFiles >= 0);
-    Preconditions.checkArgument(systemTablesMaxOpenFiles >= 0);
+    Preconditions.checkArgument(userTablesMaxOpenFiles >= 0,
+                                "Must give a non-negative value for %s.",
+                                Constants.CFG_DATA_LEVELDB_USER_TABLE_MAX_OPEN_FILES);
+    Preconditions.checkArgument(systemTablesMaxOpenFiles >= 0,
+                                "Must give a non-negative value for %s.",
+                                Constants.CFG_DATA_LEVELDB_SYSTEM_TABLE_MAX_OPEN_FILES);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.transaction.stream.leveldb.LevelDBNameConverter;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
@@ -54,14 +55,17 @@ import static org.iq80.leveldb.impl.Iq80DBFactory.factory;
 public class LevelDBTableService implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(LevelDBTableService.class);
+  private final ConcurrentMap<String, DB> tables = Maps.newConcurrentMap();
 
+  private String tablePrefix;
   private int blockSize;
   private long cacheSize;
   private String basePath;
   private WriteOptions writeOptions;
-  private boolean isClosed;
+  private int userTablesMaxOpenFiles;
+  private int systemTablesMaxOpenFiles;
 
-  private final ConcurrentMap<String, DB> tables = Maps.newConcurrentMap();
+  private boolean isClosed;
 
   /**
    * To avoid database locking issues make sure that the single LevelDBTableService instance
@@ -86,11 +90,18 @@ public class LevelDBTableService implements AutoCloseable {
   public void setConfiguration(CConfiguration config) {
     basePath = config.get(Constants.CFG_DATA_LEVELDB_DIR);
     Preconditions.checkNotNull(basePath, "No base directory configured for LevelDB.");
+    tablePrefix = config.get(Constants.Dataset.TABLE_PREFIX);
 
     blockSize = config.getInt(Constants.CFG_DATA_LEVELDB_BLOCKSIZE, Constants.DEFAULT_DATA_LEVELDB_BLOCKSIZE);
     cacheSize = config.getLong(Constants.CFG_DATA_LEVELDB_CACHESIZE, Constants.DEFAULT_DATA_LEVELDB_CACHESIZE);
     writeOptions = new WriteOptions().sync(
       config.getBoolean(Constants.CFG_DATA_LEVELDB_FSYNC, Constants.DEFAULT_DATA_LEVELDB_FSYNC));
+
+    userTablesMaxOpenFiles = config.getInt(Constants.CFG_DATA_LEVELDB_USER_TABLE_MAX_OPEN_FILES);
+    systemTablesMaxOpenFiles = config.getInt(Constants.CFG_DATA_LEVELDB_SYSTEM_TABLE_MAX_OPEN_FILES);
+    // sanity checks to fail fast
+    Preconditions.checkArgument(userTablesMaxOpenFiles >= 0);
+    Preconditions.checkArgument(systemTablesMaxOpenFiles >= 0);
   }
 
   /**
@@ -168,7 +179,7 @@ public class LevelDBTableService implements AutoCloseable {
     return size;
   }
 
-  public WriteOptions getWriteOptions() {
+  WriteOptions getWriteOptions() {
     return writeOptions;
   }
 
@@ -179,7 +190,7 @@ public class LevelDBTableService implements AutoCloseable {
       synchronized (tables) {
         db = tables.get(tableName);
         if (db == null) {
-          db = openTable(tableName);
+          db = getDB(tableName, false);
           tables.put(tableName, db);
         }
       }
@@ -194,47 +205,39 @@ public class LevelDBTableService implements AutoCloseable {
       synchronized (tables) {
         db = tables.get(tableName);
         if (db == null) {
-          createTable(tableName);
+          db = getDB(tableName, true);
+          tables.put(tableName, db);
         }
       }
     }
   }
 
-  private DB openTable(String tableName) throws IOException {
+  private DB getDB(String tableName, boolean createIfMissing) throws IOException {
     String dbPath = getDBPath(basePath, tableName);
 
     Options options = new Options();
-    options.createIfMissing(false);
+    options.createIfMissing(createIfMissing);
     options.errorIfExists(false);
     options.comparator(new KeyValueDBComparator());
     options.blockSize(blockSize);
     options.cacheSize(cacheSize);
+    options.maxOpenFiles(isSystemTable(tableName) ? systemTablesMaxOpenFiles : userTablesMaxOpenFiles);
 
-    // unfortunately, with the java version of leveldb, with createIfMissing set to false, factory.open will
-    // see that there is no table and throw an exception, but it wont clean up after itself and will leave a
-    // directory there with a lock.  So we want to avoid calling open if the path doesn't already exist and
-    // throw the exception ourselves.
-    File dbDir = new File(dbPath);
-    if (!dbDir.exists()) {
-      throw new IOException("Database " + dbPath + " does not exist and the create if missing option is disabled");
+    if (!createIfMissing) {
+      // unfortunately, with the java version of leveldb, with createIfMissing set to false, factory.open will
+      // see that there is no table and throw an exception, but it wont clean up after itself and will leave a
+      // directory there with a lock.  So we want to avoid calling open if the path doesn't already exist and
+      // throw the exception ourselves.
+      File dbDir = new File(dbPath);
+      if (!dbDir.exists()) {
+        throw new IOException("Database " + dbPath + " does not exist and the create if missing option is disabled");
+      }
     }
-    DB db = factory.open(dbDir, options);
-    tables.put(tableName, db);
-    return db;
+    return factory.open(new File(dbPath), options);
   }
 
-  private void createTable(String name) throws IOException {
-    String dbPath = getDBPath(basePath, name);
-
-    Options options = new Options();
-    options.createIfMissing(true);
-    options.errorIfExists(false);
-    options.comparator(new KeyValueDBComparator());
-    options.blockSize(blockSize);
-    options.cacheSize(cacheSize);
-
-    DB db = factory.open(new File(dbPath), options);
-    tables.put(name, db);
+  private boolean isSystemTable(String tableName) {
+    return tableName.startsWith(String.format("%s_%s", tablePrefix, NamespaceId.SYSTEM.getNamespace()));
   }
 
   public void dropTable(String name) throws IOException {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/PrefixedNamespacesTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/PrefixedNamespacesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.table.inmemory;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.id.DatasetId;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link PrefixedNamespaces}.
+ */
+public class PrefixedNamespacesTest {
+
+  @Test
+  public void testNamespacing() {
+    CConfiguration cConf = CConfiguration.create();
+    DatasetId datasetId = new DatasetId("ns1", "ds1");
+    String namespacedName = PrefixedNamespaces.namespace(cConf, datasetId.getNamespace(), datasetId.getDataset());
+    Assert.assertEquals("cdap_ns1.ds1", namespacedName);
+    Assert.assertEquals(datasetId, PrefixedNamespaces.getDatasetId(cConf, namespacedName));
+
+    cConf.set(Constants.Dataset.TABLE_PREFIX, "tblprefix");
+    namespacedName = PrefixedNamespaces.namespace(cConf, datasetId.getNamespace(), datasetId.getDataset());
+    Assert.assertEquals("tblprefix_ns1.ds1", namespacedName);
+    Assert.assertEquals(datasetId, PrefixedNamespaces.getDatasetId(cConf, namespacedName));
+  }
+
+  @Test
+  public void testDatasetWithPeriod() {
+    CConfiguration cConf = CConfiguration.create();
+    DatasetId datasetId = new DatasetId("ns1", "ds.1");
+    String namespacedName = PrefixedNamespaces.namespace(cConf, datasetId.getNamespace(), datasetId.getDataset());
+    Assert.assertEquals("cdap_ns1.ds.1", namespacedName);
+    Assert.assertEquals(datasetId, PrefixedNamespaces.getDatasetId(cConf, namespacedName));
+
+    cConf.set(Constants.Dataset.TABLE_PREFIX, "tblprefix");
+    namespacedName = PrefixedNamespaces.namespace(cConf, datasetId.getNamespace(), datasetId.getDataset());
+    Assert.assertEquals("tblprefix_ns1.ds.1", namespacedName);
+    Assert.assertEquals(datasetId, PrefixedNamespaces.getDatasetId(cConf, namespacedName));
+  }
+}

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="20c8a5ee92bf8554c7fbe48802bedc4a"
+DEFAULT_XML_MD5_HASH="ed427e07dc0222ceaec027b5ac0acfa4"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-14099
Allow configuring of the maximum number of open files per LevelDB table, on a user vs system table level. Set lower defaults.
Note that this does not fix the issue where user creates a large number of tables. For instance, the user can create 1000 tables, each one can use 100 leveldb files over time. This can result in 100,000 open files that we don't close until the table gets deleted.