### PR TITLE
[CDAP-13419] Deprecate more stream methods

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/DatasetConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/DatasetConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -31,6 +31,8 @@ public interface DatasetConfigurer {
    * Adds a {@link Stream}.
    *
    * @param stream {@link Stream}
+   *
+   * @deprecated As of release 5.0.0, use Kafka as a replacement technology for Streams
    */
   @Deprecated
   void addStream(Stream stream);
@@ -39,6 +41,7 @@ public interface DatasetConfigurer {
    * Adds a {@link Stream} given the name of the stream.
    *
    * @param streamName name of the stream
+   *
    * @deprecated As of release 5.0.0, use Kafka as a replacement technology for Streams
    */
   @Deprecated

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Input.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Input.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -140,6 +140,8 @@ public abstract class Input {
    * Returns an Input defined with the given stream name with all time range.
    *
    * @param streamName Name of the stream.
+   *
+   * @deprecated As of release 5.0.0, use Kafka as a replacement technology for Streams
    */
   @Deprecated
   public static Input ofStream(String streamName) {
@@ -152,6 +154,8 @@ public abstract class Input {
    * @param streamName Name of the stream.
    * @param startTime Start timestamp in milliseconds.
    * @param endTime End timestamp in milliseconds.
+   *
+   * @deprecated As of release 5.0.0, use Kafka as a replacement technology for Streams
    */
   @Deprecated
   public static Input ofStream(String streamName, long startTime, long endTime) {
@@ -165,6 +169,8 @@ public abstract class Input {
    * @param startTime Start timestamp in milliseconds (inclusive) of stream events provided to the job
    * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
    * @param decoderType The {@link StreamEventDecoder} class for decoding {@link StreamEvent}
+   *
+   * @deprecated As of release 5.0.0, use Kafka as a replacement technology for Streams
    */
   @Deprecated
   public static Input ofStream(String streamName, long startTime,
@@ -179,6 +185,8 @@ public abstract class Input {
    * @param startTime Start timestamp in milliseconds (inclusive) of stream events provided to the job
    * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
    * @param bodyFormatSpec The {@link FormatSpecification} class for decoding {@link StreamEvent}
+   *
+   * @deprecated As of release 5.0.0, use Kafka as a replacement technology for Streams
    */
   @Deprecated
   public static Input ofStream(String streamName, long startTime,

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Output.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Output.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/api/AbstractProgramDatasetConfigurable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/api/AbstractProgramDatasetConfigurable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -34,14 +34,20 @@ public abstract class AbstractProgramDatasetConfigurable<T extends DatasetConfig
 
   /**
    * @see DatasetConfigurer#addStream(String)
+   *
+   * @deprecated As of release 5.0.0, use Kafka as a replacement technology for Streams
    */
+  @Deprecated
   protected final void addStream(String stream) {
     getConfigurer().addStream(stream);
   }
 
   /**
    * @see DatasetConfigurer#addStream(Stream)
+   *
+   * @deprecated As of release 5.0.0, use Kafka as a replacement technology for Streams
    */
+  @Deprecated
   protected final void addStream(Stream stream) {
     getConfigurer().addStream(stream);
   }


### PR DESCRIPTION
Just a couple of places that were missed in the first PR. Most notably, the ```addStream``` in the Application configuration.