### PR TITLE
CDAP-14161 add debug logging for provisioner task cancellation

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisioningService.java
@@ -692,7 +692,9 @@ public class ProvisioningService extends AbstractIdleService {
       return Optional.empty();
     }
 
+    LOG.trace("Cancelling {} task for program run {}.", taskKey.getType(), taskKey.getProgramRunId());
     if (future.cancel(true)) {
+      LOG.debug("Cancelled {} task for program run {}.", taskKey.getType(), taskKey.getProgramRunId());
       // this is the task state after it has been cancelled
       ProvisioningTaskInfo currentTaskInfo = Transactionals.execute(transactional, dsContext -> {
         ProvisionerDataset provisionerDataset = ProvisionerDataset.get(dsContext, datasetFramework);
@@ -709,6 +711,8 @@ public class ProvisioningService extends AbstractIdleService {
           new ProvisioningOp(currentInfo.getProvisioningOp().getType(), ProvisioningOp.Status.CANCELLED);
         ProvisioningTaskInfo newTaskInfo = new ProvisioningTaskInfo(currentInfo, newOp, currentInfo.getCluster());
         provisionerDataset.putTaskInfo(newTaskInfo);
+        LOG.trace("Recorded cancelled state for {} task for program run {}.",
+                  taskKey.getType(), taskKey.getProgramRunId());
 
         return currentInfo;
       });

--- a/cdap-common/src/test/resources/logback-test.xml
+++ b/cdap-common/src/test/resources/logback-test.xml
@@ -41,6 +41,7 @@
     <logger name="co.cask.cdap.data2.datafabric.dataset.service.DatasetInstanceService" level="TRACE"/>
     <logger name="co.cask.cdap.data2.datafabric.dataset.service.executor.RemoteDatasetOpExecutor" level="TRACE"/>
     <logger name="co.cask.cdap.internal.app.runtime.AbstractProgramController" level="TRACE"/>
+    <logger name="co.cask.cdap.internal.provision.ProvisioningService" level="TRACE"/>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
Added debug logging that will help narrow down a race condition
in cancelling deprovision tasks.