### PR TITLE
[CDAP-14178] AppFabricTestBase to set HTTP timeout and properly close its HTTP clients

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/RunRecordCorrectorService.java
@@ -155,7 +155,8 @@ public abstract class RunRecordCorrectorService extends AbstractIdleService {
   protected void startUp() throws Exception {
     LOG.info("Starting RunRecordCorrectorService");
 
-    localDatasetDeleterService = Executors.newScheduledThreadPool(1);
+    localDatasetDeleterService = Executors
+      .newSingleThreadScheduledExecutor(r -> new Thread(r, "local dataset deleter"));
     long interval = cConf.getLong(Constants.AppFabric.LOCAL_DATASET_DELETER_INTERVAL_SECONDS);
     if (interval <= 0) {
       LOG.warn("Invalid interval specified for the local dataset deleter {}. Setting it to 3600 seconds.", interval);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -40,7 +40,6 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProfileId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.profile.Profile;
-import co.cask.cdap.runtime.spi.profile.ProfileStatus;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonArray;
@@ -51,6 +50,7 @@ import org.jboss.resteasy.util.HttpResponseCodes;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -306,7 +306,9 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
   public void testDeployInvalid() throws Exception {
     HttpResponse response = deploy(String.class, 400, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
     Assert.assertNotNull(response.getEntity());
-    Assert.assertTrue(response.getEntity().getContentLength() > 0);
+    try (InputStream responseContent = response.getEntity().getContent()) {
+      Assert.assertNotEquals(-1, responseContent.read());
+    }
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <hbase98.version>0.98.6.1-hadoop2</hbase98.version>
     <hive.version>1.2.1</hive.version>
     <hsql.version>2.2.4</hsql.version>
-    <http.component.version>4.2.5</http.component.version>
+    <http.component.version>4.3.2</http.component.version>
     <javamail.version>1.4.1</javamail.version>
     <jsch.version>0.1.54</jsch.version>
     <jetty.version>6.1.22</jetty.version>


### PR DESCRIPTION
I noticed in one of the test cases that the build hung because a request to AppFabric was waiting forever. 
- Adding HTTP timeout is much easier in version 4.3.2 of apache http clients, because it adds a config builder and a client builder
- Turns out that HTTP clients need to be closed. That would be a huge change throughout all the test cases, because the client can only be closed after the response has been read, and the existing doPut/doPost/etc. methods in AppFabricTestBase all create a new client, then execute the request and pass the response back to the caller. So, the caller would have to close the HTTP client. Do minimize the change right now, I keep track of all HTTP clients that are created and close all of them after each test case. It's kind of a hack but seems to work.

Also added a small change to name the local dataset deleter thread properly. 

Created https://issues.cask.co/browse/CDAP-14180 to make HTTP requests uniform across all modules. 
