### PR TITLE
[CDAP-13429] Fixes schema modal in DataPrep to correctly show nullable fields

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/SchemaModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/SchemaModal.js
@@ -96,9 +96,8 @@ export default class SchemaModal extends Component {
           fields: res
         };
 
-        let fields;
         try {
-          fields = getParsedSchemaForDataPrep(tempSchema);
+          getParsedSchemaForDataPrep(tempSchema);
         } catch (e) {
           let {message, remedies = null} = mapErrorToMessage(e);
           this.setState({
@@ -106,10 +105,11 @@ export default class SchemaModal extends Component {
             loading: false
           });
         }
+
         SchemaStore.dispatch({
           type: 'FIELD_UPDATE',
           payload: {
-            schema: { fields }
+            schema: tempSchema
           }
         });
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13429
Build: https://builds.cask.co/browse/CDAP-UDUT60

So in the code previously we were parsing the `tempSchema` object to check if it's a valid schema, which is the right thing to do. However, after parsing we need to pass the original object to the store, not the parsed object. Another component will take this object in the store and parse it later, so before we were parsing it twice basically.