### PR TITLE
CDAP-14295 Fix bootstrap step to create dataprep application

### DIFF
--- a/cdap-common/src/main/resources/bootstrap/distributed.json
+++ b/cdap-common/src/main/resources/bootstrap/distributed.json
@@ -14,20 +14,6 @@
       "label": "Load system artifacts",
       "type": "LOAD_SYSTEM_ARTIFACTS",
       "runCondition": "ALWAYS"
-    },
-    {
-      "label": "Create dataprep application",
-      "type": "CREATE_APPLICATION",
-      "runCondition": "ONCE",
-      "arguments": {
-        "namespace": "default",
-        "name": "dataprep",
-        "artifact": {
-          "name": "wrangler-service",
-          "version": "[3.0.0, 4.0.0)",
-          "scope": "SYSTEM"
-        }
-      }
     }
   ]
 }

--- a/cdap-common/src/main/resources/bootstrap/distributed.json
+++ b/cdap-common/src/main/resources/bootstrap/distributed.json
@@ -20,6 +20,7 @@
       "type": "CREATE_APPLICATION",
       "runCondition": "ONCE",
       "arguments": {
+        "namespace": "default",
         "name": "dataprep",
         "artifact": {
           "name": "wrangler-service",


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-14295

Otherwise, you see a warning in the master logs:
2018-09-12 13:19:55,327 - WARN  [bootstrap-service:c.c.c.i.b.e.BaseStepExecutor@58] - Bootstrap step Create dataprep application failed due to invalid arguments: Namespace must be specified