### PR TITLE
[CDAP-14329] Fix to not hide last tab every time realtime pipeline config modeless is opened

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineConfigurations/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/index.js
@@ -126,9 +126,16 @@ export default class PipelineConfigurations extends Component {
   }
 
   render() {
-    let tabConfig = TabConfig;
-    if (!this.props.isBatch) {
-      tabConfig.tabs = tabConfig.tabs.slice(0, -1);
+    let tabConfig;
+    if (this.props.isBatch) {
+      tabConfig = TabConfig;
+    } else {
+      tabConfig = {...TabConfig};
+      // Don't show Alerts tab for realtime pipelines
+      const alertsTabName = T.translate(`${PREFIX}.Alerts.title`);
+      tabConfig.tabs = TabConfig.tabs.filter(tab => {
+        return tab.name !== alertsTabName;
+      });
     }
     return (
       <Provider store={PipelineConfigurationsStore}>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14329
Builds: https://builds.cask.co/browse/CDAP-URUT91

Context: The `TabConfig` object defines the list of tabs to display for the pipeline config modeless. For realtime pipelines, we don't want to display the 'Alerts' tab, which is the last tab in the list. 

Before, we were slicing off the last tab in the list for realtime pipelines, but we were also mutating the source `TabConfig` directly, causing a tab to disappear every time the config modeless was opened. Worse, if we went to the detail page of a batch pipeline after doing this, the config modeless of the batch pipeline would have missing tabs as well.

The fix here is to never mutate the source `TabConfig` object, and only modify its copy to hide the Alerts tab for realtime pipeline config.