### PR TITLE
Updates ui.theme.file property in cdap-default.xml to use relative path

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -658,7 +658,7 @@
 
   <property>
     <name>ui.theme.file</name>
-    <value>/opt/cdap/ui/server/config/themes/default.json</value>
+    <value>ui/server/config/themes/default.json</value>
     <description>
       File containing the theme to be used in UI
     </description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="3f3f2f907f6a7c2475dba1900aa46518"
+DEFAULT_XML_MD5_HASH="2b0f42a374bae38cfc65ac6ea9a7b708"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14293

This should have been added as part of https://github.com/caskdata/cdap/pull/10679, but in that PR I only added the property cdap-default.xml and forgot to do the same for cdap-site.xml.

The value of this property is the path to the theme file that will be used in UI.