### PR TITLE
[CDAP-14293] Get theme properties from cdap-site.xml instead of ui-settings.json

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -656,6 +656,14 @@
     </description>
   </property>
 
+  <property>
+    <name>ui.theme.file</name>
+    <value>/opt/cdap/ui/server/config/themes/default.json</value>
+    <description>
+      File containing the theme to be used in UI
+    </description>
+  </property>
+
 
   <!-- Audit configuration -->
 

--- a/cdap-ui/app/cdap/services/ThemeHelper.ts
+++ b/cdap-ui/app/cdap/services/ThemeHelper.ts
@@ -131,13 +131,14 @@ interface IThemeObj {
 }
 
 function getTheme(): IThemeObj {
-  if (isNilOrEmpty(window.CDAP_UI_THEME)) {
-    return {};
-  }
-
   let theme: IThemeObj = {
     productName: 'CDAP',
   };
+
+  if (isNilOrEmpty(window.CDAP_UI_THEME)) {
+    return theme;
+  }
+
   const themeJSON = window.CDAP_UI_THEME;
   const specVersion = themeJSON['spec-version'];
 

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -22,7 +22,8 @@ module.exports = {
         // router check also fetches the auth server address if security is enabled
         require('./config/router-check.js').ping(),
         require('./config/parser.js').extractConfig('cdap'),
-        require('./config/parser.js').extractUISettings()
+        require('./config/parser.js').extractUISettings(),
+        require('./config/parser.js').extractUITheme()
       ])
       .spread(makeApp);
   }
@@ -60,8 +61,7 @@ const getExpressStaticConfig = () => {
     maxAge: '1y'
   };
 };
-function makeApp (authAddress, cdapConfig, {uiSettings, uiThemeConfig}) {
-
+function makeApp (authAddress, cdapConfig, uiSettings, uiThemeConfig) {
   var app = express();
 
   // middleware
@@ -92,8 +92,7 @@ function makeApp (authAddress, cdapConfig, {uiSettings, uiThemeConfig}) {
         routerServerPort: cdapConfig['router.server.port'],
         routerSSLServerPort: cdapConfig['router.ssl.server.port'],
         standaloneWebsiteSDKDownload: uiSettings['standalone.website.sdk.download'] === 'true' || false,
-        uiDebugEnabled: uiSettings['ui.debug.enabled'] === 'true' || false,
-        uiTheme: uiSettings['ui.theme']
+        uiDebugEnabled: uiSettings['ui.debug.enabled'] === 'true' || false
       },
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true'


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14293
Builds: https://builds.cask.co/browse/CDAP-UDUT108

The main reason for these changes is that we don't want the theme files created by the user to be deleted/overwritten when CDAP is upgraded. The JIRA has more details on when this can happen. Therefore, we want to allow the user to specify a directory outside of $CDAP_HOME that contains their theme files, which won't be overwritten when CDAP is upgraded.

This PR:
- Adds `ui.theme.file` property to `cdap-default.xml`, which will be the path to the theme file containing the theme to be applied. If the path is a relative path, then it will be relative to $CDAP_HOME.
- Changes the UI code look for file listed under `ui.theme.file`, then apply the contents of that file.