### PR TITLE
Remove ngCapsules Dependency

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -111,9 +111,7 @@ gulp.task('css:lib', ['fonts'], function() {
       './bower_components/c3/c3.min.css',
       './bower_components/angular-gridster/dist/angular-gridster.min.css',
       './bower_components/angular-cron-jobs/dist/angular-cron-jobs.min.css',
-    ].concat(mainBowerFiles({
-      filter: /cask\-angular\-[^\/]+\/.*\.(css|less)$/
-    }))),
+    ]),
     gulp.src('./app/styles/bootstrap.less')
       .pipe(plug.less())
   )
@@ -198,8 +196,6 @@ gulp.task('js:lib', function() {
       './bower_components/ngstorage/ngStorage.js',
       './bower_components/angular-loading-bar/build/loading-bar.js',
 
-      './bower_components/sockjs-client/dist/sockjs.js',
-
       './bower_components/d3/d3.min.js',
       // './bower_components/d3-tip/index.js', FIXME: add this when we fix multiple versions of d3 issue.
       './bower_components/d3-timeline/src/d3-timeline.js',
@@ -214,6 +210,7 @@ gulp.task('js:lib', function() {
       './bower_components/angular-bootstrap/ui-bootstrap-tpls.js',
 
       './bower_components/node-uuid/uuid.js',
+
       './bower_components/angular-cookies/angular-cookies.min.js',
       // './bower_components/c3/c3.js',
       './app/lib/c3.js',
@@ -238,12 +235,9 @@ gulp.task('js:lib', function() {
       './node_modules/ngreact/ngReact.min.js',
 
       './node_modules/cdap-avsc/dist/cdap-avsc-lib.js',
-      './node_modules/svg4everybody/dist/svg4everybody.min.js'
-    ].concat([
-      './bower_components/cask-angular-*/*/module.js'
-    ], mainBowerFiles({
-        filter: /cask\-angular\-[^\/]+\/.*\.js$/
-    })))
+      './node_modules/svg4everybody/dist/svg4everybody.min.js',
+      './node_modules/sockjs-client/dist/sockjs.js'
+    ])
     .pipe(plug.replace('glyphicon', 'fa'))
     .pipe(plug.concat('lib.js'))
     .pipe(gulp.dest('./dist/assets/bundle'));

--- a/cdap-ui/app/directives/cask-angular-confirmable/confirm-modal.html
+++ b/cdap-ui/app/directives/cask-angular-confirmable/confirm-modal.html
@@ -1,0 +1,30 @@
+<!--
+  Copyright © 2015-2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="modal {{customClass}}" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-sm">
+    <div class="modal-content">
+      <div class="modal-header" ng-show="title">
+        <h3 class="modal-title" ng-bind="title"></h3>
+      </div>
+      <div class="modal-body" ng-bind-html="content"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" ng-click="$hide()">Cancel</button>
+        <button type="button" class="btn btn-danger" ng-click="doConfirm()">OK</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cdap-ui/app/directives/cask-angular-confirmable/confirmable.js
+++ b/cdap-ui/app/directives/cask-angular-confirmable/confirmable.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskConfirmable
+ *
+ * adds a "caskConfirm" method on the scope. call that, and
+ *  the expression in "cask-confirmable" attribute will be evaluated
+ *  after the user accepts the confirmation dialog. Eg:
+ *
+ * <a ng-click="caskConfirm()"
+ *       cask-confirmable="doDelete(model)"
+ *       data-confirmable-title="Hold on..."
+ *       data-confirmable-content="Are you absolutely sure?"
+ * >delete</a>
+ */
+
+angular.module(PKG.name+'.commons').directive('caskConfirmable',
+function caskConfirmableDirective ($modal, $sce) {
+  return {
+    restrict: 'A',
+    link: function (scope, element, attrs) {
+
+      scope.caskConfirm = function () {
+
+        var modal, modalScope;
+
+        modalScope = scope.$new(true);
+
+        modalScope.customClass = attrs.confirmableModalClass || '';
+        modalScope.doConfirm = function() {
+          modal.hide();
+          scope.$eval(attrs.caskConfirmable);
+        };
+        var confirmableContent = $sce.getTrustedHtml(attrs.confirmableContent);
+        modal = $modal({
+          scope: modalScope,
+          template: 'cask-angular-confirmable/confirm-modal.html',
+          title: attrs.confirmableTitle || 'Confirmation',
+          content: confirmableContent || 'Are you sure?',
+          placement: 'center',
+          show: true
+        });
+
+      };
+
+    }
+  };
+
+});

--- a/cdap-ui/app/directives/cask-angular-dropdown-text-combo/dropdown-text-combo.html
+++ b/cdap-ui/app/directives/cask-angular-dropdown-text-combo/dropdown-text-combo.html
@@ -1,0 +1,60 @@
+<!--
+  Copyright © 2015-2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="dropdown-control-group am-fade-and-slide-right" ng-repeat="(key, value) in model">
+  <div class="row">
+    <div class="col-xs-5">
+      <input type="text" value="{{key}}" class="form-control" readonly />
+    </div>
+    <div class="col-xs-7">
+      <div ng-repeat="field in textFields">
+
+        <div class="input-group">
+          <label for="cask-ddtc-{{key}}-{{$index}}" class="input-group-addon">
+            {{field.placeholder || (field.name | caskCapitalizeFilter)}}
+          </label>
+          <input type="text"
+                  id="cask-ddtc-{{key}}-{{$index}}"
+                  ng-model="value[field.name]"
+                  name="{{field.name}}"
+                  class="form-control" />
+
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <p class="remove">
+    <a href="" class="btn btn-danger btn-xs"
+      ng-click="rmAsset(key)"
+    >
+      <span class="fa fa-trash"></span>
+      <span class="sr-only">remove {{assetLabel}}</span>
+    </a>
+  </p>
+
+</div>
+
+<p class="form-control-static">
+  <a href="" class="btn btn-info btn-xs"
+    bs-dropdown="dropdownValues"
+    ng-disabled="!dropdownValues.length"
+  >
+    <span class="fa fa-plus"></span>
+    Add {{assetLabel}}
+  </a>
+</p>

--- a/cdap-ui/app/directives/cask-angular-dropdown-text-combo/dropdown-text-combo.js
+++ b/cdap-ui/app/directives/cask-angular-dropdown-text-combo/dropdown-text-combo.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name+'.commons')
+  .directive('caskDropdownTextCombo', function caskDropdownTextComboDirective() {
+    return {
+      restrict: 'E',
+      scope: {
+        model: '=',
+        dropdownList: '=',
+        textFields: '=',
+        assetLabel: '@'
+      },
+      templateUrl: 'cask-angular-dropdown-text-combo/dropdown-text-combo.html',
+      link: function ($scope) {
+        $scope.dropdownValues = [];
+
+        function buildDropdown () {
+          //dropdownList doesn't always needs to be a $resource object with a promise.
+          if(
+              (
+                $scope.dropdownList.$promise &&
+                  !$scope.dropdownList.$resolved
+              )||
+              !$scope.model) {
+            return;
+          }
+          $scope.dropdownValues = $scope.dropdownList
+            .filter(function (item) {
+              var isValid = Object.keys($scope.model)
+                                  .indexOf(item.name) === -1;
+              return isValid;
+            })
+            .map(function (item) {
+              return {
+                text: item.name,
+                click: 'addAsset(\"'+item.name+'\")'
+              };
+            });
+        }
+
+        //dropdownList doesn't always needs to be a $resource object with a promise.
+        if ($scope.dropdownList.$promise) {
+          $scope.dropdownList.$promise.then(buildDropdown);
+        }
+
+        $scope.$watchCollection('model', buildDropdown);
+
+        $scope.rmAsset = function (pName) {
+          delete $scope.model[pName];
+        };
+
+        $scope.addAsset = function (pName) {
+          if(!$scope.model) { return; }
+
+          $scope.model[pName] = {
+            name: pName
+          };
+
+        };
+      }
+    };
+  });

--- a/cdap-ui/app/directives/cask-angular-dropdown-text-combo/dropdown-text-combo.less
+++ b/cdap-ui/app/directives/cask-angular-dropdown-text-combo/dropdown-text-combo.less
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@import "../../../bower_components/bootstrap/less/mixins/clearfix.less";
+cask-dropdown-text-combo {
+  .dropdown-control-group {
+    div.input-group {
+      margin-bottom: 1px;
+    }
+
+    .clearfix();
+
+    position: relative;
+    margin-bottom: 10px;
+    margin-right: 36px;
+
+    padding: 9px 10px 5px;
+    border: 1px solid #eeeeee;
+
+    p.remove {
+      position: absolute;
+      right: -36px;
+      top: 0;
+    }
+  }
+}

--- a/cdap-ui/app/directives/cask-angular-focus/focus-service.js
+++ b/cdap-ui/app/directives/cask-angular-focus/focus-service.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskFocusManager
+ * watched by the caskFocus directive, this service can be called
+ *  from a controller to trigger focus() events, presumably on form inputs
+ * @return {Object}  with "focus" and "select" methods
+ */
+
+angular.module(PKG.name+'.commons').service('caskFocusManager',
+function caskFocusManagerService ($rootScope, $log, $timeout) {
+
+  var last = null;
+
+  this.is = $rootScope.$new(true);
+
+  function set (k, v) {
+    var scope = this.is;
+    $timeout(function() {
+      $log.log('[caskFocusManager]', v, k);
+      scope[last] = false;
+      var o = {};
+      o[v] = Date.now();
+      scope[k] = o;
+      last = k;
+    });
+  }
+
+  /**
+   * triggers focus() on element with cask-focus = k
+   * @param  {String} k
+   */
+  this.focus = function(k) {
+    set.call(this, k, 'focus');
+  };
+
+  /**
+   * triggers select() on element with cask-focus = k
+   * @param  {String} k
+   */
+  this.select = function(k) {
+    set.call(this, k, 'select');
+  };
+
+});

--- a/cdap-ui/app/directives/cask-angular-focus/focus.js
+++ b/cdap-ui/app/directives/cask-angular-focus/focus.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskFocus
+ *
+ * add the cask-focus attribute to elements that you will want to trigger focus/select on
+ *  then in the controller, use caskFocusManager to trigger the DOM event
+ *
+ * in template:
+ * <input type="text" cask-focus="aNameForTheField" />
+ *
+ * in controller, inject caskFocusManager, then:
+ * caskFocusManager.focus('aNameForTheField');
+ */
+
+angular.module(PKG.name+'.commons').directive('caskFocus',
+function caskFocusDirective ($timeout, caskFocusManager) {
+  return {
+
+    restrict: 'A',
+
+    link: function (scope, element, attrs) {
+
+      attrs.$observe('caskFocus', function (newVal) {
+
+        var cleanup = caskFocusManager.is.$watch(newVal, function (o) {
+          if(o) {
+            $timeout(function() {
+              if(o.focus) {
+                element[0].focus();
+              }
+              else if(o.select) {
+                element[0].select();
+              }
+            });
+          }
+        });
+
+        scope.$on('$destroy', function() {
+          cleanup();
+        });
+      });
+
+    }
+  };
+});

--- a/cdap-ui/app/directives/cask-angular-json-edit/jsonedit.js
+++ b/cdap-ui/app/directives/cask-angular-json-edit/jsonedit.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskJsonEdit
+ *
+ * adapted from https://gist.github.com/maxbates/11002270
+ *
+ * <textarea cask-json-edit="myObject" rows="8" class="form-control"></textarea>
+ */
+
+angular.module(PKG.name+'.commons').directive('caskJsonEdit',
+function myJsonEditDirective () {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    template: '<textarea ng-model="jsonEditing"></textarea>',
+    replace : true,
+    scope: {
+      model: '=caskJsonEdit'
+    },
+    link: function (scope, element, attrs, ngModelCtrl) {
+
+      //init
+      setEditing(scope.model);
+
+      //check for changes going out
+      scope.$watch('jsonEditing', function (newval, oldval) {
+        if (newval !== oldval) {
+          if (isValidJson(newval)) {
+            setValid();
+            updateModel(newval);
+          } else {
+            setInvalid();
+          }
+        }
+      }, true);
+
+      //check for changes coming in
+      scope.$watch('model', function (newval, oldval) {
+        if (newval !== oldval) {
+          setEditing(newval);
+        }
+      }, true);
+
+
+      function setEditing (value) {
+        scope.jsonEditing = angular.copy(json2string(value));
+      }
+
+      function updateModel (value) {
+        scope.model = string2json(value);
+      }
+
+      function setValid() {
+        ngModelCtrl.$setValidity('json', true);
+      }
+
+      function setInvalid () {
+        ngModelCtrl.$setValidity('json', false);
+      }
+
+      function string2json(text) {
+        try {
+          return angular.fromJson(text);
+        } catch (err) {
+          setInvalid();
+          return text;
+        }
+      }
+
+      function json2string(obj) {
+        // better than JSON.stringify(), because it formats + filters $$hashKey etc.
+        // NOTE that this will remove all $-prefixed values
+        return angular.toJson(obj, true);
+      }
+
+      function isValidJson(model) {
+        var flag = true;
+        try {
+          angular.fromJson(model);
+        } catch (err) {
+          flag = false;
+        }
+        return flag;
+      }
+
+    }
+  };
+});

--- a/cdap-ui/app/directives/cask-angular-json-edit/jsonedit.less
+++ b/cdap-ui/app/directives/cask-angular-json-edit/jsonedit.less
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+textarea[cask-json-edit] {
+  font-family: monospace;
+}

--- a/cdap-ui/app/directives/cask-angular-password/click2show.html
+++ b/cdap-ui/app/directives/cask-angular-password/click2show.html
@@ -1,0 +1,35 @@
+<!--
+  Copyright © 2015-2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<span class="input-group input-group-sm">
+  <a href=""
+    class="btn btn-default input-group-addon"
+    ng-class="{'active': show}"
+    ng-click="doToggle()"
+    >
+      <span class="fa"
+        ng-class="{'fa-toggle-on': show, 'fa-toggle-off': !show}"
+      ></span>
+  </a>
+  <input type="text" value="{{show ? value : ''}}"
+    placeholder="password"
+    ng-click="show || doToggle()"
+    class="form-control"
+    style="cursor:crosshair"
+    cask-focus="{{uid}}"
+    readonly
+    />
+</span>

--- a/cdap-ui/app/directives/cask-angular-password/password.js
+++ b/cdap-ui/app/directives/cask-angular-password/password.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskPassword
+ *
+ * implements "click2show" behavior
+ *
+ * <cask-password data-value="password"></cask-password>
+ */
+
+angular.module(PKG.name+'.commons').directive('caskPassword',
+function caskPasswordDirective (caskFocusManager) {
+  return {
+    restrict: 'E',
+    templateUrl: 'cask-angular-password/click2show.html',
+    replace: true,
+    scope: {
+      value: '='
+    },
+    link: function(scope) {
+
+      scope.uid = ['caskPassword', Date.now(), Math.random().toString().substr(2)].join('_');
+
+      scope.doToggle = function() {
+        var show = !scope.show;
+        scope.show = show;
+        if (show) {
+          caskFocusManager.select(scope.uid);
+        }
+      };
+
+    }
+
+  };
+});

--- a/cdap-ui/app/directives/cask-angular-progress/bar.html
+++ b/cdap-ui/app/directives/cask-angular-progress/bar.html
@@ -1,0 +1,20 @@
+<!--
+  Copyright © 2015-2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<div class="progress">
+  <div role="progressbar" aria-valuenow="{{value}}" aria-valuemin="0" aria-valuemax="{{max}}" ng-style="{width: percent+'%'}" ng-class="cls">
+    {{percent}}%
+  </div>
+</div>

--- a/cdap-ui/app/directives/cask-angular-progress/progress.js
+++ b/cdap-ui/app/directives/cask-angular-progress/progress.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskProgress
+ *
+ *  <cask-progress
+ *      data-type="bar"
+ *      data-add-cls="success striped"
+ *      data-value="model.progress.stepscompleted"
+ *      data-max="model.progress.stepstotal"
+ *    ></cask-progress>
+ */
+
+angular.module(PKG.name+'.commons').directive('caskProgress',
+function caskProgressDirective () {
+  return {
+    restrict: 'E',
+    templateUrl: 'cask-angular-progress/bar.html',
+    replace: true,
+    scope: {
+      addCls: '@',
+      value: '=',
+      max: '='
+    },
+    link: function(scope, element, attrs) {
+
+      scope.$watch('value', function(newVal) {
+        var max = parseInt(scope.max, 10) || 100;
+
+        scope.percent = Math.floor((newVal / max) * 100);
+
+        var cls = {
+          'active': (newVal < max),
+          'progress-bar': true
+        };
+
+        if(scope.addCls) {
+          angular.forEach(scope.addCls.split(' '), function(add) {
+            if(add) {
+              switch (attrs.type) {
+                case 'bar':
+                /* falls through */
+                default:
+                  cls['progress-bar-'+add] = true;
+                  break;
+              }
+            }
+          });
+        }
+
+
+        scope.cls = cls;
+      });
+    }
+
+  };
+});

--- a/cdap-ui/app/directives/cask-angular-promptable/prompt-modal.html
+++ b/cdap-ui/app/directives/cask-angular-promptable/prompt-modal.html
@@ -1,0 +1,35 @@
+<!--
+  Copyright © 2015-2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-sm">
+    <form class="modal-content" ng-submit="evalPromptable()">
+      <div class="modal-header" ng-show="title">
+        <h3 class="modal-title" ng-bind="title"></h3>
+      </div>
+      <div class="modal-body">
+        <input type="text"
+          class="form-control input-lg"
+          ng-model="data['value']"
+          cask-focus="caskPromptModal" />
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" ng-click="$hide()">Cancel</button>
+        <button type="submit" class="btn btn-success">OK</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/cdap-ui/app/directives/cask-angular-promptable/prompt.js
+++ b/cdap-ui/app/directives/cask-angular-promptable/prompt.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskPrompt
+ *
+ * adds a "caskPrompt" method on the scope. call that, and
+ *  the specified binding will be set to the user input
+ *  from a modal dialog. Eg:
+ *
+ * <a ng-click="caskPrompt('Please enter a new name', 'new '+model.name)"
+ *       cask-promptable="model.name = $value"
+ * >rename</a>
+ */
+
+angular.module(PKG.name+'.commons').directive('caskPromptable',
+function caskPromptableDirective ($modal, caskFocusManager) {
+  return {
+    restrict: 'A',
+    link: function (scope, element, attrs) {
+
+      var m = $modal({
+        template: 'cask-angular-promptable/prompt-modal.html',
+        placement: 'center',
+        show: false,
+        prefixEvent: 'cask-promptable-modal'
+      });
+
+      angular.extend(m.$scope, {
+        value: '',
+        title: 'Prompt',
+        evalPromptable: function() {
+          scope.$eval(attrs.caskPromptable, {
+            '$value': m.$scope.data.value
+          });
+          m.hide();
+        }
+      });
+
+      scope.$on('$destroy', function() {
+        m.destroy();
+      });
+
+      m.$scope.$on('cask-promptable-modal.show', function() {
+        caskFocusManager.select('caskPromptModal');
+      });
+
+      scope.caskPrompt = function (text, prefill) {
+        if(!angular.isUndefined(text)) {
+          m.$scope.title = text;
+        }
+        if(!angular.isUndefined(prefill)) {
+          // 2.3.1 version of angular-strap's modal creates a new scope for just the modal.
+          // modalScope which gets created and destroyed as the modal is opened and closed.
+          // Hence in order to get the 2-way binding we are passing in a reference instead of
+          // a value.
+          m.$scope.data = {};
+          m.$scope.data.value = prefill;
+        }
+        m.show();
+      };
+
+    }
+  };
+
+});

--- a/cdap-ui/app/directives/cask-angular-sortable/sortable.js
+++ b/cdap-ui/app/directives/cask-angular-sortable/sortable.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskSortable
+ * makes a <table> sortable
+ *
+ * adds "sortable.predicate" and "sortable.reverse" to the scope
+ *
+ * <table my-sortable>
+ *  <thead>
+ *    <tr ng-class="{'sort-enabled': list.length>1}">
+ *      <th data-predicate="createTime" data-predicate-default="reverse">creation time</th>
+ *    </tr>
+ *  </thead>
+ *  <tbody>
+ *   <tr ng-repeat="item in list | orderBy:sortable.predicate:sortable.reverse">
+ *    <td>...
+ */
+
+angular.module(PKG.name+'.commons').directive('caskSortable',
+function caskSortableDirective ($log, $stateParams, $state) {
+
+  return {
+    restrict: 'A',
+    link: function (scope, element, attrs) {
+
+      var headers = element.find('th'),
+          defaultPredicate,
+          defaultReverse,
+          noInitialSort;
+
+      noInitialSort = (attrs.noInitialSort === 'true'? true: false);
+
+      angular.forEach(headers, function(th) {
+        th = angular.element(th);
+        var a;
+
+        if (!$stateParams.sortBy) {
+          a = th.attr('data-predicate-default');
+        }
+
+        if ($stateParams.sortBy && th.attr('data-predicate') === $stateParams.sortBy) {
+          defaultPredicate = th;
+          defaultReverse = ($stateParams.reverse==='reverse');
+        } else if (angular.isDefined(a)) {
+          defaultPredicate = th;
+          defaultReverse = (a==='reverse');
+        }
+      });
+
+      if (!defaultPredicate) {
+        defaultPredicate = headers.eq(0);
+      }
+
+      $state.go($state.$current.name, {
+        sortBy:  defaultPredicate.attr('data-predicate'),
+        reverse: defaultReverse ? 'reverse' : ''
+      }, {notify: false});
+
+      scope.sortable = {
+        reverse: defaultReverse
+      };
+
+      if (noInitialSort) {
+        scope.sortable.predicate = null;
+      } else {
+        scope.sortable.predicate = getPredicate(defaultPredicate.addClass('predicate'));
+      }
+
+      headers.append('<i class="fa fa-toggle-down"></i>');
+
+      headers.on('click', function() {
+        var th = angular.element(this),
+            predicate = getPredicate(th);
+
+        if (th.attr('skip-sort')){
+          return;
+        }
+
+        scope.$apply(function() {
+          if (scope.sortable.predicate === predicate){
+            scope.sortable.reverse = !scope.sortable.reverse;
+            th.find('i').toggleClass('fa-flip-vertical');
+          }
+          else {
+            headers.removeClass('predicate');
+            headers.find('i').removeClass('fa-flip-vertical');
+            scope.sortable = {
+              predicate: predicate,
+              reverse: false
+            };
+            th.addClass('predicate');
+          }
+        });
+
+        $state.go($state.$current.name, {
+          sortBy:  predicate,
+          reverse: scope.sortable.reverse ? 'reverse' : ''
+        }, {notify: false});
+      });
+
+    }
+  };
+
+  function getPredicate(node) {
+    return node.attr('data-predicate') || node.text();
+  }
+
+});

--- a/cdap-ui/app/directives/cask-angular-sortable/sortable.less
+++ b/cdap-ui/app/directives/cask-angular-sortable/sortable.less
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+table[cask-sortable] {
+
+  th {
+    text-transform: capitalize;
+    user-select: none;
+    white-space: nowrap;
+
+    > i {
+      visibility: hidden;
+      margin-left: 10px;
+    }
+  }
+
+  th[skip-sort] i {
+    display: none;
+  }
+
+  tr.sort-enabled th {
+
+    &.predicate > i {
+      visibility: visible;
+    }
+
+    cursor: pointer;
+
+    &:hover {
+      background-color: lightyellow;
+    }
+
+  }
+}

--- a/cdap-ui/app/filters/cask-angular-capitalize/capitalize.js
+++ b/cdap-ui/app/filters/cask-angular-capitalize/capitalize.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * myCapitalizeFilter
+ * note that bootstrap gives us .text-capitalize, use it instead of this filter
+ *  unless you really only want to capitalize the first character of a sentence.
+ */
+
+angular.module(PKG.name+'.filters').filter('caskCapitalizeFilter',
+function caskCapitalizeFilter () {
+
+  return function(input) {
+    input = input ? input.toLowerCase() : '';
+    return input.substr(0,1).toUpperCase() + input.substr(1);
+  };
+
+});

--- a/cdap-ui/app/hydrator/main.js
+++ b/cdap-ui/app/hydrator/main.js
@@ -32,26 +32,12 @@ angular
         'ngResource',
         'ngStorage',
         'ui.router',
-        'cask-angular-window-manager',
-        'cask-angular-theme',
-        'cask-angular-focus',
         'ngCookies'
       ]).name,
 
       angular.module(PKG.name+'.filters', [
-        PKG.name+'.services',
-        'cask-angular-capitalize'
+        PKG.name+'.services'
       ]).name,
-
-      'cask-angular-sortable',
-      'cask-angular-confirmable',
-      'cask-angular-promptable',
-      'cask-angular-json-edit',
-      'cask-angular-eventpipe',
-      'cask-angular-observable-promise',
-      'cask-angular-socket-datasource',
-      'cask-angular-dispatcher',
-
       'mgcrea.ngStrap.datepicker',
       'mgcrea.ngStrap.timepicker',
 

--- a/cdap-ui/app/logviewer/main.js
+++ b/cdap-ui/app/logviewer/main.js
@@ -31,26 +31,12 @@ angular
         'ngResource',
         'ngStorage',
         'ui.router',
-        'cask-angular-window-manager',
-        'cask-angular-theme',
-        'cask-angular-focus',
         'ngCookies'
       ]).name,
 
       angular.module(PKG.name+'.filters', [
-        PKG.name+'.services',
-        'cask-angular-capitalize'
+        PKG.name+'.services'
       ]).name,
-
-      'cask-angular-sortable',
-      'cask-angular-confirmable',
-      'cask-angular-promptable',
-      'cask-angular-json-edit',
-      'cask-angular-eventpipe',
-      'cask-angular-observable-promise',
-      'cask-angular-socket-datasource',
-      'cask-angular-dispatcher',
-
       'mgcrea.ngStrap.datepicker',
       'mgcrea.ngStrap.timepicker',
 

--- a/cdap-ui/app/services/cask-angular-dispatcher/dispatcher.js
+++ b/cdap-ui/app/services/cask-angular-dispatcher/dispatcher.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name+'.services').factory('CaskAngularDispatcher', function(uuid) {
+  function Dispatcher() {
+    if (!(this instanceof Dispatcher)) {
+      return new Dispatcher();
+    }
+    this.events = {};
+  }
+
+  Dispatcher.prototype.register = function(event, cb) {
+    var id = uuid.v4();
+    if (!this.events[event]) {
+      this.events[event] = {};
+    }
+    if (typeof cb === 'function') {
+      this.events[event][id] = cb;
+    } else {
+      throw 'Invalid callback. A callback registered for an event has to be a function';
+    }
+    return id;
+  };
+
+  Dispatcher.prototype.dispatch =  function(event) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    if (!this.events[event]) {
+      return;
+    }
+    angular.forEach(this.events[event], function(callback) {
+      callback.apply(null, args);
+    });
+  };
+
+  Dispatcher.prototype.unregister = function(event, registeredId) {
+    if (this.events[event] && this.events[event][registeredId]) {
+      delete this.events[event][registeredId];
+    }
+  };
+
+  return Dispatcher;
+
+});

--- a/cdap-ui/app/services/cask-angular-eventpipe/eventpipe.js
+++ b/cdap-ui/app/services/cask-angular-eventpipe/eventpipe.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name+'.services')
+  .service('EventPipe', function() {
+    var events = {};
+
+    this.on = function(event, cb) {
+      if (!events[event]) {
+        events[event] = [cb];
+      } else {
+        events[event].push(cb);
+      }
+      return function() {
+        if (!events[event]) {
+          return;
+        }
+        var index = events[event].indexOf(cb);
+        if (index !== -1) {
+          events[event].splice(index, 1);
+        }
+      };
+    };
+
+    this.emit =  function(event) {
+      var args = Array.prototype.slice.call(arguments, 1);
+      if (!events[event]) {
+        return;
+      }
+      for (var i = 0; i < events[event].length; i++) {
+        events[event][i].apply(this, args);
+      }
+    };
+
+    this.cancelEvent = function(event) {
+      if (events[event]) {
+        delete events[event];
+      }
+    };
+  });

--- a/cdap-ui/app/services/cask-angular-observable-promise/observable-promise.js
+++ b/cdap-ui/app/services/cask-angular-observable-promise/observable-promise.js
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/*
+  Purpose:
+    TL;DR
+    MyPromise is observable promise. Sounds very disturbing but this is the initial
+    attempt at sockets + $resource in an angular app.
+
+    Longer Version:
+    We cannot use promise pattern in a socket environment as promises
+    resolve only once. In the case of sockets we might want to 'poll' for a data
+    and get updated as soon something has changed.
+    MyPromise provides an interface simillar to a Promise (not $q) and accepts
+    in addition to a function a second argument. If you create your promise to
+    be an observable then the handlers are never erased and your callback/resolve
+    handler will be called whenever the promise gets resolved.
+
+    @param {function} which gets a 'resolve' and a 'reject' methods
+    @param {boolean} is observable or not.
+
+    PS: Inspired from
+      - https://www.promisejs.org/implementing/
+      - https://github.com/kriskowal/q/blob/v1/design/README.js
+*/
+angular.module(PKG.name+'.services')
+  .provider('MyPromise', function() {
+    var PENDING = 0;
+    var FULFILLED = 1;
+    var REJECTED = 2;
+    var UPDATED = 3;
+
+
+    function Promise(fn, isObservable) {
+      var isObserve = isObservable;
+      // store state which can be PENDING, FULFILLED or REJECTED
+      var state = PENDING;
+
+      // store value once FULFILLED or REJECTED
+      var value = null;
+
+      // store sucess & failure handlers
+      var handlers = [];
+
+      function fulfill(result) {
+        state = FULFILLED;
+        value = result;
+        handlers.forEach(handle);
+        if (!isObserve) {
+          handlers = null;
+        }
+      }
+
+      function reject(error) {
+        state = REJECTED;
+        value = error;
+        handlers.forEach(handle);
+        if (!isObserve) {
+          handlers = null;
+        }
+      }
+
+      function resolve(result) {
+        try {
+          var then = getThen(result);
+          if (then) {
+            doResolve(then.bind(result), resolve, reject);
+            return;
+          }
+          fulfill(result);
+        } catch (ex) {
+          reject(ex);
+        }
+      }
+
+      function handle(handler) {
+        if (state === PENDING) {
+          handlers.push(handler);
+        } else {
+          if ((state === FULFILLED || state === UPDATED) &&
+            typeof handler.onFulfilled === 'function') {
+            handler.onFulfilled(value);
+            if (isObserve) {
+              state = UPDATED;
+            }
+          }
+          if (state === REJECTED &&
+            typeof handler.onRejected === 'function') {
+            handler.onRejected(value);
+          }
+        }
+      }
+
+      this.done = function (onFulfilled, onRejected) {
+        handle({
+          onFulfilled: onFulfilled,
+          onRejected: onRejected
+        });
+      };
+
+
+      this.then = function (onFulfilled, onRejected) {
+        var self = this;
+        // Return a new promise for chaining.
+        return new Promise(function (resolve, reject) {
+          return self.done(function (result) {
+            if (typeof onFulfilled === 'function') {
+              try {
+                return resolve(onFulfilled(result));
+              } catch (ex) {
+                return reject(ex);
+              }
+            } else {
+              return resolve(result);
+            }
+          }, function (error) {
+            if (typeof onRejected === 'function') {
+              try {
+                return resolve(onRejected(error));
+              } catch (ex) {
+                return reject(ex);
+              }
+            } else {
+              return reject(error);
+            }
+          });
+        }, isObserve);
+      };
+
+      doResolve(fn, resolve, reject);
+
+      function getThen(value) {
+        var t = typeof value;
+        if (value && (t === 'object' || t === 'function')) {
+          var then = value.then;
+          if (typeof then === 'function') {
+            return then;
+          }
+        }
+        return null;
+      }
+
+      /**
+       * Take a potentially misbehaving resolver function and make sure
+       * onFulfilled and onRejected are only called once.
+       *
+       * Makes no guarantees about asynchrony.
+       *
+       * @param {Function} fn A resolver function that may not be trusted
+       * @param {Function} onFulfilled
+       * @param {Function} onRejected
+       */
+      function doResolve(fn, onFulfilled, onRejected) {
+        var done = false;
+        try {
+          fn(function (value) {
+            if (!isObserve) {
+              if (done) {
+                return;
+              }
+              done = true;
+            }
+            onFulfilled(value);
+          }, function (reason) {
+            if (!isObserve) {
+              if (done) {
+                return;
+              }
+              done = true;
+            }
+            onRejected(reason);
+          });
+        } catch (ex) {
+          if (done) {
+            return;
+          }
+          done = true;
+          onRejected(ex);
+        }
+      }
+
+    }
+
+
+    this.$get = function() {
+      return Promise;
+    };
+  });

--- a/cdap-ui/app/services/cask-angular-socket-datasource/datasource.js
+++ b/cdap-ui/app/services/cask-angular-socket-datasource/datasource.js
@@ -1,0 +1,433 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+var socketDataSource = angular.module(PKG.name+'.services');
+
+  /**
+    Example Usage:
+
+    MyCDAPDataSource // usage in a controller:
+
+    var dataSrc = new MyCDAPDataSource($scope);
+
+    // polling a namespaced resource example:
+    dataSrc.poll({
+        method: 'GET',
+        _cdapNsPath: '/foo/bar',
+        interval: 5000 // in milliseconds.
+      },
+      function(result) {
+        $scope.foo = result;
+      }
+    ); // will poll <host>:<port>/v3/namespaces/<currentNamespace>/foo/bar
+
+    // posting to a systemwide resource:
+    dataSrc.request({
+        method: 'POST',
+        _cdapPath: '/system/config',
+        body: {
+          foo: 'bar'
+        }
+      },
+      function(result) {
+        $scope.foo = result;
+      }
+    ); // will post to <host>:<port>/v3/system/config
+
+   */
+
+  socketDataSource.factory('uuid', function ($window) {
+    return $window.uuid;
+  });
+
+
+  socketDataSource.provider('MyDataSource', function () {
+
+    this.defaultPollInterval = 10;
+
+    this.$get = function($rootScope, caskWindowManager, mySocket, MYSOCKET_EVENT, $q, MyPromise, uuid, EventPipe) {
+
+      var instances = {}; // keyed by scopeid
+
+      /**
+       * Start polling of the resource - sends the action 'poll-start' to
+       * the node backend.
+       */
+      function _pollStart (resource) {
+        var re = {};
+        if (!resource.url) {
+          re = resource;
+        }else {
+          re = {
+            id: resource.id,
+            url: resource.url,
+            json: resource.json,
+            method: resource.method,
+            suppressErrors: resource.suppressErrors || false
+          };
+          if (resource.interval) {
+            re.interval = resource.interval;
+          }
+          if (resource.body) {
+            re.body = resource.body;
+          }
+        }
+
+        if (resource.headers) {
+          re.headers = resource.headers;
+        }
+
+        mySocket.send({
+          action: 'poll-start',
+          resource: re
+        });
+      }
+
+      /**
+       * Stops polling of the resource - sends the actions 'poll-stop' to
+       * the node backend.
+       */
+      function _pollStop (resource) {
+        var re = {};
+        if (!resource.url) {
+          re = resource;
+        }else {
+          re = {
+            id: resource.id,
+            url: resource.url,
+            json: resource.json,
+            method: resource.method,
+            suppressErrors: resource.suppressErrors || false
+          };
+        }
+        if (resource.header) {
+          re.header = resource.header;
+        }
+
+        mySocket.send({
+          action: 'poll-stop',
+          resource: re
+        });
+      }
+
+
+      function DataSource (scope) {
+        scope = scope || $rootScope.$new();
+
+        var id = scope.$id,
+            self = this;
+
+        if(instances[id]) {
+          // Reuse the same instance if already created.
+          return instances[id];
+        }
+
+        if (!(this instanceof DataSource)) {
+          return new DataSource(scope);
+        }
+        instances[id] = self;
+
+        this.scopeId = id;
+        this.bindings = {};
+
+        EventPipe.on(MYSOCKET_EVENT.message, function (data) {
+          var hash;
+          var isPoll;
+          hash = data.resource.id;
+
+          if(data.statusCode>299 || data.warning) {
+            if (self.bindings[hash]) {
+              if(self.bindings[hash].errorCallback) {
+                $rootScope.$apply(self.bindings[hash].errorCallback.bind(null, data.error || data.response));
+              } else if (self.bindings[hash].reject) {
+                $rootScope.$apply(self.bindings[hash].reject.bind(null, {data: data.error || data.response, statusCode: data.statusCode }));
+              }
+            }
+          } else if (self.bindings[hash]) {
+            if (self.bindings[hash].callback) {
+              data.response = data.response || {};
+              data.response.__pollId__ = hash;
+              scope.$apply(self.bindings[hash].callback.bind(null, data.response));
+            } else if (self.bindings[hash].resolve) {
+              // https://github.com/angular/angular.js/wiki/When-to-use-$scope.$apply%28%29
+              scope.$apply(self.bindings[hash].resolve.bind(null, {data: data.response, id: hash, statusCode: data.statusCode }));
+            }
+            /*
+              At first glance this condition check might be redundant with line 157,
+              however in the resolve or callback function if the user initiates a stop-poll call then
+              the execution goes to stopPoll function in line 264 and there we delete the entry from bindings
+              as we no longer need it. After the stopPoll request has gone out the execution continues back
+              here and we can do self.bindings[hash].poll as self.bindings[hash] is already deleted in stopPoll.
+            */
+            if (!self.bindings[hash]) {
+              return;
+            }
+            isPoll = self.bindings[hash].poll;
+            if (!isPoll) {
+              // We can remove the entry from the self bindings if its not a poll.
+              // Is not going to be used for anything else.
+              delete self.bindings[hash];
+            }
+          }
+          return;
+        });
+
+        scope.$on('$destroy', function () {
+          Object.keys(self.bindings).forEach(function(key) {
+            var b = self.bindings[key];
+            if (b.poll) {
+              _pollStop(b.resource);
+            }
+          });
+
+          delete instances[self.scopeId];
+        });
+
+        scope.$on(caskWindowManager.event.blur, function () {
+          Object.keys(self.bindings).forEach(function(key) {
+            var b = self.bindings[key];
+            if (b.poll) {
+              _pollStop(b.resource);
+            }
+          });
+        });
+
+        scope.$on(caskWindowManager.event.focus, function () {
+          Object.keys(self.bindings).forEach(function(key) {
+            var b = self.bindings[key];
+            if (b.poll) {
+              _pollStart(b.resource);
+            }
+          });
+        });
+
+      }
+
+      /**
+       * Start polling of a resource when in scope.
+       */
+      DataSource.prototype.poll = function (resource, cb, errorCb) {
+        var self = this;
+        var generatedResource = {};
+        var promise = new MyPromise(function(resolve, reject) {
+          generatedResource = {
+            json: resource.json,
+            interval: resource.interval || (resource.options &&  resource.options.interval) || $rootScope.defaultPollInterval,
+            body: resource.body,
+            method: resource.method || 'GET',
+            suppressErrors: resource.suppressErrors || false
+          };
+
+          if (resource.headers) {
+            generatedResource.headers = resource.headers;
+          }
+
+          generatedResource.url = buildUrl(resource.url, resource.params || {});
+          generatedResource.id = uuid.v4();
+          self.bindings[generatedResource.id] = {
+            poll: true,
+            callback: cb,
+            resource: generatedResource,
+            errorCallback: errorCb,
+            resolve: resolve,
+            reject: reject
+          };
+
+          _pollStart(generatedResource);
+        }, true);
+
+        if (!resource.$isResource) {
+          promise = promise.then(function(res) {
+            res = res.data;
+            res.__pollId__ = generatedResource.id;
+            return $q.when(res);
+          });
+        }
+        promise.__pollId__ = generatedResource.id;
+        return promise;
+      };
+
+      /**
+       * Stop polling of a resource when requested.
+       * (when scope is destroyed Line 196 takes care of deleting the polling resource)
+       */
+      DataSource.prototype.stopPoll = function(resourceId) {
+        // Duck Typing for angular's $resource.
+        var defer = $q.defer();
+        var id, resource;
+        if (angular.isObject(resourceId)) {
+          id = resourceId.params.pollId;
+        } else {
+          id = resourceId;
+        }
+
+        var match = this.bindings[resourceId];
+
+        if (match) {
+          resource = match.resource;
+          _pollStop(resource);
+          // We should probably be doing this once we get a confirmation from cdap node proxy server.
+          // Deleting the entry from this.bindings is wrong here if the stop poll fails for some god forsaken reason.
+          delete this.bindings[resourceId];
+          defer.resolve({});
+        } else {
+          defer.reject({});
+        }
+        return defer.promise;
+      };
+
+      /**
+       * Fetch a template configuration on-demand. Send the action
+       * 'template-config' to the node backend.
+       */
+      DataSource.prototype.config = function (resource, cb, errorCb) {
+        var deferred = $q.defer();
+
+        resource.suppressErrors = true;
+        resource.id = uuid.v4();
+        this.bindings[resource.id] = {
+          resource: resource,
+          callback: function (result) {
+            if (cb) {
+              cb.apply(null, result);
+            }
+            deferred.resolve(result);
+          },
+          errorCallback: function(err) {
+            if (errorCb) {
+              errorCb.apply(null, err);
+            }
+            deferred.reject(err);
+          }
+        };
+
+        mySocket.send({
+          action: resource.actionName,
+          resource: resource
+        });
+        return deferred.promise;
+      };
+
+      /**
+       * Fetch a resource on-demand. Send the action 'request' to
+       * the node backend.
+       */
+      DataSource.prototype.request = function (resource, cb, errorCb) {
+        var self = this;
+        var promise = new MyPromise(function(resolve, reject) {
+
+          var generatedResource = {
+            json: resource.json,
+            method: resource.method || 'GET',
+            suppressErrors: resource.suppressErrors || false
+          };
+          if (resource.body) {
+            generatedResource.body = resource.body;
+          }
+
+          if (resource.data) {
+            generatedResource.body = resource.data;
+          }
+
+          if (resource.headers) {
+            generatedResource.headers = resource.headers;
+          }
+          if (resource.contentType) {
+            generatedResource.headers['Content-Type'] = resource.contentType;
+          }
+
+          generatedResource.url = buildUrl(resource.url, resource.params || {});
+          generatedResource.id = uuid.v4();
+          self.bindings[generatedResource.id] = {
+            callback: cb,
+            errorCallback: errorCb,
+            resource: generatedResource,
+            resolve: resolve,
+            reject: reject
+          };
+
+          mySocket.send({
+            action: 'request',
+            resource: generatedResource
+          });
+        }, false);
+
+        if (!resource.$isResource) {
+          promise = promise.then(function(res) {
+            res = res.data;
+            return $q.when(res);
+          });
+        }
+
+        return promise;
+      };
+
+      return DataSource;
+
+    };
+
+
+  });
+
+// Lifted from $http as a helper method to parse '@params' in the url for $resource.
+function buildUrl(url, params) {
+  if (!params) {
+    return url;
+  }
+  var parts = [];
+
+  function forEachSorted(obj, iterator, context) {
+    var keys = Object.keys(params).sort();
+    for (var i = 0; i < keys.length; i++) {
+      iterator.call(context, obj[keys[i]], keys[i]);
+    }
+    return keys;
+  }
+
+  function encodeUriQuery(val, pctEncodeSpaces) {
+    return encodeURIComponent(val).
+           replace(/%40/gi, '@').
+           replace(/%3A/gi, ':').
+           replace(/%24/g, '$').
+           replace(/%2C/gi, ',').
+           replace(/%3B/gi, ';').
+           replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
+  }
+
+  forEachSorted(params, function(value, key) {
+    if (value === null || angular.isUndefined(value)) {
+      return;
+    }
+    if (!angular.isArray(value)) {
+      value = [value];
+    }
+
+    angular.forEach(value, function(v) {
+      if (angular.isObject(v)) {
+        if (angular.isDate(v)) {
+          v = v.toISOString();
+        } else {
+          v = angular.toJson(v);
+        }
+      }
+      parts.push(encodeUriQuery(key) + '=' + encodeUriQuery(v));
+    });
+  });
+  if (parts.length > 0) {
+    url += ((url.indexOf('?') === -1) ? '?' : '&') + parts.join('&');
+  }
+  return url;
+}

--- a/cdap-ui/app/services/cask-angular-socket-datasource/socket.js
+++ b/cdap-ui/app/services/cask-angular-socket-datasource/socket.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name+'.services')
+
+.factory('SockJS', function ($window) {
+  return $window.SockJS;
+})
+
+.constant('MYSOCKET_EVENT', {
+  message: 'mysocket-message',
+  closed: 'mysocket-closed',
+  reconnected: 'mysocket-reconnected'
+})
+
+.provider('mySocket', function () {
+
+  this.prefix = '/_sock';
+
+  this.$get = function (MYSOCKET_EVENT, SockJS, $log, EventPipe) {
+
+    var self = this,
+        socket = null,
+        buffer = [];
+
+    function init (attempt) {
+      $log.log('[mySocket] init');
+
+      attempt = attempt || 1;
+      socket = new SockJS(self.prefix);
+
+      socket.onmessage = function (event) {
+        try {
+          var data = JSON.parse(event.data);
+          $log.debug('[mySocket] ←', data);
+          EventPipe.emit(MYSOCKET_EVENT.message, data);
+        }
+        catch(e) {
+          $log.error(e);
+        }
+      };
+
+      socket.onopen = function (event) {
+        EventPipe.emit('backendUp', 'User interface service is online');
+        if(attempt>1) {
+          EventPipe.emit(MYSOCKET_EVENT.reconnected, event);
+          attempt = 1;
+        }
+
+        $log.info('[mySocket] opened');
+        angular.forEach(buffer, send);
+        buffer = [];
+      };
+
+      socket.onclose = function (event) {
+        $log.error(event.reason);
+        EventPipe.emit('backendDown', 'User interface service is down');
+
+        if(attempt<2) {
+          EventPipe.emit(MYSOCKET_EVENT.closed, event);
+        }
+
+        // reconnect with exponential backoff
+        var d = Math.max(500, Math.round(
+          (Math.random() + 1) * 500 * Math.pow(2, attempt)
+        ));
+        $log.log('[mySocket] will try again in ',d+'ms');
+        setTimeout(function () {
+          init(attempt+1);
+        }, d);
+      };
+
+    }
+
+    function send(obj) {
+      if(!socket.readyState) {
+        buffer.push(obj);
+        return false;
+      }
+
+      doSend(obj);
+
+      return true;
+    }
+
+    function doSend(obj) {
+      var msg = obj,
+          r = obj.resource;
+
+      if(r) {
+        msg.resource = r;
+
+        // Majority of the time, we send data as json and expect a json response, but not always (i.e. stream ingest).
+        // Default to json content-type.
+        if (msg.resource.json === undefined) {
+          msg.resource.json = true;
+        }
+
+        if (!r.method) {
+          msg.resource.method = 'GET';
+        }
+
+        $log.debug('[mySocket] →', msg.action, r.method, r.url);
+      }
+
+      socket.send(JSON.stringify(msg));
+    }
+
+    init();
+
+    return {
+      init: init,
+      send: send,
+      close: function () {
+        return socket.close.apply(socket, arguments);
+      }
+    };
+  };
+
+});

--- a/cdap-ui/app/services/cask-angular-theme/theme.js
+++ b/cdap-ui/app/services/cask-angular-theme/theme.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * caskTheme
+ */
+
+angular.module(PKG.name+'.services')
+
+  .constant('CASK_THEME_EVENT', {
+    changed: 'cask-theme-changed'
+  })
+
+  .provider('caskTheme', function CaskThemeProvider () {
+
+    var THEME_LIST = ['default'];
+
+    this.setThemes = function (t) {
+      if(angular.isArray(t) && t.length) {
+        THEME_LIST = t;
+      }
+    };
+
+    this.$get = function ($localStorage, $rootScope, CASK_THEME_EVENT) {
+
+      function Factory () {
+
+        this.current = $localStorage.theme || THEME_LIST[0];
+
+        this.set = function (theme) {
+          if (THEME_LIST.indexOf(theme)!==-1) {
+            this.current = theme;
+            $localStorage.theme = theme;
+            $rootScope.$broadcast(CASK_THEME_EVENT.changed, this.getClassName());
+          }
+        };
+
+        this.list = function () {
+          return THEME_LIST;
+        };
+
+        this.getClassName = function () {
+          return 'theme-' + this.current;
+        };
+
+      }
+
+      return new Factory();
+    };
+
+  });

--- a/cdap-ui/app/services/cask-angular-window-manager/wm.js
+++ b/cdap-ui/app/services/cask-angular-window-manager/wm.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015-2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name+'.services')
+
+  .constant('CASK_WM_EVENT', {
+    resize: 'cask-wm-resize',
+    blur: 'cask-wm-blur',
+    focus: 'cask-wm-focus'
+  })
+
+  .provider('caskWindowManager', function (CASK_WM_EVENT) {
+
+    this.resizeDebounceMs = 500;
+
+    this.pageViz = {
+      hidden: 'visibilitychange',
+      mozHidden: 'mozvisibilitychange',
+      msHidden: 'msvisibilitychange',
+      webkitHidden: 'webkitvisibilitychange'
+    };
+
+    this.$get = function ($rootScope, $window, $document, $log, $timeout) {
+
+      // resize inspired by https://github.com/danmasta/ngResize
+      var resizeDebounceMs = this.resizeDebounceMs,
+          resizePromise = null;
+
+      angular.element($window).on('resize', function () {
+        if(resizePromise) {
+          $timeout.cancel(resizePromise);
+        }
+        resizePromise = $timeout(function () {
+          $log.log('[caskWindowManager]', 'resize');
+          $rootScope.$broadcast(CASK_WM_EVENT.resize, {
+            width: $window.innerWidth,
+            height: $window.innerHeight
+          });
+        }, resizeDebounceMs, false);
+      });
+
+
+
+      // pageviz inspired by https://github.com/mz026/angular_page_visibility
+      var mkOnVizChange = function (q) {
+        return function (e) {
+          $log.log('[caskWindowManager]', e);
+          $rootScope.$broadcast(
+            CASK_WM_EVENT[ $document.prop(q) ? 'blur' : 'focus' ]
+          );
+        };
+      };
+
+      var vizImp = Object.keys(this.pageViz);
+      for (var i = 0; i < vizImp.length; i++) { // iterate through implementations
+        var p = vizImp[i];
+        if (typeof ($document.prop(p)) !== 'undefined') {
+          $log.info('[caskWindowManager] page visibility API available!');
+          $document.on(this.pageViz[p], mkOnVizChange(p));
+          break;
+        }
+      }
+
+      return {
+        event: CASK_WM_EVENT
+      };
+
+    };
+
+  })
+
+
+  /*
+  * caskOnWm Directive
+  *
+  * usage: cask-on-wm="{resize:expression()}"
+  * event data is available as $event
+  */
+  .directive('caskOnWm', function ($parse, $timeout, caskWindowManager) {
+    return {
+      compile: function ($element, attr) {
+        var obj = $parse(attr.caskOnWm);
+        return function (scope) {
+          angular.forEach(obj, function (fn, key) {
+            var eName = caskWindowManager.event[key];
+            if(eName) {
+              scope.$on(eName, function (event, data) {
+                $timeout(function () {
+                  scope.$apply(function () {
+                    fn(scope, { $event: data });
+                  });
+                });
+              });
+            }
+          });
+        };
+      }
+    };
+  });

--- a/cdap-ui/app/tracker/main.js
+++ b/cdap-ui/app/tracker/main.js
@@ -1,5 +1,3 @@
-
-
 /*
  * Copyright © 2015-2018 Cask Data, Inc.
  *
@@ -34,26 +32,12 @@ angular
         'ngResource',
         'ngStorage',
         'ui.router',
-        'cask-angular-window-manager',
-        'cask-angular-theme',
-        'cask-angular-focus',
         'ngCookies'
       ]).name,
 
       angular.module(PKG.name+'.filters', [
-        PKG.name+'.services',
-        'cask-angular-capitalize'
+        PKG.name+'.services'
       ]).name,
-
-      'cask-angular-sortable',
-      'cask-angular-confirmable',
-      'cask-angular-promptable',
-      'cask-angular-json-edit',
-      'cask-angular-eventpipe',
-      'cask-angular-observable-promise',
-      'cask-angular-socket-datasource',
-      'cask-angular-dispatcher',
-
       'mgcrea.ngStrap.datepicker',
       'mgcrea.ngStrap.timepicker',
 

--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -14,18 +14,6 @@
     "angular-ui-router": "0.3.0",
     "angular-loading-bar": "0.8.0",
     "ngstorage": "0.3.10",
-    "cask-angular-capitalize": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-capitalize.zip",
-    "cask-angular-theme": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-theme.zip",
-    "cask-angular-focus": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-focus.zip",
-    "cask-angular-window-manager": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-window-manager.zip",
-    "cask-angular-sortable": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-sortable.zip",
-    "cask-angular-confirmable": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-confirmable.zip",
-    "cask-angular-promptable": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-promptable.zip",
-    "cask-angular-json-edit": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-json-edit.zip",
-    "cask-angular-eventpipe": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-eventpipe.zip",
-    "cask-angular-observable-promise": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-observable-promise.zip",
-    "cask-angular-socket-datasource": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-socket-datasource.zip",
-    "cask-angular-dispatcher": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-dispatcher.zip",
     "d3": "3.5.5",
     "angular-breadcrumb": "0.3.3",
     "dagre-d3": "0.4.10",
@@ -44,7 +32,8 @@
     "esprima": "2.0.0",
     "ngInfiniteScroll": "1.2.1",
     "d3-timeline": "0.0.5",
-    "angular-inview": "1.5.7"
+    "angular-inview": "1.5.7",
+    "node-uuid": "1.4.3"
   },
   "resolutions": {
     "angular": "1.4.3",


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14151
Build: https://builds.cask.co/browse/CDAP-UDUT51

### Changes
- Port ngCapsules modules into CDAP
- Changed the module names to conform to CDAP's modules (commons, filters, services)
- Add SockJS client and node-uuid into bower components (before it was being loaded as part of cask-angular-socket-datasource)
- Remove ngCapsules modules from module loader in top level projects (hydrator, tracker, and logviewer)
- Fix linting errors