### PR TITLE
[CDAP-14144] Fix showing duration in UI to be consistent

### DIFF
--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/ProfileAssociations.scss
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/ProfileAssociations.scss
@@ -35,6 +35,7 @@
   }
   .grid.grid-container {
     max-height: none;
+    overflow-x: hidden;
     .grid-row {
       grid-template-columns: 1.5fr 1fr 1.5fr 1fr 1fr 1fr 1fr 1fr 1fr;
       color: $grey-01;

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/Content/ProfileAssociations/index.js
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {MySearchApi} from 'api/search';
-import {isNilOrEmpty, humanReadableDuration, objectQuery} from 'services/helpers';
+  import {isNilOrEmpty, objectQuery, timeSinceCreated} from 'services/helpers';
 import {GLOBALS, SYSTEM_NAMESPACE} from 'services/global-constants';
 import IconSVG from 'components/IconSVG';
 import T from 'i18n-react';
@@ -250,7 +250,7 @@ export default class ProfileAssociations extends Component {
               >
                 <div>{appObj.name}</div>
                 <div>{appObj.namespace}</div>
-                <div>{humanReadableDuration((Date.now() - parseInt(appObj.created, 10)) / 1000, true) || '--'}</div>
+                <div>{timeSinceCreated((Date.now() - parseInt(appObj.created, 10)) / 1000, true) || '--'}</div>
                 {/*
                   We should set the defaults in the metrics call but since it is not certain that we get metrics
                   for all the profiles all the time I have added the defaults here in the view

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -129,7 +129,7 @@ function humanReadableDuration(timeInSeconds, shortForm = false) {
     let hours = Math.floor(timeInSeconds / ONE_HOUR_SECONDS);
     return (
       shortForm ?
-        `${hours} ${pluralize(hours, 'hour')} ago`
+        `${hours} ${pluralize(hours, 'hour')}`
       :
         `${hours} ${pluralize(hours, 'hour')} ${humanReadableDuration(timeInSeconds - (ONE_HOUR_SECONDS * hours))}`
     );
@@ -148,7 +148,7 @@ function humanReadableDuration(timeInSeconds, shortForm = false) {
     let weeks = Math.floor(timeInSeconds / ONE_WEEK_SECONDS);
     return (
       shortForm ?
-        `${weeks} ${pluralize(weeks, 'week')} ago`
+        `${weeks} ${pluralize(weeks, 'week')}`
       :
         `${weeks} ${pluralize(weeks, 'week')} ${humanReadableDuration(timeInSeconds - (ONE_WEEK_SECONDS * weeks))}`
     );
@@ -157,11 +157,15 @@ function humanReadableDuration(timeInSeconds, shortForm = false) {
     let months = Math.floor(timeInSeconds / ONE_MONTH_SECONDS);
     return (
       shortForm ?
-        `${months} ${pluralize(months, 'month')} ago`
+        `${months} ${pluralize(months, 'month')}`
       :
         `${months} ${pluralize(months, 'month')} ${humanReadableDuration(timeInSeconds - (ONE_MONTH_SECONDS * months))}`
     );
   }
+}
+
+function timeSinceCreated(timeInSeconds, shortForm) {
+  return `${humanReadableDuration(timeInSeconds, shortForm)} ago`;
 }
 
 function contructUrl ({path}) {
@@ -409,6 +413,7 @@ export {
   convertBytesToHumanReadable,
   humanReadableNumber,
   humanReadableDuration,
+  timeSinceCreated,
   isDescendant,
   getArtifactNameAndVersion,
   insertAt,


### PR DESCRIPTION
- Removes 'ago' from the duration helper function as 'ago' suffix in a duration doesn't makes sense
- Adds a new `timeSinceCreated` helper function to add the 'ago' suffix to be used to show time since a pipeline is created in profile view

JIRA: https://issues.cask.co/browse/CDAP-14144
Build: https://builds.cask.co/browse/CDAP-UDUT86