### PR TITLE
[Dataprep] [UI] Fixes dataprep landing page to properly navigate to dataprep when service is running

### DIFF
--- a/cdap-ui/app/cdap/api/dataprep.js
+++ b/cdap-ui/app/cdap/api/dataprep.js
@@ -41,6 +41,7 @@ const MyDataPrepApi = {
   getApp: apiCreator(dataSrc, 'GET', 'REQUEST', appPath),
   startService: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/start`),
   stopService: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/stop`),
+  getServiceStatus: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/status`),
   pollServiceStatus: apiCreator(dataSrc, 'GET', 'POLL', `${baseServicePath}/status`),
   createApp: apiCreator(dataSrc, 'PUT', 'REQUEST', `${appPath}`),
   ping: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/usage`, { interval: 2000 }),

--- a/cdap-ui/app/cdap/api/experiments.js
+++ b/cdap-ui/app/cdap/api/experiments.js
@@ -50,6 +50,7 @@ export const myExperimentsApi = {
   startService: apiCreator(dataSrc, 'POST', 'REQUEST', `${servicePath}/start`),
   stopService: apiCreator(dataSrc, 'POST', 'REQUEST', `${servicePath}/stop`),
   createApp: apiCreator(dataSrc, 'PUT', 'REQUEST', `${appPath}`),
+  getServiceStatus: apiCreator(dataSrc, 'GET', 'REQUEST', `${servicePath}/status`),
   pollServiceStatus: apiCreator(dataSrc, 'GET', 'POLL', `${servicePath}/status`),
   ping: apiCreator(dataSrc, 'GET', 'REQUEST', `${basePath}/experiments`)
 

--- a/cdap-ui/app/cdap/api/reports.js
+++ b/cdap-ui/app/cdap/api/reports.js
@@ -37,6 +37,7 @@ export const MyReportsApi = {
   getApp: apiCreator(dataSrc, 'GET', 'REQUEST', appPath),
   startService: apiCreator(dataSrc, 'POST', 'REQUEST', `${programPath}/start`),
   stopService: apiCreator(dataSrc, 'POST', 'REQUEST', `${programPath}/stop`),
+  getServiceStatus: apiCreator(dataSrc, 'GET', 'REQUEST', `${programPath}/status`),
   pollServiceStatus: apiCreator(dataSrc, 'GET', 'POLL', `${programPath}/status`, { interval: 2000 }),
   createApp: apiCreator(dataSrc, 'PUT', 'REQUEST', appPath),
   ping: apiCreator(dataSrc, 'GET', 'REQUEST', reportsPath),

--- a/cdap-ui/app/cdap/api/rulesengine.js
+++ b/cdap-ui/app/cdap/api/rulesengine.js
@@ -41,6 +41,7 @@ const  MyRulesEngineApi = {
   getApp: apiCreator(dataSrc, 'GET', 'REQUEST', `${appPath}`),
   startService: apiCreator(dataSrc, 'POST', 'REQUEST', `${serviceBasepath}/start`),
   stopService: apiCreator(dataSrc, 'POST', 'REQUEST', `${serviceBasepath}/stop`),
+  getServiceStatus: apiCreator(dataSrc, 'GET', 'REQUEST', `${serviceBasepath}/status`),
   pollServiceStatus: apiCreator(dataSrc, 'GET', 'POLL', `${serviceBasepath}/status`),
   createApp: apiCreator(dataSrc, 'PUT', 'REQUEST', `${appPath}`),
   ping: apiCreator(dataSrc, 'GET', 'REQUEST', `${serviceMethodsBasepath}/rules`, { interval: 2000 }),

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
@@ -24,34 +24,22 @@ import MyDataPrepApi from 'api/dataprep';
 import {i18nPrefix, MIN_DATAPREP_VERSION, artifactName} from 'components/DataPrep';
 import isObject from 'lodash/isObject';
 import {Theme} from 'services/ThemeHelper';
+import {objectQuery} from 'services/helpers';
 
 require('./DataPrepServiceControl.scss');
 
 const PREFIX = `features.DataPrepServiceControl`;
 
 export default class DataPrepServiceControl extends Component {
-  constructor(props) {
-    super(props);
+  state = {
+    loading: false,
+    error: null,
+    extendedMessage: null
+  };
 
-    this.state = {
-      loading: false,
-      error: null,
-      extendedMessage: null
-    };
-
-    this.enableService = this.enableService.bind(this);
-  }
-
-  componentWillUnmount() {
-    if (this.servicePoll && this.servicePoll.unsubscribe) {
-      this.servicePoll.unsubscribe();
-    }
-  }
-
-  enableService() {
-    const featureName = Theme.featureNames.dataPrep;
-
+  enableService = () => {
     this.setState({loading: true});
+    const featureName = Theme.featureNames.dataPrep;
     enableSystemApp({
       shouldStopService: false,
       artifactName,
@@ -67,13 +55,22 @@ export default class DataPrepServiceControl extends Component {
           err.extendedMessage.response || err.extendedMessage.message
         :
           err.extendedMessage;
+        let statusCode = objectQuery(err, 'extendedMessage', 'statusCode');
+        // 409 = conflict in status, meaning when we are trying to start the app
+        // when it is already running.
+        if (
+          statusCode === 409 &&
+          (typeof extendedMessage === 'string' && extendedMessage.indexOf('already running') !== -1)
+        ) {
+          return this.props.onServiceStart();
+        }
         this.setState({
           error: err.error,
           extendedMessage,
           loading: false
         });
       });
-  }
+  };
 
   renderError() {
     if (!this.state.error) { return null; }


### PR DESCRIPTION
**Issue:**
- Open two browser windows, one with Control Center UI and the other with Dataprep UI
- Go to control center UI
- Stop dataprep app 
- Go to dataprep UI and refresh
- User should see the enable dataprep page
- Now go to the Control Center window and start dataprep service
- Once the dataprep app is running switch to the other window and click on "Enable Dataprep" button

After the last step UI used to show that the service is already running.

**Solution:**
We should detect if its already running and navigate to dataprep UI instead of confusing the user with the already running message.

Build: https://builds.cask.co/browse/CDAP-URUT142

