### PR TITLE
CDAP-13924:Support filtering based on cdap-site.xml configuration

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Requirements.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Requirements.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  * <pre>
  *     {@literal @}Plugin(type = BatchSource.PLUGIN_TYPE)
  *     {@literal @}Name("Table")
- *     {@literal @}Requirements(Capabilities.TRANSACTIONS)
+ *     {@literal @}Requirements(Requirements.TEPHRA_TX)
  *      public class Table extends{@code BatchSource<byte[], Row, StructuredRecord>} {
  *       ...
  *       ...
@@ -70,7 +70,7 @@ public @interface Requirements {
   /**
    * Defines transactional requirements
    */
-  String TRANSACTIONS = "transactions";
+  String TEPHRA_TX = "tephratx";
 
   String[] value() default {};
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -74,7 +75,9 @@ public class PluginClass {
     this.configFieldName = configfieldName;
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.endpoints = Collections.unmodifiableSet(new HashSet<>(endpoints));
-    this.requirements = Collections.unmodifiableSet(new HashSet<>(requirements));
+    // requirements are case insensitive
+    this.requirements = Collections.unmodifiableSet(requirements.stream()
+                                                      .map(String::toLowerCase).collect(Collectors.toSet()));
   }
 
   public PluginClass(String type, String name, String description, String className, @Nullable String configfieldName,
@@ -142,7 +145,7 @@ public class PluginClass {
   }
 
   /**
-   * @return the requirements of the plugin
+   * @return the requirements of the plugin (case insensitive: represented in lowercase)
    */
   public Set<String> getRequirements() {
     return requirements;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -357,10 +357,11 @@ final class ArtifactInspector {
   }
 
   /**
-   * Get all the {@link Requirements} specified by a plugin.
+   * Get all the {@link Requirements} specified by a plugin. The requirements are case insensitive and always
+   * represented in lowercase
    *
    * @param cls the plugin class whose requirement needs to be found
-   * @return requirements specified by the plugin or an empty set if the plugin does not specify any
+   * @return requirements specified by the plugin (in lowercase) or an empty set if the plugin does not specify any
    * {@link Requirements}
    */
   @VisibleForTesting

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -94,14 +94,14 @@ public class ArtifactInspectorTest {
     Assert.assertTrue(artifactInspector.getPluginRequirements(InspectionApp.AppPlugin.class).isEmpty());
 
     // check that if a plugin specify a requirement it is captured
-    Assert.assertEquals(ImmutableSet.of(Requirements.TRANSACTIONS),
+    Assert.assertEquals(ImmutableSet.of(Requirements.TEPHRA_TX),
                         artifactInspector.getPluginRequirements(InspectionApp.SingleRequirementPlugin.class));
 
     // check if a plugin specify a requirement annotation but it is empty the requirement captured is no requirement
     Assert.assertTrue(artifactInspector.getPluginRequirements(InspectionApp.EmptyRequirementPlugin.class).isEmpty());
 
     // check if a plugin specify multiple requirement all of them are captured
-    Assert.assertEquals(ImmutableSet.of(Requirements.TRANSACTIONS, "secondrequirement"),
+    Assert.assertEquals(ImmutableSet.of(Requirements.TEPHRA_TX, "secondrequirement"),
                         artifactInspector.getPluginRequirements(InspectionApp.MultipleRequirementsPlugin.class));
 
     // check if a plugin has specified empty string as requirement is captured as no requirements
@@ -109,11 +109,11 @@ public class ArtifactInspectorTest {
                         .getPluginRequirements(InspectionApp.SingleEmptyRequirementPlugin.class).isEmpty());
 
     // check if a plugin has specified empty string with a valid requirement only the valid requirement is captured
-    Assert.assertEquals(ImmutableSet.of(Requirements.TRANSACTIONS),
+    Assert.assertEquals(ImmutableSet.of(Requirements.TEPHRA_TX),
                         artifactInspector.getPluginRequirements(InspectionApp.ValidAndEmptyRequirementsPlugin.class));
 
     // test that duplicate requirements are only stored once and the beginning and ending white spaces are trimmed
-    Assert.assertEquals(ImmutableSet.of(Requirements.TRANSACTIONS, "duplicate"),
+    Assert.assertEquals(ImmutableSet.of(Requirements.TEPHRA_TX, "duplicate"),
                         artifactInspector.getPluginRequirements(InspectionApp.DuplicateRequirementsPlugin.class));
   }
 
@@ -147,7 +147,7 @@ public class ArtifactInspectorTest {
         ImmutableMap.of(
           "y", new PluginPropertyField("y", "", "double", true, true),
           "isSomething", new PluginPropertyField("isSomething", "", "boolean", true, false)),
-        new HashSet<>(), ImmutableSet.of(Requirements.TRANSACTIONS, "secondrequirement"));
+        new HashSet<>(), ImmutableSet.of(Requirements.TEPHRA_TX.toLowerCase(), "secondrequirement"));
       Assert.assertTrue(classes.getPlugins().containsAll(ImmutableSet.of(expectedPlugin, multipleRequirementPlugin)));
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/inspection/InspectionApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/inspection/InspectionApp.java
@@ -64,7 +64,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("SingleRequirementPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements(Requirements.TRANSACTIONS)
+  @Requirements(Requirements.TEPHRA_TX)
   public static class SingleRequirementPlugin {
     private PConfig pluginConf;
 
@@ -76,7 +76,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name(MULTIPLE_REQUIREMENTS_PLUGIN)
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements({Requirements.TRANSACTIONS, "secondRequirement"})
+  @Requirements({Requirements.TEPHRA_TX, "secondRequirement"})
   public static class MultipleRequirementsPlugin {
     private PConfig pluginConf;
 
@@ -112,7 +112,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("ValidAndEmptyRequirementsPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements({Requirements.TRANSACTIONS, ""})
+  @Requirements({Requirements.TEPHRA_TX, ""})
   public static class ValidAndEmptyRequirementsPlugin {
     private PConfig pluginConf;
 
@@ -124,8 +124,20 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("DuplicateRequirementsPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements({Requirements.TRANSACTIONS, "   DupliCate    ", "    duplicate    "})
+  @Requirements({Requirements.TEPHRA_TX, "   DupliCate    ", "    duplicate    "})
   public static class DuplicateRequirementsPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
+    }
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name("NonTransactionalPlugin")
+  @Description(PLUGIN_DESCRIPTION)
+  @Requirements({"req1", "req2"})
+  public static class NonTransactionalPlugin {
     private PConfig pluginConf;
 
     public double doSomething() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -299,6 +299,11 @@ public abstract class AppFabricTestBase {
     if (updateSchedules != null) {
       cConf.set(Constants.AppFabric.APP_UPDATE_SCHEDULES, updateSchedules);
     }
+    // add the plugin exclusion if one has been set by the test class
+    String excludedRequirements = System.getProperty(Constants.REQUIREMENTS_BLACKLIST);
+    if (excludedRequirements != null) {
+      cConf.set(Constants.REQUIREMENTS_BLACKLIST, excludedRequirements);
+    }
     // Use a shorter delay to speedup tests
     cConf.setLong(Constants.Scheduler.EVENT_POLL_DELAY_MILLIS, 100L);
     cConf.setLong(Constants.AppFabric.STATUS_EVENT_POLL_DELAY_MILLIS, 100L);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppScheduleUpdateTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppScheduleUpdateTest.java
@@ -35,10 +35,23 @@ import java.util.List;
 public class AppScheduleUpdateTest extends AppFabricTestBase {
   @ClassRule
   public static final ExternalResource RESOURCE = new ExternalResource() {
+    private String previousAppUpdateSchedules;
     @Override
-    protected void before() throws Throwable {
+    protected void before() {
+      // store the previous value
+      previousAppUpdateSchedules = System.getProperty(Constants.AppFabric.APP_UPDATE_SCHEDULES);
       // Set app schedule update to be false
       System.setProperty(Constants.AppFabric.APP_UPDATE_SCHEDULES, "false");
+    }
+
+    @Override
+    protected void after() {
+      // reset the system property
+      if (previousAppUpdateSchedules == null) {
+        System.clearProperty(Constants.AppFabric.APP_UPDATE_SCHEDULES);
+      } else {
+        System.setProperty(Constants.AppFabric.APP_UPDATE_SCHEDULES, previousAppUpdateSchedules);
+      }
     }
   };
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTestBase.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.services.http.handlers;
+
+import co.cask.cdap.WordCountApp;
+import co.cask.cdap.api.artifact.ArtifactInfo;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.client.MetadataClient;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.config.ConnectionConfig;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.EndpointStrategy;
+import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.gateway.handlers.ArtifactHttpHandler;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.base.Charsets;
+import com.google.common.io.ByteStreams;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.discovery.ServiceDiscovered;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Manifest;
+import javax.annotation.Nullable;
+import javax.ws.rs.HttpMethod;
+
+/**
+ * TestBase for {@link ArtifactHttpHandler}. Contains common setup and other common methods
+ */
+public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .create();
+  private static String systemArtifactsDir;
+  static ArtifactRepository artifactRepository;
+  static MetadataClient metadataClient;
+  private static ClientConfig clientConfig;
+
+  @BeforeClass
+  public static void setup() {
+    artifactRepository = getInjector().getInstance(ArtifactRepository.class);
+    systemArtifactsDir = getInjector().getInstance(CConfiguration.class).get(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR);
+    DiscoveryServiceClient discoveryClient = getInjector().getInstance(DiscoveryServiceClient.class);
+    ServiceDiscovered metadataHttpDiscovered = discoveryClient.discover(Constants.Service.METADATA_SERVICE);
+    EndpointStrategy endpointStrategy = new RandomEndpointStrategy(metadataHttpDiscovered);
+    Discoverable discoverable = endpointStrategy.pick(1, TimeUnit.SECONDS);
+    Assert.assertNotNull(discoverable);
+    String host = discoverable.getSocketAddress().getHostName();
+    int port = discoverable.getSocketAddress().getPort();
+    ConnectionConfig connectionConfig = ConnectionConfig.builder().setHostname(host).setPort(port).build();
+    clientConfig = ClientConfig.builder().setConnectionConfig(connectionConfig).build();
+    metadataClient = new MetadataClient(clientConfig);
+  }
+
+  @After
+  public void wipeData() throws Exception {
+    artifactRepository.clear(NamespaceId.DEFAULT);
+    artifactRepository.clear(NamespaceId.SYSTEM);
+  }
+
+  /**
+   * Adds {@link WordCountApp} as system artifact which can be used as parent artifact for testing purpose
+   * @throws Exception
+   */
+  void addWordCountAppAsSystemArtifacts() throws Exception {
+    File destination = new File(systemArtifactsDir + "/wordcount-1.0.0.jar");
+    buildAppArtifact(WordCountApp.class, new Manifest(), destination);
+    artifactRepository.addSystemArtifacts();
+  }
+
+  /**
+   * @return {@link ArtifactInfo} of the given artifactId
+   */
+  ArtifactInfo getArtifact(ArtifactId artifactId) throws URISyntaxException, IOException {
+    // get /artifacts/{name}/versions/{version}
+    return getArtifact(artifactId, null);
+  }
+
+  /**
+   * @return {@link ArtifactInfo} of the given artifactId in the given scope
+   */
+  ArtifactInfo getArtifact(ArtifactId artifactId, ArtifactScope scope) throws URISyntaxException, IOException {
+    // get /artifacts/{name}/versions/{version}?scope={scope}
+    URL endpoint = getEndPoint(String.format("%s/namespaces/%s/artifacts/%s/versions/%s%s",
+                                             Constants.Gateway.API_VERSION_3, artifactId.getNamespace(),
+                                             artifactId.getArtifact(), artifactId.getVersion(),
+                                             getScopeQuery(scope))).toURL();
+
+    return getResults(endpoint, ArtifactInfo.class);
+  }
+
+  /**
+   * @return the contents from doing a get on the given url as the given type, or null if a 404 is returned
+   */
+  @Nullable
+  <T> T getResults(URL endpoint, Type type) throws IOException {
+    HttpURLConnection urlConn = (HttpURLConnection) endpoint.openConnection();
+    urlConn.setRequestMethod(HttpMethod.GET);
+
+    int responseCode = urlConn.getResponseCode();
+    if (responseCode == HttpResponseStatus.NOT_FOUND.code()) {
+      return null;
+    }
+    Assert.assertEquals(HttpResponseStatus.OK.code(), responseCode);
+
+    String responseStr = new String(ByteStreams.toByteArray(urlConn.getInputStream()), Charsets.UTF_8);
+    urlConn.disconnect();
+    return GSON.fromJson(responseStr, type);
+  }
+
+  /**
+   * @return the given scope as a query parameter string or empty string if the scope is null
+   */
+  String getScopeQuery(ArtifactScope scope) {
+    return (scope == null) ? ("") : ("?scope=" + scope.name());
+  }
+
+  /**
+   * Deletes all the jar in the systemArtifactDir
+   */
+  void cleanupSystemArtifactsDirectory() {
+    File dir = new File(systemArtifactsDir);
+    for (File jarFile : DirUtils.listFiles(dir, "jar")) {
+      jarFile.delete();
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PluginExclusionTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PluginExclusionTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.services.http.handlers;
+
+import co.cask.cdap.api.annotation.Requirements;
+import co.cask.cdap.api.artifact.ArtifactRange;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.id.Id;
+import co.cask.cdap.internal.app.runtime.artifact.app.inspection.InspectionApp;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+
+import java.util.Set;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+
+/**
+ * Tests that plugins whose requirements are marked as excluded through cdap-site.xml are excluded and is not visible
+ */
+public class PluginExclusionTest extends ArtifactHttpHandlerTestBase {
+  @ClassRule
+  public static final ExternalResource RESOURCE = new ExternalResource() {
+    private String previousRequirementBlacklist;
+    @Override
+    protected void before() {
+      // store the previous value
+      previousRequirementBlacklist = System.getProperty(Constants.REQUIREMENTS_BLACKLIST);
+      // Set the system property to the excluded requirement value which will be set in cdap-site through the test base
+      System.setProperty(Constants.REQUIREMENTS_BLACKLIST, Requirements.TEPHRA_TX);
+    }
+
+    @Override
+    protected void after() {
+      // clear the system property
+      if (previousRequirementBlacklist == null) {
+        System.clearProperty(Constants.REQUIREMENTS_BLACKLIST);
+      } else {
+        System.setProperty(Constants.REQUIREMENTS_BLACKLIST, previousRequirementBlacklist);
+      }
+    }
+  };
+
+  @Test
+  public void testPluginRequirements() throws Exception {
+    // add a system artifact
+    ArtifactId systemId = NamespaceId.SYSTEM.artifact("wordcount", "1.0.0");
+    addWordCountAppAsSystemArtifacts();
+
+    Set<ArtifactRange> parents = Sets.newHashSet(new ArtifactRange(
+      systemId.getNamespace(), systemId.getArtifact(),
+      new ArtifactVersion(systemId.getVersion()), true, new ArtifactVersion(systemId.getVersion()), true));
+
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, InspectionApp.class.getPackage().getName());
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("inspection", "1.0.0");
+    Assert.assertEquals(HttpResponseStatus.OK.code(),
+                        addPluginArtifact(Id.Artifact.fromEntityId(artifactId), InspectionApp.class, manifest, parents)
+                          .getStatusLine().getStatusCode());
+    Set<PluginClass> plugins = getArtifact(artifactId).getClasses().getPlugins();
+    // Only four plugins which does not have transactions as requirement should be visible.
+    Assert.assertEquals(4, plugins.size());
+    Set<String> actualPluginClassNames = plugins.stream().map(PluginClass::getClassName).collect(Collectors.toSet());
+    Set<String> expectedPluginClassNames = ImmutableSet.of(InspectionApp.AppPlugin.class.getName(),
+                                                           InspectionApp.EmptyRequirementPlugin.class.getName(),
+                                                           InspectionApp.SingleEmptyRequirementPlugin.class.getName(),
+                                                           InspectionApp.NonTransactionalPlugin.class.getName());
+    Assert.assertEquals(expectedPluginClassNames, actualPluginClassNames);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -70,6 +70,12 @@ public final class Constants {
   /* Used by the user to specify what part of a path should be replaced by the current user's name. */
   public static final String USER_NAME_SPECIFIER = "${name}";
 
+  /* Used to specify a comma separated list of plugin requirements that cannot be met in the instance.
+  Plugins that require any of these will be treated as if they don't exist.
+  For example, if 'tephraTx' is given, any plugin that requires 'tephraTx' will be treated as
+  if they don't exist. */
+  public static final String REQUIREMENTS_BLACKLIST = "requirements.blacklist";
+
 
   /**
    * Configuration for Master startup.

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -625,6 +625,17 @@
     </description>
   </property>
 
+  <property>
+    <name>requirements.blacklist</name>
+    <value></value>
+    <description>
+      Comma separated list of plugin requirements that cannot be met in the instance.
+      Plugins that require any of these will be treated as if they don't exist.
+      For example, if 'tephraTx' is given, any plugin that requires 'tephraTx' will be treated as
+      if they don't exist.
+    </description>
+  </property>
+
 
   <!-- Audit configuration -->
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="20c8a5ee92bf8554c7fbe48802bedc4a"
+DEFAULT_XML_MD5_HASH="27099e61d6b174f0d0bb3047ac6578c6"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
### Summary
- Filters plugin based on the requirement which has been provided by them and the configuration in `cdap-site.xml`
- Added a new property in `cdap-site.xml` called `plugin.exclude.with.requirements` which defines comma separated list of requirements which cannot be meet in the instance and any plugins requiring either one these should be excluded and be inaccessible to any user.
- Note: The change has unit tests at storage level. I am working on adding some unit test at higher level in handler to have end-to-end filtering tests. Opening PR now to get initial feedback on the change before weekend in case there are any major issues.

[Design](https://wiki.cask.co/display/CE/Improving+Plugins+User+Experience+Across+Different+Modes)
[Issue](https://issues.cask.co/browse/CDAP-13924)

Build: https://builds.cask.co/browse/CDAP-DUT6588-7