### PR TITLE
[CDAP-12895][Part-1] Fix inconsistencies in CDAP modal in UI

### DIFF
--- a/cdap-ui/app/cdap/components/BtnWithLoading/BtnWithLoading.scss
+++ b/cdap-ui/app/cdap/components/BtnWithLoading/BtnWithLoading.scss
@@ -29,5 +29,11 @@
       fill: $blue-06;
     }
   }
-
+  &.darker-loading-bars {
+    svg.loading-bar {
+      rect {
+        fill: $blue-01;
+      }
+    }
+  }
 }

--- a/cdap-ui/app/cdap/components/BtnWithLoading/index.js
+++ b/cdap-ui/app/cdap/components/BtnWithLoading/index.js
@@ -17,10 +17,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import LoadingSVG from 'components/LoadingSVG';
+import classnames from 'classnames';
 require('./BtnWithLoading.scss');
 
 export default function BtnWithLoading({
   className,
+  darker = false,
   label,
   loading,
   disabled,
@@ -28,7 +30,9 @@ export default function BtnWithLoading({
 }) {
   return (
     <button
-      className={`btn btn-with-loading ${className}`}
+      className={classnames(`btn btn-with-loading`, className, {
+        'darker-loading-bars': darker
+      })}
       onClick={onClick}
       disabled={disabled || loading}
     >

--- a/cdap-ui/app/cdap/components/CardActionFeedback/index.js
+++ b/cdap-ui/app/cdap/components/CardActionFeedback/index.js
@@ -29,22 +29,41 @@ require('./CardActionFeedback.scss');
 import isObject from 'lodash/isObject';
 
 var classNames = require('classnames');
+export const CARD_ACTION_TYPES = {
+  SUCCESS: 'SUCCESS',
+  DANGER: 'DANGER',
+  WARNING: 'WARNING',
+  LOADING: 'LOADING'
+};
 
 export default class CardActionFeedback extends Component {
-  constructor(props) {
-    super(props);
 
-    this.state = {
-      isExpanded: false
-    };
-  }
+  static propTypes = {
+    type: PropTypes.oneOf([
+      CARD_ACTION_TYPES.SUCCESS,
+      CARD_ACTION_TYPES.WARNING,
+      CARD_ACTION_TYPES.DANGER,
+      CARD_ACTION_TYPES.LOADING
+    ]).isRequired,
+    message: PropTypes.string,
+    extendedMessage: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        response: PropTypes.string
+      })
+    ])
+  };
+
+  state = {
+    isExpanded: false
+  };
 
   getIcon() {
     let icon = classNames('fa',
-      { 'fa-check': this.props.type === 'SUCCESS' },
-      { 'fa-exclamation': this.props.type === 'DANGER' },
-      { 'fa-exclamation-triangle': this.props.type === 'WARNING' },
-      { 'fa-spinner fa-spin': this.props.type === 'LOADING' }
+      { 'fa-check': this.props.type === CARD_ACTION_TYPES.SUCCESS },
+      { 'fa-exclamation': this.props.type === CARD_ACTION_TYPES.DANGER },
+      { 'fa-exclamation-triangle': this.props.type === CARD_ACTION_TYPES.WARNING },
+      { 'fa-spinner fa-spin': this.props.type === CARD_ACTION_TYPES.LOADING }
     );
 
     return <span className="feedback-icon"><span className={icon}></span></span>;
@@ -111,14 +130,3 @@ export default class CardActionFeedback extends Component {
     );
   }
 }
-
-CardActionFeedback.propTypes = {
-  type: PropTypes.oneOf(['SUCCESS', 'WARNING', 'DANGER', 'LOADING']).isRequired,
-  message: PropTypes.string,
-  extendedMessage: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      response: PropTypes.string
-    })
-  ])
-};

--- a/cdap-ui/app/cdap/components/ConfirmationModal/ConfirmationModal.scss
+++ b/cdap-ui/app/cdap/components/ConfirmationModal/ConfirmationModal.scss
@@ -18,30 +18,8 @@ $button-border-color: #999999;
 $header-color: #464a57;
 
 .confirmation-modal.modal-dialog {
-  margin-top: 125px;
-  .modal-content {
-    border-radius: 0;
-    border: 0;
-  }
 
-  .modal-header {
-    padding: 0 10px;
-    background-color: $header-color;
-    border-bottom: 0;
-    height: 40px;
-
-    .modal-title {
-      font-weight: normal;
-      font-size: 14px;
-      color: white;
-      line-height: 40px;
-      .fa {
-        cursor: pointer;
-      }
-    }
-  }
-
-  .modal-body {
+  .modal-content .modal-body {
     padding: 0;
 
     &.loading {

--- a/cdap-ui/app/cdap/components/ConfirmationModal/index.js
+++ b/cdap-ui/app/cdap/components/ConfirmationModal/index.js
@@ -22,13 +22,42 @@ import CardActionFeedback from 'components/CardActionFeedback';
 import IconSVG from 'components/IconSVG';
 import Mousetrap from 'mousetrap';
 import T from 'i18n-react';
+import If from 'components/If';
 
 require('./ConfirmationModal.scss');
 
 export default class ConfirmationModal extends Component {
-  constructor(props) {
-    super(props);
-  }
+
+  static propTypes = {
+    cancelButtonText: PropTypes.string,
+    cancelFn: PropTypes.func,
+    confirmationElem: PropTypes.element,
+    confirmButtonText: PropTypes.string,
+    confirmationText: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node
+      ]))
+    ]),
+    confirmFn: PropTypes.func,
+    headerTitle: PropTypes.string,
+    isOpen: PropTypes.bool,
+    toggleModal: PropTypes.func,
+    isLoading: PropTypes.bool,
+    errorMessage: PropTypes.string,
+    extendedMessage: PropTypes.string,
+    disableAction: PropTypes.bool,
+    closeable: PropTypes.bool,
+    keyboard: PropTypes.bool
+  };
+
+  static defaultProps = {
+    confirmButtonText: T.translate('features.ConfirmationModal.confirmDefaultText'),
+    cancelButtonText: T.translate('features.ConfirmationModal.cancelDefaultText'),
+    closeable: false,
+    keyboard: true
+  };
 
   componentWillMount() {
     Mousetrap.bind('enter', this.props.confirmFn);
@@ -108,12 +137,21 @@ export default class ConfirmationModal extends Component {
       <Modal
         isOpen={this.props.isOpen}
         toggle={this.props.toggleModal}
-        className="confirmation-modal"
+        className="confirmation-modal cdap-modal"
         backdrop='static'
         zIndex={1061}
+        keyboard={this.props.keyboard}
       >
         <ModalHeader>
           {this.props.headerTitle}
+          <If condition={this.props.closeable}>
+            <div
+              className="close-section float-xs-right"
+              onClick={this.props.cancelFn}
+            >
+              <IconSVG name="icon-close" />
+            </div>
+          </If>
         </ModalHeader>
 
         {this.renderModalBody()}
@@ -122,30 +160,3 @@ export default class ConfirmationModal extends Component {
     );
   }
 }
-
-ConfirmationModal.defaultProps = {
-  confirmButtonText: T.translate('features.ConfirmationModal.confirmDefaultText'),
-  cancelButtonText:  T.translate('features.ConfirmationModal.cancelDefaultText')
-};
-
-ConfirmationModal.propTypes = {
-  cancelButtonText: PropTypes.string,
-  cancelFn: PropTypes.func,
-  confirmationElem: PropTypes.element,
-  confirmButtonText: PropTypes.string,
-  confirmationText: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.node
-    ]))
-  ]),
-  confirmFn: PropTypes.func,
-  headerTitle: PropTypes.string,
-  isOpen: PropTypes.bool,
-  toggleModal: PropTypes.func,
-  isLoading: PropTypes.bool,
-  errorMessage: PropTypes.string,
-  extendedMessage: PropTypes.string,
-  disableAction: PropTypes.bool
-};

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Calculate/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Calculate/index.js
@@ -223,7 +223,15 @@ export default class Calculate extends Component {
     }
     if (this.props.isOpen && !this.state.isDisabled && this.calculateOffset) {
       if (this.state.operationPopoverOpen) {
-        setPopoverOffset(document.querySelector('#calculate-directive > .second-level-popover .scrollable-list .option.active'), 'third-level-popover');
+        let parentPopoverSelector = '#calculate-directive > .second-level-popover .option.active';
+        let parentPopover = document.querySelector(parentPopover);
+        if (!parentPopover) {
+          parentPopoverSelector = '#calculate-directive > .second-level-popover .scrollable-list .option.active';
+          parentPopover = document.querySelector(parentPopoverSelector);
+        }
+        if (parentPopover) {
+          setPopoverOffset(parentPopover, 'third-level-popover');
+        }
       } else {
         this.calculateOffset();
       }

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/Bulkset/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/Bulkset/index.js
@@ -24,9 +24,13 @@ import DataPrepStore from 'components/DataPrep/store';
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import {preventPropagation} from 'services/helpers';
+import CardActionFeedback, {CARD_ACTION_TYPES} from 'components/CardActionFeedback';
+import If from 'components/If';
+
 require('./Bulkset.scss');
 
 const PREFIX = 'features.DataPrep.Directives.ColumnActions.Bulkset';
+const DATAPREP_PREFIX = 'features.DataPrep.Directives';
 const TEXTAREA_ROWS = 10;
 
 export default class Bulkset extends Component {
@@ -35,6 +39,7 @@ export default class Bulkset extends Component {
     this.state = {
       columnNames: '',
       error: null,
+      backendError: null,
       loading: false
     };
     this.applyDirective = this.applyDirective.bind(this);
@@ -50,7 +55,8 @@ export default class Bulkset extends Component {
     let columns = this.state.columnNames.toString();
     let directive = `set columns ${columns}`;
     this.setState({
-      loading: true
+      loading: true,
+      backendError: null
     });
     execute([directive], null, true)
       .subscribe(
@@ -60,7 +66,7 @@ export default class Bulkset extends Component {
         (err) => {
           this.setState({
             loading: false,
-            error: err.message || err.response.message
+            backendError: err.message || err.response.message || T.translate(`${DATAPREP_PREFIX}.failedApplyDirectiveMessage`)
           });
         }
       );
@@ -121,7 +127,7 @@ export default class Bulkset extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal bulkset-columnactions-modal"
+        className="bulkset-columnactions-modal cdap-modal"
       >
         <ModalHeader>
 
@@ -178,6 +184,12 @@ export default class Bulkset extends Component {
             </button>
           </fieldset>
         </ModalFooter>
+        <If condition={this.state.backendError}>
+          <CardActionFeedback
+            type={CARD_ACTION_TYPES.DANGER}
+            message={this.state.backendError}
+          />
+        </If>
       </Modal>
     );
   }

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/ReplaceColumns/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/ReplaceColumns/index.js
@@ -24,6 +24,8 @@ import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
 import IconSVG from 'components/IconSVG';
 import MouseTrap from 'mousetrap';
+import CardActionFeedback, {CARD_ACTION_TYPES} from 'components/CardActionFeedback';
+import If from 'components/If';
 
 require('./ReplaceColumns.scss');
 
@@ -188,7 +190,7 @@ export default class ReplaceColumns extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal changecolumns-columnactions-modal"
+        className="changecolumns-columnactions-modal cdap-modal"
       >
         <ModalHeader>
           <span>
@@ -273,6 +275,12 @@ export default class ReplaceColumns extends Component {
             </button>
           </fieldset>
         </ModalFooter>
+        <If condition={this.state.error}>
+          <CardActionFeedback
+            type={CARD_ACTION_TYPES.DANGER}
+            message={this.state.error}
+          />
+        </If>
       </Modal>
     );
   }

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingDelimiterModal/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingDelimiterModal/index.js
@@ -116,7 +116,7 @@ export default class UsingDelimiterModal extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal using-delimiter-modal"
+        className="dataprep-parse-modal using-delimiter-modal cdap-modal"
       >
         <ModalHeader>
 

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/UsingPatternsModal/index.js
@@ -43,7 +43,6 @@ export default class UsingPatternsModal extends Component {
         end: ''
       },
       nDigitPattern: '',
-      error: '',
       showEditPatternLabel: false,
       showEditPatternTxtBox: false
     };
@@ -329,6 +328,24 @@ export default class UsingPatternsModal extends Component {
     }
   }
 
+  renderFooterButton = () => {
+    return [
+      <button
+        className="btn btn-primary"
+        onClick={this.applyDirective}
+        disabled={isNil(this.state.pattern) ? 'disabled' : null}
+      >
+        {T.translate('features.DataPrep.Directives.ExtractFields.extractBtnLabel')}
+      </button>,
+      <button
+        className="btn btn-secondary"
+        onClick={this.props.onClose}
+      >
+        {T.translate('features.DataPrep.Directives.cancel')}
+      </button>
+    ];
+  }
+
   render() {
     let showHideLink = null;
     if (this.state.showEditPatternLabel) {
@@ -353,7 +370,7 @@ export default class UsingPatternsModal extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal using-patterns-modal"
+        className="dataprep-parse-modal using-patterns-modal cdap-modal"
       >
         <ModalHeader>
 
@@ -424,22 +441,7 @@ export default class UsingPatternsModal extends Component {
           </div>
         </ModalBody>
         <ModalFooter>
-          <span className="text-warning">
-            {this.state.error}
-          </span>
-          <button
-            className="btn btn-primary"
-            onClick={this.applyDirective}
-            disabled={isNil(this.state.pattern) ? 'disabled' : null}
-          >
-            {T.translate('features.DataPrep.Directives.ExtractFields.extractBtnLabel')}
-          </button>
-          <button
-            className="btn btn-secondary"
-            onClick={this.props.onClose}
-          >
-            {T.translate('features.DataPrep.Directives.cancel')}
-          </button>
+          {this.renderFooterButton()}
         </ModalFooter>
       </Modal>
     );

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ExtractFields/index.js
@@ -131,11 +131,13 @@ export default class ExtractFields extends Component {
       )
     });
   }
+
   handleUsingDelimiters(delimiter) {
     let column = this.props.column;
     let directive = `split-to-columns ${column} ${delimiter}`;
     this.execute([directive]);
   }
+
   execute(addDirective) {
     execute(addDirective)
       .subscribe(() => {

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Filter/index.js
@@ -23,7 +23,7 @@ import T from 'i18n-react';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import MouseTrap from 'mousetrap';
-import { Popover, PopoverTitle, PopoverContent } from 'reactstrap';
+import { Popover, PopoverHeader, PopoverBody } from 'reactstrap';
 import IconSVG from 'components/IconSVG';
 import {setPopoverOffset} from 'components/DataPrep/helper';
 
@@ -236,13 +236,15 @@ export default class FilterDirective extends Component {
           </div>
           <Popover
             placement="right"
-            tether={{classPrefix: 'filter-popover'}}
+            className="filter-popover-element"
             isOpen={this.state.customConditionTooltip}
             target="customConditionTooltip"
             toggle={this.toggleCustomTooltip.bind(this)}
           >
-            <PopoverTitle>{T.translate(`${PREFIX}.customconditiontooltiptitle`)}</PopoverTitle>
-            <PopoverContent>
+            <PopoverHeader className="popover-title">
+              {T.translate(`${PREFIX}.customconditiontooltiptitle`)}
+            </PopoverHeader>
+            <PopoverBody className="popover-content">
               <span>{T.translate(`${PREFIX}.customconditiontooltip`)}</span>
               <a
                 href="http://commons.apache.org/proper/commons-jexl/"
@@ -251,7 +253,7 @@ export default class FilterDirective extends Component {
               >
                 {T.translate(`${PREFIX}.customconditiontooltiplink`)}
               </a>
-            </PopoverContent>
+            </PopoverBody>
           </Popover>
         </div>
 

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/CSVModal.js
@@ -111,7 +111,7 @@ export default class CSVModal extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal"
+        className="dataprep-parse-modal cdap-modal"
       >
         <ModalHeader>
           <span>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
@@ -114,7 +114,7 @@ export default class ExcelModal extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal parse-as-excel"
+        className="dataprep-parse-modal parse-as-excel cdap-modal"
       >
         <ModalHeader>
           <span>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/LogModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/LogModal.js
@@ -102,7 +102,7 @@ export default class LogModal extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal"
+        className="dataprep-parse-modal cdap-modal"
       >
         <ModalHeader>
           <span>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SimpleDateModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SimpleDateModal.js
@@ -110,7 +110,7 @@ export default class SimpleDateModal extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal"
+        className="dataprep-parse-modal cdap-modal"
       >
         <ModalHeader>
           <span>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
@@ -101,7 +101,7 @@ export default class SingleFieldModal extends Component {
         size="md"
         backdrop="static"
         zIndex="1061"
-        className="dataprep-parse-modal"
+        className="dataprep-parse-modal cdap-modal"
       >
         <ModalHeader>
           <span>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/ParseDirective.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/ParseDirective.scss
@@ -41,9 +41,6 @@ $option-hover-active-bg-color: #dddddd;
 }
 
 .dataprep-parse-modal.modal-dialog {
-  margin-top: 100px;
-
-  .close-section { cursor: pointer; }
 
   .modal-body {
     h5 {
@@ -67,11 +64,6 @@ $option-hover-active-bg-color: #dddddd;
     .list-options { margin-bottom: 10px; }
   }
 
-  .modal-footer {
-    .btn {
-      margin-left: 5px;
-    }
-  }
 }
 
 .dataprep-parse-modal {

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
-import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import DataPrepStore from 'components/DataPrep/store';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
 import {getCurrentNamespace} from 'services/NamespaceStore';
@@ -27,6 +27,8 @@ import classnames from 'classnames';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import CardActionFeedback from 'components/CardActionFeedback';
 import getPipelineConfig from 'components/DataPrep/TopPanel/PipelineConfigHelper';
+import isString from 'lodash/isString';
+import If from 'components/If';
 
 const mapErrorToMessage = (message) => {
   if (message.indexOf('invalid field name') !== -1) {
@@ -234,7 +236,7 @@ export default class AddToHydratorModal extends Component {
         isOpen={true}
         toggle={this.props.toggle}
         size="lg"
-        className="add-to-pipeline-dataprep-modal"
+        className="add-to-pipeline-dataprep-modal cdap-modal"
       >
         <ModalHeader>
           <span>
@@ -250,20 +252,14 @@ export default class AddToHydratorModal extends Component {
         </ModalHeader>
         <ModalBody>
           {showContent ? content : this.renderInvalidFieldError()}
-
         </ModalBody>
-        {
-          this.state.error && showContent ?
-            <ModalFooter className="dataset-copy-error-container">
-              <CardActionFeedback
-                type='DANGER'
-                message={T.translate(`${PREFIX}.addToPipelineModal.errorTitle`)}
-                extendedMessage={this.state.error}
-              />
-            </ModalFooter>
-          :
-            null
-        }
+        <If condition={this.state.error}>
+          <CardActionFeedback
+            type='DANGER'
+            message={T.translate(`${PREFIX}.addToPipelineModal.errorTitle`)}
+            extendedMessage={isString(this.state.error) ? this.state.error : null}
+          />
+        </If>
       </Modal>
     );
   }

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/IngestDataFromDataPrep/IngestDataFromDataPrep.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/IngestDataFromDataPrep/IngestDataFromDataPrep.scss
@@ -20,8 +20,8 @@ $error-bg-color: #2c3e50;
 $error-font-color: #cdcdcd;
 $max_height_error_container: 200px;
 
-.dataprep-parse-modal {
-  &.create-dataset-modal {
+.cdap-modal {
+  &.dataprep-create-dataset-modal {
     form {
       input.form-control,
       select.form-control {
@@ -81,21 +81,6 @@ $max_height_error_container: 200px;
           .btn.btn-primary {
             margin-top: 15px;
           }
-        }
-      }
-    }
-    .modal-footer {
-      &.dataset-copy-error-container {
-        padding: 0;
-        text-align: left;
-        .step-error-container {
-          background: $error-bg-color;
-          color: $error-font-color;
-          padding: 5px 15px;
-          width: 100%;
-          text-align: left;
-          max-height: $max_height_error_container;
-          overflow-y: auto;
         }
       }
     }

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/IngestDataFromDataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/IngestDataFromDataPrep/index.js
@@ -719,13 +719,11 @@ export default class IngestDataFromDataPrep extends Component {
   renderFooter() {
     if (this.state.error) {
       return (
-        <ModalFooter className="dataset-copy-error-container">
-          <CardActionFeedback
-            type='DANGER'
-            message={T.translate(`${PREFIX}.ingestFailMessage`)}
-            extendedMessage={this.state.error}
-          />
-        </ModalFooter>
+        <CardActionFeedback
+          type='DANGER'
+          message={T.translate(`${PREFIX}.ingestFailMessage`)}
+          extendedMessage={this.state.error}
+        />
       );
     }
     if (!this.state.copyInProgress) {
@@ -766,9 +764,8 @@ export default class IngestDataFromDataPrep extends Component {
           isOpen={this.state.showModal}
           size="md"
           backdrop="static"
-          keyboard={false}
           zIndex="1061"
-          className="dataprep-parse-modal create-dataset-modal"
+          className="cdap-modal dataprep-create-dataset-modal"
         >
           <ModalHeader>
             <span>

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/SchemaModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/SchemaModal.js
@@ -26,11 +26,13 @@ import MyDataPrepApi from 'api/dataprep';
 import DataPrepStore from 'components/DataPrep/store';
 import fileDownload from 'js-file-download';
 import NamespaceStore from 'services/NamespaceStore';
-import {objectQuery} from 'services/helpers';
+import {objectQuery, isNilOrEmpty} from 'services/helpers';
 import T from 'i18n-react';
 import {directiveRequestBodyCreator} from 'components/DataPrep/helper';
 import {execute} from 'components/DataPrep/store/DataPrepActionCreator';
 import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import CardActionFeedback from 'components/CardActionFeedback';
+import If from 'components/If';
 
 var SchemaEditor = Loadable({
   loader: () => import(/* webpackChunkName: "SchemaEditor" */ 'components/SchemaEditor'),
@@ -177,12 +179,6 @@ export default class SchemaModal extends Component {
     } else if (this.state.error) {
       content = (
         <div>
-          <div className="text-danger">
-            <span className="fa fa-exclamation-triangle"></span>
-            <span>
-              {typeof this.state.error === 'object' ? this.state.error.message : this.state.error}
-            </span>
-          </div>
           <div className="remedy-message">
               {
                 objectQuery(this.state, 'error', 'remedies') ? this.state.error.remedies : null
@@ -214,7 +210,7 @@ export default class SchemaModal extends Component {
         toggle={this.props.toggle}
         size="lg"
         zIndex="1061"
-        className="dataprep-schema-modal"
+        className="dataprep-schema-modal cdap-modal"
       >
         <ModalHeader>
           <span>
@@ -240,6 +236,13 @@ export default class SchemaModal extends Component {
         <ModalBody>
           {content}
         </ModalBody>
+        <If condition={this.state.error}>
+          <CardActionFeedback
+            type="DANGER"
+            message={!isNilOrEmpty(this.state.error) ? this.state.error.message : this.state.error}
+            extendedMessage={this.props.extendedMessage}
+          />
+        </If>
       </Modal>
     );
   }

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -14,11 +14,10 @@
  * the License.
  */
 
-$top-panel-connection-color: #999999;
-$action-btn-inactive-color: #aaaaaa;
-
 @import '../../../styles/variables.scss';
 
+$action-btn-inactive-color: #aaaaaa;
+$top-panel-connection-color: $grey-03;
 $dropdown_menu_color: $link-color;
 $dropdown_item_font_color: black;
 $success_alert_color: white;
@@ -27,7 +26,7 @@ $success_alert_bg_color: $brand-success;
 .dataprep-container {
   .top-panel {
     height: 50px;
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid $grey-05;
     margin-left: 0;
     display: flex;
 
@@ -211,7 +210,6 @@ $success_alert_bg_color: $brand-success;
 
 .add-to-pipeline-dataprep-modal.modal-dialog,
 .dataprep-upgrade-modal.modal-dialog {
-  margin-top: 100px;
 
   .modal-body {
     padding: 0;
@@ -247,10 +245,10 @@ $success_alert_bg_color: $brand-success;
         width: 50%;
         border-radius: 0;
         border: none;
-        border-top: 1px solid #cccccc;
+        border-top: 1px solid $grey-05;
         padding: 10px 0;
 
-        &:first-child { border-right: 1px solid #cccccc; }
+        &:first-child { border-right: 1px solid $grey-05; }
         .fa { margin-right: 10px; }
 
         &.inactive {
@@ -273,15 +271,10 @@ $success_alert_bg_color: $brand-success;
   }
 }
 .dataprep-schema-modal.modal-dialog {
-  margin-top: 100px;
   .modal-header {
-    .fa {
-      cursor: pointer;
-    }
-
     .btn.btn-link {
       padding: 0;
-      margin-right: 50px;
+      margin-right: 20px;
       color: inherit;
       font-size: inherit;
 
@@ -306,10 +299,6 @@ $success_alert_bg_color: $brand-success;
     .btn-link {
       cursor: pointer;
       color: var(--brand-primary-color);
-    }
-    .fa.fa-exclamation-triangle {
-      margin-right: 5px;
-      font-size: 15px;
     }
   }
 }

--- a/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTabs.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/WorkspaceTabs.scss
@@ -89,19 +89,7 @@ $workspace-link-active-color: var(--brand-primary-color);
 }
 
 .workspace-delete-confirmation {
-  .modal-header {
-    border-bottom: 0;
-
-    .close { opacity: 1; }
-  }
-
   .modal-body {
     h4 { margin-bottom: 15px; }
-
-    .action-buttons {
-      margin-top: 25px;
-
-      .btn { margin-right: 10px; }
-    }
   }
 }

--- a/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/WorkspaceTabs/index.js
@@ -26,7 +26,8 @@ import UncontrolledPopover from 'components/UncontrolledComponents/Popover';
 import {Link} from 'react-router-dom';
 import IconSVG from 'components/IconSVG';
 import classnames from 'classnames';
-import {Modal, ModalHeader, ModalBody} from 'reactstrap';
+import {Modal, ModalHeader, ModalBody, ModalFooter} from 'reactstrap';
+import ConfirmationModal from 'components/ConfirmationModal';
 import T from 'i18n-react';
 import findIndex from 'lodash/findIndex';
 import debounce from 'lodash/debounce';
@@ -164,7 +165,7 @@ export default class WorkspaceTabs extends Component {
     });
   }
 
-  toggleDeleteWorkspace(workspace) {
+  toggleDeleteWorkspace = (workspace) => {
     this.setState({deleteWorkspace: workspace});
   }
 
@@ -236,39 +237,25 @@ export default class WorkspaceTabs extends Component {
 
   renderWorkspaceDeleteConfirmation() {
     if (!this.state.deleteWorkspace) { return null; }
+    const ConfirmationElement = (
+      <>
+        <h5>{T.translate(`${PREFIX}.DeleteModal.mainMessage`, {workspace: this.state.deleteWorkspace.name})}</h5>
+        <div>{T.translate(`${PREFIX}.DeleteModal.helperMessage`)}</div>
+      </>
+    );
 
     return (
-      <Modal
-        backdrop="static"
+      <ConfirmationModal
+        confirmationElem={ConfirmationElement}
+        confirmButtonText={T.translate(`${PREFIX}.DeleteModal.confirmButton`)}
+        cancelButtonText={T.translate(`${PREFIX}.DeleteModal.cancelButton`)}
+        confirmFn={this.handleDeleteWorkspace.bind(this, this.state.deleteWorkspace.id)}
+        cancelFn={this.toggleDeleteWorkspace.bind(this, null)}
         isOpen={true}
-        toggle={this.toggleDeleteWorkspace.bind(this, null)}
-        className="workspace-delete-confirmation"
-      >
-        <ModalHeader toggle={this.toggleDeleteWorkspace.bind(this, null)}>
-          {T.translate(`${PREFIX}.DeleteModal.header`)}
-        </ModalHeader>
-
-        <ModalBody>
-          <h5>{T.translate(`${PREFIX}.DeleteModal.mainMessage`, {workspace: this.state.deleteWorkspace.name})}</h5>
-          <p>{T.translate(`${PREFIX}.DeleteModal.helperMessage`)}</p>
-
-          <div className="action-buttons">
-            <button
-              className="btn btn-primary"
-              onClick={this.handleDeleteWorkspace.bind(this, this.state.deleteWorkspace.id)}
-            >
-              {T.translate(`${PREFIX}.DeleteModal.confirmButton`)}
-            </button>
-
-            <button
-              className="btn btn-link"
-              onClick={this.toggleDeleteWorkspace.bind(this, null)}
-            >
-              {T.translate(`${PREFIX}.DeleteModal.cancelButton`)}
-            </button>
-          </div>
-        </ModalBody>
-      </Modal>
+        headerTitle={T.translate(`${PREFIX}.DeleteModal.header`)}
+        closeable={true}
+        toggleModal={this.toggleDeleteWorkspace.bind(this, null)}
+      />
     );
   }
 

--- a/cdap-ui/app/cdap/components/DataPrepConnections/BigQueryConnection/BigQueryConnection.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/BigQueryConnection/BigQueryConnection.scss
@@ -15,31 +15,8 @@
  */
 
 $asterisk-color: #d50000;
-$success-color: #00c853;
-$modal-header-bg-color: #efefef;
-$close-button-color: #333333;
 
 .modal-dialog.bigquery-connection-modal {
-  .modal-content { border-radius: 0; }
-
-  .modal-header {
-    border-bottom: none;
-    background-color: $modal-header-bg-color;
-
-    .modal-title { font-size: 16px; }
-
-    .close {
-      color: $close-button-color;
-      font-size: 23px;
-      opacity: 1;
-    }
-  }
-
-  .modal-footer {
-    padding: 0;
-    text-align: left;
-    border-top: 0;
-  }
 
   .bigquery-detail {
     .col-form-label {

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseConnection.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseConnection.scss
@@ -25,23 +25,6 @@ $db-sprite-url: url('/cdap_assets/img/db-sprite.png');
   background-position: 0 $index*-100px;
 }
 
-.modal-dialog.database-connection-modal {
-  .modal-content { border-radius: 0; }
-
-  .modal-header {
-    border-bottom: none;
-    background-color: $modal-header-bg-color;
-
-    .modal-title { font-size: 16px; }
-
-    .close {
-      color: $close-button-color;
-      font-size: 23px;
-      opacity: 1;
-    }
-  }
-}
-
 .database-options {
   .db-image-container,
   .db-info {

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
@@ -629,13 +629,6 @@ export default class DatabaseDetail extends Component {
         <div className="database-detail-content">
           {this.renderDriverInfo()}
 
-          <div className="row">
-            <div className="col-xs-12 text-xs-right">
-              <span className="asterisk">*</span>
-              <em>{T.translate(`${PREFIX}.required`)}</em>
-            </div>
-          </div>
-
           <form onSubmit={this.preventDefault}>
             <div className="form-group row">
               <label className={LABEL_COL_CLASS}>

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/index.js
@@ -148,7 +148,7 @@ export default class DatabaseConnection extends Component {
           isOpen={true}
           toggle={this.props.close}
           size="lg"
-          className="database-connection-modal"
+          className="database-connection-modal cdap-modal"
           backdrop="static"
           zIndex="1061"
         >

--- a/cdap-ui/app/cdap/components/DataPrepConnections/GCSConnection/GCSConnection.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/GCSConnection/GCSConnection.scss
@@ -20,26 +20,6 @@ $modal-header-bg-color: #efefef;
 $close-button-color: #333333;
 
 .modal-dialog.gcs-connection-modal {
-  .modal-content { border-radius: 0; }
-
-  .modal-header {
-    border-bottom: none;
-    background-color: $modal-header-bg-color;
-
-    .modal-title { font-size: 16px; }
-
-    .close {
-      color: $close-button-color;
-      font-size: 23px;
-      opacity: 1;
-    }
-  }
-
-  .modal-footer {
-    padding: 0;
-    text-align: left;
-    border-top: 0;
-  }
 
   .gcs-detail {
     .col-form-label {

--- a/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/KafkaConnection.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/KafkaConnection/KafkaConnection.scss
@@ -20,25 +20,9 @@ $modal-header-bg-color: #efefef;
 $close-button-color: #333333;
 
 .kafka-connection-modal.modal-dialog {
-  .modal-content { border-radius: 0; }
-
-  .modal-header {
-    border-bottom: none;
-    background-color: $modal-header-bg-color;
-
-    .modal-title { font-size: 16px; }
-
-    .close {
-      color: $close-button-color;
-      font-size: 23px;
-      opacity: 1;
-    }
-  }
-
-  .modal-footer {
-    padding: 0;
-    text-align: left;
-    border-top: 0;
+  .modal-body {
+    max-height: 50vh;
+    overflow-y: auto;
   }
 
   .kafka-detail {

--- a/cdap-ui/app/cdap/components/DataPrepConnections/S3Connection/S3Connection.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/S3Connection/S3Connection.scss
@@ -20,26 +20,6 @@ $modal-header-bg-color: #efefef;
 $close-button-color: #333333;
 
 .modal-dialog.s3-connection-modal {
-  .modal-content { border-radius: 0; }
-
-  .modal-header {
-    border-bottom: none;
-    background-color: $modal-header-bg-color;
-
-    .modal-title { font-size: 16px; }
-
-    .close {
-      color: $close-button-color;
-      font-size: 23px;
-      opacity: 1;
-    }
-  }
-
-  .modal-footer {
-    padding: 0;
-    text-align: left;
-    border-top: 0;
-  }
 
   .s3-detail {
     .col-form-label {

--- a/cdap-ui/app/cdap/styles/bootstrap_4_patch.scss
+++ b/cdap-ui/app/cdap/styles/bootstrap_4_patch.scss
@@ -39,21 +39,6 @@
         }
       }
     }
-    .modal-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      clear: both;
-      width: 100%;
-      h5 {
-        width: 100%;
-      }
-      button.close {
-        float: right;
-        padding: 1rem;
-        margin: -1rem -1rem -1rem auto;
-      }
-    }
   }
   .modal-backdrop.fade.show {
     opacity: 0.5;

--- a/cdap-ui/app/cdap/styles/common.scss
+++ b/cdap-ui/app/cdap/styles/common.scss
@@ -16,6 +16,7 @@
 
 @import "./fonts";
 @import "./variables.scss";
+@import "./modals.scss";
 
 /*
 NOTE: Always define CSS variables here (global scope). This is because if the

--- a/cdap-ui/app/cdap/styles/modals.scss
+++ b/cdap-ui/app/cdap/styles/modals.scss
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@import "./variables.scss";
+
+$header-color: $modal-header-color;
+$modal-spacing: 10px;
+
+.cdap-modal.modal-dialog {
+  margin-top: 125px;
+  .modal-content {
+    border-radius: 0;
+    border: 0;
+  }
+
+  .modal-header {
+    padding: 0 $modal-spacing;
+    background-color: $header-color;
+    border-bottom: 0;
+    height: 40px;
+    display: flex;
+    align-items: center;
+
+    .modal-title {
+      font-weight: normal;
+      font-size: 14px;
+      color: white;
+      line-height: 40px;
+      width: 100%;
+      .fa,
+      .icon-svg {
+        cursor: pointer;
+      }
+    }
+    button.close {
+      background: transparent;
+      border: 0;
+      color: white;
+      font-weight: bold;
+      font-size: 18px;
+      opacity: 1;
+      text-shadow: none;
+      padding: 0;
+      float: none;
+      margin: 0;
+      &:hover,
+      &:active,
+      &:focus {
+        outline: none;
+      }
+    }
+  }
+
+  .modal-body {
+    padding: $modal-spacing;
+
+    &.loading {
+      padding: 25px;
+      h3 {
+        margin: 0;
+        font-size: 45px;
+      }
+    }
+  }
+  .modal-footer {
+    text-align: left;
+    padding: $modal-spacing;
+    .btn {
+      margin: 0;
+      &:first-of-type {
+        margin-right: $modal-spacing;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -665,6 +665,7 @@ features:
           pipe: Pipe
           tab: Tab
           whitespace: Whitespace
+      failedApplyDirectiveMessage: Failed to apply directive. Please modify input and try again #temporary fallback until backend sends non-null error
       FillNullOrEmpty:
         title: Fill null or empty cells
       Filter:
@@ -1044,7 +1045,6 @@ features:
           EDIT: "Edit connection: {connection}"
         name: Name
         projectId: Project ID
-        required: Required
         serviceAccountKeyfile: Service account key file location
         testConnection: Test Connection
       Database:
@@ -1125,7 +1125,6 @@ features:
         testConnection: Test Connection
         zkQuorum: Zookeeper host
         zookeeper: Zookeeper
-
       label: Add Connection
       Popover:
         title: Select a source to connect
@@ -1149,6 +1148,9 @@ features:
         region: Region
         required: Required
         testConnection: Test Connection
+      TestConnectionLabels:
+        danger: Test connection failed
+        success: Test connection succcessful
     bigquery: Google BigQuery ({count})
 
     ConnectionManagement:

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -17,6 +17,7 @@
 @import (less) "./fonts.less"; // must be first to support external @import (css)
 @import (less) "./variables.less";
 @import (less) "../../bower_components/bootstrap/less/mixins.less";
+@import (less) "./modals.less";
 
 /*
 NOTE: Need to have these definitions here so that these CSS variables have default

--- a/cdap-ui/app/styles/modals.less
+++ b/cdap-ui/app/styles/modals.less
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@import (less) "./variables.less";
+@header-color: @modal-header-color;
+@modal-spacing: 10px;
+
+.cdap-modal.modal-dialog {
+  margin-top: 125px;
+  .modal-content {
+    border-radius: 0;
+    border: 0;
+  }
+
+  .modal-header {
+    padding: 0 @modal-spacing;
+    background-color: @header-color;
+    border-bottom: 0;
+    height: 40px;
+    display: flex;
+    align-items: center;
+
+    .modal-title {
+      font-weight: normal;
+      font-size: 14px;
+      color: white;
+      line-height: 40px;
+      width: 100%;
+      .fa {
+        cursor: pointer;
+      }
+    }
+    button.close {
+      background: transparent;
+      border: 0;
+      color: white;
+      font-weight: bold;
+      font-size: 18px;
+      opacity: 1;
+      text-shadow: none;
+      padding: 0;
+      float: none;
+      margin: 0;
+      &:hover,
+      &:active,
+      &:focus {
+        outline: none;
+      }
+    }
+  }
+
+  .modal-body {
+    padding: @modal-spacing;
+
+    &.loading {
+      padding: 25px;
+      h3 {
+        margin: 0;
+        font-size: 45px;
+      }
+    }
+  }
+  .modal-footer {
+    text-align: left;
+    padding: @modal-spacing;
+    .btn {
+      margin: 0;
+      &:first-of-type {
+        margin-right: @modal-spacing;
+      }
+    }
+
+  }
+}

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -162,3 +162,6 @@
 
 @brand-primary-color: #3b78e7;
 @navbar-bg: #333333;
+
+// MODALS/WIZARDS
+@modal-header-color: rgba(70, 74, 87, 1); // #464a57


### PR DESCRIPTION
- Fixes modals to be consistent in following features in UI,
  - Dataprep directives (parse, extract fields, filter)
  - Dataprep ingest data, viewing schema, add to pipeline modals
  - Delete dataprep workspace
  - Dataprep connections (BigQuery, GCS, S3, Kafka, Database)

- Things still pending,
  - Delete connection modal (missed in this PR)
  - Error handling in database connections modal is not done right yet. Will require a slightly bigger change (database connections vs database connection detail)
  - Modal styling changes in pipelines is not done yet. Not a straight forward change.

JIRA:
https://issues.cask.co/browse/CDAP-12895
https://issues.cask.co/browse/CDAP-14163
https://issues.cask.co/browse/CDAP-11791

Build: https://builds.cask.co/browse/CDAP-UDUT53