### PR TITLE
[CDAP-14205] Fix "No tables" message flashing when loading tables in Spanner

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/DatasetList/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/DatasetList/index.js
@@ -17,12 +17,16 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {listBigQueryTables} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
+import {
+  listBigQueryTables,
+  listBiqQueryDatasets,
+} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import IconSVG from 'components/IconSVG';
 import {Link} from 'react-router-dom';
 import {getCurrentNamespace} from 'services/NamespaceStore';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import T from 'i18n-react';
+import {objectQuery} from 'services/helpers';
 
 const PREFIX = `features.DataPrep.DataPrepBrowser.BigQueryBrowser`;
 
@@ -31,12 +35,36 @@ class DatasetListView extends Component {
     datasetList: PropTypes.array,
     connectionId: PropTypes.string,
     enableRouting: PropTypes.bool,
-    loading: PropTypes.bool
+    loading: PropTypes.bool,
+    match: PropTypes.object
   };
 
   static defaultProps = {
     enableRouting: true
   };
+
+  state = {
+    connectionId: this.props.connectionId || objectQuery(this.props, 'match', 'params', 'connectionId'),
+  };
+
+  componentDidMount() {
+    if (!this.props.enableRouting) { return; }
+
+    const {connectionId} = this.props.match.params;
+
+    listBiqQueryDatasets(connectionId);
+  }
+
+  componentDidUpdate() {
+    const connectionId = this.props.connectionId || objectQuery(this.props, 'match', 'params', 'connectionId');
+
+    if (connectionId !== this.state.connectionId) {
+      listBiqQueryDatasets(connectionId);
+      this.setState({
+        connectionId,
+      });
+    }
+  }
 
   clickHandler = (datasetId) => {
     if (this.props.enableRouting) { return; }

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/bigquery.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/bigquery.js
@@ -20,11 +20,18 @@ import {getCurrentNamespace} from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
 import {objectQuery} from 'services/helpers';
 
-const setBigQueryAsActiveBrowser = (payload) => {
-  let {bigquery} = DataPrepBrowserStore.getState();
-  if (bigquery.loading) { return; }
+const setBigQueryAsActiveBrowser = (payload, getDatasets = false) => {
+  let {bigquery, activeBrowser} = DataPrepBrowserStore.getState();
+
+  if (activeBrowser.name !== payload.name) {
+    setActiveBrowser(payload);
+  }
 
   let {id: connectionId} = payload;
+
+  if (bigquery.connectionId === connectionId) { return; }
+
+  setBigQueryLoading();
 
   DataPrepBrowserStore.dispatch({
     type: BrowserStoreActions.SET_BIGQUERY_CONNECTION_ID,
@@ -32,10 +39,6 @@ const setBigQueryAsActiveBrowser = (payload) => {
       connectionId
     }
   });
-
-  setActiveBrowser(payload);
-  setBigQueryLoading();
-  listBiqQueryDatasets(connectionId);
 
   let namespace = getCurrentNamespace();
   let params = {
@@ -53,6 +56,9 @@ const setBigQueryAsActiveBrowser = (payload) => {
           connectionId
         }
       });
+      if (getDatasets) {
+        listBiqQueryDatasets(connectionId);
+      }
     }, (err) => {
       setError(err);
     });

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/database.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/database.js
@@ -30,11 +30,15 @@ const setDatabaseInfoLoading = () => {
 };
 
 const setDatabaseAsActiveBrowser = (payload) => {
-  let {database} = DataPrepBrowserStore.getState();
+  let {database, activeBrowser} = DataPrepBrowserStore.getState();
 
-  if (database.loading) { return; }
+  if (activeBrowser.name !== payload.name) {
+    setActiveBrowser(payload);
+  }
 
   let {id: connectionId} = payload;
+
+  if (database.connectionId === connectionId) { return; }
 
   DataPrepBrowserStore.dispatch({
     type: BrowserStoreActions.SET_DATABASE_CONNECTION_ID,
@@ -43,7 +47,6 @@ const setDatabaseAsActiveBrowser = (payload) => {
     }
   });
 
-  setActiveBrowser(payload);
   setDatabaseInfoLoading();
 
   let namespace = NamespaceStore.getState().selectedNamespace;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/gcs.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/gcs.js
@@ -21,27 +21,35 @@ import MyDataPrepApi from 'api/dataprep';
 import {objectQuery} from 'services/helpers';
 
 const setGCSAsActiveBrowser = (payload) => {
-  let {gcs} = DataPrepBrowserStore.getState();
+  let {gcs, activeBrowser} = DataPrepBrowserStore.getState();
 
-  if (gcs.loading) { return; }
+  if (activeBrowser.name !== payload.name) {
+    setActiveBrowser(payload);
+  }
 
-  setActiveBrowser(payload);
+  let {id: connectionId, path} = payload;
 
-  let namespace = NamespaceStore.getState().selectedNamespace;
-  let {id, path} = payload;
-  let params = {
-    namespace,
-    connectionId: id
-  };
+  if (gcs.connectionId === connectionId) {
+    if (path && path !== gcs.prefix) {
+      setGCSPrefix(path);
+    }
+    return;
+  }
 
   DataPrepBrowserStore.dispatch({
     type: BrowserStoreActions.SET_GCS_CONNECTION_ID,
     payload: {
-      connectionId: id
+      connectionId
     }
   });
 
   setGCSLoading();
+
+  let namespace = NamespaceStore.getState().selectedNamespace;
+  let params = {
+    namespace,
+    connectionId
+  };
 
   MyDataPrepApi.getConnection(params)
     .subscribe((res) => {
@@ -50,11 +58,13 @@ const setGCSAsActiveBrowser = (payload) => {
         type: BrowserStoreActions.SET_GCS_CONNECTION_DETAILS,
         payload: {
           info,
-          connectionId: id
+          connectionId
         }
       });
       if (path) {
         setGCSPrefix(path);
+      } else {
+        fetchGCSDetails();
       }
     }, (err) => {
       setError(err);

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/kafka.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/kafka.js
@@ -21,11 +21,15 @@ import MyDataPrepApi from 'api/dataprep';
 import {objectQuery} from 'services/helpers';
 
 const setKafkaAsActiveBrowser = (payload) => {
-  let {kafka} = DataPrepBrowserStore.getState();
+  let {kafka, activeBrowser} = DataPrepBrowserStore.getState();
 
-  if (kafka.loading) { return; }
+  if (activeBrowser.name !== payload.name) {
+    setActiveBrowser(payload);
+  }
 
   let {id: connectionId} = payload;
+
+  if (kafka.connectionId === connectionId) { return; }
 
   DataPrepBrowserStore.dispatch({
     type: BrowserStoreActions.SET_KAFKA_CONNECTION_ID,
@@ -33,7 +37,7 @@ const setKafkaAsActiveBrowser = (payload) => {
       connectionId
     }
   });
-  setActiveBrowser(payload);
+
   setKafkaInfoLoading();
 
   let namespace = NamespaceStore.getState().selectedNamespace;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/spanner.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/spanner.js
@@ -20,11 +20,16 @@ import {getCurrentNamespace} from 'services/NamespaceStore';
 import MyDataPrepApi from 'api/dataprep';
 import {objectQuery} from 'services/helpers';
 
-const setSpannerAsActiveBrowser = (payload) => {
-  let {spanner} = DataPrepBrowserStore.getState();
-  if (spanner.loading) { return; }
+const setSpannerAsActiveBrowser = (payload, getInstances = false) => {
+  let {spanner, activeBrowser} = DataPrepBrowserStore.getState();
+
+  if (activeBrowser.name !== payload.name) {
+    setActiveBrowser(payload);
+  }
 
   let {id: connectionId} = payload;
+
+  if (spanner.connectionId === connectionId) { return; }
 
   DataPrepBrowserStore.dispatch({
     type: BrowserStoreActions.SET_SPANNER_CONNECTION_ID,
@@ -33,9 +38,8 @@ const setSpannerAsActiveBrowser = (payload) => {
     }
   });
 
-  setActiveBrowser(payload);
-
   setSpannerLoading();
+
   let namespace = getCurrentNamespace();
   let params = {
     namespace,
@@ -52,7 +56,9 @@ const setSpannerAsActiveBrowser = (payload) => {
           connectionId
         }
       });
-      listSpannerInstances(connectionId);
+      if (getInstances) {
+        listSpannerInstances(connectionId);
+      }
     }, (err) => {
       setError(err);
     });

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
@@ -207,6 +207,8 @@ const database = (state = defaultDatabaseValue, action = defaultAction) => {
         ...state,
         loading: false
       };
+    case Actions.SET_ACTIVEBROWSER:
+      return defaultDatabaseValue;
     case Actions.RESET:
       return defaultDatabaseValue;
     default:
@@ -244,6 +246,8 @@ const kafka = (state = defaultKafkaValue, action = defaultAction) => {
         ...state,
         loading: false
       };
+    case Actions.SET_ACTIVEBROWSER:
+      return defaultKafkaValue;
     case Actions.RESET:
       return defaultKafkaValue;
     default:
@@ -295,6 +299,8 @@ const s3 = (state = defaultS3Value, action = defaultAction) => {
         ...state,
         loading: false
       };
+    case Actions.SET_ACTIVEBROWSER:
+      return defaultS3Value;
     case Actions.RESET:
       return defaultS3Value;
     default:
@@ -346,6 +352,8 @@ const gcs = (state = defaultGCSValue, action = defaultAction) => {
         ...state,
         loading: false
       };
+    case Actions.SET_ACTIVEBROWSER:
+      return defaultGCSValue;
     case Actions.RESET:
       return defaultGCSValue;
     default:
@@ -396,6 +404,8 @@ const bigquery = (state = defaultBigQueryValue, action = defaultAction) => {
         ...state,
         loading: false
       };
+    case Actions.SET_ACTIVEBROWSER:
+      return defaultBigQueryValue;
     case Actions.RESET:
       return defaultBigQueryValue;
     default:
@@ -455,6 +465,8 @@ const spanner = (state = defaultSpannerValue, action = defaultAction) => {
         ...state,
         loading: false
       };
+    case Actions.SET_ACTIVEBROWSER:
+      return defaultSpannerValue;
     case Actions.RESET:
       return defaultSpannerValue;
     default:

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/SpannerBrowser/InstanceList/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/SpannerBrowser/InstanceList/index.tsx
@@ -51,6 +51,10 @@ class SpannerInstanceListView extends React.PureComponent<ISpannerInstanceListVi
     enableRouting: true,
   };
 
+  public state = {
+    connectionId: this.props.connectionId || objectQuery(this.props, 'match', 'params', 'connectionId'),
+  };
+
   private clickHandler = (instanceId: string) => {
     if (this.props.enableRouting) { return; }
     listSpannerDatabases(this.props.connectionId, instanceId);
@@ -62,6 +66,17 @@ class SpannerInstanceListView extends React.PureComponent<ISpannerInstanceListVi
     const {connectionId} = this.props.match.params;
 
     listSpannerInstances(connectionId);
+  }
+
+  public componentDidUpdate() {
+    const connectionId = this.props.connectionId || objectQuery(this.props, 'match', 'params', 'connectionId');
+
+    if (connectionId !== this.state.connectionId) {
+      listSpannerInstances(connectionId);
+      this.setState({
+        connectionId,
+      });
+    }
   }
 
   public render() {

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/index.js
@@ -99,7 +99,6 @@ export default class DataPrepBrowser extends Component {
   }
 }
 DataPrepBrowser.propTypes = {
-  location: PropTypes.object,
   match: PropTypes.object,
   setActiveConnection: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -196,7 +196,6 @@ export default class DataPrepConnections extends Component {
 
   handlePropagation(browserName, e) {
     if (this.props.enableRouting && !this.props.singleWorkspaceMode) {
-      setActiveBrowser({name: typeof browserName === 'object' ? browserName.name : browserName});
       return;
     }
     preventPropagation(e);
@@ -233,11 +232,11 @@ export default class DataPrepConnections extends Component {
       activeConnectionid = browserName.id;
       activeConnectionType = ConnectionType.GCS;
     } else if (typeof browserName === 'object' && browserName.type === ConnectionType.BIGQUERY) {
-      setBigQueryAsActiveBrowser({name: ConnectionType.BIGQUERY, id: browserName.id});
+      setBigQueryAsActiveBrowser({name: ConnectionType.BIGQUERY, id: browserName.id}, true);
       activeConnectionid = browserName.id;
       activeConnectionType = ConnectionType.BIGQUERY;
     } else if (typeof browserName === 'object' && browserName.type === ConnectionType.SPANNER) {
-      setSpannerAsActiveBrowser({name: ConnectionType.SPANNER, id: browserName.id});
+      setSpannerAsActiveBrowser({name: ConnectionType.SPANNER, id: browserName.id}, true);
       activeConnectionid = browserName.id;
       activeConnectionType = ConnectionType.SPANNER;
     }
@@ -763,12 +762,11 @@ export default class DataPrepConnections extends Component {
       <Switch>
         <Route
           path={`${BASEPATH}/file`}
-          render={({match, location}) => {
+          render={({match}) => {
             const setActiveConnection = setActiveBrowser.bind(null, {name: ConnectionType.FILE});
             return (
               <DataPrepBrowser
                 match={match}
-                location={location}
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
@@ -795,7 +793,6 @@ export default class DataPrepConnections extends Component {
             return (
               <DataPrepBrowser
                 match={match}
-                location={location}
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
@@ -811,7 +808,6 @@ export default class DataPrepConnections extends Component {
             return (
               <DataPrepBrowser
                 match={match}
-                location={location}
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
@@ -828,7 +824,6 @@ export default class DataPrepConnections extends Component {
             return (
               <DataPrepBrowser
                 match={match}
-                location={location}
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
@@ -845,7 +840,6 @@ export default class DataPrepConnections extends Component {
             return (
               <DataPrepBrowser
                 match={match}
-                location={location}
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
@@ -861,7 +855,6 @@ export default class DataPrepConnections extends Component {
             return (
               <DataPrepBrowser
                 match={match}
-                location={location}
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
@@ -935,38 +928,52 @@ export default class DataPrepConnections extends Component {
       setActiveConnection = setActiveBrowser.bind(null, {name: ConnectionType.FILE});
     } else if (this.state.activeConnectionType === ConnectionType.S3) {
       let {workspaceInfo} = DataPrepStore.getState().dataprep;
-      let path;
-      if (isObject(workspaceInfo)) {
-        let {key} = workspaceInfo.properties;
-        let bucketName = workspaceInfo.properties['bucket-name'];
-        if (bucketName) {
-          path = `/${bucketName}/${key}`;
-        } else {
-          let state = DataPrepBrowserStore.getState();
-          path = state.s3.prefix;
+      let {s3} = DataPrepBrowserStore.getState();
+      // So the code path below will set the path of the s3 browser to current path,
+      // when opening up connections from S3 workspace. However, this function is also
+      // called when the user clicks on another S3 connection from this view :(. So
+      // this if condition is to make sure we only set path to current workspace path
+      // when the user is going back to connections view, not when they select another
+      // S3 connection
+      if (!s3.connectionId || s3.connectionId === objectQuery(workspaceInfo, 'properties', 'connectionId')) {
+        let path;
+        if (isObject(workspaceInfo)) {
+          let {key} = workspaceInfo.properties;
+          let bucketName = workspaceInfo.properties['bucket-name'];
+          if (bucketName) {
+            path = `/${bucketName}/${key}`;
+          } else {
+            let state = DataPrepBrowserStore.getState();
+            path = state.s3.prefix;
+          }
         }
+        setActiveConnection = setS3AsActiveBrowser.bind(null, {name: ConnectionType.S3, id: this.state.activeConnectionid, path});
       }
-      setActiveConnection = setS3AsActiveBrowser.bind(null, {name: ConnectionType.S3, id: this.state.activeConnectionid, path});
     } else if (this.state.activeConnectionType === ConnectionType.GCS) {
       let {workspaceInfo} = DataPrepStore.getState().dataprep;
-      let path;
-      if (isObject(workspaceInfo) && workspaceInfo.properties.path) {
-        path = workspaceInfo.properties.path;
-        path = path.split('/');
-        path = path.slice(0, path.length - 1).join('/');
-        let bucketName = workspaceInfo.properties.bucket;
-        if (bucketName) {
-          path = !isNilOrEmpty(path) ? `/${bucketName}/${path}/` : `/${bucketName}`;
-        } else {
-          let state = DataPrepBrowserStore.getState();
-          path = state.gcs.prefix;
+      let {gcs} = DataPrepBrowserStore.getState();
+      // Same as S3 connection above
+      if (!gcs.connectionId || gcs.connectionId === objectQuery(workspaceInfo, 'properties', 'connectionId')) {
+        let path;
+        if (isObject(workspaceInfo) && workspaceInfo.properties.path) {
+          path = workspaceInfo.properties.path;
+          path = path.split('/');
+          path = path.slice(0, path.length - 1).join('/');
+          let bucketName = workspaceInfo.properties.bucket;
+          if (bucketName) {
+            path = !isNilOrEmpty(path) ? `/${bucketName}/${path}/` : `/${bucketName}`;
+          } else {
+            let state = DataPrepBrowserStore.getState();
+            path = state.gcs.prefix;
+          }
         }
+        setActiveConnection = setGCSAsActiveBrowser.bind(null, {name: ConnectionType.GCS, id: this.state.activeConnectionid, path});
       }
-      setActiveConnection = setGCSAsActiveBrowser.bind(null, {name: ConnectionType.GCS, id: this.state.activeConnectionid, path});
+
     } else if (this.state.activeConnectionType === ConnectionType.BIGQUERY) {
-      setActiveConnection = setBigQueryAsActiveBrowser.bind(null, {name: ConnectionType.BIGQUERY, id: this.state.activeConnectionid});
+      setActiveConnection = setBigQueryAsActiveBrowser.bind(null, {name: ConnectionType.BIGQUERY, id: this.state.activeConnectionid}, true);
     } else if (this.state.activeConnectionType === ConnectionType.SPANNER) {
-      setActiveConnection = setSpannerAsActiveBrowser.bind(null, {name: ConnectionType.SPANNER, id: this.state.activeConnectionid});
+      setActiveConnection = setSpannerAsActiveBrowser.bind(null, {name: ConnectionType.SPANNER, id: this.state.activeConnectionid}, true);
     }
 
     let {

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -158,13 +158,18 @@ export default class FileBrowser extends Component {
       hdfsPath = this.props.initialDirectoryPath;
       return;
     } else {
-      hdfsPath = props.location.pathname.slice(props.match.url.length);
-      hdfsPath = hdfsPath || this.props.initialDirectoryPath || BASEPATH;
+      if (objectQuery(props, 'match', 'url')) {
+        let pathname = window.location.pathname.replace(/\/cdap/, '');
+        hdfsPath = pathname.slice(props.match.url.length);
+        hdfsPath = hdfsPath || this.props.initialDirectoryPath || BASEPATH;
+      }
     }
 
     if (hdfsPath === this.state.path) { return; }
 
-    goToPath(hdfsPath);
+    if (hdfsPath) {
+      goToPath(hdfsPath);
+    }
   }
 
   handleSearch = (e) => {

--- a/cdap-ui/server/config/ui-settings.json
+++ b/cdap-ui/server/config/ui-settings.json
@@ -1,5 +1,4 @@
 {
   "standalone.website.sdk.download": "true",
-  "ui.debug.enabled": "false",
-  "ui.theme": "default"
+  "ui.debug.enabled": "false"
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14205
Builds: https://builds.cask.co/browse/CDAP-URUT95

The JIRA is about file system, but I could only reproduce issue for tables in Spanner e.g. select an instance and database in Spanner to get list of tables, then refresh.

The root cause was that we were calling `setSpannerAsActiveBrowser` for every Spanner route, and `setSpannerAsActiveBrowser` always called `listSpannerInstances` even when it didn't need to e.g. when on the databases page or on the tables page.  The only time we need to call `listSpannerInstances` is when we navigate back from a Spanner workspace to the connections panel, then we need to list the Spanner instances available. 