### PR TITLE
[CDAP-14290]Fix dataprep connection UI for default connection specification change in backend

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/BigQueryConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/BigQueryConnection/index.js
@@ -207,7 +207,6 @@ export default class BigQueryConnection extends Component {
   renderTestButton = () => {
     let disabled = !this.state.name ||
       !this.state.projectId ||
-      !this.state.serviceAccountKeyfile ||
       !this.state.bucket;
 
     return (
@@ -227,7 +226,6 @@ export default class BigQueryConnection extends Component {
   renderAddConnectionButton = () => {
     let disabled = !this.state.name ||
       !this.state.projectId ||
-      !this.state.serviceAccountKeyfile ||
       this.state.testConnectionLoading ||
       !this.state.bucket;
 
@@ -304,7 +302,6 @@ export default class BigQueryConnection extends Component {
           <div className="form-group row">
             <label className={LABEL_COL_CLASS}>
               {T.translate(`${PREFIX}.serviceAccountKeyfile`)}
-              <span className="asterisk">*</span>
             </label>
             <div className={INPUT_COL_CLASS}>
               <div className="input-text">

--- a/cdap-ui/app/cdap/components/DataPrepConnections/GCSConnection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/GCSConnection/index.js
@@ -204,7 +204,6 @@ export default class GCSConnection extends Component {
   renderTestButton() {
     let disabled = !this.state.name ||
       !this.state.projectId ||
-      !this.state.serviceAccountKeyfile ||
       this.state.testConnectionLoading;
 
     return (
@@ -221,8 +220,7 @@ export default class GCSConnection extends Component {
 
   renderAddConnectionButton() {
     let disabled = !this.state.name ||
-      !this.state.projectId ||
-      !this.state.serviceAccountKeyfile;
+      !this.state.projectId;
 
     let onClickFn = this.addConnection;
 
@@ -297,7 +295,6 @@ export default class GCSConnection extends Component {
           <div className="form-group row">
             <label className={LABEL_COL_CLASS}>
               {T.translate(`${PREFIX}.serviceAccountKeyfile`)}
-              <span className="asterisk">*</span>
             </label>
             <div className={INPUT_COL_CLASS}>
               <div className="input-text">

--- a/cdap-ui/app/cdap/components/DataPrepConnections/NoDefaultConnection/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/NoDefaultConnection/index.tsx
@@ -25,24 +25,27 @@ import T from 'i18n-react';
 
 const PREFIX: string = 'features.DataPrepConnections.NoDefaultConnection';
 
-interface IDefaultConnection {
-  name: string;
-  type: ConnectionType;
+interface IPartialConnectionType {
+  id?: string;
+  name?: string;
+  type?: string;
+  properties?: object;
 }
+
 interface INoDefaultConnectionProps {
-  defaultConnection: IDefaultConnection;
+  defaultConnection: string;
   showAddConnectionPopover: () => void;
   toggleSidepanel: (e: React.MouseEvent<HTMLElement>) => void;
+  connectionsList: IPartialConnectionType[];
 }
 const NoDefaultConnection: React.SFC<INoDefaultConnectionProps> = ({
   defaultConnection,
   showAddConnectionPopover,
+  connectionsList = [],
   toggleSidepanel,
 }) => {
-  if (
-    isNilOrEmpty(defaultConnection) ||
-    (defaultConnection && isNilOrEmpty(defaultConnection.name))
-  ) {
+  const defaultConnectionObj = connectionsList.find((conn) => conn.id === defaultConnection);
+  if (isNilOrEmpty(defaultConnection) || !defaultConnectionObj) {
     return (
       <div>
         <DataprepBrowserTopPanel
@@ -71,7 +74,7 @@ const NoDefaultConnection: React.SFC<INoDefaultConnectionProps> = ({
       </div>
     );
   }
-  const { name: connectionId, type } = defaultConnection;
+  const { type, name: connectionId } = defaultConnectionObj;
   const connectionType = type.toLowerCase();
   const namespace = getCurrentNamespace();
   const BASEPATH = `/ns/${namespace}/connections`;

--- a/cdap-ui/app/cdap/components/DataPrepConnections/SpannerConnection/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/SpannerConnection/index.tsx
@@ -216,8 +216,7 @@ export default class SpannerConnection extends React.PureComponent<ISpannerConne
 
   private renderTestButton = () => {
     const disabled = !this.state.name ||
-      !this.state.projectId ||
-      !this.state.serviceAccountKeyfile;
+      !this.state.projectId;
 
     return (
       <span className="test-connection-button">
@@ -236,7 +235,6 @@ export default class SpannerConnection extends React.PureComponent<ISpannerConne
   private renderAddConnectionButton = () => {
     const disabled = !this.state.name ||
       !this.state.projectId ||
-      !this.state.serviceAccountKeyfile ||
       this.state.testConnectionLoading;
 
     let onClickFn = this.addConnection;
@@ -312,7 +310,6 @@ export default class SpannerConnection extends React.PureComponent<ISpannerConne
           <div className="form-group row">
             <label className={LABEL_COL_CLASS}>
               {T.translate(`${PREFIX}.serviceAccountKeyfile`)}
-              <span className="asterisk">*</span>
             </label>
             <div className={INPUT_COL_CLASS}>
               <div className="input-text">

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -314,10 +314,10 @@ export default class DataPrepConnections extends Component {
       // need to group by connection type
       let state = {};
 
-      if (res.defaultConnection) {
+      if (res.default) {
         // Once we get a default connection from backend
         // set appropriate browser as active
-        state.defaultConnection = res.defaultConnection;
+        state.defaultConnection = res.default;
       }
 
       let databaseList = [],
@@ -350,6 +350,7 @@ export default class DataPrepConnections extends Component {
 
       state = {
         ...state,
+        connectionsList: res.values,
         databaseList,
         kafkaList,
         s3List,
@@ -907,6 +908,7 @@ export default class DataPrepConnections extends Component {
           return (
             <NoDefaultConnection
               defaultConnection={this.state.defaultConnection}
+              connectionsList={this.state.connectionsList}
               showAddConnectionPopover={this.toggleAddConnectionPopover.bind(this, true)}
               toggleSidepanel={this.toggleSidePanel}
             />
@@ -991,6 +993,7 @@ export default class DataPrepConnections extends Component {
         return (
           <NoDefaultConnection
             defaultConnection={this.state.defaultConnection}
+            connectionsList={this.state.connectionsList}
             showAddConnectionPopover={this.toggleAddConnectionPopover.bind(this, true)}
             toggleSidepanel={this.toggleSidePanel}
           />


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14290

- Fixes UI to go to right default connection based on the change in the API format
- Fixes BigQuery, GCS and Spanner to have service account file as optional