### PR TITLE
CDAP-14168: API Change for Lineage getFields

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/FieldLineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/FieldLineageAdminTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.metadata.lineage.DatasetField;
+import co.cask.cdap.proto.metadata.lineage.Field;
 import co.cask.cdap.proto.metadata.lineage.FieldLineageDetails;
 import co.cask.cdap.proto.metadata.lineage.FieldLineageSummary;
 import co.cask.cdap.proto.metadata.lineage.FieldOperationInfo;
@@ -48,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Test for {@link FieldLineageAdmin}.
@@ -56,17 +58,18 @@ public class FieldLineageAdminTest {
 
   @Test
   public void testFields() {
-    FieldLineageAdmin fieldLineageAdmin = new FieldLineageAdmin(new FakeFieldLineageReader(fields(),
+    FieldLineageAdmin fieldLineageAdmin = new FieldLineageAdmin(new FakeFieldLineageReader(getFieldNames(),
                                                                                            Collections.emptySet(),
                                                                                            Collections.emptySet()));
     EndPoint endPoint = EndPoint.of("ns", "file");
 
     // test all fields
-    Assert.assertEquals(fields(), fieldLineageAdmin.getFields(endPoint, 0, Long.MAX_VALUE, null));
+    Assert.assertEquals(getFields(getFieldNames()), fieldLineageAdmin.getFields(endPoint, 0, Long.MAX_VALUE, null,
+                                                                                false));
 
     // test fields prefixed with string "add"
-    Assert.assertEquals(new HashSet<>(Arrays.asList("address", "address_original")),
-                        fieldLineageAdmin.getFields(endPoint, 0, Long.MAX_VALUE, "add"));
+    Assert.assertEquals(new HashSet<>(Arrays.asList(new Field("address", true), new Field("address_original", true))),
+                        fieldLineageAdmin.getFields(endPoint, 0, Long.MAX_VALUE, "add", false));
   }
 
   @Test
@@ -186,7 +189,11 @@ public class FieldLineageAdminTest {
     Assert.assertEquals(expectedInfos, new HashSet<>(incomings));
   }
 
-  private Set<String> fields() {
+  private Set<Field> getFields(Set<String> fieldNames) {
+    return fieldNames.stream().map(fieldName -> new Field(fieldName, true)).collect(Collectors.toSet());
+  }
+
+  private Set<String> getFieldNames() {
     return new HashSet<>(Arrays.asList("name", "address", "address_original", "offset", "body"));
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/lineage/Field.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/lineage/Field.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.metadata.lineage;
+
+import java.util.Objects;
+
+/**
+ * A class which contains field name and whether the field has lineage info present or not.
+ */
+public class Field {
+  private final String name;
+  private final boolean lineage;
+
+  public Field(String name, boolean lineage) {
+    this.name = name;
+    this.lineage = lineage;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public boolean hasLineage() {
+    return lineage;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Field field = (Field) o;
+    return lineage == field.lineage &&
+      Objects.equals(name, field.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, lineage);
+  }
+
+  @Override
+  public String toString() {
+    return "Field{" +
+      "name='" + name + '\'' +
+      ", lineage=" + lineage +
+      '}';
+  }
+}


### PR DESCRIPTION
### Summary of Change
- For [CDAP-14168](https://issues.cask.co/browse/CDAP-14168) we want to return the dataset schema while displaying lineage. 
- This PR changes the return type of the `getField` API to return `Field` object rather than `String`.
- The `Field` object beside the field name contains a `boolean` which is set if the field was obtained from lineage record. This boolean will be false if the field is only present in dataset schema and there is no lineage information for the field. 
- The UI can look up the the value of this boolean flag and enable/disable the field for lineage retrieval.

[Issue](https://issues.cask.co/browse/CDAP-14168)
Build: https://builds.cask.co/browse/CDAP-DUT6627/latest

