### PR TITLE
CDAP-14489 only log cask classes as debug in sandbox

### DIFF
--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -46,6 +46,7 @@
   <logger name="org.quartz.core" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="io.netty.util.internal" level="WARN"/>
+  <logger name="co.cask" level="DEBUG"/>
   <logger name="co.cask.cdap.operations.OperationalStats" level="ERROR"/>
   <logger name="co.cask.cdap.extension.AbstractExtensionLoader" level="ERROR"/>
   <logger name="akka" level="WARN"/>
@@ -138,7 +139,7 @@
     <appender-ref ref="EXTERNAL_AUTH_AUDIT" />
   </logger>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="Rolling"/>
     <appender-ref ref="Debug"/>
     <appender-ref ref="Error"/>


### PR DESCRIPTION
Changed logback configuration so that the root log level is info,
but the default log level for cask classes is debug. This is to
avoid situations where a chatty dependency in a plugin or app
will cause the logs to be flooded.