### PR TITLE
[CDAP-8555] Fixes tooltip to show right in schema tab in entity's overview and detailed view

### DIFF
--- a/cdap-ui/app/cdap/components/AppDetailedView/AppDetailedView.scss
+++ b/cdap-ui/app/cdap/components/AppDetailedView/AppDetailedView.scss
@@ -23,6 +23,10 @@
   color: rgba(51, 51, 51, 1);
   overflow-y: auto;
   position: relative;
+  height: 100%;
+  display: grid;
+  // Top panel, metadata section and tab content
+  grid-template-rows: auto auto 1fr;
 
   @media (min-width: 1701px) {
     .entity-cards {

--- a/cdap-ui/app/cdap/components/AppDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/index.js
@@ -162,12 +162,6 @@ export default class AppDetailedView extends Component {
     }
     this.setState({
       successMessage
-    }, () => {
-      setTimeout(() => {
-        this.setState({
-          successMessage: null
-        });
-      }, 3000);
     });
   }
   render() {
@@ -208,13 +202,15 @@ export default class AppDetailedView extends Component {
           />
           <PlusButton mode={PlusButton.MODE.resourcecenter} />
         </div>
-        <OverviewHeader successMessage={this.state.successMessage} />
-        <OverviewMetaSection
-          entity={this.state.entityDetail}
-          onFastActionSuccess={this.goToHome.bind(this)}
-          onFastActionUpdate={this.goToHome.bind(this)}
-          showFullCreationTime={true}
-        />
+        <div>
+          <OverviewHeader successMessage={this.state.successMessage} />
+          <OverviewMetaSection
+            entity={this.state.entityDetail}
+            onFastActionSuccess={this.goToHome.bind(this)}
+            onFastActionUpdate={this.goToHome.bind(this)}
+            showFullCreationTime={true}
+          />
+        </div>
         <AppDetailedViewTab
           params={this.props.match.params}
           pathname={this.props.location.pathname}

--- a/cdap-ui/app/cdap/components/Overview/Overview.scss
+++ b/cdap-ui/app/cdap/components/Overview/Overview.scss
@@ -51,6 +51,10 @@
       > div {
         height: 100%;
         width: 100%;
+        display: grid;
+        // Top panel, metadata section and tab content
+        grid-template-rows: auto auto 1fr;
+        grid-template-columns: 100%;
       }
 
       > div.overview-error-container {

--- a/cdap-ui/app/cdap/components/Overview/Tabs/OverviewTab.scss
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/OverviewTab.scss
@@ -17,6 +17,9 @@
 @import '../../../styles/variables.scss';
 
 .overview-tab {
+  display: grid;
+  // tab header, tab content
+  grid-template-rows: auto 1fr;
   .nav-tabs {
     background: white;
     border: 0;


### PR DESCRIPTION
- The fix for tooltips to align correct was having enough space for it to be rendered.
- Fixed the layout of overview and detailed views to use grid so that it can automatically scale based on the container height.

JIRA: https://issues.cask.co/browse/CDAP-8555
Build: https://builds.cask.co/browse/CDAP-URUT82
