### PR TITLE
[CDAP-14416] Fixes KeyvaluePairs component to update properly on user interaction

### DIFF
--- a/cdap-ui/app/cdap/components/KeyValuePairs/KeyValuePair.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/KeyValuePair.js
@@ -138,6 +138,11 @@ class KeyValuePair extends Component {
     );
   }
 
+  getResettedKeyValue = (index, e) => {
+    this.props.getResettedKeyValue(index);
+    preventPropagation(e);
+  };
+
   renderProvidedCheckboxAndResetBtn() {
     if (typeof this.props.provided !== 'boolean') {
       return null;
@@ -152,7 +157,7 @@ class KeyValuePair extends Component {
         />
         <span
           className={classnames("reset-action", {"hidden": !this.props.showReset})}
-          onClick={this.props.getResettedKeyValue.bind(this, this.props.index)}
+          onClick={this.getResettedKeyValue.bind(this, this.props.index)}
         >
           {T.translate('commons.keyValPairs.reset')}
         </span>

--- a/cdap-ui/app/cdap/components/KeyValuePairs/index.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/index.js
@@ -33,6 +33,7 @@ import KeyValueStore from './KeyValueStore';
 import KeyValueStoreActions from './KeyValueStoreActions';
 import KeyValuePair from './KeyValuePair';
 import {objectQuery} from 'services/helpers';
+import cloneDeep from 'lodash/cloneDeep';
 
 // Prop Name is used in place of the reserved prop 'key'
 const mapStateToFieldNameProps = (state, ownProps) => {
@@ -95,7 +96,7 @@ export default class KeyValuePairs extends Component {
     super(props);
     var { keyValues } = props;
     this.state = {
-      pairs: [...keyValues.pairs]
+      pairs: cloneDeep(keyValues.pairs)
     };
     KeyValueStore.dispatch({
       type: KeyValueStoreActions.onUpdate,
@@ -120,9 +121,11 @@ export default class KeyValuePairs extends Component {
     });
   }
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      pairs: [...nextProps.keyValues.pairs]
-    });
+    if (nextProps.keyValues.pairs.length !== this.state.pairs.length) {
+      this.setState({
+        pairs: [...nextProps.keyValues.pairs]
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
**Problem**
- Source of the problem seems to be when we removed `shouldComponentUpdate` react lifecycle function in this PR 
https://github.com/caskdata/cdap/commit/2463bccde2e56a4571cddbba4408e4163a504e67#diff-0d7d30f4387615503bfa64e71d68c4b9L114
- This made the component update everytime there was an update which took the focus away.

**Solution**
- Update the wrapper component on `componentWillReceiveProps` only when there is a new entry to the key value pairs
- This way the individual values directly update the store and doesn't update the wrapper.

JIRA: https://issues.cask.co/browse/CDAP-14416
Build: https://builds.cask.co/browse/CDAP-URUT126