### PR TITLE
[CDAP-14153] Fix UI to not break with js error while reading a database table

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
@@ -29,8 +29,8 @@ import {setDatabaseAsActiveBrowser, setError} from 'components/DataPrep/DataPrep
 import DataPrepBrowserPageTitle from 'components/DataPrep/DataPrepBrowser/PageTitle';
 import {Provider} from 'react-redux';
 import DataprepBrowserTopPanel from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel';
-import If from 'components/If';
 import {ConnectionType} from 'components/DataPrepConnections/ConnectionType';
+import isNil from 'lodash/isNil';
 
 require('./DatabaseBrowser.scss');
 
@@ -111,7 +111,19 @@ export default class DatabaseBrowser extends Component {
           window.location.href = `${window.location.origin}/cdap/ns/${namespace}/dataprep/${workspaceId}`;
         },
         (err) => {
-          setError(err);
+          let error = err;
+          let errorMessage = T.translate(`${PREFIX}.defaultErrorMessage`, {tableId});
+          if (isNil(objectQuery(err, 'response', 'message'))) {
+            err = err || {};
+            error = {
+              ...err,
+              response: {
+                ...(err.response || {}),
+                message: errorMessage
+              }
+            };
+          }
+          setError(error);
         }
       );
   }
@@ -216,30 +228,28 @@ export default class DatabaseBrowser extends Component {
           toggle={this.props.toggle}
           browserTitle={T.translate(`${PREFIX}.title`)}
         />
-        <If condition={this.state.error}>
-          <div>
-            <div className="database-browser-header">
-              <div className="database-metadata">
-                <h5>{objectQuery(this.state.info, 'info', 'name')}</h5>
-                <span className="tables-count">
-                  {
-                    T.translate(`${PREFIX}.tableCount`, {
-                      context: this.state.tables.length
-                    })
-                  }
-                </span>
-              </div>
-              <div className="table-name-search">
-                <Input
-                  placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
-                  value={this.state.search}
-                  onChange={this.handleSearch}
-                  autoFocus={this.state.searchFocus}
-                />
-              </div>
+        <div>
+          <div className="database-browser-header">
+            <div className="database-metadata">
+              <h5>{objectQuery(this.state.info, 'info', 'name')}</h5>
+              <span className="tables-count">
+                {
+                  T.translate(`${PREFIX}.tableCount`, {
+                    context: this.state.tables.length
+                  })
+                }
+              </span>
+            </div>
+            <div className="table-name-search">
+              <Input
+                placeholder={T.translate(`${PREFIX}.searchPlaceholder`)}
+                value={this.state.search}
+                onChange={this.handleSearch}
+                autoFocus={this.state.searchFocus}
+              />
             </div>
           </div>
-        </If>
+        </div>
 
         <div className="database-browser-content">
           { renderContents(filteredTables) }

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -246,6 +246,13 @@ export default class DataPrepConnections extends Component {
           // TODO get default connection from backend and integrate.
         },
         err => {
+          // If the user happens to use older dataprep artifact `/connectionTypes` won't exist.
+          // So just query connections list instead of showing a spinner.
+          if (err && err.statusCode === 404) {
+            this.setState({
+              connectionTypes: Object.keys(ConnectionType).map((conn) => ({ type: conn }))
+            }, this.fetchConnectionsList);
+          }
           console.log(err);
           // Will rebase with error handling PR to actually surface the error.
         }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -424,6 +424,7 @@ features:
         pageTitle: CDAP | Connections | Google BigQuery | {connectionId}
         title: Select table
       DatabaseBrowser:
+        defaultErrorMessage: Reading {tableId} failed. Please try again.
         EmptyMessage:
           clearLabel: Clear
           emptyDatabase: 'No tables in connection _{connectionName}_'


### PR DESCRIPTION
- Handle empty error messages from backend.
- Handle older wrangler artifacts that does not have `/connectionTypes` endpoint.

JIRA: https://issues.cask.co/browse/CDAP-14153
Build: https://builds.cask.co/browse/CDAP-UDUT82