### PR TITLE
CDAP-13924:Refactor ProgramSpecification to store Plugin information

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/AbstractProgramSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/AbstractProgramSpecification.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api;
+
+import co.cask.cdap.api.plugin.Plugin;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base abstract class for {@link ProgramSpecification} which contains common information for various program
+ * specifications.
+ */
+public abstract class AbstractProgramSpecification implements ProgramSpecification {
+  private final String className;
+  private final String name;
+  private final String description;
+  private final Map<String, Plugin> plugins;
+
+  public AbstractProgramSpecification(String className, String name, String description, Map<String, Plugin> plugins) {
+    this.className = className;
+    this.name = name;
+    this.description = description;
+    this.plugins = plugins.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(plugins));
+  }
+
+  @Override
+  public String getClassName() {
+    return className;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public Map<String, Plugin> getPlugins() {
+    return plugins;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/ProgramSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ProgramSpecification.java
@@ -15,6 +15,10 @@
  */
 package co.cask.cdap.api;
 
+import co.cask.cdap.api.plugin.Plugin;
+
+import java.util.Map;
+
 /**
  * This interface provides for getting the name, class name, and description specifications of any type of program.
  */
@@ -34,4 +38,9 @@ public interface ProgramSpecification {
    * @return Description of the program.
    */
   String getDescription();
+
+  /**
+   * @return {@link Plugin} informations if there are any plugins associated with this program else returns an empty map
+   */
+  Map<String, Plugin> getPlugins();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
@@ -16,9 +16,10 @@
 
 package co.cask.cdap.api.mapreduce;
 
-import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.AbstractProgramSpecification;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.api.plugin.Plugin;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,11 +31,7 @@ import javax.annotation.Nullable;
 /**
  * This class provides the specification for a MapReduce job.
  */
-public class MapReduceSpecification implements ProgramSpecification, PropertyProvider {
-
-  private final String className;
-  private final String name;
-  private final String description;
+public class MapReduceSpecification extends AbstractProgramSpecification implements PropertyProvider {
   private final Set<String> dataSets;
   private final Map<String, String> properties;
   private final String inputDataSet;
@@ -46,10 +43,9 @@ public class MapReduceSpecification implements ProgramSpecification, PropertyPro
   public MapReduceSpecification(String className, String name, String description, String inputDataSet,
                                 String outputDataSet, Set<String> dataSets, Map<String, String> properties,
                                 @Nullable Resources driverResources,
-                                @Nullable Resources mapperResources, @Nullable Resources reducerResources) {
-    this.className = className;
-    this.name = name;
-    this.description = description;
+                                @Nullable Resources mapperResources, @Nullable Resources reducerResources,
+                                Map<String, Plugin> plugins) {
+    super(className, name, description, plugins);
     this.inputDataSet = inputDataSet;
     this.outputDataSet = outputDataSet;
     this.properties = Collections.unmodifiableMap(properties == null ? Collections.<String, String>emptyMap()
@@ -58,21 +54,6 @@ public class MapReduceSpecification implements ProgramSpecification, PropertyPro
     this.mapperResources = mapperResources;
     this.reducerResources = reducerResources;
     this.dataSets = getAllDatasets(dataSets, inputDataSet, outputDataSet);
-  }
-
-  @Override
-  public String getClassName() {
-    return className;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceSpecification.java
@@ -16,8 +16,9 @@
 
 package co.cask.cdap.api.service;
 
-import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.AbstractProgramSpecification;
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
 
 import java.util.Collections;
@@ -27,38 +28,18 @@ import java.util.Map;
 /**
  * Specification for a {@link Service}.
  */
-public final class ServiceSpecification implements ProgramSpecification {
-  private final String className;
-  private final String name;
-  private final String description;
+public final class ServiceSpecification extends AbstractProgramSpecification {
   private final Map<String, HttpServiceHandlerSpecification> handlers;
   private final Resources resources;
   private final int instances;
 
   public ServiceSpecification(String className, String name, String description,
                               Map<String, HttpServiceHandlerSpecification> handlers,
-                              Resources resources, int instances) {
-    this.className = className;
-    this.name = name;
-    this.description = description;
+                              Resources resources, int instances, Map<String, Plugin> plugins) {
+    super(className, name, description, plugins);
     this.handlers = Collections.unmodifiableMap(new HashMap<>(handlers));
     this.resources = resources;
     this.instances = instances;
-  }
-
-  @Override
-  public String getClassName() {
-    return className;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandlerSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandlerSpecification.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.api.service.http;
 
-import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.AbstractProgramSpecification;
 import co.cask.cdap.api.common.PropertyProvider;
 import co.cask.cdap.api.dataset.Dataset;
 
@@ -31,11 +31,7 @@ import java.util.Set;
 /**
  * Specification for a {@link HttpServiceHandler}.
  */
-public final class HttpServiceHandlerSpecification implements PropertyProvider, ProgramSpecification {
-
-  private final String className;
-  private final String name;
-  private final String description;
+public final class HttpServiceHandlerSpecification extends AbstractProgramSpecification implements PropertyProvider {
   private final Map<String, String> properties;
   private final Set<String> datasets;
   private final List<ServiceHttpEndpoint> endpoints;
@@ -46,36 +42,10 @@ public final class HttpServiceHandlerSpecification implements PropertyProvider, 
   public HttpServiceHandlerSpecification(String className, String name,
                                          String description, Map<String, String> properties,
                                          Set<String> datasets, List<ServiceHttpEndpoint> endpoints) {
-    this.className = className;
-    this.name = name;
-    this.description = description;
+    super(className, name, description, Collections.emptyMap());
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
     this.endpoints = Collections.unmodifiableList(new ArrayList<>(endpoints));
-  }
-
-  /**
-   * @return the class name
-   */
-  @Override
-  public String getClassName() {
-    return className;
-  }
-
-  /**
-   * @return the name
-   */
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  /**
-   * @return the description
-   */
-  @Override
-  public String getDescription() {
-    return description;
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
@@ -16,10 +16,11 @@
 
 package co.cask.cdap.api.spark;
 
-import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.AbstractProgramSpecification;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.api.plugin.Plugin;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,11 +35,8 @@ import javax.annotation.Nullable;
  * A default specification for {@link Spark} programs
  */
 @Beta
-public final class SparkSpecification implements ProgramSpecification, PropertyProvider {
+public final class SparkSpecification extends AbstractProgramSpecification implements PropertyProvider {
 
-  private final String className;
-  private final String name;
-  private final String description;
   private final String mainClassName;
   private final Set<String> datasets;
   private final Map<String, String> properties;
@@ -54,10 +52,8 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
                             @Nullable Resources clientResources,
                             @Nullable Resources driverResources,
                             @Nullable Resources executorResources,
-                            List<SparkHttpServiceHandlerSpecification> handlers) {
-    this.className = className;
-    this.name = name;
-    this.description = description;
+                            List<SparkHttpServiceHandlerSpecification> handlers, Map<String, Plugin> plugins) {
+    super(className, name, description, plugins);
     this.mainClassName = mainClassName;
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
@@ -65,21 +61,6 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
     this.driverResources = driverResources;
     this.executorResources = executorResources;
     this.handlers = Collections.unmodifiableList(new ArrayList<>(handlers));
-  }
-
-  @Override
-  public String getClassName() {
-    return className;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerSpecification.java
@@ -16,10 +16,11 @@
 
 package co.cask.cdap.api.worker;
 
-import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.AbstractProgramSpecification;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.PropertyProvider;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.plugin.Plugin;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,39 +31,19 @@ import java.util.Set;
 /**
  * Specification for {@link Worker}s.
  */
-public final class WorkerSpecification implements ProgramSpecification, PropertyProvider {
-  private final String className;
-  private final String name;
-  private final String description;
+public final class WorkerSpecification extends AbstractProgramSpecification implements PropertyProvider {
   private final Map<String, String> properties;
   private final Set<String> datasets;
   private final Resources resources;
   private final int instances;
 
   public WorkerSpecification(String className, String name, String description, Map<String, String> properties,
-                             Set<String> datasets, Resources resources, int instances) {
-    this.className = className;
-    this.name = name;
-    this.description = description;
+                             Set<String> datasets, Resources resources, int instances, Map<String, Plugin> plugins) {
+    super(className, name, description, plugins);
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
     this.resources = resources;
     this.instances = instances;
-  }
-
-  @Override
-  public String getClassName() {
-    return className;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
@@ -15,8 +15,9 @@
  */
 package co.cask.cdap.api.workflow;
 
-import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.AbstractProgramSpecification;
 import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 
 import java.util.ArrayList;
@@ -30,10 +31,7 @@ import java.util.Queue;
 /**
  * Specification for a {@link Workflow}
  */
-public final class WorkflowSpecification implements ProgramSpecification, PropertyProvider {
-  private final String className;
-  private final String name;
-  private final String description;
+public final class WorkflowSpecification extends AbstractProgramSpecification implements PropertyProvider {
   private final Map<String, String> properties;
   private final List<WorkflowNode> nodes;
   private final Map<String, WorkflowNode> nodeIdMap;
@@ -41,10 +39,8 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
 
   public WorkflowSpecification(String className, String name, String description,
                                Map<String, String> properties, List<WorkflowNode> nodes,
-                               Map<String, DatasetCreationSpec> localDatasetSpecs) {
-    this.className = className;
-    this.name = name;
-    this.description = description;
+                               Map<String, DatasetCreationSpec> localDatasetSpecs, Map<String, Plugin> plugins) {
+    super(className, name, description, plugins);
     this.properties = properties == null ? Collections.<String, String>emptyMap() :
                                            Collections.unmodifiableMap(new HashMap<>(properties));
     this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
@@ -85,21 +81,6 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
   }
 
   @Override
-  public String getClassName() {
-    return className;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
   public Map<String, String> getProperties() {
     return properties;
   }
@@ -132,14 +113,15 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder("WorkflowSpecification{");
-    sb.append("className='").append(className).append('\'');
-    sb.append(", name='").append(name).append('\'');
-    sb.append(", description='").append(description).append('\'');
-    sb.append(", properties=").append(properties);
-    sb.append(", nodes=").append(nodes);
-    sb.append(", localDatasetSpecs=").append(localDatasetSpecs);
-    sb.append('}');
-    return sb.toString();
+    return "WorkflowSpecification{" +
+      "className='" + getClassName() + '\'' +
+      ", name='" + getName() + '\'' +
+      ", description='" + getDescription() + '\'' +
+      ", plugins=" + getPlugins() +
+      ", properties=" + properties +
+      ", nodes=" + nodes +
+      ", nodeIdMap=" + nodeIdMap +
+      ", localDatasetSpecs=" + localDatasetSpecs +
+      '}';
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowSpecification.java
@@ -16,6 +16,9 @@
 
 package co.cask.cdap.internal.flow;
 
+import co.cask.cdap.api.AbstractProgramSpecification;
+import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.flow.Flow;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.FlowletConnection;
 import co.cask.cdap.api.flow.FlowletDefinition;
@@ -27,13 +30,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- *
+ * {@link ProgramSpecification} for {@link Flow}.
  */
-public final class DefaultFlowSpecification implements FlowSpecification {
-
-  private final String className;
-  private final String name;
-  private final String description;
+public final class DefaultFlowSpecification extends AbstractProgramSpecification implements FlowSpecification {
   private final Map<String, FlowletDefinition> flowlets;
   private final List<FlowletConnection> connections;
 
@@ -48,26 +47,10 @@ public final class DefaultFlowSpecification implements FlowSpecification {
 
   public DefaultFlowSpecification(String className, String name, String description,
                                   Map<String, FlowletDefinition> flowlets, List<FlowletConnection> connections) {
-    this.className = className;
-    this.name = name;
-    this.description = description;
+    // Flows as of now don't support plugin and is deprecated hence just pass empty map as plugins
+    super(className, name, description, Collections.emptyMap());
     this.flowlets = Collections.unmodifiableMap(new HashMap<>(flowlets));
     this.connections = Collections.unmodifiableList(new ArrayList<>(connections));
-  }
-
-  @Override
-  public String getClassName() {
-    return className;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingFlowSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingFlowSpecification.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.FlowletConnection;
 import co.cask.cdap.api.flow.FlowletDefinition;
+import co.cask.cdap.api.plugin.Plugin;
 
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,11 @@ public abstract class ForwardingFlowSpecification implements FlowSpecification {
   @Override
   public String getDescription() {
     return delegate.getDescription();
+  }
+
+  @Override
+  public Map<String, Plugin> getPlugins() {
+    return delegate.getPlugins();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
@@ -28,6 +28,7 @@ import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.internal.specification.DataSetFieldExtractor;
 import co.cask.cdap.internal.specification.PropertyFieldExtractor;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -92,8 +93,10 @@ public final class DefaultMapReduceConfigurer extends AbstractConfigurer impleme
     Set<String> datasets = new HashSet<>();
     Reflections.visit(mapReduce, mapReduce.getClass(), new PropertyFieldExtractor(properties),
                       new DataSetFieldExtractor(datasets));
+    // TODO (Rohit) Pass in plugin information
     return new MapReduceSpecification(mapReduce.getClass().getName(), name, description,
                                       inputDataset, outputDataset, datasets,
-                                      properties, driverResources, mapperResources, reducerResources);
+                                      properties, driverResources, mapperResources, reducerResources,
+                                      Collections.emptyMap());
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/InMemoryWorkerRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/InMemoryWorkerRunner.java
@@ -63,7 +63,7 @@ public class InMemoryWorkerRunner extends AbstractInMemoryProgramRunner {
     WorkerSpecification newWorkerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
                                                                 workerSpec.getDescription(), workerSpec.getProperties(),
                                                                 workerSpec.getDatasets(), workerSpec.getResources(),
-                                                                Integer.valueOf(instances));
+                                                                Integer.valueOf(instances), workerSpec.getPlugins());
     return startAll(program, options, newWorkerSpec.getInstances());
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -116,7 +116,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     WorkerSpecification newWorkerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
                                                                 workerSpec.getDescription(), workerSpec.getProperties(),
                                                                 workerSpec.getDatasets(), workerSpec.getResources(),
-                                                                Integer.valueOf(instances));
+                                                                Integer.valueOf(instances), workerSpec.getPlugins());
 
     // Setup dataset framework context, if required
     if (datasetFramework instanceof ProgramContextAware) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
@@ -85,7 +85,6 @@ public class DefaultHttpServiceHandlerConfigurer extends AbstractConfigurer impl
                       new DataSetFieldExtractor(datasets),
                       new PropertyFieldExtractor(properties),
                       new ServiceEndpointExtractor(endpoints));
-
     return new HttpServiceHandlerSpecification(handler.getClass().getName(), name, "", properties, datasets, endpoints);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -97,8 +98,10 @@ public class DefaultServiceConfigurer extends AbstractConfigurer implements Serv
   }
 
   public ServiceSpecification createSpecification() {
+    // TODO (Rohit) Pass in plugin information
     Map<String, HttpServiceHandlerSpecification> handleSpecs = createHandlerSpecs(handlers);
-    return new ServiceSpecification(className, name, description, handleSpecs, resources, instances);
+    return new ServiceSpecification(className, name, description, handleSpecs, resources, instances,
+                                    Collections.emptyMap());
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
@@ -101,9 +101,11 @@ public class DefaultSparkConfigurer extends AbstractConfigurer implements SparkC
     // Grab all @Property and @Dataset fields
     Reflections.visit(spark, spark.getClass(), new PropertyFieldExtractor(properties),
                       new DataSetFieldExtractor(datasets));
+    // TODO (Rohit) Pass in plugin information
     return new SparkSpecification(spark.getClass().getName(), name, description,
                                   mainClassName, datasets, properties,
-                                  clientResources, driverResources, executorResources, getHandlers());
+                                  clientResources, driverResources, executorResources, getHandlers(),
+                                  Collections.emptyMap());
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -501,7 +501,7 @@ public class DefaultStore implements Store {
                                                                      workerSpec.getProperties(),
                                                                      workerSpec.getDatasets(),
                                                                      workerSpec.getResources(),
-                                                                     instances);
+                                                                     instances, workerSpec.getPlugins());
       ApplicationSpecification newAppSpec = replaceWorkerInAppSpec(appSpec, id, newSpecification);
       metaStore.updateAppSpec(id.getNamespace(), id.getApplication(), id.getVersion(), newAppSpec);
 
@@ -522,7 +522,7 @@ public class DefaultStore implements Store {
       // Create a new spec copy from the old one, except with updated instances number
       serviceSpec = new ServiceSpecification(serviceSpec.getClassName(), serviceSpec.getName(),
                                              serviceSpec.getDescription(), serviceSpec.getHandlers(),
-                                             serviceSpec.getResources(), instances);
+                                             serviceSpec.getResources(), instances, serviceSpec.getPlugins());
 
       ApplicationSpecification newAppSpec = replaceServiceSpec(appSpec, id.getProgram(), serviceSpec);
       metaStore.updateAppSpec(id.getNamespace(), id.getApplication(), id.getVersion(), newAppSpec);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
@@ -29,6 +29,7 @@ import co.cask.cdap.internal.specification.PropertyFieldExtractor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -89,7 +90,8 @@ public class DefaultWorkerConfigurer extends AbstractConfigurer implements Worke
   public WorkerSpecification createSpecification() {
     // Grab all @Property fields
     Reflections.visit(worker, worker.getClass(), new PropertyFieldExtractor(properties));
+    // TODO (Rohit) Pass in plugin information
     return new WorkerSpecification(worker.getClass().getName(), name, description,
-                                   properties, datasets, resource, instances);
+                                   properties, datasets, resource, instances, Collections.emptyMap());
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
@@ -44,6 +44,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -162,8 +163,9 @@ public class DefaultWorkflowConfigurer extends AbstractConfigurer
   }
 
   public WorkflowSpecification createSpecification() {
+    // TODO (Rohit) Pass in plugin information
     return new WorkflowSpecification(className, name, description, properties, createNodesWithId(nodes),
-                                     localDatasetSpecs);
+                                     localDatasetSpecs, Collections.emptyMap());
   }
 
   private List<WorkflowNode> createNodesWithId(List<WorkflowNode> nodes) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
@@ -301,29 +301,30 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
   private void addAppSpecs() {
     WorkflowSpecification scheduledWorfklow1 =
       new WorkflowSpecification("DummyClass", SCHEDULED_PROG1_ID.getProgram(), "scheduled workflow",
-                                Collections.EMPTY_MAP, Collections.EMPTY_LIST, Collections.EMPTY_MAP);
+                                Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
+                                Collections.emptyMap());
     ApplicationSpecification dummyAppSpec1 =
       new DefaultApplicationSpecification(APP1_ID.getApplication(), "dummy app", null,
-                                          ARTIFACT_ID1.toApiArtifactId(), Collections.EMPTY_MAP,
-                                          Collections.EMPTY_MAP, Collections.EMPTY_MAP,
-                                          Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP,
+                                          ARTIFACT_ID1.toApiArtifactId(), Collections.emptyMap(),
+                                          Collections.emptyMap(), Collections.emptyMap(),
+                                          Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
                                           ImmutableMap.of(SCHEDULED_PROG1_ID.getProgram(), scheduledWorfklow1),
-                                          Collections.EMPTY_MAP, Collections.EMPTY_MAP,
-                                          Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+                                          Collections.emptyMap(), Collections.emptyMap(),
+                                          Collections.emptyMap(), Collections.emptyMap());
 
     store.addApplication(APP1_ID, dummyAppSpec1);
     WorkflowSpecification scheduledWorfklow2 =
       new WorkflowSpecification("DummyClass", SCHEDULED_PROG2_ID.getProgram(), "scheduled workflow",
-                                Collections.EMPTY_MAP, Collections.EMPTY_LIST, Collections.EMPTY_MAP);
+                                Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
+                                Collections.emptyMap());
     ApplicationSpecification dummyAppSpec2 =
       new DefaultApplicationSpecification(APP2_ID.getApplication(), "dummy app", null,
-
-                                          ARTIFACT_ID2.toApiArtifactId(), Collections.EMPTY_MAP, Collections.EMPTY_MAP,
-                                          Collections.EMPTY_MAP,
-                                          Collections.EMPTY_MAP, Collections.EMPTY_MAP, Collections.EMPTY_MAP,
+                                          ARTIFACT_ID2.toApiArtifactId(), Collections.emptyMap(),
+                                          Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+                                          Collections.emptyMap(), Collections.emptyMap(),
                                           ImmutableMap.of(SCHEDULED_PROG2_ID.getProgram(), scheduledWorfklow2),
-                                          Collections.EMPTY_MAP, Collections.EMPTY_MAP,
-                                          Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+                                          Collections.emptyMap(), Collections.emptyMap(),
+                                          Collections.emptyMap(), Collections.emptyMap());
     store.addApplication(APP2_ID, dummyAppSpec2);
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/MapReduceSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/MapReduceSpecificationCodec.java
@@ -18,6 +18,7 @@ package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.plugin.Plugin;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -40,6 +41,7 @@ public final class MapReduceSpecificationCodec extends AbstractSpecificationCode
     jsonObj.addProperty("className", src.getClassName());
     jsonObj.addProperty("name", src.getName());
     jsonObj.addProperty("description", src.getDescription());
+    jsonObj.add("plugins", serializeMap(src.getPlugins(), context, Plugin.class));
 
     if (src.getDriverResources() != null) {
       jsonObj.add("driverResources", context.serialize(src.getDriverResources()));
@@ -70,6 +72,7 @@ public final class MapReduceSpecificationCodec extends AbstractSpecificationCode
     String className = jsonObj.get("className").getAsString();
     String name = jsonObj.get("name").getAsString();
     String description = jsonObj.get("description").getAsString();
+    Map<String, Plugin> plugins = deserializeMap(jsonObj.get("plugins"), context, Plugin.class);
     Resources driverResources = deserializeResources(jsonObj, "driver", context);
     Resources mapperResources = deserializeResources(jsonObj, "mapper", context);
     Resources reducerResources = deserializeResources(jsonObj, "reducer", context);
@@ -81,7 +84,8 @@ public final class MapReduceSpecificationCodec extends AbstractSpecificationCode
     Set<String> dataSets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
     return new MapReduceSpecification(className, name, description, inputDataSet, outputDataSet,
-                                      dataSets, properties, driverResources, mapperResources, reducerResources);
+                                      dataSets, properties, driverResources, mapperResources, reducerResources,
+                                      plugins);
   }
 
   /**

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/SparkSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/SparkSpecificationCodec.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.spark.SparkHttpServiceHandlerSpecification;
 import co.cask.cdap.api.spark.SparkSpecification;
 import com.google.gson.JsonDeserializationContext;
@@ -44,6 +45,7 @@ public final class SparkSpecificationCodec extends AbstractSpecificationCodec<Sp
     jsonObj.add("className", new JsonPrimitive(src.getClassName()));
     jsonObj.add("name", new JsonPrimitive(src.getName()));
     jsonObj.add("description", new JsonPrimitive(src.getDescription()));
+    jsonObj.add("plugins", serializeMap(src.getPlugins(), context, Plugin.class));
     if (src.getMainClassName() != null) {
       jsonObj.add("mainClassName", new JsonPrimitive(src.getMainClassName()));
     }
@@ -67,6 +69,7 @@ public final class SparkSpecificationCodec extends AbstractSpecificationCodec<Sp
     String className = jsonObj.get("className").getAsString();
     String name = jsonObj.get("name").getAsString();
     String description = jsonObj.get("description").getAsString();
+    Map<String, Plugin> plugins = deserializeMap(jsonObj.get("plugins"), context, Plugin.class);
     String mainClassName = jsonObj.has("mainClassName") ? jsonObj.get("mainClassName").getAsString() : null;
     Set<String> datasets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
@@ -79,7 +82,7 @@ public final class SparkSpecificationCodec extends AbstractSpecificationCodec<Sp
                                                                           SparkHttpServiceHandlerSpecification.class);
 
     return new SparkSpecification(className, name, description, mainClassName, datasets,
-                                  properties, clientResources, driverResources, executorResources, handlers);
+                                  properties, clientResources, driverResources, executorResources, handlers, plugins);
   }
 
   /**

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkerSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkerSpecificationCodec.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
@@ -35,15 +36,16 @@ public final class WorkerSpecificationCodec extends AbstractSpecificationCodec<W
 
   @Override
   public JsonElement serialize(WorkerSpecification spec, Type typeOfSrc, JsonSerializationContext context) {
-    JsonObject object = new JsonObject();
-    object.addProperty("className", spec.getClassName());
-    object.addProperty("name", spec.getName());
-    object.addProperty("description", spec.getDescription());
-    object.add("properties", serializeMap(spec.getProperties(), context, String.class));
-    object.add("resources", context.serialize(spec.getResources(), Resources.class));
-    object.add("datasets", serializeSet(spec.getDatasets(), context, String.class));
-    object.addProperty("instances", spec.getInstances());
-    return object;
+    JsonObject jsonObj = new JsonObject();
+    jsonObj.addProperty("className", spec.getClassName());
+    jsonObj.addProperty("name", spec.getName());
+    jsonObj.addProperty("description", spec.getDescription());
+    jsonObj.add("plugins", serializeMap(spec.getPlugins(), context, Plugin.class));
+    jsonObj.add("properties", serializeMap(spec.getProperties(), context, String.class));
+    jsonObj.add("resources", context.serialize(spec.getResources(), Resources.class));
+    jsonObj.add("datasets", serializeSet(spec.getDatasets(), context, String.class));
+    jsonObj.addProperty("instances", spec.getInstances());
+    return jsonObj;
   }
 
   @Override
@@ -54,11 +56,12 @@ public final class WorkerSpecificationCodec extends AbstractSpecificationCodec<W
     String className = jsonObj.get("className").getAsString();
     String name = jsonObj.get("name").getAsString();
     String description = jsonObj.get("description").getAsString();
+    Map<String, Plugin> plugins = deserializeMap(jsonObj.get("plugins"), context, Plugin.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
     Resources resources = context.deserialize(jsonObj.get("resources"), Resources.class);
     Set<String> datasets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     int instances = jsonObj.get("instances").getAsInt();
 
-    return new WorkerSpecification(className, name, description, properties, datasets, resources, instances);
+    return new WorkerSpecification(className, name, description, properties, datasets, resources, instances, plugins);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowSpecificationCodec.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto.codec;
 
+import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
@@ -40,6 +41,7 @@ public final class WorkflowSpecificationCodec extends AbstractSpecificationCodec
     jsonObj.add("className", new JsonPrimitive(src.getClassName()));
     jsonObj.add("name", new JsonPrimitive(src.getName()));
     jsonObj.add("description", new JsonPrimitive(src.getDescription()));
+    jsonObj.add("plugins", serializeMap(src.getPlugins(), context, Plugin.class));
     jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
     jsonObj.add("nodes", serializeList(src.getNodes(), context, WorkflowNode.class));
     jsonObj.add("localDatasetSpecs", serializeMap(src.getLocalDatasetSpecs(), context, DatasetCreationSpec.class));
@@ -54,11 +56,12 @@ public final class WorkflowSpecificationCodec extends AbstractSpecificationCodec
     String className = jsonObj.get("className").getAsString();
     String name = jsonObj.get("name").getAsString();
     String description = jsonObj.get("description").getAsString();
+    Map<String, Plugin> plugins = deserializeMap(jsonObj.get("plugins"), context, Plugin.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
     List<WorkflowNode> nodes = deserializeList(jsonObj.get("nodes"), context, WorkflowNode.class);
     Map<String, DatasetCreationSpec> localDatasetSpec = deserializeMap(jsonObj.get("localDatasetSpecs"), context,
                                                                        DatasetCreationSpec.class);
 
-    return new WorkflowSpecification(className, name, description, properties, nodes, localDatasetSpec);
+    return new WorkflowSpecification(className, name, description, properties, nodes, localDatasetSpec, plugins);
   }
 }


### PR DESCRIPTION
### Background
- To perform [Provisioner checks](https://wiki.cask.co/display/CE/Improving+Plugins+User+Experience+Across+Different+Modes#ImprovingPluginsUserExperienceAcrossDifferentModes-ProvisionerChecks) for a pipeline it is needed to store the plugins details with the program if there are any plugins in the program.
- Currently the plugin information is only stored in the ApplicationSpecification and not individual Program's specification.
- Also the plugin information stored for a program should only be the plugin which are associated in that program and not plugins in other program. (Plugin information stored at the AppSpec level contains plugin info across all programs)

### Summary of Change
- This PR introduces `AbstractProgramSpecification` to store the common info across program specs.
- Currently all the program specs passes `Collections.emptyMap()` for plugin information. They pass the plugin information in the following PRs.

[Issue](https://issues.cask.co/browse/CDAP-13924)
[Design](https://wiki.cask.co/display/CE/Improving+Plugins+User+Experience+Across+Different+Modes)
Build: https://builds.cask.co/browse/CDAP-DUT6600-2