### PR TITLE
set cdap-conf default appropriate for cdap context

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1437,11 +1437,17 @@ cdap_sdk() {
 #
 # User-definable variables
 
-# Default CDAP_CONF to /etc/cdap/conf (package default)
-export CDAP_CONF=${CDAP_CONF:-/etc/cdap/conf}
-
 # Set CDAP_HOME
 export CDAP_HOME=$(cdap_home)
+
+# Default CDAP_CONF to either:
+# /etc/cdap/conf (package default), or
+# ${CDAP_HOME}/conf (sandbox default)
+if [[ $(cdap_context) == 'sdk' ]]; then
+  export CDAP_CONF=${CDAP_CONF:-${CDAP_HOME}/conf}
+else
+  export CDAP_CONF=${CDAP_CONF:-/etc/cdap/conf}
+fi
 
 # Make sure HOSTNAME is in the environment
 export HOSTNAME=$(hostname -f)


### PR DESCRIPTION
Previously, `${CDAP_CONF}` would always default to `/etc/cdap/conf`, even for sandbox.  Now, if it detects it is running in sandbox mode, it will instead default `${CDAP_CONF}` to `${CDAP_HOME}/conf` where there is already cdap-site.xml, etc.