### PR TITLE
[CDAP-14171] Fixes the font size of headings to be consistent

### DIFF
--- a/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/EntityCardHeader.scss
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/EntityCardHeader.scss
@@ -18,7 +18,7 @@
 .entity-card-header {
   padding-left: 10px;
   width: 100%;
-  h4 {
+  > div {
     line-height: 13px;
     margin-top: 5px;
     margin-bottom: 5px;

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
@@ -40,13 +40,13 @@ export default class EntityCardHeader extends Component {
           !isEmpty(this.props.successMessage) ?
             (
               <div className="entity-card-header success-message">
-                <h4>
+                <div>
                   <span>
                     {
                       this.props.successMessage
                     }
                   </span>
-                </h4>
+                </div>
               </div>
             )
           :
@@ -55,7 +55,7 @@ export default class EntityCardHeader extends Component {
                 onClick={this.props.onClick}
                 className={classnames("entity-card-header", this.props.className)}
               >
-                <h4>
+                <div>
                   <IconSVG
                     name={this.props.entity.icon}
                     className="entity-icon"
@@ -63,7 +63,7 @@ export default class EntityCardHeader extends Component {
                   <span className="entity-type">
                     {T.translate(`commons.entity.${this.getEntityType()}.singular`)}
                   </span>
-                </h4>
+                </div>
               </div>
             )
         }

--- a/cdap-ui/app/cdap/styles/bootstrap_4_patch.scss
+++ b/cdap-ui/app/cdap/styles/bootstrap_4_patch.scss
@@ -188,4 +188,22 @@
     max-width: 100%;
     height: auto;
   }
+  h1 {
+    font-size: $font-size-base * 2.5;
+  }
+  h2 {
+    font-size: $font-size-base * 2;
+  }
+  h3 {
+    font-size: $font-size-base * 1.75;
+  }
+  h4 {
+    font-size: $font-size-base * 1.5;
+  }
+  h5 {
+    font-size: $font-size-base * 1.25;
+  }
+  h6 {
+    font-size: $font-size-base;
+  }
 }

--- a/cdap-ui/app/directives/complex-schema/complex-schema.html
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.html
@@ -19,16 +19,16 @@
     <div class="clearfix"
          ng-if="::!ComplexSchema.isRecordSchema">
       <div class="input-column header">
-        <h4>Name</h4>
+        <h6>Name</h6>
       </div>
 
       <div class="type-column header">
-        <h4>Type</h4>
+        <h6>Type</h6>
       </div>
 
       <div class="fields-actions">
         <div class="nullable-header text-center">
-          <h4>Null</h4>
+          <h6>Null</h6>
         </div>
       </div>
     </div>

--- a/cdap-ui/app/directives/complex-schema/complex-schema.less
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.less
@@ -93,6 +93,13 @@ my-complex-schema {
       .select-wrapper(@background-color: transparent, @arrow-color: @cdap-header, @right: 7px);
     }
 
+    .input-column,
+    .type-column,
+    .fields-actions {
+      h6 {
+        font-weight: bold;
+      }
+    }
     div.tab-header {
       border-radius: 4px 4px 0 0;
       box-shadow: rgba(1, 0, 0, 0.25) 0 0 10px;

--- a/cdap-ui/app/directives/my-post-run-action-wizard/my-post-run-action-wizard-modal.html
+++ b/cdap-ui/app/directives/my-post-run-action-wizard/my-post-run-action-wizard-modal.html
@@ -17,13 +17,13 @@
   <h4 class="modal-title pull-left" ng-if="!action.name">
     Alerts
   </h4>
-  <h4 ng-if="action.name" class="modal-title pull-left">
+  <h5 ng-if="action.name" class="modal-title pull-left">
     <span>{{action.plugin.name || action.name}}</span>
     <small>{{action.defaultArtifact.version || action.plugin.artifact.version}}</small>
     <p>
       <small>{{action.description}}</small>
     </p>
-  </h4>
+  </h5>
   <div class="btn-group pull-right">
     <a class="btn" ng-click="$close()">
       <span class="fa fa-remove"></span>

--- a/cdap-ui/app/directives/plugin-templates/plugin-templates.html
+++ b/cdap-ui/app/directives/plugin-templates/plugin-templates.html
@@ -91,7 +91,7 @@
       <div ng-if="!PluginTemplatesCtrl.noConfig">
         <div ng-repeat="group in PluginTemplatesCtrl.groupsConfig.groups">
           <div class="widget-group-container">
-            <h4>{{::group.display}}</h4>
+            <h5>{{::group.display}}</h5>
             <div ng-repeat="field in group.fields">
               <div ng-if="field.name !== PluginTemplatesCtrl.groupsConfig.outputSchema.schemaProperty">
 
@@ -150,7 +150,7 @@
 
       <div ng-if="!PluginTemplatesCtrl.noConfig">
         <div class="output-schema">
-          <h4>Output Schema</h4>
+          <h5>Output Schema</h5>
 
           <fieldset ng-disabled="PluginTemplatesCtrl.isDisabled">
             <my-output-schema

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -49,7 +49,6 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      > h4,
       .modal-title {
         padding-left: 15px;
         max-width: 80%;
@@ -58,6 +57,7 @@
         overflow: hidden;
         font-weight: 500;
         margin-right: auto;
+        line-height: 1.4;
 
         @media (max-width: @screen-sm-max) {
           max-width: 70%;
@@ -76,6 +76,7 @@
           overflow-wrap: break-word;
           overflow: hidden;
           white-space: nowrap;
+          line-height: 1.4;
         }
       }
 

--- a/cdap-ui/app/hydrator/templates/create/popovers/leftpanel-plugin-popover.html
+++ b/cdap-ui/app/hydrator/templates/create/popovers/leftpanel-plugin-popover.html
@@ -25,7 +25,7 @@
 <div ng-init="contentData.showAllVersion=false;">
   <ul class="list-group">
     <li class="list-group-item">
-      <h5>
+      <h6>
         <strong>{{ popoverContext.generateLabel(contentData) }}</strong>
         <a href="#" ng-if="!contentData.pluginTemplate"
            class="template-label"
@@ -33,7 +33,7 @@
           <span class="fa fa-plus-circle"></span>
           <span>Template</span>
         </a>
-      </h5>
+      </h6>
     </li>
     <li class="list-group-item">
       <h6>

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
@@ -15,7 +15,7 @@
 -->
 <div class="modal-header clearfix">
 
-  <h4 class="modal-title pull-left"
+  <h5 class="modal-title pull-left"
       ng-class="{'with-jump': HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.jumpConfig.datasets.length}">
     <span>
       {{ HydratorPlusPlusNodeConfigCtrl.state.config['display-name'] || HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name }} Properties
@@ -25,7 +25,7 @@
     <p>
       <small>{{HydratorPlusPlusNodeConfigCtrl.state.node.description}}</small>
     </p>
-  </h4>
+  </h5>
   <div class="btn-group pull-right">
     <my-link-button
       class="btn"

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -32,6 +32,7 @@ values in Angular apps
 html {
   position: relative;
   min-height: 100%;
+  font-size: @root-font-size;
 }
 
 body {

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -16,6 +16,7 @@
 
 @import "../../bower_components/bootstrap/less/variables.less";
 
+@root-font-size: 13px;
 // new variables for use in themes
 @cdap-white:            rgb(255, 255, 255); // #fff, white
 @cdap-orange:           rgb(255, 102, 0);   // #ff6600


### PR DESCRIPTION
**Context:**
- We have different versions of bootstrap in different parts of the UI.
- The react side uses `4.0.0-alpha.5` and the angular side of it uses `3.3.6`
- In the version difference between 3 and 4, bootstrap has modified the base font size from `10px` to `13px`
- In addition to that the `h[1-6]` tags' font size have been modified from `px` to `rem`. 

Because of these two issues we had different `h[1-6]` tags' across UI.

**Solution:**
- Fix the base font size to be `13px` in angular side as well
- Fix the `h[1-6]` tags' font size to be in rem in angular side. This should be fine as long as they are consistent with react side

**Note:**
- I tried playing around the UI and didn't find any regressions
- Source of regression in angular side would be in the use `rem` units for any font size or margin or padding. Since I didn't find any I didn't hit on any regressions. Please do play around before agreeing to this PR.

JIRA: https://issues.cask.co/browse/CDAP-14171
Build: https://builds.cask.co/browse/CDAP-UDUT101
