### PR TITLE
Fix failing doc build

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="349a48b9f2ccb7c60db71506521d676c"
+DEFAULT_XML_MD5_HASH="3f3f2f907f6a7c2475dba1900aa46518"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -23,7 +23,7 @@ MANUALS="${CDAP_MANUALS} ${EXTENSION_MANUALS}"
 # Used to monitor any changes in scripts or commands for the building of Javadocs
 BUILD_RST="BUILD.rst"
 BUILD_RST_HASH_LOCATION="cdap-docs/vars"
-BUILD_RST_HASH="4bf28417b1e801c889c692eaad99b3c9"
+BUILD_RST_HASH="2c620335553feca3f5b9c49e1eb5c998"
 
 #
 # All "GIT_" variables are loaded by the Sphinx build and need to be static as they are not sourced


### PR DESCRIPTION
Docs build has been failing for a while after [this commit](https://github.com/caskdata/cdap/pull/10538/commits/ce178dd9a1fcb77bdc77f15e8605a8105bb74567#diff-746d9009b526ac912029b597a56a8076). Fixing BUILD.rst hash to make it green.

Build: https://builds.cask.co/browse/CDAP-DBT35-2