### PR TITLE
CDAP-14295 fix bootstrap step to start dataprep service

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/bootstrap/executor/ProgramStarter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/bootstrap/executor/ProgramStarter.java
@@ -106,7 +106,7 @@ public class ProgramStarter extends BaseStepExecutor<ProgramStarter.Arguments> {
         throw new IllegalArgumentException("Namespace must be specified");
       }
       if (application == null || application.isEmpty()) {
-        throw new IllegalArgumentException("Application name must be specified");
+        throw new IllegalArgumentException("Application must be specified");
       }
       if (type == null || type.isEmpty()) {
         throw new IllegalArgumentException("Program type must be specified");

--- a/cdap-common/src/main/resources/bootstrap/sandbox.json
+++ b/cdap-common/src/main/resources/bootstrap/sandbox.json
@@ -35,6 +35,7 @@
       "runCondition": "ALWAYS",
       "arguments": {
         "namespace": "default",
+        "application": "dataprep",
         "type": "service",
         "name": "service"
       }


### PR DESCRIPTION
The config is missing the application name. Also changing the
error message to make it more clear that the application field is
missing and not the name field.