### PR TITLE
[CDAP-14198] Makes product name configurable across UI

### DIFF
--- a/cdap-ui/app/cdap/cdap.html
+++ b/cdap-ui/app/cdap/cdap.html
@@ -17,7 +17,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>CDAP</title>
+    <title></title>
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/index.js
@@ -23,6 +23,7 @@ import SystemPrefsAccordion from 'components/Administration/AdminConfigTabConten
 import {MyNamespaceApi} from 'api/namespace';
 import {Link} from 'react-router-dom';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 import T from 'i18n-react';
 
 require('./AdminConfigTabContent.scss');
@@ -83,7 +84,9 @@ export default class AdminConfigTabContent extends Component {
   render() {
     return (
       <div className="admin-config-tab-content">
-        <Helmet title={T.translate(`${I18N_PREFIX}.pageTitle`)} />
+        <Helmet title={T.translate(`${I18N_PREFIX}.pageTitle`, {
+          productName: Theme.productName,
+        })} />
         <div className="action-buttons">
           <ReloadSystemArtifacts />
           <Link

--- a/cdap-ui/app/cdap/components/Administration/AdminManagementTabContent/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminManagementTabContent/index.js
@@ -20,6 +20,7 @@ import T from 'i18n-react';
 import PlatformsDetails from 'components/Administration/AdminManagementTabContent/PlatformsDetails';
 import ServicesTable from 'components/Administration/AdminManagementTabContent/ServicesTable';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.Administration';
 const I18NPREFIX = `${PREFIX}.Management`;
@@ -28,7 +29,9 @@ require('./AdminManagementTabContent.scss');
 export default function AdminManagementTabContent(props) {
   return (
     <div className="admin-management-tab-content">
-    <Helmet title={T.translate(`${I18NPREFIX}.pageTitle`)} />
+      <Helmet title={T.translate(`${I18NPREFIX}.pageTitle`, {
+        productName: Theme.productName,
+      })} />
       <div className="services-details">
         <div className="services-table-section">
           <strong> {T.translate(`${PREFIX}.Services.title`)} </strong>

--- a/cdap-ui/app/cdap/components/AppDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/index.js
@@ -39,6 +39,7 @@ import OverviewHeader from 'components/Overview/OverviewHeader';
 import {MyMetadataApi} from 'api/metadata';
 import EntityType from 'services/metadata-parser/EntityType';
 import {SCOPES} from 'services/global-constants';
+import {Theme} from 'services/ThemeHelper';
 require('./AppDetailedView.scss');
 
 export default class AppDetailedView extends Component {
@@ -194,7 +195,10 @@ export default class AppDetailedView extends Component {
     return (
       <div className="app-detailed-view">
         <Helmet
-          title={T.translate('features.AppDetailedView.Title', {appId: this.props.match.params.appId})}
+          title={T.translate('features.AppDetailedView.Title', {
+            appId: this.props.match.params.appId,
+            productName: Theme.productName,
+          })}
         />
         <div className="bread-crumb-wrapper">
           <BreadCrumb

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/ProvisionerSelection/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/ProvisionerSelection/index.js
@@ -29,6 +29,7 @@ import ExperimentalBanner from 'components/ExperimentalBanner';
 import IconSVG from 'components/IconSVG';
 import {SYSTEM_NAMESPACE} from 'services/global-constants';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 import T from 'i18n-react';
 
 const PREFIX = 'features.Cloud.Profiles.CreateView';
@@ -179,7 +180,9 @@ export default function ProfileCreateProvisionerSelectionFn({...props}) {
   return (
     <Provider store={ProvisionerInfoStore}>
       <div>
-        <Helmet title={T.translate(`${PREFIX}.ProvisionerSelection.pageTitle`)} />
+        <Helmet title={T.translate(`${PREFIX}.ProvisionerSelection.pageTitle`, {
+          productName: Theme.productName,
+        })} />
         <ConnectedProfileCreateProvisionerSelection {...props} />
       </div>
     </Provider>

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -43,6 +43,7 @@ import {highlightNewProfile} from 'components/Cloud/Profiles/Store/ActionCreator
 import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import {SCOPES, SYSTEM_NAMESPACE} from 'services/global-constants';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.Cloud.Profiles.CreateView';
 
@@ -305,7 +306,10 @@ class ProfileCreateView extends Component {
     return (
       <Provider store={CreateProfileStore}>
         <div className="profile-create-view">
-          <Helmet title={T.translate(`${PREFIX}.pageTitle`, {provisioner_name: this.getProvisionerLabel()})} />
+          <Helmet title={T.translate(`${PREFIX}.pageTitle`, {
+            provisioner_name: this.getProvisionerLabel(),
+            productName: Theme.productName,
+          })} />
           <EntityTopPanel
             title={`Create a profile for ${this.getProvisionerLabel()}`}
             closeBtnAnchorLink={linkObj}

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
@@ -28,6 +28,7 @@ import {ONEDAYMETRICKEY, OVERALLMETRICKEY, fetchAggregateProfileMetrics} from 'c
 import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import {SYSTEM_NAMESPACE} from 'services/global-constants';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.Cloud.Profiles.DetailView';
 require('./DetailView.scss');
@@ -141,7 +142,10 @@ export default class ProfileDetailView extends Component {
     }
     return (
       <div className="profile-detail-view">
-        <Helmet title={T.translate(`${PREFIX}.pageTitle`, {profile_name: this.state.profile.label || this.state.profile.name})} />
+        <Helmet title={T.translate(`${PREFIX}.pageTitle`, {
+          profile_name: this.state.profile.label || this.state.profile.name,
+          productName: Theme.productName,
+        })} />
         <EntityTopPanel
           breadCrumbAnchorLink={breadCrumbAnchorLink}
           breadCrumbAnchorLabel={breadCrumbLabel}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/PageTitle/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/PageTitle/index.js
@@ -20,10 +20,14 @@ import Helmet from 'react-helmet';
 import {connect} from 'react-redux';
 import T from 'i18n-react';
 import {isNilOrEmpty, objectQuery} from 'services/helpers';
+import {Theme} from 'services/ThemeHelper';
 const PREFIX = 'features.DataPrep.DataPrepBrowser';
 
 function DataPrepBrowserPageTitle({connectionId, browserI18NName, path}) {
-  let title = T.translate(`${PREFIX}.${browserI18NName}.pageTitle`, {connectionId });
+  let title = T.translate(`${PREFIX}.${browserI18NName}.pageTitle`, {
+    connectionId,
+    productName: Theme.productName,
+  });
   if (!isNilOrEmpty(path)) {
     title = `${title} - ${path}`;
   }

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -37,6 +37,7 @@ import T from 'i18n-react';
 import isEmpty from 'lodash/isEmpty';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 
 require('./DataPrep.scss');
 
@@ -289,7 +290,8 @@ export default class DataPrep extends Component {
             null
           :
             <Helmet title={T.translate(`${DATAPREP_I18N_PREFIX}.pageTitle`, {
-              workspaceUri: !isNilOrEmpty(this.state.workspaceName) ? `| ${this.state.workspaceName}` : ''
+              workspaceUri: !isNilOrEmpty(this.state.workspaceName) ? `| ${this.state.workspaceName}` : '',
+              productName: Theme.productName,
             })} />
         }
         <DataPrepErrorAlert />

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -53,6 +53,7 @@ import If from 'components/If';
 import NoDefaultConnection from 'components/DataPrepConnections/NoDefaultConnection';
 import isObject from 'lodash/isObject';
 import DataPrepBrowserStore from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore';
+import {Theme} from 'services/ThemeHelper';
 
 require('./DataPrepConnections.scss');
 const PREFIX = 'features.DataPrepConnections';
@@ -946,7 +947,9 @@ export default class DataPrepConnections extends Component {
   render() {
     let pageTitle = (
       <Helmet
-        title={T.translate(DATAPREP_I18N_PREFIX)}
+        title={T.translate(DATAPREP_I18N_PREFIX, {
+          productName: Theme.productName,
+        })}
       />
     );
     if (this.state.backendChecking) {
@@ -977,7 +980,9 @@ export default class DataPrepConnections extends Component {
       <div className="dataprep-connections-container">
         {
           this.props.enableRouting ?
-            <Helmet title={T.translate(`${PREFIX}.pageTitle`)} />
+            <Helmet title={T.translate(`${PREFIX}.pageTitle`, {
+              productName: Theme.productName,
+            })} />
           :
             null
         }

--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -33,6 +33,7 @@ import {objectQuery} from 'services/helpers';
 import isNil from 'lodash/isNil';
 import ee from 'event-emitter';
 import Version from 'services/VersionRange/Version';
+import {Theme} from 'services/ThemeHelper';
 
 require('./DataPrepHome.scss');
 /**
@@ -272,7 +273,9 @@ export default class DataPrepHome extends Component {
   render() {
     let pageTitle = (
       <Helmet
-        title={T.translate('features.DataPrep.pageTitle')}
+        title={T.translate('features.DataPrep.pageTitle', {
+          productName: Theme.productName,
+        })}
       />
     );
     const renderPageTitle = () => {

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
@@ -37,6 +37,7 @@ import queryString from 'query-string';
 import {Route, Switch} from 'react-router-dom';
 import FieldLevelLineage from 'components/FieldLevelLineage';
 import {SCOPES} from 'services/global-constants';
+import {Theme} from 'services/ThemeHelper';
 require('./DatasetDetailedView.scss');
 
 export default class DatasetDetailedView extends Component {
@@ -217,7 +218,10 @@ export default class DatasetDetailedView extends Component {
     return (
       <div className="app-detailed-view dataset-detailed-view">
         <Helmet
-          title={T.translate('features.DatasetDetailedView.Title', {datasetId: datasetId})}
+          title={T.translate('features.DatasetDetailedView.Title', {
+            datasetId: datasetId,
+            productName: Theme.productName,
+          })}
         />
         <div className="bread-crumb-wrapper">
           <BreadCrumb

--- a/cdap-ui/app/cdap/components/EntityListView/SearchStore/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/EntityListView/SearchStore/ActionCreator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,6 +25,7 @@ import {fetchTables} from 'services/ExploreTables/ActionCreator';
 import {DEFAULT_SEARCH_QUERY} from 'components/EntityListView/SearchStore/SearchConstants';
 import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStoreActions';
 import isNil from 'lodash/isNil';
+import {Theme} from 'services/ThemeHelper';
 
 const search = () => {
   let namespace = NamespaceStore.getState().selectedNamespace;
@@ -152,7 +153,7 @@ const updateQueryString = () => {
   }
 
   let obj = {
-    title: 'CDAP',
+    title: Theme.productName,
     url: location.pathname + queryString
   };
 

--- a/cdap-ui/app/cdap/components/EntityListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/index.js
@@ -41,6 +41,7 @@ import classnames from 'classnames';
 import T from 'i18n-react';
 import queryString from 'query-string';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 
 import {
   DEFAULT_SEARCH_FILTERS, DEFAULT_SEARCH_SORT,
@@ -346,7 +347,9 @@ export default class EntityListView extends Component {
 
     return (
       <div>
-        <Helmet title={T.translate('features.EntityListView.Title')} />
+        <Helmet title={T.translate('features.EntityListView.Title', {
+          productName: Theme.productName,
+        })} />
         <EntityListHeader />
         <div className="entity-list-view">
           {

--- a/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/CreateView/index.js
@@ -53,6 +53,7 @@ import Alert from 'components/Alert';
 import T from 'i18n-react';
 import classnames from 'classnames';
 import {isNilOrEmpty} from 'services/helpers';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.Experiments.CreateView';
 
@@ -306,12 +307,14 @@ export default class ExperimentCreateView extends Component {
     const {experimentId, addModel} = queryString.parse(this.props.location.search);
     let expId = experimentId ? `${experimentId} | ` : '';
     let labelSuffix = addModel ? 'Add model' : 'Create Experiment';
-    let pageTitle = `CDAP | Analytics | ${expId} ${labelSuffix}`;
     return (
       <div className={classnames("experiments-create-view", {
         'add-model': !isNilOrEmpty(this.state.experimentId)
       })}>
-        <Helmet title={pageTitle} />
+        <Helmet title={T.translate(`${PREFIX}.pageTitle`, {
+          productName: Theme.productName,
+          experimentIdWithSuffix: `${expId} ${labelSuffix}`
+        })} />
         {this.renderSteps()}
         {this.renderError()}
         <Prompt

--- a/cdap-ui/app/cdap/components/Experiments/DetailedView/ExperimentDetailPageTitle/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/DetailedView/ExperimentDetailPageTitle/index.js
@@ -19,12 +19,16 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import {connect} from 'react-redux';
+import {Theme} from 'services/ThemeHelper';
 const EXPERIMENTS_I18N_PREFIX = 'features.Experiments.DetailedView';
 
 function ExperimentDetailPageTitle ({experiment_name}) {
   return (
     <Helmet
-      title={T.translate(`${EXPERIMENTS_I18N_PREFIX}.pageTitle`, {experiment_name})}
+      title={T.translate(`${EXPERIMENTS_I18N_PREFIX}.pageTitle`, {
+        experiment_name,
+        productName: Theme.productName,
+      })}
     />
   );
 }

--- a/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ExperimentsServiceControl/index.js
@@ -24,6 +24,7 @@ import isObject from 'lodash/isObject';
 import {myExperimentsApi} from 'api/experiments';
 import {isSpark2Available} from 'services/CDAPComponentsVersions';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 
 require('./ExperimentsServiceControl.scss');
 
@@ -140,7 +141,9 @@ export default class ExperimentsServiceControl extends Component {
   render() {
     return (
       <div className="experiments-service-control">
-        <Helmet title={T.translate(`${EXPERIMENTS_I18N_PREFIX}.pageTitle`)} />
+        <Helmet title={T.translate(`${EXPERIMENTS_I18N_PREFIX}.pageTitle`, {
+          productName: Theme.productName,
+        })} />
         <div className="image-containers">
           <img className="img-thumbnail" src="/cdap_assets/img/MMDS_preview1.png" />
           <img className="img-thumbnail" src="/cdap_assets/img/MMDS_preview2.png" />

--- a/cdap-ui/app/cdap/components/Experiments/ListView/index.js
+++ b/cdap-ui/app/cdap/components/Experiments/ListView/index.js
@@ -23,7 +23,10 @@ import { getExperimentsList, setAlgorithmsListForListView, updateQueryParameters
 import queryString from 'query-string';
 import isNil from 'lodash/isNil';
 import Mousetrap from 'mousetrap';
+import T from 'i18n-react';
+import {Theme} from 'services/ThemeHelper';
 
+const PREFIX = 'features.Experiments.ListView';
 export default class ExperimentsList extends Component {
   componentWillMount() {
     setAlgorithmsListForListView();
@@ -98,7 +101,9 @@ export default class ExperimentsList extends Component {
     return (
       <Provider store={experimentsStore}>
         <div className="experiments-list-container">
-          <Helmet title="CDAP | All Experiments" />
+          <Helmet title={T.translate(`${PREFIX}.pageTitle`, {
+            productName: Theme.productName,
+          })} />
           <ExperimentsListViewWrapper />
         </div>
       </Provider>

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -279,7 +279,7 @@ export default class SetPreferenceModal extends Component {
     const actionLabel = T.translate(`${PREFIX}.actionLabel`);
     let entity, entityWithType, description, tooltipID;
     if (this.props.setAtLevel === PREFERENCES_LEVEL.SYSTEM) {
-      entityWithType = 'CDAP';
+      entityWithType = 'system';
       description = T.translate(`${PREFIX}.DescriptionLabel.system`);
       tooltipID = `${entityWithType}-title`;
     } else {

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/store/ActionCreator.js
@@ -12,13 +12,14 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
 import {MyMetadataApi} from 'api/metadata';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import Store, {Actions, TIME_OPTIONS} from 'components/FieldLevelLineage/store/Store';
 import debounce from 'lodash/debounce';
 import {parseQueryString} from 'services/helpers';
+import {Theme} from 'services/ThemeHelper';
 
 const TIME_OPTIONS_MAP = {
   [TIME_OPTIONS[1]]: {
@@ -278,7 +279,7 @@ export function replaceHistory() {
   if (url === currentLocation) { return; }
 
   const stateObj = {
-    title: 'CDAP',
+    title: Theme.productName,
     url
   };
 

--- a/cdap-ui/app/cdap/components/Header/BrandSection/index.tsx
+++ b/cdap-ui/app/cdap/components/Header/BrandSection/index.tsx
@@ -29,7 +29,7 @@ interface IBrandSectionProps {
 const BrandSection: React.SFC<IBrandSectionProps> = ({ context }) => {
   const {namespace, isNativeLink } = context;
   const baseCDAPUrl = `/ns/${namespace}`;
-  const brandLogoSrc = Theme.logo || '/cdap_assets/img/company_logo.png';
+  const brandLogoSrc = Theme.productLogoNavbar || '/cdap_assets/img/company_logo.png';
   return (
     <div className="brand-section">
         <NavLinkWrapper

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/AboutPageModal/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/AboutPageModal/index.js
@@ -21,11 +21,13 @@ import {Modal, ModalBody} from 'reactstrap';
 import T from 'i18n-react';
 import {getModeWithCloudProvider} from 'components/Header/ProductDropdown/helper';
 import Footer from 'components/Footer';
+import { Theme } from 'services/ThemeHelper';
 
 require('./AboutPageModal.scss');
 
 export default function AboutPageModal({cdapVersion, isOpen, toggle}) {
   let mode = getModeWithCloudProvider();
+  const productLogoSrc = Theme.productLogoAbout || '/cdap_assets/img/CDAP_darkgray.png';
   return (
     <Modal
       isOpen={isOpen}
@@ -44,7 +46,7 @@ export default function AboutPageModal({cdapVersion, isOpen, toggle}) {
         <div className="about-title">
           <div className="cdap-logo-with-version">
             <div className="logo-container">
-              <img src='/cdap_assets/img/CDAP_darkgray.png' />
+              <img src={productLogoSrc} />
             </div>
             <span className="cdap-version">
               {T.translate('features.AboutPage.version', {version: cdapVersion})}

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/index.js
@@ -31,6 +31,7 @@ import getLastSelectedNamespace from 'services/get-last-selected-namespace';
 import T from 'i18n-react';
 import {getMode} from 'components/Header/ProductDropdown/helper';
 import classnames from 'classnames';
+import {Theme} from 'services/ThemeHelper';
 
 require('./ProductDropdown.scss');
 
@@ -156,7 +157,9 @@ export default class ProductDropdown extends Component {
               tag="li"
               onClick={this.toggleAboutPage}
             >
-              <a>{T.translate('features.Navbar.ProductDropdown.aboutLabel')}</a>
+              <a>{T.translate('features.Navbar.ProductDropdown.aboutLabel', {
+                productName: Theme.productName,
+              })}</a>
             </DropdownItem>
             <DropdownItem tag="li">
               {

--- a/cdap-ui/app/cdap/components/Header/Tour/index.ts
+++ b/cdap-ui/app/cdap/components/Header/Tour/index.ts
@@ -16,6 +16,7 @@
 
 import GuidedTour, { ITourStep } from 'services/GuidedTour';
 import T from 'i18n-react';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.NUX';
 
@@ -62,7 +63,9 @@ const steps: ITourStep[] = [
     id: 'hub',
     title: T.translate(`${PREFIX}.Hub.title`).toString(),
     text: [
-      T.translate(`${PREFIX}.Hub.text`).toString(),
+      T.translate(`${PREFIX}.Hub.text`, {
+        productName: Theme.productName,
+      }).toString(),
       '<img class="img-fluid" src="/cdap_assets/img/nux/Hub_NUX.png" />',
     ],
     attachTo: '#navbar-hub bottom',

--- a/cdap-ui/app/cdap/components/Header/Welcome/index.tsx
+++ b/cdap-ui/app/cdap/components/Header/Welcome/index.tsx
@@ -22,6 +22,7 @@ import IconSVG from 'components/IconSVG';
 import Tour from 'components/Header/Tour';
 import {objectQuery} from 'services/helpers';
 import T from 'i18n-react';
+import {Theme} from 'services/ThemeHelper';
 
 import './Welcome.scss';
 
@@ -109,7 +110,9 @@ export default class Welcome extends React.PureComponent<void, IWelcomeState> {
         >
           <ModalHeader>
             <span className="header-text">
-              {T.translate(`${PREFIX}.header`)}
+              {T.translate(`${PREFIX}.header`, {
+                productName: Theme.productName,
+              })}
             </span>
 
             <div className="close-section float-xs-right" >
@@ -122,7 +125,9 @@ export default class Welcome extends React.PureComponent<void, IWelcomeState> {
 
           <ModalBody>
             <p>
-              {T.translate(`${PREFIX}.bodyText`)}
+              {T.translate(`${PREFIX}.bodyText`, {
+                productName: Theme.productName,
+              })}
             </p>
             <p>
               {T.translate(`${PREFIX}.takeTour`)}

--- a/cdap-ui/app/cdap/components/LoadingIndicator/index.js
+++ b/cdap-ui/app/cdap/components/LoadingIndicator/index.js
@@ -19,6 +19,7 @@ import LoadingIndicatorStore, {BACKENDSTATUS, LOADINGSTATUS} from 'components/Lo
 import T from 'i18n-react';
 import {Modal} from 'reactstrap';
 import LoadingSVG from 'components/LoadingSVG';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.LoadingIndicator';
 
@@ -77,7 +78,9 @@ export default class LoadingIndicator extends Component {
         return (
           <div>
             <strong> {T.translate(`${PREFIX}.tryMessage`)}</strong>
-            <div>{T.translate(`${PREFIX}.restartCDAP`)}</div>
+            <div>{T.translate(`${PREFIX}.restartCDAP`, {
+              productName: Theme.productName,
+            })}</div>
           </div>
         );
       }

--- a/cdap-ui/app/cdap/components/NamespaceDetails/NamespaceDetailsPageTitle/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/NamespaceDetailsPageTitle/index.js
@@ -19,13 +19,17 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import {connect} from 'react-redux';
+import {Theme} from 'services/ThemeHelper';
 
 const NAMESPACE_I18N_PREFIX = 'features.NamespaceDetails';
 
 function NamespaceDetailsPageTitle({namespace_name}) {
   return (
     <Helmet
-      title={T.translate(`${NAMESPACE_I18N_PREFIX}.pageTitle`, {namespace_name})}
+      title={T.translate(`${NAMESPACE_I18N_PREFIX}.pageTitle`, {
+        namespace_name,
+        productName: Theme.productName,
+      })}
     />
   );
 }

--- a/cdap-ui/app/cdap/components/NamespaceDetails/Preferences/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/Preferences/index.js
@@ -117,7 +117,7 @@ class NamespaceDetailsPreferences extends Component {
     return sortedPrefObjectKeys.map(prefKey => {
       return {
         key: prefKey,
-        scope: prefKey in namespacePrefs ? T.translate('features.NamespaceDetails.namespace') : T.translate('commons.cdap'),
+        scope: prefKey in namespacePrefs ? T.translate('features.NamespaceDetails.namespace') : 'System',
         value: prefs[prefKey],
       };
     });

--- a/cdap-ui/app/cdap/components/OpsDashboard/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/index.js
@@ -24,6 +24,7 @@ import NamespacesPicker from 'components/NamespacesPicker';
 import {setNamespacesPick} from 'components/OpsDashboard/store/ActionCreator';
 import T from 'i18n-react';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.OpsDashboard';
 
@@ -44,7 +45,9 @@ export default class OpsDashboard extends Component {
     return (
       <Provider store={DashboardStore}>
         <div className="ops-dashboard">
-          <Helmet title={T.translate(`${PREFIX}.pageTitle`)} />
+          <Helmet title={T.translate(`${PREFIX}.pageTitle`, {
+            productName: Theme.productName,
+          })} />
           <div className="header clearfix">
             <div className="links float-xs-left">
               <span>{T.translate(`${PREFIX}.header`)}</span>

--- a/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Reports/ReportsServiceControl/index.js
@@ -24,6 +24,7 @@ import T from 'i18n-react';
 import {isSpark2Available} from 'services/CDAPComponentsVersions';
 import isObject from 'lodash/isObject';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 
 require('./ReportsServiceControl.scss');
 
@@ -133,7 +134,9 @@ export default class ReportsServiceControl extends Component {
   render() {
     return (
       <div className="reports-service-control">
-        <Helmet title={T.translate('features.Reports.pageTitle')} />
+        <Helmet title={T.translate('features.Reports.pageTitle', {
+          productName: Theme.productName,
+        })} />
         <div className="image-containers">
           <img className="img-thumbnail" src="/cdap_assets/img/Reports_preview1.png" />
           <img className="img-thumbnail" src="/cdap_assets/img/Reports_preview2.png" />

--- a/cdap-ui/app/cdap/components/Reports/index.js
+++ b/cdap-ui/app/cdap/components/Reports/index.js
@@ -26,6 +26,7 @@ import ReportsServiceControl from 'components/Reports/ReportsServiceControl';
 import ReportsAppDelete from 'components/Reports/ReportsAppDelete';
 import T from 'i18n-react';
 import Helmet from 'react-helmet';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.Reports';
 
@@ -79,7 +80,9 @@ export default class Reports extends Component {
     return (
       <Provider store={ReportsStore}>
         <div>
-          <Helmet title={T.translate(`${PREFIX}.pageTitle`)} />
+          <Helmet title={T.translate(`${PREFIX}.pageTitle`, {
+            productName: Theme.productName,
+          })} />
           <Switch>
             <Route exact path="/ns/:namespace/reports" component={ReportsList} />
             <Route exact path="/ns/:namespace/reports/details/:reportId" component={ReportsDetail} />

--- a/cdap-ui/app/cdap/components/RulesEngineHome/index.js
+++ b/cdap-ui/app/cdap/components/RulesEngineHome/index.js
@@ -28,6 +28,7 @@ import Helmet from 'react-helmet';
 import T from 'i18n-react';
 import RulesEngineWrapper from 'components/RulesEngineHome/RulesEngineWrapper';
 import isNil from 'lodash/isNil';
+import {Theme} from 'services/ThemeHelper';
 
 const PREFIX = 'features.RulesEngine.Home';
 
@@ -122,7 +123,9 @@ export default class RulesEngineHome extends Component {
   render() {
     let pageTitle = (
       <Helmet
-        title={T.translate(`${PREFIX}.pageTitle`)}
+        title={T.translate(`${PREFIX}.pageTitle`, {
+          productName: Theme.productName,
+        })}
       />
     );
     const renderPageTitle = () => !this.props.embedded ? pageTitle : null;

--- a/cdap-ui/app/cdap/components/StreamDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/index.js
@@ -35,6 +35,7 @@ import PlusButton from 'components/PlusButton';
 import Helmet from 'react-helmet';
 import queryString from 'query-string';
 import {SCOPES} from 'services/global-constants';
+import {Theme} from 'services/ThemeHelper';
 
 require('./StreamDetailedView.scss');
 
@@ -213,7 +214,10 @@ export default class StreamDetailedView extends Component {
     return (
       <div className="app-detailed-view streams-detailed-view">
         <Helmet
-          title={T.translate('features.StreamDetailedView.Title', {streamId: this.props.match.params.streamId})}
+          title={T.translate('features.StreamDetailedView.Title', {
+            streamId: this.props.match.params.streamId,
+            productName: Theme.productName,
+          })}
         />
         <div className="bread-crumb-wrapper">
           <BreadCrumb

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -33,7 +33,6 @@ import Footer from 'components/Footer';
 import ConnectionExample from 'components/ConnectionExample';
 import cookie from 'react-cookie';
 import {BrowserRouter, Route, Switch} from 'react-router-dom';
-import T from 'i18n-react';
 import NamespaceStore from 'services/NamespaceStore';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
 import RouteToNamespace from 'components/RouteToNamespace';
@@ -52,6 +51,7 @@ import HttpExecutor from 'components/HttpExecutor';
 import {applyTheme} from 'services/ThemeHelper';
 import ErrorBoundary from 'components/ErrorBoundary';
 import OverlayFocus from 'components/OverlayFocus';
+import {Theme} from 'services/ThemeHelper';
 const SampleTSXComponent = Loadable({
   loader: () => import (/* webpackChunkName: "SampleTSXComponent" */ 'components/SampleTSXComponent'),
   loading: LoadingSVGCentered
@@ -106,11 +106,10 @@ class CDAP extends Component {
   }
 
   render() {
-
     return (
       <BrowserRouter basename="/cdap">
         <div className="cdap-container">
-          <Helmet title={T.translate('commons.cdap')} />
+          <Helmet title={Theme.productName} />
           <Header />
           <LoadingIndicator />
           <StatusAlertMessage />

--- a/cdap-ui/app/cdap/services/ThemeHelper.ts
+++ b/cdap-ui/app/cdap/services/ThemeHelper.ts
@@ -30,7 +30,15 @@ interface IOnePoint0SpecJSON extends IThemeJSON {
     "font-family"?: string;
   };
   "content"?: {
-    "logo"?: {
+    "product-name"?: string;
+    "product-logo-navbar"?: {
+      "type"?: string;
+      "arguments"?: {
+         "url"?: string;
+         "data"?: string;
+      }
+    },
+    "product-logo-about"?: {
       "type"?: string;
       "arguments"?: {
          "url"?: string;
@@ -104,9 +112,11 @@ export function applyTheme() {
 }
 
 interface IThemeObj {
+  productName?: string;
   footerText?: string;
   footerLink?: string;
-  logo?: string;
+  productLogoNavbar?: string;
+  productLogoAbout?: string;
   showDashboard?: boolean;
   showReports?: boolean;
   showDataPrep?: boolean;
@@ -125,13 +135,22 @@ function getTheme(): IThemeObj {
     return {};
   }
 
-  let theme: IThemeObj = {};
+  let theme: IThemeObj = {
+    productName: 'CDAP',
+  };
   const themeJSON = window.CDAP_UI_THEME;
   const specVersion = themeJSON['spec-version'];
 
   if (specVersion === '1.0') {
-    theme = parse1Point0Spec(themeJSON);
+    theme = {
+      ...theme,
+      ...parse1Point0Spec(themeJSON),
+    };
   }
+  // Need to specify this here to show default/customized title when a CDAP page
+  // is not active in the browser, since the <Helmet> titles of the pages won't
+  // take effect until the page is active/rendered
+  document.title = theme.productName;
   return theme;
 }
 
@@ -144,20 +163,34 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
     if (isNilOrEmpty(contentJson)) {
       return content;
     }
+    if ('product-name' in contentJson) {
+      content.productName = contentJson['product-name'] || 'CDAP';
+    }
     if ('footer-text' in contentJson) {
       content.footerText = contentJson['footer-text'];
     }
     if ('footer-link' in contentJson) {
       content.footerLink = contentJson['footer-link'];
     }
-    if ('logo' in contentJson) {
-      const logo = window.CDAP_UI_THEME.content.logo;
-      if (logo.type) {
-        const logoType = logo.type;
-        if (logoType === 'inline') {
-          content.logo = objectQuery(logo, 'arguments', 'data');
-        } else if (logoType === 'link') {
-          content.logo = objectQuery(logo, 'arguments', 'url');
+    if ('product-logo-navbar' in contentJson) {
+      const productLogoNavbar = window.CDAP_UI_THEME.content['product-logo-navbar'];
+      if (productLogoNavbar.type) {
+        const productLogoNavbarType = productLogoNavbar.type;
+        if (productLogoNavbarType === 'inline') {
+          content.productLogoNavbar = objectQuery(productLogoNavbar, 'arguments', 'data');
+        } else if (productLogoNavbarType === 'link') {
+          content.productLogoNavbar = objectQuery(productLogoNavbar, 'arguments', 'url');
+        }
+      }
+    }
+    if ('product-logo-about' in contentJson) {
+      const productLogoAbout = window.CDAP_UI_THEME.content['product-logo-about'];
+      if (productLogoAbout.type) {
+        const productLogoAboutType = productLogoAbout.type;
+        if (productLogoAboutType === 'inline') {
+          content.productLogoAbout = objectQuery(productLogoAbout, 'arguments', 'data');
+        } else if (productLogoAboutType === 'link') {
+          content.productLogoAbout = objectQuery(productLogoAbout, 'arguments', 'url');
         }
       }
     }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -168,10 +168,9 @@ features:
           confirmationText: "Are you sure you want to reload all system artifacts?"
           errorMessage: Failed to load system artifacts
           label: Reload System Artifacts
-      pageTitle: CDAP | Administration | Configuration
+      pageTitle: '{productName} | Administration | Configuration'
     Management:
-      pageTitle: CDAP | Administration | Management
-    PageTitle: CDAP | Management
+      pageTitle: '{productName} | Administration | Management'
     Services:
       title: Services
       headers:
@@ -222,7 +221,7 @@ features:
       historyLabel: Program runs
       programsLabel: Programs
       propertiesLabel: Properties
-    Title: CDAP | Applications | {appId}
+    Title: '{productName} | Applications | {appId}'
   AuthorizationMessage:
     callToAction1: Please contact your system administrator to request access to a namespace
     callToAction2:
@@ -231,7 +230,7 @@ features:
       message2: as another user
     callToAction3:
       message1: "Create a new namespace "
-      message2: "(Note: You will require ADMIN privileges on CDAP for creating a namespace)"
+      message2: "(Note: You will require ADMIN privileges for creating a namespace)"
     mainMessage: " You are not authorized to access any existing namespace"
   Cloud:
     Profiles:
@@ -250,8 +249,8 @@ features:
         totalRuns: Total runs
       CreateView:
         ProvisionerSelection:
-          pageTitle: CDAP | Profiles | Create
-        pageTitle: CDAP | Profiles | Create | {provisioner_name}
+          pageTitle: '{productName} | Profiles | Create'
+        pageTitle: '{productName} | Profiles | Create | {provisioner_name}'
         profileName: Profile name
         profileLabel: Profile label
       DetailView:
@@ -277,7 +276,7 @@ features:
         enableError: "There was a problem enabling the profile: {message}"
         hideDetails: Hide Details
         noProperties: No properties available for this profile
-        pageTitle: CDAP | Profiles | {profile_name}
+        pageTitle: '{productName} | Profiles | {profile_name}'
         profileDetails: Profile details
         profileUsage: "{profile} usage"
         secureKeyPopover: Service account is stored using a secure key
@@ -321,8 +320,8 @@ features:
       retryNow: Retry now
       retrying: Retrying...
       secondsLabel: seconds.
-      tryAgain: Unable to communicate with CDAP services. Retrying in
-      timeOut: Timed out while attempting to communicate with CDAP services. Please contact your system administrator.
+      tryAgain: Unable to communicate with system services. Retrying in
+      timeOut: Timed out while attempting to communicate with system services. Please contact your system administrator.
     Header:
       filterBy: Filter by
       search-placeholder: Search
@@ -358,11 +357,11 @@ features:
       errorMessage: Page {pageNum} not found
       suggestionMessage1: "Go back to:"
       suggestionMessage2: Page 1
-    Title: CDAP | Control Center
+    Title: '{productName} | Control Center'
   DataPrepServiceControl:
     btnLabel: Enable Data Preparation
     btnLoadingLabel: "Enabling..."
-    description: CDAP Data Preparation provides an easy and interactive way to visualize, transform, and cleanse data. It allows the user to view data from a local source, a cluster or a database, and derive new schemas and operationalize the data preparation with a few clicks.
+    description: Data Preparation provides an easy and interactive way to visualize, transform, and cleanse data. It allows the user to view data from a local source, a cluster or a database, and derive new schemas and operationalize the data preparation with a few clicks.
     list:
       1: Easy and interactive way to work with messy data
       2: Apply transformations using a variety of operations on various data types
@@ -421,7 +420,7 @@ features:
           emptyDatasetList: 'No datasets in connection _{connectionName}_'
           emptyTableList: 'No tables in dataset _{datasetName}_'
         name: Name
-        pageTitle: CDAP | Connections | Google BigQuery | {connectionId}
+        pageTitle: '{productName} | Connections | Google BigQuery | {connectionId}'
         title: Select table
       DatabaseBrowser:
         defaultErrorMessage: Reading {tableId} failed. Please try again.
@@ -431,7 +430,7 @@ features:
           suggestionTitle: "You can try to:"
           suggestion1: your search
           title: 'No match found for "{searchText}"'
-        pageTitle: CDAP | Connections | Database | {connectionId}
+        pageTitle: '{productName} | Connections | Database | {connectionId}'
         searchPlaceholder: Search table name
         table:
           namecollabel: NAME
@@ -452,7 +451,7 @@ features:
             Name: Name
             Size: Size
             Type: Type
-        pageTitle: CDAP | Connections | Google Cloud Storage | {connectionId}
+        pageTitle: '{productName} | Connections | Google Cloud Storage | {connectionId}'
         Search:
           placeholder: Search this directory
         TopPanel:
@@ -466,7 +465,7 @@ features:
           suggestionTitle: "You can try to:"
           suggestion1: your search
           title: 'No match found for "{searchText}"'
-        pageTitle: CDAP | Connections | Kafka | {connectionId}
+        pageTitle: '{productName} | Connections | Kafka | {connectionId}'
         searchPlaceholder: Search topic
         table:
           topics: Topics
@@ -487,7 +486,7 @@ features:
             Name: Name
             Owner: Owner
             Size: Size
-        pageTitle: CDAP | Connections | S3 | {connectionId}
+        pageTitle: '{productName} | Connections | S3 | {connectionId}'
         Search:
           placeholder: Search this directory
         TopPanel:
@@ -942,7 +941,7 @@ features:
         variableNamePlaceholder: Enter counter name
       Swap:
         title: Swap two column names
-    pageTitle: CDAP | Data Preparation {workspaceUri}
+    pageTitle: '{productName} | Data Preparation {workspaceUri}'
     PipelineError:
       bigquery: Unable to find Google BigQuery plugin. Please install Google Cloud Plugins from Hub.
       database: Unable to find Database Plugins. Please make sure Database Plugins are available.
@@ -1007,7 +1006,7 @@ features:
       more: More
       PlusButton:
         addDirective: Add directive
-        successMessage: You successfully added a custom directive to CDAP. Apply that directive by typing it into the power mode input area.
+        successMessage: You successfully added a custom directive. Apply that directive by typing it into the power mode input area.
       realtimeDisabledTooltip: "Importing data from {type} in realtime is currently not supported."
       s3: S3
       SchemaModal:
@@ -1179,7 +1178,7 @@ features:
     kafka: Kafka ({count})
     NoDefaultConnection:
       title: No default connection available
-    pageTitle: CDAP | Connections
+    pageTitle: '{productName} | Connections'
     s3: S3 ({count})
     title: "Connections in \"{namespace}\""
     upload: Upload
@@ -1196,7 +1195,7 @@ features:
       programsWithCount: Programs ({count})
       properties: Properties
       schema: Schema
-    Title: CDAP | Dataset | {datasetId}
+    Title: '{productName} | Dataset | {datasetId}'
   Dashboard:
     Title: Dashboard
   Description:
@@ -1230,6 +1229,7 @@ features:
       moreInfo: for more info
       nextSelect: Next, select a machine learning algorithm
       numDirectives: "No of directives: "
+      pageTitle: '{productName} | Analytics | {experimentIdWithSuffix}'
       random: Random
       selectMLAlgorithm: Select a machine learning algorithm
       selectOutcome: Select an outcome
@@ -1272,7 +1272,7 @@ features:
       modelTrainingLogs: Model training logs
       numModels: No of models
       outcome: Outcome
-      pageTitle: CDAP | Analytics | {experiment_name}
+      pageTitle: '{productName} | Analytics | {experiment_name}'
       precision: Precision
       r2: R2
       recall: Recall
@@ -1287,7 +1287,8 @@ features:
         1: "{context} experiment"
         _: "{context} experiments"
       numModels: No of models
-    pageTitle: CDAP | Analytics
+      pageTitle: '{productName} | Analytics | All Experiments'
+    pageTitle: '{productName} | Analytics'
     ServiceControl:
       Benefits:
         b1: Intuitive Web UI for building, training, testing and evaluating machine learning models.
@@ -1297,7 +1298,7 @@ features:
         b5: Support for tuning custom hyperparameters for algorithms.
         b6: Integrated metrics and visualization providing rich summaries and graphs for model evaluation.
         title: "Some key benefits of MMDS are:"
-      description: "Data scientists typically build custom tooling for managing their machine learning models and deploying them. Model Management and Distribution Service (MMDS) provides a seamless, automated interface to help users develop, train, test, evaluate and deploy their machine learning models using CDAP."
+      description: "Data scientists typically build custom tooling for managing their machine learning models and deploying them. Model Management and Distribution Service (MMDS) provides a seamless, automated interface to help users develop, train, test, evaluate and deploy their machine learning models."
       enableBtnLabel: Enable MMDS
       environmentCheckMessage: Checking for environment before enabling Analytics
       errorCommunicating: Error while communicating with MMDS service
@@ -1446,12 +1447,10 @@ features:
     viewTracker: View in Tracker
 
   LoadingIndicator:
-    backendDown: 'Unable to connect to CDAP'
-    backendDownSubtitle: 'Attempting to connect...'
     contactadmin: Contact system administrator
     defaultMessage: 'Loading...'
     nodeserverDown: 'User interface service is down'
-    restartCDAP: Restart CDAP
+    restartCDAP: Restart {productName}
     restartUI: Restart the UI; or
     servicesDown: A few system services are down
     serviceDown: The system service {serviceName} is down
@@ -1532,7 +1531,7 @@ features:
       schedulerQueueName: 'Scheduler queue name: '
     namespace: Namespace
     namespaceName: Namespace '{namespace}'
-    pageTitle: CDAP | Namespace | {namespace_name}
+    pageTitle: '{productName} | Namespace | {namespace_name}'
     pipelines: Pipelines
     preferences:
       label: Preferences
@@ -1572,7 +1571,7 @@ features:
       streams: Streams
     pipelinesLabel: Pipelines
     ProductDropdown:
-      aboutLabel: About CDAP
+      aboutLabel: About {productName}
       accessToken: Access Token
       dataPrep: Data Preparation
       documentationLabel: Documentation
@@ -1588,7 +1587,7 @@ features:
       text: Control Center allows you to create, manage, operate, and monitor datasets and applications.
       title: Control Center
     Hub:
-      text: The Hub allows administrators to distribute re-usable pipelines, applications, plugins, and solutions to all CDAP users in their organizations.
+      text: The Hub allows administrators to distribute re-usable pipelines, applications, plugins, and solutions to all {productName} users in their organizations.
       title: Hub
     Metadata:
       text: Metadata enables data discovery through search, and data governance through lineage.
@@ -1600,16 +1599,16 @@ features:
       text: Preparation allows you to easily connect to a variety of data sources and cleanse data using point and click interactions. Once you are satisfied, you can operationalize your transformations in a pipeline.
       title: Preparation
     Welcome:
-      bodyText: CDAP is an open source framework that simplifies data application development, data integration, and data management.
+      bodyText: '{productName} is an open source framework that simplifies data application development, data integration, and data management.'
       close: No, Thanks
-      header: Welcome to CDAP
+      header: Welcome to {productName}
       showAgainToggle: Don't show tour again.
       startTour: Start Tour
       takeTour: Take a short tour to discover all that you can do.
 
   OpsDashboard:
     header: Dashboard
-    pageTitle: CDAP | Dashboard
+    pageTitle: '{productName} | Dashboard'
     RunsGraph:
       chart: Chart
       disabledArrowTooltip: The runs timelime is only available for the past 7 days
@@ -2112,7 +2111,7 @@ features:
         select: Select time
         timeRange: "{startTime} to {endTime}"
     header: Reports
-    pageTitle: CDAP | Reports
+    pageTitle: '{productName} | Reports'
     reportName: Report name
     reports:
       1: "{context} report"
@@ -2242,7 +2241,7 @@ features:
       owner: Owner
       version: Version {version}
     Home:
-      pageTitle: CDAP | Rules Engine
+      pageTitle: '{productName} | Rules Engine'
       Tabs:
         rbTitle: RuleBooks
         rulesTitle: Rules
@@ -2320,7 +2319,7 @@ features:
   StatusAlertMessage:
     message: 'Services are back online'
   StreamDetailedView:
-    Title: CDAP | Stream | {streamId}
+    Title: '{productName} | Stream | {streamId}'
 
   Tags:
     allTags: All Tags
@@ -2394,8 +2393,8 @@ features:
         keytab-uri-label: "Keytab URI"
         keytab-uri-placeholder: "Location of keytab file associated with the principal"
         principal-label: "Principal"
-        principal-placeholder: "Kerberos principal of the user to run CDAP programs as"
-        sld-label: "Specify credentials for securely impersonating CDAP programs in this namespace."
+        principal-placeholder: "Kerberos principal of the user to run programs as"
+        sld-label: "Specify credentials for securely impersonating programs in this namespace."
         ssd-label: "Security"
       Step4:
         name-label: "Name"
@@ -2652,7 +2651,7 @@ features:
         shorttitle: Setup format and schema
         title: Set format and schema
       Step3:
-        description: Setting up a trigger configures CDAP to notify systems observing to start processing.
+        description: Setting up a trigger notifies systems observing to start processing.
         mblabel: Megabytes (MB)
         shorttitle: Trigger setup
         thresholdlabel: The stream will notify any observers upon reaching this threshold to start processing the data in this stream.

--- a/cdap-ui/app/hydrator/routes.js
+++ b/cdap-ui/app/hydrator/routes.js
@@ -16,6 +16,7 @@
 
 angular.module(PKG.name + '.feature.hydrator')
   .config(function($stateProvider, $urlRouterProvider, MYAUTH_ROLE) {
+    const productName = window.CaskCommon.ThemeHelper.Theme.productName;
     $stateProvider
       .state('home', {
         url: '/',
@@ -51,7 +52,7 @@ angular.module(PKG.name + '.feature.hydrator')
         .state('hydrator.create', {
           url: '/studio?artifactType&draftId&workspaceId&configParams&rulesengineid&resourceCenterId&cloneId',
           onEnter: function() {
-            document.title = 'CDAP | Studio';
+            document.title = `${productName} | Studio`;
           },
           params: {
             data: null,
@@ -271,7 +272,7 @@ angular.module(PKG.name + '.feature.hydrator')
             highlightTab: 'hydratorList'
           },
           onEnter: function($stateParams) {
-            document.title = 'CDAP | Pipelines | ' + $stateParams.pipelineId;
+            document.title = `${productName} | Pipelines | ${$stateParams.pipelineId}`;
           },
           resolve : {
             rPipelineDetail: function($stateParams, $q, myPipelineApi, myAlertOnValium, $state) {
@@ -343,7 +344,7 @@ angular.module(PKG.name + '.feature.hydrator')
           url: '?page&sortBy&reverse',
           title: 'Published Pipelines',
           onEnter: function() {
-            document.title = 'CDAP | Pipelines';
+            document.title = `${productName} | Pipelines`;
           },
           data: {
             authorizedRoles: MYAUTH_ROLE.all,

--- a/cdap-ui/app/logviewer/logviewer.html
+++ b/cdap-ui/app/logviewer/logviewer.html
@@ -18,7 +18,7 @@
 <html lang="en" ng-app="cdap-ui">
 
 <head>
-  <title>CDAP | Logs </title>
+  <title></title>
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/cdap-ui/app/logviewer/routes.js
+++ b/cdap-ui/app/logviewer/routes.js
@@ -16,13 +16,13 @@
 
 angular.module(PKG.name + '.feature.logviewer')
   .config(function($stateProvider) {
-
+    const productName = window.CaskCommon.ThemeHelper.Theme.productName;
     $stateProvider
       .state('logviewerhome', {
         url: '/view?namespace&appId&programType&programId&runId&filter&startTime&endTime',
         templateUrl: '/assets/features/logviewer/templates/home.html',
         onEnter: function($stateParams) {
-          document.title = 'CDAP | Logs | ' + $stateParams.programId;
+          document.title = `${productName} | Logs | ${$stateParams.programId}`;
         },
         controller: 'LogsAppHomeController',
         controllerAs: 'Home'

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -169,4 +169,4 @@
 // NOTE: This is the base Bootstrap 4 font. We use it in Angular to make sure
 // our fonts look consistent in both React and Angular sides. Make sure to
 // double-check this when/if we upgrade Bootstrap on the React side!
-@bootstrap4-font-family: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
+@bootstrap4-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;

--- a/cdap-ui/app/tracker/routes.js
+++ b/cdap-ui/app/tracker/routes.js
@@ -16,7 +16,7 @@
 
 angular.module(PKG.name + '.feature.tracker')
   .config(function($stateProvider, MYAUTH_ROLE) {
-
+    const productName = window.CaskCommon.ThemeHelper.Theme.productName;
     $stateProvider
       .state('home', {
         url: '/',
@@ -53,7 +53,7 @@ angular.module(PKG.name + '.feature.tracker')
         templateUrl: '/assets/features/tracker/templates/main.html',
         controller: 'TrackerMainController',
         onEnter: function() {
-          document.title = 'CDAP | Search';
+          document.title = `${productName} | Search`;
         },
         controllerAs: 'MainController'
       })
@@ -75,7 +75,7 @@ angular.module(PKG.name + '.feature.tracker')
           controller: 'TrackerResultsController',
           controllerAs: 'ResultsController',
           onEnter: function() {
-            document.title = 'CDAP | Search Results';
+            document.title = `${productName} | Search Results`;
           },
           data: {
             authorizedRoles: MYAUTH_ROLE.all,
@@ -89,7 +89,7 @@ angular.module(PKG.name + '.feature.tracker')
           controller: 'TrackerEntityController',
           controllerAs: 'EntityController',
           onEnter: function($stateParams) {
-            document.title = 'CDAP | Search | ' + $stateParams.entityId;
+            document.title = `${productName} | Search | ${$stateParams.entityId}`;
           },
           data: {
             authorizedRoles: MYAUTH_ROLE.all,
@@ -102,7 +102,7 @@ angular.module(PKG.name + '.feature.tracker')
             controller: 'TrackerMetadataController',
             controllerAs: 'MetadataController',
             onEnter: function($stateParams) {
-              document.title = 'CDAP | Search | ' + $stateParams.entityId + ' | Summary';
+              document.title = `${productName} | Search | ${$stateParams.entityId} | Summary`;
             },
             data: {
               authorizedRoles: MYAUTH_ROLE.all,
@@ -114,7 +114,7 @@ angular.module(PKG.name + '.feature.tracker')
             templateUrl: '/assets/features/tracker/templates/lineage.html',
             controller: 'TrackerLineageController',
             onEnter: function($stateParams) {
-              document.title = 'CDAP | Search | ' + $stateParams.entityId + ' | Lineage';
+              document.title = `${productName} | Search | ${$stateParams.entityId} | Lineage`;
             },
             controllerAs: 'LineageController',
             data: {

--- a/cdap-ui/server/config/themes/default.json
+++ b/cdap-ui/server/config/themes/default.json
@@ -6,10 +6,17 @@
     "font-family": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif"
   },
   "content": {
-    "logo": {
+    "product-name": "CDAP",
+    "product-logo-navbar": {
       "type": "link",
       "arguments": {
          "url": "/cdap_assets/img/company_logo.png"
+      }
+    },
+    "product-logo-about": {
+      "type": "link",
+      "arguments": {
+         "url": "/cdap_assets/img/CDAP_darkgray.png"
       }
     },
     "footer-text": "Licensed under the Apache License, Version 2.0",


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14198
Builds: https://builds.cask.co/browse/CDAP-UDUT88

Things done in this PR:
- Adds a property called "product-name" in the theme spec, with "CDAP" as default value
- Changes CDAP references in page titles, NUX tour, Restart CDAP link to use dynamic product name instead of hardcoded
- Changes the displayed scope of system prefs in namespace detail page to 'System' instead of 'CDAP'
- Makes logo in About Us modal customizable, by adding an image property called "product-logo-about" to the theme spec. The property corresponding to the logo on the navbar is renamed from "logo" to "product-logo-navbar".