### PR TITLE
Do PipelineSpec generation of DataPipelineApp in the Workflow rather than the App

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
@@ -57,7 +57,7 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
     ETLBatchConfig config = getConfig();
     setDescription(Objects.firstNonNull(config.getDescription(), DEFAULT_DESCRIPTION));
 
-    addWorkflow(new SmartWorkflow(config, supportedPluginTypes, getConfigurer(), config.getEngine()));
+    addWorkflow(new SmartWorkflow(config, supportedPluginTypes, getConfigurer()));
 
     String timeSchedule = config.getSchedule();
     if (timeSchedule != null) {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
@@ -57,15 +57,7 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
     ETLBatchConfig config = getConfig();
     setDescription(Objects.firstNonNull(config.getDescription(), DEFAULT_DESCRIPTION));
 
-    BatchPipelineSpec spec = new BatchPipelineSpecGenerator<>(getConfigurer(),
-                                                              ImmutableSet.of(BatchSource.PLUGIN_TYPE),
-                                                              ImmutableSet.of(BatchSink.PLUGIN_TYPE,
-                                                                              SparkSink.PLUGIN_TYPE,
-                                                                              AlertPublisher.PLUGIN_TYPE),
-                                                              config.getEngine())
-      .generateSpec(config);
-
-    addWorkflow(new SmartWorkflow(spec, supportedPluginTypes, getConfigurer(), config.getEngine()));
+    addWorkflow(new SmartWorkflow(config, supportedPluginTypes, getConfigurer(), config.getEngine()));
 
     String timeSchedule = config.getSchedule();
     if (timeSchedule != null) {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -327,7 +327,8 @@ public class DataPipelineTest extends HydratorTestBase {
         }
       }
     }
-    Assert.assertEquals(expectedLines, actualLines);
+    Assert.assertEquals(expectedLines.size(), actualLines.size());
+    Assert.assertTrue(expectedLines.containsAll(actualLines) && actualLines.containsAll(expectedLines));
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -110,6 +110,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -328,7 +329,7 @@ public class DataPipelineTest extends HydratorTestBase {
       }
     }
     Assert.assertEquals(expectedLines.size(), actualLines.size());
-    Assert.assertTrue(expectedLines.containsAll(actualLines) && actualLines.containsAll(expectedLines));
+    CollectionUtils.isEqualCollection(expectedLines, actualLines);
   }
 
   @Test


### PR DESCRIPTION
### Summary
- Moves the BatchPipelineSpec generation to the Workflow of the app so that later identified plugins can be stored in Workflow specification. (This will be the next PR)
- Fixes flakiness in DataPipelineTest testExternalSparkProgramPipelines() 

Issue:
- https://issues.cask.co/browse/CDAP-13924
- https://issues.cask.co/browse/CDAP-14182

Build: https://builds.cask.co/browse/CDAP-DUT6602-2