### PR TITLE
[CDAP-13904] Fixes reloading dataprep on clicking on navbar

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -34,6 +34,7 @@ import isNil from 'lodash/isNil';
 import ee from 'event-emitter';
 import Version from 'services/VersionRange/Version';
 import {Theme} from 'services/ThemeHelper';
+import {setWorkspace} from 'components/DataPrep/store/DataPrepActionCreator';
 
 require('./DataPrepHome.scss');
 /**
@@ -151,13 +152,29 @@ export default class DataPrepHome extends Component {
             DataPrepStore.dispatch({
               type: DataPrepActions.disableLoading
             });
+            DataPrepStore.dispatch({
+              type: DataPrepActions.setWorkspaceList,
+              payload: {
+                list: []
+              }
+            });
+
             return;
           }
           let sortedWorkspace = orderBy(res.values, [(workspace) => workspace.name.toLowerCase()], ['asc']);
+          DataPrepStore.dispatch({
+            type: DataPrepActions.setWorkspaceList,
+            payload: {
+              list: sortedWorkspace
+            }
+          });
+
           let isCurrentWorkspaceIdValid = sortedWorkspace.find(ws => ws.id === this.props.match.params.workspaceId);
           if (this.props.match.params.workspaceId && !isCurrentWorkspaceIdValid) {
             let url = this.props.match.url.slice(0, this.props.match.url.indexOf(this.props.match.params.workspaceId));
             this.props.history.replace(url);
+          } else {
+            setWorkspace(sortedWorkspace[0].id).subscribe();
           }
           this.setState({
             rerouteTo: sortedWorkspace[0].id,

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -105,7 +105,7 @@
     "@babel/polyfill": "^7.0.0-beta.53",
     "body-parser": "1.14.2",
     "bootstrap": "4.0.0-alpha.5",
-    "cask-datavoyager": "2.0.0-alpha.12.7",
+    "cask-datavoyager": "2.0.0-alpha.12.8",
     "cdap-avsc": "4.1.12",
     "classnames": "2.2.5",
     "clipboard": "1.7.1",

--- a/cdap-ui/yarn.lock
+++ b/cdap-ui/yarn.lock
@@ -1978,9 +1978,9 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-cask-datavoyager@2.0.0-alpha.12.7:
-  version "2.0.0-alpha.12.7"
-  resolved "https://registry.yarnpkg.com/cask-datavoyager/-/cask-datavoyager-2.0.0-alpha.12.7.tgz#d0b14a0776cf8fe6b7e2d6f0208bc661a4eaa4fb"
+cask-datavoyager@2.0.0-alpha.12.8:
+  version "2.0.0-alpha.12.8"
+  resolved "https://registry.yarnpkg.com/cask-datavoyager/-/cask-datavoyager-2.0.0-alpha.12.8.tgz#a2fc9a43aa350a8b2a08b5be84f47f722a90aa89"
 
 cdap-avsc@4.1.12:
   version "4.1.12"


### PR DESCRIPTION
Exact same PR: #10635 
- Fixes on re-render of workspace tabs to update the store instead of simply resetting it.
- Updates voyager to fix a js error on switching between different tabs from insights (corresponding PR ajainarayanan/voyager#3)

For some reason #10635 was closed automatically when force pushed.
Build: https://builds.cask.co/browse/CDAP-UDUT99