### PR TITLE
CDAP-14021 Adding Date time support in schema

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -78,6 +78,42 @@ public final class Schema implements Serializable {
      */
     public boolean isSimpleType() {
       return simpleType;
+    }
+  }
+
+  /**
+   * Logical type to represent date and time using {@link Schema}. Schema of logical types is the schema of primitive
+   * types with an extra attribute `logicalType`.
+   *
+   * Logical type DATE relies on INT as underlying primitive type
+   * Logical type TIMESTAMP_MILLIS relies on LONG as underlying primitive type
+   * Logical type TIMESTAMP_MICROS relies on LONG as underlying primitive type
+   * Logical type TIME_MILLIS relies on INT as underlying primitive type
+   * Logical type TIME_MICROS relies on LONG as underlying primitive type
+   *
+   * For example, the json schema for logicaltype date will be as below:
+   * {
+   *   "type" : "int",
+   *   "logicalType" : "date"
+   * }
+   *
+   */
+  public enum LogicalType {
+    DATE(Type.INT),
+    TIMESTAMP_MILLIS(Type.LONG),
+    TIMESTAMP_MICROS(Type.LONG),
+    TIME_MILLIS(Type.INT),
+    TIME_MICROS(Type.LONG);
+
+    private final Type type;
+
+    /**
+     * Creates {@link LogicalType} with underlying primitive type.
+     *
+     * @param type primitive type on which this {@link LogicalType} relies on
+     */
+    LogicalType(Type type) {
+      this.type = type;
     }
   }
 
@@ -204,7 +240,17 @@ public final class Schema implements Serializable {
     if (!type.isSimpleType()) {
       throw new IllegalArgumentException("Type " + type + " is not a simple type.");
     }
-    return new Schema(type, null, null, null, null, null, null, null);
+    return new Schema(type, null, null, null, null, null, null, null, null);
+  }
+
+  /**
+   * Creates a {@link Schema} for the given logical type. The logical type given must be a
+   * {@link Schema.LogicalType}.
+   * @param logicalType LogicalType of the schema to create.
+   * @return A {@link Schema} with the given logical type.
+   */
+  public static Schema of(LogicalType logicalType) {
+    return new Schema(logicalType.type, logicalType, null, null, null, null, null, null, null);
   }
 
   /**
@@ -251,7 +297,7 @@ public final class Schema implements Serializable {
     if (uniqueValues.isEmpty()) {
       throw new IllegalArgumentException("No enum value provided.");
     }
-    return new Schema(Type.ENUM, uniqueValues, null, null, null, null, null, null);
+    return new Schema(Type.ENUM, null, uniqueValues, null, null, null, null, null, null);
   }
 
   /**
@@ -276,7 +322,7 @@ public final class Schema implements Serializable {
    * @return A {@link Schema} of {@link Type#ARRAY ARRAY} type.
    */
   public static Schema arrayOf(Schema componentSchema) {
-    return new Schema(Type.ARRAY, null, componentSchema, null, null, null, null, null);
+    return new Schema(Type.ARRAY, null, null, componentSchema, null, null, null, null, null);
   }
 
   /**
@@ -286,7 +332,7 @@ public final class Schema implements Serializable {
    * @return A {@link Schema} of {@link Type#MAP MAP} type.
    */
   public static Schema mapOf(Schema keySchema, Schema valueSchema) {
-    return new Schema(Type.MAP, null, null, keySchema, valueSchema, null, null, null);
+    return new Schema(Type.MAP, null, null, null, keySchema, valueSchema, null, null, null);
   }
 
   /**
@@ -301,7 +347,7 @@ public final class Schema implements Serializable {
     if (name == null) {
       throw new IllegalArgumentException("Record name cannot be null.");
     }
-    return new Schema(Type.RECORD, null, null, null, null, name, null, null);
+    return new Schema(Type.RECORD, null, null, null, null, null, name, null, null);
   }
 
   /**
@@ -335,7 +381,7 @@ public final class Schema implements Serializable {
     if (fieldMap.isEmpty()) {
       throw new IllegalArgumentException("No record field provided for " + name);
     }
-    return new Schema(Type.RECORD, null, null, null, null, name, fieldMap, null);
+    return new Schema(Type.RECORD, null, null, null, null, null, name, fieldMap, null);
   }
 
   /**
@@ -364,10 +410,11 @@ public final class Schema implements Serializable {
     if (schemaList.isEmpty()) {
       throw new IllegalArgumentException("No union schema provided.");
     }
-    return new Schema(Type.UNION, null, null, null, null, null, null, schemaList);
+    return new Schema(Type.UNION, null, null, null, null, null, null, null, schemaList);
   }
 
   private final Type type;
+  private final LogicalType logicalType;
 
   private final Map<String, Integer> enumValues;
   private final Map<Integer, String> enumIndexes;
@@ -393,12 +440,14 @@ public final class Schema implements Serializable {
   private transient Map<String, Field> ignoreCaseFieldMap;
 
   private Schema(Type type,
+                 @Nullable LogicalType logicalType,                                   // Not null for logical type
                  @Nullable Set<String> enumValues,                                    // Not null for enum type
                  @Nullable Schema componentSchema,                                    // Not null for array type
                  @Nullable Schema keySchema, @Nullable Schema valueSchema,            // Not null for map type
                  @Nullable String recordName, @Nullable Map<String, Field> fieldMap,  // Not null for record type
                  @Nullable List<Schema> unionSchemas) {                               // Not null for union type
     this.type = type;
+    this.logicalType = logicalType;
     Map.Entry<Map<String, Integer>, Map<Integer, String>> enumValuesIndexes = createIndex(enumValues);
     this.enumValues = enumValuesIndexes.getKey();
     this.enumIndexes = enumValuesIndexes.getValue();
@@ -414,7 +463,7 @@ public final class Schema implements Serializable {
     // Resolve name only records. Only need this step for RECORD or UNION type schemas
     // For array and map schema types, they should already get resolved when the component type is being constructed.
     if (type == Type.RECORD || type == Type.UNION) {
-      resolveSchema(this, new HashMap<String, Schema>());
+      resolveSchema(this, new HashMap<>());
     }
   }
 
@@ -423,6 +472,14 @@ public final class Schema implements Serializable {
    */
   public Type getType() {
     return type;
+  }
+
+  /**
+   * @return the {@link LogicalType} that this schema represents.
+   */
+  @Nullable
+  public LogicalType getLogicalType() {
+    return logicalType;
   }
 
   /**
@@ -779,7 +836,9 @@ public final class Schema implements Serializable {
    * @return A json string representing this schema.
    */
   private String buildString() {
-    if (type.isSimpleType()) {
+    // Return type only if this type does not represent logical type, otherwise use jsonwriter to convert logical type
+    // to correct schema.
+    if (type.isSimpleType() && logicalType == null) {
       return '"' + type.name().toLowerCase() + '"';
     }
 
@@ -787,7 +846,7 @@ public final class Schema implements Serializable {
     try (JsonWriter jsonWriter = new JsonWriter(writer)) {
       SCHEMA_TYPE_ADAPTER.write(jsonWriter, this);
     } catch (IOException e) {
-      // It should never throw IOException on the StringWriter, if it does, something very wrong.
+      // It should never throw IOException on the StringWriter, if it does, something is very wrong.
       throw new RuntimeException(e);
     }
     return writer.toString();

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/SchemaHash.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/SchemaHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -169,6 +169,11 @@ public final class SchemaHash implements Serializable {
         }
         break;
     }
+
+    if (schema.getLogicalType() != null) {
+      md5.update((byte) 13);
+    }
+
     return md5;
   }
 }

--- a/cdap-common/src/test/java/co/cask/cdap/io/SchemaHashTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/SchemaHashTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.cdap.io;
+
+import co.cask.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SchemaHashTest {
+  private Schema schema = Schema.recordOf(
+    "union",
+    Schema.Field.of("a", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.arrayOf(Schema.of(Schema.Type.STRING)))),
+    Schema.Field.of("b", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.arrayOf(Schema.of(Schema.Type.INT)))),
+    Schema.Field.of("c", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.enumWith("something"))),
+    Schema.Field.of("d", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING)))),
+    Schema.Field.of("e", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.mapOf(Schema.of(Schema.Type.INT),
+                                                     Schema.of(Schema.Type.LONG)))),
+    Schema.Field.of("f", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+    Schema.Field.of("g", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+    Schema.Field.of("h", Schema.nullableOf(Schema.of(Schema.Type.LONG))));
+
+  private Schema schemaWithLogicalType = Schema.recordOf(
+    "union",
+    Schema.Field.of("a", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.arrayOf(Schema.of(Schema.Type.STRING)))),
+    Schema.Field.of("b", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.arrayOf(Schema.of(Schema.LogicalType.DATE)))),
+    Schema.Field.of("c", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.enumWith("something"))),
+    Schema.Field.of("d", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING)))),
+    Schema.Field.of("e", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                        Schema.mapOf(Schema.of(Schema.LogicalType.DATE),
+                                                     Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)))),
+    Schema.Field.of("f", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+    Schema.Field.of("g", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
+    Schema.Field.of("h", Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS))));
+
+  @Test
+  public void testDifferentSchemaHash() {
+    Assert.assertNotEquals(schema.getSchemaHash(), schemaWithLogicalType.getSchemaHash());
+  }
+
+  @Test
+  public void testSameSchemaHash() {
+    Assert.assertEquals(schema.getSchemaHash(), schema.getSchemaHash());
+    Assert.assertEquals(schemaWithLogicalType.getSchemaHash(), schemaWithLogicalType.getSchemaHash());
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/io/SchemaTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -462,6 +462,40 @@ public class SchemaTest {
     // Serialize and deserialize it back and validate again
     union = Schema.parseJson(union.toString());
     Assert.assertEquals(first, union.getUnionSchemas().get(1).getField("firsts").getSchema().getComponentSchema());
+  }
+
+  @Test
+  public void testLogicalTypes() throws Exception {
+    Schema dateType = Schema.nullableOf(Schema.of(Schema.LogicalType.DATE));
+    Schema timeMicrosType = Schema.nullableOf(Schema.of(Schema.LogicalType.TIME_MICROS));
+    Schema timeMillisType = Schema.nullableOf(Schema.of(Schema.LogicalType.TIME_MILLIS));
+    Schema timestampMicrosType = Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS));
+    Schema timestampMillisType = Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS));
+
+    Assert.assertEquals(dateType, Schema.parseJson(dateType.toString()));
+    Assert.assertEquals(timeMicrosType, Schema.parseJson(timeMicrosType.toString()));
+    Assert.assertEquals(timeMillisType, Schema.parseJson(timeMillisType.toString()));
+    Assert.assertEquals(timestampMicrosType, Schema.parseJson(timestampMicrosType.toString()));
+    Assert.assertEquals(timestampMillisType, Schema.parseJson(timestampMillisType.toString()));
+
+    Schema complexSchema = Schema.recordOf(
+      "union",
+      Schema.Field.of("a", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.arrayOf(Schema.of(Schema.Type.STRING)))),
+      Schema.Field.of("b", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.arrayOf(Schema.of(Schema.LogicalType.DATE)))),
+      Schema.Field.of("c", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.enumWith("something"))),
+      Schema.Field.of("d", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING)))),
+      Schema.Field.of("e", Schema.unionOf(Schema.of(Schema.Type.NULL),
+                                          Schema.mapOf(Schema.of(Schema.LogicalType.DATE),
+                                                       Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)))),
+      Schema.Field.of("f", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("g", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
+      Schema.Field.of("h", Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS))));
+
+    Assert.assertEquals(complexSchema, Schema.parseJson(complexSchema.toString()));
   }
 
 

--- a/cdap-formats/src/test/java/co/cask/cdap/format/StructuredRecordBuilderTest.java
+++ b/cdap-formats/src/test/java/co/cask/cdap/format/StructuredRecordBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,11 +17,17 @@
 package co.cask.cdap.format;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.format.UnexpectedFormatException;
 import co.cask.cdap.api.data.schema.Schema;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -71,5 +77,175 @@ public class StructuredRecordBuilderTest {
       .build();
 
     Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testDateSupport() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("date", Schema.of(Schema.LogicalType.DATE)));
+
+    LocalDate expected = LocalDate.of(2002, 11, 18);
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("id", 1)
+      .set("name", "test")
+      .setDate("date", expected).build();
+
+    LocalDate actual = record.getDate("date");
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testTimeSupport() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("time", Schema.of(Schema.LogicalType.TIME_MILLIS)));
+
+    LocalTime expected = LocalTime.now();
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("id", 1)
+      .set("name", "test")
+      .setTime("time", expected).build();
+
+    LocalTime actual = record.getTime("time");
+
+    Assert.assertEquals(expected, actual);
+
+    schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                             Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("time", Schema.of(Schema.LogicalType.TIME_MICROS)));
+    record = StructuredRecord.builder(schema)
+      .set("id", 1)
+      .set("name", "test")
+      .setTime("time", expected).build();
+
+    actual = record.getTime("time");
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testTimestampSupport() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("timestamp", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)));
+
+    ZonedDateTime expectedMillis = ZonedDateTime.of(2018, 11, 11, 11, 11, 11, 123 * 1000 * 1000,
+                                                    ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("id", 1)
+      .set("name", "test")
+      .setTimestamp("timestamp", expectedMillis).build();
+
+    ZonedDateTime actual = record.getTimestamp("timestamp", ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    Assert.assertEquals(expectedMillis, actual);
+
+    ZonedDateTime expectedMicros = ZonedDateTime.of(2018, 11, 11, 11, 11, 11, 123456 * 1000,
+                                                    ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                             Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("timestamp", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)));
+    record = StructuredRecord.builder(schema)
+      .set("id", 1)
+      .set("name", "test")
+      .setTimestamp("timestamp", expectedMicros).build();
+    actual = record.getTimestamp("timestamp");
+    Assert.assertEquals(expectedMicros, actual);
+  }
+
+  @Test
+  public void testNullLogicalType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("date", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))));
+
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("id", 1)
+      .set("name", "test")
+      .setDate("date", null).build();
+
+    LocalDate actual = record.getDate("date");
+
+    Assert.assertNull(actual);
+  }
+
+  @Test
+  public void testUnionSchemaType() {
+    Schema schema = Schema.recordOf("x", Schema.Field.of("x", Schema.unionOf(
+      Schema.unionOf(Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
+                     Schema.of(Schema.Type.STRING)),
+      Schema.of(Schema.Type.NULL),
+      Schema.of(Schema.Type.INT),
+      Schema.of(Schema.Type.LONG),
+      Schema.of(Schema.LogicalType.DATE),
+      Schema.nullableOf(Schema.of(Schema.LogicalType.TIME_MILLIS)))));
+
+    LocalDate date = LocalDate.of(2018, 11, 11);
+    ZonedDateTime zonedDateTime = ZonedDateTime.of(2018, 11, 11, 11, 11, 11, 0, ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+    LocalTime time = LocalTime.of(21, 1, 1);
+    Assert.assertEquals(date, StructuredRecord.builder(schema).setDate("x", date).build().getDate("x"));
+    StructuredRecord x = StructuredRecord.builder(schema).setTimestamp("x", zonedDateTime).build();
+    Assert.assertEquals(zonedDateTime, x.getTimestamp("x"));
+    Assert.assertEquals(time, StructuredRecord.builder(schema).setTime("x", time).build().getTime("x"));
+    Assert.assertNull(StructuredRecord.builder(schema).setTime("x", null).build().getTime("x"));
+  }
+
+  @Test
+  public void testGetNonExistentField() {
+    Schema schema = Schema.recordOf("record", Schema.Field.of("x", Schema.of(Schema.LogicalType.DATE)));
+    LocalDate date = LocalDate.of(2018, 11, 11);
+    Assert.assertNull(StructuredRecord.builder(schema).setDate("x", date).build().getDate("y"));
+  }
+
+  @Test(expected = UnexpectedFormatException.class)
+  public void testSetNonExistentField() {
+    Schema schema = Schema.recordOf("record", Schema.Field.of("x", Schema.of(Schema.LogicalType.DATE)));
+    LocalDate date = LocalDate.of(2018, 11, 11);
+    StructuredRecord.builder(schema).setDate("y", date).build();
+  }
+
+  @Test(expected = UnexpectedFormatException.class)
+  public void testInvalidNestedUnionSchemaType() {
+    Schema schema = Schema.recordOf("x", Schema.Field.of("x", Schema.unionOf(
+      Schema.unionOf(Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
+                     Schema.of(Schema.Type.STRING)),
+      Schema.of(Schema.Type.NULL),
+      Schema.of(Schema.Type.INT),
+      Schema.of(Schema.Type.LONG),
+      Schema.nullableOf(Schema.of(Schema.LogicalType.TIME_MILLIS)))));
+
+    LocalDate date = LocalDate.of(2018, 11, 11);
+    Assert.assertEquals(date, StructuredRecord.builder(schema).setDate("x", date).build().getDate("x"));
+  }
+
+  @Test(expected = UnexpectedFormatException.class)
+  public void testInvalidDateLogicalType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("date", Schema.of(Schema.LogicalType.DATE)));
+
+    LocalTime expected = LocalTime.now();
+    StructuredRecord.builder(schema).set("id", 1).set("name", "test").setTime("date", expected).build();
+  }
+
+  @Test(expected = UnexpectedFormatException.class)
+  public void testInvalidTimeLogicalType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("time", Schema.of(Schema.LogicalType.TIME_MILLIS)));
+
+    LocalDate expected = LocalDate.now();
+    StructuredRecord.builder(schema).set("id", 1).set("name", "test").setDate("time", expected).build();
+  }
+
+  @Test(expected = UnexpectedFormatException.class)
+  public void testInvalidTimestampLogicalType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("timestamp", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)));
+
+    LocalDate expected = LocalDate.now();
+    StructuredRecord.builder(schema).set("id", 1).set("name", "test").setDate("timestamp", expected).build();
   }
 }

--- a/cdap-formats/src/test/java/co/cask/cdap/format/StructuredRecordStringConverterTest.java
+++ b/cdap-formats/src/test/java/co/cask/cdap/format/StructuredRecordStringConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,9 +26,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Test for {@link StructuredRecordStringConverter} class from {@link StructuredRecord} to json string
@@ -78,6 +80,60 @@ public class StructuredRecordStringConverterTest {
       StructuredRecord recordOfJson = StructuredRecordStringConverter.fromJsonString(jsonOfRecord, schema);
       assertRecordsEqual(initial, recordOfJson);
     }
+  }
+
+  @Test
+  public void testDateLogicalTypeConversion() throws Exception {
+    Schema dateSchema = Schema.recordOf(
+      "date",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("date", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))));
+
+    StructuredRecord record = StructuredRecord.builder(dateSchema).set("id", 1)
+      .set("name", "alice")
+      .setDate("date", LocalDate.now()).build();
+
+    String jsonOfRecord = StructuredRecordStringConverter.toJsonString(record);
+    StructuredRecord recordOfJson = StructuredRecordStringConverter.fromJsonString(jsonOfRecord, dateSchema);
+
+    assertRecordsEqual(record, recordOfJson);
+  }
+
+  @Test
+  public void testTimeLogicalTypeConversion() throws Exception {
+    Schema dateSchema = Schema.recordOf(
+      "date",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("time", Schema.nullableOf(Schema.of(Schema.LogicalType.TIME_MILLIS))));
+
+    StructuredRecord record = StructuredRecord.builder(dateSchema).set("id", 1)
+      .set("name", "alice")
+      .setTime("time", LocalTime.now()).build();
+
+    String jsonOfRecord = StructuredRecordStringConverter.toJsonString(record);
+    StructuredRecord recordOfJson = StructuredRecordStringConverter.fromJsonString(jsonOfRecord, dateSchema);
+
+    assertRecordsEqual(record, recordOfJson);
+  }
+
+  @Test
+  public void testTimestampLogicalTypeConversion() throws Exception {
+    Schema dateSchema = Schema.recordOf(
+      "date",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("timestamp", Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS))));
+
+    StructuredRecord record = StructuredRecord.builder(dateSchema).set("id", 1)
+      .set("name", "alice")
+      .setTimestamp("timestamp", ZonedDateTime.now()).build();
+
+    String jsonOfRecord = StructuredRecordStringConverter.toJsonString(record);
+    StructuredRecord recordOfJson = StructuredRecordStringConverter.fromJsonString(jsonOfRecord, dateSchema);
+
+    assertRecordsEqual(record, recordOfJson);
   }
 
   private StructuredRecord getStructuredRecord(boolean withNullValue) {


### PR DESCRIPTION
Design: https://wiki.cask.co/display/CE/Date+and+Time+support+in+Schema

Summary of changes:

- Added apis in Schema to support logical types - date, time-millis, time-micros, timestamp-millis, timestamp-micros.
- Added apis to StructuredRecord for reading and writing date, time and timestamp
- Added corresponding tests.
- Corresponding PR for Database plugins to read and write date/time fields from a database such as mysql.
https://github.com/caskdata/hydrator-plugins/pull/809

Build: https://builds.cask.co/browse/CDAP-DUT6586-11