### PR TITLE
CDAP-14308 fix flaky SparkTest

### DIFF
--- a/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
@@ -60,6 +60,21 @@ public abstract class AbstractProgramManager<T extends ProgramManager> implement
   }
 
   @Override
+  public T startAndWaitForRun(ProgramRunStatus status, long timeout,
+                              TimeUnit timeoutUnit) throws InterruptedException, ExecutionException, TimeoutException {
+    return startAndWaitForRun(Collections.emptyMap(), status, timeout, timeoutUnit);
+  }
+
+  @Override
+  public T startAndWaitForRun(Map<String, String> arguments, ProgramRunStatus status, long timeout,
+                              TimeUnit timeoutUnit) throws InterruptedException, ExecutionException, TimeoutException {
+    int count = getHistory(status).size();
+    T manager = start(arguments);
+    waitForRuns(status, count + 1, timeout, timeoutUnit);
+    return manager;
+  }
+
+  @Override
   public void stop() {
     applicationManager.stopProgram(programId);
   }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.test;
 
-import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.common.id.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
@@ -40,11 +39,39 @@ public interface ProgramManager<T extends ProgramManager> {
   T start();
 
   /**
+   * Starts the program and waits for one additional run of the specified status. This is essentially a
+   * call to {@link #start()} followed by a call to {@link #waitForRuns(ProgramRunStatus, int, long, TimeUnit)}.
+   * It should not be used if there is another run in progress.
+   *
+   * @param status the status of the run to wait for
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @return the program manager itself
+   */
+  T startAndWaitForRun(ProgramRunStatus status, long timeout, TimeUnit timeoutUnit)
+    throws InterruptedException, ExecutionException, TimeoutException;
+
+  /**
    * Starts the program with arguments
    * @param arguments the arguments to start the program with
    * @return T the ProgramManager, itself
    */
   T start(Map<String, String> arguments);
+
+  /**
+   * Starts the program with arguments and waits for one additional run of the specified status.
+   * This method assumes another run is not started by another thread. This is essentially a
+   * call to {@link #start(Map)} ()} followed by a call to {@link #waitForRuns(ProgramRunStatus, int, long, TimeUnit)}.
+   * It should not be used if there is another run in progress.
+   *
+   * @param arguments the arguments to start the program with
+   * @param status the status of the run to wait for
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @return the program manager itself
+   */
+  T startAndWaitForRun(Map<String, String> arguments, ProgramRunStatus status, long timeout, TimeUnit timeoutUnit)
+    throws InterruptedException, ExecutionException, TimeoutException;
 
   /**
    * Stops the program.


### PR DESCRIPTION
The test could fail because of incorrect assumptions about
ProgramManager's waitForRun method. That method wait for there
to be any run records with the given status. If the program has
already run, that means it will not wait at all.

Added new startAndWaitForRun methods that will wait for one
additional run of the given status. This method basically
implements the fix that we have had to add to all of these types
of tests, where the number of run records is counted before the
run is started, and it waits for one more run record.