### PR TITLE
[CDAP-14441] Fixes pipeline properties to be stored as strings

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/CustomConfig.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/ConfigurationsContent/EngineConfigTabContent/CustomConfig.js
@@ -23,6 +23,7 @@ import Popover from 'components/Popover';
 import {getEngineDisplayLabel, ACTIONS as PipelineConfigurationsActions} from 'components/PipelineConfigurations/Store';
 import {convertKeyValuePairsObjToMap} from 'components/KeyValuePairs/KeyValueStoreActions';
 import T from 'i18n-react';
+import isEmpty from 'lodash/isEmpty';
 
 const PREFIX = 'features.PipelineConfigurations.EngineConfig';
 
@@ -69,6 +70,9 @@ const mapStateToCustomConfigProps = (state, ownProps) => {
 
 const CustomConfig = ({isDetailView, isBatch, showCustomConfig, toggleCustomConfig, engine, customConfigKeyValuePairs}) => {
   let engineDisplayLabel = getEngineDisplayLabel(engine, isBatch);
+  let numberOfCustomConfigFilled = customConfigKeyValuePairs.pairs
+    .filter(pair => !isEmpty(pair.key) && !isEmpty(pair.value))
+    .length;
 
   const StudioViewCustomConfigLabel = () => {
     return (
@@ -92,8 +96,8 @@ const CustomConfig = ({isDetailView, isBatch, showCustomConfig, toggleCustomConf
             (
               <span>
                 <span className="float-xs-right num-rows">
-                  {`${customConfigKeyValuePairs.pairs.length}`}
-                  {T.translate(`${PREFIX}.customConfigCount`, {context: customConfigKeyValuePairs.pairs.length})}
+                  {`${numberOfCustomConfigFilled}`}
+                  {T.translate(`${PREFIX}.customConfigCount`, {context: numberOfCustomConfigFilled})}
                 </span>
                 <hr />
               </span>
@@ -119,7 +123,7 @@ const CustomConfig = ({isDetailView, isBatch, showCustomConfig, toggleCustomConf
             {T.translate(`${PREFIX}.customConfigTooltip`, {engineDisplayLabel})}
           </Popover>
           <span className="float-xs-right num-rows">
-            {T.translate(`${PREFIX}.customConfigCount`, {context: customConfigKeyValuePairs.pairs.length})}
+            {T.translate(`${PREFIX}.customConfigCount`, {context: numberOfCustomConfigFilled})}
           </span>
         </div>
       </div>

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -153,6 +153,11 @@ const updatePipeline = () => {
     maxConcurrentRuns,
   } = PipelineConfigurationsStore.getState();
 
+  properties = Object.keys(properties)
+    .reduce(
+      (obj, key) => (obj[key] = properties[key].toString(), obj),
+      {}
+    );
   let commonConfig = {
     stages,
     connections,

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -64,6 +64,13 @@ export default class PipelineDetailsActionsButton extends Component {
     });
   };
 
+  componentWillReceiveProps(nextProps) {
+    this.pipelineConfig = {
+      ...this.pipelineConfig,
+      config: nextProps.config
+    };
+  }
+
   pipelineConfig = {
     name: this.props.pipelineName,
     description: this.props.description,

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
@@ -48,13 +48,21 @@ const mapStateToButtonsProps = (state) => {
 const ConnectedPipelineDetailsButtons = connect(mapStateToButtonsProps)(PipelineDetailsButtons);
 
 export default class PipelineDetailsTopPanel extends Component {
-  componentWillMount() {
+  componentDidMount() {
+    const pipelineDetailStore = PipelineDetailStore.getState();
+    const pipelineDetailStoreConfig = pipelineDetailStore.config;
+    PipelineConfigurationsStore.dispatch({
+      type: PipelineConfigurationsActions.SET_PIPELINE_VISUAL_CONFIGURATION,
+      payload: {
+        pipelineVisualConfiguration: {
+          isBatch: pipelineDetailStore.artifact.name === GLOBALS.etlDataPipeline
+        }
+      }
+    });
     PipelineConfigurationsStore.dispatch({
       type: PipelineConfigurationsActions.INITIALIZE_CONFIG,
-      payload: {...PipelineDetailStore.getState().config}
+      payload: {...pipelineDetailStoreConfig}
     });
-  }
-  componentDidMount() {
     fetchAndUpdateRuntimeArgs();
   }
   render() {

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
@@ -79,6 +79,10 @@ class MyBatchPipelineConfigCtrl {
     this.updatePipelineEditStatus();
   }
 
+  numOfCustomEngineConfigFilled() {
+    return this.customEngineConfig.pairs.filter(pair => !_.isEmpty(pair.key) && !_.isEmpty(pair.value)).length;
+  }
+
   onEngineChange() {
     this.engineForDisplay = this.engine === 'mapreduce' ? 'MapReduce' : 'Apache Spark Streaming';
   }

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
@@ -251,9 +251,9 @@
             </i>
             <span class="float-xs-right num-rows"
                   ng-if="BatchPipelineConfigCtrl.showCustomConfig">
-                {{ BatchPipelineConfigCtrl.customEngineConfig.pairs.length }}
+                {{ BatchPipelineConfigCtrl.numOfCustomEngineConfigFilled() }}
               <ng-pluralize
-                count="BatchPipelineConfigCtrl.customEngineConfig.pairs.length"
+                count="BatchPipelineConfigCtrl.numOfCustomEngineConfigFilled()"
                 when="{'one': 'custom config',
                       'other': 'custom configs'}">
               </ng-pluralize>

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config-ctrl.js
@@ -107,6 +107,10 @@ class MyRealtimePipelineConfigCtrl {
     this.updatePipelineEditStatus();
   }
 
+  numOfCustomEngineConfigFilled() {
+    return this.customEngineConfig.pairs.filter(pair => !_.isEmpty(pair.key) && !_.isEmpty(pair.value)).length;
+  }
+
   applyConfig() {
     this.applyRuntimeArguments();
     this.store.setBackpressure(this.backpressure);

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config.html
@@ -284,9 +284,9 @@
             </i>
             <span class="float-xs-right num-rows"
                   ng-if="RealtimePipelineConfigCtrl.showCustomConfig">
-                {{ RealtimePipelineConfigCtrl.customEngineConfig.pairs.length }}
+                {{ RealtimePipelineConfigCtrl.numOfCustomEngineConfigFilled() }}
               <ng-pluralize
-                count="RealtimePipelineConfigCtrl.customEngineConfig.pairs.length"
+                count="RealtimePipelineConfigCtrl.numOfCustomEngineConfigFilled()"
                 when="{'one': 'custom config',
                       'other': 'custom configs'}">
               </ng-pluralize>
@@ -301,9 +301,9 @@
                  tooltip-placement="right">
               </i>
               <span class="float-xs-right num-rows">
-                  {{ RealtimePipelineConfigCtrl.customEngineConfig.pairs.length }}
+                  {{ RealtimePipelineConfigCtrl.numOfCustomEngineConfigFilled() }}
                 <ng-pluralize
-                  count="RealtimePipelineConfigCtrl.customEngineConfig.pairs.length"
+                  count="RealtimePipelineConfigCtrl.numOfCustomEngineConfigFilled()"
                   when="{'one': 'custom config',
                         'other': 'custom configs'}">
                 </ng-pluralize>

--- a/cdap-ui/app/hydrator/controllers/list-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/list-ctrl.js
@@ -184,8 +184,8 @@ angular.module(PKG.name + '.feature.hydrator')
                     latestRun.end - latestRun.starting
                   :
                     (new Date().getTime() / 1000) - latestRun.starting;
+                  latestRun.duration = window.CaskCommon.CDAPHelpers.humanReadableDuration(Math.round(latestRun.duration));
                 }
-                latestRun.duration = window.CaskCommon.CDAPHelpers.humanReadableDuration(Math.round(latestRun.duration));
                 app = Object.assign({}, app, {
                   latestRun: latestRun
                 });

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -432,16 +432,20 @@ class HydratorPlusPlusConfigStore {
       this.getEngine() === window.CaskCommon.PipelineConfigConstants.ENGINE_OPTIONS.SPARK ||
       this.state.artifact.name === this.GLOBALS.etlDataStreams
     ) {
-      this.state.config.properties[numExecutorKey] = this.state.config.properties[numExecutorKey] || 1;
       if (this.state.config.properties.hasOwnProperty(numExecutorOldKey)) {
         // format on standalone is 'local[{number}] === local[2]'
         // So the magic number 6 here is for skipping 'local[' and get the number
         let numOfExecutors = this.state.config.properties[numExecutorOldKey];
-        numOfExecutors = typeof numOfExecutors === 'string' ? numOfExecutors.substring(6, numOfExecutors.length - 1) : numOfExecutors;
+        numOfExecutors = typeof numOfExecutors === 'string' ? numOfExecutors.substring(6, numOfExecutors.length - 1) : numOfExecutors.toString();
         this.state.config.properties[numExecutorKey] = numOfExecutors;
         delete this.state.config.properties[numExecutorOldKey];
       }
     }
+    this.state.config.properties = Object.keys(this.state.config.properties)
+      .reduce(
+        (obj, key) => (obj[key] = this.state.config.properties[key].toString(), obj),
+        {}
+      );
   }
   getCustomConfig() {
     let customConfig = {};


### PR DESCRIPTION
- Converts all pipeline properties to be strings before publishing/updating the pipeline
- Fixes pipeline detailed view to actually show the custom config. Right now UI doesn't show it for batch pipelines running in spark.
- Fixes custom config count to update only when the user enters both key and value
- Fixes pipelines list view to show `--` instead `0 sec` for deployed pipelines. This is to be consistent with pipeline detailed view.

JIRA: https://issues.cask.co/browse/CDAP-14441
Build: https://builds.cask.co/browse/CDAP-URUT138