### PR TITLE
CDAP-13924 Perform Provisioner checks for plugin capability before pr…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -132,4 +132,9 @@ public final class ProgramOptionConstants {
    * Option for the program runtime {@link ClusterMode}.
    */
   public static final String CLUSTER_MODE = "clusterMode";
+
+  /**
+   * Option for requirements of various plugins present in the program
+   */
+  public static final String PLUGIN_REQUIREMENTS = "pluginRequirements";
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/PluginRequirement.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/PluginRequirement.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.pipeline;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A wrapper class around plugin name, type and {@link Set} of requirements.
+ */
+public class PluginRequirement {
+  private final String name;
+  private final String type;
+  private final Set<String> requirements;
+
+  public PluginRequirement(String name, String type, Set<String> requirements) {
+    this.name = name;
+    this.type = type;
+    this.requirements = Collections.unmodifiableSet(new HashSet<>(requirements));
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public Set<String> getRequirements() {
+    return requirements;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PluginRequirement that = (PluginRequirement) o;
+    return Objects.equals(name, that.name) &&
+      Objects.equals(type, that.type) &&
+      Objects.equals(requirements, that.requirements);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, requirements);
+  }
+
+  @Override
+  public String toString() {
+    return "PluginRequirement{" +
+      "name='" + name + '\'' +
+      ", type='" + type + '\'' +
+      ", requirements=" + requirements +
+      '}';
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/NativeProvisioner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/NativeProvisioner.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.provision;
 
+import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.proto.profile.Profile;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
@@ -26,8 +27,8 @@ import co.cask.cdap.runtime.spi.provisioner.ProvisionerContext;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -74,5 +75,10 @@ public class NativeProvisioner implements Provisioner {
   public PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster) {
     // shouldn't matter, as we won't ever poll
     return PollingStrategies.fixedInterval(2, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public Set<String> getCapabilities() {
+    return Collections.singleton(Requirements.TEPHRA_TX);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.provision;
 
+import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.proto.profile.Profile;
 import co.cask.cdap.proto.provisioner.ProvisionerInfo;
 import co.cask.cdap.proto.provisioner.ProvisionerPropertyValue;
@@ -32,7 +33,6 @@ import com.google.inject.Singleton;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -131,6 +131,11 @@ public class MockProvisioner implements Provisioner {
   public PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster) {
     // retry immediately in unit tests
     return PollingStrategies.fixedInterval(0, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public Set<String> getCapabilities() {
+    return Collections.singleton(Requirements.TEPHRA_TX);
   }
 
   // throws a RetryableProvisionException every other time this is called

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/IncapableSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/IncapableSink.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.annotation.Requirements;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.Collections;
+
+
+/**
+ * Sink which has an requirement which can be meet with another special requirement
+ */
+@Plugin(type = BatchSink.PLUGIN_TYPE)
+@Name(IncapableSink.NAME)
+@Requirements({Requirements.TEPHRA_TX, IncapableSink.REQUIREMENT})
+public class IncapableSink extends BatchSink<StructuredRecord, byte[], Put> {
+
+  public static final String NAME = "IncapableSink";
+  public static final String REQUIREMENT = "unicorn";
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+
+  }
+
+  /**
+   * @return {@link IncapableSink} as the ETLPlugin
+   */
+  public static ETLPlugin getPlugin() {
+    return new ETLPlugin(IncapableSink.NAME, BatchSink.PLUGIN_TYPE, Collections.emptyMap(), null);
+  }
+}
+
+

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/IncapableSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/IncapableSource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.annotation.Requirements;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.Collections;
+
+/**
+ * Source which has special requirement
+ */
+@Plugin(type = BatchSource.PLUGIN_TYPE)
+@Name(IncapableSource.NAME)
+@Requirements(IncapableSource.REQUIREMENT)
+public class IncapableSource extends BatchSource<byte[], Row, StructuredRecord> {
+
+  public static final String NAME = "IncapableSource";
+  public static final String REQUIREMENT = "unicorn";
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+
+  }
+
+  /**
+   * @return {@link IncapableSource} as the ETLPlugin
+   */
+  public static ETLPlugin getPlugin() {
+    return new ETLPlugin(IncapableSource.NAME, BatchSource.PLUGIN_TYPE, Collections.emptyMap(), null);
+  }
+}
+
+

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -28,6 +28,8 @@ import co.cask.cdap.etl.mock.action.MockAction;
 import co.cask.cdap.etl.mock.alert.NullAlertTransform;
 import co.cask.cdap.etl.mock.alert.TMSAlertPublisher;
 import co.cask.cdap.etl.mock.batch.FilterTransform;
+import co.cask.cdap.etl.mock.batch.IncapableSink;
+import co.cask.cdap.etl.mock.batch.IncapableSource;
 import co.cask.cdap.etl.mock.batch.LookupTransform;
 import co.cask.cdap.etl.mock.batch.MockExternalSink;
 import co.cask.cdap.etl.mock.batch.MockExternalSource;
@@ -71,7 +73,6 @@ public class HydratorTestBase extends TestBase {
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, GroupFilterAggregator.PLUGIN_CLASS,
     MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
-    co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS, co.cask.cdap.etl.mock.batch.MockSource.PLUGIN_CLASS,
     MockRuntimeDatasetSink.PLUGIN_CLASS, MockRuntimeDatasetSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, AllErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
@@ -119,7 +120,8 @@ public class HydratorTestBase extends TestBase {
                       IntValueFilterTransform.class, StringValueFilterTransform.class,
                       FieldCountAggregator.class, IdentityAggregator.class, FieldsPrefixTransform.class,
                       StringValueFilterCompute.class, NodeStatesAction.class, LookupTransform.class,
-                      NullFieldSplitterTransform.class, NullAlertTransform.class);
+                      NullFieldSplitterTransform.class, NullAlertTransform.class,
+                      IncapableSource.class, IncapableSink.class);
   }
 
   protected static void setupStreamingArtifacts(ArtifactId artifactId, Class<?> appClass) throws Exception {

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -38,6 +38,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -185,6 +186,11 @@ public class DataProcProvisioner implements Provisioner {
     }
     LOG.warn("Received a request to get the polling strategy for unexpected cluster status {}", cluster.getStatus());
     return strategy;
+  }
+
+  @Override
+  public Set<String> getCapabilities() {
+    return Collections.singleton("gcp");
   }
 
   // Name must start with a lowercase letter followed by up to 51 lowercase letters,

--- a/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisioner.java
+++ b/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisioner.java
@@ -39,6 +39,7 @@ import java.net.ConnectException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -167,5 +168,10 @@ public class ElasticMapReduceProvisioner implements Provisioner {
       cleanedAppName = cleanedAppName.substring(0, maxAppLength);
     }
     return CLUSTER_PREFIX + cleanedAppName + "-" + programRun.getRun();
+  }
+
+  @Override
+  public Set<String> getCapabilities() {
+    return Collections.singleton("emr");
   }
 }

--- a/cdap-runtime-ext-remote-hadoop/src/main/java/co/cask/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
+++ b/cdap-runtime-ext-remote-hadoop/src/main/java/co/cask/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
@@ -29,6 +29,7 @@ import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -79,5 +80,10 @@ public class RemoteHadoopProvisioner implements Provisioner {
   public PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster) {
     // shouldn't matter, as we won't ever poll.
     return PollingStrategies.fixedInterval(0, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public Set<String> getCapabilities() {
+    return Collections.emptySet();
   }
 }

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.runtime.spi.provisioner;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A Provisioner is responsible for creating and deleting clusters for program runs. Each method may be retried
@@ -115,5 +116,15 @@ public interface Provisioner {
    * @param cluster the cluster to poll status for
    */
   PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster);
+
+  /**
+   * Returns a {@link Set} of capabilities (lowercase) of this provisioner. Capabilities allow plugins requiring special
+   * Requirements to be run in the provisioner if all the requirements are met. If a program requires a
+   * capability that is not supported by the provisioner, the platform will fail the program run before provisioning
+   * begins.
+   *
+   * @return the capabilities
+   */
+  Set<String> getCapabilities();
 
 }


### PR DESCRIPTION
…ogram runs

### Background
- In [PR 10550](https://github.com/caskdata/cdap/pull/10550) we added capability to filter incapable plugin at instance level through `cdap-site.xml`
- Although it is not always possible to filter incapable plugin. Incapability might be due the provisioned instance on which the program is being run. For details please see design [here](https://wiki.cask.co/display/CE/Improving+Plugins+User+Experience+Across+Different+Modes#ImprovingPluginsUserExperienceAcrossDifferentModes-ProvisionerChecks)
- In such cases where the program/pipeline is incapable to run on the provisioned instance the failure happens after the provisioning is done and the program tries to run which is expensive and not a great user experience.

### Introduction
- In this PR a provisioner level check is added which checks that the provisioner on which the program will run meets all the requirements defined by all the plugins in the program
- If the provisioner does not meet one or more requirement the program start calls fails immediately (before provisioning) with a helpful message which explicitly describe the plugins and the requirements not meet.

### Summary of Change
- Provisioners now implements an interface `getCapabilities()` and provide their capabilities.
- This PR uses the information captured and stored about plugins in `ProgramSpecification` which was added in [earlier PR](https://github.com/caskdata/cdap/pull/10577) to find whether any of the plugins have a requirement which is not met. This check is performed in `ProgramLifecycleService` while handling the `start` program call.
- The `ProvisioingService` is responsible is used to perform the check which can throw an `IncapableException` if there are incapabilities.
- Added unit tests for provisioner level checks which fail program start call in case of incapabilities.

### Links
[Issue](https://issues.cask.co/browse/CDAP-13924)
[Design](https://wiki.cask.co/display/CE/Improving+Plugins+User+Experience+Across+Different+Modes#ImprovingPluginsUserExperienceAcrossDifferentModes-ProvisionerChecks)
[Build](https://builds.cask.co/browse/CDAP-DUT6610/latest)