### PR TITLE
[CDAP-14315] Fixes surfacing error while deleting connection in dataprep

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/ConnectionPopover/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/ConnectionPopover/index.js
@@ -31,6 +31,8 @@ import SpannerConnection from 'components/DataPrepConnections/SpannerConnection'
 import T from 'i18n-react';
 import {objectQuery} from 'services/helpers';
 import {ConnectionType} from 'components/DataPrepConnections/ConnectionType';
+import CardActionFeedback from 'components/CardActionFeedback';
+import If from 'components/If';
 require('./ConnectionPopover.scss');
 
 const PREFIX = 'features.DataPrepConnections.ConnectionManagement';
@@ -50,6 +52,8 @@ export default class ConnectionPopover extends Component {
 
     this.state = {
       deleteConfirmation: false,
+      extendedErrorMessage: null,
+      error: null,
       edit: false,
       duplicate: false,
       loading: false
@@ -94,11 +98,14 @@ export default class ConnectionPopover extends Component {
         this.props.onAction('delete', connectionId);
 
       }, (err) => {
-        let errMessage = objectQuery(err, 'message') || objectQuery(err, 'response', 'message');
+        let errMessage = objectQuery(err, 'message') ||
+          objectQuery(err, 'response', 'message') ||
+          objectQuery(err, 'response') || null;
 
         this.setState({
           loading: false,
-          error: errMessage || err
+          error: T.translate(`${PREFIX}.Confirmations.failedDeleteMessage`),
+          extendedErrorMessage: errMessage
         });
       });
   }
@@ -170,6 +177,13 @@ export default class ConnectionPopover extends Component {
             {T.translate(`${PREFIX}.Confirmations.DatabaseDelete.cancel`)}
           </button>
         </ModalFooter>
+        <If condition={this.state.error}>
+          <CardActionFeedback
+            type="DANGER"
+            message={this.state.error}
+            extendedMessage={this.state.extendedErrorMessage}
+          />
+        </If>
       </Modal>
     );
   }

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -41,7 +41,7 @@ import isNil from 'lodash/isNil';
 import ExpandableMenu from 'components/UncontrolledComponents/ExpandableMenu';
 import ConnectionPopover from 'components/DataPrepConnections/ConnectionPopover';
 import DataPrepStore from 'components/DataPrep/store';
-import {objectQuery, preventPropagation} from 'services/helpers';
+import {objectQuery, preventPropagation, isNilOrEmpty} from 'services/helpers';
 import Helmet from 'react-helmet';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import queryString from 'query-string';
@@ -186,17 +186,11 @@ export default class DataPrepConnections extends Component {
         });
 
         this.fetchConnectionTypes();
-      }, (err) => {
-        if (err.statusCode === 503) {
-          console.log('backend not started');
-
-          this.setState({
-            backendChecking: false,
-            backendDown: true
-          });
-
-          return;
-        }
+      }, () => {
+        this.setState({
+          backendChecking: false,
+          backendDown: true
+        });
       });
   }
 
@@ -979,8 +973,10 @@ export default class DataPrepConnections extends Component {
       activeConnectionType,
       activeConnectionid,
       defaultConnection,
-      connectionTypes
+      connectionTypes,
+      connectionsList
     } = this.state;
+    defaultConnection = isNilOrEmpty(find(connectionsList, { name: defaultConnection})) ? null : defaultConnection;
     const isFileConnectionValid = find(connectionTypes, {type: ConnectionType.FILE});
     if (
       !activeConnectionType &&

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/AccessTokenModal/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/AccessTokenModal/index.js
@@ -165,7 +165,7 @@ export default class AccessTokenModal extends Component {
         isOpen={this.props.isOpen}
         toggle={this.toggleModal}
         size="md"
-        className="access-token-modal"
+        className="access-token-modal cdap-modal"
         backdrop='static'
       >
         <ModalHeader>

--- a/cdap-ui/app/cdap/services/redirect-to-login.js
+++ b/cdap-ui/app/cdap/services/redirect-to-login.js
@@ -17,7 +17,9 @@
 import cookie from 'react-cookie';
 export default function RedirectToLogin(data) {
   let {statusCode} = data;
-  if (statusCode === 401) {
+  let {url} = data.resource;
+  let namespaceAPIRegex = new RegExp(/\/v3\/namespaces$/g);
+  if (statusCode === 401 && namespaceAPIRegex.test(url)) {
     cookie.remove('CDAP_Auth_Token', { path: '/' });
     cookie.remove('CDAP_Auth_User', { path: '/' });
     window.location.href = window.getAbsUIUrl({

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1212,6 +1212,7 @@ features:
           helper1: You will no longer able to access data from this source.
           helper2: "You can reconnect to this source at any time by clicking \"Add Connection\""
           mainMessage: "Are you sure you want to delete connection to {connection}?"
+        failedDeleteMessage: Deleting connection failed
       delete: Delete
       duplicate: Duplicate
       edit: Edit


### PR DESCRIPTION
- Fixes delete connection confirmation modal to show error if delete fails
- Fixes `redirect-to-login` api service handler to not redirect to login if any API other than namespaces list returns 401. Right now if any API response returns 401 UI redirects to login.
- Fixes access token modal to be consistent with other CDAP UI modals

JIRA: https://issues.cask.co/browse/CDAP-14315
Build: https://builds.cask.co/browse/CDAP-URUT92