### PR TITLE
add packer googlecompute builder

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -7,7 +7,9 @@
     "azure_client_secret": "{{env `ARM_CLIENT_SECRET`}}",
     "azure_resource_group": "{{env `ARM_RESOURCE_GROUP`}}",
     "azure_storage_account": "{{env `ARM_STORAGE_ACCOUNT`}}",
-    "azure_subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
+    "azure_subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+    "gcp_account_file": "{{env `GCP_ACCOUNT_FILE`}}",
+    "gcp_project_id": "{{env `GCP_PROJECT_ID`}}"
   },
   "builders": [
     {
@@ -98,6 +100,18 @@
       "location": "West US",
       "vm_size": "Standard_DS1_v2",
       "name": "cdap-cloud-sandbox-azure"
+    },
+    {
+      "type": "googlecompute",
+      "account_file": "{{user `gcp_account_file`}}",
+      "project_id": "{{user `gcp_project_id`}}",
+      "source_image": "ubuntu-1604-xenial-v20180814",
+      "source_image_family": "ubuntu-1604-lts",
+      "source_image_project_id": "ubuntu-os-cloud",
+      "ssh_username": "packer",
+      "zone": "us-central1-a",
+      "name": "cdap-cloud-sandbox-gcp",
+      "use_internal_ip": "true"
     }
   ],
   "provisioners": [

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -3,6 +3,9 @@
     "version": "{{VERSION}}",
     "sdk": {
       "url": "{{URI}}"
+    },
+    "cdap_site": {
+      "dashboard.bind.address": "0.0.0.0"
     }
   },
   "nodejs": {

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -1,6 +1,9 @@
 {
   "cdap": {
-    "version": "5.1.0-1"
+    "version": "5.1.0-1",
+    "cdap_site": {
+      "dashboard.bind.address": "0.0.0.0"
+    }
   },
   "nodejs": {
     "install_method": "binary",


### PR DESCRIPTION
Add googlecompute builder for Packer. 

Note: Because of https://issues.cask.co/browse/CDAP-14110, `dashboard.bind.address` was updated to  `0.0.0.0`. This is needed to test how the released image would act. Once the value is reverted from the JIRA the `dashboard.bind.address` properties can be removed. 