### PR TITLE
CDAP-14433 change kafka log level sandbox

### DIFF
--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -61,6 +61,7 @@
 
 
   <logger name="WriteAheadLogManager " level="WARN"/>
+  <logger name="org.apache.kafka" level="INFO"/>
   <logger name="org.apache.kafka.common.config.AbstractConfig" level="WARN"/>
 
   <!-- HttpRequestLog is not used and expects log4j logging or logs a WARN message -->


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14433

Kafka will generate a lot of DEBUG messages when it cannot connect to broker, which can generate several thousands of messages in minutes, we should suppress the logs