### PR TITLE
[CDAP-14396] [CDAP-14391] Fix to navigate to right path in gcs when the file is in root folder

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
@@ -52,8 +52,13 @@ export default class S3Browser extends Component {
     const {selectedNamespace: namespace} = NamespaceStore.getState();
     const {connectionId, prefix} = DataPrepBrowserStore.getState().s3;
     let activeBucket = prefix;
-    if (prefix.length > 1 && prefix[prefix.length - 1] === '/') {
-      activeBucket = prefix.slice(0, prefix.length - 1);
+    /**
+     * This is to extract the bucket name from S3 for url param
+     * eg: /bucket-1/folder1/folder2/file.csv
+     * we need /bucket-1 alone for the api request
+     */
+    if (activeBucket.slice(1).split('/').length > 1) {
+      activeBucket = activeBucket.slice(0, activeBucket.slice(1).indexOf('/') + 1);
     }
     setS3Loading();
     let headers = {

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -956,7 +956,7 @@ export default class DataPrepConnections extends Component {
         path = path.slice(0, path.length - 1).join('/');
         let bucketName = workspaceInfo.properties.bucket;
         if (bucketName) {
-          path = `/${bucketName}/${path}/`;
+          path = !isNilOrEmpty(path) ? `/${bucketName}/${path}/` : `/${bucketName}`;
         } else {
           let state = DataPrepBrowserStore.getState();
           path = state.gcs.prefix;


### PR DESCRIPTION
**GCS**
- When the file is at the root level of the bucket the path we construct to show the data while in dataprep is incorrect. 
- This is to check if we have a path, since root level files won't have a path but just the file name

**S3**
- Fix extracting active bucket for S3 while reading a file.

JIRA: 
https://issues.cask.co/browse/CDAP-14391
https://issues.cask.co/browse/CDAP-14396

Build:
https://builds.cask.co/browse/CDAP-URUT119