### PR TITLE
CDAP-13924 Capture and store plugin requirements

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
@@ -18,6 +18,8 @@ package co.cask.cdap.api.plugin;
 
 import co.cask.cdap.api.annotation.Beta;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -29,7 +31,6 @@ import javax.annotation.Nullable;
  */
 @Beta
 public class PluginClass {
-
   private final String type;
   private final String name;
   private final String description;
@@ -37,10 +38,11 @@ public class PluginClass {
   private final String configFieldName;
   private final Map<String, PluginPropertyField> properties;
   private final Set<String> endpoints;
+  private final Set<String> requirements;
 
   public PluginClass(String type, String name, String description, String className,
                      @Nullable String configfieldName, Map<String, PluginPropertyField> properties,
-                     Set<String> endpoints) {
+                     Set<String> endpoints, Set<String> requirements) {
     if (type == null) {
       throw new IllegalArgumentException("Plugin class type cannot be null");
     }
@@ -57,18 +59,34 @@ public class PluginClass {
       throw new IllegalArgumentException("Plugin class properties cannot be null");
     }
 
+    if (endpoints == null) {
+      throw new IllegalArgumentException("Plugin endpoints cannot be null");
+    }
+
+    if (requirements == null) {
+      throw new IllegalArgumentException("Plugin requirements cannot be null");
+    }
+
     this.type = type;
     this.name = name;
     this.description = description;
     this.className = className;
     this.configFieldName = configfieldName;
-    this.properties = properties;
-    this.endpoints = endpoints;
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+    this.endpoints = Collections.unmodifiableSet(new HashSet<>(endpoints));
+    this.requirements = Collections.unmodifiableSet(new HashSet<>(requirements));
+  }
+
+  public PluginClass(String type, String name, String description, String className, @Nullable String configfieldName,
+                     Map<String, PluginPropertyField> properties) {
+    this(type, name, description, className, configfieldName, properties, Collections.emptySet(),
+         Collections.emptySet());
   }
 
   public PluginClass(String type, String name, String description, String className,
-                     @Nullable String configfieldName, Map<String, PluginPropertyField> properties) {
-    this(type, name, description, className, configfieldName, properties, new HashSet<>());
+                     @Nullable String configfieldName, Map<String, PluginPropertyField> properties,
+                     Set<String> endpoints) {
+    this(type, name, description, className, configfieldName, properties, endpoints, Collections.emptySet());
   }
 
   /**
@@ -123,6 +141,13 @@ public class PluginClass {
     return properties;
   }
 
+  /**
+   * @return the requirements of the plugin
+   */
+  public Set<String> getRequirements() {
+    return requirements;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -140,31 +165,26 @@ public class PluginClass {
       && Objects.equals(className, that.className)
       && Objects.equals(configFieldName, that.configFieldName)
       && Objects.equals(properties, that.properties)
-      && Objects.equals(endpoints, that.endpoints);
+      && Objects.equals(endpoints, that.endpoints)
+      && Objects.equals(requirements, that.requirements);
   }
 
   @Override
   public int hashCode() {
-    int result = type.hashCode();
-    result = 31 * result + name.hashCode();
-    result = 31 * result + description.hashCode();
-    result = 31 * result + className.hashCode();
-    result = 31 * result + (configFieldName != null ? configFieldName.hashCode() : 0);
-    result = 31 * result + properties.hashCode();
-    result = 31 * result + (endpoints != null ? endpoints.hashCode() : 0);
-    return result;
+    return Objects.hash(type, name, description, className, configFieldName, properties, endpoints, requirements);
   }
 
   @Override
   public String toString() {
     return "PluginClass{" +
-      "className='" + className + '\'' +
-      ", type='" + type + '\'' +
+      "type='" + type + '\'' +
       ", name='" + name + '\'' +
       ", description='" + description + '\'' +
+      ", className='" + className + '\'' +
       ", configFieldName='" + configFieldName + '\'' +
-      ", properties=" + properties + '\'' +
-      ", endpoints='" + endpoints +
+      ", properties=" + properties +
+      ", endpoints=" + endpoints +
+      ", requirements=" + requirements +
       '}';
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/inspection/InspectionApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/inspection/InspectionApp.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.plugin.PluginConfig;
 
@@ -31,6 +32,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   public static final String PLUGIN_DESCRIPTION = "some plugin";
   public static final String PLUGIN_NAME = "pluginA";
   public static final String PLUGIN_TYPE = "A";
+  public static final String MULTIPLE_REQUIREMENTS_PLUGIN = "MultipleRequirementsPlugin";
 
   public static class AConfig extends Config {
     private int x;
@@ -52,6 +54,78 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Name(PLUGIN_NAME)
   @Description(PLUGIN_DESCRIPTION)
   public static class AppPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
+    }
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name("SingleRequirementPlugin")
+  @Description(PLUGIN_DESCRIPTION)
+  @Requirements(Requirements.TRANSACTIONS)
+  public static class SingleRequirementPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
+    }
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name(MULTIPLE_REQUIREMENTS_PLUGIN)
+  @Description(PLUGIN_DESCRIPTION)
+  @Requirements({Requirements.TRANSACTIONS, "secondRequirement"})
+  public static class MultipleRequirementsPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
+    }
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name("EmptyRequirementPlugin")
+  @Description(PLUGIN_DESCRIPTION)
+  @Requirements({})
+  public static class EmptyRequirementPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
+    }
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name("SingleEmptyRequirementPlugin")
+  @Description(PLUGIN_DESCRIPTION)
+  @Requirements("")
+  public static class SingleEmptyRequirementPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
+    }
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name("ValidAndEmptyRequirementsPlugin")
+  @Description(PLUGIN_DESCRIPTION)
+  @Requirements({Requirements.TRANSACTIONS, ""})
+  public static class ValidAndEmptyRequirementsPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
+    }
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name("DuplicateRequirementsPlugin")
+  @Description(PLUGIN_DESCRIPTION)
+  @Requirements({Requirements.TRANSACTIONS, "   DupliCate    ", "    duplicate    "})
+  public static class DuplicateRequirementsPlugin {
     private PConfig pluginConf;
 
     public double doSomething() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/PluginClassDeserializer.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/PluginClassDeserializer.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +42,7 @@ public class PluginClassDeserializer implements JsonDeserializer<PluginClass> {
   // Type for the PluginClass.properties map.
   private static final Type PROPERTIES_TYPE = new TypeToken<Map<String, PluginPropertyField>>() { }.getType();
   //Type for endpoints property
-  private static final Type ENDPOINTS_TYPE = new TypeToken<Set<String>>() { }.getType();
+  private static final Type SET_OF_STRING_TYPE = new TypeToken<Set<String>>() { }.getType();
 
   @Override
   public PluginClass deserialize(JsonElement json, Type typeOfT,
@@ -59,14 +60,19 @@ public class PluginClassDeserializer implements JsonDeserializer<PluginClass> {
 
     Set<String> endpointsSet = new HashSet<>();
     if (jsonObj.has("endpoints")) {
-      endpointsSet = context.deserialize(jsonObj.get("endpoints"), ENDPOINTS_TYPE);
+      endpointsSet = context.deserialize(jsonObj.get("endpoints"), SET_OF_STRING_TYPE);
     }
 
     Map<String, PluginPropertyField> properties = jsonObj.has("properties")
       ? context.<Map<String, PluginPropertyField>>deserialize(jsonObj.get("properties"), PROPERTIES_TYPE)
       : ImmutableMap.<String, PluginPropertyField>of();
 
-    return new PluginClass(type, name, description, className, null, properties, endpointsSet);
+    Set<String> requirements = Collections.emptySet();
+    if (jsonObj.has("requirements")) {
+      requirements = context.deserialize(jsonObj.get("requirements"), SET_OF_STRING_TYPE);
+    }
+
+    return new PluginClass(type, name, description, className, null, properties, endpointsSet, requirements);
   }
 
   private JsonElement getRequired(JsonObject jsonObj, String name) {


### PR DESCRIPTION
### Summary
- `ArtifactInspector` inspects all plugins classes for `Requirement` annotation and capture the requirements. The requirements in stored in `PluginClass` as a part of `ArtifactMeta` in `ArtifactStore`.
- The requirements are served back in `ArtifactInfo`. 
- For more details refer to [storage design](https://wiki.cask.co/display/CE/Improving+Plugins+User+Experience+Across+Different+Modes#ImprovingPluginsUserExperienceAcrossDifferentModes-Approach1:ArtifactStore(Selected)).

[Issue](https://issues.cask.co/browse/CDAP-13924)
[Design](https://wiki.cask.co/display/CE/Improving+Plugins+User+Experience+Across+Different+Modes)

Build: https://builds.cask.co/browse/CDAP-DUT6585-2