### PR TITLE
[CDAP-14446] Fixes S3 & GCS browsers in dataprep UI for large amount of data

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/gcs.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/gcs.js
@@ -100,7 +100,8 @@ const fetchGCSDetails = (path = '') => {
         DataPrepBrowserStore.dispatch({
           type: BrowserStoreActions.SET_GCS_ACTIVE_BUCKET_DETAILS,
           payload: {
-            activeBucketDetails: res.values
+            activeBucketDetails: res.values,
+            truncated: res.truncated === 'true' || false
           }
         });
       }, (err) => {

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/s3.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/Actions/s3.js
@@ -98,7 +98,8 @@ const fetchBucketDetails = (path = '') => {
         DataPrepBrowserStore.dispatch({
           type: BrowserStoreActions.SET_S3_ACTIVE_BUCKET_DETAILS,
           payload: {
-            activeBucketDetails: res.values
+            activeBucketDetails: res.values,
+            truncated: res.truncated === 'true' || false
           }
         });
       },

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
@@ -99,6 +99,7 @@ const defaultS3Value = {
   info: {},
   loading: false,
   activeBucketDetails: [],
+  truncated: false,
   prefix: '',
   connectionId: '',
   search: ''
@@ -108,6 +109,7 @@ const defaultGCSValue = {
   info: {},
   loading: false,
   activeBucketDetails: [],
+  truncated: false,
   prefix: '',
   connectionId: '',
   search: ''
@@ -282,6 +284,7 @@ const s3 = (state = defaultS3Value, action = defaultAction) => {
       return {
         ...state,
         activeBucketDetails: action.payload.activeBucketDetails,
+        truncated: action.payload.truncated,
         loading: false
       };
     case Actions.SET_S3_PREFIX:
@@ -335,6 +338,7 @@ const gcs = (state = defaultGCSValue, action = defaultAction) => {
       return {
         ...state,
         activeBucketDetails: action.payload.activeBucketDetails,
+        truncated: action.payload.truncated,
         loading: false
       };
     case Actions.SET_GCS_PREFIX:

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/BrowserData/TableContents.tsx
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/BrowserData/TableContents.tsx
@@ -1,0 +1,260 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+/**
+ * This is here purely for the lack of time. This is mostly a copy-paste of
+ * TableContents from S3. Ideally we need a component that accepts data
+ * and a callback for each row of the content for lazy loading.
+ *
+ * Either that or we need to, the very least, extract the common parts
+ * between S3 and GCS and use a generic component (Typescipt React<generic> component)
+ */
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { preventPropagation } from 'services/helpers';
+import classnames from 'classnames';
+import EmptyMessageContainer from 'components/EmptyMessageContainer';
+import { humanReadableDate, convertBytesToHumanReadable, HUMANREADABLESTORAGE_NODECIMAL } from 'services/helpers';
+import IconSVG from 'components/IconSVG';
+import T from 'i18n-react';
+import { setGCSPrefix } from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
+const PREFIX = 'features.DataPrep.DataPrepBrowser.GCSBrowser.BrowserData';
+
+// Lazy load polyfill in safari as InteresectionObservers are not implemented there yet.
+(async () => {
+  typeof IntersectionObserver === 'undefined' ?
+    await import(/* webpackChunkName: "intersection-observer" */'intersection-observer')
+  :
+    Promise.resolve();
+})();
+
+interface IBucketData {
+  directory?: boolean;
+  name: string;
+  size: string;
+  wrangle?: boolean;
+  type?: string;
+  scrollId: number;
+  updated?: string;
+}
+
+interface ITableContentsProps {
+  enableRouting: boolean;
+  search: string;
+  data: Array<Partial<IBucketData>>;
+  onWorkspaceCreate: (file: string) => void;
+  prefix: string;
+  clearSearch: () => void;
+}
+interface ITableContentState {
+  windowSize: number;
+  data: Array<Partial<IBucketData>>;
+}
+
+export default class TableContents extends React.PureComponent<ITableContentsProps, ITableContentState> {
+  private static DEFAULT_WINDOW_SIZE = 100;
+
+  public state: ITableContentState = {
+    windowSize: TableContents.DEFAULT_WINDOW_SIZE,
+    data: this.props.data.map((d, i) => ({...d, scrollId: i})),
+  };
+
+  public componentDidMount() {
+    Array.from(document.querySelectorAll(`#gcs-buckets-container .row`))
+      .forEach((entry) => {
+        this.io.observe(entry);
+      });
+  }
+
+  public componentDidUpdate() {
+    Array.from(document.querySelectorAll(`#gcs-buckets-container .row`))
+      .forEach((entry) => {
+        this.io.observe(entry);
+      });
+  }
+
+  public componentWillReceiveProps(nextProps: Partial<ITableContentsProps>) {
+    this.setState({
+      data: nextProps.data.map((d, i) => ({ ...d, scrollId: i })),
+    });
+  }
+  private io = new IntersectionObserver((entries) => {
+    let lastVisibleElement = this.state.windowSize;
+    for (const entry of entries) {
+      let id = entry.target.getAttribute("id");
+      id = id.split('-').pop();
+      const scrollId = parseInt(id, 10);
+      if (entry.isIntersecting) {
+        lastVisibleElement = scrollId + 50 > this.state.windowSize ?
+          scrollId + TableContents.DEFAULT_WINDOW_SIZE
+          :
+          scrollId;
+      }
+    }
+    if (lastVisibleElement > this.state.windowSize) {
+      this.setState({
+        windowSize: lastVisibleElement,
+      });
+    }
+  }, {
+    root: document.getElementById('gcs-buckets-container'),
+    threshold: [0, 1],
+  });
+
+  private getPrefix = (file, prefix) => {
+    return file.path ? file.path : `${prefix}${file.name}/`;
+  }
+
+  private onClickHandler = (enableRouting, onWorkspaceCreate, file, prefix, e) => {
+    if (!file.directory) {
+      if (file.wrangle) {
+        this.props.onWorkspaceCreate(file);
+      }
+      preventPropagation(e);
+      return false;
+    }
+    if (enableRouting) {
+      return;
+    }
+    if (file.directory) {
+      setGCSPrefix(this.getPrefix(file, prefix));
+    }
+    preventPropagation(e);
+    return false;
+  }
+
+  private renderData() {
+    const {
+      enableRouting,
+      onWorkspaceCreate,
+      prefix,
+    } = this.props;
+    const {data} = this.state;
+    const ContainerElement = enableRouting ? Link : 'div';
+    const pathname = window.location.pathname.replace(/\/cdap/, '');
+    if (enableRouting) {
+      return (
+        <div className="gcs-buckets" id="gcs-buckets-container">
+          {
+            data.slice(0, this.state.windowSize)
+              .map((file, i) => {
+                const lastModified = humanReadableDate(file.updated, true);
+                const size = convertBytesToHumanReadable(file.size, HUMANREADABLESTORAGE_NODECIMAL, true) || '--';
+                let type = file.directory ? T.translate(`${PREFIX}.Content.directory`) : file.type;
+
+                if (file.type === 'UNKNOWN') {
+                  type = '--';
+                }
+
+                return (
+                  <ContainerElement
+                    key={file.name}
+                    className={classnames({ disabled: !file.directory && !file.wrangle })}
+                    to={`${pathname}?prefix=${this.getPrefix(file, prefix)}`}
+                    onClick={this.onClickHandler.bind(null, enableRouting, onWorkspaceCreate, file, prefix)}
+                  >
+                    <div
+                      className="row"
+                      id={`gcsconnection-${file.scrollId}`}
+                    >
+                      <div className="col-xs-3">
+                        <IconSVG name={file.directory ? 'icon-folder-o' : 'icon-file-o'} />
+                        {file.name}
+                      </div>
+                      <div className="col-xs-3">
+                        {type}
+                      </div>
+                      <div className="col-xs-3">
+                        {size}
+                      </div>
+                      <div className="col-xs-3">
+                        {lastModified}
+                      </div>
+                    </div>
+                  </ContainerElement>
+                );
+              })
+          }
+        </div>
+      );
+    }
+
+    return (
+      <div className="gcs-buckets" id="gcs-buckets-container">
+        {
+          data.slice(0, this.state.windowSize)
+            .map((file, i) => (
+              <ContainerElement
+                className={classnames({ disabled: !file.directory && !file.wrangle })}
+                to={`${pathname}?prefix=${this.getPrefix(file, prefix)}`}
+                onClick={this.onClickHandler.bind(null, enableRouting, onWorkspaceCreate, file, prefix)}
+                key={`${file.name}-${i}`}
+              >
+                <div
+                  className="row"
+                  id={`s3connection-${file.scrollId}`}
+                >
+                  <div className="col-xs-12">
+                    <IconSVG name={file.directory ? 'icon-folder-o' : 'icon-file-o'} />
+                    {file.name}
+                  </div>
+                </div>
+              </ContainerElement>
+            ))
+        }
+      </div>
+    );
+  }
+
+  public renderContents() {
+    const {
+      search,
+      data,
+      clearSearch,
+    } = this.props;
+    if (!data.length) {
+      return (
+        <div className="gcs-buckets empty-message">
+          <div className="row">
+            <div className="col-xs-12">
+              <EmptyMessageContainer searchText={search}>
+                <ul>
+                  <li>
+                    <span
+                      className="link-text"
+                      onClick={clearSearch}
+                    >
+                      {T.translate(`features.EmptyMessageContainer.clearLabel`)}
+                    </span>
+                    <span>{T.translate(`${PREFIX}.Content.EmptymessageContainer.suggestion1`)}</span>
+                  </li>
+                </ul>
+              </EmptyMessageContainer>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.renderData();
+  }
+  public render() {
+    return (
+      <div className="gcs-content-body">
+        {this.renderContents()}
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/BrowserData/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/BrowserData/index.js
@@ -19,15 +19,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
-import {Link} from 'react-router-dom';
-import {setGCSPrefix, setGCSSearch} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
-import {preventPropagation} from 'services/helpers';
-import classnames from 'classnames';
-import EmptyMessageContainer from 'components/EmptyMessageContainer';
+import { setGCSSearch} from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
 import T from 'i18n-react';
-import IconSVG from 'components/IconSVG';
-import {humanReadableDate, convertBytesToHumanReadable, HUMANREADABLESTORAGE_NODECIMAL} from 'services/helpers';
 import If from 'components/If';
+import TableContents from 'components/DataPrep/DataPrepBrowser/GCSBrowser/BrowserData/TableContents';
 
 const PREFIX = 'features.DataPrep.DataPrepBrowser.GCSBrowser.BrowserData';
 const props = {
@@ -40,28 +35,6 @@ const props = {
   onWorkspaceCreate: PropTypes.func
 };
 
-const getPrefix = (file, prefix) => {
-
-  return file.path ? file.path : `${prefix}${file.name}/`;
-};
-
-const onClickHandler = (enableRouting, onWorkspaceCreate, file, prefix, e) => {
-  if (!file.directory) {
-    if (file.wrangle) {
-      onWorkspaceCreate(file);
-    }
-    preventPropagation(e);
-    return false;
-  }
-  if (enableRouting) {
-    return;
-  }
-  if (file.directory) {
-    setGCSPrefix(getPrefix(file, prefix));
-  }
-  preventPropagation(e);
-  return false;
-};
 
 const TableHeader = ({enableRouting}) => {
   if (enableRouting) {
@@ -91,102 +64,6 @@ const TableHeader = ({enableRouting}) => {
   );
 };
 TableHeader.propTypes = props;
-
-const TableContents = ({enableRouting, search, filteredData, onWorkspaceCreate, prefix, clearSearch}) => {
-  let ContainerElement = enableRouting ? Link : 'div';
-  let pathname = window.location.pathname.replace(/\/cdap/, '');
-  if (!filteredData.length) {
-    return (
-      <div className="gcs-buckets empty-message">
-        <div className="row">
-          <div className="col-xs-12">
-            <EmptyMessageContainer searchText={search}>
-              <ul>
-                <li>
-                  <span
-                    className="link-text"
-                    onClick={clearSearch}
-                  >
-                    {T.translate(`features.EmptyMessageContainer.clearLabel`)}
-                  </span>
-                  <span>{T.translate(`${PREFIX}.Content.EmptymessageContainer.suggestion1`)} </span>
-                </li>
-              </ul>
-            </EmptyMessageContainer>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (enableRouting) {
-    return (
-      <div className="gcs-buckets">
-        {
-          filteredData.map(file => {
-            let lastModified = humanReadableDate(file['updated'], true);
-            let size = convertBytesToHumanReadable(file['size'], HUMANREADABLESTORAGE_NODECIMAL, true);
-            let type = file.directory ? T.translate(`${PREFIX}.Content.directory`) : file.type;
-
-            if (file.type === 'UNKNOWN') {
-              type = '--';
-            }
-
-            return (
-              <ContainerElement
-                key={file.name}
-                className={classnames({'disabled': !file.directory && !file.wrangle})}
-                to={`${pathname}?prefix=${getPrefix(file, prefix)}`}
-                onClick={onClickHandler.bind(null, enableRouting, onWorkspaceCreate, file, prefix)}
-              >
-                <div className="row">
-                  <div className="col-xs-3">
-                    <IconSVG name={file.directory ? 'icon-folder-o' : 'icon-file-o'} />
-                    {file.name}
-                  </div>
-                  <div className="col-xs-3">
-                    {type}
-                  </div>
-                  <div className="col-xs-3">
-                    {size}
-                  </div>
-                  <div className="col-xs-3">
-                    {lastModified}
-                  </div>
-                </div>
-              </ContainerElement>
-            );
-          })
-        }
-      </div>
-    );
-  }
-  return (
-    <div className="gcs-buckets">
-      {
-        filteredData.map(file => (
-          <ContainerElement
-            key={file.name}
-            className={classnames({'disabled': !file.directory && !file.wrangle})}
-            to={`${pathname}?prefix=${getPrefix(file, prefix)}`}
-            onClick={onClickHandler.bind(null, enableRouting, onWorkspaceCreate, file, prefix)}
-          >
-            <div className="row">
-              <div className="col-xs-12">
-                <IconSVG name={file.directory ? 'icon-folder-o' : 'icon-file-o'} />
-                {file.name}
-              </div>
-            </div>
-          </ContainerElement>
-        ))
-      }
-    </div>
-  );
-};
-TableContents.propTypes = {
-  ...props,
-  filteredData: PropTypes.array
-};
 
 const BrowserData = ({data, search, clearSearch, loading, prefix, enableRouting, onWorkspaceCreate}) => {
   if (loading) {
@@ -223,16 +100,14 @@ const BrowserData = ({data, search, clearSearch, loading, prefix, enableRouting,
           <TableHeader enableRouting={enableRouting} />
         </div>
       </If>
-      <div className="gcs-content-body">
-        <TableContents
-          search={search}
-          clearSearch={clearSearch}
-          filteredData={filteredData}
-          prefix={prefix}
-          enableRouting={enableRouting}
-          onWorkspaceCreate={onWorkspaceCreate}
-        />
-      </div>
+      <TableContents
+        search={search}
+        clearSearch={clearSearch}
+        data={filteredData}
+        prefix={prefix}
+        enableRouting={enableRouting}
+        onWorkspaceCreate={onWorkspaceCreate}
+      />
     </div>
   );
 };

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/ListingInfo/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/ListingInfo/index.js
@@ -17,25 +17,46 @@
 import PropTypes from 'prop-types';
 import T from 'i18n-react';
 import React from 'react';
+import IconSVG from 'components/IconSVG';
+import Popover from 'components/Popover';
 import {connect} from 'react-redux';
 
-const ListingInfo = ({bucketData, loading}) => {
+const ListingInfo = ({bucketData, loading, truncated}) => {
   if (loading) {
     return <span>.</span>;
   }
   let dirsCount = bucketData.filter(file => file.directory).length;
   let filesCount = bucketData.length - dirsCount;
+  if (truncated) {
+    return (
+      <div className="truncated-listing-info-container">
+        <Popover
+          target={() => <IconSVG name="icon-exclamation-triangle" className="text-warning" />}
+          showOn="Hover"
+          placement="left"
+          tag="span"
+        >
+          {T.translate('features.DataPrep.DataPrepBrowser.GCSBrowser.TopPanel.ListingInfo.truncatedContentsTooltip')}
+        </Popover>
+        <span>
+          {T.translate('features.DataPrep.DataPrepBrowser.GCSBrowser.TopPanel.ListingInfo.truncatedLabel', {filesCount, dirsCount})}
+        </span>
+      </div>
+    );
+  }
   return <span> {T.translate('features.DataPrep.DataPrepBrowser.GCSBrowser.TopPanel.ListingInfo.label', {filesCount, dirsCount})} </span>;
 };
 
 ListingInfo.propTypes = {
   bucketData: PropTypes.arrayOf(PropTypes.object),
+  truncated: PropTypes.bool,
   loading: PropTypes.bool
 };
 
 const mapStateToProps = (state) => {
   return {
     bucketData: state.gcs.activeBucketDetails,
+    truncated: state.gcs.truncated,
     loading: state.gcs.loading
   };
 };

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/BucketData/TableContents.tsx
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/BucketData/TableContents.tsx
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import * as React from 'react';
+import { humanReadableDate } from 'services/helpers';
+import { Link } from 'react-router-dom';
+import { setPrefix } from 'components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/ActionCreator';
+import { preventPropagation } from 'services/helpers';
+import classnames from 'classnames';
+import EmptyMessageContainer from 'components/EmptyMessageContainer';
+import IconSVG from 'components/IconSVG';
+import T from 'i18n-react';
+const PREFIX = 'features.DataPrep.DataPrepBrowser.S3Browser.BucketData';
+
+// Lazy load polyfill in safari as InteresectionObservers are not implemented there yet.
+(async () => {
+  typeof IntersectionObserver === 'undefined' ?
+    await import(/* webpackChunkName: "intersection-observer" */'intersection-observer')
+  :
+    Promise.resolve();
+})();
+
+interface IBucketData {
+  directory?: boolean;
+  name: string;
+  "last-modified": string;
+  owner: string;
+  size: string;
+  wrangle?: boolean;
+  type?: string;
+  scrollId: number;
+}
+
+interface ITableContentsProps {
+  enableRouting: boolean;
+  search: string;
+  data: Array<Partial<IBucketData>>;
+  onWorkspaceCreate: (file: string) => void;
+  prefix: string;
+  clearSearch: () => void;
+}
+interface ITableContentState {
+  windowSize: number;
+  data: Array<Partial<IBucketData>>;
+}
+
+export default class TableContents extends React.PureComponent<ITableContentsProps, ITableContentState> {
+  private static DEFAULT_WINDOW_SIZE = 100;
+
+  public state: ITableContentState = {
+    windowSize: TableContents.DEFAULT_WINDOW_SIZE,
+    data: this.props.data.map((d, i) => ({...d, scrollId: i})),
+  };
+
+  public componentDidMount() {
+    Array.from(document.querySelectorAll(`#s3-buckets-container .row`))
+      .forEach((entry) => {
+        this.io.observe(entry);
+      });
+  }
+
+  public componentDidUpdate() {
+    Array.from(document.querySelectorAll(`#s3-buckets-container .row`))
+      .forEach((entry) => {
+        this.io.observe(entry);
+      });
+  }
+
+  public componentWillReceiveProps(nextProps: Partial<ITableContentsProps>) {
+    this.setState({
+      data: nextProps.data.map((d, i) => ({ ...d, scrollId: i })),
+    });
+  }
+  private io = new IntersectionObserver((entries) => {
+    let lastVisibleElement = this.state.windowSize;
+    for (const entry of entries) {
+      let id = entry.target.getAttribute("id");
+      id = id.split('-').pop();
+      const scrollId = parseInt(id, 10);
+      if (entry.isIntersecting) {
+        lastVisibleElement = scrollId + 50 > this.state.windowSize ?
+          scrollId + TableContents.DEFAULT_WINDOW_SIZE
+          :
+          scrollId;
+      }
+    }
+    if (lastVisibleElement > this.state.windowSize) {
+      this.setState({
+        windowSize: lastVisibleElement,
+      });
+    }
+  }, {
+    root: document.getElementById('s3-buckets-container'),
+    threshold: [0, 1],
+  });
+
+  private renderIcon = (type) => {
+    switch (type) {
+      case 'bucket':
+        return <IconSVG name="icon-S3_bucket" />;
+      case 'directory':
+        return <IconSVG name="icon-folder-o" />;
+      default:
+        return <IconSVG name="icon-file-o" />;
+    }
+  }
+
+  private getPrefix = (file, prefix) => {
+    const handleSlashAtEnd = (path) => {
+      return (
+        path.length > 1 &&
+        path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path
+      );
+    };
+    const addSuffixSlash = (path) => `${handleSlashAtEnd(path)}/`;
+    return file.type === 'bucket' ? `/${file.name}` : `${handleSlashAtEnd(prefix)}/${addSuffixSlash(file.name)}`;
+  }
+
+  private onClickHandler = (enableRouting, onWorkspaceCreate, file, prefix, e) => {
+    if (!file.directory) {
+      if (file.wrangle) {
+        this.props.onWorkspaceCreate(file);
+      }
+      preventPropagation(e);
+      return false;
+    }
+    if (enableRouting) {
+      return;
+    }
+    if (file.directory) {
+      setPrefix(this.getPrefix(file, prefix));
+    }
+    preventPropagation(e);
+    return false;
+  }
+
+  private renderData() {
+    const {
+      enableRouting,
+      onWorkspaceCreate,
+      prefix,
+    } = this.props;
+    const {data} = this.state;
+    const ContainerElement = enableRouting ? Link : 'div';
+    const pathname = window.location.pathname.replace(/\/cdap/, '');
+    if (enableRouting) {
+      return (
+        <div className="s3-buckets" id="s3-buckets-container">
+          {
+            data.slice(0, this.state.windowSize)
+              .map((file, i) => {
+                const lastModified = humanReadableDate(file['last-modified'], true);
+
+                return (
+                  <ContainerElement
+                    className={classnames({ disabled: !file.directory && !file.wrangle })}
+                    to={`${pathname}?prefix=${this.getPrefix(file, prefix)}`}
+                    onClick={this.onClickHandler.bind(null, enableRouting, onWorkspaceCreate, file, prefix)}
+                    key={`${file.name}-${i}`}
+                  >
+                    <div
+                      className="row"
+                      id={`s3connection-${file.scrollId}`}
+                    >
+                      <div className="col-xs-3">
+                        {this.renderIcon(file.type)}
+                        {file.name}
+                      </div>
+                      <div className="col-xs-3">
+                        {file.owner || '--'}
+                      </div>
+                      <div className="col-xs-3">
+                        {file.size || '--'}
+                      </div>
+                      <div className="col-xs-3">
+                        {lastModified}
+                      </div>
+                    </div>
+                  </ContainerElement>
+                );
+              })
+          }
+        </div>
+      );
+    }
+
+    return (
+      <div className="s3-buckets" id="s3-buckets-container">
+        {
+          data.slice(0, this.state.windowSize)
+            .map((file, i) => (
+              <ContainerElement
+                className={classnames({ disabled: !file.directory && !file.wrangle })}
+                to={`${pathname}?prefix=${this.getPrefix(file, prefix)}`}
+                onClick={this.onClickHandler.bind(null, enableRouting, onWorkspaceCreate, file, prefix)}
+                key={`${file.name}-${i}`}
+              >
+                <div
+                  className="row"
+                  id={`s3connection-${file.scrollId}`}
+                >
+                  <div className="col-xs-12">
+                    {this.renderIcon(file.type)}
+                    {file.name}
+                  </div>
+                </div>
+              </ContainerElement>
+            ))
+        }
+      </div>
+    );
+  }
+
+  public renderContents() {
+    const {
+      search,
+      data,
+      clearSearch,
+    } = this.props;
+    if (!data.length) {
+      return (
+        <div className="s3-buckets empty-message">
+          <div className="row">
+            <div className="col-xs-12">
+              <EmptyMessageContainer searchText={search}>
+                <ul>
+                  <li>
+                    <span
+                      className="link-text"
+                      onClick={clearSearch}
+                    >
+                      {T.translate(`features.EmptyMessageContainer.clearLabel`)}
+                    </span>
+                    <span>{T.translate(`${PREFIX}.Content.EmptymessageContainer.suggestion1`)}</span>
+                  </li>
+                </ul>
+              </EmptyMessageContainer>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.renderData();
+  }
+  public render() {
+    return (
+      <div className="s3-content-body">
+        {this.renderContents()}
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/ListingInfo/ListingInfo.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/ListingInfo/ListingInfo.scss
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+.truncated-listing-info-container {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  > :first-child {
+    margin-right: 3px;
+  }
+  .icon-svg {
+    font-size: 1.1rem;
+  }
+  .popper.tooltip {
+    padding: 5px;
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/ListingInfo/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/ListingInfo/index.js
@@ -18,24 +18,46 @@ import PropTypes from 'prop-types';
 import T from 'i18n-react';
 import React from 'react';
 import {connect} from 'react-redux';
+import IconSVG from 'components/IconSVG';
+import Popover from 'components/Popover';
+require('./ListingInfo.scss');
 
-const ListingInfo = ({bucketData, loading}) => {
+const ListingInfo = ({bucketData, loading, truncated}) => {
   if (loading) {
     return <span>.</span>;
   }
   let dirsCount = bucketData.filter(file => file.directory).length;
   let filesCount = bucketData.length - dirsCount;
+  if (truncated) {
+    return (
+      <div className="truncated-listing-info-container">
+        <Popover
+          target={() => <IconSVG name="icon-exclamation-triangle" className="text-warning" />}
+          showOn="Hover"
+          placement="left"
+          tag="span"
+        >
+          {T.translate('features.DataPrep.DataPrepBrowser.S3Browser.TopPanel.ListingInfo.truncatedContentsTooltip')}
+        </Popover>
+        <span>
+          {T.translate('features.DataPrep.DataPrepBrowser.S3Browser.TopPanel.ListingInfo.truncatedLabel', {filesCount, dirsCount})}
+        </span>
+      </div>
+    );
+  }
   return <span> {T.translate('features.DataPrep.DataPrepBrowser.S3Browser.TopPanel.ListingInfo.label', {filesCount, dirsCount})} </span>;
 };
 
 ListingInfo.propTypes = {
   bucketData: PropTypes.arrayOf(PropTypes.object),
+  truncated: PropTypes.bool,
   loading: PropTypes.bool
 };
 
 const mapStateToProps = (state) => {
   return {
     bucketData: state.s3.activeBucketDetails,
+    truncated: state.s3.truncated,
     loading: state.s3.loading
   };
 };

--- a/cdap-ui/app/cdap/components/EmptyMessageContainer/index.js
+++ b/cdap-ui/app/cdap/components/EmptyMessageContainer/index.js
@@ -22,7 +22,7 @@ require('./EmptyMessageContainer.scss');
 
 const PREFIX = 'features.EmptyMessageContainer';
 
-export default function EmptyMessageContainer({title, searchText = '', children}) {
+export default function EmptyMessageContainer({title = null, searchText = '', children}) {
   return (
     <div className="empty-search-container">
       <div className="empty-search">

--- a/cdap-ui/app/cdap/components/Popover/index.js
+++ b/cdap-ui/app/cdap/components/Popover/index.js
@@ -46,7 +46,8 @@ export default class Popover extends PureComponent {
     injectOnToggle: PropTypes.bool,
     showPopover: PropTypes.bool,
     onTogglePopover: PropTypes.func,
-    modifiers: PropTypes.object
+    modifiers: PropTypes.object,
+    tag: PropTypes.string
   };
 
   eventEmitter = ee(ee);
@@ -61,7 +62,8 @@ export default class Popover extends PureComponent {
         enabled: true,
         boundariesElement: 'scrollParent'
       }
-    }
+    },
+    tag: 'div'
   };
 
   state = {
@@ -171,7 +173,10 @@ export default class Popover extends PureComponent {
     }
     const TargetElement = this.props.target;
     return (
-      <Manager className={this.props.className}>
+      <Manager
+        className={this.props.className}
+        tag={this.props.tag}
+      >
         <Target {...targetProps}>
           <TargetElement />
         </Target>

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -457,6 +457,8 @@ features:
         TopPanel:
           ListingInfo:
             label: "{dirsCount} directories and {filesCount} files"
+            truncatedContentsTooltip: The GCS account you are viewing contains more directories and files we can currently display.
+            truncatedLabel: "{dirsCount} directories and {fileCount} files of many"
           selectData: Select data
       KafkaBrowser:
         EmptyMessage:
@@ -492,6 +494,8 @@ features:
         TopPanel:
           ListingInfo:
             label: "{dirsCount} directories and {filesCount} files"
+            truncatedContentsTooltip: The bucket you are viewing contains more directories and files we can currently display.
+            truncatedLabel: "{dirsCount} directories and {fileCount} files of many"
           selectData: Select data
       SpannerBrowser:
         databaseCount:


### PR DESCRIPTION
**Context**
- If there are a lot of folders/files in a S3 bucket UI freezes for couple of reasons,
    - Making the call in the backend creates a lot of logs
    - The query takes a long time return back as there is too much amount of data
    - Rendering that much amount of data literally breaks the browser as we don't have any lazy loading

**Solution**
- Backend fix is to limit the response to 10000 directories/files (https://github.com/data-integrations/wrangler/pull/245)
- UI fix would be to lazyload this 10000 directories/files and show appropriate message to the user about the limited content.
- Right fix would be to add pagination, but given the time constraint for 5.1 release this is an interim solution that will prevent taking the CDAP down (or UI down)

_NOTE:_
- Right now this fix is applicable only for S3 as that is the only dataprep connection that provides batching API to fetch data. Other connections like GCS or Bigquery does not have batching API.

JIRA: https://issues.cask.co/browse/CDAP-14446
Build: https://builds.cask.co/browse/CDAP-URUT139