### PR TITLE
[CDAP-14413] Makes Hub and Add Entity modal headers consistent with other modals

### DIFF
--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/ProductDropdown.scss
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/ProductDropdown.scss
@@ -16,7 +16,7 @@
 @import '~styles/variables.scss';
 
 $dropdown_divider_bg_color: $grey-06;
-$product-dropdown-border-color: $grey-02;
+$product-dropdown-border-color: $grey-04;
 
 #product-dropdown {
   border-left: 1px solid $product-dropdown-border-color;

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.scss
@@ -16,7 +16,7 @@
 
 @import "~styles/variables.scss";
 $namespace-action-bg: #d8d8d8;
-$dropdown-border-color: $grey-02;
+$dropdown-border-color: $grey-04;
 $namespace-dropdown-color: $grey-08;
 $current-namespace-hover-bg: $cdap-white-light;
 $namespace-hover-bg: #9b9b9b;

--- a/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.scss
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.scss
@@ -104,9 +104,7 @@ $sidepanel-width: 160px;
         }
       }
       .modal-header {
-        height: 52px;
         padding: 10px 8px;
-        background: $navbar-bg;
         color: white;
         fill: white;
         border-bottom: 0;

--- a/cdap-ui/app/cdap/components/PlusButtonModal/index.js
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/index.js
@@ -73,7 +73,7 @@ export default class PlusButtonModal extends Component {
       <Modal
         isOpen={this.props.isOpen}
         toggle={this.closeHandler.bind(this)}
-        className={classnames("plus-button-modal", {
+        className={classnames("plus-button-modal cdap-modal", {
           "cask-market": this.state.viewMode === 'marketplace',
           "add-entity-modal": this.state.viewMode === 'resourcecenter'
         })}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14413

This PR makes Hub and Add Entity modal headers to be the same as other modals, by applying the 'cdap-modal' class. Also removed the special casing of `height: 52px` and `background: $navbar-bg`.