### PR TITLE
[CDAP-14211] Fix runs count in pipeline detail view

### DIFF
--- a/cdap-ui/app/cdap/api/pipeline.js
+++ b/cdap-ui/app/cdap/api/pipeline.js
@@ -23,6 +23,7 @@ let artifactBasePath = `/namespaces/:namespace/artifacts/:artifactName/versions/
 let statsPath = `${basepath}/workflows/:workflowId/statistics?start=0`;
 let schedulePath = `${basepath}/schedules/:scheduleId`;
 let programPath = `${basepath}/:programType/:programName`;
+let runsCountPath = '/namespaces/:namespace/runcount';
 
 export const MyPipelineApi = {
   publish: apiCreator(dataSrc, 'PUT', 'REQUEST', basepath),
@@ -34,6 +35,8 @@ export const MyPipelineApi = {
   getStatistics: apiCreator(dataSrc, 'GET', 'REQUEST', statsPath),
   getRuns: apiCreator(dataSrc, 'GET', 'REQUEST', `${programPath}/runs`),
   pollRuns: apiCreator(dataSrc, 'GET', 'POLL', `${programPath}/runs`),
+  getRunsCount: apiCreator(dataSrc, 'POST', 'REQUEST', `${runsCountPath}`),
+  pollRunsCount: apiCreator(dataSrc, 'POST', 'POLL', `${runsCountPath}`),
   getNextRunTime: apiCreator(dataSrc, 'GET', 'REQUEST', `${programPath}/nextruntime)`),
   fetchMacros: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/plugins`),
   fetchWidgetJson: apiCreator(dataSrc, 'GET', 'REQUEST', artifactBasePath)

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/CurrentRunIndex.js
@@ -27,12 +27,13 @@ const PREFIX = 'features.PipelineDetails.RunLevel';
 
 const mapStateToProps = (state) => {
   return {
+    runsCount: state.runsCount,
     runs: state.runs,
     currentRun: state.currentRun
   };
 };
 
-const CurrentRunIndex = ({runs, currentRun}) => {
+const CurrentRunIndex = ({runs, currentRun, runsCount}) => {
   let reversedRuns = reverseArrayWithoutMutating(runs);
   let currentRunIndex = findIndex(reversedRuns, {runid: objectQuery(currentRun, 'runid')});
 
@@ -65,7 +66,7 @@ const CurrentRunIndex = ({runs, currentRun}) => {
   return (
     <div className="run-number-container run-info-container">
       <h4 className="run-number">
-        {T.translate(`${PREFIX}.currentRunIndex`, {currentRunIndex: currentRunIndex + 1, numRuns: runs.length})}
+        {T.translate(`${PREFIX}.currentRunIndex`, {currentRunIndex: currentRunIndex + 1, numRuns: runsCount})}
       </h4>
       <div className="run-number-switches">
         <button
@@ -87,6 +88,7 @@ const CurrentRunIndex = ({runs, currentRun}) => {
 
 CurrentRunIndex.propTypes = {
   runs: PropTypes.array,
+  runsCount: PropTypes.number,
   currentRun: PropTypes.object
 };
 

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLogs.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLogs.js
@@ -39,7 +39,7 @@ const RunLogs = ({currentRun, runs, appId, artifactName}) => {
       <Popover
         target={LogsBtnComp}
         showOn='Hover'
-        placement='bottom'
+        placement='bottom-end'
         className="run-info-container run-logs-container disabled"
       >
         {T.translate(`${PREFIX}.pipelineNeverRun`)}

--- a/cdap-ui/app/cdap/components/PipelineDetails/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/store/ActionCreator.js
@@ -185,6 +185,25 @@ const getRuns = (params) => {
   return runsFetch;
 };
 
+const pollRunsCount = ({appId, programType, programName: programId, namespace}) => {
+  let postBody = [{
+    appId,
+    programType,
+    programId
+  }];
+  return MyPipelineApi
+    .pollRunsCount({ namespace }, postBody)
+    .subscribe(runsCountArray => {
+      let runsCount = runsCountArray[0].runCount;
+      PipelineDetailStore.dispatch({
+        type: ACTIONS.SET_RUNS_COUNT,
+        payload: {
+          runsCount
+        }
+      });
+    });
+};
+
 const pollRuns = (params) => {
   return MyPipelineApi
     .pollRuns(params)
@@ -337,6 +356,7 @@ export {
   setCurrentRunId,
   getRuns,
   pollRuns,
+  pollRunsCount,
   getNextRunTime,
   getStatistics,
   setMacros,

--- a/cdap-ui/app/cdap/components/PipelineDetails/store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/store/index.js
@@ -31,6 +31,7 @@ const ACTIONS = {
   SET_NEXT_RUN_TIME: 'SET_NEXT_RUN_TIME',
   SET_CURRENT_RUN_ID: 'SET_CURRENT_RUN_ID',
   SET_RUNS: 'SET_RUNS',
+  SET_RUNS_COUNT: 'SET_RUNS_COUNT',
   SET_STATISTICS: 'SET_STATISTICS',
   SET_USER_RUNTIME_ARGUMENTS: 'SET_USER_RUNTIME_ARGUMENTS',
   SET_MACROS_AND_USER_RUNTIME_ARGUMENTS: 'SET_MACROS_AND_USER_RUNTIME_ARGUMENTS',
@@ -62,6 +63,7 @@ const DEFAULT_PIPELINE_DETAILS = {
 
   // Run level info
   runs: [],
+  runsCount: null,
   currentRun: {},
   nextRunTime: null,
   statistics: '',
@@ -169,6 +171,11 @@ const pipelineDetails = (state = DEFAULT_PIPELINE_DETAILS, action = defaultActio
         stopButtonLoading: false
       };
     }
+    case ACTIONS.SET_RUNS_COUNT:
+      return {
+        ...state,
+        runsCount: action.payload.runsCount
+      };
     case ACTIONS.SET_STATISTICS:
       return {
         ...state,

--- a/cdap-ui/app/hydrator/controllers/detail-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail-ctrl.js
@@ -23,6 +23,7 @@ angular.module(PKG.name + '.feature.hydrator')
 
     this.pipelineType = rPipelineDetail.artifact.name;
     let programType = this.pipelineType === GLOBALS.etlDataPipeline ? 'workflows' : 'spark';
+    let programTypeForRunsCount = this.pipelineType === GLOBALS.etlDataPipeline ? 'Workflow' : 'Spark';
     let programName = this.pipelineType === GLOBALS.etlDataPipeline ? 'DataPipelineWorkflow' : 'DataStreamsSparkStreaming';
     let scheduleId = GLOBALS.defaultScheduleId;
 
@@ -49,6 +50,12 @@ angular.module(PKG.name + '.feature.hydrator')
         programType,
         programName
       });
+    });
+    let pollRunsCount = pipelineDetailsActionCreator.pollRunsCount({
+      namespace: $stateParams.namespace,
+      appId: rPipelineDetail.name,
+      programType: programTypeForRunsCount,
+      programName
     });
 
     pipelineDetailsActionCreator.fetchScheduleStatus({
@@ -107,6 +114,9 @@ angular.module(PKG.name + '.feature.hydrator')
       // FIXME: This should essentially be moved to a scaffolding service that will do stuff for a state/view
       if (runsPoll) {
         runsPoll.unsubscribe();
+      }
+      if (pollRunsCount) {
+        pollRunsCount.unsubscribe();
       }
       if (metricsObservable) {
         metricsObservable.unsubscribe();


### PR DESCRIPTION
- Adds right runs count in pipeline detail view

**Note:**
We should eliminate calling the `/runs` endpoint in detailed view and just fetch the run record lazily as and when we require. Owing to the time and amount of change I am not doing it in this PR. 

JIRA: https://issues.cask.co/browse/CDAP-14211
Build: https://builds.cask.co/browse/CDAP-URUT106