### PR TITLE
CDAP-13878 fix an hbase version error message for cloud runs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
+import co.cask.cdap.app.guice.ClusterMode;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
@@ -197,10 +198,12 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
         hConf.set(JobContext.QUEUE_NAME, schedulerQueue);
       }
 
+      ClusterMode clusterMode = ProgramRunners.getClusterMode(options);
       Service mapReduceRuntimeService = new MapReduceRuntimeService(injector, cConf, hConf, mapReduce, spec,
                                                                     context, program.getJarLocation(), locationFactory,
                                                                     streamAdmin, authorizationEnforcer,
-                                                                    authenticationContext, fieldLineageWriter);
+                                                                    authenticationContext, fieldLineageWriter,
+                                                                    clusterMode);
       mapReduceRuntimeService.addListener(createRuntimeServiceListener(closeables), Threads.SAME_THREAD_EXECUTOR);
 
       ProgramController controller = new MapReduceProgramController(mapReduceRuntimeService, context);


### PR DESCRIPTION
Fixed a bug where program logs would always contain an error
message about HBase classes not being available. It is expected
that HBase is not available for cloud runs so fixed the mapreduce
runtime service to only try to get them when the run is on premise.