### PR TITLE
CDAP-14444 fix structured record serde with delimited strings

### DIFF
--- a/cdap-formats/src/test/java/co/cask/cdap/format/StructuredRecordStringConverterTest.java
+++ b/cdap-formats/src/test/java/co/cask/cdap/format/StructuredRecordStringConverterTest.java
@@ -136,6 +136,20 @@ public class StructuredRecordStringConverterTest {
     assertRecordsEqual(record, recordOfJson);
   }
 
+  @Test
+  public void testDelimitedWithNullsConversion() {
+    Schema schema = Schema.recordOf("x",
+                                    Schema.Field.of("x", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                    Schema.Field.of("y", Schema.nullableOf(Schema.of(Schema.Type.INT))));
+    StructuredRecord record = StructuredRecord.builder(schema).set("x", "abc").build();
+    Assert.assertEquals("abc,", StructuredRecordStringConverter.toDelimitedString(record, ","));
+    Assert.assertEquals(record, StructuredRecordStringConverter.fromDelimitedString("abc,", ",", schema));
+
+    record = StructuredRecord.builder(schema).set("y", 5).build();
+    Assert.assertEquals(",5", StructuredRecordStringConverter.toDelimitedString(record, ","));
+    Assert.assertEquals(record, StructuredRecordStringConverter.fromDelimitedString(",5", ",", schema));
+  }
+
   private StructuredRecord getStructuredRecord(boolean withNullValue) {
     Schema.Field mapField = Schema.Field.of("headers", Schema.mapOf(Schema.of(Schema.Type.STRING),
                                                                     Schema.of(Schema.Type.STRING)));


### PR DESCRIPTION
Fixed null handling for serialization of a StructuredRecord into
a delimited string and deserialization from a delimited string.
The previous behavior would throw a NPE when serializing null
values and would skip null values on deserialization.