### PR TITLE
CDAP-13924 Change Requirement specification

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Requirements.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Requirements.java
@@ -25,8 +25,8 @@ import java.lang.annotation.Target;
  *
  * <p>Requirements are case insensitive.</p>
  *
- * <p>If a plugin is not annotated with {@link Requirements} or the annotation {@link #value()} is empty, then it
- * is assumed that the plugin does not have any specific requirements and can run everywhere.</p>
+ * <p>If a plugin is not annotated with {@link Requirements} or the annotation {@link #datasetTypes()} is empty,
+ * then it is assumed that the plugin does not have any specific requirements and can run everywhere.</p>
  *
  * <p>Usage Examples:</p>
  * <ul>
@@ -40,24 +40,24 @@ import java.lang.annotation.Target;
  *       ...
  *      }
  *   </pre>
- * <li><b>Specifying a particular requirement:</b> If a plugin is capable to run only when 'transactions' are
- * available then this can be specified as below.</li>
+ * <li><b>Specifying a particular requirement:</b> If a plugin requires CDAP 'table' dataset then this can be specified
+ * as below.</li>
  * <pre>
  *     {@literal @}Plugin(type = BatchSource.PLUGIN_TYPE)
  *     {@literal @}Name("Table")
- *     {@literal @}Requirements(Requirements.TEPHRA_TX)
+ *     {@literal @}Requirements(datasetTypes = {"table"})
  *      public class Table extends{@code BatchSource<byte[], Row, StructuredRecord>} {
  *       ...
  *       ...
  *      }
  *   </pre>
  * <li><b>Specifying multiple requirements:</b> A plugin can also specify multiple requirements. For example if a
- * plugin needs 'spark' and 'kafka' to run this can specified as below.</li>
+ * plugin needs 'table' and 'keyValueTable' to run this can specified as below.</li>
  * <pre>
  *     {@literal @}Plugin(type = BatchSource.PLUGIN_TYPE)
- *     {@literal @}Name("KafkaStreaming")
- *     {@literal @}Requirements({"spark", "kafka"})
- *      public class KafkaStreamingSource extends{@code BatchSource<byte[], Row, StructuredRecord>} {
+ *     {@literal @}Name("MultiTable")
+ *     {@literal @}Requirements(datasetTypes = {"table", "keyValueTable"})
+ *      public class MultiTableSource extends{@code BatchSource<byte[], Row, StructuredRecord>} {
  *       ...
  *       ...
  *      }
@@ -67,10 +67,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Requirements {
-  /**
-   * Defines transactional requirements
-   */
-  String TEPHRA_TX = "tephratx";
 
-  String[] value() default {};
+  String[] datasetTypes() default {};
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTable.java
@@ -38,6 +38,11 @@ import java.util.NoSuchElementException;
 public class CounterTimeseriesTable extends TimeseriesDataset {
 
   /**
+   * Type name
+   */
+  public static final String TYPE = "counterTimeseriesTable";
+
+  /**
    * Creates an instance of the DataSet.
    */
   public CounterTimeseriesTable(DatasetSpecification spec, Table table) {

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSet.java
@@ -38,6 +38,11 @@ import java.util.Map;
 public interface FileSet extends Dataset, InputFormatProvider, OutputFormatProvider {
 
   /**
+   * Type name
+   */
+  String TYPE = "fileSet";
+
+  /**
    * Allows to interact directly with the location of this dataset in the underlying file system.
    *
    * @return the location of the base directory

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStore.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStore.java
@@ -39,6 +39,12 @@ import java.util.stream.Collectors;
  * @param <T> the type of objects in the store
  */
 public class IndexedObjectStore<T> extends AbstractDataset {
+
+  /**
+   * Type name
+   */
+  public static final String TYPE = "indexedObjectStore";
+
   //NOTE: cannot use byte[0] as empty value because byte[0] is treated as null
   private static final byte[] EMPTY_VALUE = new byte[1];
   //KEY_PREFIX is used to prefix primary key when it stores PrimaryKey -> Categories mapping.

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
@@ -97,6 +97,12 @@ import javax.annotation.Nullable;
  * @see #INDEX_COLUMNS_CONF_KEY
  */
 public class IndexedTable extends AbstractDataset implements Table {
+
+  /**
+   * Type name
+   */
+  public static final String TYPE = "indexedTable";
+
   private static final Logger LOG = LoggerFactory.getLogger(IndexedTable.class);
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
@@ -50,6 +50,11 @@ public class KeyValueTable extends AbstractDataset implements
   BatchReadable<byte[], byte[]>, BatchWritable<byte[], byte[]>,
   RecordScannable<KeyValue<byte[], byte[]>>, RecordWritable<KeyValue<byte[], byte[]>> {
 
+  /**
+   * Type name
+   */
+  public static final String TYPE = "keyValueTable";
+
   // the fixed single column to use for the key
   static final byte[] KEY_COLUMN = { 'c' };
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectMappedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectMappedTable.java
@@ -49,6 +49,11 @@ public interface ObjectMappedTable<T> extends Dataset, BatchReadable<byte[], T>,
   BatchWritable<byte[], T>, RecordScannable<StructuredRecord>, RecordWritable<StructuredRecord> {
 
   /**
+   * Type name
+   */
+  String TYPE = "objectMappedTable";
+
+  /**
    * Write an object with a given key.
    *
    * @param key the key of the object

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStore.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStore.java
@@ -46,6 +46,11 @@ import java.util.List;
 public interface ObjectStore<T> extends Dataset, BatchReadable<byte[], T>, BatchWritable<byte[], T> {
 
   /**
+   * Type name
+   */
+  String TYPE = "objectStore";
+
+  /**
    * Write an object with a given key.
    *
    * @param key the key of the object

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -45,6 +45,11 @@ import javax.annotation.Nullable;
 public interface PartitionedFileSet extends Dataset, InputFormatProvider, OutputFormatProvider {
 
   /**
+   * Type name
+   */
+  String TYPE = "partitionedFileSet";
+
+  /**
    * Get the partitioning declared for the file set.
    */
   Partitioning getPartitioning();

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -47,6 +47,11 @@ import javax.annotation.Nullable;
 public interface TimePartitionedFileSet extends PartitionedFileSet {
 
   /**
+   * Type name
+   */
+  String TYPE = "timePartitionedFileSet";
+
+  /**
    * Add a partition for a given time, stored at a given path (relative to the file set's base path).
    *
    * @param time the partition time in milliseconds since the Epoch

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesDataset.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesDataset.java
@@ -36,6 +36,11 @@ import java.util.concurrent.TimeUnit;
  */
 abstract class TimeseriesDataset extends AbstractDataset {
 
+  /**
+   * Type name
+   */
+  public static final String TYPE = "timeseriesTable";
+
   public static final String ATTR_TIME_INTERVAL_TO_STORE_PER_ROW = "timeIntervalToStorePerRow";
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Cube.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Cube.java
@@ -30,6 +30,12 @@ import java.util.List;
  */
 @Beta
 public interface Cube extends Dataset, BatchWritable<Object, CubeFact> {
+
+  /**
+   * Type name
+   */
+  String TYPE = "cube";
+
   /**
    * Property set to configure resolutions to aggregate for. Value is a comma-separated list of resolutions in seconds.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
@@ -37,6 +37,11 @@ public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[],
   Dataset, RecordScannable<StructuredRecord>, RecordWritable<StructuredRecord> {
 
   /**
+   * Type name
+   */
+  String TYPE = "table";
+
+  /**
    * Property set to configure time-to-live on data within this dataset. The value given is in seconds.
    * Once a cell's data has surpassed the given value in age,
    * the cell's data will no longer be visible and may be garbage collected.

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -39,11 +38,11 @@ public class PluginClass {
   private final String configFieldName;
   private final Map<String, PluginPropertyField> properties;
   private final Set<String> endpoints;
-  private final Set<String> requirements;
+  private final Requirements requirements;
 
   public PluginClass(String type, String name, String description, String className,
                      @Nullable String configfieldName, Map<String, PluginPropertyField> properties,
-                     Set<String> endpoints, Set<String> requirements) {
+                     Set<String> endpoints, Requirements requirements) {
     if (type == null) {
       throw new IllegalArgumentException("Plugin class type cannot be null");
     }
@@ -75,21 +74,20 @@ public class PluginClass {
     this.configFieldName = configfieldName;
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.endpoints = Collections.unmodifiableSet(new HashSet<>(endpoints));
-    // requirements are case insensitive
-    this.requirements = Collections.unmodifiableSet(requirements.stream()
-                                                      .map(String::toLowerCase).collect(Collectors.toSet()));
+    this.requirements = requirements;
   }
 
   public PluginClass(String type, String name, String description, String className, @Nullable String configfieldName,
                      Map<String, PluginPropertyField> properties) {
     this(type, name, description, className, configfieldName, properties, Collections.emptySet(),
-         Collections.emptySet());
+         Requirements.EMPTY);
   }
 
   public PluginClass(String type, String name, String description, String className,
                      @Nullable String configfieldName, Map<String, PluginPropertyField> properties,
                      Set<String> endpoints) {
-    this(type, name, description, className, configfieldName, properties, endpoints, Collections.emptySet());
+    this(type, name, description, className, configfieldName, properties, endpoints,
+         Requirements.EMPTY);
   }
 
   /**
@@ -145,9 +143,9 @@ public class PluginClass {
   }
 
   /**
-   * @return the requirements of the plugin (case insensitive: represented in lowercase)
+   * @return the {@link Requirements} which represents the requirements of the plugin
    */
-  public Set<String> getRequirements() {
+  public Requirements getRequirements() {
     return requirements;
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/Requirements.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/Requirements.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.plugin;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A class to encapsulate all the different types of requirements provided by
+ * {@link co.cask.cdap.api.annotation.Requirements}.
+ */
+public class Requirements {
+
+  public static final Requirements EMPTY = new Requirements(Collections.emptySet());
+
+  // currently this class only contains one set but we are using the object for storage during serialization so that we
+  // can add more when needed in future
+  private final Set<String> datasetTypes;
+
+  /**
+   * Creates a {@link Requirements} object from the given {@link Set}. Note: Requirements are case insensitive and all
+   * the requisites will be converted into lowercase.
+   *
+   * @param datasetTypes a {@link Set} containing dataset type requirements
+   */
+  public Requirements(Set<String> datasetTypes) {
+    this.datasetTypes = datasetTypes.isEmpty() ? Collections.emptySet() :
+      Collections.unmodifiableSet(datasetTypes.stream().map(String::toLowerCase).collect(Collectors.toSet()));
+  }
+
+  /**
+   * @return {@link Set} containing the dataset type requirement which can be be empty if there are no requirements
+   */
+  public Set<String> getDatasetTypes() {
+    return datasetTypes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Requirements that = (Requirements) o;
+    return Objects.equals(datasetTypes, that.datasetTypes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(datasetTypes);
+  }
+
+  @Override
+  public String toString() {
+    return "Requirements{" +
+      "datasetTypes=" + datasetTypes +
+      '}';
+  }
+
+  public boolean isEmpty() {
+    return datasetTypes.isEmpty();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
-import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.artifact.ApplicationClass;
 import co.cask.cdap.api.artifact.ArtifactClasses;
@@ -33,6 +32,7 @@ import co.cask.cdap.api.plugin.EndpointPluginContext;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.api.plugin.Requirements;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.common.InvalidArtifactException;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -357,21 +357,23 @@ final class ArtifactInspector {
   }
 
   /**
-   * Get all the {@link Requirements} specified by a plugin. The requirements are case insensitive and always
-   * represented in lowercase
+   * Get all the {@link co.cask.cdap.api.annotation.Requirements} specified by a plugin as {@link Requirements}.
+   * The requirements are case insensitive and always represented in lowercase.
    *
    * @param cls the plugin class whose requirement needs to be found
-   * @return requirements specified by the plugin (in lowercase) or an empty set if the plugin does not specify any
-   * {@link Requirements}
+   *
+   * @return {@link Requirements} containing the requirements specified by the plugin (in lowercase). If the plugin does
+   * not specify any {@link co.cask.cdap.api.annotation.Requirements} then the {@link Requirements} will be empty.
    */
   @VisibleForTesting
-  Set<String> getPluginRequirements(Class<?> cls) {
-    Requirements annotation = cls.getAnnotation(Requirements.class);
+  Requirements getPluginRequirements(Class<?> cls) {
+    co.cask.cdap.api.annotation.Requirements annotation =
+      cls.getAnnotation(co.cask.cdap.api.annotation.Requirements.class);
     if (annotation == null) {
-      return Collections.emptySet();
+      return Requirements.EMPTY;
     }
-    return Arrays.stream(annotation.value()).map(s -> s.trim().toLowerCase())
-      .filter(s -> !Strings.isNullOrEmpty(s)).collect(Collectors.toSet());
+    return new Requirements(Arrays.stream(annotation.datasetTypes()).map(s -> s.trim().toLowerCase())
+                              .filter(s -> !Strings.isNullOrEmpty(s)).collect(Collectors.toSet()));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -212,7 +212,7 @@ public class ArtifactStore {
     );
     this.impersonator = impersonator;
     this.requirementBlacklist =
-      new HashSet<>(cConf.getTrimmedStringCollection(Constants.REQUIREMENTS_BLACKLIST))
+      new HashSet<>(cConf.getTrimmedStringCollection(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE))
         .stream().map(String::toLowerCase).collect(Collectors.toSet());
   }
 
@@ -1080,14 +1080,15 @@ public class ArtifactStore {
   /**
    * Checks whether the plugin is excluded from being displayed/used and should be filtered out. The exclusion is
    * determined by the requirements of the plugin and the configuration for
-   * {@link Constants#REQUIREMENTS_BLACKLIST}
+   * {@link Constants#REQUIREMENTS_DATASET_TYPE_EXCLUDE}
    *
    * @param pluginClass the plugins class to check
    * @return true if the plugin should not be excluded and is allowed else false
    */
   private boolean isAllowed(PluginClass pluginClass) {
-    // if a plugin has any requirement which is marked excluded in the config then the plugin should not be allowed
-    return pluginClass.getRequirements().stream().noneMatch(requirementBlacklist::contains);
+    // if a plugin has any requirement which is marked excluded in the config then the plugin should not be allowed.
+    // currently we only allow dataset type requirements
+    return pluginClass.getRequirements().getDatasetTypes().stream().noneMatch(requirementBlacklist::contains);
   }
 
   private static class AppClassKey {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/PluginRequirement.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/PluginRequirement.java
@@ -16,34 +16,42 @@
 
 package co.cask.cdap.internal.pipeline;
 
-import java.util.Collections;
-import java.util.HashSet;
+import co.cask.cdap.api.plugin.Requirements;
+
 import java.util.Objects;
-import java.util.Set;
 
 /**
- * A wrapper class around plugin name, type and {@link Set} of requirements.
+ * A wrapper class around plugin name, type and it's requirements
  */
 public class PluginRequirement {
   private final String name;
   private final String type;
-  private final Set<String> requirements;
+  private final Requirements requirements;
 
-  public PluginRequirement(String name, String type, Set<String> requirements) {
+  public PluginRequirement(String name, String type, Requirements requirements) {
     this.name = name;
     this.type = type;
-    this.requirements = Collections.unmodifiableSet(new HashSet<>(requirements));
+    this.requirements = requirements;
   }
 
+  /**
+   * @return the name of the plugin
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * @return the type of the plugin
+   */
   public String getType() {
     return type;
   }
 
-  public Set<String> getRequirements() {
+  /**
+   * @return {@link Requirements} containing requirements of the plugin
+   */
+  public Requirements getRequirements() {
     return requirements;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/NativeProvisioner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/NativeProvisioner.java
@@ -16,8 +16,20 @@
 
 package co.cask.cdap.internal.provision;
 
-import co.cask.cdap.api.annotation.Requirements;
+import co.cask.cdap.api.dataset.lib.CounterTimeseriesTable;
+import co.cask.cdap.api.dataset.lib.IndexedObjectStore;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.lib.ObjectMappedTable;
+import co.cask.cdap.api.dataset.lib.ObjectStore;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.TimeseriesTable;
+import co.cask.cdap.api.dataset.lib.cube.Cube;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.dataset2.lib.external.ExternalDataset;
 import co.cask.cdap.proto.profile.Profile;
+import co.cask.cdap.runtime.spi.provisioner.Capabilities;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.PollingStrategies;
@@ -28,8 +40,9 @@ import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Native provisioner that doesn't provision a cluster
@@ -38,6 +51,12 @@ public class NativeProvisioner implements Provisioner {
 
   public static final ProvisionerSpecification SPEC = new ProvisionerSpecification(
     Profile.NATIVE_NAME, "Native", "Runs programs on the CDAP master cluster. Does not provision any resources.");
+  public static final Capabilities SYSTEM_DATASETS =
+    new Capabilities(Stream.of(Table.TYPE, KeyValueTable.TYPE, ObjectMappedTable.TYPE, ObjectStore.TYPE,
+                               IndexedObjectStore.TYPE, IndexedTable.TYPE, TimeseriesTable.TYPE,
+                               CounterTimeseriesTable.TYPE, TimePartitionedFileSet.TYPE, PartitionedFileSet.TYPE,
+                               ExternalDataset.TYPE, Cube.TYPE)
+                       .collect(Collectors.toSet()));
 
   @Override
   public ProvisionerSpecification getSpec() {
@@ -78,7 +97,7 @@ public class NativeProvisioner implements Provisioner {
   }
 
   @Override
-  public Set<String> getCapabilities() {
-    return Collections.singleton(Requirements.TEPHRA_TX);
+  public Capabilities getCapabilities() {
+    return SYSTEM_DATASETS;
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -16,12 +16,14 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
-import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.api.artifact.ApplicationClass;
 import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.CloseableClassLoader;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.api.plugin.Requirements;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.app.runtime.DummyProgramRunnerFactory;
 import co.cask.cdap.common.InvalidArtifactException;
@@ -94,14 +96,14 @@ public class ArtifactInspectorTest {
     Assert.assertTrue(artifactInspector.getPluginRequirements(InspectionApp.AppPlugin.class).isEmpty());
 
     // check that if a plugin specify a requirement it is captured
-    Assert.assertEquals(ImmutableSet.of(Requirements.TEPHRA_TX),
+    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE)),
                         artifactInspector.getPluginRequirements(InspectionApp.SingleRequirementPlugin.class));
 
     // check if a plugin specify a requirement annotation but it is empty the requirement captured is no requirement
     Assert.assertTrue(artifactInspector.getPluginRequirements(InspectionApp.EmptyRequirementPlugin.class).isEmpty());
 
     // check if a plugin specify multiple requirement all of them are captured
-    Assert.assertEquals(ImmutableSet.of(Requirements.TEPHRA_TX, "secondrequirement"),
+    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE, KeyValueTable.TYPE)),
                         artifactInspector.getPluginRequirements(InspectionApp.MultipleRequirementsPlugin.class));
 
     // check if a plugin has specified empty string as requirement is captured as no requirements
@@ -109,11 +111,11 @@ public class ArtifactInspectorTest {
                         .getPluginRequirements(InspectionApp.SingleEmptyRequirementPlugin.class).isEmpty());
 
     // check if a plugin has specified empty string with a valid requirement only the valid requirement is captured
-    Assert.assertEquals(ImmutableSet.of(Requirements.TEPHRA_TX),
+    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE)),
                         artifactInspector.getPluginRequirements(InspectionApp.ValidAndEmptyRequirementsPlugin.class));
 
     // test that duplicate requirements are only stored once and the beginning and ending white spaces are trimmed
-    Assert.assertEquals(ImmutableSet.of(Requirements.TEPHRA_TX, "duplicate"),
+    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE, "duplicate")),
                         artifactInspector.getPluginRequirements(InspectionApp.DuplicateRequirementsPlugin.class));
   }
 
@@ -147,7 +149,7 @@ public class ArtifactInspectorTest {
         ImmutableMap.of(
           "y", new PluginPropertyField("y", "", "double", true, true),
           "isSomething", new PluginPropertyField("isSomething", "", "boolean", true, false)),
-        new HashSet<>(), ImmutableSet.of(Requirements.TEPHRA_TX.toLowerCase(), "secondrequirement"));
+        new HashSet<>(), new Requirements(ImmutableSet.of(Table.TYPE, KeyValueTable.TYPE)));
       Assert.assertTrue(classes.getPlugins().containsAll(ImmutableSet.of(expectedPlugin, multipleRequirementPlugin)));
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/inspection/InspectionApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/inspection/InspectionApp.java
@@ -23,6 +23,8 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.plugin.PluginConfig;
 
 /**
@@ -64,7 +66,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("SingleRequirementPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements(Requirements.TEPHRA_TX)
+  @Requirements(datasetTypes = Table.TYPE)
   public static class SingleRequirementPlugin {
     private PConfig pluginConf;
 
@@ -76,7 +78,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name(MULTIPLE_REQUIREMENTS_PLUGIN)
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements({Requirements.TEPHRA_TX, "secondRequirement"})
+  @Requirements(datasetTypes = {Table.TYPE, KeyValueTable.TYPE})
   public static class MultipleRequirementsPlugin {
     private PConfig pluginConf;
 
@@ -88,7 +90,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("EmptyRequirementPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements({})
+  @Requirements(datasetTypes = {})
   public static class EmptyRequirementPlugin {
     private PConfig pluginConf;
 
@@ -100,7 +102,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("SingleEmptyRequirementPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements("")
+  @Requirements(datasetTypes = "")
   public static class SingleEmptyRequirementPlugin {
     private PConfig pluginConf;
 
@@ -112,7 +114,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("ValidAndEmptyRequirementsPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements({Requirements.TEPHRA_TX, ""})
+  @Requirements(datasetTypes = {Table.TYPE, ""})
   public static class ValidAndEmptyRequirementsPlugin {
     private PConfig pluginConf;
 
@@ -124,7 +126,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("DuplicateRequirementsPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements({Requirements.TEPHRA_TX, "   DupliCate    ", "    duplicate    "})
+  @Requirements(datasetTypes = {Table.TYPE, "   DupliCate    ", "    duplicate    "})
   public static class DuplicateRequirementsPlugin {
     private PConfig pluginConf;
 
@@ -136,7 +138,7 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   @Plugin(type = PLUGIN_TYPE)
   @Name("NonTransactionalPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements({"req1", "req2"})
+  @Requirements(datasetTypes = {"req1", "req2"})
   public static class NonTransactionalPlugin {
     private PConfig pluginConf;
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -346,9 +346,9 @@ public abstract class AppFabricTestBase {
       cConf.set(Constants.AppFabric.APP_UPDATE_SCHEDULES, updateSchedules);
     }
     // add the plugin exclusion if one has been set by the test class
-    String excludedRequirements = System.getProperty(Constants.REQUIREMENTS_BLACKLIST);
+    String excludedRequirements = System.getProperty(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE);
     if (excludedRequirements != null) {
-      cConf.set(Constants.REQUIREMENTS_BLACKLIST, excludedRequirements);
+      cConf.set(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE, excludedRequirements);
     }
     // Use a shorter delay to speedup tests
     cConf.setLong(Constants.Scheduler.EVENT_POLL_DELAY_MILLIS, 100L);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
@@ -18,7 +18,6 @@ package co.cask.cdap.internal.app.services.http.handlers;
 
 import co.cask.cdap.ConfigTestApp;
 import co.cask.cdap.WordCountApp;
-import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.api.artifact.ApplicationClass;
 import co.cask.cdap.api.artifact.ArtifactInfo;
 import co.cask.cdap.api.artifact.ArtifactRange;
@@ -27,9 +26,11 @@ import co.cask.cdap.api.artifact.ArtifactSummary;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.artifact.ArtifactVersionRange;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.api.plugin.Requirements;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.common.conf.Constants;
@@ -134,7 +135,7 @@ public class ArtifactHttpHandlerTest extends ArtifactHttpHandlerTestBase {
     Assert.assertEquals(8, plugins.size());
     // check that requirement is being stored
     validateRequirement(plugins, InspectionApp.SingleRequirementPlugin.class.getName(),
-                        ImmutableSet.of(Requirements.TEPHRA_TX.toLowerCase()));
+                        new Requirements(ImmutableSet.of(Table.TYPE)));
   }
 
   @Test
@@ -934,7 +935,7 @@ public class ArtifactHttpHandlerTest extends ArtifactHttpHandlerTestBase {
   }
 
   private void validateRequirement(Set<PluginClass> plugins, String pluginClassName,
-                                   ImmutableSet<String> expectedRequirements) {
+                                   Requirements expectedRequirements) {
     for (PluginClass plugin : plugins) {
       if (plugin.getClassName().equals(pluginClassName)) {
         Assert.assertEquals(expectedRequirements, plugin.getRequirements());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PluginExclusionTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PluginExclusionTest.java
@@ -15,9 +15,9 @@
  */
 package co.cask.cdap.internal.app.services.http.handlers;
 
-import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.api.artifact.ArtifactRange;
 import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.common.conf.Constants;
@@ -47,18 +47,18 @@ public class PluginExclusionTest extends ArtifactHttpHandlerTestBase {
     @Override
     protected void before() {
       // store the previous value
-      previousRequirementBlacklist = System.getProperty(Constants.REQUIREMENTS_BLACKLIST);
+      previousRequirementBlacklist = System.getProperty(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE);
       // Set the system property to the excluded requirement value which will be set in cdap-site through the test base
-      System.setProperty(Constants.REQUIREMENTS_BLACKLIST, Requirements.TEPHRA_TX);
+      System.setProperty(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE, Table.TYPE);
     }
 
     @Override
     protected void after() {
       // clear the system property
       if (previousRequirementBlacklist == null) {
-        System.clearProperty(Constants.REQUIREMENTS_BLACKLIST);
+        System.clearProperty(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE);
       } else {
-        System.setProperty(Constants.REQUIREMENTS_BLACKLIST, previousRequirementBlacklist);
+        System.setProperty(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE, previousRequirementBlacklist);
       }
     }
   };

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/MockProvisioner.java
@@ -16,10 +16,10 @@
 
 package co.cask.cdap.internal.provision;
 
-import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.proto.profile.Profile;
 import co.cask.cdap.proto.provisioner.ProvisionerInfo;
 import co.cask.cdap.proto.provisioner.ProvisionerPropertyValue;
+import co.cask.cdap.runtime.spi.provisioner.Capabilities;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.PollingStrategies;
@@ -134,8 +134,8 @@ public class MockProvisioner implements Provisioner {
   }
 
   @Override
-  public Set<String> getCapabilities() {
-    return Collections.singleton(Requirements.TEPHRA_TX);
+  public Capabilities getCapabilities() {
+    return NativeProvisioner.SYSTEM_DATASETS;
   }
 
   // throws a RetryableProvisionException every other time this is called

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/IncapableSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/IncapableSink.java
@@ -20,7 +20,9 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -33,11 +35,10 @@ import java.util.Collections;
  */
 @Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name(IncapableSink.NAME)
-@Requirements({Requirements.TEPHRA_TX, IncapableSink.REQUIREMENT})
+@Requirements(datasetTypes = {Table.TYPE, KeyValueTable.TYPE})
 public class IncapableSink extends BatchSink<StructuredRecord, byte[], Put> {
 
   public static final String NAME = "IncapableSink";
-  public static final String REQUIREMENT = "unicorn";
 
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/IncapableSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/IncapableSource.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.annotation.Requirements;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -28,15 +29,14 @@ import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import java.util.Collections;
 
 /**
- * Source which has special requirement
+ * Source which has a requirement
  */
 @Plugin(type = BatchSource.PLUGIN_TYPE)
 @Name(IncapableSource.NAME)
-@Requirements(IncapableSource.REQUIREMENT)
+@Requirements(datasetTypes = {Table.TYPE})
 public class IncapableSource extends BatchSource<byte[], Row, StructuredRecord> {
 
   public static final String NAME = "IncapableSource";
-  public static final String REQUIREMENT = "unicorn";
 
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -72,11 +72,11 @@ public final class Constants {
   /* Used by the user to specify what part of a path should be replaced by the current user's name. */
   public static final String USER_NAME_SPECIFIER = "${name}";
 
-  /* Used to specify a comma separated list of plugin requirements that cannot be met in the instance.
+  /* Used to specify a comma separated list of plugin dataset type requirements that cannot be met in the instance.
   Plugins that require any of these will be treated as if they don't exist.
-  For example, if 'tephraTx' is given, any plugin that requires 'tephraTx' will be treated as
+  For example, if 'table' is given, any plugin that requires 'table' will be treated as
   if they don't exist. */
-  public static final String REQUIREMENTS_BLACKLIST = "requirements.blacklist";
+  public static final String REQUIREMENTS_DATASET_TYPE_EXCLUDE = "requirements.datasetTypes.exclude.list";
 
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/PluginClassDeserializer.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/PluginClassDeserializer.java
@@ -19,6 +19,7 @@ package co.cask.cdap.common.conf;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.api.plugin.Requirements;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.JsonDeserializationContext;
@@ -67,12 +68,14 @@ public class PluginClassDeserializer implements JsonDeserializer<PluginClass> {
       ? context.<Map<String, PluginPropertyField>>deserialize(jsonObj.get("properties"), PROPERTIES_TYPE)
       : ImmutableMap.<String, PluginPropertyField>of();
 
-    Set<String> requirements = Collections.emptySet();
+    Set<String> datasetTypes = Collections.emptySet();
     if (jsonObj.has("requirements")) {
-      requirements = context.deserialize(jsonObj.get("requirements"), SET_OF_STRING_TYPE);
+      datasetTypes = context.deserialize(jsonObj.getAsJsonObject("requirements").get("datasetTypes"),
+                                         SET_OF_STRING_TYPE);
     }
 
-    return new PluginClass(type, name, description, className, null, properties, endpointsSet, requirements);
+    return new PluginClass(type, name, description, className, null, properties, endpointsSet,
+                           new Requirements(datasetTypes));
   }
 
   private JsonElement getRequired(JsonObject jsonObj, String name) {

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -646,12 +646,12 @@
   </property>
 
   <property>
-    <name>requirements.blacklist</name>
+    <name>requirements.datasetTypes.exclude.list</name>
     <value></value>
     <description>
-      Comma separated list of plugin requirements that cannot be met in the instance.
+      Comma separated list of plugin datset type requirements that cannot be met in the instance.
       Plugins that require any of these will be treated as if they don't exist.
-      For example, if 'tephraTx' is given, any plugin that requires 'tephraTx' will be treated as
+      For example, if 'table' is given, any plugin that requires 'table' will be treated as
       if they don't exist.
     </description>
   </property>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
@@ -16,12 +16,18 @@
 
 package co.cask.cdap.data.runtime;
 
+import co.cask.cdap.api.dataset.lib.ObjectMappedTable;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.cube.Cube;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.external.ExternalDataset;
 import co.cask.cdap.data2.dataset2.lib.external.ExternalDatasetModule;
+import co.cask.cdap.data2.dataset2.lib.file.FileSetDataset;
 import co.cask.cdap.data2.dataset2.lib.file.FileSetModule;
 import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetModule;
 import co.cask.cdap.data2.dataset2.lib.partitioned.TimePartitionedFileSetModule;
@@ -132,15 +138,15 @@ public class SystemDatasetRuntimeModule extends RuntimeModule {
    */
   private void bindDefaultModules(MapBinder<String, DatasetModule> mapBinder) {
     mapBinder.addBinding("core").toInstance(new CoreDatasetsModule());
-    mapBinder.addBinding("fileSet").toInstance(new FileSetModule());
-    mapBinder.addBinding("timePartitionedFileSet").toInstance(new TimePartitionedFileSetModule());
-    mapBinder.addBinding("partitionedFileSet").toInstance(new PartitionedFileSetModule());
-    mapBinder.addBinding("objectMappedTable").toInstance(new ObjectMappedTableModule());
-    mapBinder.addBinding("cube").toInstance(new CubeModule());
+    mapBinder.addBinding(FileSetDataset.TYPE).toInstance(new FileSetModule());
+    mapBinder.addBinding(TimePartitionedFileSet.TYPE).toInstance(new TimePartitionedFileSetModule());
+    mapBinder.addBinding(PartitionedFileSet.TYPE).toInstance(new PartitionedFileSetModule());
+    mapBinder.addBinding(ObjectMappedTable.TYPE).toInstance(new ObjectMappedTableModule());
+    mapBinder.addBinding(Cube.TYPE).toInstance(new CubeModule());
     mapBinder.addBinding("usage").toInstance(new UsageDatasetModule());
     mapBinder.addBinding("metadata").toInstance(new MetadataDatasetModule());
     mapBinder.addBinding("lineage").toInstance(new LineageDatasetModule());
     mapBinder.addBinding("fieldLineage").toInstance(new FieldLineageDatasetModule());
-    mapBinder.addBinding("externalDataset").toInstance(new ExternalDatasetModule());
+    mapBinder.addBinding(ExternalDataset.TYPE).toInstance(new ExternalDatasetModule());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDataset.java
@@ -30,6 +30,10 @@ import java.util.Map;
  */
 @Beta
 public class ExternalDataset implements Dataset, InputFormatProvider, OutputFormatProvider {
+  /**
+   * Type name
+   */
+  public static final String TYPE = "externalDataset";
   private final String inputFormatClassName;
   private final String outputFormatClassName;
   private final Map<String, String> inputFormatConfiguration;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/external/ExternalDatasetModule.java
@@ -25,6 +25,6 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 public class ExternalDatasetModule implements DatasetModule {
   @Override
   public void register(DatasetDefinitionRegistry registry) {
-    registry.add(new ExternalDatasetDefinition("externalDataset"));
+    registry.add(new ExternalDatasetDefinition(ExternalDataset.TYPE));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetModule.java
@@ -28,6 +28,6 @@ public class FileSetModule implements DatasetModule {
   public void register(DatasetDefinitionRegistry registry) {
     // file dataset
     registry.add(new FileSetDefinition(FileSet.class.getName()));
-    registry.add(new FileSetDefinition("fileSet"));
+    registry.add(new FileSetDefinition(FileSet.TYPE));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetModule.java
@@ -38,6 +38,6 @@ public class PartitionedFileSetModule implements DatasetModule {
 
     // file dataset
     registry.add(new PartitionedFileSetDefinition(PartitionedFileSet.class.getName(), fileSetDef, indexedTableDef));
-    registry.add(new PartitionedFileSetDefinition("partitionedFileSet", fileSetDef, indexedTableDef));
+    registry.add(new PartitionedFileSetDefinition(PartitionedFileSet.TYPE, fileSetDef, indexedTableDef));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetModule.java
@@ -40,6 +40,6 @@ public class TimePartitionedFileSetModule implements DatasetModule {
     // file dataset
     registry.add(new TimePartitionedFileSetDefinition(TimePartitionedFileSet.class.getName(), fileSetDef,
                                                       indexedTableDef));
-    registry.add(new TimePartitionedFileSetDefinition("timePartitionedFileSet", fileSetDef, indexedTableDef));
+    registry.add(new TimePartitionedFileSetDefinition(TimePartitionedFileSet.TYPE, fileSetDef, indexedTableDef));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/CoreDatasetsModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/CoreDatasetsModule.java
@@ -32,6 +32,7 @@ import co.cask.cdap.api.dataset.lib.TimeseriesTableDefinition;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.dataset2.lib.table.inmemory.InMemoryTable;
 import co.cask.cdap.data2.dataset2.lib.table.inmemory.InMemoryTableDefinition;
 
 /**
@@ -45,27 +46,29 @@ public class CoreDatasetsModule implements DatasetModule {
   public void register(DatasetDefinitionRegistry registry) {
     DatasetDefinition<Table, DatasetAdmin> tableDef = registry.get("table");
 
-    DatasetDefinition<KeyValueTable, DatasetAdmin> kvTableDef = new KeyValueTableDefinition("keyValueTable", tableDef);
+    DatasetDefinition<KeyValueTable, DatasetAdmin> kvTableDef = new KeyValueTableDefinition(KeyValueTable.TYPE,
+                                                                                            tableDef);
     registry.add(kvTableDef);
     registry.add(new KeyValueTableDefinition(KeyValueTable.class.getName(), tableDef));
 
-    DatasetDefinition<ObjectStore, DatasetAdmin> objectStoreDef = new ObjectStoreDefinition("objectStore", kvTableDef);
-    registry.add(new ObjectStoreDefinition("objectStore", kvTableDef));
+    DatasetDefinition<ObjectStore, DatasetAdmin> objectStoreDef = new ObjectStoreDefinition(ObjectStore.TYPE,
+                                                                                            kvTableDef);
+    registry.add(new ObjectStoreDefinition(ObjectStore.TYPE, kvTableDef));
     registry.add(new ObjectStoreDefinition(ObjectStore.class.getName(), kvTableDef));
 
-    registry.add(new IndexedObjectStoreDefinition("indexedObjectStore", tableDef, objectStoreDef));
+    registry.add(new IndexedObjectStoreDefinition(IndexedObjectStore.TYPE, tableDef, objectStoreDef));
     registry.add(new IndexedObjectStoreDefinition(IndexedObjectStore.class.getName(), tableDef, objectStoreDef));
 
-    registry.add(new IndexedTableDefinition("indexedTable", tableDef));
+    registry.add(new IndexedTableDefinition(IndexedTable.TYPE, tableDef));
     registry.add(new IndexedTableDefinition(IndexedTable.class.getName(), tableDef));
 
-    registry.add(new TimeseriesTableDefinition("timeseriesTable", tableDef));
+    registry.add(new TimeseriesTableDefinition(TimeseriesTable.TYPE, tableDef));
     registry.add(new TimeseriesTableDefinition(TimeseriesTable.class.getName(), tableDef));
 
-    registry.add(new CounterTimeseriesTableDefinition("counterTimeseriesTable", tableDef));
+    registry.add(new CounterTimeseriesTableDefinition(CounterTimeseriesTable.TYPE, tableDef));
     registry.add(new CounterTimeseriesTableDefinition(CounterTimeseriesTable.class.getName(), tableDef));
 
     // in-memory table
-    registry.add(new InMemoryTableDefinition("memoryTable"));
+    registry.add(new InMemoryTableDefinition(InMemoryTable.TYPE));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/CubeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/CubeModule.java
@@ -28,12 +28,12 @@ import co.cask.cdap.data2.dataset2.lib.cube.CubeDatasetDefinition;
  * {@link co.cask.cdap.api.dataset.module.DatasetModule} for {@link co.cask.cdap.api.dataset.lib.cube.Cube}.
  */
 public class CubeModule implements DatasetModule {
-  public static final String SHORT_NAME = "cube";
+  public static final String SHORT_NAME = Cube.TYPE;
   public static final String FULL_NAME = Cube.class.getName();
 
   @Override
   public void register(DatasetDefinitionRegistry registry) {
-    DatasetDefinition<Table, ? extends DatasetAdmin> tableDef = registry.get("table");
+    DatasetDefinition<Table, ? extends DatasetAdmin> tableDef = registry.get(Table.TYPE);
     DatasetDefinition<MetricsTable, ? extends DatasetAdmin> metricsTableDef =
       registry.get(MetricsTable.class.getName());
     registry.add(new CubeDatasetDefinition(FULL_NAME, tableDef, metricsTableDef));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableModule.java
@@ -27,12 +27,12 @@ import co.cask.cdap.api.dataset.table.Table;
  * {@link DatasetModule} for {@link ObjectMappedTable}.
  */
 public class ObjectMappedTableModule implements DatasetModule {
-  public static final String SHORT_NAME = "objectMappedTable";
+  public static final String SHORT_NAME = ObjectMappedTable.TYPE;
   public static final String FULL_NAME = ObjectMappedTable.class.getName();
 
   @Override
   public void register(DatasetDefinitionRegistry registry) {
-    DatasetDefinition<Table, ? extends DatasetAdmin> tableDef = registry.get("table");
+    DatasetDefinition<Table, ? extends DatasetAdmin> tableDef = registry.get(Table.TYPE);
     // object mapped table dataset
     registry.add(new ObjectMappedTableDefinition(FULL_NAME, tableDef));
     registry.add(new ObjectMappedTableDefinition(SHORT_NAME, tableDef));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTable.java
@@ -47,6 +47,11 @@ import javax.annotation.Nullable;
 public class InMemoryTable extends BufferingTable {
 
   /**
+   * Type name
+   */
+  public static final String TYPE = "memoryTable";
+
+  /**
    * To be used in tests which do not need namespaces
    */
   @VisibleForTesting

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -186,6 +186,10 @@ import javax.annotation.Nullable;
  * and the value written will contain all properties and tags for that mapreduce program at that time.
  */
 public class MetadataDataset extends AbstractDataset {
+  /**
+   * Type name
+   */
+  public static final String TYPE = "metadataDataset";
   private static final Logger LOG = LoggerFactory.getLogger(MetadataDataset.class);
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetModule.java
@@ -30,7 +30,7 @@ public class MetadataDatasetModule implements DatasetModule {
   public void register(DatasetDefinitionRegistry registry) {
     DatasetDefinition<IndexedTable, ? extends DatasetAdmin> indexedTableDef =
       registry.get(IndexedTable.class.getName());
-    registry.add(new MetadataDatasetDefinition("metadataDataset", indexedTableDef));
+    registry.add(new MetadataDatasetDefinition(MetadataDataset.TYPE, indexedTableDef));
     registry.add(new MetadataDatasetDefinition(MetadataDataset.class.getName(), indexedTableDef));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDataset.java
@@ -78,6 +78,10 @@ public class LineageDataset extends AbstractDataset {
   // | p | <id.run>     | <inverted-start-time> | s | <id.stream>  | <access-type> |
   // -------------------------------------------------------------------------------
 
+  /**
+   * Type name
+   */
+  public static final String TYPE = "lineageDataset";
   public static final DatasetId LINEAGE_DATASET_ID = NamespaceId.SYSTEM.dataset("lineage");
 
   private static final Logger LOG = LoggerFactory.getLogger(LineageDataset.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetModule.java
@@ -29,7 +29,7 @@ public class LineageDatasetModule implements DatasetModule {
   @Override
   public void register(DatasetDefinitionRegistry registry) {
     DatasetDefinition<Table, ? extends DatasetAdmin> tableDef = registry.get(Table.class.getName());
-    registry.add(new LineageDatasetDefinition("lineageDataset", tableDef));
+    registry.add(new LineageDatasetDefinition(LineageDataset.TYPE, tableDef));
     registry.add(new LineageDatasetDefinition(LineageDataset.class.getName(), tableDef));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasetModule.java
@@ -40,7 +40,7 @@ public class UsageDatasetModule implements DatasetModule {
 
   @Override
   public void register(DatasetDefinitionRegistry registry) {
-    DatasetDefinition<Table, DatasetAdmin> tableDef = registry.get("table");
+    DatasetDefinition<Table, DatasetAdmin> tableDef = registry.get(Table.TYPE);
     registry.add(new UsageDatasetDefinition(UsageDataset.class.getSimpleName(), tableDef));
   }
 

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.runtime.spi.provisioner.dataproc;
 
+import co.cask.cdap.runtime.spi.provisioner.Capabilities;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.Node;
@@ -35,10 +36,11 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.security.GeneralSecurityException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -189,8 +191,8 @@ public class DataProcProvisioner implements Provisioner {
   }
 
   @Override
-  public Set<String> getCapabilities() {
-    return Collections.singleton("gcp");
+  public Capabilities getCapabilities() {
+    return new Capabilities(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("fileSet", "externalDataset"))));
   }
 
   // Name must start with a lowercase letter followed by up to 51 lowercase letters,

--- a/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisioner.java
+++ b/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisioner.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.runtime.spi.provisioner.emr;
 
 import co.cask.cdap.runtime.spi.SparkCompat;
+import co.cask.cdap.runtime.spi.provisioner.Capabilities;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.Node;
@@ -36,10 +37,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -171,7 +173,7 @@ public class ElasticMapReduceProvisioner implements Provisioner {
   }
 
   @Override
-  public Set<String> getCapabilities() {
-    return Collections.singleton("emr");
+  public Capabilities getCapabilities() {
+    return new Capabilities(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("fileSet", "externalDataset"))));
   }
 }

--- a/cdap-runtime-ext-remote-hadoop/src/main/java/co/cask/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
+++ b/cdap-runtime-ext-remote-hadoop/src/main/java/co/cask/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
@@ -17,6 +17,7 @@
 
 package co.cask.cdap.runtime.spi.provisioner.remote;
 
+import co.cask.cdap.runtime.spi.provisioner.Capabilities;
 import co.cask.cdap.runtime.spi.provisioner.Cluster;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.Node;
@@ -26,10 +27,11 @@ import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerContext;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -83,7 +85,7 @@ public class RemoteHadoopProvisioner implements Provisioner {
   }
 
   @Override
-  public Set<String> getCapabilities() {
-    return Collections.emptySet();
+  public Capabilities getCapabilities() {
+    return new Capabilities(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("fileSet", "externalDataset"))));
   }
 }

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Capabilities.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Capabilities.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.runtime.spi.provisioner;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A class to encapsulate all the different capabilities of a {@link Provisioner}
+ */
+public class Capabilities {
+
+  public static final Capabilities EMPTY = new Capabilities(Collections.emptySet());
+
+  private final Set<String> datasetTypes;
+
+  /**
+   * Creates a {@link Capabilities} object from the given {@link Set}. Note: Capabilities are case insensitive and all
+   * the capabilities will be converted into lowercase.
+   *
+   * @param datasetTypes a {@link Set} containing dataset type capabilities
+   */
+  public Capabilities(Set<String> datasetTypes) {
+    this.datasetTypes = datasetTypes.isEmpty() ? Collections.emptySet() :
+      Collections.unmodifiableSet(datasetTypes.stream().map(String::toLowerCase).collect(Collectors.toSet()));
+  }
+
+  /**
+   * @return {@link Set} containing the dataset type capabilities which can be be empty if there are no requirements
+   */
+  public Set<String> getDatasetTypes() {
+    return datasetTypes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Capabilities that = (Capabilities) o;
+    return Objects.equals(datasetTypes, that.datasetTypes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(datasetTypes);
+  }
+
+  @Override
+  public String toString() {
+    return "Capabilities{" +
+      "datasetTypes=" + datasetTypes +
+      '}';
+  }
+
+  public boolean isEmpty() {
+    return datasetTypes.isEmpty();
+  }
+}

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.runtime.spi.provisioner;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A Provisioner is responsible for creating and deleting clusters for program runs. Each method may be retried
@@ -118,13 +117,12 @@ public interface Provisioner {
   PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster);
 
   /**
-   * Returns a {@link Set} of capabilities (lowercase) of this provisioner. Capabilities allow plugins requiring special
-   * Requirements to be run in the provisioner if all the requirements are met. If a program requires a
-   * capability that is not supported by the provisioner, the platform will fail the program run before provisioning
-   * begins.
+   * Returns {@link Capabilities} of this provisioner. Capabilities allow plugins requiring special Requirements
+   * to be run in the provisioner if all the requirements are met. If a program requires a requirement that is not
+   * supported by the provisioner, the platform will fail the program run before provisioning begins.
    *
-   * @return the capabilities
+   * @return {@link Capabilities} of this provisioner
    */
-  Set<String> getCapabilities();
+  Capabilities getCapabilities();
 
 }


### PR DESCRIPTION
### Summary of Change:
Changes the Requirements annotation to accept datasetTypes

`Requirements(datasetTypes = { "table" })`

Currently the only field supported in Requirements will be datasetTypes as that is the only known use case which we are trying to solve. Although the implementation is done in a way which makes it easily extensible for other fields if needed.

