### PR TITLE
[CDAP-13996] Disables Ingest Data option for uploaded file in DataPrep

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -151,6 +151,10 @@ $success_alert_bg_color: $brand-success;
                 margin-left: 5px;
               }
             }
+            &.disabled {
+              cursor: not-allowed;
+              opacity: 0.5;
+            }
           }
         }
       }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -966,6 +966,7 @@ features:
           Step2Error: 'Unable to submit copy task.'
         createBtnLabel: Ingest Data
         description: You are creating a new dataset, select a type and enter information about this new entity
+        disabledTooltip: The Ingest Data option is unavailable for uploaded files.
         Form:
           datasetNameLabel: Dataset name
           datasetTooltip: Name of the dataset to copy to


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13996
Build: https://builds.cask.co/browse/CDAP-UDUT55

When we show the contents of a file uploaded to DataPrep, we will disable the 'Ingest Data' button. When the user hovers over it, the tooltip is `The 'Ingest Data' option is unavailable for uploaded files.`