### PR TITLE
CDAP-14236 fix and cleanup dataproc property validation

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataProcProvisioner.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.ConnectException;
-import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -62,12 +61,7 @@ public class DataProcProvisioner implements Provisioner {
 
   @Override
   public void validateProperties(Map<String, String> properties) {
-    DataProcConf conf = DataProcConf.fromProperties(properties);
-    try {
-      DataProcClient.fromConf(conf);
-    } catch (IOException | GeneralSecurityException e) {
-      throw new IllegalArgumentException(e.getMessage(), e);
-    }
+    DataProcConf.fromProperties(properties);
   }
 
   @Override


### PR DESCRIPTION
Fixed a bug where the provisioner would attempt to create
credentials for the unsubstituted macro for service account key.
Ideally the account key would be validated if it is not a macro,
but there that would require additional features in the provisioner
framework. For now, ensure that the account key is not validated
unless it is empty. This mirrors the behavior in the last release.

Also performed some cleanup to move logic to lookup the project,
network, and zone from the client into the configuration. This
ensures that the project, network, and zone fields in the conf
are always set and always return non-null values.