### PR TITLE
Update pom to restrict snapshot repo usage for snapshot artifacts only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,15 +60,39 @@
     <repository>
       <id>apache</id>
       <url>https://repository.apache.org/content/repositories/public/</url>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
     <repository>
       <id>sonatype</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
     </repository>
-   <repository>
-     <id>snapshot</id>
-     <url>https://repository.apache.org/content/repositories/snapshots/</url>
-   </repository>
+    <repository>
+      <id>snapshot</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+    </repository>
   </repositories>
 
 


### PR DESCRIPTION
This is an attempt to fix recent failures observed in build