### PR TITLE
[CDAP-14272] Fixes deleting empty custom config causing broken UI

### DIFF
--- a/cdap-ui/app/cdap/components/KeyValuePairs/index.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/index.js
@@ -1,5 +1,5 @@
 /*
-* Copyright © 2016-2017 Cask Data, Inc.
+* Copyright © 2016-2018 Cask Data, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not
 * use this file except in compliance with the License. You may obtain a copy of
@@ -32,15 +32,16 @@ import {connect , Provider} from 'react-redux';
 import KeyValueStore from './KeyValueStore';
 import KeyValueStoreActions from './KeyValueStoreActions';
 import KeyValuePair from './KeyValuePair';
+import {objectQuery} from 'services/helpers';
 
 // Prop Name is used in place of the reserved prop 'key'
 const mapStateToFieldNameProps = (state, ownProps) => {
   return {
-    name: state.keyValues.pairs[ownProps.index].key,
-    value: state.keyValues.pairs[ownProps.index].value,
-    provided: state.keyValues.pairs[ownProps.index].provided,
-    notDeletable: state.keyValues.pairs[ownProps.index].notDeletable,
-    showReset: state.keyValues.pairs[ownProps.index].showReset
+    name: objectQuery(state.keyValues.pairs, ownProps.index, 'key'),
+    value: objectQuery(state.keyValues.pairs, ownProps.index, 'value'),
+    provided: objectQuery(state.keyValues.pairs, ownProps.index, 'provided'),
+    notDeletable: objectQuery(state.keyValues.pairs, ownProps.index, 'notDeletable'),
+    showReset: objectQuery(state.keyValues.pairs, ownProps.index, 'showReset')
   };
 };
 
@@ -110,15 +111,6 @@ export default class KeyValuePairs extends Component {
         onKeyValueChange(KeyValueStore.getState().keyValues);
       }
     });
-  }
-  shouldComponentUpdate(nextProps) {
-    if (this.state.pairs.length !== nextProps.keyValues.pairs.length) {
-      KeyValueStore.dispatch({
-        type: KeyValueStoreActions.onUpdate,
-        payload: {pairs: nextProps.keyValues.pairs}
-      });
-    }
-    return this.state.pairs.length !== nextProps.keyValues.pairs.length;
   }
 
   componentWillUnmount() {

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsTopPanel.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsTopPanel.scss
@@ -182,6 +182,7 @@ $btn-border-color: transparent;
       display: inline-flex;
       &:hover {
         background-color: inherit;
+        border-top: 1px solid $grey-05;
       }
     }
 


### PR DESCRIPTION
JIRA: 
https://issues.cask.co/browse/CDAP-14272
https://issues.cask.co/browse/CDAP-14348
https://issues.cask.co/browse/CDAP-14332

Builds: https://builds.cask.co/browse/CDAP-URUT87

Not sure why the deleted block of code was originally added. Since we only update the state of the component when there's a change in the store, we shouldn't update the store when there's a change in state. Removing the block fixes the problem mentioned in the JIRA.