### PR TITLE
CDAP-13008 fix alert publisher

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -195,10 +195,10 @@ public class DataPipelineTest extends HydratorTestBase {
       .addStage(new ETLStage("source", MockSource.getPlugin(sourceName)))
       .addStage(new ETLStage("nullAlert", NullAlertTransform.getPlugin("id")))
       .addStage(new ETLStage("sink", MockSink.getPlugin(sinkName)))
-      .addStage(new ETLStage("tms", TMSAlertPublisher.getPlugin(topic, NamespaceId.DEFAULT.getNamespace())))
+      .addStage(new ETLStage("tms alert", TMSAlertPublisher.getPlugin(topic, NamespaceId.DEFAULT.getNamespace())))
       .addConnection("source", "nullAlert")
       .addConnection("nullAlert", "sink")
-      .addConnection("nullAlert", "tms")
+      .addConnection("nullAlert", "tms alert")
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
@@ -239,7 +239,7 @@ public class DataPipelineTest extends HydratorTestBase {
     validateMetric(2, appId, "nullAlert.records.out");
     validateMetric(1, appId, "nullAlert.records.alert");
     validateMetric(2, appId, "sink.records.in");
-    validateMetric(1, appId, "tms.records.in");
+    validateMetric(1, appId, "tms alert.records.in");
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/PipelinePluginInstantiator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/PipelinePluginInstantiator.java
@@ -112,7 +112,8 @@ public class PipelinePluginInstantiator implements PluginContext {
     }
     StageSpec stageSpec = phaseSpec.getPhase().getStage(stageName);
     if (stageSpec.getPluginType().equals(AlertPublisher.PLUGIN_TYPE)) {
-      return (T) new AlertPublisherSink(stageName, phaseSpec.getPhaseName());
+      String datasetName = phaseSpec.getConnectorDatasets().get(stageName);
+      return (T) new AlertPublisherSink(datasetName, phaseSpec.getPhaseName());
     }
     return null;
   }


### PR DESCRIPTION
Fix the broken alert publisher due to the use of the stage name as the dataset name since stage name allows space inside, which means each alert publisher with a label with space will break. Fixing that by creating a unique dataset id for each alert publisher and pass them as a property so that the `destroy()` can get aware of the mapping of the stage name to the dataset name. 
JIRA: https://issues.cask.co/browse/CDAP-13008
build: https://builds.cask.co/browse/CDAP-RUT1610