### PR TITLE
CDAP-13924:use boolean as beta in Provisioner

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerConfig.java
@@ -31,9 +31,9 @@ public class ProvisionerConfig {
   @SerializedName("icon")
   private final Object icon;
   @SerializedName("beta")
-  private final Boolean beta;
+  private final boolean beta;
 
-  public ProvisionerConfig(List<Object> configurationGroups, @Nullable Object icon, @Nullable Boolean beta) {
+  public ProvisionerConfig(List<Object> configurationGroups, @Nullable Object icon, boolean beta) {
     this.configurationGroups = configurationGroups;
     this.icon = icon;
     this.beta = beta;
@@ -48,8 +48,7 @@ public class ProvisionerConfig {
     return icon;
   }
 
-  @Nullable
-  public Boolean isBeta() {
+  public boolean isBeta() {
     return beta;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
@@ -398,7 +398,7 @@ public class ProvisioningService extends AbstractIdleService {
       ProvisionerSpecification spec = provisionerEntry.getValue().getSpec();
       String provisionerName = provisionerEntry.getKey();
       ProvisionerConfig config = provisionerConfigs.getOrDefault(provisionerName,
-                                                                 new ProvisionerConfig(new ArrayList<>(), null, null));
+                                                                 new ProvisionerConfig(new ArrayList<>(), null, false));
       details.put(provisionerName, new ProvisionerDetail(spec.getName(), spec.getLabel(), spec.getDescription(),
                                                          config.getConfigurationGroups(), config.getIcon(),
                                                          config.isBeta()));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProfileHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProfileHttpHandlerTest.java
@@ -162,7 +162,7 @@ public class ProfileHttpHandlerTest extends AppFabricTestBase {
     // if given some unrelated json, it should return a 400 instead of 500
     ProvisionerSpecification spec = new MockProvisioner().getSpec();
     ProvisionerDetail test = new ProvisionerDetail(spec.getName(), spec.getLabel(), spec.getDescription(),
-                                                   new ArrayList<>(), null, null);
+                                                   new ArrayList<>(), null, false);
     putProfile(NamespaceId.DEFAULT.profile(test.getName()), test, 400);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProvisionerHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProvisionerHttpHandlerTest.java
@@ -44,7 +44,7 @@ public class ProvisionerHttpHandlerTest extends AppFabricTestBase {
     // in unit test, we only have the mock provisioner currently
     ProvisionerSpecification spec = new MockProvisioner().getSpec();
     ProvisionerDetail expected = new ProvisionerDetail(spec.getName(), spec.getLabel(),
-                                                       spec.getDescription(), new ArrayList<>(), null, null);
+                                                       spec.getDescription(), new ArrayList<>(), null, false);
     List<ProvisionerDetail> details = listProvisioners();
     Assert.assertEquals(ImmutableList.of(expected), details);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
@@ -156,7 +156,7 @@ public class ProvisioningServiceTest {
 
     ProvisionerSpecification spec = new MockProvisioner().getSpec();
     ProvisionerDetail expected = new ProvisionerDetail(spec.getName(), spec.getLabel(),
-                                                       spec.getDescription(), new ArrayList<>(), null, null);
+                                                       spec.getDescription(), new ArrayList<>(), null, false);
     Assert.assertEquals(expected, specs.iterator().next());
 
     Assert.assertEquals(expected, provisioningService.getProvisionerDetail(MockProvisioner.NAME));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/provisioner/ProvisionerDetail.java
@@ -34,10 +34,10 @@ public class ProvisionerDetail {
   @SerializedName("icon")
   private final Object icon;
   @SerializedName("beta")
-  private final Boolean beta;
+  private final boolean beta;
 
   public ProvisionerDetail(String name, String label, String description, List<Object> configurationGroups,
-                           @Nullable Object icon, @Nullable Boolean beta) {
+                           @Nullable Object icon, boolean beta) {
     this.name = name;
     this.label = label;
     this.description = description;


### PR DESCRIPTION
- Use primitive boolean instead of Boolean in provisioner to not have to deal with nulls
- GSON deserialize will handle the deserialization if the config does not specify isBeta as false (default value of boolean primitive)