### PR TITLE
CDAP-14323 fix flaky spark stream format test

### DIFF
--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/app/StreamFormatSpecSpark.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/app/StreamFormatSpecSpark.java
@@ -78,7 +78,8 @@ public class StreamFormatSpecSpark extends AbstractSpark implements JavaSparkMai
         public Tuple2<String, Integer> call(Row row) throws Exception {
           return new Tuple2<>(row.getString(0), row.getInt(1));
         }
-      });
+      })
+      .repartition(1);
 
     sec.saveAsDataset(resultRDD, sec.getRuntimeArguments().get("output.dataset"));
   }


### PR DESCRIPTION
Fixed the test program to only write a single output file,
as the test case assumes there is only one. Without this,
the test can sometimes read the file with content and sometime
ready an empty output file.