### PR TITLE
[CDAP-14206][CDAP-14213] Fixes clicking on BQ dataset taking user to File System instead

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/commons.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/commons.js
@@ -17,7 +17,6 @@
 import DataPrepBrowserStore, {Actions as BrowserStoreActions} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
 
 const setActiveBrowser = (payload) => {
-  reset();
   DataPrepBrowserStore.dispatch({
     type: BrowserStoreActions.SET_ACTIVEBROWSER,
     payload


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-14213
- https://issues.cask.co/browse/CDAP-14206

The problem was that we were calling `reset();` every time `setActiveBrowser()` is called, which will reset the store. In our current implementation, `setActiveBrowser()` is called every time the user opens up a dataset/bucket in any browser. Resetting the store causes two issues:

- Resets the content of the BQ connection state, so the `connectionId` becomes undefined. This will cause the link of a dataset in BQ to become something like this `http://localhost:11011/cdap/ns/default/connections/bigquery//datasets/demo`. Notice the missing info after `/bigquery/`. Since the url is not valid, clicking on it will lead the user back to the default connection, which is File system on sandboc.
- The path the user has navigated so far in the file system is reset when `reset()` is called, causing the issue described in CDAP-14206.

Build: https://builds.cask.co/browse/CDAP-UDUT67