### PR TITLE
[CDAP-14278] Fixes creating a pipeline for uploaded file

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/PipelineConfigHelper.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/PipelineConfigHelper.js
@@ -478,19 +478,21 @@ function constructProperties(workspaceInfo, pluginVersion) {
       let realtimeStages = [wranglerStage];
       let batchStages = [wranglerStage];
 
-      let sourceConfigs;
-      if (state.workspaceInfo.properties.connection === 'file') {
+      let sourceConfigs, realtimeSource, batchSource;
+      let connections = [];
+      const connectionType = state.workspaceInfo.properties.connection;
+      if (connectionType === 'file') {
         sourceConfigs = constructFileSource(res[0], res[2]);
-      } else if (state.workspaceInfo.properties.connection === 'database') {
+      } else if (connectionType === 'database') {
         sourceConfigs = constructDatabaseSource(res[0], res[2]);
         delete sourceConfigs.batchSource.plugin.properties.schema;
-      } else if (state.workspaceInfo.properties.connection === 'kafka') {
+      } else if (connectionType === 'kafka') {
         sourceConfigs = constructKafkaSource(res[0], res[2]);
-      } else if (state.workspaceInfo.properties.connection === 's3') {
+      } else if (connectionType === 's3') {
         sourceConfigs = constructS3Source(res[0], res[2]);
-      } else if (state.workspaceInfo.properties.connection === 'gcs') {
+      } else if (connectionType === 'gcs') {
         sourceConfigs = constructGCSSource(res[0], res[2]);
-      } else if (state.workspaceInfo.properties.connection === 'bigquery') {
+      } else if (connectionType === 'bigquery') {
         sourceConfigs = constructBigQuerySource(res[0], res[2]);
       }
 
@@ -499,17 +501,21 @@ function constructProperties(workspaceInfo, pluginVersion) {
         return;
       }
 
-      let {
-        realtimeSource,
-        batchSource,
-        connections
-      } = sourceConfigs;
+      if (sourceConfigs) {
+        ({
+          realtimeSource,
+          batchSource,
+          connections
+        } = sourceConfigs);
+      }
 
       let realtimeConfig = null,
           batchConfig = null;
 
-      if (realtimeSource) {
-        realtimeStages.push(realtimeSource);
+      if (realtimeSource || connectionType === 'upload') {
+        if (realtimeSource) {
+          realtimeStages.push(realtimeSource);
+        }
         realtimeConfig = {
           artifact: realtimeArtifact,
           config: {
@@ -528,8 +534,10 @@ function constructProperties(workspaceInfo, pluginVersion) {
         };
       }
 
-      if (batchSource) {
-        batchStages.push(batchSource);
+      if (batchSource || connectionType === 'upload') {
+        if (batchSource) {
+          batchStages.push(batchSource);
+        }
         batchConfig = {
           artifact: batchArtifact,
           config: {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14278
Builds: https://builds.cask.co/browse/CDAP-UDUT93

The problem was that we didn't construct the `sourceConfigs` object if the connection type was `upload`, hence when we did `let {...} = sourceConfigs`, `sourceConfigs` would be undefined for uploaded file.

The fix is to check if `sourceConfigs` exists before destructuring it. Also, construct `batchConfig` and `realtimeConfig` even when there's no source node for uploaded file, since we still want to be able to create batch and realtime pipelines (with just a Wrangler node).