### PR TITLE
CDAP:13924 add stream in supported capability for native provisioner

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/NativeProvisioner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/NativeProvisioner.java
@@ -55,7 +55,7 @@ public class NativeProvisioner implements Provisioner {
     new Capabilities(Stream.of(Table.TYPE, KeyValueTable.TYPE, ObjectMappedTable.TYPE, ObjectStore.TYPE,
                                IndexedObjectStore.TYPE, IndexedTable.TYPE, TimeseriesTable.TYPE,
                                CounterTimeseriesTable.TYPE, TimePartitionedFileSet.TYPE, PartitionedFileSet.TYPE,
-                               ExternalDataset.TYPE, Cube.TYPE)
+                               ExternalDataset.TYPE, Cube.TYPE, "stream")
                        .collect(Collectors.toSet()));
 
   @Override


### PR DESCRIPTION
In [PR](https://github.com/caskdata/hydrator-plugins/pull/810) we [marked StreamSource](https://github.com/caskdata/hydrator-plugins/pull/810/files#diff-44bff7ef6d709402ba9f66ec4d3dc66fR61) to require `stream`. We need to add stream as a capability of native provisioner else the Stream source will not be able to run.

