### PR TITLE
[CDAP-12654][CDAP-13886] Improves error handling in DataPrep

### DIFF
--- a/cdap-ui/app/cdap/components/Alert/Alert.scss
+++ b/cdap-ui/app/cdap/components/Alert/Alert.scss
@@ -14,6 +14,7 @@
  * the License.
  */
 @import "../../styles/variables.scss";
+$close-btn-size: 13px;
 
 .global-alert {
   &.modal-dialog {
@@ -38,8 +39,13 @@
       .error {
         background-color: $brand-danger;
       }
+      .message {
+        max-width: calc(100% - #{$close-btn-size});
+        padding-right: 5px;
+      }
       .icon-close {
         cursor: pointer;
+        font-size: $close-btn-size;
       }
     }
   }

--- a/cdap-ui/app/cdap/components/Alert/index.js
+++ b/cdap-ui/app/cdap/components/Alert/index.js
@@ -86,9 +86,16 @@ export default class Alert extends Component {
   render() {
     let msgElem = null;
     if (this.state.element) {
-      msgElem = this.state.element;
+      msgElem = <span className="message truncate">{this.state.element}</span>;
     } else if (this.state.message) {
-      msgElem = <span className="message">{this.state.message}</span>;
+      msgElem = (
+        <span
+          className="message truncate"
+          title={this.state.message}
+        >
+          {this.state.message}
+        </span>
+      );
     }
     return (
       <Modal

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/DatasetList/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/DatasetList/index.js
@@ -48,12 +48,28 @@ class DatasetListView extends Component {
       return <LoadingSVGCentered />;
     }
 
+    const datasetList = this.props.datasetList;
+
+    if (!datasetList.length) {
+      return (
+        <div className="empty-search-container">
+          <div className="empty-search text-xs-center">
+            <strong>
+              {T.translate(`${PREFIX}.EmptyMessage.emptyDatasetList`, {
+                connectionName: this.props.connectionId
+              })}
+            </strong>
+          </div>
+        </div>
+      );
+    }
+
     let namespace = getCurrentNamespace();
 
     return (
       <div className="list-view-container">
         <div className="sub-panel">
-          {T.translate(`${PREFIX}.datasetCount`, {context: this.props.datasetList.length})}
+          {T.translate(`${PREFIX}.datasetCount`, {context: datasetList.length})}
         </div>
 
         <div className="list-table">
@@ -67,12 +83,13 @@ class DatasetListView extends Component {
 
           <div className="table-body">
             {
-              this.props.datasetList.map((dataset) => {
+              datasetList.map((dataset) => {
                 let Tag = this.props.enableRouting ? Link : 'div';
                 let path = `/ns/${namespace}/connections/bigquery/${this.props.connectionId}/datasets/${dataset.name}`;
 
                 return (
                   <Tag
+                    key={dataset.name}
                     to={path}
                     onClick={this.clickHandler.bind(null, dataset.name)}
                   >

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,6 +14,7 @@
  * the License.
  */
 
+export * from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/file';
 export * from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/database';
 export * from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/commons';
 export * from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/kafka';

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/bigquery.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/bigquery.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import {setActiveBrowser} from './commons';
+import {setActiveBrowser, setError} from './commons';
 import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
@@ -66,23 +66,24 @@ const setBigQueryAsActiveBrowser = (payload) => {
     bigquery.connectionId === payload.id
   ) { return; }
 
-  let {id} = payload;
-  setActiveBrowser(payload);
-  setBigQueryLoading();
-  listBiqQueryDatasets(id);
-
-  let namespace = getCurrentNamespace();
-  let params = {
-    namespace,
-    connectionId: id
-  };
+  let {id: connectionId} = payload;
 
   DataPrepBrowserStore.dispatch({
     type: BrowserStoreActions.SET_BIGQUERY_CONNECTION_ID,
     payload: {
-      connectionId: id
+      connectionId
     }
   });
+
+  setActiveBrowser(payload);
+  setBigQueryLoading();
+  listBiqQueryDatasets(connectionId);
+
+  let namespace = getCurrentNamespace();
+  let params = {
+    namespace,
+    connectionId
+  };
 
   MyDataPrepApi.getConnection(params)
     .subscribe((res) => {
@@ -91,9 +92,11 @@ const setBigQueryAsActiveBrowser = (payload) => {
         type: BrowserStoreActions.SET_BIGQUERY_CONNECTION_DETAILS,
         payload: {
           info,
-          connectionId: id
+          connectionId
         }
       });
+    }, (err) => {
+      setError(err);
     });
 };
 
@@ -113,6 +116,8 @@ const listBiqQueryDatasets = (connectionId) => {
           datasetList: res.values
         }
       });
+    }, (err) => {
+      setError(err);
     });
 };
 
@@ -134,6 +139,8 @@ const listBigQueryTables = (connectionId, datasetId) => {
           tableList: res.values
         }
       });
+    }, (err) => {
+      setError(err);
     });
 };
 

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/database.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/database.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import {setActiveBrowser} from './commons';
+import {setActiveBrowser, setError} from './commons';
 import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
@@ -30,14 +30,23 @@ const setDatabaseInfoLoading = () => {
 };
 
 const setDatabaseAsActiveBrowser = (payload) => {
+  let {id: connectionId} = payload;
+
+  DataPrepBrowserStore.dispatch({
+    type: BrowserStoreActions.SET_DATABASE_CONNECTION_ID,
+    payload: {
+      connectionId
+    }
+  });
+
   setActiveBrowser(payload);
   setDatabaseInfoLoading();
 
   let namespace = NamespaceStore.getState().selectedNamespace;
-  let {id} = payload;
+
   let params = {
     namespace,
-    connectionId: id
+    connectionId
   };
   MyDataPrepApi.getConnection(params)
     .subscribe((res) => {
@@ -51,15 +60,10 @@ const setDatabaseAsActiveBrowser = (payload) => {
             connectionId: params.connectionId,
           });
         }, (err) => {
-          setDatabaseError({
-            error: err,
-            info
-          });
+          setError(err);
         });
     }, (err) => {
-      setDatabaseError({
-        payload: err
-      });
+      setError(err);
     });
 };
 
@@ -70,16 +74,8 @@ const setDatabaseProperties = (payload) => {
   });
 };
 
-const setDatabaseError = (payload) => {
-  DataPrepBrowserStore.dispatch({
-    type: BrowserStoreActions.SET_DATABASE_ERROR,
-    payload: payload
-  });
-};
-
 export {
   setDatabaseInfoLoading,
   setDatabaseAsActiveBrowser,
-  setDatabaseProperties,
-  setDatabaseError
+  setDatabaseProperties
 };

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/file.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/file.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {setActiveBrowser, setError} from './commons';
+import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
+import NamespaceStore from 'services/NamespaceStore';
+import MyDataPrepApi from 'api/dataprep';
+import {convertBytesToHumanReadable, HUMANREADABLESTORAGE_NODECIMAL} from 'services/helpers';
+import uuidV4 from 'uuid/v4';
+import moment from 'moment';
+import T from 'i18n-react';
+const PREFIX = 'features.FileBrowser';
+
+const trimSuffixSlash = (path) => path.replace(/\/\//, '/');
+
+const formatResponse = (contents) => {
+  return contents.map((content) => {
+    content.uniqueId = uuidV4();
+    content['last-modified'] = moment(content['last-modified']).format('MM/DD/YY HH:mm');
+    content.displaySize = convertBytesToHumanReadable(content.size, HUMANREADABLESTORAGE_NODECIMAL, true);
+
+    if (content.directory) {
+      content.type = T.translate(`${PREFIX}.directory`);
+    }
+    content.type = content.type === 'UNKNOWN' ? '--' : content.type;
+
+    return content;
+  });
+};
+
+const goToPath = (path) => {
+  path = trimSuffixSlash(path);
+  setFileSystemLoading();
+  setFileSystemPath(path);
+
+  let namespace = NamespaceStore.getState().selectedNamespace;
+
+  MyDataPrepApi.explorer({
+    namespace,
+    path,
+    hidden: true
+  }).subscribe((res) => {
+    DataPrepBrowserStore.dispatch({
+      type: BrowserStoreActions.SET_FILE_SYSTEM_CONTENTS,
+      payload: {
+        contents: formatResponse(res.values)
+      }
+    });
+  }, (err) => {
+    setError(err);
+  });
+};
+
+const setFileSystemLoading = () => {
+  DataPrepBrowserStore.dispatch({
+    type: BrowserStoreActions.SET_FILE_SYSTEM_LOADING,
+    payload: {
+      loading: true
+    }
+  });
+};
+
+const setFileSystemAsActiveBrowser = (payload) => {
+  setActiveBrowser(payload);
+  goToPath(payload.path);
+};
+
+const setFileSystemPath = (path) => {
+  DataPrepBrowserStore.dispatch({
+    type: BrowserStoreActions.SET_FILE_SYSTEM_PATH,
+    payload: {
+      path
+    }
+  });
+};
+
+const setFileSystemSearch = (search) => {
+  DataPrepBrowserStore.dispatch({
+    type: BrowserStoreActions.SET_FILE_SYSTEM_SEARCH,
+    payload: {
+      search
+    }
+  });
+};
+
+export {
+  goToPath,
+  trimSuffixSlash,
+  setFileSystemLoading,
+  setFileSystemAsActiveBrowser,
+  setFileSystemSearch
+};

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/gcs.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/gcs.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import {setActiveBrowser} from './commons';
+import {setActiveBrowser, setError} from './commons';
 import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
@@ -55,6 +55,8 @@ const setGCSAsActiveBrowser = (payload) => {
         if (path) {
           setGCSPrefix(path);
         }
+      }, (err) => {
+        setError(err);
       });
   } else {
     if (path) {
@@ -89,13 +91,15 @@ const fetchGCSDetails = (path = '') => {
   }
   MyDataPrepApi.exploreGCSBucketDetails(params)
     .subscribe(
-      res => {
+      (res) => {
         DataPrepBrowserStore.dispatch({
           type: BrowserStoreActions.SET_GCS_ACTIVE_BUCKET_DETAILS,
           payload: {
             activeBucketDetails: res.values
           }
         });
+      }, (err) => {
+        setError(err);
       }
     );
 };

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/kafka.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/kafka.js
@@ -14,21 +14,29 @@
  * the License.
  */
 
-import {setActiveBrowser} from './commons';
+import {setActiveBrowser, setError} from './commons';
 import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
 import {objectQuery} from 'services/helpers';
 
 const setKafkaAsActiveBrowser = (payload) => {
+  let {id: connectionId} = payload;
+
+  DataPrepBrowserStore.dispatch({
+    type: BrowserStoreActions.SET_KAFKA_CONNECTION_ID,
+    payload: {
+      connectionId
+    }
+  });
   setActiveBrowser(payload);
   setKafkaInfoLoading();
 
   let namespace = NamespaceStore.getState().selectedNamespace;
-  let {id} = payload;
+
   let params = {
     namespace,
-    connectionId: id
+    connectionId
   };
 
   MyDataPrepApi.getConnection(params)
@@ -43,24 +51,11 @@ const setKafkaAsActiveBrowser = (payload) => {
             connectionId: params.connectionId
           });
         }, (err) => {
-          setKafkaError({
-            error: err,
-            info
-          });
+          setError(err);
         });
-
     }, (err) => {
-      setKafkaError({
-        payload: err
-      });
+      setError(err);
     });
-};
-
-const setKafkaError = (payload) => {
-  DataPrepBrowserStore.dispatch({
-    type: BrowserStoreActions.SET_KAFKA_ERROR,
-    payload: payload
-  });
 };
 
 const setKafkaProperties = (payload) => {
@@ -81,7 +76,6 @@ const setKafkaInfoLoading = () => {
 
 export {
   setKafkaAsActiveBrowser,
-  setKafkaError,
   setKafkaProperties,
   setKafkaInfoLoading
 };

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/s3.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/s3.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import {setActiveBrowser} from './commons';
+import {setActiveBrowser, setError} from './commons';
 import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
@@ -53,6 +53,8 @@ const setS3AsActiveBrowser = (payload) => {
         if (path) {
           setPrefix(path);
         }
+      }, (err) => {
+        setError(err);
       });
   } else {
     if (path) {
@@ -88,13 +90,16 @@ const fetchBucketDetails = (path = '') => {
   MyDataPrepApi
     .exploreBucketDetails(params)
     .subscribe(
-      res => {
+      (res) => {
         DataPrepBrowserStore.dispatch({
           type: BrowserStoreActions.SET_S3_ACTIVE_BUCKET_DETAILS,
           payload: {
             activeBucketDetails: res.values
           }
         });
+      },
+      (err) => {
+        setError(err);
       }
     );
 };

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
@@ -19,7 +19,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import DataPrepApi from 'api/dataprep';
-import isNil from 'lodash/isNil';
 import NamespaceStore from 'services/NamespaceStore';
 import T from 'i18n-react';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
@@ -27,7 +26,7 @@ import {Input} from 'reactstrap';
 import IconSVG from 'components/IconSVG';
 import ee from 'event-emitter';
 import {objectQuery} from 'services/helpers';
-import {setDatabaseAsActiveBrowser} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
+import {setDatabaseAsActiveBrowser, setError} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import DataPrepBrowserPageTitle from 'components/DataPrep/DataPrepBrowser/PageTitle';
 
 require('./DatabaseBrowser.scss');
@@ -35,29 +34,25 @@ require('./DatabaseBrowser.scss');
 const PREFIX = `features.DataPrep.DataPrepBrowser.DatabaseBrowser`;
 
 export default class DatabaseBrowser extends Component {
-  constructor(props) {
-    super(props);
-    let store = DataPrepBrowserStore.getState();
-    this.state = {
-      info: store.database.info,
-      connectionId: store.database.connectionId,
-      connectionName: '',
-      tables: [],
-      loading: true,
-      search: '',
-      searchFocus: true,
-      error: null
-    };
+  static propTypes = {
+    toggle: PropTypes.func,
+    onWorkspaceCreate: PropTypes.func
+  };
 
-    this.eventEmitter = ee(ee);
-    this.handleSearch = this.handleSearch.bind(this);
-    this.prepTable = this.prepTable.bind(this);
-    this.eventBasedFetchTable = this.eventBasedFetchTable.bind(this);
+  state = {
+    info: DataPrepBrowserStore.getState().database.info,
+    connectionId: DataPrepBrowserStore.getState().database.connectionId,
+    connectionName: '',
+    tables: [],
+    loading: true,
+    search: '',
+    searchFocus: true
+  };
 
-    this.eventEmitter.on('DATAPREP_CONNECTION_EDIT_DATABASE', this.eventBasedFetchTable);
-  }
+  eventEmitter = ee(ee);
 
   componentDidMount() {
+    this.eventEmitter.on('DATAPREP_CONNECTION_EDIT_DATABASE', this.eventBasedFetchTable);
     this.storeSubscription = DataPrepBrowserStore.subscribe(() => {
       let {database, activeBrowser} = DataPrepBrowserStore.getState();
       if (activeBrowser.name !== 'database') {
@@ -68,8 +63,7 @@ export default class DatabaseBrowser extends Component {
         info: database.info,
         connectionId: database.connectionId,
         loading: database.loading,
-        tables: database.tables,
-        error: database.error
+        tables: database.tables
       });
     });
   }
@@ -77,24 +71,24 @@ export default class DatabaseBrowser extends Component {
   componentWillUnmount() {
     this.eventEmitter.off('DATAPREP_CONNECTION_EDIT_DATABASE', this.eventBasedFetchTable);
 
-    if (this.storeSubscription) {
+    if (typeof this.storeSubscription === 'function') {
       this.storeSubscription();
     }
   }
 
-  eventBasedFetchTable(connectionId) {
+  eventBasedFetchTable = (connectionId) => {
     if (this.state.connectionId === connectionId) {
       setDatabaseAsActiveBrowser({name: 'database', id: connectionId});
     }
   }
 
-  handleSearch(e) {
+  handleSearch = (e) => {
     this.setState({
       search: e.target.value
     });
   }
 
-  prepTable(tableId) {
+  prepTable = (tableId) => {
     let namespace = NamespaceStore.getState().selectedNamespace;
     let params = {
       namespace,
@@ -114,7 +108,7 @@ export default class DatabaseBrowser extends Component {
           window.location.href = `${window.location.origin}/cdap/ns/${namespace}/dataprep/${workspaceId}`;
         },
         (err) => {
-          console.log('ERROR: ', err);
+          setError(err);
         }
       );
   }
@@ -142,7 +136,7 @@ export default class DatabaseBrowser extends Component {
                 >
                   {T.translate(`${PREFIX}.EmptyMessage.clearLabel`)}
                 </span>
-                <span> {T.translate(`${PREFIX}.EmptyMessage.suggestion1`)} </span>
+                <span>{T.translate(`${PREFIX}.EmptyMessage.suggestion1`)}</span>
               </li>
             </ul>
           </div>
@@ -162,21 +156,7 @@ export default class DatabaseBrowser extends Component {
   }
 
   render() {
-    const renderNoPluginMessage = (error) => {
-      let errorMessage = objectQuery(error, 'response', 'message') || objectQuery(error, 'response') || error;
-
-      return (
-        <div className="empty-search-container">
-          <div className="empty-search">
-            <strong>{errorMessage}</strong>
-          </div>
-        </div>
-      );
-    };
     const renderContents = (tables) => {
-      if (this.state.error) {
-        return renderNoPluginMessage(this.state.error);
-      }
       if (!tables.length) {
         return this.renderEmpty();
       }
@@ -194,6 +174,7 @@ export default class DatabaseBrowser extends Component {
               tables.map(table => {
                 return (
                   <div
+                    key={table.name}
                     className="row content-row"
                     onClick={this.prepTable.bind(this, table.name)}
                   >
@@ -241,34 +222,26 @@ export default class DatabaseBrowser extends Component {
             </h5>
           </div>
         </div>
-        {
-          isNil(this.state.error) ?
-            <div>
-              <div className="database-browser-header">
-                <div className="database-metadata">
-                  <h5>{objectQuery(this.state.info, 'info', 'name')}</h5>
-                  <span className="tables-count">
-                    {
-                      T.translate(`${PREFIX}.tableCount`, {
-                        context: this.state.tables.length
-                      })
-                    }
-                  </span>
-                </div>
-                <div className="table-name-search">
-                  <Input
-                    placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
-                    value={this.state.search}
-                    onChange={this.handleSearch}
-                    autoFocus={this.state.searchFocus}
-                  />
-                </div>
-              </div>
-            </div>
-          :
-            null
-        }
-
+        <div className="database-browser-header">
+          <div className="database-metadata">
+            <h5>{objectQuery(this.state.info, 'info', 'name')}</h5>
+            <span className="tables-count">
+              {
+                T.translate(`${PREFIX}.tableCount`, {
+                  context: this.state.tables.length
+                })
+              }
+            </span>
+          </div>
+          <div className="table-name-search">
+            <Input
+              placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
+              value={this.state.search}
+              onChange={this.handleSearch}
+              autoFocus={this.state.searchFocus}
+            />
+          </div>
+        </div>
         <div className="database-browser-content">
           { renderContents(filteredTables) }
         </div>
@@ -276,8 +249,3 @@ export default class DatabaseBrowser extends Component {
     );
   }
 }
-
-DatabaseBrowser.propTypes = {
-  toggle: PropTypes.func,
-  onWorkspaceCreate: PropTypes.func
-};

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/ErrorBanner/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/ErrorBanner/index.js
@@ -12,34 +12,27 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
-import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
+import { connect } from 'react-redux';
+import {setError} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/commons';
+import ErrorBanner from 'components/ErrorBanner';
 
-const setActiveBrowser = (payload) => {
-  DataPrepBrowserStore.dispatch({
-    type: BrowserStoreActions.SET_ACTIVEBROWSER,
-    payload
-  });
+const mapStateToProps = (state) => {
+  return {
+    error: state.error
+  };
 };
 
-const setError = (error = null) => {
-  DataPrepBrowserStore.dispatch({
-    type: BrowserStoreActions.SET_ERROR,
-    payload: {
-      error
-    }
-  });
+const mapDispatchToProps = () => {
+  return {
+    onClose: setError
+  };
 };
 
-const reset = () => {
-  DataPrepBrowserStore.dispatch({
-    type: BrowserStoreActions.RESET
-  });
-};
+const DataPrepErrorBanner = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ErrorBanner);
 
-export {
-  setActiveBrowser,
-  setError,
-  reset
-};
+export default DataPrepErrorBanner;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@ import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
-import {setGCSLoading} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
+import {setGCSLoading, setError} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import {Route, Switch} from 'react-router-dom';
 import Page404 from 'components/404';
 import {Provider} from 'react-redux';
@@ -69,7 +69,7 @@ export default class GCSBrowser extends Component {
 
     MyDataPrepApi.readGCSFile(params, null, headers)
       .subscribe(
-        res => {
+        (res) => {
           let {id: workspaceId} = res.values[0];
           if (this.props.enableRouting) {
             window.location.href = `${window.location.origin}/cdap/ns/${namespace}/dataprep/${workspaceId}`;
@@ -77,6 +77,8 @@ export default class GCSBrowser extends Component {
           if (this.props.onWorkspaceCreate && typeof this.props.onWorkspaceCreate === 'function') {
             this.props.onWorkspaceCreate(workspaceId);
           }
+        }, (err) => {
+          setError(err);
         }
       );
   };

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,9 +24,7 @@ import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import {Input} from 'reactstrap';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
-import isNil from 'lodash/isNil';
-import {setKafkaAsActiveBrowser} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
-import {objectQuery} from 'services/helpers';
+import {setKafkaAsActiveBrowser, setError} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import ee from 'event-emitter';
 import DataPrepBrowserPageTitle from 'components/DataPrep/DataPrepBrowser/PageTitle';
 import {Provider} from 'react-redux';
@@ -41,33 +39,25 @@ export default class KafkaBrowser extends Component {
     enableRouting: PropTypes.bool,
     onWorkspaceCreate: PropTypes.func
   };
+
   static defaultProps = {
     enableRouting: true
   };
 
-  constructor(props) {
-    super(props);
+  state = {
+    connectionId: DataPrepBrowserStore.getState().kafka.connectionId,
+    info: DataPrepBrowserStore.getState().kafka.info,
+    loading: DataPrepBrowserStore.getState().kafka.loading,
+    search: '',
+    searchFocus: true,
+    error: null,
+    topics: []
+  };
 
-    let store = DataPrepBrowserStore.getState();
-
-    this.state = {
-      connectionId: store.kafka.connectionId,
-      info: store.kafka.info,
-      loading: store.kafka.loading,
-      search: '',
-      searchFocus: true,
-      error: null,
-      topics: []
-    };
-
-    this.eventEmitter = ee(ee);
-    this.handleSearch = this.handleSearch.bind(this);
-    this.eventBasedFetchTopics = this.eventBasedFetchTopics.bind(this);
-
-    this.eventEmitter.on('DATAPREP_CONNECTION_EDIT_KAFKA', this.eventBasedFetchTopics);
-  }
+  eventEmitter = ee(ee);
 
   componentDidMount() {
+    this.eventEmitter.on('DATAPREP_CONNECTION_EDIT_KAFKA', this.eventBasedFetchTopics);
     this.storeSubscription = DataPrepBrowserStore.subscribe(() => {
       let {kafka, activeBrowser} = DataPrepBrowserStore.getState();
       if (activeBrowser.name !== 'kafka') {
@@ -78,7 +68,6 @@ export default class KafkaBrowser extends Component {
         info: kafka.info,
         connectionId: kafka.connectionId,
         topics: kafka.topics,
-        error: kafka.error,
         loading: kafka.loading
       });
     });
@@ -86,22 +75,22 @@ export default class KafkaBrowser extends Component {
 
   componentWillUnmount() {
     this.eventEmitter.off('DATAPREP_CONNECTION_EDIT_KAFKA', this.eventBasedFetchTopics);
-    if (this.storeSubscription) {
+    if (typeof this.storeSubscription === 'function') {
       this.storeSubscription();
     }
   }
 
-  eventBasedFetchTopics(connectionId) {
+  eventBasedFetchTopics = (connectionId) => {
     if (this.state.connectionId === connectionId) {
       setKafkaAsActiveBrowser({name: 'database', id: connectionId});
     }
-  }
+  };
 
-  handleSearch(e) {
+  handleSearch = (e) => {
     this.setState({
       search: e.target.value
     });
-  }
+  };
 
   prepTopic(topic) {
     this.setState({
@@ -126,7 +115,7 @@ export default class KafkaBrowser extends Component {
           window.location.href = `${window.location.origin}/cdap/ns/${namespace}/dataprep/${workspaceId}`;
         },
         (err) => {
-          console.log('ERROR: ', err);
+          setError(err);
         }
       );
   }
@@ -154,7 +143,7 @@ export default class KafkaBrowser extends Component {
                 >
                   {T.translate(`${PREFIX}.EmptyMessage.clearLabel`)}
                 </span>
-                <span> {T.translate(`${PREFIX}.EmptyMessage.suggestion1`)} </span>
+                <span>{T.translate(`${PREFIX}.EmptyMessage.suggestion1`)}</span>
               </li>
             </ul>
           </div>
@@ -173,23 +162,7 @@ export default class KafkaBrowser extends Component {
     );
   }
 
-  renderError() {
-    let error = this.state.error;
-    let errorMessage = objectQuery(error, 'response', 'message') || objectQuery(error, 'response') || error;
-
-    return (
-      <div className="empty-search-container">
-        <div className="empty-search">
-          <strong>{errorMessage}</strong>
-        </div>
-      </div>
-    );
-  }
-
   renderContents(topics) {
-    if (this.state.error) {
-      return this.renderError();
-    }
     if (!topics.length) {
       return this.renderEmpty();
     }
@@ -264,34 +237,28 @@ export default class KafkaBrowser extends Component {
             </h5>
           </div>
         </div>
-        {
-          isNil(this.state.error) ?
-            <div>
-              <div className="kafka-browser-header">
-                <div className="kafka-metadata">
-                  <h5>{this.state.info.name}</h5>
-                  <span className="tables-count">
-                    {
-                      T.translate(`${PREFIX}.topicCount`, {
-                        count: this.state.topics.length
-                      })
-                    }
-                  </span>
-                </div>
-                <div className="table-name-search">
-                  <Input
-                    placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
-                    value={this.state.search}
-                    onChange={this.handleSearch}
-                    autoFocus={this.state.searchFocus}
-                  />
-                </div>
-              </div>
+        <div>
+          <div className="kafka-browser-header">
+            <div className="kafka-metadata">
+              <h5>{this.state.info.name}</h5>
+              <span className="tables-count">
+                {
+                  T.translate(`${PREFIX}.topicCount`, {
+                    count: this.state.topics.length
+                  })
+                }
+              </span>
             </div>
-          :
-            null
-        }
-
+            <div className="table-name-search">
+              <Input
+                placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
+                value={this.state.search}
+                onChange={this.handleSearch}
+                autoFocus={this.state.searchFocus}
+              />
+            </div>
+          </div>
+        </div>
         <div className="kafka-browser-content">
           { this.renderContents(filteredTopics) }
         </div>

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/BucketData/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/BucketData/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,6 +27,7 @@ import EmptyMessageContainer from 'components/EmptyMessageContainer';
 import T from 'i18n-react';
 import IconSVG from 'components/IconSVG';
 import {humanReadableDate} from 'services/helpers';
+import If from 'components/If';
 
 const PREFIX = 'features.DataPrep.DataPrepBrowser.S3Browser.BucketData';
 const props = {
@@ -92,18 +93,7 @@ const TableHeader = ({enableRouting}) => {
 };
 TableHeader.propTypes = props;
 
-const TableContents = ({enableRouting, search, data, onWorkspaceCreate, prefix, clearSearch}) => {
-  let filteredData = data.filter(d => {
-    if (search && search.length) {
-      let isSearchTextInName = d.name.indexOf(search);
-      if (d.type === 'bucket') {
-        return isSearchTextInName !== -1 || d.owner.indexOf(search) !== -1;
-      }
-      return isSearchTextInName !== -1 || d.path.indexOf(search) !== -1;
-    }
-    return true;
-  });
-
+const TableContents = ({enableRouting, search, filteredData, onWorkspaceCreate, prefix, clearSearch}) => {
   let ContainerElement = enableRouting ? Link : 'div';
   let pathname = window.location.pathname.replace(/\/cdap/, '');
   if (!filteredData.length) {
@@ -120,7 +110,7 @@ const TableContents = ({enableRouting, search, data, onWorkspaceCreate, prefix, 
                   >
                     {T.translate(`features.EmptyMessageContainer.clearLabel`)}
                   </span>
-                  <span>{T.translate(`${PREFIX}.Content.EmptymessageContainer.suggestion1`)} </span>
+                  <span>{T.translate(`${PREFIX}.Content.EmptymessageContainer.suggestion1`)}</span>
                 </li>
               </ul>
             </EmptyMessageContainer>
@@ -151,6 +141,7 @@ const TableContents = ({enableRouting, search, data, onWorkspaceCreate, prefix, 
                 className={classnames({'disabled': !file.directory && !file.wrangle})}
                 to={`${pathname}?prefix=${getPrefix(file, prefix)}`}
                 onClick={onClickHandler.bind(null, enableRouting, onWorkspaceCreate, file, prefix)}
+                key={file.name}
               >
                 <div className="row">
                   <div className="col-xs-3">
@@ -182,6 +173,7 @@ const TableContents = ({enableRouting, search, data, onWorkspaceCreate, prefix, 
             className={classnames({'disabled': !file.directory && !file.wrangle})}
             to={`${pathname}?prefix=${getPrefix(file, prefix)}`}
             onClick={onClickHandler.bind(null, enableRouting, onWorkspaceCreate, file, prefix)}
+            key={file.name}
           >
             <div className="row">
               <div className="col-xs-12">
@@ -195,28 +187,51 @@ const TableContents = ({enableRouting, search, data, onWorkspaceCreate, prefix, 
     </div>
   );
 };
-TableContents.propTypes = props;
+TableContents.propTypes = {
+  ...props,
+  filteredData: PropTypes.array
+};
 
 const BucketData = ({data, search, clearSearch, loading, prefix, enableRouting, onWorkspaceCreate}) => {
   if (loading) {
     return <LoadingSVGCentered />;
   }
 
-  // FIXME: Possible? May be a proper empty message?
-  if (!Object.keys(data).length) {
-    return null;
+  if (!data.length && !search.length) {
+    return (
+      <div className="empty-search-container">
+        <div className="empty-search text-xs-center">
+          <strong>
+            {T.translate(`${PREFIX}.Content.emptyBucket`)}
+          </strong>
+        </div>
+      </div>
+    );
   }
+
+  const filteredData = data.filter(d => {
+    if (search && search.length && d.name) {
+      let isSearchTextInName = d.name.indexOf(search);
+      if (d.type && d.type === 'bucket') {
+        return isSearchTextInName !== -1 || (d.owner && d.owner.indexOf(search) !== -1);
+      }
+      return isSearchTextInName !== -1 || (d.path && d.path.indexOf(search) !== -1);
+    }
+    return true;
+  });
 
   return (
     <div>
-      <div className="s3-content-header">
-        <TableHeader enableRouting={enableRouting} />
-      </div>
+      <If condition={filteredData.length}>
+        <div className="s3-content-header">
+          <TableHeader enableRouting={enableRouting} />
+        </div>
+      </If>
       <div className="s3-content-body">
         <TableContents
           search={search}
           clearSearch={clearSearch}
-          data={data}
+          filteredData={filteredData}
           prefix={prefix}
           enableRouting={enableRouting}
           onWorkspaceCreate={onWorkspaceCreate}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,7 @@ import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
-import {setS3Loading} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
+import {setS3Loading, setError} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import BucketDataView from 'components/DataPrep/DataPrepBrowser/S3Browser/BucketData';
 import {Route, Switch} from 'react-router-dom';
 import Page404 from 'components/404';
@@ -39,7 +39,6 @@ const PREFIX = 'features.DataPrep.DataPrepBrowser.S3Browser';
 export default class S3Browser extends Component {
   static propTypes = {
     toggle: PropTypes.func,
-    location: PropTypes.object,
     match: PropTypes.object,
     enableRouting: PropTypes.bool,
     onWorkspaceCreate: PropTypes.func
@@ -70,7 +69,7 @@ export default class S3Browser extends Component {
         sampler: 'first'
       }, null, headers)
       .subscribe(
-        res => {
+        (res) => {
           let {id: workspaceId} = res.values[0];
           if (this.props.enableRouting) {
             window.location.href = `${window.location.origin}/cdap/ns/${namespace}/dataprep/${workspaceId}`;
@@ -78,6 +77,9 @@ export default class S3Browser extends Component {
           if (this.props.onWorkspaceCreate && typeof this.props.onWorkspaceCreate === 'function') {
             this.props.onWorkspaceCreate(workspaceId);
           }
+        },
+        (err) => {
+          setError(err);
         }
       );
   };

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,26 +55,34 @@ export default class ColumnsTab extends Component {
     this.clearAllColumns = this.clearAllColumns.bind(this);
     this.selectAllColumns = this.selectAllColumns.bind(this);
     this.setSelect = this.setSelect.bind(this);
+  }
 
+  componentDidMount() {
+    this._isMounted = true;
     this.sub = DataPrepStore.subscribe(() => {
-      let {dataprep: dataprepstate, columnsInformation: columnInfo} = DataPrepStore.getState();
-      this.setState({
-        selectedHeaders: dataprepstate.selectedHeaders,
-        columns: columnInfo.columns,
-        headers: dataprepstate.headers.map((res) => {
-          let obj = {
-            name: res,
-            uniqueId: uuidV4()
-          };
-          return obj;
-        }),
-        loading: dataprepstate.loading
-      });
+      if (this._isMounted) {
+        let {dataprep: dataprepstate, columnsInformation: columnInfo} = DataPrepStore.getState();
+        this.setState({
+          selectedHeaders: dataprepstate.selectedHeaders,
+          columns: columnInfo.columns,
+          headers: dataprepstate.headers.map((res) => {
+            let obj = {
+              name: res,
+              uniqueId: uuidV4()
+            };
+            return obj;
+          }),
+          loading: dataprepstate.loading
+        });
+      }
     });
   }
 
   componentWillUnmount() {
-    this.sub();
+    this._isMounted = false;
+    if (this.sub && typeof this.sub === 'function') {
+      this.sub();
+    }
   }
 
   componentDidUpdate() {
@@ -226,7 +234,7 @@ export default class ColumnsTab extends Component {
                   >
                     {T.translate(`${PREFIX}.EmptyMessage.clearLabel`)}
                   </span>
-                  <span> {T.translate(`${PREFIX}.EmptyMessage.suggestion1`)} </span>
+                  <span>{T.translate(`${PREFIX}.EmptyMessage.suggestion1`)}</span>
                 </li>
               </ul>
             </div>

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
@@ -37,7 +37,9 @@ export default class DataPrepSidePanel extends Component {
       directives: storeState.directives,
       summary: {}
     };
+  }
 
+  componentDidMount() {
     this.sub = DataPrepStore.subscribe(() => {
       let state = DataPrepStore.getState().dataprep;
 
@@ -49,7 +51,9 @@ export default class DataPrepSidePanel extends Component {
   }
 
   componentWillUnmount() {
-    this.sub();
+    if (this.sub && typeof this.sub === 'function') {
+      this.sub();
+    }
   }
 
   setActiveTab(tab) {

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -70,30 +70,11 @@ export default class DataPrep extends Component {
 
     this.eventEmitter.on('DATAPREP_BACKEND_DOWN', this.toggleBackendDown);
     this.eventEmitter.on('DATAPREP_CLOSE_SIDEPANEL', this.closeSidePanel);
-
-    this.eventEmitter.on('REFRESH_DATAPREP', () => {
-      this.setState({
-        loading: true
-      });
-      /*
-        Not sure if this is necessary but added it is safer when doing an upgrade.
-        - Modified directives?
-        - Modified API calls that are not compatible with earlier version?
-      */
-      DataPrepStore.dispatch({
-        type: DataPrepActions.reset
-      });
-      let workspaceId = this.props.workspaceId;
-      this.setCurrentWorkspace(workspaceId);
-      setTimeout(() => {
-        this.setState({
-          loading: false
-        });
-      });
-    });
+    this.eventEmitter.on('REFRESH_DATAPREP', this.refreshDataPrep);
   }
 
-  componentWillMount() {
+  componentDidMount() {
+    this._isMounted = true;
     this.checkBackendUp(this.props);
     checkDataPrepHigherVersion();
   }
@@ -105,6 +86,7 @@ export default class DataPrep extends Component {
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     if (this.props.onSubmit) {
       let workspaceId = DataPrepStore.getState().dataprep.workspaceId;
       this.props.onSubmit({workspaceId});
@@ -114,10 +96,28 @@ export default class DataPrep extends Component {
     });
     this.eventEmitter.off('DATAPREP_BACKEND_DOWN', this.toggleBackendDown);
     this.eventEmitter.off('DATAPREP_CLOSE_SIDEPANEL', this.closeSidePanel);
+    this.eventEmitter.off('REFRESH_DATAPREP', this.refreshDataPrep);
     if (this.dataprepStoreSubscription) {
       this.dataprepStoreSubscription();
     }
   }
+
+  refreshDataPrep = () => {
+    this.setState({
+      loading: true
+    }, () => {
+      /*
+        Not sure if this is necessary but added it is safer when doing an upgrade.
+        - Modified directives?
+        - Modified API calls that are not compatible with earlier version?
+      */
+      DataPrepStore.dispatch({
+        type: DataPrepActions.reset
+      });
+      let workspaceId = this.props.workspaceId;
+      this.setCurrentWorkspace(workspaceId);
+    });
+  };
 
   checkBackendUp() {
     // On single workspace mode (within pipeline), the service management is
@@ -163,18 +163,21 @@ export default class DataPrep extends Component {
       .subscribe(() => {
         let {properties} = DataPrepStore.getState().dataprep;
         let workspaceName = properties.name;
-        this.setState({
-          loading: false,
-          currentWorkspace: workspaceId,
-          workspaceName
-        });
+        if (this._isMounted) {
+          this.setState({
+            loading: false,
+            currentWorkspace: workspaceId,
+            workspaceName
+          });
+        }
       }, () => {
-        this.setState({loading: false});
-
-        DataPrepStore.dispatch({
-          type: DataPrepActions.setInitialized
-        });
-        this.eventEmitter.emit('DATAPREP_NO_WORKSPACE_ID');
+        if (this._isMounted) {
+          this.setState({loading: false});
+          DataPrepStore.dispatch({
+            type: DataPrepActions.setInitialized
+          });
+          this.eventEmitter.emit('DATAPREP_NO_WORKSPACE_ID');
+        }
       });
   }
 

--- a/cdap-ui/app/cdap/components/EmptyMessageContainer/EmptyMessageContainer.scss
+++ b/cdap-ui/app/cdap/components/EmptyMessageContainer/EmptyMessageContainer.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -48,6 +48,7 @@ $empty-message-link-color: var(--brand-primary-color);
       .link-text {
         cursor: pointer;
         color: $empty-message-link-color;
+        margin-right: 0.25em;
       }
     }
   }

--- a/cdap-ui/app/cdap/components/ErrorBanner/index.tsx
+++ b/cdap-ui/app/cdap/components/ErrorBanner/index.tsx
@@ -12,34 +12,32 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
-import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
+import * as React from 'react';
+import {objectQuery} from 'services/helpers';
+import Alert from 'components/Alert';
 
-const setActiveBrowser = (payload) => {
-  DataPrepBrowserStore.dispatch({
-    type: BrowserStoreActions.SET_ACTIVEBROWSER,
-    payload
-  });
+interface IErrorProps {
+  error: object | string | null;
+  onClose: () => void;
+}
+
+const ErrorBanner: React.SFC<IErrorProps> = ({ error, onClose }) => {
+  if (!error) {
+    return null;
+  }
+
+  const errorMessage: string = objectQuery(error, 'response', 'message') || objectQuery(error, 'response') || error;
+
+  return (
+    <Alert
+      message={errorMessage}
+      type='error'
+      showAlert={true}
+      onClose={onClose}
+    />
+  );
 };
 
-const setError = (error = null) => {
-  DataPrepBrowserStore.dispatch({
-    type: BrowserStoreActions.SET_ERROR,
-    payload: {
-      error
-    }
-  });
-};
-
-const reset = () => {
-  DataPrepBrowserStore.dispatch({
-    type: BrowserStoreActions.RESET
-  });
-};
-
-export {
-  setActiveBrowser,
-  setError,
-  reset
-};
+export default ErrorBanner;

--- a/cdap-ui/app/cdap/components/Popover/index.js
+++ b/cdap-ui/app/cdap/components/Popover/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/cdap/components/UncontrolledComponents/ExpandableMenu.js
+++ b/cdap-ui/app/cdap/components/UncontrolledComponents/ExpandableMenu.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -69,6 +69,6 @@ export default class ExpandableMenu extends Component {
 }
 ExpandableMenu.propTypes = {
   // Assumption: First child is the menu title and the Second child is the actual menu items.
-  children: PropTypes.number,
+  children: PropTypes.array,
   className: PropTypes.string
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -416,6 +416,9 @@ features:
           1: "{context} dataset"
           _: "{context} datasets"
         datasets: Datasets
+        EmptyMessage:
+          emptyDatasetList: 'No datasets in connection _{connectionName}_'
+          emptyTableList: 'No tables in dataset _{datasetName}_'
         name: Name
         pageTitle: CDAP | Connections | Google BigQuery | {connectionId}
         title: Select table
@@ -439,6 +442,7 @@ features:
         BrowserData:
           Content:
             directory: Directory
+            emptyBucket: No files or directories found in this bucket
             EmptymessageContainer:
               suggestion1: your search
           Headers:
@@ -469,9 +473,11 @@ features:
           1: '{count} topic'
           _: "{count} topics"
         title: Select topic
+      noDataMsg: No data
       S3Browser:
         BucketData:
           Content:
+            emptyBucket: No files or directories found in this bucket
             EmptymessageContainer:
               suggestion1: your search
           Headers:


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-12654
- https://issues.cask.co/browse/CDAP-13886
- https://issues.cask.co/browse/CDAP-14155

Build: https://builds.cask.co/browse/CDAP-UDUT52

This PR:
- Fixes various JS issues in DataPrep connections after the React upgrade. Most of these were in `DataprepConnections/index.js`, where we were dispatching actions to update DataPrepBrowserStore inside `render()` functions. Have updated these components to dispatch actions in `componentDidMount()` instead.
- Fixes various issues where `key` property was missing in `render()` functions that were missing `map()`
- Adds an error state to `DataPrepBrowserStore`, to display errors in Alert banner at the top, no matter which connections the error came from.
- Truncates and shows ellipsis for long error messages in Alert banner
- Adds error handler for all API calls in the various DataPrep connections components.
- Shows empty page with message in the center when we can't access a connection/bucket, instead of showing spinning wheel forever.