### PR TITLE
CDAP-14156 fix flaky preview test

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -167,9 +167,10 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
             public void run() {
               try {
                 LOG.info("Stopping the preview since it has reached running time: {} mins.", timeOutMinutes);
-                stopPreview();
                 killedByTimer = true;
+                stopPreview();
               } catch (Exception e) {
+                killedByTimer = false;
                 LOG.debug("Error shutting down the preview run with id: {}", programId);
               }
             }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14156
Build: https://builds.cask.co/browse/CDAP-DUT6592-1

Thanks @sagarkapare for the investigation.
The preview stream test fails because of the race condition:
1. We stop the preview run after 1 min of running.
2. Set the volatile flag killedByTimer to true to indicate that the current stop is because of the timer event. https://github.com/caskdata/cdap/blob/develop/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewRunner.java#L170

If the listener is called after step 1 but before setting the flag, the run is recorded as KILLED - https://github.com/caskdata/cdap/blob/develop/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewRunner.java#L190

We can set the flag to true before we call stop() and set it back if we fail to stop the program.