### PR TITLE
[CDAP-14211] Batches runs count API in UI

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsTopPanel.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsTopPanel.scss
@@ -94,6 +94,7 @@ $btn-border-color: transparent;
         background-color: $grey-08;
         color: $grey-01;
         border: 1px solid $grey-05;
+        border-top: 0;
 
         .pipeline-action-btn {
           &:not(.pipeline-stop-btn):not(.pipeline-run-btn) {

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -42,6 +42,7 @@ var PipelineTriggersSidebars = require('../cdap/components/PipelineTriggersSideb
 var TriggeredPipelineStore = require('../cdap/components/TriggeredPipelines/store/TriggeredPipelineStore').default;
 var PipelineErrorFactory = require('../cdap/services/PipelineErrorFactory');
 var GLOBALS = require('../cdap/services/global-constants').GLOBALS;
+var PROGRAM_STATUSES = require('../cdap/services/global-constants').PROGRAM_STATUSES;
 var HYDRATOR_DEFAULT_VALUES = require('../cdap/services/global-constants').HYDRATOR_DEFAULT_VALUES;
 var StatusMapper = require('../cdap/services/StatusMapper').default;
 var PipelineDetailStore = require('../cdap/components/PipelineDetails/store').default;
@@ -88,6 +89,7 @@ export {
   TriggeredPipelineStore,
   PipelineErrorFactory,
   GLOBALS,
+  PROGRAM_STATUSES,
   HYDRATOR_DEFAULT_VALUES,
   StatusMapper,
   PipelineDetailStore,

--- a/cdap-ui/app/directives/cask-angular-sortable/sortable.js
+++ b/cdap-ui/app/directives/cask-angular-sortable/sortable.js
@@ -69,7 +69,7 @@ function caskSortableDirective ($log, $stateParams, $state) {
       $state.go($state.$current.name, {
         sortBy:  defaultPredicate.attr('data-predicate'),
         reverse: defaultReverse ? 'reverse' : ''
-      }, {notify: false});
+      });
 
       scope.sortable = {
         reverse: defaultReverse
@@ -87,12 +87,12 @@ function caskSortableDirective ($log, $stateParams, $state) {
         var th = angular.element(this),
             predicate = getPredicate(th);
 
-        if (th.attr('skip-sort')){
+        if (th.attr('skip-sort')) {
           return;
         }
 
         scope.$apply(function() {
-          if (scope.sortable.predicate === predicate){
+          if (scope.sortable.predicate === predicate) {
             scope.sortable.reverse = !scope.sortable.reverse;
             th.find('i').toggleClass('fa-flip-vertical');
           }
@@ -110,7 +110,7 @@ function caskSortableDirective ($log, $stateParams, $state) {
         $state.go($state.$current.name, {
           sortBy:  predicate,
           reverse: scope.sortable.reverse ? 'reverse' : ''
-        }, {notify: false});
+        });
       });
 
     }

--- a/cdap-ui/app/hydrator/templates/list.html
+++ b/cdap-ui/app/hydrator/templates/list.html
@@ -47,12 +47,12 @@
           <tr ng-class="{'sort-enabled': ListController.pipelineList.length>0}">
             <th data-predicate="name">Pipeline name</th>
             <th data-predicate="artifact.name">Type</th>
-            <th data-predicate="displayStatus">Status</th>
-            <th data-predicate="_stats.numRuns">Total runs</th>
-            <th data-predicate="_stats.lastStartTime"
-                  data-predicate-default>Last start time</th>
-            <th data-predicate="duration">Duration</th>
-            <th data-predicate="_stats.nextRun">Next run</th>
+            <th data-predicate="latestRun.status">Status</th>
+            <th skip-sort>Total runs</th>
+            <th data-predicate="latestRun.starting"
+                  data-predicate-default="reverse">Last start time</th>
+            <th data-predicate="latestRun.duration">Duration</th>
+            <th data-predicate="nextRun">Next run</th>
             <th skip-sort></th>
           </tr>
         </thead>
@@ -79,22 +79,21 @@
               <span>{{ pipeline.displayStatus }}</span>
             </td>
             <td>
-              <span ng-if="pipeline._stats.numRuns !== 'N/A'">{{ pipeline._stats.numRuns }}</span>
-              <span ng-if="pipeline._stats.numRuns === 'N/A'"> &mdash; </span>
+              <span>{{ pipeline.numRuns }}</span>
             </td>
             <td>
-              <span ng-if="pipeline._stats.lastStartTime === 'N/A' || !pipeline._stats.lastStartTime"> &mdash; </span>
-              <span ng-if="pipeline._stats.lastStartTime !== 'N/A'">{{ pipeline._stats.lastStartTime * 1000 | amDateFormat: 'MM/DD/YY h:mm:ss A' }}</span>
-            </td>
-
-            <td>
-              <span class="metric-value" ng-if="!pipeline.duration"> &mdash; </span>
-              <span class="metric-value" ng-if="pipeline.duration" ng-bind="pipeline.duration"></span>
+              <span ng-if="!pipeline.latestRun.starting"> &mdash; </span>
+              <span ng-if="pipeline.latestRun.starting">{{ pipeline.latestRun.starting * 1000 | amDateFormat: 'MM/DD/YY h:mm:ss A' }}</span>
             </td>
 
             <td>
-              <span ng-if="!pipeline._stats.nextRun"> &mdash; </span>
-              <span ng-if="pipeline._stats.nextRun !== 'N/A'">{{ pipeline._stats.nextRun | amDateFormat: 'MM/DD/YY h:mm:ss A' }}</span>
+              <span class="metric-value" ng-if="!pipeline.latestRun.duration"> &mdash; </span>
+              <span class="metric-value" ng-if="pipeline.latestRun.duration" ng-bind="pipeline.latestRun.duration"></span>
+            </td>
+
+            <td>
+              <span ng-if="!pipeline.nextRun"> &mdash; </span>
+              <span ng-if="pipeline.nextRun !== 'N/A'">{{ pipeline.nextRun | amDateFormat: 'MM/DD/YY h:mm:ss A' }}</span>
             </td>
 
             <td>
@@ -118,7 +117,7 @@
       </table>
     </div>
 
-    <div class="text-center" ng-if="ListController.pipelineList.length > 10">
+    <div class="text-center" ng-if="ListController.pipelineList.length > ListController.PAGE_SIZE">
       <uib-pagination
         total-items="ListController.pipelineList.length"
         ng-change="ListController.goToPage()"

--- a/cdap-ui/app/services/constants.js
+++ b/cdap-ui/app/services/constants.js
@@ -15,4 +15,5 @@
  */
 
 angular.module(PKG.name + '.services')
-  .constant('GLOBALS', window.CaskCommon.GLOBALS);
+  .constant('GLOBALS', window.CaskCommon.GLOBALS)
+  .constant('PROGRAM_STATUSES', window.CaskCommon.PROGRAM_STATUSES);

--- a/cdap-ui/app/services/hydrator/my-pipeline-api.js
+++ b/cdap-ui/app/services/hydrator/my-pipeline-api.js
@@ -33,7 +33,9 @@ angular.module(PKG.name + '.services')
         postActionDetailFetch = pluginFetchBase + '/plugins/:pluginName',
         artifactPropertiesPath = '/namespaces/:namespace/artifacts/:artifactName/versions/:artifactVersion/properties',
         pluginMethodsPath = '/namespaces/:namespace/artifacts/:artifactName/versions/:version/plugintypes/:pluginType/plugins/:pluginName/methods/:methodName',
-        previewPath = '/namespaces/:namespace/previews';
+        previewPath = '/namespaces/:namespace/previews',
+        runsCountPath = '/namespaces/:namespace/runcount',
+        latestRuns = '/namespaces/:namespace/runs';
 
 
     return $resource(
@@ -80,6 +82,11 @@ angular.module(PKG.name + '.services')
         datasets: myHelpers.getConfig('GET', 'REQUEST', pipelinePath + '/datasets', true),
         streams: myHelpers.getConfig('GET', 'REQUEST', pipelinePath + '/streams', true),
         action: myHelpers.getConfig('POST', 'REQUEST', pipelinePath + '/:action'),
+
+        // Batch runs count for pipelines
+
+        getRunsCount: myHelpers.getConfig('POST', 'REQUEST', runsCountPath, true),
+        getLatestRuns: myHelpers.getConfig('POST', 'REQUEST', latestRuns, true),
 
         postPluginMethod: myHelpers.getConfig('POST', 'REQUEST', pluginMethodsPath, false, { suppressErrors: true }),
         getPluginMethod: myHelpers.getConfig('GET', 'REQUEST', pluginMethodsPath, false, { suppressErrors: true }),


### PR DESCRIPTION
- Modifies the way UI uses runs endoint for each pipeline.
  - Queries runs endpoint with a limit of 1 only to the pipelines visible in UI 
  - Queries for next runtime endpoint to batch pipelines that are currently visible in UI
- Modifies the way UI gets runs count. Now uses the batch API added in backend.

**Note:**
 ~~- Since now UI only fetches the metadata (runs) for pipelines that are ONLY visible in UI right now the sorting is not possible. Users won't be able to sort by any field as UI doesn't have the entire data to sort. @bdmogal to update on this.~~
UPDATE:
  Decided to have a batch endpoint that gives latest runs for a list of pipelines. This will allow us to sort the pipelines by start time. However we still cannot sort by runs as the batch endpoint is fetched only for the currently visible pipelines.

~Adding on-hold for the corresponding backend PR: https://github.com/caskdata/cdap/pull/10560 to be merged.~

https://github.com/caskdata/cdap/pull/10653 & https://github.com/caskdata/cdap/pull/10560 merged. Removing on-hold

JIRA: https://issues.cask.co/browse/CDAP-14211
Build: https://builds.cask.co/browse/CDAP-UDUT80