### PR TITLE
Fixes deleting schedules/triggers when pipeline is updated

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -193,7 +193,26 @@ const updatePipeline = () => {
     description,
     artifact,
     config,
-    principal
+    principal,
+    /*
+      Ref: CDAP-13853
+      TL;DR - This is here so that when we update the pipeline we don't delete
+      the existing schedules (like triggers).
+
+      Longer version:
+      The existing behavior was,
+      1. User creates a pipeline
+      2. Sets up a trigger
+      3. Modifies the pipeline engine config
+
+      After step 3 UI was updating the pipeline (PUT /apps/:appId)
+      This used to delete any existing schedule as we have deployed/updated
+      the app.
+
+      This config will prevent CDAP from deleting existing schedules(triggers)
+      when we update the pipeline
+    */
+    'app.deploy.update.schedules': false
   });
 
   publishObservable.subscribe(() => {


### PR DESCRIPTION
**TL;DR** 
This is here so that when we update the pipeline we don't delete the existing schedules (like triggers).

**Longer version**
The existing behavior was,
  1. User creates a pipeline
  2. Sets up a trigger
  3. Modifies the pipeline engine config and clicks "Save"
  
After step 3 UI was updating the pipeline (PUT /apps/:appId). This used to delete any existing schedules or triggers as we have deployed/updated the app.

**Solution:**
The current fix of setting `app.deploy.update.schedules` to false prevents the schedules from being deleted.

JIRA: https://issues.cask.co/browse/CDAP-13853
Build: https://builds.cask.co/browse/CDAP-UDUT102