### PR TITLE
[CDAP-14377] Gets cdap config from cConf, instead of API call

### DIFF
--- a/cdap-ui/server/config/development/cdap.json
+++ b/cdap-ui/server/config/development/cdap.json
@@ -10,5 +10,6 @@
   "dashboard.bind.port": "11011",
   "enable.preview": "true",
   "dashboard.router.check.timeout.secs": "0",
-  "market.base.url": "http://market.cask.co/dev/v2"
+  "market.base.url": "http://market.cask.co/dev/v2",
+  "ui.theme.file": "cdap-ui/server/config/themes/default.json"
 }

--- a/cdap-ui/server/config/parser.js
+++ b/cdap-ui/server/config/parser.js
@@ -18,8 +18,7 @@
 
 module.exports = {
   extractConfig: extractConfig,
-  extractUISettings: extractUISettings,
-  extractUITheme: extractUITheme
+  extractUISettings: extractUISettings
 };
 
 var promise = require('q'),
@@ -29,8 +28,7 @@ var promise = require('q'),
     log4js = require('log4js'),
     cache = {},
     path,
-    buffer = '',
-    request = require('request');
+    buffer = '';
 
 var log = log4js.getLogger('default');
 
@@ -43,41 +41,6 @@ function extractUISettings() {
     log.info('Unable to find UI settings json file.');
     return {};
   }
-}
-
-/*
- *  Extracts contents of theme object in the specified theme file
- *  @returns {promise}
- */
-
-async function extractUITheme() {
-  const uiThemePropertyName = 'ui.theme.file';
-  const DEFAULT_CONFIG = {};
-  const cdapConfig = await extractConfig('cdap');
-  let cdapSiteContents;
-  try {
-    cdapSiteContents = await getCdapSiteContents(cdapConfig);
-  } catch (e) {
-    log.info(e.toString());
-    return DEFAULT_CONFIG;
-  }
-
-  try {
-    cdapSiteContents = JSON.parse(cdapSiteContents);
-    const uiThemeProperty = cdapSiteContents.find(property => property.name === uiThemePropertyName);
-    if (!uiThemeProperty) {
-      log.info(`Unable to find ${uiThemePropertyName} property`);
-      return DEFAULT_CONFIG;
-    }
-    const uiThemeConfig = getUIThemeConfig(uiThemeProperty);
-    return uiThemeConfig;
-
-  } catch (error) {
-    log.info('Unable to parse CDAP config');
-    return DEFAULT_CONFIG;
-  }
-
-
 }
 
 /*
@@ -162,56 +125,4 @@ function configReadFail (data) {
   if (textChunk) {
     log.error(textChunk);
   }
-}
-
-function getCdapSiteContents(cdapConfig) {
-  let url;
-  const deferred = promise.defer();
-  const routerServerAddress = cdapConfig['router.server.address'];
-
-  if (cdapConfig['ssl.external.enabled'] === 'true') {
-    url = `https://${routerServerAddress}:${cdapConfig['router.ssl.server.port']}`;
-  } else {
-    url = `http://${routerServerAddress}:${cdapConfig['router.server.port']}`;
-  }
-  url += '/v3/config/cdap';
-
-  const requestConfig = {
-    method: 'GET',
-    url,
-    rejectUnauthorized: false,
-    requestCert: true,
-    agent: false
-  };
-
-  request(requestConfig, function(err, response, body) {
-    if (err || response.statusCode >= 400) {
-      deferred.reject(new Error('Unable to get CDAP config'));
-      return;
-    }
-    deferred.resolve(body);
-  });
-
-  return deferred.promise;
-}
-
-function getUIThemeConfig(uiThemeProperty) {
-  let uiThemeConfig = {};
-  let uiThemePath = uiThemeProperty.value;
-  if (uiThemePath[0] !== '/') {
-    // if path doesn't start with /, then it's a relative path
-    // have to add the ellipses to navigate back to $CDAP_HOME, before
-    // going through the path
-    uiThemePath = `../../../${uiThemePath}`;
-  }
-  try {
-    if (require.resolve(uiThemePath)) {
-      uiThemeConfig = require(uiThemePath);
-      log.info(`UI using theme located at ${uiThemeProperty.value}`);
-    }
-  } catch (e) {
-    // The error can either be file doesn't exist, or file contains invalid json
-    log.info(e.toString());
-  }
-  return uiThemeConfig;
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14377
Builds: https://builds.cask.co/browse/CDAP-URUT112

Currently, we were doing an API call to `/v3/config/cdap` to get the value of `ui.theme.file` property. However, most of the time we don't need to do this, since path to cdap config is passed in as runtime arguments to the node process. 

This PR modifies the code to look for the value of the 'ui.theme.property' in the cdap config passed in through cConf, which should always be there since we've added the property to 'cdap-default.xml'. In UI development we typically don't pass the cConf however, so in that case we can dispatch an API call to '/v3/cdap/config' to get cdap config contents.

EDIT: Instead of dispatching an API call at all, have edited to add 'ui.theme.file' to development `cdap.json`. This will guarantee that `cdapConfig` variable will always have 'ui.theme.file' property. 