### PR TITLE
CDAP-14161 fix cancel provisioning task

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/bootstrap/BootstrapStep.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/bootstrap/BootstrapStep.java
@@ -63,6 +63,7 @@ public class BootstrapStep {
     if (label == null || label.isEmpty()) {
       throw new IllegalArgumentException("A bootstrap step must contain a label.");
     }
+
     if (type == null) {
       throw new IllegalArgumentException("A bootstrap step must contain a type.");
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/DeprovisionTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/DeprovisionTask.java
@@ -121,7 +121,7 @@ public class DeprovisionTask extends ProvisioningTask {
   }
 
   @Override
-  protected void handleStateSaveFailure(ProvisioningTaskInfo taskInfo, TransactionFailureException e) {
+  protected void handleStateSaveFailure(ProvisioningTaskInfo taskInfo, Exception e) {
     provisionerNotifier.orphaned(programRunId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisionTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisionTask.java
@@ -106,7 +106,7 @@ public class ProvisionTask extends ProvisioningTask {
   }
 
   @Override
-  protected void handleStateSaveFailure(ProvisioningTaskInfo taskInfo, TransactionFailureException e) {
+  protected void handleStateSaveFailure(ProvisioningTaskInfo taskInfo, Exception e) {
     notifyFailed(e);
   }
 


### PR DESCRIPTION
Provisioner task cancellation had a bug where the task thread
could save state after it was cancelled, overwriting the
task state from cancelled to something else.

In general, the tasks also would not quit running as early as
possible. Fixed ProvisioningTask so that it will never successfully
persist task state after it has been cancelled, and so that it
will not execute the next subtask after it has been interrupted.