### PR TITLE
CDAP-14221 Use - instead of _ for logical types

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
@@ -99,21 +99,54 @@ public final class Schema implements Serializable {
    *
    */
   public enum LogicalType {
-    DATE(Type.INT),
-    TIMESTAMP_MILLIS(Type.LONG),
-    TIMESTAMP_MICROS(Type.LONG),
-    TIME_MILLIS(Type.INT),
-    TIME_MICROS(Type.LONG);
+    DATE(Type.INT, "date"),
+    TIMESTAMP_MILLIS(Type.LONG, "timestamp-millis"),
+    TIMESTAMP_MICROS(Type.LONG, "timestamp-micros"),
+    TIME_MILLIS(Type.INT, "time-millis"),
+    TIME_MICROS(Type.LONG, "time-micros");
 
     private final Type type;
+    private final String token;
+
+    private static final Map<String, LogicalType> LOOKUP_BY_TOKEN;
+    static {
+      Map<String, LogicalType> map = new HashMap<>();
+      for (LogicalType logicalType : values()) {
+        map.put(logicalType.token, logicalType);
+      }
+      LOOKUP_BY_TOKEN = Collections.unmodifiableMap(map);
+    }
 
     /**
      * Creates {@link LogicalType} with underlying primitive type.
      *
      * @param type primitive type on which this {@link LogicalType} relies on
+     * @param token token string associated with {@link LogicalType}
      */
-    LogicalType(Type type) {
+    LogicalType(Type type, String token) {
       this.type = type;
+      this.token = token;
+    }
+
+    /**
+     * @return returns the token string associated with logical type.
+     */
+    public String getToken() {
+      return token;
+    }
+
+    /**
+     * Returns {@link LogicalType} associated with the token string provided.
+     *
+     * @param token token string for the logical type
+     * @return logical type associated with the token string
+     */
+    public static LogicalType fromToken(String token) {
+      LogicalType logicalType = LOOKUP_BY_TOKEN.get(token);
+      if (logicalType != null) {
+        return logicalType;
+      }
+      throw new IllegalArgumentException("Unknown logical type for token: " + token);
     }
   }
 

--- a/cdap-api-common/src/main/java/co/cask/cdap/internal/io/SchemaTypeAdapter.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/internal/io/SchemaTypeAdapter.java
@@ -154,7 +154,7 @@ public final class SchemaTypeAdapter extends TypeAdapter<Schema> {
       String name = reader.nextName();
       switch (name) {
         case LOGICAL_TYPE:
-          logicalType = Schema.LogicalType.valueOf(reader.nextString().toUpperCase());
+          logicalType = Schema.LogicalType.fromToken(reader.nextString());
           break;
         case TYPE:
           schemaType = Schema.Type.valueOf(reader.nextString().toUpperCase());
@@ -322,8 +322,8 @@ public final class SchemaTypeAdapter extends TypeAdapter<Schema> {
    */
   private JsonWriter write(JsonWriter writer, Schema schema, Set<String> knownRecords) throws IOException {
     if (schema.getLogicalType() != null) {
-      writer.beginObject().name(LOGICAL_TYPE).value(schema.getLogicalType().name().toLowerCase());
-      writer.name(TYPE).value(schema.getType().name().toLowerCase());
+      writer.beginObject().name(TYPE).value(schema.getType().name().toLowerCase());
+      writer.name(LOGICAL_TYPE).value(schema.getLogicalType().getToken());
       writer.endObject();
       return writer;
     }

--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -201,6 +201,12 @@
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.8.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
**Summary**
To convert schema to json string logical type should use `-` instead of `_`. For example, timestamp in micros should have `timestamp-micro` in json schema. 

Current implementation is relying on Java `Enum.name()` to create json schema for logical types. Instead, it should map `Enum.name()` to correct string values. 