### PR TITLE
[CDAP-14365] Fixes showing 'Pending' state as 'Provisioning' state in UI for pipelines

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/RunsHistoryGraph/index.js
@@ -46,7 +46,7 @@ require('react-vis/dist/styles/plot.scss');
 const MARKSERIESSTROKECOLOR = colorVariables.grey03;
 const FAILEDRUNCOLOR = colorVariables.red01;
 const SUCCESSRUNCOLOR = colorVariables.green02;
-const PENDINGSTATUSFILLCOLOR = 'transparent';
+const PENDINGSTATUSFILLCOLOR = colorVariables.white01;
 const PENDINGSTATUSSTROKECOLOR = colorVariables.blue02;
 const RUNNINGSTATUSCOLOR = colorVariables.blue02;
 const LINECOLOR = colorVariables.grey06;

--- a/cdap-ui/app/cdap/services/StatusMapper.js
+++ b/cdap-ui/app/cdap/services/StatusMapper.js
@@ -35,7 +35,7 @@ const statusMap = {
   [PROGRAM_STATUSES.SCHEDULING]: 'Scheduling',
   [PROGRAM_STATUSES.STOPPING]: 'Stopping',
   [PROGRAM_STATUSES.SUSPENDING]: 'Suspending',
-  [PROGRAM_STATUSES.PENDING]: 'Pending',
+  [PROGRAM_STATUSES.PENDING]: 'Provisioning',
 };
 
 function lookupDisplayStatus (systemStatus) {

--- a/cdap-ui/app/cdap/styles/variables.scss
+++ b/cdap-ui/app/cdap/styles/variables.scss
@@ -153,6 +153,8 @@ $green-04: #0f9d58;
 $green-05: #0b8043;
 
 :export {
+  white01: $cdap-white;
+
   green01: $green-01;
   green02: $green-02;
   green03: $green-03;

--- a/cdap-ui/app/hydrator/controllers/list-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/list-ctrl.js
@@ -185,6 +185,7 @@ angular.module(PKG.name + '.feature.hydrator')
                   :
                     (new Date().getTime() / 1000) - latestRun.starting;
                 }
+                latestRun.duration = window.CaskCommon.CDAPHelpers.humanReadableDuration(Math.round(latestRun.duration));
                 app = Object.assign({}, app, {
                   latestRun: latestRun
                 });


### PR DESCRIPTION
- Showing 'Pending' as a state in UI for pipeline seems to confusing
- Since we know 'Pending' for program status means 'Provisioning' for cluster state, we map 'Pending' to 'Provisioning' in UI while displaying status of the pipeline
- Minor fix for duration in pipeline list view. To be consistent with the pipeline detailed view.

JIRA: https://issues.cask.co/browse/CDAP-14365
Build: https://builds.cask.co/browse/CDAP-URUT109