### PR TITLE
[CDAP-14439] Minor styling fixes in CDAP UI

### DIFF
--- a/cdap-ui/app/cdap/components/AuthRefresher/AuthRefresher.scss
+++ b/cdap-ui/app/cdap/components/AuthRefresher/AuthRefresher.scss
@@ -14,16 +14,9 @@
  * the License.
  */
 
-import * as React from 'react';
-require('./AuthRefresher.scss');
-
-const AuthRefresher: React.SFC = () => {
-  const url = (window as any).CDAP_CONFIG.authRefreshURL;
-  if (url === false) { return null; }
-
-  return (
-    <iframe src={url} className="auth-refresher" />
-  );
-};
-
-export default AuthRefresher;
+.auth-refresher {
+  width: 0;
+  height: 0;
+  border: 0;
+  position: absolute;
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/BigQueryBrowser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/BigQueryBrowser.scss
@@ -28,12 +28,6 @@ $content-font-color: $grey-01;
 
   .row { margin: 0; }
 
-  .top-panel,
-  .list-view-container {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-
   .list-view-container {
     display: grid;
     grid-template-rows: $browser-list-subpanel-line-height calc(100% - #{$browser-list-subpanel-line-height});

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/DatabaseBrowser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/DatabaseBrowser.scss
@@ -29,7 +29,9 @@ $content-font-color: #333333;
     padding-right: 15px;
   }
 
-  .database-browser-content { height: calc(100% - 56px - 46px); }
+  .database-browser-content {
+    height: calc(100% - 50px - 39px);
+  }
 
   .database-content-table {
     padding: 0;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/GCSBrowser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/GCSBrowser.scss
@@ -28,7 +28,7 @@ $gcs_file_icon_color: $blue-03;
   height: 100%;
 
   .gcs-content {
-    height: calc(100% - 56px - 46px);
+    height: calc(100% - 50px - 39px);
     > div {
       height: 100%;
     }

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/S3Browser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/S3Browser.scss
@@ -28,7 +28,7 @@ $s3_file_icon_color: $blue-03;
   height: 100%;
 
   .s3-content {
-    height: calc(100% - 56px - 46px);
+    height: calc(100% - 50px - 39px);
     > div {
       height: 100%;
     }

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/SpannerBrowser/SpannerBrowser.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/SpannerBrowser/SpannerBrowser.scss
@@ -30,12 +30,6 @@ $instance-fill-color: $blue-02;
 
   .row { margin: 0; }
 
-  .top-panel,
-  .list-view-container {
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-
   .list-view-container {
     display: grid;
     grid-template-rows: $browser-list-subpanel-line-height calc(100% - #{$browser-list-subpanel-line-height});

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DataPrepConnections.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DataPrepConnections.scss
@@ -125,9 +125,9 @@ $info-font-color: $grey-03;
     width: calc(100% - 250px);
 
     .sub-panel {
-      line-height: $browser-list-subpanel-line-height;
-      padding: 0 10px;
+      padding: 4px 10px;
       display: flex;
+      align-items: center;
       .path-container,
       .info-container {
         width: 50%;
@@ -167,6 +167,10 @@ $info-font-color: $grey-03;
           color: $info-font-color;
           text-align: right;
           padding-right: 5px;
+          overflow: hidden;
+          word-break: inherit;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
         .search-container {
           flex: 0.3;

--- a/cdap-ui/app/cdap/components/FileBrowser/FileBrowser.scss
+++ b/cdap-ui/app/cdap/components/FileBrowser/FileBrowser.scss
@@ -34,7 +34,7 @@ $empty-message-link-color: var(--brand-primary-color);
 
   .directory-content-table {
     padding: 0;
-    height: calc(100% - 50px - 51px);
+    height: calc(100% - 50px - 39px);
 
     .row { margin: 0; }
 

--- a/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/FilePath/index.js
@@ -127,8 +127,12 @@ export default class FilePath extends Component {
   }
 
   renderBreadcrumb(links) {
+    let pathsTitle = links.map(path => path.name).join('/') || '';
     return (
-      <div className="paths">
+      <div
+        className="paths"
+        title={pathsTitle}
+      >
         {
           links.map((path, index) => {
             return (

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -513,7 +513,10 @@ export default class FileBrowser extends Component {
             />
           </div>
 
-          <div className="info-container">
+          <div
+            className="info-container"
+            title={T.translate(`${PREFIX}.TopPanel.directoryMetrics`, {count: this.state.contents.length})}
+          >
             <div className="info">
               <span>
                 {T.translate(`${PREFIX}.TopPanel.directoryMetrics`, {count: this.state.contents.length})}

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsTopPanel.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsTopPanel.scss
@@ -19,12 +19,13 @@
 $pipeline-type-icon-size: 20px;
 $top-panel-height: 55px;
 $btn-border-color: transparent;
+$toppanel-border-bottom-color: $grey-05;
 
 .pipeline-details-top-panel {
   height: $top-panel-height;
   background-color: white;
   color: $grey-02;
-  border-bottom: 1px solid $grey-06;
+  border-bottom: 1px solid $toppanel-border-bottom-color;
   z-index: 999;
   width: 100%;
   display: grid;
@@ -88,6 +89,7 @@ $btn-border-color: transparent;
       position: relative;
       height: 100%;
       border-left: 1px solid $btn-border-color;
+      border-bottom: 1px solid $btn-border-color;
 
       &.active,
       &:hover {
@@ -162,7 +164,7 @@ $btn-border-color: transparent;
       }
 
       &:after {
-        @include border-element(61px);
+        @include border-element(67px);
       }
     }
 

--- a/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraph.js
+++ b/cdap-ui/app/cdap/components/PipelineNodeGraphs/NodeMetricsGraph.js
@@ -179,7 +179,7 @@ export default class NodeMetricsGraph extends Component {
         .map(key => {
           let dataToPlot = data[key].data;
           if (!dataToPlot || !dataToPlot.length) {
-            dataToPlot = this.dummyData;
+            return null;
           }
           return (
             <AreaSeries
@@ -218,6 +218,9 @@ export default class NodeMetricsGraph extends Component {
         .keys(data)
         .filter(key => this.state.dataToShow.indexOf(data[key].label) !== -1)
         .map(key => {
+          if (Array.isArray(data[key].data) && !data[key].data.length) {
+            return null;
+          }
           return (
             <LineMarkSeries
               color={data[key].color || metricTypeToColorMap[metricType]}

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -66,9 +66,7 @@ body.theme-cdap {
 
       div.btn {
         .cask-btn(@border: 0, @border-radius: 0, @color: #666, @padding: 3px 0);
-        border-top: 1px solid transparent;
         border-right: 1px solid transparent;
-        border-bottom: 1px solid transparent;
         transition: all 0.2s ease;
         width: 60px;
         margin-left: 0;
@@ -117,8 +115,6 @@ body.theme-cdap {
         &:focus,
         &.btn-select {
           background-color: #ebebeb;
-          border-top: 1px solid #ebebeb;
-          border-bottom: 1px solid #ebebeb;
         }
         &:active {
           background-color: #828da0;


### PR DESCRIPTION
- Fix one pixel gap on top when hovering over logs and runtime args in pipeline detailed view.
- Fix One pixel gap to the top and bottom on preview and configure buttons when the user goes to lower resolution on the page (CTRL + ++)
- Don't show weird scroll bars in dataprep when it is not required. This is introduced from the iframe we inject based on auth environment. Which causes the app-container to scroll. This was seen in dataprep very evidently.
- Fix dataprep browser top panel (search text and breadcrumb) not overflow and push contents.
- Remove showing weird error lines in plugin metrics graph where there is no data for error records in the plugin
- Adds border bottom to pipeline action buttons to not jump on hover.

JIRA: https://issues.cask.co/browse/CDAP-14439
Build: https://builds.cask.co/browse/CDAP-URUT136