### PR TITLE
(CDAP-13566) Part 2/2: Use SSH tunnel for Runtime Monitor traffic

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -399,9 +399,6 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
       // Publish CUD (Create, Update, Delete) operations on dataset instance
       result.set(Constants.Dataset.Manager.PUBLISH_CUD, Boolean.TRUE.toString());
 
-      // Bind the runtime monitor server to all interfaces
-      result.set(Constants.RuntimeMonitor.SERVER_HOST, "::");
-
       // The following services will be running in the edge node host.
       // Set the bind addresses for all of them to "${master.services.bind.address}"
       // Which the value of `"master.services.bind.address" will be set in the AbstractProgramTwillRunnable when it

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillPreparer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillPreparer.java
@@ -457,7 +457,7 @@ class RemoteExecutionTwillPreparer implements TwillPreparer {
 
           // Create the controller first. If the creation failed, the process won't get started.
           RemoteExecutionTwillController controller = controllerFactory.create();
-          session.executeAndWait("sudo " + targetPath + "/launcher.sh");
+          session.executeAndWait(targetPath + "/launcher.sh");
 
           return controller;
         }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/remote/SSHRemoteProcessController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/remote/SSHRemoteProcessController.java
@@ -39,7 +39,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * Implementation of {@link RemoteProcessController} that SSH into the remote machine and look for the running process.
  */
-public class SSHRemoteProcessController implements RemoteProcessController {
+final class SSHRemoteProcessController implements RemoteProcessController {
 
   private static final Logger LOG = LoggerFactory.getLogger(SSHRemoteProcessController.class);
   private static final Gson GSON = new Gson();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/remote/SSHSessionManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/remote/SSHSessionManager.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.distributed.remote;
+
+import co.cask.cdap.common.ssh.DefaultSSHSession;
+import co.cask.cdap.common.ssh.SSHConfig;
+import co.cask.cdap.internal.app.runtime.monitor.SSHSessionProvider;
+import co.cask.cdap.internal.app.runtime.monitor.proxy.MonitorSocksProxy;
+import co.cask.cdap.runtime.spi.ssh.PortForwarding;
+import co.cask.cdap.runtime.spi.ssh.SSHProcess;
+import co.cask.cdap.runtime.spi.ssh.SSHSession;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.Nullable;
+
+/**
+ * Manages SSH sessions for the runtime {@link MonitorSocksProxy}.
+ */
+final class SSHSessionManager implements SSHSessionProvider, AutoCloseable {
+
+  private final ConcurrentMap<InetSocketAddress, SSHInfo> sshInfos;
+
+  SSHSessionManager() {
+    this.sshInfos = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Adds a {@link SSHConfig} to this manager such that {@link SSHSession} can be acquired from the
+   * {@link #getSession(InetSocketAddress)} method that goes to the same host.
+   *
+   * @param serverAddr the {@link InetSocketAddress} of where the runtime monitor server is running
+   * @param sshConfig the {@link SSHConfig} to add
+   */
+  void addSSHConfig(InetSocketAddress serverAddr, SSHConfig sshConfig) {
+    sshInfos.putIfAbsent(serverAddr, new SSHInfo(sshConfig));
+  }
+
+  /**
+   * Removes a {@link SSHConfig} from this manager such that {@link SSHSession} cannot be acquired from the
+   * {@link #getSession(InetSocketAddress)} method that goes to the same host.
+   * This method will also InetSocketAddress the active {@link SSHSession} managed by this manager that is
+   * associated with the given {@link SSHConfig}.
+   *
+   * @param serverAddr the {@link InetSocketAddress} of where the runtime monitor server is running
+   */
+  void removeSSHConfig(InetSocketAddress serverAddr) {
+    SSHInfo info = sshInfos.remove(serverAddr);
+    CloseDisabledSSHSession session = info.getSession();
+    if (session != null) {
+      session.getDelegate().close();
+    }
+  }
+
+  /**
+   * Close this manager by close all {@link SSHSession}s that are managed by this class.
+   */
+  @Override
+  public void close() {
+    for (SSHInfo info : sshInfos.values()) {
+      CloseDisabledSSHSession session = info.getSession();
+      if (session != null) {
+        session.getDelegate().close();
+      }
+    }
+    sshInfos.clear();
+  }
+
+  @Override
+  public SSHSession getSession(InetSocketAddress serverAddr) {
+    SSHSession session = getAliveSession(serverAddr);
+    if (session != null) {
+      return session;
+    }
+
+    synchronized (this) {
+      // Check again to make sure we don't create multiple SSHSession
+      session = getAliveSession(serverAddr);
+      if (session != null) {
+        return session;
+      }
+
+      try {
+        SSHInfo sshInfo = sshInfos.get(serverAddr);
+        if (sshInfo == null) {
+          throw new IllegalStateException("No SSHSession available for " + serverAddr);
+        }
+        SSHConfig config = sshInfo.getConfig();
+
+        session = new DefaultSSHSession(config) {
+          @Override
+          public void close() {
+            // On closing of the ssh session, replace the SSHInfo with a null session
+            // We do replace such that if the SSHInfo was removed, we won't add it back.
+            sshInfos.replace(serverAddr, new SSHInfo(config));
+          }
+        };
+
+        // Replace the SSHInfo. If the replacement was not successful, it means the removeSSHConfig was called
+        // in between, hence we should close the new session and throw exception.
+        // It is also possible that the info was removed and then added back.
+        // In that case, we still treat that it is no longer valid to create the SSH session using the old config.
+        CloseDisabledSSHSession resultSession = new CloseDisabledSSHSession(session);
+        if (!sshInfos.replace(serverAddr, sshInfo, new SSHInfo(config, resultSession))) {
+          session.close();
+          throw new IllegalStateException("No SSHSession available for " + serverAddr);
+        }
+        return resultSession;
+      } catch (IOException e) {
+        throw new IllegalStateException("Failed to create SSHSession for " + serverAddr);
+      }
+    }
+  }
+
+  /**
+   * Returns an existing {@link SSHSession} for the given host.
+   *
+   * @param serverAddr the {@link InetSocketAddress} of where the runtime monitor server is running
+   * @return a {@link SSHSession} or {@code null} if no existing {@link SSHSession} are available.
+   */
+  @Nullable
+  private SSHSession getAliveSession(InetSocketAddress serverAddr) {
+    SSHInfo sshInfo = sshInfos.get(serverAddr);
+    if (sshInfo == null) {
+      throw new IllegalStateException("No SSHSession available for " + serverAddr);
+    }
+
+    SSHSession session = sshInfo.getSession();
+    if (session == null) {
+      return null;
+    }
+
+    if (session.isAlive()) {
+      return session;
+    }
+
+    // If the session is not alive, remove it from the map by replacing the value with a SSHInfo that
+    // doesn't have SSHSession.
+    sshInfos.replace(serverAddr, sshInfo, new SSHInfo(sshInfo.getConfig()));
+    return null;
+  }
+
+  /**
+   * A class that contains a {@link SSHConfig} and a {@link SSHSession}.
+   */
+  private static final class SSHInfo {
+
+    private final SSHConfig config;
+    private final CloseDisabledSSHSession session;
+
+    SSHInfo(SSHConfig config) {
+      this(config, null);
+    }
+
+    SSHInfo(SSHConfig config, @Nullable CloseDisabledSSHSession session) {
+      this.config = config;
+      this.session = session;
+    }
+
+    SSHConfig getConfig() {
+      return config;
+    }
+
+    @Nullable
+    CloseDisabledSSHSession getSession() {
+      return session;
+    }
+  }
+
+  /**
+   * A {@link SSHSession} wrapper that forward calls to another {@link SSHSession},
+   * with the {@link #close()} method disabled.
+   */
+  private static final class CloseDisabledSSHSession implements SSHSession {
+
+    private final SSHSession delegate;
+
+    CloseDisabledSSHSession(SSHSession delegate) {
+      this.delegate = delegate;
+    }
+
+    SSHSession getDelegate() {
+      return delegate;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return getDelegate().isAlive();
+    }
+
+    @Override
+    public InetSocketAddress getAddress() {
+      return getDelegate().getAddress();
+    }
+
+    @Override
+    public String getUsername() {
+      return getDelegate().getUsername();
+    }
+
+    @Override
+    public SSHProcess execute(List<String> commands) throws IOException {
+      return getDelegate().execute(commands);
+    }
+
+    @Override
+    public String executeAndWait(List<String> commands) throws IOException {
+      return getDelegate().executeAndWait(commands);
+    }
+
+    @Override
+    public void copy(Path sourceFile, String targetPath) throws IOException {
+      getDelegate().copy(sourceFile, targetPath);
+    }
+
+    @Override
+    public void copy(InputStream input, String targetPath, String targetName, long size, int permission,
+                     @Nullable Long lastAccessTime, @Nullable Long lastModifiedTime) throws IOException {
+      getDelegate().copy(input, targetPath, targetName, size, permission, lastAccessTime, lastModifiedTime);
+    }
+
+    @Override
+    public PortForwarding createLocalPortForward(String targetHost, int targetPort, int originatePort,
+                                                 PortForwarding.DataConsumer dataConsumer) throws IOException {
+      return getDelegate().createLocalPortForward(targetHost, targetPort, originatePort, dataConsumer);
+    }
+
+    @Override
+    public void close() {
+      throw new UnsupportedOperationException("Should not close managed SSHSession");
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/RuntimeMonitorServerInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/RuntimeMonitorServerInfo.java
@@ -16,21 +16,21 @@
 
 package co.cask.cdap.internal.app.runtime.monitor;
 
-import co.cask.cdap.internal.app.runtime.monitor.proxy.MonitorSocksProxy;
-import co.cask.cdap.runtime.spi.ssh.SSHSession;
-
-import java.net.InetSocketAddress;
-
 /**
- * An interface for getting {@link SSHSession}. It is intended to be used by {@link MonitorSocksProxy} to get
- * registered {@link SSHSession} for tunneling.
+ * A class containing information about the {@link RuntimeMonitorServer} that are used by the client.
  */
-public interface SSHSessionProvider {
+public final class RuntimeMonitorServerInfo {
+
+  private final int port;
+
+  public RuntimeMonitorServerInfo(int port) {
+    this.port = port;
+  }
 
   /**
-   * Returns the {@link SSHSession} for the given server address.
-   *
-   * @param serverAddr the {@link InetSocketAddress} of where the runtime monitor server is running
+   * Returns the port that the {@link RuntimeMonitorServer} is listening on.
    */
-  SSHSession getSession(InetSocketAddress serverAddr);
+  public int getPort() {
+    return port;
+  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/proxy/SocksServerConnectHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/proxy/SocksServerConnectHandler.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
@@ -174,7 +175,7 @@ final class SocksServerConnectHandler extends SimpleChannelInboundHandler<SocksM
    */
   private ChannelHandler createForwardingChannelHandler(Channel channel,
                                                         String destAddress, int destPort) throws IOException {
-    SSHSession sshSession = sshSessionProvider.getSession(destAddress, destPort);
+    SSHSession sshSession = sshSessionProvider.getSession(new InetSocketAddress(destAddress, destPort));
     PortForwarding portForwarding = sshSession.createLocalPortForward("localhost", destPort,
                                                                       destPort, new PortForwarding.DataConsumer() {
       @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/monitor/proxy/MonitorSocksProxyTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/monitor/proxy/MonitorSocksProxyTest.java
@@ -102,9 +102,9 @@ public class MonitorSocksProxyTest {
     httpService.start();
 
     sshSession = new TestSSHSession(getSSHConfig());
-    proxyServer = new MonitorSocksProxy(CConfiguration.create(), (host, port) ->
+    proxyServer = new MonitorSocksProxy(CConfiguration.create(), host ->
       Optional.ofNullable(sshSession).orElseThrow(() -> new IllegalArgumentException("No SSH session available for "
-                                                                                       + host + ":" + port)));
+                                                                                       + host)));
     proxyServer.startAndWait();
 
     Proxy proxy = new Proxy(Proxy.Type.SOCKS, proxyServer.getBindAddress());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/monitor/proxy/MonitorSocksProxyTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/monitor/proxy/MonitorSocksProxyTest.java
@@ -26,11 +26,18 @@ import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
 import co.cask.http.AbstractHttpHandler;
+import co.cask.http.BodyProducer;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
 import co.cask.http.NettyHttpService;
+import com.google.common.base.Strings;
+import com.google.common.io.ByteStreams;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.KeyPair;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
@@ -46,6 +53,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
@@ -53,11 +62,14 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
 /**
@@ -144,6 +156,23 @@ public class MonitorSocksProxyTest {
 
     Assert.assertEquals(1, sshSession.portForwardCreated.get());
     Assert.assertEquals(1, sshSession.portForwardClosed.get());
+  }
+
+  @Test
+  public void testChunkCall() throws Exception {
+    InetSocketAddress httpAddr = httpService.getBindAddress();
+
+    URL url = new URL(String.format("http://%s:%d/chunk", httpAddr.getHostName(), httpAddr.getPort()));
+    HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();
+    urlConn.setDoOutput(true);
+    try (OutputStream os = urlConn.getOutputStream()) {
+      os.write("Testing".getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Verify the response. The server repeats the request body for 10 times
+    Assert.assertEquals(200, urlConn.getResponseCode());
+    String content = new String(ByteStreams.toByteArray(urlConn.getInputStream()), StandardCharsets.UTF_8);
+    Assert.assertEquals(Strings.repeat("Testing", 10), content);
   }
 
   /**
@@ -246,6 +275,35 @@ public class MonitorSocksProxyTest {
     @Path("/ping")
     public void ping(HttpRequest request, HttpResponder responder) {
       responder.sendStatus(HttpResponseStatus.OK);
+    }
+
+    @POST
+    @Path("/chunk")
+    public void chunk(FullHttpRequest request, HttpResponder responder) {
+      ByteBuf content = request.content().copy();
+
+      responder.sendContent(HttpResponseStatus.OK, new BodyProducer() {
+
+        int count = 0;
+
+        @Override
+        public ByteBuf nextChunk() {
+          if (count++ < 10) {
+            return content.copy();
+          }
+          return Unpooled.EMPTY_BUFFER;
+        }
+
+        @Override
+        public void finished() {
+          // no-op
+        }
+
+        @Override
+        public void handleError(@Nullable Throwable cause) {
+          // no-op
+        }
+      }, new DefaultHttpHeaders());
     }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -874,9 +874,8 @@ public final class Constants {
     public static final String INIT_BATCH_SIZE = "app.program.runtime.monitor.initialize.batch.size";
 
     // Configuration keys for the runtime monitor server
-    public static final String SERVER_HOST = "app.program.runtime.monitor.server.host";
-    public static final String SERVER_PORT = "app.program.runtime.monitor.server.port";
     public static final String SERVER_CONSUME_CHUNK_SIZE = "app.program.runtime.monitor.server.consume.chunk.size";
+    public static final String SERVER_INFO_FILE = "app.program.runtime.monitor.server.info.file";
 
     // Constants for secure connections
     public static final String SSH_USER = "ssh.user";

--- a/cdap-common/src/main/java/co/cask/cdap/common/ssh/DefaultPortForwarding.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ssh/DefaultPortForwarding.java
@@ -41,6 +41,13 @@ final class DefaultPortForwarding implements PortForwarding {
   private final OutputStream outputStream;
   private final byte[] transferBuf;
 
+  /**
+   * Creates a new instance of this class by connecting the direct TCPIP channel for port forwarding.
+   *
+   * @param sshChannel an unconnected {@link ChannelDirectTCPIP} created from a ssh session
+   * @param dataConsumer the {@link DataConsumer} for receiving incoming data
+   * @throws IOException if failed to connect to the channel
+   */
   DefaultPortForwarding(ChannelDirectTCPIP sshChannel, DataConsumer dataConsumer) throws IOException {
     sshChannel.setOutputStream(createIncomingOutputStream(dataConsumer));
 
@@ -49,11 +56,11 @@ final class DefaultPortForwarding implements PortForwarding {
     this.transferBuf = new byte[TRANSFER_SIZE];
 
     try {
+      sshChannel.connect();
       Session session = sshChannel.getSession();
       LOG.trace("Opened port forwarding channel {} through host {}:{}",
                 sshChannel.getId(), session.getHost(), session.getPort());
     } catch (JSchException e) {
-      // This shouldn't happen
       throw new IOException(e);
     }
   }
@@ -165,5 +172,4 @@ final class DefaultPortForwarding implements PortForwarding {
       }
     };
   }
-
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/ssh/DefaultSSHSession.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ssh/DefaultSSHSession.java
@@ -85,6 +85,11 @@ public class DefaultSSHSession implements SSHSession {
   }
 
   @Override
+  public boolean isAlive() {
+    return session.isConnected();
+  }
+
+  @Override
   public InetSocketAddress getAddress() {
     return remoteAddress;
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/ssh/DefaultSSHSession.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ssh/DefaultSSHSession.java
@@ -232,14 +232,8 @@ public class DefaultSSHSession implements SSHSession {
 
       sshChannel.setOrgIPAddress(originateIP);
       sshChannel.setOrgPort(originatePort);
-      sshChannel.connect();
 
-      try {
-        return new DefaultPortForwarding(sshChannel, dataConsumer);
-      } catch (IOException e) {
-        sshChannel.disconnect();
-        throw e;
-      }
+      return new DefaultPortForwarding(sshChannel, dataConsumer);
     } catch (JSchException e) {
       throw new IOException(e);
     }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2433,11 +2433,13 @@
   </property>
 
   <property>
-    <name>app.program.runtime.monitor.server.port</name>
-    <value>443</value>
+    <name>app.program.runtime.monitor.server.info.file</name>
+    <value>runtime.monitor.server.info</value>
     <description>
-      CDAP Runtime monitor server port
+      File name for the runtime monitor to store the port number.
+      This configuration is for internal use only and should not be changed.
     </description>
+    <final>true</final>
   </property>
 
   <property>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="17ac16da2f865223a1d29c903052c53f"
+DEFAULT_XML_MD5_HASH="349a48b9f2ccb7c60db71506521d676c"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -290,10 +290,14 @@ public class DataprocClient implements AutoCloseable {
     }
   }
 
-  // finds ingress firewalls for the configured network that open ports 22 and 443,
-  // returning target tags for those rules
+  /**
+   * Finds ingress firewall rules for the configured network that matches the required firewall port as
+   * defined in {@link FirewallPort}.
+   *
+   * @return a {@link Collection} of tags that need to be added to the VM to have those firewall rules applies
+   * @throws IOException If failed to discover those firewall rules
+   */
   private Collection<String> getFirewallTargetTags() throws IOException {
-    // figure out the tag to open port 443
     FirewallList firewalls = compute.firewalls().list(projectId).execute();
     List<String> tags = new ArrayList<>();
     Set<FirewallPort> requiredPorts = EnumSet.allOf(FirewallPort.class);
@@ -318,10 +322,6 @@ public class DataprocClient implements AutoCloseable {
           requiredPorts.clear();
           addTag = true;
         } else if ("tcp".equals(protocol)) {
-          if (allowed.getPorts() == null || allowed.getPorts().contains(String.valueOf(FirewallPort.HTTPS.port))) {
-            requiredPorts.remove(FirewallPort.HTTPS);
-            addTag = true;
-          }
           if (allowed.getPorts() == null || allowed.getPorts().contains(String.valueOf(FirewallPort.SSH.port))) {
             requiredPorts.remove(FirewallPort.SSH);
             addTag = true;
@@ -417,8 +417,8 @@ public class DataprocClient implements AutoCloseable {
    * Firewall ports that we're concerned about.
    */
   private enum FirewallPort {
-    SSH(22),
-    HTTPS(443);
+    SSH(22);
+
     private final int port;
 
     FirewallPort(int port) {

--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -212,8 +212,8 @@ public class DataprocProvisioner implements Provisioner {
     } catch (IOException ioe) {
       if (Throwables.getRootCause(ioe) instanceof ConnectException) {
         throw new IOException(String.format(
-                "Failed to connect to host %s. Ensure that GCP Firewall Ingress Rules exist that allow ssh and" +
-                        " https (ports 22 and 443).", host),
+                "Failed to connect to host %s. Ensure that GCP Firewall Ingress Rules exist that allow ssh " +
+                        "on port 22.", host),
                 ioe);
       }
       throw ioe;

--- a/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisioner.java
+++ b/cdap-runtime-ext-emr/src/main/java/co/cask/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisioner.java
@@ -125,7 +125,7 @@ public class ElasticMapReduceProvisioner implements Provisioner {
         throw new IOException(String.format(
                 "Failed to connect to host %s. Ensure that the the provisioner property for \"Additional Master" +
                         " Security Group\" has been configured with an EC2 Security Group that has inbound rules" +
-                        " allowing ssh and https (ports 22 and 443).", host),
+                        " allowing ssh on port 22.", host),
                 ioe);
       }
       throw ioe;

--- a/cdap-runtime-ext-emr/src/main/resources/aws-emr.json
+++ b/cdap-runtime-ext-emr/src/main/resources/aws-emr.json
@@ -82,7 +82,7 @@
           "label": "Additional Master Security Group",
           "name": "additionalMasterSecurityGroup",
           "required": true,
-          "description": "An additional EMR managed security group that will be applied to the master instance. It must have an inbound rule that allows ssh and https (ports 22 and 443). For more information, refer to https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-man-sec-groups.html.",
+          "description": "An additional EMR managed security group that will be applied to the master instance. It must have an inbound rule that allows ssh on ports 22. For more information, refer to https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-man-sec-groups.html.",
           "widget-attributes": {
             "placeholder": "Specify your EMR managed security group"
           }

--- a/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/ssh/SSHSession.java
+++ b/cdap-runtime-spi/src/main/java/co/cask/cdap/runtime/spi/ssh/SSHSession.java
@@ -30,6 +30,11 @@ import javax.annotation.Nullable;
 public interface SSHSession extends AutoCloseable {
 
   /**
+   * Returns {@code true} if the session is alive; otherwise return {@code false}.
+   */
+  boolean isAlive();
+
+  /**
    * Returns the remote host and port that this session is connected to.
    *
    * @return a {@link InetSocketAddress} containing the target host and port of this session


### PR DESCRIPTION
This PR are organized into three commits

1. Fix a bug in the MonitorSocksProxy by copying `byte[]` before performing async operation.
2. Use SSH tunneling for runtime monitoring. This is the main logic change.
  - Use ephemeral port instead of port 443
  - Because of that, we don't need to run as sudo
  - Need to have the server to write the port out to a local file so that client can know what port it is running on
  - Use the MonitorSocksProxy to tunnel all runtime monitor traffic
3. Remove the logic that requires HTTPS/443 firewall rule from the provisioners.