### PR TITLE
[CDAP-9226] Makes font family the same in both React and Angular apps

### DIFF
--- a/cdap-ui/app/cdap/components/Header/DropdownStyling.scss
+++ b/cdap-ui/app/cdap/components/Header/DropdownStyling.scss
@@ -62,7 +62,7 @@ $dropdown_divider_bg_color: $grey-06;
         }
       }
       &:after {
-        margin-left: 1rem;
+        margin-left: 13px;
         display: inline-block;
         width: 0;
         height: 0;

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -26,7 +26,7 @@ values in Angular apps
 :root {
   --brand-primary-color: @brand-primary-color;
   --navbar-color: @navbar-bg;
-  --font-family: @font-family-base; // base font defined in bootstrap/less/variables.less
+  --font-family: @bootstrap4-font-family; // Bootstrap 4 base font
 }
 
 html {
@@ -37,6 +37,8 @@ html {
 body {
   // visibility: hidden; // themes start the show
   margin-bottom: 80px;
+  font-family: var(--font-family);
+
   .dropdown-menu {
     > li > a,
     > li.dropdown-header {

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -165,3 +165,8 @@
 
 // MODALS/WIZARDS
 @modal-header-color: rgba(70, 74, 87, 1); // #464a57
+
+// NOTE: This is the base Bootstrap 4 font. We use it in Angular to make sure
+// our fonts look consistent in both React and Angular sides. Make sure to
+// double-check this when/if we upgrade Bootstrap on the React side!
+@bootstrap4-font-family: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-9226
Build: https://builds.cask.co/browse/CDAP-UDUT65

The motivation for this change is that currently the Header/navbar looks different in React apps and in Angular apps. This is because of two things:

- Currently in Angular we use Bootstrap3, which has a different base font-family than Bootstrap4, which is used in the React apps. The Bootstrap3 base font family is applied to the Header, causing it to have a different font than in the React apps. The fix is to explicitly use Bootstrap4 base font in the Angular apps.
- For the caret next to the 'Control Center' label, the `margin-left` property before my changes was `1rem`. In React/Bootstrap4, the font-size for `<html>` tag is 13px, while in Angular/Bootstrap it is 10px, causing the `1rem` to resolve in different values. The fix is to explicitly set the `margin-left` to 13px to be consistent everywhere.