### PR TITLE
CDAP-13887 fix metrics skip on provision failure

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsQueryHelper.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsQueryHelper.java
@@ -115,7 +115,7 @@ public class MetricsQueryHelper {
       .put(Constants.Metrics.Tag.PROGRAM, "program")
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, "programtype")
 
-      // put profiel related tag
+      // put profile related tag
       .put(Constants.Metrics.Tag.PROFILE, "profile")
       .put(Constants.Metrics.Tag.PROFILE_SCOPE, "profilescope")
       .build();


### PR DESCRIPTION
Fixed a bug where a failure to provision a cluster would not
increment the failed program runs metric for that profile.
The bug is due to the fact that transition of the program run
state from pending to failed was being implicitly handled by
the AppMetadataStore when it processed a message to store
provisioning state.

Fixed the bug by having the provision task explicitly write
a failed program state instead of relying on the store to handle
the state transition. This allows the ProgramNotificationSubscriber
to retain its existing logic of incrementing counters when it
notices that a program run transitions to an end state.