### PR TITLE
[CDAP-14146] Fixes pipeline summary to use starting time of a run instead of start time to include provisioning time

### DIFF
--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
@@ -126,7 +126,7 @@ export default class HistoryTab extends Component {
               return (
                 <tr key={history.runid}>
                   <td>{history.programName}</td>
-                  <td>{history.start ? humanReadableDate(history.start) : '--'}</td>
+                  <td>{history.starting ? humanReadableDate(history.starting) : '--'}</td>
                   <td>{history.runid}</td>
                   <td>{StatusMapper.lookupDisplayStatus(history.status)}</td>
                   <td>

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsList/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsList/index.js
@@ -41,11 +41,11 @@ const GRID_HEADERS = [
     label: T.translate(`${PREFIX}.type`)
   },
   {
-    property: 'start',
+    property: 'starting',
     label: T.translate(`${PREFIX}.start`)
   },
   {
-    property: (run) => run.end ? run.end - run.start : 0,
+    property: (run) => run.end ? run.end - run.starting : 0,
     label: T.translate(`${PREFIX}.duration`)
   },
   {
@@ -74,7 +74,7 @@ function renderBody(data) {
 
           const displayStatus = StatusMapper.lookupDisplayStatus(run.status) || '';
 
-          let startTime = run.running || run.start;
+          let startTime = run.running || run.starting;
           startTime = humanReadableDate(startTime, false);
 
           const user = run.user || '--';
@@ -89,7 +89,7 @@ function renderBody(data) {
           return (
             <div
               className="grid-row"
-              key={`${run.application.name}${run.program}${run.start}${i}`}
+              key={`${run.application.name}${run.program}${run.starting}${i}`}
             >
               <div title={run.namespace}>
                 {run.namespace}

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineStopButton/PipelineStopPopover.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineStopButton/PipelineStopPopover.js
@@ -153,8 +153,8 @@ export default class PipelineStopPopover extends Component {
               {
                 this.props.runs.map((run, i) => {
                   let runStartTime;
-                  if (run.start) {
-                    runStartTime = moment.unix(run.start).calendar();
+                  if (run.starting) {
+                    runStartTime = moment.unix(run.starting).calendar();
                   } else {
                     runStartTime = '--';
                   }
@@ -175,7 +175,7 @@ export default class PipelineStopPopover extends Component {
                       <td>{runStartTime}</td>
                       <td>
                         <Duration
-                          targetTime={run.start}
+                          targetTime={run.starting}
                           isMillisecond={false}
                           showFullDuration={true}
                         />

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunDuration.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunDuration.js
@@ -35,13 +35,13 @@ const RunDuration = ({currentRun}) => {
     if (currentRun.end) {
       DurationComp = (
         <span>
-          {`${humanReadableDuration(currentRun.end - currentRun.start)}`}
+          {`${humanReadableDuration(currentRun.end - currentRun.starting)}`}
         </span>
       );
     } else {
       DurationComp = (
         <Duration
-          targetTime={currentRun.start}
+          targetTime={currentRun.starting}
           isMillisecond={false}
           showFullDuration={true}
         />
@@ -55,7 +55,7 @@ const RunDuration = ({currentRun}) => {
       </div>
       <span>
         {
-          currentRun && currentRun.start ?
+          currentRun && currentRun.starting ?
             DurationComp
           :
             '--'

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunNumErrors.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunNumErrors.js
@@ -37,7 +37,7 @@ const RunNumErrorsComp = ({logsMetrics, currentRun}) => {
       </div>
       <span>
         {
-          currentRun && currentRun.start ?
+          currentRun && currentRun.starting ?
             `${logsMetrics['system.app.log.error'] || 0}`
           :
             '--'

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunNumWarnings.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunNumWarnings.js
@@ -37,7 +37,7 @@ const RunNumWarningsComp = ({logsMetrics, currentRun}) => {
       </div>
       <span>
         {
-          currentRun && currentRun.start ?
+          currentRun && currentRun.starting ?
             `${logsMetrics['system.app.log.warn'] || 0}`
           :
             '--'

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunStartTime.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunStartTime.js
@@ -36,8 +36,8 @@ const RunStartTime = ({currentRun}) => {
       </div>
       <span>
         {
-          currentRun && currentRun.start ?
-            `${humanReadableDate(currentRun.start)}`
+          currentRun ?
+            `${humanReadableDate(currentRun.starting)}`
           :
             '--'
         }

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunningRunsPopover/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunningRunsPopover/index.js
@@ -94,10 +94,10 @@ export default function RunningRunsPopover({runs, currentRunId, pipelineId}) {
                         null
                     }
                   </td>
-                  <td>{moment.unix(run.start).calendar()}</td>
+                  <td>{moment.unix(run.starting).calendar()}</td>
                   <td>
                     <Duration
-                      targetTime={run.start}
+                      targetTime={run.starting}
                       isMillisecond={false}
                       showFullDuration={true}
                     />

--- a/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/LogsMetricsGraph/index.js
@@ -114,7 +114,7 @@ export default class LogsMetricsGraph extends Component {
         x = x + (i + 1);
       }
       if (xDomainType === 'time') {
-        x = run.start;
+        x = run.starting;
       }
       warnings.push({
         x,
@@ -269,7 +269,7 @@ export default class LogsMetricsGraph extends Component {
                   }
                   <div>
                     <strong>{T.translate(`${PREFIX}.hint.startTime`)}: </strong>
-                    <span>{ moment(popOverData.start * 1000).format('llll')}</span>
+                    <span>{ moment(popOverData.starting * 1000).format('llll')}</span>
                   </div>
                 </Hint>
               )
@@ -316,7 +316,7 @@ export default class LogsMetricsGraph extends Component {
                   <td>
                     <a href={logUrl} target="_blank">{T.translate(`${PREFIX}.table.body.viewLog`)} </a>
                   </td>
-                  <td> {moment(run.start * 1000).format('llll')}</td>
+                  <td> {moment(run.starting * 1000).format('llll')}</td>
                 </tr>
               );
             })
@@ -331,7 +331,7 @@ export default class LogsMetricsGraph extends Component {
         index: i + 1,
         warnings: objectQuery(run, 'logsMetrics', 'system.app.log.warn') || 0,
         errors: objectQuery(run, 'logsMetrics', 'system.app.log.error') || 0,
-        start: run.start
+        start: run.starting
       });
     });
     return (

--- a/cdap-ui/app/cdap/components/PipelineSummary/NodesMetricsGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/NodesMetricsGraph/index.js
@@ -80,7 +80,6 @@ export default class NodesMetricsGraph extends Component {
     let activeNode = Object.keys(this.props.nodesMap).pop();
     let activeNodeRuns = this.props.nodesMap[activeNode].map((run, i) => ({
       ...run,
-      start: run.start || run.starting,
       index: i + 1
     }));
     this.setState({
@@ -92,7 +91,6 @@ export default class NodesMetricsGraph extends Component {
     let activeNodeRuns = objectQuery(this.state.nodesMap, activeNode).map((run, i) => ({
       ...run,
       index: i + 1,
-      start: run.start || run.starting
     }));
     this.setState({
       activeNode,
@@ -158,7 +156,7 @@ export default class NodesMetricsGraph extends Component {
                   <td>
                     <span>{record.numberOfRecords}</span>
                   </td>
-                  <td> {moment(record.start * 1000).format('llll')}</td>
+                  <td> {moment(record.starting * 1000).format('llll')}</td>
                 </tr>
               );
             })

--- a/cdap-ui/app/cdap/components/PipelineSummary/NodesRecordsGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/NodesRecordsGraph/index.js
@@ -82,7 +82,7 @@ export default class NodesRecordsGraph extends Component {
         x = x + (id + 1);
       }
       if (xDomainType === 'time') {
-        x = run.start || run.starting;
+        x = run.starting;
       }
       return {
         x,
@@ -181,7 +181,7 @@ export default class NodesRecordsGraph extends Component {
                   }
                   <div>
                     <strong>{T.translate(`${PREFIX}.hint.startTime`)}: </strong>
-                    <span>{ moment(popOverData.start * 1000).format('llll')}</span>
+                    <span>{ moment(popOverData.starting * 1000).format('llll')}</span>
                   </div>
                 </Hint>
               )

--- a/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
@@ -94,7 +94,7 @@ $min_height_of_graph: 340px;
     border: 1px solid $summary_border_color;
     > div {
       &:nth-child(1) {
-        flex: 0.2;
+        flex: 1;
         font-size: 16px;
         font-weight: 500;
       }

--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
@@ -36,7 +36,6 @@ import SortableStickyTable from 'components/SortableStickyTable';
 import ee from 'event-emitter';
 import EmptyMessageContainer from 'components/PipelineSummary/EmptyMessageContainer';
 import isEqual from 'lodash/isEqual';
-import isNil from 'lodash/isNil';
 import StatusMapper from 'services/StatusMapper';
 
 require('./RunsHistoryGraph.scss');
@@ -128,7 +127,7 @@ export default class RunsHistoryGraph extends Component {
         x = x + (id + 1);
       }
       if (xDomainType === 'time') {
-        x = isNil(run.start) ? 0 : run.start;
+        x = run.starting;
       }
       return {
         x,
@@ -280,7 +279,7 @@ export default class RunsHistoryGraph extends Component {
                   }
                   <div>
                     <strong>{T.translate(`${PREFIX}.hint.startTime`)}: </strong>
-                    <span>{moment(popOverData.start * 1000).format('llll')}</span>
+                    <span>{moment(popOverData.starting * 1000).format('llll')}</span>
                   </div>
                 </Hint>
               )
@@ -312,7 +311,7 @@ export default class RunsHistoryGraph extends Component {
         <tbody>
           {
             runs.map(run => {
-              let startTime = run.start ? moment(run.start * 1000).format('llll') : '--';
+              let startTime = moment(run.starting * 1000).format('llll');
               let duration = humanReadableDuration(run.duration || 0);
 
               return (

--- a/cdap-ui/app/cdap/components/PipelineSummary/Store/PipelineSummaryActions.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/Store/PipelineSummaryActions.js
@@ -32,7 +32,7 @@ function setRuns(runs) {
         starting: run.starting,
         end: run.end,
         // If the pipeline is starting there is either start nor end times.
-        duration: isNil(run.start) ? 0 : isNil(run.end) ? (Math.ceil(Date.now()/1000) - run.start) : (run.end - run.start),
+        duration: isNil(run.end) ? (Math.ceil(Date.now()/1000) - run.starting) : (run.end - run.starting),
         status: run.status
       }))
     }

--- a/cdap-ui/app/cdap/components/PipelineSummary/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/index.js
@@ -184,18 +184,20 @@ export default class PipelineSummary extends Component {
       let {runs, loading, nodesMap, nodeMetricsLoading} = PipelineSummaryStore.getState().pipelinerunssummary;
       runs = runs.map(run => ({
         ...run,
-        start: run.start || run.starting
+        starting: run.starting,
       }));
       let logsMetrics = runs.map(run => ({
         runid: run.runid,
         logsMetrics: run.logsMetrics || {},
         start: run.start,
+        starting: run.starting,
         end: run.end
       }));
       runs = runs.map(run => ({
         runid: run.runid,
         duration: run.duration,
         start: run.start,
+        starting: run.starting,
         end: run.end,
         status: run.status
       }));
@@ -211,8 +213,8 @@ export default class PipelineSummary extends Component {
           let start, end;
           // Will happen if chosen 'Since Inception' as UI doesn't know a start and end beforehand.
           if (isNil(this.state.start) || isNil(this.state.end)) {
-            end = runs[0].start;
-            start = runs[runs.length - 1].start;
+            end = runs[0].starting;
+            start = runs[runs.length - 1].starting;
           }
           return !isNil(start) && !isNil(end) ? {start, end} : {};
         };

--- a/cdap-ui/app/cdap/components/ProgramTable/index.js
+++ b/cdap-ui/app/cdap/components/ProgramTable/index.js
@@ -42,7 +42,7 @@ const tableHeaders = [
   {
     property: 'latestRun',
     label: T.translate('features.ViewSwitch.ProgramTable.lastStartedLabel'),
-    sortFunc: (entity) => { return moment(entity.latestRun.start).valueOf(); }
+    sortFunc: (entity) => { return moment(entity.latestRun.starting).valueOf(); }
   },
   {
     property: 'status',
@@ -114,7 +114,7 @@ export default class ProgramTable extends Component {
                 </td>
                 <td>
                   {
-                    !isEmpty(program.latestRun) ? humanReadableDate(program.latestRun.start) : 'n/a'
+                    !isEmpty(program.latestRun) ? humanReadableDate(program.latestRun.starting) : 'n/a'
                   }
                 </td>
                 <td className={statusClass}>

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1953,7 +1953,7 @@ features:
     statsContainer:
       avgRunTime: Average duration
       totalRuns: Total runs
-    title: 'Summary'
+    title: 'Summary (Max: 100 runs)'
 
   PipelineTriggers:
     collapsedTabLabel: "Show inbound triggers ({count})"

--- a/cdap-ui/app/hydrator/controllers/list-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/list-ctrl.js
@@ -183,7 +183,7 @@ angular.module(PKG.name + '.feature.hydrator')
         .then(function (runs) {
           if (runs.length) {
             app._stats.numRuns = runs.length;
-            app._stats.lastStartTime = runs.length > 0 ? runs[0].start : 'N/A';
+            app._stats.lastStartTime = runs.length > 0 ? runs[0].starting : 'N/A';
             var currentRun = runs[0];
             setDuration(app, currentRun);
             app._latest = currentRun;


### PR DESCRIPTION
- Fixes pipeline summary to use starting time as opposed to start time while showing summary of a pipeline.
- Modifies the title of pipeline summary to indicate the summary is only for 100 runs maximum. 

@bdmogal `title: 'Summary (100 Runs at maximum)'` is what I have used. Let me know if you want something else. I feel `Summary (Latest 100 runs)` would be more straight forward. Let me know if it makes. I can change.

JIRA:
https://issues.cask.co/browse/CDAP-14146
https://issues.cask.co/browse/CDAP-14094

Build: 
https://builds.cask.co/browse/CDAP-UDUT54