### PR TITLE
Update functions.sh to give more memory for Docker and VM installs of Sandbox

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1013,8 +1013,8 @@ cdap_sdk_start() {
   local readonly __args=${@}
   local readonly __ret __pid
 
-  # Default JVM_OPTS for CDAP SDK (use larger heap for /opt/cdap SDK installs)
-  if [[ ${CDAP_HOME} == /opt/cdap ]] || [[ ${CDAP_HOME} == /opt/cdap/sdk* ]]; then
+  # Default JVM_OPTS for CDAP Sandbox (use larger heap for /opt/cdap Sandbox installs)
+  if [[ ${CDAP_HOME} == /opt/cdap ]] || [[ ${CDAP_HOME} == /opt/cdap/sandbox* ]]; then
     CDAP_SDK_DEFAULT_JVM_OPTS="-Xmx3072m"
   else
     CDAP_SDK_DEFAULT_JVM_OPTS="-Xmx2048m"


### PR DESCRIPTION
Update functions.sh to give more memory for Docker and VM installs of Sandbox.

This should fix the integration test `BatchJoinerTest` for Docker and Sandbox integration test builds.