### PR TITLE
add cdap env file to sdk

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1058,13 +1058,13 @@ cdap_sdk_start() {
   # Start SDK processes
   echo -n "$(date) Starting CDAP Sandbox ..."
   if ${__foreground}; then
-    nice -1 "${JAVA}" "${KILL_ON_OOM_OPTS}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
-      | tee -a "${LOG_DIR}"/cdap.log
+    # this eval is needed to get around the double quote issue in KILL_ON_OOM_OPTS
+    eval "nice -1 \"${JAVA}\" ${KILL_ON_OOM_OPTS} ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath \"${CLASSPATH}\" co.cask.cdap.StandaloneMain | tee -a \"${LOG_DIR}\"/cdap.log"
     __ret=${?}
     return ${__ret}
   else
-    nohup nice -1 "${JAVA}" "${KILL_ON_OOM_OPTS}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
-      </dev/null >>"${LOG_DIR}"/cdap.log 2>&1 &
+    # this eval is needed to get around the double quote issue in KILL_ON_OOM_OPTS
+    eval "nohup nice -1 \"${JAVA}\" ${KILL_ON_OOM_OPTS} ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath \"${CLASSPATH}\" co.cask.cdap.StandaloneMain </dev/null >>\"${LOG_DIR}\"/cdap.log 2>&1 &"
     __ret=${?}
     __pid=${!}
     sleep 2 # wait for JVM spin up
@@ -1479,7 +1479,3 @@ CDAP_SDK_OPTS="${OPTS} -Djava.security.krb5.realm= -Djava.security.krb5.kdc= -Dj
 export HEAPDUMP_ON_OOM=${HEAPDUMP_ON_OOM:-false}
 
 export NICENESS=${NICENESS:-0}
-
-# Default jvm option for the kill command, it cannot be combined with the SDK options because split_jvm_opts() method will
-# always split the "kill -9 %p" into three different commands
-export KILL_ON_OOM_OPTS=${KILL_ON_OOM_OPTS:--XX:OnOutOfMemoryError="kill -9 %p"}

--- a/cdap-standalone/src/main/resources/cdap-env.sh
+++ b/cdap-standalone/src/main/resources/cdap-env.sh
@@ -1,0 +1,19 @@
+# Copyright © 2018 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# By default, kill the CDAP Sandbox process if it runs out of memory
+export KILL_ON_OOM_OPTS="-XX:OnOutOfMemoryError=\"kill -9 %p\""
+
+# Uncomment to perform Java heap dump on OutOfMemory errors
+# export HEAPDUMP_ON_OOM=true


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14461
Add the cdap-env file for sandbox, which allows user to configure the KILL_ON_OOM_OPTS and the HEAPDUMP_OPTS, the `eval "command"` is needed to get around the double quote issue.