### PR TITLE
CDAP-14395 create dataproc clusters with all api access

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -149,6 +149,7 @@ public class DataprocClient implements AutoCloseable {
 
       GceClusterConfig.Builder clusterConfig = GceClusterConfig.newBuilder()
         .setNetworkUri(conf.getNetwork())
+        .addServiceAccountScopes("https://www.googleapis.com/auth/cloud-platform")
         .setZoneUri(conf.getZone())
         .putAllMetadata(metadata);
       for (String targetTag : getFirewallTargetTags()) {


### PR DESCRIPTION
This change will ensure that the dataproc cluster will have
access to any cloud API that the default compute service account
has access to. This will make the Spanner and PubSub plugins
work out of the box.