### PR TITLE
CDAP-14161 fix flaky cancel deprovision test

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/provision/ProvisioningServiceTest.java
@@ -299,7 +299,7 @@ public class ProvisioningServiceTest {
     TaskFields taskFields = testProvision(ProvisioningOp.Status.CREATED, provisionerInfo);
 
     Runnable task = Transactionals.execute(transactional, dsContext -> {
-      return provisioningService.deprovision(taskFields.programRunId, dsContext);
+      return provisioningService.deprovision(taskFields.programRunId, dsContext, t -> { });
     });
 
     task.run();


### PR DESCRIPTION
In the provisioning tests, we need to call the deprovision method
that lets the caller specify what sort of task cleanup to perform.
This is to prevent the default behavior, which is to delete task
state after a deprovision task is complete, which would not allow
the test to verify state.