### PR TITLE
[CDAP-14331] Makes favicon customizable

### DIFF
--- a/cdap-ui/app/cdap/services/ThemeHelper.ts
+++ b/cdap-ui/app/cdap/services/ThemeHelper.ts
@@ -45,6 +45,7 @@ interface IOnePoint0SpecJSON extends IThemeJSON {
          "data"?: string;
       }
     },
+    "favicon-path"?: string,
     "footer-text"?: string;
     "footer-link"?: string;
   };
@@ -117,6 +118,7 @@ interface IThemeObj {
   footerLink?: string;
   productLogoNavbar?: string;
   productLogoAbout?: string;
+  favicon?: string;
   showDashboard?: boolean;
   showReports?: boolean;
   showDataPrep?: boolean;
@@ -131,16 +133,13 @@ interface IThemeObj {
 }
 
 function getTheme(): IThemeObj {
-  let theme: IThemeObj = {
-    productName: 'CDAP',
+  let theme: IThemeObj = {};
+  const DEFAULT_THEME_JSON: IThemeJSON = {
+    'spec-version': '1.0',
   };
 
-  if (isNilOrEmpty(window.CDAP_UI_THEME)) {
-    return theme;
-  }
-
-  const themeJSON = window.CDAP_UI_THEME;
-  const specVersion = themeJSON['spec-version'];
+  const themeJSON = window.CDAP_UI_THEME || DEFAULT_THEME_JSON;
+  const specVersion = themeJSON['spec-version'] || '1.0';
 
   if (specVersion === '1.0') {
     theme = {
@@ -160,12 +159,19 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
 
   function getContent(): IThemeObj {
     const contentJson = themeJSON.content;
-    const content: IThemeObj = {};
+    const content: IThemeObj = {
+      productName: 'CDAP',
+      productLogoNavbar: '/cdap_assets/img/company_logo.png',
+      productLogoAbout: '/cdap_assets/img/CDAP_darkgray.png',
+      favicon: '/cdap_assets/img/favicon.png',
+      footerText: 'Licensed under the Apache License, Version 2.0',
+      footerLink: 'https://www.apache.org/licenses/LICENSE-2.0',
+    };
     if (isNilOrEmpty(contentJson)) {
       return content;
     }
     if ('product-name' in contentJson) {
-      content.productName = contentJson['product-name'] || 'CDAP';
+      content.productName = contentJson['product-name'];
     }
     if ('footer-text' in contentJson) {
       content.footerText = contentJson['footer-text'];

--- a/cdap-ui/server/config/themes/default.json
+++ b/cdap-ui/server/config/themes/default.json
@@ -19,6 +19,7 @@
          "url": "/cdap_assets/img/CDAP_darkgray.png"
       }
     },
+    "favicon-path": "/cdap_assets/img/favicon.png",
     "footer-text": "Licensed under the Apache License, Version 2.0",
     "footer-link": "https://www.apache.org/licenses/LICENSE-2.0"
   },

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -45,7 +45,8 @@ var express = require('express'),
     LOGIN_DIST_PATH= path.normalize(__dirname + '/../login_dist'),
     CDAP_DIST_PATH= path.normalize(__dirname + '/../cdap_dist'),
     MARKET_DIST_PATH= path.normalize(__dirname + '/../common_dist'),
-    fs = require('fs');
+    fs = require('fs'),
+    objectQuery = require('lodash/get');
 
 var log = log4js.getLogger('default');
 
@@ -61,11 +62,29 @@ const getExpressStaticConfig = () => {
     maxAge: '1y'
   };
 };
+
+function getFaviconPath(uiThemeConfig) {
+  let faviconPath = DIST_PATH + '/assets/img/favicon.png';
+  let themeFaviconPath = objectQuery(uiThemeConfig, ['content', 'favicon-path']);
+  if (themeFaviconPath) {
+    themeFaviconPath = CDAP_DIST_PATH + themeFaviconPath;
+    try {
+      if (require.resolve(themeFaviconPath)) {
+        faviconPath = themeFaviconPath;
+      }
+    } catch (e) {
+      log.info(`Unable to find favicon at path ${themeFaviconPath}`);
+    }
+  }
+  return faviconPath;
+}
+
 function makeApp (authAddress, cdapConfig, uiSettings, uiThemeConfig) {
   var app = express();
 
+  const faviconPath = getFaviconPath(uiThemeConfig);
   // middleware
-  try { app.use(serveFavicon(DIST_PATH + '/assets/img/favicon.png')); }
+  try { app.use(serveFavicon(faviconPath)); }
   catch (e) { log.error('Favicon missing! Please run `gulp build`'); }
 
   app.use(compression());


### PR DESCRIPTION
JIRAs:
https://issues.cask.co/browse/CDAP-14331
https://issues.cask.co/browse/CDAP-14350

This PR:
- Makes favicon customizable by adding a "favicon" property to the theme spec. Since we render favicon server-side the customization handling code is done in the `express.js` code, instead of in `ThemeHelper` like other properties.
- Exports the default theme object when the theme file can't be found, instead of exporting an empty theme object like before.