### PR TITLE
(CDAP-13566) Part 1: Implement classes for dynamic socks proxy using SSH tunneling

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -197,6 +197,10 @@
       <artifactId>jsch</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
     </dependency>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/SSHSessionProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/SSHSessionProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.monitor;
+
+import co.cask.cdap.internal.app.runtime.monitor.proxy.MonitorSocksProxy;
+import co.cask.cdap.runtime.spi.ssh.SSHSession;
+
+/**
+ * An interface for getting {@link SSHSession}. It is intended to be used by {@link MonitorSocksProxy} to get
+ * registered {@link SSHSession} for tunneling.
+ */
+public interface SSHSessionProvider {
+
+  /**
+   * Returns the {@link SSHSession} for the given host and port.
+   */
+  SSHSession getSession(String host, int port);
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/proxy/MonitorSocksProxy.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/proxy/MonitorSocksProxy.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.monitor.proxy;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.app.runtime.monitor.SSHSessionProvider;
+import com.google.common.util.concurrent.AbstractIdleService;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.socksx.SocksPortUnificationServerHandler;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The SOCKS proxy server for forwarding runtime monitor https calls. It uses SSH port forwarding (tunneling)
+ * to relay data between client and server. Unlike regular SSH dynamic tunneling, this proxy server
+ * always forward network traffic to the {@code localhost} of the destination SSH host as specified from the request.
+ */
+public class MonitorSocksProxy extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MonitorSocksProxy.class);
+
+  private final CConfiguration cConf;
+  private final SSHSessionProvider sshSessionProvider;
+  private volatile InetSocketAddress bindAddress;
+  private ChannelGroup channelGroup;
+  private EventLoopGroup eventLoopGroup;
+
+  public MonitorSocksProxy(CConfiguration cConf, SSHSessionProvider sshSessionProvider) {
+    this.cConf = cConf;
+    this.sshSessionProvider = sshSessionProvider;
+  }
+
+  public InetSocketAddress getBindAddress() {
+    InetSocketAddress addr = this.bindAddress;
+    if (addr == null) {
+      throw new IllegalStateException("Monitor proxy server hasn't been started");
+    }
+    return addr;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    ServerBootstrap bootstrap = new ServerBootstrap();
+
+    // Use a thread pool of size runtime monitor threads + 1. There can be at most that many threads making
+    // call to this socks proxy, plus 1 for the boss thread.
+    eventLoopGroup = new NioEventLoopGroup(cConf.getInt(Constants.RuntimeMonitor.THREADS) + 1,
+                                           Threads.createDaemonThreadFactory("monitor-socks-proxy"));
+    bootstrap
+      .group(eventLoopGroup)
+      .channel(NioServerSocketChannel.class)
+      .childHandler(new ChannelInitializer<SocketChannel>() {
+        @Override
+        protected void initChannel(SocketChannel ch) {
+          channelGroup.add(ch);
+
+          ch.pipeline()
+            .addLast(new SocksPortUnificationServerHandler())
+            .addLast(new SocksServerHandler(sshSessionProvider));
+        }
+      });
+
+    Channel serverChannel = bootstrap.bind(InetAddress.getLoopbackAddress(), 0).sync().channel();
+    bindAddress = (InetSocketAddress) serverChannel.localAddress();
+
+    channelGroup = new DefaultChannelGroup(ImmediateEventExecutor.INSTANCE);
+    channelGroup.add(serverChannel);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    channelGroup.close().awaitUninterruptibly();
+    bindAddress = null;
+    eventLoopGroup.shutdownGracefully(0, 5, TimeUnit.SECONDS);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/proxy/SocksServerConnectHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/proxy/SocksServerConnectHandler.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.monitor.proxy;
+
+import co.cask.cdap.common.http.Channels;
+import co.cask.cdap.common.logging.LogSamplers;
+import co.cask.cdap.common.logging.Loggers;
+import co.cask.cdap.internal.app.runtime.monitor.SSHSessionProvider;
+import co.cask.cdap.runtime.spi.ssh.PortForwarding;
+import co.cask.cdap.runtime.spi.ssh.SSHSession;
+import com.google.common.io.Closeables;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.socksx.SocksMessage;
+import io.netty.handler.codec.socksx.v4.DefaultSocks4CommandResponse;
+import io.netty.handler.codec.socksx.v4.Socks4CommandRequest;
+import io.netty.handler.codec.socksx.v4.Socks4CommandStatus;
+import io.netty.handler.codec.socksx.v4.Socks4CommandType;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandResponse;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequest;
+import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
+import io.netty.handler.codec.socksx.v5.Socks5CommandType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The Netty handler for handling socks connect request and relaying data.
+ */
+final class SocksServerConnectHandler extends SimpleChannelInboundHandler<SocksMessage> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SocksServerHandler.class);
+  private static final Logger OUTAGE_LOG = Loggers.sampling(
+    LOG, LogSamplers.perMessage(() -> LogSamplers.limitRate(TimeUnit.MINUTES.toMillis(1))));
+
+  private final SSHSessionProvider sshSessionProvider;
+
+  SocksServerConnectHandler(SSHSessionProvider sshSessionProvider) {
+    this.sshSessionProvider = sshSessionProvider;
+  }
+
+  @Override
+  public void channelRead0(final ChannelHandlerContext ctx, final SocksMessage message) throws SocksException {
+    // Socks4
+    if (message instanceof Socks4CommandRequest) {
+      Socks4CommandRequest request = (Socks4CommandRequest) message;
+
+      // We only support CONNECT command
+      if (request.type().equals(Socks4CommandType.CONNECT)) {
+        try {
+          handleConnectRequest(ctx, request.dstAddr(), request.dstPort(),
+                               new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS,
+                                                                request.dstAddr(), request.dstPort()));
+        } catch (Exception e) {
+          throw new SocksException(new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED), e);
+        }
+      } else {
+        sendAndClose(ctx, new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED));
+      }
+      return;
+    }
+
+    // Socks5
+    if (message instanceof Socks5CommandRequest) {
+      Socks5CommandRequest request = (Socks5CommandRequest) message;
+
+      // We only support CONNECT command
+      if (request.type().equals(Socks5CommandType.CONNECT)) {
+        try {
+          handleConnectRequest(ctx, request.dstAddr(), request.dstPort(),
+                               new DefaultSocks5CommandResponse(Socks5CommandStatus.SUCCESS, request.dstAddrType(),
+                                                                request.dstAddr(), request.dstPort()));
+        } catch (Exception e) {
+          throw new SocksException(new DefaultSocks5CommandResponse(Socks5CommandStatus.FAILURE,
+                                                                    request.dstAddrType()), e);
+        }
+      } else {
+        sendAndClose(ctx, new DefaultSocks5CommandResponse(Socks5CommandStatus.FAILURE, request.dstAddrType()));
+      }
+      return;
+    }
+
+    // Unsupported command, just close the channel.
+    Channels.closeOnFlush(ctx.channel());
+  }
+
+  @Override
+  public void channelReadComplete(ChannelHandlerContext ctx) {
+    ctx.flush();
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    OUTAGE_LOG.warn("Failed to tunnel traffic for channel {}", ctx.channel(), cause);
+
+    if (cause instanceof SocksException) {
+      // This means we cannot create port forwarding channel, response with SOCKS failure message.
+      sendAndClose(ctx, ((SocksException) cause).getResponse());
+    } else {
+      // For other exceptions, just close the channel
+      ctx.close();
+    }
+  }
+
+  /**
+   * Handles the CONNECT socks request.
+   *
+   * @param ctx the context object for the channel
+   * @param destAddress the destination address
+   * @param destPort the destination port that the remote {@code localhost} is listening to
+   * @param successResponse a {@link SocksMessage} to send back to client once the port forwarding channel has been
+   *                        established
+   * @throws IOException if failed to open the port forwarding channel
+   */
+  private void handleConnectRequest(ChannelHandlerContext ctx, String destAddress, int destPort,
+                                    SocksMessage successResponse) throws IOException {
+    // Before sending back the success response,
+    // creates the forwarding handler first, which will open the port forwarding channel.
+    ChannelHandler forwardingHandler = createForwardingChannelHandler(ctx.channel(), destAddress, destPort);
+    ctx.channel().write(successResponse).addListener((ChannelFutureListener) future -> {
+      if (future.isSuccess()) {
+        ctx.pipeline().remove(SocksServerConnectHandler.this);
+        ctx.pipeline().addLast(forwardingHandler);
+      } else {
+        Channels.closeOnFlush(ctx.channel());
+      }
+    });
+  }
+
+  /**
+   * Sends a message and close the channel once the sending is completed.
+   *
+   * @param ctx the {@link ChannelHandlerContext} for sending the message
+   * @param message the message to send.
+   */
+  private void sendAndClose(ChannelHandlerContext ctx, Object message) {
+    ctx.writeAndFlush(message).addListener(ChannelFutureListener.CLOSE);
+  }
+
+  /**
+   * Creates a {@link ChannelHandler} for relaying future traffic between the client and the destination server.
+   * It creates a SSH tunnel to the destination host and relays all traffic to the {@code localhost} of the
+   * destination host.
+   *
+   * @param channel the {@link Channel} for reading and writing data
+   * @param destAddress the destination address
+   * @param destPort the destination port that the remote {@code localhost} is listening to
+   * @return a {@link ChannelHandler} ready to be added to the {@link ChannelPipeline} for relaying
+   * @throws IOException if failed to open the port forwarding channel
+   */
+  private ChannelHandler createForwardingChannelHandler(Channel channel,
+                                                        String destAddress, int destPort) throws IOException {
+    SSHSession sshSession = sshSessionProvider.getSession(destAddress, destPort);
+    PortForwarding portForwarding = sshSession.createLocalPortForward("localhost", destPort,
+                                                                      destPort, new PortForwarding.DataConsumer() {
+      @Override
+      public void received(ByteBuffer buffer) {
+        channel.write(Unpooled.wrappedBuffer(buffer));
+      }
+
+      @Override
+      public void flushed() {
+        channel.flush();
+      }
+
+      @Override
+      public void finished() {
+        Channels.closeOnFlush(channel);
+      }
+    });
+
+    // Close the port forwarding channel when the connect get closed
+    channel.closeFuture().addListener(future -> Closeables.closeQuietly(portForwarding));
+
+    // Creates a handler that forward everything to the port forwarding channel
+    return new ChannelInboundHandlerAdapter() {
+
+      @Override
+      public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        ByteBuf buf = (ByteBuf) msg;
+        portForwarding.write(buf.nioBuffer());
+      }
+
+      @Override
+      public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        portForwarding.flush();
+      }
+
+      @Override
+      public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        // If there is exception, just close the channel
+        OUTAGE_LOG.warn("Exception raised when relaying messages", cause);
+        ctx.close();
+      }
+    };
+  }
+
+  /**
+   * An exception that wraps a cause and a {@link SocksMessage} for responding back to client.
+   */
+  private static final class SocksException extends Exception {
+
+    private final SocksMessage response;
+
+    private SocksException(SocksMessage response, Throwable cause) {
+      super(cause);
+      this.response = response;
+    }
+
+    SocksMessage getResponse() {
+      return response;
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/proxy/SocksServerHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/proxy/SocksServerHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.monitor.proxy;
+
+import co.cask.cdap.internal.app.runtime.monitor.SSHSessionProvider;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.socksx.SocksMessage;
+import io.netty.handler.codec.socksx.v5.DefaultSocks5InitialResponse;
+import io.netty.handler.codec.socksx.v5.Socks5AuthMethod;
+import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder;
+import io.netty.handler.codec.socksx.v5.Socks5InitialRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.NotSupportedException;
+
+/**
+ * A {@link ChannelHandler} for handling SOCKS handshake requests.
+ */
+final class SocksServerHandler extends SimpleChannelInboundHandler<SocksMessage> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SocksServerHandler.class);
+
+  private final SSHSessionProvider sshSessionProvider;
+
+  SocksServerHandler(SSHSessionProvider sshSessionProvider) {
+    this.sshSessionProvider = sshSessionProvider;
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext ctx, SocksMessage msg) throws Exception {
+    switch (msg.version()) {
+      case SOCKS4a:
+        ctx.pipeline().remove(this);
+        ctx.pipeline().addLast(new SocksServerConnectHandler(sshSessionProvider));
+        ctx.fireChannelRead(msg);
+        break;
+      case SOCKS5:
+        // For SOCKS5 protocol, needs to handle the initial authentication handshake
+        if (msg instanceof Socks5InitialRequest) {
+          ctx.pipeline().remove(this);
+          ctx.pipeline().addFirst(new Socks5CommandRequestDecoder());
+          ctx.pipeline().addLast(new SocksServerConnectHandler(sshSessionProvider));
+          ctx.write(new DefaultSocks5InitialResponse(Socks5AuthMethod.NO_AUTH));
+        } else {
+          // We don't expect other type of Socks5 message
+          throw new NotSupportedException("Unsupported SOCKS message " + msg);
+        }
+        break;
+      default:
+        throw new NotSupportedException("Unsupported SOCKS version '" + msg.version() + "'");
+    }
+  }
+
+  @Override
+  public void channelReadComplete(ChannelHandlerContext ctx) {
+    ctx.flush();
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("Exception raised while handling socks request for {}", ctx.channel(), cause);
+    } else {
+      LOG.debug("Exception raised while handling socks request for {} due to {}", ctx.channel(), cause);
+    }
+
+    // Just close the channel if there is exception
+    ctx.close();
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/monitor/proxy/MonitorSocksProxyTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/monitor/proxy/MonitorSocksProxyTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.monitor.proxy;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.ssh.DefaultSSHSession;
+import co.cask.cdap.common.ssh.SSHConfig;
+import co.cask.cdap.common.ssh.TestSSHServer;
+import co.cask.cdap.runtime.spi.ssh.PortForwarding;
+import co.cask.cdap.runtime.spi.ssh.SSHSession;
+import co.cask.common.http.HttpMethod;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpHandler;
+import co.cask.http.HttpResponder;
+import co.cask.http.NettyHttpService;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.KeyPair;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Unit tests for {@link MonitorSocksProxy}.
+ */
+public class MonitorSocksProxyTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MonitorSocksProxyTest.class);
+
+  @ClassRule
+  public static final TestSSHServer SSH_SERVER = new TestSSHServer();
+
+  private static KeyPair keyPair;
+  private NettyHttpService httpService;
+  private TestSSHSession sshSession;
+  private MonitorSocksProxy proxyServer;
+  private ProxySelector defaultProxySelector;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    keyPair = KeyPair.genKeyPair(new JSch(), KeyPair.RSA, 1024);
+    SSH_SERVER.addAuthorizedKey(keyPair, "cdap");
+  }
+
+  @Before
+  public void beforeTest() throws Exception {
+    httpService = NettyHttpService.builder("test")
+      .setHttpHandlers(new TestHandler())
+      .build();
+    httpService.start();
+
+    sshSession = new TestSSHSession(getSSHConfig());
+    proxyServer = new MonitorSocksProxy(CConfiguration.create(), (host, port) ->
+      Optional.ofNullable(sshSession).orElseThrow(() -> new IllegalArgumentException("No SSH session available for "
+                                                                                       + host + ":" + port)));
+    proxyServer.startAndWait();
+
+    Proxy proxy = new Proxy(Proxy.Type.SOCKS, proxyServer.getBindAddress());
+    defaultProxySelector = ProxySelector.getDefault();
+
+    // Set the proxy for URLConnection
+    ProxySelector.setDefault(new ProxySelector() {
+      @Override
+      public List<Proxy> select(URI uri) {
+        return Collections.singletonList(proxy);
+      }
+
+      @Override
+      public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+        LOG.error("Connect failed {} {}", uri, sa, ioe);
+      }
+    });
+  }
+
+  @After
+  public void afterTest() throws Exception {
+    ProxySelector.setDefault(defaultProxySelector);
+    proxyServer.stopAndWait();
+    httpService.stop();
+  }
+
+  /**
+   * This test the normal operations of the SOCKS proxy.
+   */
+  @Test
+  public void testSocksProxy() throws Exception {
+    InetSocketAddress httpAddr = httpService.getBindAddress();
+
+    // Make 10 requests. With connection keep-alive, there should only be one SSH tunnel created
+    URL url = new URL(String.format("http://%s:%d/ping", httpAddr.getHostName(), httpAddr.getPort()));
+    for (int i = 0; i < 10; i++) {
+      HttpResponse response = HttpRequests.execute(co.cask.common.http.HttpRequest.get(url).build());
+      Assert.assertEquals(200, response.getResponseCode());
+    }
+
+    Assert.assertEquals(1, sshSession.portForwardCreated.get());
+
+    // Make one more call with Connection: close. This should close the connection, hence close the tunnel.
+    HttpResponse response = HttpRequests.execute(
+      co.cask.common.http.HttpRequest.builder(HttpMethod.GET, url)
+        .addHeader(HttpHeaderNames.CONNECTION.toString(), HttpHeaderValues.CLOSE.toString())
+        .build());
+    Assert.assertEquals(200, response.getResponseCode());
+
+    Assert.assertEquals(1, sshSession.portForwardCreated.get());
+    Assert.assertEquals(1, sshSession.portForwardClosed.get());
+  }
+
+  /**
+   * This test failure in creating SSH tunnel
+   */
+  @Test(expected = IOException.class)
+  public void testFailTunnel() throws Exception {
+    InetSocketAddress httpAddr = httpService.getBindAddress();
+
+    // Close the SSH session, hence can't create port forwarding
+    sshSession.close();
+
+    // On proxy failure, IOException will be thrown
+    URL url = new URL(String.format("http://%s:%d/ping", httpAddr.getHostName(), httpAddr.getPort()));
+    HttpRequests.execute(co.cask.common.http.HttpRequest.get(url).build());
+  }
+
+  /**
+   * This test failure in looking up a {@link SSHSession} to use
+   */
+  @Test(expected = IOException.class)
+  public void testMissingSSHSession() throws IOException {
+    TestSSHSession oldSession = sshSession;
+    // Remove the ssh session, hence the lookup will fail
+    sshSession = null;
+    try {
+      // On proxy failure, IOException will be thrown
+      InetSocketAddress httpAddr = httpService.getBindAddress();
+      URL url = new URL(String.format("http://%s:%d/ping", httpAddr.getHostName(), httpAddr.getPort()));
+      HttpRequests.execute(co.cask.common.http.HttpRequest.get(url).build());
+    } finally {
+      sshSession = oldSession;
+    }
+  }
+
+  /**
+   * Creates a {@link SSHConfig} for connecting to the test ssh server.
+   */
+  private SSHConfig getSSHConfig() {
+    return SSHConfig.builder(SSH_SERVER.getHost())
+      .setPort(SSH_SERVER.getPort())
+      .setUser("cdap")
+      .setPrivateKeySupplier(() -> {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        keyPair.writePrivateKey(bos, null);
+        return bos.toByteArray();
+      })
+      .build();
+  }
+
+  /**
+   * A {@link SSHSession} for testing. It wraps and instruments method so that it can be inspected later.
+   */
+  private static final class TestSSHSession extends DefaultSSHSession {
+
+    private final AtomicInteger portForwardCreated = new AtomicInteger();
+    private final AtomicInteger portForwardClosed = new AtomicInteger();
+
+    TestSSHSession(SSHConfig config) throws IOException {
+      super(config);
+    }
+
+    @Override
+    public PortForwarding createLocalPortForward(String targetHost, int targetPort, int originatePort,
+                                                 PortForwarding.DataConsumer dataConsumer) throws IOException {
+      PortForwarding portForwarding = super.createLocalPortForward(targetHost, targetPort, originatePort, dataConsumer);
+      portForwardCreated.incrementAndGet();
+
+      return new PortForwarding() {
+        @Override
+        public int write(ByteBuffer buf) throws IOException {
+          return portForwarding.write(buf);
+        }
+
+        @Override
+        public void flush() throws IOException {
+          portForwarding.flush();
+        }
+
+        @Override
+        public boolean isOpen() {
+          return portForwarding.isOpen();
+        }
+
+        @Override
+        public void close() throws IOException {
+          portForwarding.close();
+          portForwardClosed.incrementAndGet();
+        }
+      };
+    }
+  }
+
+  /**
+   * A {@link HttpHandler} for testing.
+   */
+  public static final class TestHandler extends AbstractHttpHandler {
+
+    @GET
+    @Path("/ping")
+    public void ping(HttpRequest request, HttpResponder responder) {
+      responder.sendStatus(HttpResponseStatus.OK);
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/Channels.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/Channels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.gateway.router.handlers;
+package co.cask.cdap.common.http;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;

--- a/cdap-common/src/main/java/co/cask/cdap/common/ssh/DefaultPortForwarding.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ssh/DefaultPortForwarding.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.ssh;
+
+import co.cask.cdap.runtime.spi.ssh.PortForwarding;
+import com.jcraft.jsch.ChannelDirectTCPIP;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Default implementation of {@link PortForwarding}.
+ */
+final class DefaultPortForwarding implements PortForwarding {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultPortForwarding.class);
+
+  private static final int TRANSFER_SIZE = 8192;
+
+  private final ChannelDirectTCPIP sshChannel;
+  private final OutputStream outputStream;
+  private final byte[] transferBuf;
+
+  DefaultPortForwarding(ChannelDirectTCPIP sshChannel, DataConsumer dataConsumer) throws IOException {
+    sshChannel.setOutputStream(createIncomingOutputStream(dataConsumer));
+
+    this.outputStream = sshChannel.getOutputStream();
+    this.sshChannel = sshChannel;
+    this.transferBuf = new byte[TRANSFER_SIZE];
+
+    try {
+      Session session = sshChannel.getSession();
+      LOG.trace("Opened port forwarding channel {} through host {}:{}",
+                sshChannel.getId(), session.getHost(), session.getPort());
+    } catch (JSchException e) {
+      // This shouldn't happen
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public int write(ByteBuffer buf) throws IOException {
+    if (!isOpen()) {
+      throw new IOException("Port forwarding channel is not opened");
+    }
+
+    int remaining = buf.remaining();
+    writeFully(buf);
+
+    return remaining;
+  }
+
+  @Override
+  public synchronized void flush() throws IOException {
+    outputStream.flush();
+  }
+
+  @Override
+  public boolean isOpen() {
+    return sshChannel.isConnected();
+  }
+
+  @Override
+  public synchronized void close() {
+    Session session = null;
+    try {
+      session = sshChannel.getSession();
+    } catch (JSchException e) {
+      // Ignore as it only affects logging and normally shouldn't happen
+    }
+
+    int id = sshChannel.getId();
+    sshChannel.disconnect();
+
+    if (session != null) {
+      LOG.trace("Disconnected port forwarding channel {} through host {}:{}", id, session.getHost(), session.getPort());
+    } else {
+      LOG.trace("Disconnected port forwarding channel {}", id);
+    }
+  }
+
+  /**
+   * Writes all the bytes from the given {@link ByteBuffer} to the channel {@link OutputStream}.
+   *
+   * @param buf the {@link ByteBuffer} to write
+   * @throws IOException if an I/O error occurs
+   */
+  private synchronized void writeFully(ByteBuffer buf) throws IOException {
+    // If the ByteBuffer is backed by array, use it directly without copying
+    if (buf.hasArray()) {
+      outputStream.write(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
+      buf.position(buf.limit());
+      return;
+    }
+
+    // Otherwise, we have to copy the content into a byte[] and write to the OutputStream
+    int remaining = buf.remaining();
+    while (remaining > 0) {
+      int len = Math.min(remaining, transferBuf.length);
+      buf.get(transferBuf, 0, len);
+      outputStream.write(transferBuf, 0, len);
+      remaining = buf.remaining();
+    }
+  }
+
+  /**
+   * Creates the {@link OutputStream} that will be provided to the SSH channel for receiving incoming data.
+   *
+   * @param dataConsumer the {@link DataConsumer} to invoke when there is data received.
+   * @return an {@link OutputStream}
+   */
+  private OutputStream createIncomingOutputStream(DataConsumer dataConsumer) {
+    byte[] oneByte = new byte[1];
+
+    final AtomicBoolean closed = new AtomicBoolean();
+    return new OutputStream() {
+      @Override
+      public void write(int b) throws IOException {
+        oneByte[0] = (byte) b;
+        write(oneByte, 0, 1);
+      }
+
+      @Override
+      public void write(byte[] b, int off, int len) throws IOException {
+        if (closed.get()) {
+          throw new IOException("Channel already closed");
+        }
+        dataConsumer.received(ByteBuffer.wrap(b, off, len));
+      }
+
+      @Override
+      public void flush() throws IOException {
+        if (closed.get()) {
+          throw new IOException("Channel already closed");
+        }
+
+        dataConsumer.flushed();
+      }
+
+      @Override
+      public void close() {
+        if (closed.compareAndSet(false, true)) {
+          dataConsumer.finished();
+        }
+      }
+    };
+  }
+
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/ssh/SSHSessionTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/ssh/SSHSessionTest.java
@@ -25,15 +25,6 @@ import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.KeyPair;
-import org.apache.sshd.server.Command;
-import org.apache.sshd.server.Environment;
-import org.apache.sshd.server.ExitCallback;
-import org.apache.sshd.server.SshServer;
-import org.apache.sshd.server.config.keys.AuthorizedKeysAuthenticator;
-import org.apache.sshd.server.forward.AcceptAllForwardingFilter;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.scp.ScpCommandFactory;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -55,6 +46,7 @@ import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -72,73 +64,15 @@ public class SSHSessionTest {
   @ClassRule
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
-  private static SshServer sshd;
+  @ClassRule
+  public static final TestSSHServer SSH_SERVER = new TestSSHServer();
+
   private static KeyPair keyPair;
 
   @BeforeClass
-  public static void init() throws IOException, JSchException {
+  public static void init() throws IOException, JSchException, GeneralSecurityException {
     keyPair = KeyPair.genKeyPair(new JSch(), KeyPair.RSA, 1024);
-
-    File authorizedKeysFile = TEMP_FOLDER.newFile();
-    keyPair.writePublicKey(authorizedKeysFile.getAbsolutePath(), "cdap@cask.co");
-
-    sshd = SshServer.setUpDefaultServer();
-    sshd.setHost(InetAddress.getLoopbackAddress().getCanonicalHostName());
-    sshd.setPort(0);
-    sshd.setForwardingFilter(AcceptAllForwardingFilter.INSTANCE);
-    sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-    sshd.setPublickeyAuthenticator(new AuthorizedKeysAuthenticator(authorizedKeysFile));
-    // Support SCP and a CommandFactory that always response back the request command
-    sshd.setCommandFactory(new ScpCommandFactory.Builder().withDelegate(command -> new Command() {
-
-      private OutputStream out;
-      private OutputStream err;
-      private ExitCallback callback;
-
-      @Override
-      public void setInputStream(InputStream in) {
-      }
-
-      @Override
-      public void setOutputStream(OutputStream out) {
-        this.out = out;
-      }
-
-      @Override
-      public void setErrorStream(OutputStream err) {
-        this.err = err;
-      }
-
-      @Override
-      public void setExitCallback(ExitCallback callback) {
-        this.callback = callback;
-      }
-
-      @Override
-      public void start(Environment env) throws IOException {
-        // Just echo the command back and terminate
-
-        // If the command contains "fail", then echo back to the error stream with non-zero exit code
-        boolean failure = command.contains("fail");
-        OutputStream output = failure ? err : out;
-        output.write(command.getBytes(StandardCharsets.UTF_8));
-        output.flush();
-
-        callback.onExit(failure ? 1 : 0);
-      }
-
-      @Override
-      public void destroy() throws Exception {
-
-      }
-    }).build());
-
-    sshd.start();
-  }
-
-  @AfterClass
-  public static void finish() throws IOException {
-    sshd.stop();
+    SSH_SERVER.addAuthorizedKey(keyPair, "cdap");
   }
 
   @Test
@@ -304,9 +238,9 @@ public class SSHSessionTest {
   }
 
   private SSHConfig getSSHConfig() {
-    return SSHConfig.builder(sshd.getHost())
+    return SSHConfig.builder(SSH_SERVER.getHost())
       .setUser("cdap")
-      .setPort(sshd.getPort())
+      .setPort(SSH_SERVER.getPort())
       .setPrivateKeySupplier(() -> {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         keyPair.writePrivateKey(bos, null);

--- a/cdap-common/src/test/java/co/cask/cdap/common/ssh/SSHSessionTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/ssh/SSHSessionTest.java
@@ -17,7 +17,11 @@
 package co.cask.cdap.common.ssh;
 
 
+import co.cask.cdap.runtime.spi.ssh.PortForwarding;
 import co.cask.cdap.runtime.spi.ssh.SSHSession;
+import com.google.common.base.Splitter;
+import com.google.common.io.Closeables;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.KeyPair;
@@ -26,6 +30,7 @@ import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.config.keys.AuthorizedKeysAuthenticator;
+import org.apache.sshd.server.forward.AcceptAllForwardingFilter;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.scp.ScpCommandFactory;
 import org.junit.AfterClass;
@@ -34,6 +39,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -42,8 +49,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Unit tests for {@link SSHSession}.
@@ -66,6 +85,7 @@ public class SSHSessionTest {
     sshd = SshServer.setUpDefaultServer();
     sshd.setHost(InetAddress.getLoopbackAddress().getCanonicalHostName());
     sshd.setPort(0);
+    sshd.setForwardingFilter(AcceptAllForwardingFilter.INSTANCE);
     sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
     sshd.setPublickeyAuthenticator(new AuthorizedKeysAuthenticator(authorizedKeysFile));
     // Support SCP and a CommandFactory that always response back the request command
@@ -169,6 +189,120 @@ public class SSHSessionTest {
     }
   }
 
+  @Test
+  public void testLocalPortForwarding() throws Exception {
+    // Starts an echo server for testing the port forwarding
+    EchoServer echoServer = new EchoServer();
+
+    echoServer.startAndWait();
+    try {
+      // Creates the DataConsumer for receiving data and validating the lifecycle
+      StringBuilder received = new StringBuilder();
+      AtomicBoolean finished = new AtomicBoolean();
+
+      PortForwarding.DataConsumer dataConsumer = new PortForwarding.DataConsumer() {
+        private final List<String> messages = new ArrayList<>();
+
+        @Override
+        public void received(ByteBuffer buffer) {
+          messages.add(StandardCharsets.UTF_8.decode(buffer).toString());
+        }
+
+        @Override
+        public synchronized void flushed() {
+          messages.forEach(received::append);
+        }
+
+        @Override
+        public void finished() {
+          finished.set(true);
+        }
+      };
+
+
+      SSHConfig sshConfig = getSSHConfig();
+
+      // Creates a SSH session.
+      try (SSHSession session = new DefaultSSHSession(sshConfig)) {
+        InetSocketAddress bindAddress = echoServer.getBindAddress();
+
+        // Creates local port forward and send data to the echo server through that forwarding channel
+        try (PortForwarding portForwarding = session.createLocalPortForward(bindAddress.getHostName(),
+                                                                            bindAddress.getPort(),
+                                                                            12345, dataConsumer)) {
+          List<String> messages = new ArrayList<>();
+          for (int i = 0; i < 10; i++) {
+            String msg = "Testing" + i;
+            portForwarding.write(StandardCharsets.UTF_8.encode(msg));
+            portForwarding.write(StandardCharsets.UTF_8.encode("\n"));
+            messages.add(msg);
+          }
+          portForwarding.flush();
+
+          Iterable<String> splits = Splitter.on("\n").omitEmptyStrings().split(received);
+          Assert.assertEquals(messages, StreamSupport.stream(splits.spliterator(), false).collect(Collectors.toList()));
+        }
+
+        // After closing the port forwarding, the data consumer should have finished.
+        Assert.assertTrue(finished.get());
+      }
+
+    } finally {
+      echoServer.stopAndWait();
+    }
+  }
+
+  @Test
+  public void testForwardingOnSessionClose() throws Exception {
+    EchoServer echoServer = new EchoServer();
+
+    echoServer.startAndWait();
+    try {
+      SSHConfig sshConfig = getSSHConfig();
+      AtomicBoolean finished = new AtomicBoolean(false);
+      PortForwarding portForwarding;
+
+      // Creates a SSH session
+      try (SSHSession session = new DefaultSSHSession(sshConfig)) {
+        InetSocketAddress bindAddress = echoServer.getBindAddress();
+
+        // Creates a port forwarding and send some data
+        BlockingQueue<String> received = new LinkedBlockingQueue<>();
+        portForwarding = session.createLocalPortForward(bindAddress.getHostName(), bindAddress.getPort(),
+                                                        12345, new PortForwarding.DataConsumer() {
+          @Override
+          public void received(ByteBuffer buffer) {
+            received.add(StandardCharsets.UTF_8.decode(buffer).toString());
+          }
+
+          @Override
+          public void finished() {
+            finished.set(true);
+          }
+        });
+
+        portForwarding.write(StandardCharsets.UTF_8.encode("Testing"));
+        portForwarding.flush();
+
+        Assert.assertEquals("Testing", received.poll(5, TimeUnit.SECONDS));
+      }
+
+      // After closing of the SSH session, the port forwarding should be closed as well
+      Assert.assertTrue(finished.get());
+
+      // Writing to a closed port forwarding should fails.
+      try {
+        portForwarding.write(StandardCharsets.UTF_8.encode("Testing 2"));
+        Assert.fail("Expected failure when writing to closed PortForwarding");
+      } catch (IOException e) {
+        // expected
+      }
+
+    } finally {
+      echoServer.stopAndWait();
+    }
+  }
+
   private SSHConfig getSSHConfig() {
     return SSHConfig.builder(sshd.getHost())
       .setUser("cdap")
@@ -179,5 +313,66 @@ public class SSHSessionTest {
         return bos.toByteArray();
       })
       .build();
+  }
+
+  /**
+   * A simple Echo server for testing.
+   */
+  private static final class EchoServer extends AbstractExecutionThreadService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EchoServer.class);
+
+    private ServerSocket serverSocket;
+    private volatile boolean stopped;
+
+    InetSocketAddress getBindAddress() {
+      return (InetSocketAddress) serverSocket.getLocalSocketAddress();
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+      serverSocket = new ServerSocket();
+      serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+    }
+
+    @Override
+    protected void run() throws IOException {
+      while (!stopped) {
+        try {
+          Socket socket = serverSocket.accept();
+          Thread t = new Thread(() -> {
+            byte[] buffer = new byte[1024];
+            try {
+              InputStream is = socket.getInputStream();
+              OutputStream os = socket.getOutputStream();
+
+              int len = is.read(buffer);
+              while (len > 0) {
+                os.write(buffer, 0, len);
+                os.flush();
+                len = is.read(buffer);
+              }
+            } catch (IOException e) {
+              LOG.error("Exception raised from the EchoServer handling thread", e);
+            } finally {
+              Closeables.closeQuietly(socket);
+            }
+          });
+
+          t.setName("EchoServerHandler " + socket.getPort());
+          t.start();
+        } catch (IOException e) {
+          if (!stopped) {
+            throw e;
+          }
+        }
+      }
+    }
+
+    @Override
+    protected void triggerShutdown() {
+      stopped = true;
+      Closeables.closeQuietly(serverSocket);
+    }
   }
 }

--- a/cdap-common/src/test/java/co/cask/cdap/common/ssh/TestSSHServer.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/ssh/TestSSHServer.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.ssh;
+
+import com.jcraft.jsch.KeyPair;
+import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
+import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.ExitCallback;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.pubkey.KeySetPublickeyAuthenticator;
+import org.apache.sshd.server.forward.AcceptAllForwardingFilter;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.scp.ScpCommandFactory;
+import org.junit.rules.ExternalResource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.PublicKey;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A SSH server for testing purpose.
+ */
+public class TestSSHServer extends ExternalResource {
+
+  private final Set<PublicKey> authorizedKeys = Collections.synchronizedSet(new HashSet<>());
+  private SshServer sshd;
+
+  @Override
+  protected void before() throws Throwable {
+    sshd = SshServer.setUpDefaultServer();
+    sshd.setHost(InetAddress.getLoopbackAddress().getCanonicalHostName());
+    sshd.setPort(0);
+    sshd.setForwardingFilter(AcceptAllForwardingFilter.INSTANCE);
+    sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+    sshd.setPublickeyAuthenticator(new KeySetPublickeyAuthenticator(authorizedKeys));
+
+    // Support SCP and a CommandFactory that always response back the request command
+    sshd.setCommandFactory(new ScpCommandFactory.Builder().withDelegate(command -> new Command() {
+
+      private OutputStream out;
+      private OutputStream err;
+      private ExitCallback callback;
+
+      @Override
+      public void setInputStream(InputStream in) {
+      }
+
+      @Override
+      public void setOutputStream(OutputStream out) {
+        this.out = out;
+      }
+
+      @Override
+      public void setErrorStream(OutputStream err) {
+        this.err = err;
+      }
+
+      @Override
+      public void setExitCallback(ExitCallback callback) {
+        this.callback = callback;
+      }
+
+      @Override
+      public void start(Environment env) throws IOException {
+        // Just echo the command back and terminate
+
+        // If the command contains "fail", then echo back to the error stream with non-zero exit code
+        boolean failure = command.contains("fail");
+        OutputStream output = failure ? err : out;
+        output.write(command.getBytes(StandardCharsets.UTF_8));
+        output.flush();
+
+        callback.onExit(failure ? 1 : 0);
+      }
+
+      @Override
+      public void destroy() {
+
+      }
+    }).build());
+
+    sshd.start();
+
+  }
+
+  @Override
+  protected void after() {
+    try {
+      sshd.stop();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Adds an authorized public key from the given {@link KeyPair}.
+   */
+  public void addAuthorizedKey(KeyPair keyPair, String user) throws IOException, GeneralSecurityException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    keyPair.writePublicKey(bos, user);
+    AuthorizedKeyEntry entry = AuthorizedKeyEntry.parseAuthorizedKeyEntry(new String(bos.toByteArray(),
+                                                                                     StandardCharsets.US_ASCII));
+    addAuthorizedKey(entry.resolvePublicKey(PublicKeyEntryResolver.IGNORING));
+  }
+
+  /**
+   * Adds the given {@link PublicKey} to the authorized keys.
+   */
+  public void addAuthorizedKey(PublicKey publicKey) {
+    authorizedKeys.add(publicKey);
+  }
+
+  /**
+   * Returns the host that the SSH server is bind to.
+   */
+  public String getHost() {
+    return sshd.getHost();
+  }
+
+  /**
+   * Returns the port that the SSH server is bind to.
+   */
+  public int getPort() {
+    return sshd.getPort();
+  }
+}

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestRouter.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.HandlerException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
+import co.cask.cdap.common.http.Channels;
 import co.cask.cdap.gateway.router.RouterServiceLookup;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/OutboundHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/OutboundHandler.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.gateway.router.handlers;
 
+import co.cask.cdap.common.http.Channels;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/ssh/PortForwarding.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/ssh/PortForwarding.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.runtime.spi.ssh;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Represents a SSH port forwarding channel.
+ */
+public interface PortForwarding extends WritableByteChannel, Flushable {
+
+  @Override
+  int write(ByteBuffer buf) throws IOException;
+
+  @Override
+  void flush() throws IOException;
+
+  @Override
+  boolean isOpen();
+
+  @Override
+  void close() throws IOException;
+
+  /**
+   * This class is for consuming incoming data from the SSH port forwarding channel.
+   */
+  abstract class DataConsumer {
+
+    /**
+     * Invoked when new data is received.
+     *
+     * @param buffer the content of the data received
+     */
+    public abstract void received(ByteBuffer buffer);
+
+    /**
+     * Invoked when there is a flush event received from the channel.
+     */
+    public void flushed() {
+      // no-op
+    }
+
+    /**
+     * Invoked when the channel is closed and no more data will be received.
+     */
+    public void finished() {
+      // no-op
+    }
+  }
+}

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/ssh/SSHSession.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/ssh/SSHSession.java
@@ -112,6 +112,19 @@ public interface SSHSession extends AutoCloseable {
             @Nullable Long lastAccessTime, @Nullable Long lastModifiedTime) throws IOException;
 
   /**
+   * Creates a local port forwarding channel from this SSH session.
+   *
+   * @param targetHost the target hostname to forward to
+   * @param targetPort the target port to forward to
+   * @param originatePort the original port that the client is connect to
+   * @param dataConsumer A {@link PortForwarding.DataConsumer} for consuming incoming data from the forwarding channel
+   * @return a {@link PortForwarding} for communicating with the forwarding channel
+   * @throws IOException if failed to open the port forwarding channel
+   */
+  PortForwarding createLocalPortForward(String targetHost, int targetPort, int originatePort,
+                                        PortForwarding.DataConsumer dataConsumer) throws IOException;
+
+  /**
    * Close this SSH session.
    */
   @Override

--- a/cdap-security/src/test/java/co/cask/cdap/security/tools/HttpsEnablerTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/tools/HttpsEnablerTest.java
@@ -29,7 +29,6 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.security.KeyStore;
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
@@ -87,9 +86,9 @@ public class HttpsEnablerTest {
    * Private method to verify https connection.
    *
    * @param useTrustStore {@code true} to have the client use a trust store that contains the certificate of the server
-   * @param trustAny {@code true} to have the client trust any https server
+   * @param trustAll {@code true} to have the client trust any https server
    */
-  private void testServer(boolean useTrustStore, boolean trustAny) throws Exception {
+  private void testServer(boolean useTrustStore, boolean trustAll) throws Exception {
     String ksPass = "xyz";
     KeyStore keyStore = KeyStores.generatedCertKeyStore(1, ksPass);
 
@@ -108,14 +107,14 @@ public class HttpsEnablerTest {
       InetSocketAddress address = httpService.getBindAddress();
       URL url = new URL(String.format("https://%s:%d/ping", address.getHostName(), address.getPort()));
 
-      HttpsEnabler enabler = new HttpsEnabler();
+      HttpsEnabler enabler = new HttpsEnabler().setTrustAll(trustAll);
 
       // Optionally validates the server
       if (useTrustStore) {
         enabler = enabler.setTrustStore(KeyStores.createTrustStore(keyStore));
       }
 
-      HttpsURLConnection urlConn = enabler.enable((HttpsURLConnection) url.openConnection(), trustAny);
+      HttpsURLConnection urlConn = enabler.enable((HttpsURLConnection) url.openConnection());
       Assert.assertEquals(200, urlConn.getResponseCode());
     } finally {
       httpService.stop();
@@ -154,12 +153,12 @@ public class HttpsEnablerTest {
       InetSocketAddress address = httpService.getBindAddress();
       URL url = new URL(String.format("https://%s:%d/ping", address.getHostName(), address.getPort()));
 
-      HttpsEnabler clientEnabler = new HttpsEnabler();
+      HttpsEnabler clientEnabler = new HttpsEnabler().setTrustAll(true);
       if (useClientAuth) {
         clientEnabler.setKeyStore(clientKeyStore, ksPass::toCharArray);
       }
 
-      HttpsURLConnection urlConn = clientEnabler.enable((HttpsURLConnection) url.openConnection(), true);
+      HttpsURLConnection urlConn = clientEnabler.enable((HttpsURLConnection) url.openConnection());
       Assert.assertEquals(200, urlConn.getResponseCode());
     } finally {
       httpService.stop();


### PR DESCRIPTION
This is part 1 of 2 for using SSH tunneling for runtime monitor. Please see https://issues.cask.co/browse/CDAP-13566 for the design details.

This PR is organized into three commits:

1. Adding SSH local port forwarding support to SSHSession. This is the basis for doing SSH tunneling.
2. Small refactoring and fixes that helps testing SSH code and also fix the keep-alive support for HTTPS.
3. Added the SOCKS proxy server implementation as per the design, which uses SSH tunnel to relay network traffic.