### PR TITLE
[CDAP-14208] Fixes instances of spark executor instances property to be consistent

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/NumExecutors.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/NumExecutors.js
@@ -22,13 +22,12 @@ import Popover from 'components/Popover';
 import SelectWithOptions from 'components/SelectWithOptions';
 import {NUM_EXECUTORS_OPTIONS, ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
 import T from 'i18n-react';
-
+import {SPARK_EXECUTOR_INSTANCES} from 'components/PipelineConfigurations/PipelineConfigConstants';
 const PREFIX = 'features.PipelineConfigurations.EngineConfig';
 
 const mapStateToProps = (state) => {
-  let numExecutorsKeyName = window.CDAP_CONFIG.isEnterprise ? 'system.spark.spark.executor.instances' : 'system.spark.spark.master';
   return {
-    numExecutors: state.properties[numExecutorsKeyName]
+    numExecutors: state.properties[SPARK_EXECUTOR_INSTANCES]
   };
 };
 const mapDispatchToProps = (dispatch) => {

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/index.js
@@ -16,7 +16,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {ENGINE_OPTIONS} from 'components/PipelineConfigurations/Store';
+import {ENGINE_OPTIONS} from 'components/PipelineConfigurations/PipelineConfigConstants';
 import EngineRadioInput from 'components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/EngineRadioInput';
 import Backpressure from 'components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/Backpressure';
 import NumExecutors from 'components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/NumExecutors';

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/ExecutorResources.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/ResourcesTabContent/ExecutorResources.js
@@ -21,7 +21,8 @@ import classnames from 'classnames';
 import IconSVG from 'components/IconSVG';
 import Popover from 'components/Popover';
 import PipelineResources from 'components/PipelineResources';
-import {ENGINE_OPTIONS, ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
+import {ENGINE_OPTIONS} from 'components/PipelineConfigurations/PipelineConfigConstants';
+import {ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
 import T from 'i18n-react';
 
 const PREFIX = 'features.PipelineConfigurations.Resources';

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/PipelineConfigConstants.tsx
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/PipelineConfigConstants.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+const SPARK_EXECUTOR_INSTANCES = 'system.spark.spark.executor.instances';
+const DEPRECATED_SPARK_MASTER = 'system.spark.spark.master';
+const SPARK_BACKPRESSURE_ENABLED = 'system.spark.spark.streaming.backpressure.enabled';
+
+const ENGINE_OPTIONS = {
+  MAPREDUCE: 'mapreduce',
+  SPARK: 'spark',
+};
+
+export {
+  SPARK_EXECUTOR_INSTANCES,
+  DEPRECATED_SPARK_MASTER,
+  SPARK_BACKPRESSURE_ENABLED,
+  ENGINE_OPTIONS,
+};

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -59,6 +59,7 @@ var ThemeHelper = require('../cdap/services/ThemeHelper');
 var Footer = require('../cdap/components/Footer').default;
 var cdapavscwrapper = require('../cdap/services/cdapavscwrapper').default;
 var IconSVG = require('../cdap/components/IconSVG').default;
+var PipelineConfigConstants = require('../cdap/components/PipelineConfigurations/PipelineConfigConstants');
 
 export {
   Store,
@@ -104,4 +105,5 @@ export {
   Footer,
   cdapavscwrapper,
   IconSVG,
+  PipelineConfigConstants,
 };


### PR DESCRIPTION
- Fixes `system.spark.spark.executor.instances` to be consistent for standalone vs distributed pipelines
- Fixes pipeline configuration to show executor instances for both batch pipelines with spark engine and for real time pipelines
- Fixes UI to handle old format during import. UI will now read if `system.spark.spark.master` property and converts it to `system.spark.spark.executor.instances`.

For instance, 
I/P:
```
"properties": {
  "system.spark.spark.streaming.backpressure.enabled": true,
  "system.spark.spark.master": "2"
},
```

O/P:
```
"properties": {
  "system.spark.spark.streaming.backpressure.enabled": true,
  "system.spark.spark.executor.instances": "2"
},
```
This is however only when importing via UI. If the user deploys a pipeline via CLI UI will still show the older format in key value pairs.

JIRA:
https://issues.cask.co/browse/CDAP-14208
Build:
https://builds.cask.co/browse/CDAP-UDUT87