### PR TITLE
[CDAP-14492] Fix profile node hours in UI to fix to 2 decimal

### DIFF
--- a/cdap-ui/app/cdap/components/Cloud/Profiles/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/Store/ActionCreator.js
@@ -476,7 +476,8 @@ export const highlightNewProfile = (profileName) => {
 
 export const getNodeHours = (nodeminutes) => {
   if (typeof nodeminutes === 'number') {
-    return nodeminutes / 60;
+    let nodeHours = (nodeminutes / 60);
+    return typeof nodeHours.toFixed === 'function' ? nodeHours.toFixed(2) : nodeHours;
   }
   return nodeminutes;
 };

--- a/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
@@ -31,7 +31,9 @@ $min_height_of_graph: 340px;
     flex-wrap: wrap;
     background: $pipeline-summary-bg;
     overflow: auto;
-    height: calc(100vh - 240px); // Header + Top panel = 95 + Footer = 51 + summary title bar = 49 + border 1px
+    // Header + Top panel = 105 + Footer = 54 + summary title bar = 54 + border 1px + 41px for filter section
+    // anti-pattern. This is now how we should do this.
+    height: calc(100vh - 254px);
 
     > div {
       width: calc(50% - 20px);


### PR DESCRIPTION
- Fixes node hours for profiles in namespace page to fix to 2 decimal 
- Fix pipeline summary container to scroll properly on all 4 charts displayed.

JIRA: https://issues.cask.co/browse/CDAP-14492
Build: https://builds.cask.co/browse/CDAP-URUT154