### PR TITLE
CDAP-13554 | CDAP-13982 | Pipelines with many sinks may exceed the Variable substi…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/macro/Macros.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/macro/Macros.java
@@ -18,6 +18,7 @@ package co.cask.cdap.api.macro;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -44,5 +45,33 @@ public class Macros implements Serializable {
 
   public Set<MacroFunction> getMacroFunctions() {
     return macroFunctions;
+  }
+  
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Macros macros = (Macros) o;
+
+    return Objects.equals(lookupProperties, macros.lookupProperties) &&
+      Objects.equals(macroFunctions, macros.macroFunctions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(lookupProperties, macroFunctions);
+  }
+
+  @Override
+  public String toString() {
+    return "Macros{" +
+      "lookupProperties=" + lookupProperties +
+      ", macroFunctions=" + macroFunctions +
+      '}';
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginProperties.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import javax.annotation.Nullable;
 
 /**
@@ -67,6 +69,31 @@ public class PluginProperties implements Serializable {
    */
   public PluginProperties setMacros(Macros macros) {
     return new PluginProperties(getProperties(), macros);
+  }
+  
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PluginProperties that = (PluginProperties) o;
+    return Objects.equals(properties, that.properties) && Objects.equals(macros, that.macros);
+  }
+
+  @Override
+  public String toString() {
+    return "PluginProperties{" +
+      "properties=" + properties +
+      ", macros=" + macros +
+      '}';
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(properties, macros);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -72,7 +72,7 @@ public final class MapReduceContextConfig {
   private static final String HCONF_ATTR_APP_SPEC = "cdap.mapreduce.app.spec";
   private static final String HCONF_ATTR_PROGRAM_ID = "cdap.mapreduce.program.id";
   private static final String HCONF_ATTR_WORKFLOW_INFO = "cdap.mapreduce.workflow.info";
-  public static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
+  static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
   private static final String HCONF_ATTR_PROGRAM_JAR_URI = "cdap.mapreduce.program.jar.uri";
   private static final String HCONF_ATTR_CCONF = "cdap.mapreduce.cconf";
   private static final String HCONF_ATTR_LOCAL_FILES = "cdap.mapreduce.local.files";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -183,7 +183,7 @@ public final class MapReduceContextConfig {
    * Returns the plugins being used in the MapReduce program.
    */
   public Map<String, Plugin> getPlugins() {
-    String spec = hConf.get(HCONF_ATTR_PLUGINS);
+    String spec = hConf.getRaw(HCONF_ATTR_PLUGINS);
     if (spec == null) {
       return ImmutableMap.of();
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -72,7 +72,7 @@ public final class MapReduceContextConfig {
   private static final String HCONF_ATTR_APP_SPEC = "cdap.mapreduce.app.spec";
   private static final String HCONF_ATTR_PROGRAM_ID = "cdap.mapreduce.program.id";
   private static final String HCONF_ATTR_WORKFLOW_INFO = "cdap.mapreduce.workflow.info";
-  private static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
+  public static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
   private static final String HCONF_ATTR_PROGRAM_JAR_URI = "cdap.mapreduce.program.jar.uri";
   private static final String HCONF_ATTR_CCONF = "cdap.mapreduce.cconf";
   private static final String HCONF_ATTR_LOCAL_FILES = "cdap.mapreduce.local.files";

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
@@ -15,7 +15,6 @@
  */
 
 package co.cask.cdap.internal.app.runtime.batch;
-
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.artifact.ArtifactScope;
@@ -24,50 +23,107 @@ import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.DefaultApplicationSpecification;
+import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
+import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+
 
 /**
  */
 public class MapReduceContextConfigTest {
 
-  @Test
-  public void testManyMacrosInAppSpec() {
-    Configuration hConf = new Configuration();
-    MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
-    StringBuilder appCfg = new StringBuilder();
-    for (int i = 0; i < 100; i++) {
-      appCfg.append("${").append(i).append("}");
-      hConf.setInt(String.valueOf(i), i);
-    }
-    ApplicationSpecification appSpec = new DefaultApplicationSpecification(
-      "name", "desc", appCfg.toString(),
-      new ArtifactId("artifact", new ArtifactVersion("1.0.0"), ArtifactScope.USER),
-      Collections.<String, StreamSpecification>emptyMap(),
-      Collections.<String, String>emptyMap(),
-      Collections.<String, DatasetCreationSpec>emptyMap(),
-      Collections.<String, FlowSpecification>emptyMap(),
-      Collections.<String, MapReduceSpecification>emptyMap(),
-      Collections.<String, SparkSpecification>emptyMap(),
-      Collections.<String, WorkflowSpecification>emptyMap(),
-      Collections.<String, ServiceSpecification>emptyMap(),
-      Collections.<String, ScheduleSpecification>emptyMap(),
-      Collections.<String, ScheduleCreationSpec>emptyMap(),
-      Collections.<String, WorkerSpecification>emptyMap(),
-      Collections.<String, Plugin>emptyMap()
-    );
-    cfg.setApplicationSpecification(appSpec);
-    Assert.assertEquals(appSpec.getConfiguration(), cfg.getApplicationSpecification().getConfiguration());
+    private static final Type PLUGIN_MAP_TYPE = new TypeToken<Map<String, Plugin>>() { }.getType();
+    private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
+            .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
+            .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec()).create();
+    private static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
+
+    @Test
+    public void testManyMacrosInAppSpec() {
+        Configuration hConf = new Configuration();
+        MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
+        StringBuilder appCfg = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            appCfg.append("${").append(i).append("}");
+            hConf.setInt(String.valueOf(i), i);
+        }
+        ApplicationSpecification appSpec = 
+           new DefaultApplicationSpecification("name", "desc", appCfg.toString(),
+           new ArtifactId("artifact", 
+           new ArtifactVersion("1.0.0"), ArtifactScope.USER),
+           Collections.<String, StreamSpecification>emptyMap(), 
+           Collections.<String, String>emptyMap(),
+           Collections.<String, DatasetCreationSpec>emptyMap(), 
+           Collections.<String, FlowSpecification>emptyMap(),
+           Collections.<String, MapReduceSpecification>emptyMap(),
+           Collections.<String, SparkSpecification>emptyMap(),
+           Collections.<String, WorkflowSpecification>emptyMap(),
+           Collections.<String, ServiceSpecification>emptyMap(),
+           Collections.<String, ScheduleSpecification>emptyMap(),
+           Collections.<String, ScheduleCreationSpec>emptyMap(),
+           Collections.<String, WorkerSpecification>emptyMap(), 
+           Collections.<String, Plugin>emptyMap());
+           cfg.setApplicationSpecification(appSpec);
+           Assert.assertEquals(appSpec.getConfiguration(), 
+           cfg.getApplicationSpecification().getConfiguration());
+     }
+
+@Test
+public void testGetPluginsWithMacrosMoreThan20() {
+  Configuration hConf = new Configuration();
+  MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
+  Map<String, Plugin> mockPlugins = new HashMap<String, Plugin>();
+  ArtifactId artifactId = new ArtifactId("plugins", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM);
+  Map<String, String> properties = new HashMap<String, String>();
+  properties.put("path",
+      "${input.directory}/${a}${b}${c}${d}${e}${f}${g}${h}${i}${j}"
+       + "${k}${l}${m}${n}${o}${p}${q}${r}${s}${t}${u}${v}${w}${x}${y}${z}.txt");
+  hConf.set("input.directory", "/dummy/path");
+  String[] alphabetsArr = { "a", "b", "c", "d", "e", "f", "g", "h",
+      "i", "j", "k", "l", "m", "n", "o", "p", "q",
+      "r", "s", "t", "u", "v", "w", "x", "y", "z" };
+  for (String alphabet : alphabetsArr) {
+     hConf.set(alphabet, alphabet);
   }
+  LinkedHashSet<ArtifactId> parents = new LinkedHashSet<>();
+  Plugin filePlugin1 = new Plugin(parents, artifactId,
+     new PluginClass("type", "name", "desc", "clsname", "cfgfield",
+  ImmutableMap.<String, PluginPropertyField>of()),
+     PluginProperties.builder().addAll(properties).build());
+
+  mockPlugins.put("File1", filePlugin1);
+  hConf.set(HCONF_ATTR_PLUGINS, GSON.toJson(mockPlugins, PLUGIN_MAP_TYPE));
+
+  Map<String, Plugin> plugins = cfg.getPlugins();
+  Assert.assertEquals(plugins.size(), 1);
+ }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
@@ -32,16 +32,10 @@ import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
-import co.cask.cdap.app.runtime.Arguments;
-import co.cask.cdap.app.runtime.ProgramOptions;
-import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.DefaultApplicationSpecification;
-import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
-import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,9 +51,7 @@ import java.util.Set;
  */
 public class MapReduceContextConfigTest {
 
-  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
-    .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
-    .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec()).create();
+  private static final Gson GSON = new Gson();
 
   @Test
   public void testManyMacrosInAppSpec() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
@@ -40,14 +40,12 @@ import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -59,12 +57,9 @@ import java.util.Set;
  */
 public class MapReduceContextConfigTest {
 
-  private static final Type PLUGIN_MAP_TYPE = new TypeToken<Map<String, Plugin>>() {
-  }.getType();
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
     .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
     .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec()).create();
-  private static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
 
   @Test
   public void testManyMacrosInAppSpec() {
@@ -75,25 +70,24 @@ public class MapReduceContextConfigTest {
       appCfg.append("${").append(i).append("}");
       hConf.setInt(String.valueOf(i), i);
     }
-    ApplicationSpecification appSpec =
-      new DefaultApplicationSpecification("name", "desc", appCfg.toString(),
-                                          new ArtifactId("artifact",
-                                                         new ArtifactVersion("1.0.0"), ArtifactScope.USER),
-                                          Collections.<String, StreamSpecification>emptyMap(),
-                                          Collections.<String, String>emptyMap(),
-                                          Collections.<String, DatasetCreationSpec>emptyMap(),
-                                          Collections.<String, FlowSpecification>emptyMap(),
-                                          Collections.<String, MapReduceSpecification>emptyMap(),
-                                          Collections.<String, SparkSpecification>emptyMap(),
-                                          Collections.<String, WorkflowSpecification>emptyMap(),
-                                          Collections.<String, ServiceSpecification>emptyMap(),
-                                          Collections.<String, ScheduleSpecification>emptyMap(),
-                                          Collections.<String, ScheduleCreationSpec>emptyMap(),
-                                          Collections.<String, WorkerSpecification>emptyMap(),
-                                          Collections.<String, Plugin>emptyMap());
+    ApplicationSpecification appSpec = new DefaultApplicationSpecification(
+      "name", "desc", appCfg.toString(),
+      new ArtifactId("artifact", new ArtifactVersion("1.0.0"), ArtifactScope.USER),
+      Collections.<String, StreamSpecification>emptyMap(),
+      Collections.<String, String>emptyMap(),
+      Collections.<String, DatasetCreationSpec>emptyMap(),
+      Collections.<String, FlowSpecification>emptyMap(),
+      Collections.<String, MapReduceSpecification>emptyMap(),
+      Collections.<String, SparkSpecification>emptyMap(),
+      Collections.<String, WorkflowSpecification>emptyMap(),
+      Collections.<String, ServiceSpecification>emptyMap(),
+      Collections.<String, ScheduleSpecification>emptyMap(),
+      Collections.<String, ScheduleCreationSpec>emptyMap(),
+      Collections.<String, WorkerSpecification>emptyMap(),
+      Collections.<String, Plugin>emptyMap()
+    );
     cfg.setApplicationSpecification(appSpec);
-    Assert.assertEquals(appSpec.getConfiguration(),
-                        cfg.getApplicationSpecification().getConfiguration());
+    Assert.assertEquals(appSpec.getConfiguration(), cfg.getApplicationSpecification().getConfiguration());
   }
 
   @Test
@@ -120,9 +114,9 @@ public class MapReduceContextConfigTest {
                                     PluginProperties.builder().addAll(properties).build());
 
     mockPlugins.put("File1", filePlugin1);
-    hConf.set(HCONF_ATTR_PLUGINS, GSON.toJson(mockPlugins, PLUGIN_MAP_TYPE));
+    hConf.set(MapReduceContextConfig.HCONF_ATTR_PLUGINS, GSON.toJson(mockPlugins));
 
     Map<String, Plugin> plugins = cfg.getPlugins();
-    Assert.assertEquals(plugins.size(), 1);
+    Assert.assertEquals(plugins, mockPlugins);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
@@ -15,6 +15,7 @@
  */
 
 package co.cask.cdap.internal.app.runtime.batch;
+
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.artifact.ArtifactScope;
@@ -39,12 +40,9 @@ import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
-
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -54,76 +52,77 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
-
+import java.util.Set;
 
 
 /**
  */
 public class MapReduceContextConfigTest {
 
-    private static final Type PLUGIN_MAP_TYPE = new TypeToken<Map<String, Plugin>>() { }.getType();
-    private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
-            .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
-            .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec()).create();
-    private static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
+  private static final Type PLUGIN_MAP_TYPE = new TypeToken<Map<String, Plugin>>() {
+  }.getType();
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
+    .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
+    .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec()).create();
+  private static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
 
-    @Test
-    public void testManyMacrosInAppSpec() {
-        Configuration hConf = new Configuration();
-        MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
-        StringBuilder appCfg = new StringBuilder();
-        for (int i = 0; i < 100; i++) {
-            appCfg.append("${").append(i).append("}");
-            hConf.setInt(String.valueOf(i), i);
-        }
-        ApplicationSpecification appSpec = 
-           new DefaultApplicationSpecification("name", "desc", appCfg.toString(),
-           new ArtifactId("artifact", 
-           new ArtifactVersion("1.0.0"), ArtifactScope.USER),
-           Collections.<String, StreamSpecification>emptyMap(), 
-           Collections.<String, String>emptyMap(),
-           Collections.<String, DatasetCreationSpec>emptyMap(), 
-           Collections.<String, FlowSpecification>emptyMap(),
-           Collections.<String, MapReduceSpecification>emptyMap(),
-           Collections.<String, SparkSpecification>emptyMap(),
-           Collections.<String, WorkflowSpecification>emptyMap(),
-           Collections.<String, ServiceSpecification>emptyMap(),
-           Collections.<String, ScheduleSpecification>emptyMap(),
-           Collections.<String, ScheduleCreationSpec>emptyMap(),
-           Collections.<String, WorkerSpecification>emptyMap(), 
-           Collections.<String, Plugin>emptyMap());
-           cfg.setApplicationSpecification(appSpec);
-           Assert.assertEquals(appSpec.getConfiguration(), 
-           cfg.getApplicationSpecification().getConfiguration());
-     }
-
-@Test
-public void testGetPluginsWithMacrosMoreThan20() {
-  Configuration hConf = new Configuration();
-  MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
-  Map<String, Plugin> mockPlugins = new HashMap<String, Plugin>();
-  ArtifactId artifactId = new ArtifactId("plugins", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM);
-  Map<String, String> properties = new HashMap<String, String>();
-  properties.put("path",
-      "${input.directory}/${a}${b}${c}${d}${e}${f}${g}${h}${i}${j}"
-       + "${k}${l}${m}${n}${o}${p}${q}${r}${s}${t}${u}${v}${w}${x}${y}${z}.txt");
-  hConf.set("input.directory", "/dummy/path");
-  String[] alphabetsArr = { "a", "b", "c", "d", "e", "f", "g", "h",
-      "i", "j", "k", "l", "m", "n", "o", "p", "q",
-      "r", "s", "t", "u", "v", "w", "x", "y", "z" };
-  for (String alphabet : alphabetsArr) {
-     hConf.set(alphabet, alphabet);
+  @Test
+  public void testManyMacrosInAppSpec() {
+    Configuration hConf = new Configuration();
+    MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
+    StringBuilder appCfg = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      appCfg.append("${").append(i).append("}");
+      hConf.setInt(String.valueOf(i), i);
+    }
+    ApplicationSpecification appSpec =
+      new DefaultApplicationSpecification("name", "desc", appCfg.toString(),
+                                          new ArtifactId("artifact",
+                                                         new ArtifactVersion("1.0.0"), ArtifactScope.USER),
+                                          Collections.<String, StreamSpecification>emptyMap(),
+                                          Collections.<String, String>emptyMap(),
+                                          Collections.<String, DatasetCreationSpec>emptyMap(),
+                                          Collections.<String, FlowSpecification>emptyMap(),
+                                          Collections.<String, MapReduceSpecification>emptyMap(),
+                                          Collections.<String, SparkSpecification>emptyMap(),
+                                          Collections.<String, WorkflowSpecification>emptyMap(),
+                                          Collections.<String, ServiceSpecification>emptyMap(),
+                                          Collections.<String, ScheduleSpecification>emptyMap(),
+                                          Collections.<String, ScheduleCreationSpec>emptyMap(),
+                                          Collections.<String, WorkerSpecification>emptyMap(),
+                                          Collections.<String, Plugin>emptyMap());
+    cfg.setApplicationSpecification(appSpec);
+    Assert.assertEquals(appSpec.getConfiguration(),
+                        cfg.getApplicationSpecification().getConfiguration());
   }
-  LinkedHashSet<ArtifactId> parents = new LinkedHashSet<>();
-  Plugin filePlugin1 = new Plugin(parents, artifactId,
-     new PluginClass("type", "name", "desc", "clsname", "cfgfield",
-  ImmutableMap.<String, PluginPropertyField>of()),
-     PluginProperties.builder().addAll(properties).build());
 
-  mockPlugins.put("File1", filePlugin1);
-  hConf.set(HCONF_ATTR_PLUGINS, GSON.toJson(mockPlugins, PLUGIN_MAP_TYPE));
+  @Test
+  public void testGetPluginsWithMacrosMoreThan20() {
+    Configuration hConf = new Configuration();
+    MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
+    Map<String, Plugin> mockPlugins = new HashMap<String, Plugin>();
+    ArtifactId artifactId = new ArtifactId("plugins", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM);
+    Map<String, String> properties = new HashMap<String, String>();
+    properties.put("path",
+                   "${input.directory}/${a}${b}${c}${d}${e}${f}${g}${h}${i}${j}"
+                     + "${k}${l}${m}${n}${o}${p}${q}${r}${s}${t}${u}${v}${w}${x}${y}${z}.txt");
+    hConf.set("input.directory", "/dummy/path");
+    String[] alphabetsArr = {"a", "b", "c", "d", "e", "f", "g", "h",
+      "i", "j", "k", "l", "m", "n", "o", "p", "q",
+      "r", "s", "t", "u", "v", "w", "x", "y", "z"};
+    for (String alphabet : alphabetsArr) {
+      hConf.set(alphabet, alphabet);
+    }
+    Set<ArtifactId> parents = new LinkedHashSet<>();
+    Plugin filePlugin1 = new Plugin(parents, artifactId,
+                                    new PluginClass("type", "name", "desc", "clsname", "cfgfield",
+                                                    Collections.<String, PluginPropertyField>emptyMap()),
+                                    PluginProperties.builder().addAll(properties).build());
 
-  Map<String, Plugin> plugins = cfg.getPlugins();
-  Assert.assertEquals(plugins.size(), 1);
- }
+    mockPlugins.put("File1", filePlugin1);
+    hConf.set(HCONF_ATTR_PLUGINS, GSON.toJson(mockPlugins, PLUGIN_MAP_TYPE));
+
+    Map<String, Plugin> plugins = cfg.getPlugins();
+    Assert.assertEquals(plugins.size(), 1);
+  }
 }


### PR DESCRIPTION
CDAP-13982 | Pipelines with many sinks may exceed the Variable substitution depth in the Hadoop conf
CDAP-13554 | Malformed json exceptions in Mapreduce context config while deserializing plugins map