### PR TITLE
[CDAP-14373] Naive fix for not showing scrollbar for plugin names in pipeline studio left panel

### DIFF
--- a/cdap-ui/app/hydrator/leftpanel.less
+++ b/cdap-ui/app/hydrator/leftpanel.less
@@ -233,6 +233,7 @@ body.theme-cdap.state-hydrator-create {
                       &.plugin-name {
                         line-height: 14px;
                         padding-top: 8px;
+                        overflow: hidden;
                       }
                     }
                   }


### PR DESCRIPTION
- On really high resolution we seem to be showing scrollbars in left panel. This PR is to have overflow hidden for names since it doesn't make sense to show scroll bar for names :sigh:

JIRA: https://issues.cask.co/browse/CDAP-14373
Build: https://builds.cask.co/browse/CDAP-URUT108