### PR TITLE
CDAP-14223 Close the DataprocClient that we create when validating properties

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -60,10 +60,12 @@ public class DataprocProvisioner implements Provisioner {
   @Override
   public void validateProperties(Map<String, String> properties) {
     DataprocConf conf = DataprocConf.fromProperties(properties);
-    try {
-      DataprocClient.fromConf(conf);
+    try (DataprocClient ignored = DataprocClient.fromConf(conf)) {
+      // simply creating the client to validate that we can create it
     } catch (IOException | GeneralSecurityException e) {
       throw new IllegalArgumentException(e.getMessage(), e);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-14223
Close the DataprocClient that we create when validating properties (done during profile creation).
Otherwise, there can be SEVERE messages in the logs, as described in the Jira.

Depends on https://github.com/caskdata/cdap/pull/10596