### PR TITLE
Revert "CDAP-14102:Bind http services to localhost in sandbox"

### DIFF
--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -454,8 +454,6 @@ public class StandaloneMain {
     cConf.set(Constants.CFG_DATA_INMEMORY_PERSISTENCE, Constants.InMemoryPersistenceType.LEVELDB.name());
 
     // configure all services except for router and auth to bind to 127.0.0.1
-    // For details see: https://issues.cask.co/browse/CDAP-7992. Router and auth bind addresses are configured by
-    // cdap-site.xml and are not overridden here.
     String localhost = InetAddress.getLoopbackAddress().getHostAddress();
     cConf.set(Constants.Service.MASTER_SERVICES_BIND_ADDRESS, localhost);
     cConf.set(Constants.Transaction.Container.ADDRESS, localhost);
@@ -467,7 +465,6 @@ public class StandaloneMain {
     cConf.set(Constants.Explore.SERVER_ADDRESS, localhost);
     cConf.set(Constants.Metadata.SERVICE_BIND_ADDRESS, localhost);
     cConf.set(Constants.Preview.ADDRESS, localhost);
-    cConf.set(Constants.RemoteSystemOpService.SERVICE_BIND_ADDRESS, localhost);
 
     return ImmutableList.of(
       new ConfigModule(cConf, hConf),

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -204,11 +204,9 @@
     </description>
   </property>
 
-  <!-- Bind to 127.0.0.1 (localhost) to protect from xss vulnerabilities while running in sandbox.
-  This must be changed if access to router is needed from a machine other than local machine. See CDAP-14102 -->
   <property>
     <name>router.bind.address</name>
-    <value>127.0.0.1</value>
+    <value>0.0.0.0</value>
     <description>
       CDAP Router service bind address
     </description>
@@ -254,25 +252,6 @@
       The 'file' provider is only used in the sandbox. In distributed environments, this should
       be set to 'kms', presuming your cluster has been configured to use KMS. The 'file' provider
       will not work in distributed environments.
-    </description>
-  </property>
-
-  <!-- Override default 0.0.0.0 to 127.0.0.1 (localhost) to protect from xss vulnerabilities while
-  running in sandbox. These must be changed if access is needed from a machine other than local machine.
-  See CDAP-14102 -->
-  <property>
-    <name>dashboard.bind.address</name>
-    <value>127.0.0.1</value>
-    <description>
-      CDAP UI bind address
-    </description>
-  </property>
-
-  <property>
-    <name>security.auth.server.bind.address</name>
-    <value>127.0.0.1</value>
-    <description>
-      CDAP Authentication service bind address
     </description>
   </property>
 

--- a/cdap-ui/server/config/development/cdap.json
+++ b/cdap-ui/server/config/development/cdap.json
@@ -1,6 +1,6 @@
 {
   "router.ssl.bind.port": "10443",
-  "dashboard.bind.address": "127.0.0.1",
+  "dashboard.bind.address": "0.0.0.0",
   "router.ssl.server.port": "10443",
   "router.server.port": "11015",
   "dashboard.ssl.bind.port": "9443",


### PR DESCRIPTION
Reverts caskdata/cdap#10520

Reverting this change since it causes docker and sandbox integration test failure as these changes made router and auth server accessible only locally. 