### PR TITLE
(CDAP-14062) Fix Spark Classloader close issue

### DIFF
--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
@@ -26,7 +26,6 @@ import co.cask.cdap.common.logging.RedirectedPrintStream;
 import co.cask.cdap.internal.asm.Classes;
 import co.cask.cdap.internal.asm.Methods;
 import co.cask.cdap.internal.asm.Signatures;
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
@@ -58,6 +57,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 /**

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkContainerClassLoader.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkContainerClassLoader.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.app.runtime.spark.classloader;
 
 import co.cask.cdap.common.app.MainClassLoader;
-import com.google.common.base.Function;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -40,13 +39,7 @@ public class SparkContainerClassLoader extends MainClassLoader {
    */
   public SparkContainerClassLoader(URL[] urls, ClassLoader parent) {
     super(urls, parent);
-    this.sparkClassRewriter = new SparkClassRewriter(new Function<String, URL>() {
-      @Nullable
-      @Override
-      public URL apply(String resourceName) {
-        return findResource(resourceName);
-      }
-    }, false);
+    this.sparkClassRewriter = new SparkClassRewriter(this::getResource, false);
   }
 
   @Override


### PR DESCRIPTION
(CDAP-14062) Use `getResource` instead of `findResource` for locating Spark classes

- If the resource is already available in the parent, which it does in unit-test case, it open the resource from the parent class loader, which never get closed