### PR TITLE
[CDAP-14101] Fix namespace dropdown to be associated with the namespace 

### DIFF
--- a/cdap-ui/app/cdap/components/Header/AnalyticsLink/AnalyticsLink.scss
+++ b/cdap-ui/app/cdap/components/Header/AnalyticsLink/AnalyticsLink.scss
@@ -12,32 +12,15 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
 @import '~styles/variables.scss';
 
-#navbar-control-center {
+#navbar-analytics {
+  &:hover,
+  &:active,
   &.active {
-    .control-center.header-dropdown {
-      background: $cdap-white-light;
-    }
+    color: white;
+    background: $cdap-white-light;
   }
-  .control-center.header-dropdown {
-    padding: 5px 10px;
-    border-radius: 4px;
-    margin: 0 5px;
-    &:hover {
-      &:not(.show) {
-        background: $cdap-white-light;
-      }
-    }
-    .dropdown-menu {
-      // offset to align the dropdown to the begining of the Control Center button
-      left: -16px;
-    }
-    &.show {
-      background: $cdap-white-light;
-    }
-  }
-
 }

--- a/cdap-ui/app/cdap/components/Header/AnalyticsLink/index.tsx
+++ b/cdap-ui/app/cdap/components/Header/AnalyticsLink/index.tsx
@@ -20,6 +20,8 @@ import {withContext} from 'components/Header/NamespaceLinkContext';
 import classnames from 'classnames';
 import T from 'i18n-react';
 
+require('./AnalyticsLink.scss');
+
 interface IAnalyticsLinkProps {
   context: {
     namespace: string;
@@ -39,9 +41,12 @@ class AnalyticsLink extends React.PureComponent<IAnalyticsLinkProps> {
     const { namespace, isNativeLink } = this.props.context;
     const analyticsUrl = `/ns/${namespace}/experiments`;
     return (
-      <li className={classnames({
-        active: this.isMMDSActive(),
-      })}>
+      <li
+        id="navbar-analytics"
+        className={classnames({
+          active: this.isMMDSActive(),
+        })}
+      >
         <NavLinkWrapper
           isNativeLink={isNativeLink}
           to={isNativeLink ? `/cdap${analyticsUrl}` : analyticsUrl}

--- a/cdap-ui/app/cdap/components/Header/DataPrepLink/DataPrepLink.scss
+++ b/cdap-ui/app/cdap/components/Header/DataPrepLink/DataPrepLink.scss
@@ -12,32 +12,15 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
 @import '~styles/variables.scss';
 
-#navbar-control-center {
+#navbar-preparation {
+  &:hover,
+  &:active,
   &.active {
-    .control-center.header-dropdown {
-      background: $cdap-white-light;
-    }
+    color: white;
+    background: $cdap-white-light;
   }
-  .control-center.header-dropdown {
-    padding: 5px 10px;
-    border-radius: 4px;
-    margin: 0 5px;
-    &:hover {
-      &:not(.show) {
-        background: $cdap-white-light;
-      }
-    }
-    .dropdown-menu {
-      // offset to align the dropdown to the begining of the Control Center button
-      left: -16px;
-    }
-    &.show {
-      background: $cdap-white-light;
-    }
-  }
-
 }

--- a/cdap-ui/app/cdap/components/Header/DataPrepLink/index.tsx
+++ b/cdap-ui/app/cdap/components/Header/DataPrepLink/index.tsx
@@ -19,6 +19,7 @@ import { Theme } from 'services/ThemeHelper';
 import {withContext} from 'components/Header/NamespaceLinkContext';
 import classnames from 'classnames';
 import T from 'i18n-react';
+require('./DataPrepLink.scss');
 
 interface IDataPrepLinkProps {
   context: {

--- a/cdap-ui/app/cdap/components/Header/DropdownStyling.scss
+++ b/cdap-ui/app/cdap/components/Header/DropdownStyling.scss
@@ -14,7 +14,7 @@
  * the License.
 */
 
-@import '../../styles/variables.scss';
+@import '~styles/variables.scss';
 
 $dropdown_divider_bg_color: $grey-06;
 
@@ -115,11 +115,12 @@ $dropdown_divider_bg_color: $grey-06;
       }
     }
     &.show {
+      background: $cdap-white-light;
       .dropdown-menu {
         display: flex;
         flex-direction: column;
-        top: 33px;
-        left: -10px;
+        top: 38px;
+        left: -1px;
       }
     }
   }

--- a/cdap-ui/app/cdap/components/Header/Header.scss
+++ b/cdap-ui/app/cdap/components/Header/Header.scss
@@ -14,9 +14,9 @@
  * the License.
 */
 
-@import '../../styles/variables.scss';
+@import '~styles/variables.scss';
 @import './DropdownStyling.scss';
-@import "../../styles/bootstrap_4_patch.scss";
+@import "~styles/bootstrap_4_patch.scss";
 
 .global-navbar {
   height: 50px;
@@ -89,7 +89,7 @@
           border: 1px solid $grey-04;
           border-radius: 4px;
           &:hover {
-            background: rgba(255, 255, 255, 0.3);
+            background: $cdap-white-light;
             border-radius: 4px;
           }
         }
@@ -105,17 +105,6 @@
           .dropdown {
             .dropdown-menu {
               padding: 0;
-            }
-            .current-namespace {
-              background: transparent;
-              &:hover {
-                background: rgba(255, 255, 255, 0.3);
-              }
-            }
-            &.open {
-              .current-namespace {
-                background: rgba(255, 255, 255, 0.3);
-              }
             }
           }
         }
@@ -154,15 +143,18 @@
 
     &.control-center {
       > li {
-        padding: 5px 10px;
-        border-radius: 4px;
-        margin: 0 5px;
+        /*
+          This is because the first control center dropdown has a dropdown
+          toggle that needs to be highlighted and not the list element
 
-        &:hover,
-        &:active,
-        &.active {
-          color: white;
-          background: rgba(255, 255, 255, 0.3);
+          The reason for it being, when the dropdown is opened (.show)
+          we need to highlight the list element. This is right now done
+          in css (.dropdown.show change background).
+        */
+        &:not(:first-child) {
+          padding: 5px 10px;
+          border-radius: 4px;
+          margin: 0 5px;
         }
       }
     }
@@ -184,7 +176,7 @@
           &:focus,
           &:active {
             color: inherit;
-            background: rgba(255, 255, 255, 0.3);
+            background: $cdap-white-light;
           }
         }
       }

--- a/cdap-ui/app/cdap/components/Header/MetadataLink/MetadataLink.scss
+++ b/cdap-ui/app/cdap/components/Header/MetadataLink/MetadataLink.scss
@@ -12,32 +12,15 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
 @import '~styles/variables.scss';
 
-#navbar-control-center {
+#navbar-metadata {
+  &:hover,
+  &:active,
   &.active {
-    .control-center.header-dropdown {
-      background: $cdap-white-light;
-    }
+    color: white;
+    background: $cdap-white-light;
   }
-  .control-center.header-dropdown {
-    padding: 5px 10px;
-    border-radius: 4px;
-    margin: 0 5px;
-    &:hover {
-      &:not(.show) {
-        background: $cdap-white-light;
-      }
-    }
-    .dropdown-menu {
-      // offset to align the dropdown to the begining of the Control Center button
-      left: -16px;
-    }
-    &.show {
-      background: $cdap-white-light;
-    }
-  }
-
 }

--- a/cdap-ui/app/cdap/components/Header/MetadataLink/index.tsx
+++ b/cdap-ui/app/cdap/components/Header/MetadataLink/index.tsx
@@ -18,6 +18,7 @@ import { Theme } from 'services/ThemeHelper';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import {withContext} from 'components/Header/NamespaceLinkContext';
+require('./MetadataLink.scss');
 
 declare global {
   /* tslint:disable:interface-name */

--- a/cdap-ui/app/cdap/components/Header/PipelinesLink/PipelinesLink.scss
+++ b/cdap-ui/app/cdap/components/Header/PipelinesLink/PipelinesLink.scss
@@ -12,32 +12,15 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
 @import '~styles/variables.scss';
 
-#navbar-control-center {
+#navbar-pipelines {
+  &:hover,
+  &:active,
   &.active {
-    .control-center.header-dropdown {
-      background: $cdap-white-light;
-    }
+    color: white;
+    background: $cdap-white-light;
   }
-  .control-center.header-dropdown {
-    padding: 5px 10px;
-    border-radius: 4px;
-    margin: 0 5px;
-    &:hover {
-      &:not(.show) {
-        background: $cdap-white-light;
-      }
-    }
-    .dropdown-menu {
-      // offset to align the dropdown to the begining of the Control Center button
-      left: -16px;
-    }
-    &.show {
-      background: $cdap-white-light;
-    }
-  }
-
 }

--- a/cdap-ui/app/cdap/components/Header/PipelinesLink/index.tsx
+++ b/cdap-ui/app/cdap/components/Header/PipelinesLink/index.tsx
@@ -18,6 +18,7 @@ import { Theme } from 'services/ThemeHelper';
 import {withContext} from 'components/Header/NamespaceLinkContext';
 import classnames from 'classnames';
 import T from 'i18n-react';
+require('./PipelinesLink.scss');
 
 declare global {
   /* tslint:disable:interface-name */

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/ProductDropdown.scss
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/ProductDropdown.scss
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-@import '../../../styles/variables.scss';
+@import '~styles/variables.scss';
 
 $dropdown_divider_bg_color: $grey-06;
 
@@ -21,6 +21,7 @@ $dropdown_divider_bg_color: $grey-06;
   @media (max-width: 580px) {
     &.dropdown {
       &.show {
+        background: $cdap-white-light;
         .dropdown-menu {
           &.dropdown-menu-right {
             left: 0;
@@ -56,9 +57,10 @@ $dropdown_divider_bg_color: $grey-06;
 
       &:focus {
         outline: none;
+        background: transparent;
       }
       &:hover {
-        background: rgba(255, 255, 255, 0.3);
+        background: transparent;
         outline: none;
         color: inherit;
         .cdap-secure-mode-icon,
@@ -166,6 +168,11 @@ $dropdown_divider_bg_color: $grey-06;
         }
       }
     }
+    &:not(.show) {
+      &:hover {
+        background: $cdap-white-light;
+      }
+    }
     &.show {
       // This is because we patch the bootstrap 4 dropdowns to have a display block
       // When we upgrade bootstrap to 4 we should be able to remove this.
@@ -174,7 +181,7 @@ $dropdown_divider_bg_color: $grey-06;
         flex-direction: column;
       }
       .dropdown-toggle {
-        background: rgba(255, 255, 255, 0.3);
+        background: $cdap-white-light;
       }
     }
   }

--- a/cdap-ui/app/cdap/components/Header/RulesEngineLink/RulesEngineLink.scss
+++ b/cdap-ui/app/cdap/components/Header/RulesEngineLink/RulesEngineLink.scss
@@ -12,32 +12,15 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
 @import '~styles/variables.scss';
 
-#navbar-control-center {
+#navbar-rules-engine {
+  &:hover,
+  &:active,
   &.active {
-    .control-center.header-dropdown {
-      background: $cdap-white-light;
-    }
+    color: white;
+    background: $cdap-white-light;
   }
-  .control-center.header-dropdown {
-    padding: 5px 10px;
-    border-radius: 4px;
-    margin: 0 5px;
-    &:hover {
-      &:not(.show) {
-        background: $cdap-white-light;
-      }
-    }
-    .dropdown-menu {
-      // offset to align the dropdown to the begining of the Control Center button
-      left: -16px;
-    }
-    &.show {
-      background: $cdap-white-light;
-    }
-  }
-
 }

--- a/cdap-ui/app/cdap/components/Header/RulesEngineLink/index.tsx
+++ b/cdap-ui/app/cdap/components/Header/RulesEngineLink/index.tsx
@@ -19,6 +19,7 @@ import { Theme } from 'services/ThemeHelper';
 import {withContext} from 'components/Header/NamespaceLinkContext';
 import classnames from 'classnames';
 import T from 'i18n-react';
+require('./RulesEngineLink.scss');
 
 interface IRulesEngineLinkProps {
   context: {
@@ -39,9 +40,12 @@ class RulesEngineLink extends React.PureComponent<IRulesEngineLinkProps> {
     const { namespace, isNativeLink } = this.props.context;
     const rulesEngineUrl = `/ns/${namespace}/rulesengine`;
     return (
-      <li className={classnames({
-        active: this.isRulesEngineActive(),
-      })}>
+      <li
+        id="navbar-rules-engine"
+        className={classnames({
+          active: this.isRulesEngineActive(),
+        })}
+      >
           <NavLinkWrapper
             isNativeLink={isNativeLink}
             to={isNativeLink ? `/cdap${rulesEngineUrl}` : rulesEngineUrl}

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.scss
@@ -14,10 +14,10 @@
 * the License.
 */
 
-@import "../../styles/variables.scss";
+@import "~styles/variables.scss";
 $namespace-action-bg: #d8d8d8;
 $namespace-dropdown-color: $grey-08;
-$current-namespace-hover-bg: #262933;
+$current-namespace-hover-bg: $cdap-white-light;
 $namespace-hover-bg: #9b9b9b;
 $current-namespace-metadata-hover-bg: $grey-08;
 $dark-font: #666666;
@@ -35,13 +35,11 @@ $star-color: #373a3c;
   line-height: 50px;
   cursor: initial;
 
-  .dropdown {
-    &.open {
-      .current-namespace {
-        background-color: $current-namespace-hover-bg;
-      }
-    }
+  &.opened,
+  &:hover {
+    background: $cdap-white-light;
   }
+
   div[disabled] { cursor: not-allowed; }
 
   .dropdown-toggle { height: 50px; }
@@ -69,9 +67,6 @@ $star-color: #373a3c;
     padding-left: 10px;
     color: inherit;
 
-    &:hover {
-      background-color: $current-namespace-hover-bg;
-    }
     &:hover,
     &:active,
     &:focus {

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -36,6 +36,7 @@ import EntityType from 'services/metadata-parser/EntityType';
 import {preventPropagation} from 'services/helpers';
 import { Theme } from 'services/ThemeHelper';
 import If from 'components/If';
+import classnames from 'classnames';
 require('./NamespaceDropdown.scss');
 
 export default class NamespaceDropdown extends Component {
@@ -239,7 +240,9 @@ export default class NamespaceDropdown extends Component {
       </div>
     );
     return (
-      <div className="namespace-dropdown">
+      <div className={classnames("namespace-dropdown", {
+        'opened': this.state.openDropdown
+      })}>
         <Dropdown
           isOpen={this.state.openDropdown}
           toggle={this.toggle}

--- a/cdap-ui/app/cdap/styles/variables.scss
+++ b/cdap-ui/app/cdap/styles/variables.scss
@@ -19,6 +19,7 @@
 $cdap_body_min_width:   700px;
 // new variables for use in themes
 $cdap-white:            rgb(255, 255, 255); // #fff, white
+$cdap-white-light:      rgba(255, 255, 255, 0.3);
 $cdap-orange:           rgb(255, 102, 0);   // #ff6600
 $cdap-light-orange:     rgb(255, 167, 38);
 $cdap-darkorange:       rgb(138, 56, 0);    // #8A3800


### PR DESCRIPTION
- Fixes namespace link in navbar to be highlighted when the dropdown is opened
- Modifies the logic for highlighting links in navbar to individual link elements
- Minor addition of new color for lighter cdap white for reuse for links on hover.

JIRA: https://issues.cask.co/browse/CDAP-14101
Build: https://builds.cask.co/browse/CDAP-URUT81