### PR TITLE
Add jvm option to kill CDAP if there is an OOM

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1058,13 +1058,12 @@ cdap_sdk_start() {
   # Start SDK processes
   echo -n "$(date) Starting CDAP Sandbox ..."
   if ${__foreground}; then
-    echo
-    nice -1 "${JAVA}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
+    nice -1 "${JAVA}" "${KILL_ON_OOM_OPTS}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
       | tee -a "${LOG_DIR}"/cdap.log
     __ret=${?}
     return ${__ret}
   else
-    nohup nice -1 "${JAVA}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
+    nohup nice -1 "${JAVA}" "${KILL_ON_OOM_OPTS}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
       </dev/null >>"${LOG_DIR}"/cdap.log 2>&1 &
     __ret=${?}
     __pid=${!}
@@ -1474,3 +1473,7 @@ CDAP_SDK_OPTS="${OPTS} -Djava.security.krb5.realm= -Djava.security.krb5.kdc= -Dj
 export HEAPDUMP_ON_OOM=${HEAPDUMP_ON_OOM:-true}
 
 export NICENESS=${NICENESS:-0}
+
+# Default jvm option for the kill command, it cannot be combined with the SDK options because split_jvm_opts() method will
+# always split the "kill -9 %p" into three different commands 
+export KILL_ON_OOM_OPTS=${KILL_ON_OOM_OPTS:--XX:OnOutOfMemoryError="kill -9 %p"}

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1470,10 +1470,10 @@ export TEMP_DIR=${CDAP_TEMP_DIR:-/tmp}
 # Default SDK options
 CDAP_SDK_OPTS="${OPTS} -Djava.security.krb5.realm= -Djava.security.krb5.kdc= -Djava.awt.headless=true"
 
-export HEAPDUMP_ON_OOM=${HEAPDUMP_ON_OOM:-true}
+export HEAPDUMP_ON_OOM=${HEAPDUMP_ON_OOM:-false}
 
 export NICENESS=${NICENESS:-0}
 
 # Default jvm option for the kill command, it cannot be combined with the SDK options because split_jvm_opts() method will
-# always split the "kill -9 %p" into three different commands 
+# always split the "kill -9 %p" into three different commands
 export KILL_ON_OOM_OPTS=${KILL_ON_OOM_OPTS:--XX:OnOutOfMemoryError="kill -9 %p"}


### PR DESCRIPTION
The split_jvm_opts() method will always split the "kill -9 %p" to three commands `"kill`, `-9`, `%p`, so it will always trigger a `Unrecognized option: -9` when we try to start cdap. So we should not call this method on this jvm option, we will directly pass it when we start the sandbox .
Verified adding this option will kill CDAP when there is OOM. 
