### PR TITLE
[CDAP-14479]Fixes dataprep connection to show upload section when going from dataprep to connections

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -104,7 +104,7 @@ export default class DataPrepConnections extends Component {
       activeConnectionid,
       activeConnectionType,
       showAddConnectionPopover: false,
-      showUpload: false, // FIXME: This is used only when showing with no routing. We can do better.,
+      showUpload: activeConnectionType === 'UPLOAD' || false, // FIXME: This is used only when showing with no routing. We can do better.,
       redirectToDefaultConnectionOnDelete: false
     };
   }


### PR DESCRIPTION
**Issue:**
- Go to dataprep connections
- Click upload and upload a csv file
- Once in dataprep click on connections arrow

After the last step the UI shows a blank connections screen instead of upload section.

**Fix:**
- Based on workspace connection type show upload section if workspace created from upload

JIRA: https://issues.cask.co/browse/CDAP-14479
Build: https://builds.cask.co/browse/CDAP-URUT149
