### PR TITLE
CDAP-13746 add provisioner system properties capability

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/DefaultSystemProvisionerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/DefaultSystemProvisionerContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.internal.provision;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.ProjectInfo;
+import co.cask.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Context for initializing a provisioner.
+ */
+public class DefaultSystemProvisionerContext implements ProvisionerSystemContext {
+  private final Map<String, String> properties;
+  private final String cdapVersion;
+
+  DefaultSystemProvisionerContext(CConfiguration cConf, String provisionerName) {
+    String prefix = String.format("%s%s.", Constants.Provisioner.SYSTEM_PROPERTY_PREFIX, provisionerName);
+    this.properties = Collections.unmodifiableMap(cConf.getPropsWithPrefix(prefix));
+    this.cdapVersion = ProjectInfo.getVersion().toString();
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public String getCDAPVersion() {
+    return cdapVersion;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1429,6 +1429,7 @@ public final class Constants {
    */
   public static final class Provisioner {
     public static final String EXTENSIONS_DIR = "runtime.extensions.dir";
+    public static final String SYSTEM_PROPERTY_PREFIX = "provisioner.system.properties.";
   }
 
   /**

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -26,9 +26,11 @@ import co.cask.cdap.runtime.spi.provisioner.ProgramRun;
 import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerContext;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerSpecification;
+import co.cask.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
 import co.cask.cdap.runtime.spi.ssh.SSHKeyPair;
 import co.cask.cdap.runtime.spi.ssh.SSHSession;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +39,13 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * Provisions a cluster using GCP Dataproc.
@@ -53,10 +58,83 @@ public class DataprocProvisioner implements Provisioner {
     "Google Cloud Dataproc is a fast, easy-to-use, fully-managed cloud service for running Apache Spark and Apache " +
       "Hadoop clusters in a simpler, more cost-efficient way.");
   private static final String CLUSTER_PREFIX = "cdap-";
+  // keys and values cannot be longer than 63 characters
+  // keys and values can only contain lowercase letters, numbers, underscores, and dashes
+  // keys must start with a lowercase letter
+  // keys cannot be empty
+  private static final Pattern LABEL_KEY_PATTERN = Pattern.compile("^[a-z][a-z0-9_-]{0,62}$");
+  private static final Pattern LABEL_VAL_PATTERN = Pattern.compile("^[a-z0-9_-]{0,63}$");
+  private Map<String, String> systemLabels;
 
   @Override
   public ProvisionerSpecification getSpec() {
     return SPEC;
+  }
+
+  @Override
+  public void initialize(ProvisionerSystemContext systemContext) {
+    Map<String, String> labels = new HashMap<>();
+    // dataproc only allows label values to be lowercase letters, numbers, or dashes
+    String cdapVersion = systemContext.getCDAPVersion().toLowerCase();
+    cdapVersion = cdapVersion.replaceAll("\\.", "_");
+    labels.put("cdap-version", cdapVersion);
+
+    String extraLabelsStr = systemContext.getProperties().get("labels");
+    // labels are expected to be in format:
+    // name1=val1,name2=val2
+    if (extraLabelsStr != null) {
+      labels.putAll(parseLabels(extraLabelsStr));
+    }
+
+    systemLabels = Collections.unmodifiableMap(labels);
+  }
+
+  /**
+   * Parses labels that are expected to be of the form key1=val1,key2=val2 into a map of key values.
+   *
+   * If a label key or value is invalid, a message will be logged but the key-value will not be returned in the map.
+   * Keys and values cannot be longer than 63 characters.
+   * Keys and values can only contain lowercase letters, numeric characters, underscores, and dashes.
+   * Keys must start with a lowercase letter and must not be empty.
+   *
+   * If a label is given without a '=', the label value will be empty.
+   * If a label is given as 'key=', the label value will be empty.
+   * If a label has multiple '=', it will be ignored. For example, 'key=val1=val2' will be ignored.
+   *
+   * @param labelsStr the labels string to parse
+   * @return valid labels from the parsed string
+   */
+  @VisibleForTesting
+  static Map<String, String> parseLabels(String labelsStr) {
+    Splitter labelSplitter = Splitter.on(',').trimResults().omitEmptyStrings();
+    Splitter kvSplitter = Splitter.on('=').trimResults().omitEmptyStrings();
+
+    Map<String, String> validLabels = new HashMap<>();
+    for (String keyvalue : labelSplitter.split(labelsStr)) {
+      Iterator<String> iter = kvSplitter.split(keyvalue).iterator();
+      if (!iter.hasNext()) {
+        continue;
+      }
+      String key = iter.next();
+      String val = iter.hasNext() ? iter.next() : "";
+      if (iter.hasNext()) {
+        LOG.info("Ignoring invalid label {}. Labels should be of the form 'key=val' or just 'key'", keyvalue);
+        continue;
+      }
+      if (!LABEL_KEY_PATTERN.matcher(key).matches()) {
+        LOG.info("Ignoring invalid label key {}. Label keys cannot be longer than 63 characters, must start with "
+                   + "a lowercase letter, and can only contain lowercase letters, numeric characters, underscores,"
+                   + " and dashes.", key);
+        continue;
+      }
+      if (!LABEL_VAL_PATTERN.matcher(val).matches()) {
+        LOG.info("Ignoring invalid label value {}. Label values cannot be longer than 63 characters, "
+                   + "and can only contain lowercase letters, numeric characters, underscores, and dashes.", val);
+        continue;
+      }
+      validLabels.put(key, val);
+    }
+    return validLabels;
   }
 
   @Override
@@ -91,11 +169,7 @@ public class DataprocProvisioner implements Provisioner {
           break;
       }
 
-      // dataproc only allows label values to be lowercase letters, numbers, or dashes
-      String cdapVersion = context.getCDAPVersion().toLowerCase();
-      cdapVersion = cdapVersion.replaceAll("\\.", "_");
-      Map<String, String> labels = Collections.singletonMap("cdap-version", cdapVersion);
-      client.createCluster(clusterName, imageVersion, labels);
+      client.createCluster(clusterName, imageVersion, systemLabels);
       return new Cluster(clusterName, ClusterStatus.CREATING, Collections.emptyList(), Collections.emptyMap());
     }
   }

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/Provisioner.java
@@ -32,6 +32,22 @@ public interface Provisioner {
   ProvisionerSpecification getSpec();
 
   /**
+   * Initialize the provisioner. This method is guaranteed to be called before any other method is called.
+   * It will only be called once for the lifetime of the provisioner.
+   *
+   * If this method throws a runtime exception, the provisioner will not be available for use.
+   * This can cause clusters that were created by the provisioner to be stranded in an orphaned state.
+   * As such, provisioners should be careful to only throw exceptions when there is absolutely nothing that can be done.
+   * For example, if an optional property is set to an invalid value, that property should be ignored.
+   * An exception should not be thrown in that case.
+   *
+   * @param systemContext the system context that can be used to initialize the provisioner
+   */
+  default void initialize(ProvisionerSystemContext systemContext) {
+    // no-op
+  }
+
+  /**
    * Check that the specified properties are valid. If they are not, an IllegalArgumentException should be thrown.
    *
    * @param properties properties to validate

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/ProvisionerSystemContext.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/provisioner/ProvisionerSystemContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.runtime.spi.provisioner;
+
+import java.util.Map;
+
+/**
+ * Context for system level provisioner information. System level information cannot be seen or modified by end
+ * users.
+ */
+public interface ProvisionerSystemContext {
+
+  /**
+   * System properties are derived from the CDAP configuration. Anything in the CDAP configuration that is prefixed by
+   * 'provisioner.system.properties.[provisioner-name].' will be adding as an entry in the system properties.
+   * For example, if the provisioner is named 'abc', and there is a configuration property
+   * 'provisioner.system.properties.abc.retry.timeout' with value '60', the system properties map will contain
+   * a key 'retry.timeout' with value '60'. System properties are not visible to end users and cannot be overwritten
+   * by end users.
+   *
+   * @return unmodifiable system properties for the provisioner
+   */
+  Map<String, String> getProperties();
+
+  /**
+   * Returns the CDAP version
+   */
+  String getCDAPVersion();
+}


### PR DESCRIPTION
Adds a new initialize() method to the Provisioner SPI to allow
system level configuration that is invisible to users.

Use the new method to allow admins to configure labels that should
be applied to every cluster created by the Dataproc provisioner.