### PR TITLE
(CDAP-14062) Disable URLConnection cache in unit-test

### DIFF
--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -45,6 +45,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.io.URLConnections;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.test.TestRunner;
 import co.cask.cdap.common.utils.OSDetector;
@@ -225,6 +226,7 @@ public class TestBase {
     if (nestedStartCount++ > 0) {
       return;
     }
+    URLConnections.setDefaultUseCaches(false);
     File localDataDir = TMP_FOLDER.newFolder();
 
     cConf = createCConf(localDataDir);


### PR DESCRIPTION
We already disable it in StandaloneMain long time ago (for different reason).