### PR TITLE
[CDAP-14189] Reduce the number of scheduler threads in unit tests

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/queue/JobQueueDatasetDefinition.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/queue/JobQueueDatasetDefinition.java
@@ -24,6 +24,8 @@ import co.cask.cdap.api.dataset.lib.CompositeDatasetDefinition;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.dataset.table.TableProperties;
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.base.Preconditions;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -43,6 +45,9 @@ public class JobQueueDatasetDefinition extends CompositeDatasetDefinition<JobQue
     TableProperties.Builder tableProps = TableProperties.builder();
     tableProps.addAll(properties.getProperties());
     tableProps.setConflictDetection(ConflictDetection.COLUMN);
+    Preconditions.checkNotNull(properties.getProperties().get(Constants.Scheduler.JOB_QUEUE_NUM_PARTITIONS),
+                               "Property '{}' must be given when creating job queue dataset",
+                               Constants.Scheduler.JOB_QUEUE_NUM_PARTITIONS);
     DatasetSpecification tableSpec = super.getDelegate(JobQueueDataset.EMBEDDED_TABLE_NAME).configure(
       JobQueueDataset.EMBEDDED_TABLE_NAME, tableProps.build());
     return DatasetSpecification.builder(instanceName, getName())
@@ -57,6 +62,6 @@ public class JobQueueDatasetDefinition extends CompositeDatasetDefinition<JobQue
     throws IOException {
     Table table = getDataset(
       datasetContext, JobQueueDataset.EMBEDDED_TABLE_NAME, spec, arguments, classLoader);
-    return new JobQueueDataset(spec.getName(), table);
+    return new JobQueueDataset(spec, table);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/Schedulers.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/Schedulers.java
@@ -20,6 +20,8 @@ import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.schedule.queue.JobQueueDataset;
@@ -39,6 +41,7 @@ import java.lang.reflect.Type;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -74,10 +77,14 @@ public class Schedulers {
     return triggerKeysBuilder.build();
   }
 
-  public static JobQueueDataset getJobQueue(DatasetContext context, DatasetFramework dsFramework) {
+  public static JobQueueDataset getJobQueue(DatasetContext context, DatasetFramework dsFramework,
+                                            CConfiguration cConf) {
     try {
-      return DatasetsUtil.getOrCreateDataset(context, dsFramework, JOB_QUEUE_DATASET_ID,
-                                             JobQueueDataset.class.getName(), DatasetProperties.EMPTY);
+      return DatasetsUtil.getOrCreateDataset(
+        context, dsFramework, JOB_QUEUE_DATASET_ID, JobQueueDataset.class.getName(),
+        () -> DatasetProperties.of(
+          Collections.singletonMap(Constants.Scheduler.JOB_QUEUE_NUM_PARTITIONS,
+                                   cConf.get(Constants.Scheduler.JOB_QUEUE_NUM_PARTITIONS))));
     } catch (DatasetManagementException | IOException e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ScheduleNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ScheduleNotificationSubscriberService.java
@@ -131,18 +131,18 @@ public class ScheduleNotificationSubscriberService extends AbstractIdleService {
 
     @Nullable
     @Override
-    protected String loadMessageId(DatasetContext datasetContext) throws Exception {
+    protected String loadMessageId(DatasetContext datasetContext) {
       return getJobQueue(datasetContext).retrieveSubscriberState(getTopicId().getTopic());
     }
 
     @Override
-    protected void storeMessageId(DatasetContext datasetContext, String messageId) throws Exception {
+    protected void storeMessageId(DatasetContext datasetContext, String messageId) {
       getJobQueue(datasetContext).persistSubscriberState(getTopicId().getTopic(), messageId);
     }
 
     @Override
     protected void processMessages(DatasetContext datasetContext,
-                                   Iterator<ImmutablePair<String, Notification>> messages) throws Exception {
+                                   Iterator<ImmutablePair<String, Notification>> messages) {
       ProgramScheduleStoreDataset scheduleStore = getScheduleStore(datasetContext);
       JobQueueDataset jobQueue = getJobQueue(datasetContext);
 
@@ -163,7 +163,7 @@ public class ScheduleNotificationSubscriberService extends AbstractIdleService {
                                                 JobQueueDataset jobQueue, Notification notification);
 
     private JobQueueDataset getJobQueue(DatasetContext datasetContext) {
-      return Schedulers.getJobQueue(datasetContext, datasetFramework);
+      return Schedulers.getJobQueue(datasetContext, datasetFramework, cConf);
     }
 
     private ProgramScheduleStoreDataset getScheduleStore(DatasetContext datasetContext) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/queue/JobQueueDatasetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/queue/JobQueueDatasetTest.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
-import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -33,7 +32,6 @@ import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.internal.app.AppFabricDatasetModule;
@@ -60,7 +58,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
-import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionAware;
@@ -147,7 +144,10 @@ public class JobQueueDatasetTest {
 
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     DatasetsUtil.createIfNotExists(datasetFramework, Schedulers.JOB_QUEUE_DATASET_ID,
-                                   JobQueueDataset.class.getName(), DatasetProperties.EMPTY);
+                                   JobQueueDataset.class.getName(),
+                                   DatasetProperties.builder().
+                                     add(Constants.Scheduler.JOB_QUEUE_NUM_PARTITIONS, 5)
+                                     .build());
 
     jobQueue = datasetFramework.getDataset(Schedulers.JOB_QUEUE_DATASET_ID, new HashMap<>(), null);
     txExecutor = new DynamicTransactionExecutorFactory(new InMemoryTxSystemClient(txManager))

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -347,6 +347,9 @@ public abstract class AppFabricTestBase {
 
     cConf.setBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE, true);
     cConf.set(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR, tmpFolder.newFolder("system-artifacts").getAbsolutePath());
+
+    // reduce the number of constraint checker threads
+    cConf.setInt(Constants.Scheduler.JOB_QUEUE_NUM_PARTITIONS, 2);
     return cConf;
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -341,6 +341,8 @@ public final class Constants {
     public static final String TIME_EVENT_FETCH_SIZE = "scheduler.time.event.fetch.size";
     public static final String DATA_EVENT_FETCH_SIZE = "scheduler.data.event.fetch.size";
     public static final String PROGRAM_STATUS_EVENT_FETCH_SIZE = "scheduler.program.status.event.fetch.size";
+
+    public static final String JOB_QUEUE_NUM_PARTITIONS = "scheduler.job.queue.num.partitions";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -531,6 +531,15 @@
   </property>
 
   <property>
+    <name>scheduler.job.queue.num.partitions</name>
+    <value>16</value>
+    <description>
+      Number of partitions in the scheduler's job queue. This is the same
+      as the number of constraint checker threads started by the scheduler.
+    </description>
+  </property>
+
+  <property>
     <name>scheduler.max.thread.pool.size</name>
     <value>100</value>
     <description>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -58,7 +59,7 @@ public final class DatasetsUtil {
 
   /**
    * Gets instance of {@link Dataset}, while add instance to
-   * {@link co.cask.cdap.data2.dataset2.DatasetFramework} and creating the physical data set
+   * {@link DatasetFramework} and creating the physical data set
    * if that one doesn't exist.
    */
   public static <T extends Dataset> T getOrCreateDataset(DatasetFramework datasetFramework,
@@ -88,6 +89,25 @@ public final class DatasetsUtil {
       return datasetContext.getDataset(datasetId.getNamespace(), datasetId.getDataset());
     } catch (DatasetInstantiationException e) {
       createIfNotExists(datasetFramework, datasetId, datasetTypename, datasetProperties);
+      return datasetContext.getDataset(datasetId.getNamespace(), datasetId.getDataset());
+    }
+  }
+
+  /**
+   * Gets a {@link Dataset} instance through the given {@link DatasetContext}. If the dataset doesn't exist,
+   * it will be created using the given {@link DatasetFramework}.
+   */
+  public static <T extends Dataset> T getOrCreateDataset(DatasetContext datasetContext,
+                                                         DatasetFramework datasetFramework,
+                                                         DatasetId datasetId,
+                                                         String datasetTypename,
+                                                         Supplier<DatasetProperties> datasetPropertiesSupplier)
+    throws DatasetManagementException, IOException {
+
+    try {
+      return datasetContext.getDataset(datasetId.getNamespace(), datasetId.getDataset());
+    } catch (DatasetInstantiationException e) {
+      createIfNotExists(datasetFramework, datasetId, datasetTypename, datasetPropertiesSupplier.get());
       return datasetContext.getDataset(datasetId.getNamespace(), datasetId.getDataset());
     }
   }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/JobQueueDebugger.java
@@ -141,19 +141,19 @@ public class JobQueueDebugger extends AbstractIdleService {
   }
 
   @Override
-  protected void startUp() throws Exception {
+  protected void startUp() {
     zkClientService.startAndWait();
   }
 
   @Override
-  protected void shutDown() throws Exception {
+  protected void shutDown() {
     zkClientService.stopAndWait();
   }
 
   private JobQueueScanner getJobQueueScanner() {
     if (jobQueueScanner == null) {
       jobQueueScanner = new JobQueueScanner(cConf, transactional,
-                                            Schedulers.getJobQueue(multiThreadDatasetCache, datasetFramework));
+                                            Schedulers.getJobQueue(multiThreadDatasetCache, datasetFramework, cConf));
     }
     return jobQueueScanner;
   }
@@ -162,12 +162,12 @@ public class JobQueueDebugger extends AbstractIdleService {
     getJobQueueScanner().printTopicMessageIds();
   }
 
-  private void scanPartitions(boolean trace) throws Exception {
+  private void scanPartitions(boolean trace) {
     getJobQueueScanner().scanPartitions(trace);
   }
 
-  private JobStatistics scanPartition(int partition, boolean trace) {
-    return getJobQueueScanner().scanPartition(partition, trace);
+  private void scanPartition(int partition, boolean trace) {
+    getJobQueueScanner().scanPartition(partition, trace);
   }
 
   /**
@@ -190,7 +190,7 @@ public class JobQueueDebugger extends AbstractIdleService {
 
     private void printTopicMessageIds() throws TransactionFailureException {
       transactional.execute(context -> {
-        System.out.printf("Getting notification subscriber messageIds.\n");
+        System.out.println("Getting notification subscriber messageIds.");
         List<String> topics = ImmutableList.of(cConf.get(Constants.Scheduler.TIME_EVENT_TOPIC),
                                                cConf.get(Constants.Dataset.DATA_EVENT_TOPIC));
         for (String topic : topics) {
@@ -202,7 +202,7 @@ public class JobQueueDebugger extends AbstractIdleService {
       });
     }
 
-    private void scanPartitions(boolean trace) throws Exception {
+    private void scanPartitions(boolean trace) {
       final JobStatistics totalStats = new JobStatistics();
 
       System.out.println("\nScanning JobQueue.");


### PR DESCRIPTION
- the number of threads is controlled by a data set constant in job queue dataset (#partitions)
- changed that to a dataset property, with default to old hard-coded value
