### PR TITLE
[CDAP-14263][MMDS] Fix Analytics based on Dataprep connection changes.

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -116,7 +116,9 @@ export default class DataPrepConnections extends Component {
         ) {
           let activeConnectionid = objectQuery(workspaceInfo, 'properties', 'connectionid') || objectQuery(workspaceInfo, 'properties', 'id');
           let activeConnectionType = objectQuery(workspaceInfo, 'properties', 'connection');
-          activeConnectionType = ConnectionType[activeConnectionType.toUpperCase()];
+          if (activeConnectionType) {
+            activeConnectionType = ConnectionType[activeConnectionType.toUpperCase()];
+          }
           this.setState({
             activeConnectionid,
             activeConnectionType,
@@ -310,7 +312,7 @@ export default class DataPrepConnections extends Component {
         loading: false
       };
 
-      if (!state.defaultConnection && this.props.singleWorkspaceMode) {
+      if (!state.defaultConnection && this.props.singleWorkspaceMode && this.props.sidePanelExpanded) {
         state.sidePanelExpanded = true;
       }
 

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/CreateView.scss
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/CreateView.scss
@@ -32,10 +32,18 @@
     }
   }
   .dataprep-connections-container {
-    height: calc(100% - 50px);
+    height: 100%;
     overflow-y: auto;
     .file-browser-container {
       height: 100%;
+    }
+    // This is to hide the hamburger menu in the top panel
+    // Even though clicking on it doesn't toggle the sidepanel
+    // showing it is still giving a wrong impression to the user.
+    .dataprep-browser-top-panel {
+      .title h5 .fa.fa-fw {
+        display: none;
+      }
     }
   }
   .dataprephome-wrapper {
@@ -93,5 +101,18 @@
   }
   > :not([class*="experiments-"]) {
     height: calc(100% - 50px);
+  }
+
+  // This is to hide the side toggle while adding a model under an experiment
+  // The user should not be able to change the file once an experiment is created
+  &.add-model {
+    .top-section {
+      .panel-toggle {
+        display: none;
+      }
+      .top-section-content {
+        width: 100%;
+      }
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
@@ -51,6 +51,8 @@ import {directiveRequestBodyCreator} from 'components/DataPrep/helper';
 import MyDataPrepApi from 'api/dataprep';
 import Alert from 'components/Alert';
 import T from 'i18n-react';
+import classnames from 'classnames';
+import {isNilOrEmpty} from 'services/helpers';
 
 const PREFIX = 'features.Experiments.CreateView';
 
@@ -306,7 +308,9 @@ export default class ExperimentCreateView extends Component {
     let labelSuffix = addModel ? 'Add model' : 'Create Experiment';
     let pageTitle = `CDAP | Analytics | ${expId} ${labelSuffix}`;
     return (
-      <div className="experiments-create-view">
+      <div className={classnames("experiments-create-view", {
+        'add-model': !isNilOrEmpty(this.state.experimentId)
+      })}>
         <Helmet title={pageTitle} />
         {this.renderSteps()}
         {this.renderError()}

--- a/cdap-ui/app/cdap/components/Experiments/store/createExperimentStore.js
+++ b/cdap-ui/app/cdap/components/Experiments/store/createExperimentStore.js
@@ -310,6 +310,23 @@ const active_step = (state = DEFAULT_ACTIVE_STEP, action = defaultAction) => {
     return state.active_step;
   };
   switch (action.type) {
+    case ACTIONS.SET_WORKSPACE_ID: {
+      const newState = {
+        ...state,
+        experiments_create: {
+          ...state.experiments_create,
+          workspaceId: action.payload.workspaceId
+        },
+        active_step: {
+          ...state.active_step,
+          step_name: state.active_step.step_name
+        }
+      };
+      return {
+        ...state.active_step,
+        step_name: getActiveStep(newState).step_name
+      };
+    }
     case ACTIONS.MODEL_UPDATE: {
       const newState = {
         ...state,


### PR DESCRIPTION
- Fix Analytics to not show side panel at any point in time
- Fix the experiment create store to transition properly to appropriate steps (File Browser -> DataPrep -> Split Data -> ML Algorithm configuration)

JIRA: 
https://issues.cask.co/browse/CDAP-14263
Build:
https://builds.cask.co/browse/CDAP-UDUT84