### PR TITLE
More trace logging for Dataset Service

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/CoreSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/CoreSchedulerService.java
@@ -79,6 +79,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -122,6 +123,12 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
     this.impersonator = impersonator;
     // Use a retry on failure service to make it resilience to transient service unavailability during startup
     this.internalService = new RetryOnStartFailureService(() -> new AbstractIdleService() {
+
+      @Override
+      protected Executor executor(final State state) {
+        return command -> new Thread(command, "core scheduler service " + state).start();
+      }
+
       @Override
       protected void startUp() throws Exception {
         if (!datasetFramework.hasInstance(Schedulers.STORE_DATASET_ID)) {

--- a/cdap-common/src/test/resources/logback-test.xml
+++ b/cdap-common/src/test/resources/logback-test.xml
@@ -36,6 +36,7 @@
     <logger name="co.cask.cdap" level="DEBUG" />
     <logger name="co.cask.cdap.app.runtime.spark.SparkProgramRunner" level="TRACE"/>
     <logger name="co.cask.cdap.data2.datafabric.dataset.DatasetServiceClient" level="TRACE"/>
+    <logger name="co.cask.cdap.data2.datafabric.dataset.service.DatasetService" level="TRACE"/>
     <logger name="co.cask.cdap.data2.datafabric.dataset.service.DatasetInstanceHandler" level="TRACE"/>
     <logger name="co.cask.cdap.data2.datafabric.dataset.service.DatasetInstanceService" level="TRACE"/>
     <logger name="co.cask.cdap.data2.datafabric.dataset.service.executor.RemoteDatasetOpExecutor" level="TRACE"/>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -178,10 +178,9 @@ public class DatasetInstanceService {
   }
 
   /**
-   * Gets a dataset instance.
+   * Gets the metadata for a dataset instance.
    *
    * @param instance instance to get
-   * @param owners the {@link EntityId entities} that will be using the dataset instance
    * @return the dataset instance's {@link DatasetMeta}
    * @throws NotFoundException if either the namespace or dataset instance is not found,
    * @throws IOException if there is a problem in making an HTTP request to check if the namespace exists
@@ -267,7 +266,6 @@ public class DatasetInstanceService {
     if (spec == null) {
       throw new NotFoundException(instance);
     }
-
     return DatasetsUtil.fixOriginalProperties(spec).getOriginalProperties();
   }
 
@@ -288,9 +286,6 @@ public class DatasetInstanceService {
     DatasetId datasetId = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
     Principal requestingUser = authenticationContext.getPrincipal();
     String ownerPrincipal = props.getOwnerPrincipal();
-
-    LOG.info("Received request to create dataset {}.{}, type name: {}, properties: {}",
-             namespaceId, name, props.getTypeName(), props.getProperties());
 
     // need to enforce on the principal id if impersonation is involved
     KerberosPrincipalId effectiveOwner = SecurityUtil.getEffectiveOwner(ownerAdmin, namespace, ownerPrincipal);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
@@ -206,8 +206,9 @@ public abstract class NettyRouterTestBase {
         public void onThrowable(Throwable t) {
           LOG.error("Got exception while posting {}", elem, t);
           latch.countDown();
+
         }
-     });
+      });
 
       // Sleep so as not to overrun the server.
       TimeUnit.MILLISECONDS.sleep(1);


### PR DESCRIPTION
- log all requests in dataset service client and handler
- add a header with the callers thread name and log that on the server side 
- log requests in netty pipeline before they are routed to a handler
- log thread dump in dataset service client in case of timeout
- misc minor fixes
