### PR TITLE
[CDAP-14025] Fix DataPrep UI change for environment specific connector types

### DIFF
--- a/cdap-ui/app/cdap/api/dataprep.js
+++ b/cdap-ui/app/cdap/api/dataprep.js
@@ -23,6 +23,7 @@ const appPath = '/namespaces/:namespace/apps/dataprep';
 const baseServicePath = `${appPath}/services/service`;
 const basepath = `${baseServicePath}/methods/workspaces/:workspaceId`;
 const connectionsPath = `${baseServicePath}/methods/connections`;
+const connectionTypesPath = `${baseServicePath}/methods/connectionTypes`;
 
 const MyDataPrepApi = {
   create: apiCreator(dataSrc, 'PUT', 'REQUEST', basepath),
@@ -37,7 +38,7 @@ const MyDataPrepApi = {
   getWorkspaceList: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/workspaces`),
 
   // WRANGLER SERVICE MANAGEMENT
-  getApp: apiCreator(dataSrc, 'GET', 'REQUEST', `${appPath}`),
+  getApp: apiCreator(dataSrc, 'GET', 'REQUEST', appPath),
   startService: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/start`),
   stopService: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/stop`),
   pollServiceStatus: apiCreator(dataSrc, 'GET', 'POLL', `${baseServicePath}/status`),
@@ -92,8 +93,10 @@ const MyDataPrepApi = {
   updateConnection: apiCreator(dataSrc, 'POST', 'REQUEST', `${connectionsPath}/:connectionId/update`),
   deleteConnection: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${connectionsPath}/:connectionId`),
   getConnection: apiCreator(dataSrc, 'GET', 'REQUEST', `${connectionsPath}/:connectionId`),
-  listDrivers: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/list/drivers`)
+  listDrivers: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/list/drivers`),
 
+  // Connection types
+  listConnectionTypes: apiCreator(dataSrc, 'GET', 'REQUEST', connectionTypesPath)
 };
 
 export default MyDataPrepApi;

--- a/cdap-ui/app/cdap/components/Alert/index.js
+++ b/cdap-ui/app/cdap/components/Alert/index.js
@@ -103,7 +103,9 @@ export default class Alert extends Component {
         toggle={() => {}}
         backdrop={false}
         keyboard={true}
-        className="global-alert">
+        className="global-alert"
+        zIndex={1061/* This is required for showing error in angular side*/}
+      >
         <div className={this.state.type}>
           {msgElem}
           <IconSVG

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/index.js
@@ -16,7 +16,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import {Provider} from 'react-redux';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
@@ -26,6 +25,7 @@ import TableList from 'components/DataPrep/DataPrepBrowser/BigQueryBrowser/Table
 import {Route, Switch} from 'react-router-dom';
 import Page404 from 'components/404';
 import DataPrepBrowserPageTitle from 'components/DataPrep/DataPrepBrowser/PageTitle';
+import DataprepBrowserTopPanel from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel';
 
 require('./BigQueryBrowser.scss');
 
@@ -56,23 +56,12 @@ export default class BiqQueryBrowser extends Component {
             :
               null
           }
-          <div className="top-panel">
-            <div className="title">
-              <h5>
-                <span
-                  className="fa fa-fw"
-                  onClick={this.props.toggle}
-                >
-                  <IconSVG name="icon-bars" />
-                </span>
 
-                <span>
-                  {T.translate(`${PREFIX}.title`)}
-                </span>
-              </h5>
-            </div>
-          </div>
-
+          <DataprepBrowserTopPanel
+            allowSidePanelToggle={true}
+            toggle={this.props.toggle}
+            browserTitle={T.translate(`${PREFIX}.title`)}
+          />
           {
             this.props.enableRouting ?
               (

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
@@ -115,7 +115,7 @@ const defaultBigQueryValue = {
 };
 
 const defaultActiveBrowser = {
-  name: 'database'
+  name: ''
 };
 
 const defaultError = null;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel/DataPrepBrowserTopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel/DataPrepBrowserTopPanel.scss
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import '~styles/variables.scss';
+
+$top-panel-bg-color: $grey-07;
+$top-panel-height: 50px;
+$gutter-width: 15px;
+$border-color: $grey-05;
+
+.dataprep-browser-top-panel {
+  height: $top-panel-height;
+  background-color: $top-panel-bg-color;
+  border-bottom: 1px solid $border-color;
+
+  .title > h5 {
+    padding-left: $gutter-width;
+    margin-bottom: 0;
+    margin-top: 0;
+    line-height: $top-panel-height;
+    font-weight: 500;
+
+    .fa {
+      margin-right: 10px;
+      cursor: pointer;
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel/index.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import classnames from 'classnames';
+import * as React from 'react';
+import IconSVG from 'components/IconSVG';
+
+require('./DataPrepBrowserTopPanel.scss');
+
+interface IDataprepBrowserTopPanel {
+  allowSidePanelToggle: boolean;
+  toggle: (e: React.MouseEvent<HTMLElement>) => void;
+  browserTitle: string;
+}
+export default class DataprepBrowserTopPanel extends React.PureComponent<IDataprepBrowserTopPanel> {
+  public render() {
+    return (
+      <div className="dataprep-browser-top-panel">
+        <div className="title">
+          <h5>
+            <span
+              className={classnames("fa fa-fw", {
+                disabled: !this.props.allowSidePanelToggle,
+              })}
+              onClick={this.props.toggle}
+            >
+              <IconSVG name="icon-bars" />
+            </span>
+
+            <span>
+              {this.props.browserTitle}
+            </span>
+          </h5>
+        </div>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/index.js
@@ -16,7 +16,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import {setGCSLoading, setError} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
@@ -31,6 +30,7 @@ import GCSSearch from 'components/DataPrep/DataPrepBrowser/GCSBrowser/GCSSearch'
 import BrowserData from 'components/DataPrep/DataPrepBrowser/GCSBrowser/BrowserData';
 import classnames from 'classnames';
 import DataPrepBrowserPageTitle from 'components/DataPrep/DataPrepBrowser/PageTitle';
+import DataprepBrowserTopPanel from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel';
 
 require('./GCSBrowser.scss');
 
@@ -115,22 +115,11 @@ export default class GCSBrowser extends Component {
             :
               null
           }
-          <div className="top-panel">
-            <div className="title">
-              <h5>
-                <span
-                  className="fa fa-fw"
-                  onClick={this.props.toggle}
-                >
-                  <IconSVG name="icon-bars" />
-                </span>
-
-                <span>
-                  {T.translate(`${PREFIX}.TopPanel.selectData`)}
-                </span>
-              </h5>
-            </div>
-          </div>
+          <DataprepBrowserTopPanel
+            allowSidePanelToggle={true}
+            toggle={this.props.toggle}
+            browserTitle={T.translate(`${PREFIX}.TopPanel.selectData`)}
+          />
           <div className={classnames("sub-panel", {'routing-disabled': !this.props.enableRouting})}>
             <div className="path-container">
               <GCSPath

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/index.js
@@ -22,12 +22,14 @@ import NamespaceStore from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import {Input} from 'reactstrap';
-import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import {setKafkaAsActiveBrowser, setError} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import ee from 'event-emitter';
 import DataPrepBrowserPageTitle from 'components/DataPrep/DataPrepBrowser/PageTitle';
 import {Provider} from 'react-redux';
+import DataprepBrowserTopPanel from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel';
+import {ConnectionType} from 'components/DataPrepConnections/ConnectionType';
+import If from 'components/If';
 
 const PREFIX = `features.DataPrep.DataPrepBrowser.KafkaBrowser`;
 
@@ -60,7 +62,7 @@ export default class KafkaBrowser extends Component {
     this.eventEmitter.on('DATAPREP_CONNECTION_EDIT_KAFKA', this.eventBasedFetchTopics);
     this.storeSubscription = DataPrepBrowserStore.subscribe(() => {
       let {kafka, activeBrowser} = DataPrepBrowserStore.getState();
-      if (activeBrowser.name !== 'kafka') {
+      if (activeBrowser.name !== ConnectionType.KAFKA) {
         return;
       }
 
@@ -82,7 +84,7 @@ export default class KafkaBrowser extends Component {
 
   eventBasedFetchTopics = (connectionId) => {
     if (this.state.connectionId === connectionId) {
-      setKafkaAsActiveBrowser({name: 'database', id: connectionId});
+      setKafkaAsActiveBrowser({name: ConnectionType.KAFKA, id: connectionId});
     }
   };
 
@@ -207,11 +209,12 @@ export default class KafkaBrowser extends Component {
     if (this.state.search) {
       filteredTopics = this.state.topics.filter(topic => topic.toLowerCase().indexOf(this.state.search.toLowerCase()) !== -1);
     }
-    const PageTitle = () => (
+    const PageTitle = (...props) => (
       this.props.enableRouting ?
         <DataPrepBrowserPageTitle
           browserI18NName="KafkaBrowser"
           browserStateName="kafka"
+          {...props}
         />
       :
         null
@@ -221,44 +224,35 @@ export default class KafkaBrowser extends Component {
         <Provider store={DataPrepBrowserStore}>
           <PageTitle />
         </Provider>
-        <div className="top-panel">
-          <div className="title">
-            <h5>
-              <span
-                className="fa fa-fw"
-                onClick={this.props.toggle}
-              >
-                <IconSVG name="icon-bars" />
-              </span>
-
-              <span>
-                {T.translate(`${PREFIX}.title`)}
-              </span>
-            </h5>
-          </div>
-        </div>
-        <div>
-          <div className="kafka-browser-header">
-            <div className="kafka-metadata">
-              <h5>{this.state.info.name}</h5>
-              <span className="tables-count">
-                {
-                  T.translate(`${PREFIX}.topicCount`, {
-                    count: this.state.topics.length
-                  })
-                }
-              </span>
-            </div>
-            <div className="table-name-search">
-              <Input
-                placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
-                value={this.state.search}
-                onChange={this.handleSearch}
-                autoFocus={this.state.searchFocus}
-              />
+        <DataprepBrowserTopPanel
+          allowSidePanelToggle={true}
+          toggle={this.props.toggle}
+          browserTitle={T.translate(`${PREFIX}.title`)}
+        />
+        <If condition={this.state.error}>
+          <div>
+            <div className="kafka-browser-header">
+              <div className="kafka-metadata">
+                <h5>{this.state.info.name}</h5>
+                <span className="tables-count">
+                  {
+                    T.translate(`${PREFIX}.topicCount`, {
+                      count: this.state.topics.length
+                    })
+                  }
+                </span>
+              </div>
+              <div className="table-name-search">
+                <Input
+                  placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
+                  value={this.state.search}
+                  onChange={this.handleSearch}
+                  autoFocus={this.state.searchFocus}
+                />
+              </div>
             </div>
           </div>
-        </div>
+        </If>
         <div className="kafka-browser-content">
           { this.renderContents(filteredTopics) }
         </div>

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
@@ -17,7 +17,6 @@
 import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
-import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 import {setS3Loading, setError} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
@@ -32,6 +31,7 @@ import ListingInfo from 'components/DataPrep/DataPrepBrowser/S3Browser/ListingIn
 import S3Search from 'components/DataPrep/DataPrepBrowser/S3Browser/S3Search';
 import classnames from 'classnames';
 import DataPrepBrowserPageTitle from 'components/DataPrep/DataPrepBrowser/PageTitle';
+import DataprepBrowserTopPanel from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel';
 
 require('./S3Browser.scss');
 
@@ -116,22 +116,11 @@ export default class S3Browser extends Component {
           :
             null
           }
-          <div className="top-panel">
-            <div className="title">
-              <h5>
-                <span
-                  className="fa fa-fw"
-                  onClick={this.props.toggle}
-                >
-                  <IconSVG name="icon-bars" />
-                </span>
-
-                <span>
-                  {T.translate(`${PREFIX}.TopPanel.selectData`)}
-                </span>
-              </h5>
-            </div>
-          </div>
+          <DataprepBrowserTopPanel
+            allowSidePanelToggle={true}
+            toggle={this.props.toggle}
+            browserTitle={T.translate(`${PREFIX}.TopPanel.selectData`)}
+          />
           <div className={classnames("sub-panel", {'routing-disabled': !this.props.enableRouting})}>
             <div className="path-container">
               <S3Path

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
@@ -26,14 +26,15 @@ import GCSBrowser from 'components/DataPrep/DataPrepBrowser/GCSBrowser';
 import BigQueryBrowser from 'components/DataPrep/DataPrepBrowser/BigQueryBrowser';
 import DataPrepErrorBanner from 'components/DataPrep/DataPrepBrowser/ErrorBanner';
 import {Provider} from 'react-redux';
+import {ConnectionType} from 'components/DataPrepConnections/ConnectionType';
 
 const browserMap = {
-  database: DatabaseBrowser,
-  file: FileBrowser,
-  kafka: KafkaBrowser,
-  s3: S3Browser,
-  gcs: GCSBrowser,
-  bigquery: BigQueryBrowser
+  [ConnectionType.DATABASE]: DatabaseBrowser,
+  [ConnectionType.FILE]: FileBrowser,
+  [ConnectionType.KAFKA]: KafkaBrowser,
+  [ConnectionType.S3]: S3Browser,
+  [ConnectionType.GCS]: GCSBrowser,
+  [ConnectionType.BIGQUERY]: BigQueryBrowser
 };
 
 export default class DataPrepBrowser extends Component {
@@ -77,7 +78,7 @@ export default class DataPrepBrowser extends Component {
   }
 
   render() {
-    let activeBrowser = this.state.activeBrowser.name.toLowerCase();
+    let activeBrowser = this.state.activeBrowser.name;
     if (browserMap.hasOwnProperty(activeBrowser)) {
       let Tag = browserMap[activeBrowser];
       return (

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -14,7 +14,6 @@
  * the License.
  */
 
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Loadable from 'react-loadable';
@@ -294,7 +293,7 @@ export default class DataPrepTopPanel extends Component {
       );
     };
 
-    const MenuItem = () => {
+    const MenuItem = (props) => {
       return (
         <li
           className={classnames(`popover-menu-item ${menuItem.className}`, {
@@ -302,6 +301,7 @@ export default class DataPrepTopPanel extends Component {
           })}
           title={menuItem.label}
           onClick={isDisabled ? preventPropagation : menuItem.onClick}
+          {...props}
         >
           {getMenuItem(menuItem)}
         </li>

--- a/cdap-ui/app/cdap/components/DataPrepConnections/AddConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/AddConnection/index.js
@@ -25,7 +25,8 @@ import S3Connection from 'components/DataPrepConnections/S3Connection';
 import GCSConnection from 'components/DataPrepConnections/GCSConnection';
 import BigQueryConnection from 'components/DataPrepConnections/BigQueryConnection';
 import T from 'i18n-react';
-
+import find from 'lodash/find';
+import {ConnectionType} from 'components/DataPrepConnections/ConnectionType';
 require('./AddConnection.scss');
 
 const PREFIX = 'features.DataPrepConnections.AddConnections';
@@ -36,38 +37,50 @@ export default class AddConnection extends Component {
 
     this.state = {
       activeModal: null,
-      showPopover: false
+      showPopover: this.props.showPopover
     };
 
     this.CONNECTIONS_TYPE = [
       {
-        type: 'Database',
+        type: ConnectionType.DATABASE,
+        label: 'Database',
         icon: 'icon-database',
         component: DatabaseConnection
       },
       {
-        type: 'Kafka',
+        type: ConnectionType.KAFKA,
+        label: 'Kafka',
         icon: 'icon-kafka',
         component: KafkaConnection
       },
       {
-        type: 'S3',
+        type: ConnectionType.S3,
+        label: 'S3',
         icon: 'icon-s3',
         component: S3Connection
       },
       {
-        type: 'Google Cloud Storage',
+        type: ConnectionType.GCS,
+        label: 'Google Cloud Storage',
         icon: 'icon-storage',
         component: GCSConnection
       },
       {
-        type: 'Google BigQuery',
+        type: ConnectionType.BIGQUERY,
+        label: 'Google BigQuery',
         icon: 'icon-bigquery',
         component: BigQueryConnection
       }
     ];
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.showPopover !== nextProps.showPopover) {
+      this.setState({
+        showPopover: nextProps.showPopover
+      });
+    }
+  }
   connectionClickHandler(component) {
     this.setState({
       activeModal: component,
@@ -89,6 +102,12 @@ export default class AddConnection extends Component {
     );
   }
 
+  onPopoverClose = (showPopover) => {
+    if (!showPopover) {
+      this.props.onPopoverClose();
+    }
+  };
+
   renderPopover() {
     const target = () => (
       <button className="btn btn-secondary">
@@ -101,6 +120,7 @@ export default class AddConnection extends Component {
         </span>
       </button>
     );
+
     return (
       <Popover
         placement="top"
@@ -108,6 +128,7 @@ export default class AddConnection extends Component {
         className="add-connection-popover"
         enableInteractionInPopover={true}
         showPopover={this.state.showPopover}
+        onTogglePopover={this.onPopoverClose}
       >
         <div className="popover-header">
           {T.translate(`${PREFIX}.Popover.title`)}
@@ -115,9 +136,12 @@ export default class AddConnection extends Component {
         <div className="popover-body">
           {
             this.CONNECTIONS_TYPE.map((connection) => {
+              if (!find(this.props.validConnectionTypes, {type: connection.type})) {
+                return null;
+              }
               return (
                 <div
-                  key={connection.type}
+                  key={connection.label}
                   className="connection-type-option"
                   onClick={this.connectionClickHandler.bind(this, connection.component)}
                 >
@@ -126,7 +150,7 @@ export default class AddConnection extends Component {
                   </span>
 
                   <span className="connection-name">
-                    {connection.type}
+                    {connection.label}
                   </span>
                 </div>
               );
@@ -147,7 +171,13 @@ export default class AddConnection extends Component {
   }
 }
 
+AddConnection.defaultProps = {
+  showPopover: false
+};
 AddConnection.propTypes = {
-  onAdd: PropTypes.func
+  onAdd: PropTypes.func,
+  validConnectionTypes: PropTypes.arrayOf(PropTypes.object),
+  showPopover: PropTypes.bool,
+  onPopoverClose: PropTypes.func
 };
 

--- a/cdap-ui/app/cdap/components/DataPrepConnections/ConnectionType.ts
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/ConnectionType.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+export enum ConnectionType {
+  UPLOAD = "UPLOAD",
+  FILE = "FILE",
+  DATABASE = "DATABASE",
+  TABLE = "TABLE",
+  S3 = "S3",
+  GCS = "GCS",
+  BIGQUERY = "BIGQUERY",
+  KAFKA = "KAFKA",
+}

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DataPrepConnections.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DataPrepConnections.scss
@@ -16,37 +16,15 @@
 
 @import '../../styles/variables.scss';
 
-$connections-panel-bg-color: #efefef;
-$connections-panel-border-color: #cccccc;
+$connections-panel-bg-color: $grey-07;
+$connections-panel-border-color: $grey-05;
 $connections-menu-active-color: var(--brand-primary-color);
-$connections-menu-item-color: #333333;
-$top-panel-bg-color: #efefef;
-$info-font-color: #999999;
-$border-color: #cccccc;
-$top-panel-height: 50px;
-$gutter-width: 15px;
+$connections-menu-item-color: $grey-01;
+$info-font-color: $grey-03;
 
 .dataprep-connections-container {
   height: calc(100vh - 104px);
   border-right: 1px solid $connections-panel-border-color;
-
-  .top-panel {
-    height: $top-panel-height;
-    background-color: $top-panel-bg-color;
-    border-bottom: 1px solid $border-color;
-
-    .title > h5 {
-      padding-left: $gutter-width;
-      margin-bottom: 0;
-      line-height: $top-panel-height;
-      font-weight: 500;
-
-      .fa {
-        margin-right: 10px;
-        cursor: pointer;
-      }
-    }
-  }
 
   .connections-panel,
   .connections-content {

--- a/cdap-ui/app/cdap/components/DataPrepConnections/NoDefaultConnection/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/NoDefaultConnection/index.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import {ConnectionType} from 'components/DataPrepConnections/ConnectionType';
+import {isNilOrEmpty} from 'services/helpers';
+import {Redirect} from 'react-router-dom';
+import {getCurrentNamespace} from 'services/NamespaceStore';
+import EmptyMessageContainer from 'components/EmptyMessageContainer';
+import DataprepBrowserTopPanel from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel';
+import T from 'i18n-react';
+
+const PREFIX: string = 'features.DataPrepConnections.NoDefaultConnection';
+
+interface IDefaultConnection {
+  name: string;
+  type: ConnectionType;
+}
+interface INoDefaultConnectionProps {
+  defaultConnection: IDefaultConnection;
+  showAddConnectionPopover: () => void;
+  toggleSidepanel: (e: React.MouseEvent<HTMLElement>) => void;
+}
+const NoDefaultConnection: React.SFC<INoDefaultConnectionProps> = ({
+  defaultConnection,
+  showAddConnectionPopover,
+  toggleSidepanel,
+}) => {
+  if (
+    isNilOrEmpty(defaultConnection) ||
+    (defaultConnection && isNilOrEmpty(defaultConnection.name))
+  ) {
+    return (
+      <div>
+        <DataprepBrowserTopPanel
+          allowSidePanelToggle={true}
+          toggle={toggleSidepanel}
+          browserTitle={T.translate(`${PREFIX}.title`).toString()}
+        />
+
+        <EmptyMessageContainer title={T.translate(`${PREFIX}.title`)}>
+          <span>
+            <br />
+            <ul>
+              <li>
+                <span
+                  className="link-text"
+                  onClick={showAddConnectionPopover}
+                >Create</span>
+                <span>a new connection; or</span>
+              </li>
+              <li>
+                <span>Click on an existing connection to browse</span>
+              </li>
+            </ul>
+          </span>
+        </EmptyMessageContainer>
+      </div>
+    );
+  }
+  const { name: connectionId, type } = defaultConnection;
+  const connectionType = type.toLowerCase();
+  const namespace = getCurrentNamespace();
+  const BASEPATH = `/ns/${namespace}/connections`;
+  return (
+    <Redirect to={`${BASEPATH}/${connectionType}/${connectionId}`} />
+  );
+};
+export default NoDefaultConnection;

--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -301,7 +301,7 @@ export default class DataPrepHome extends Component {
 
     if (!this.props.singleWorkspaceMode && this.state.isEmpty) {
       return (
-        <Redirect to={`/ns/${this.namespace}/connections/browser`} />
+        <Redirect to={`/ns/${this.namespace}/connections`} />
       );
     }
 

--- a/cdap-ui/app/cdap/components/EmptyMessageContainer/EmptyMessageContainer.scss
+++ b/cdap-ui/app/cdap/components/EmptyMessageContainer/EmptyMessageContainer.scss
@@ -46,6 +46,7 @@ $empty-message-link-color: var(--brand-primary-color);
       list-style: none;
       font-size: 14px;
       .link-text {
+        margin-right: 4px;
         cursor: pointer;
         color: $empty-message-link-color;
         margin-right: 0.25em;

--- a/cdap-ui/app/cdap/components/EmptyMessageContainer/index.js
+++ b/cdap-ui/app/cdap/components/EmptyMessageContainer/index.js
@@ -22,7 +22,7 @@ require('./EmptyMessageContainer.scss');
 
 const PREFIX = 'features.EmptyMessageContainer';
 
-export default function EmptyMessageContainer({title, searchText, children}) {
+export default function EmptyMessageContainer({title, searchText = '', children}) {
   return (
     <div className="empty-search-container">
       <div className="empty-search">

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -15,7 +15,6 @@
  */
 
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import MyDataPrepApi from 'api/dataprep';
 import NamespaceStore from 'services/NamespaceStore';
@@ -27,12 +26,13 @@ import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBr
 import {setError, goToPath, trimSuffixSlash} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import T from 'i18n-react';
 import orderBy from 'lodash/orderBy';
-import IconSVG from 'components/IconSVG';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import isEmpty from 'lodash/isEmpty';
 import DataPrepStore from 'components/DataPrep/store';
 import lastIndexOf from 'lodash/lastIndexOf';
 import isNil from 'lodash/isNil';
+import DataprepBrowserTopPanel from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel';
+import {ConnectionType} from 'components/DataPrepConnections/ConnectionType';
 
 require('./FileBrowser.scss');
 
@@ -90,7 +90,7 @@ export default class FileBrowser extends Component {
 
     this.browserStoreSubscription = DataPrepBrowserStore.subscribe(() => {
       let {file, activeBrowser} = DataPrepBrowserStore.getState();
-      if (activeBrowser.name !== 'file') {
+      if (activeBrowser.name !== ConnectionType.FILE) {
         return;
       }
 
@@ -492,24 +492,11 @@ export default class FileBrowser extends Component {
   render() {
     return (
       <div className="file-browser-container">
-        <div className="top-panel">
-          <div className="title">
-            <h5>
-              <span
-                className={classnames("fa fa-fw", {
-                  'disabled': !this.props.allowSidePanelToggle
-                })}
-                onClick={this.props.toggle}
-              >
-                <IconSVG name="icon-bars" />
-              </span>
-
-              <span>
-                {this.props.browserTitle}
-              </span>
-            </h5>
-          </div>
-        </div>
+        <DataprepBrowserTopPanel
+          allowSidePanelToggle={this.props.allowSidePanelToggle}
+          toggle={this.props.toggle}
+          browserTitle={this.props.browserTitle}
+        />
 
         <div className="sub-panel">
           <div className="path-container">

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1174,6 +1174,8 @@ features:
     gcs: Google Cloud Storage ({count})
     hdfs: File System
     kafka: Kafka ({count})
+    NoDefaultConnection:
+      title: No default connection available
     pageTitle: CDAP | Connections
     s3: S3 ({count})
     title: "Connections in \"{namespace}\""


### PR DESCRIPTION
- Changes the route for file browser and landing page for connections
- `<host>:<port>/cdap/ns/NS1/connections` will land to dataprep connections and will determine which connection to open.
- The logic for choosing a default connection,
   - _Cloud environment:_ 
       - default connection from backend. 
       - _Otherwise:_ Show a "No default connection available" page with possible actions
   - _Sandbox:_ 
      - If no default connection available and if FILE connection type is available go to file
      - _Otherwise:_ Show a "No default connection available" page with possible actions
- Adds `ConnectionType` enum
- Modifies connections to use `ConnectionType` enum to refer to connection type names
- Adds generic top panel for dataprep browsers.

**Note:**
  - Workspace info still has connection type in lowercase so have not modified that.

JIRA: https://issues.cask.co/browse/CDAP-14025
Build: https://builds.cask.co/browse/CDAP-DRC8393
