### PR TITLE
CDAP-14498 improve app deployment failure messages

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
@@ -161,7 +161,7 @@ public class WorkflowTest {
       Assert.fail("Should have thrown Exception because Workflow is configured with schedules having same name.");
     } catch (Exception ex) {
       Assert.assertEquals("Duplicate schedule name for schedule: 'DailySchedule'",
-                          ex.getCause().getCause().getMessage());
+                          ex.getCause().getMessage());
     }
 
     // try deploying app containing a schedule for non existent workflow

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactSummary;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.artifact.ArtifactVersionRange;
-import co.cask.cdap.api.artifact.InvalidArtifactRangeException;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.metrics.MetricDeleteQuery;
 import co.cask.cdap.api.metrics.MetricStore;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/SynchronousPipeline.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/SynchronousPipeline.java
@@ -23,6 +23,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.ExecutionException;
+
 /**
  * Concrete implementation of synchronous {@link Pipeline}.
  * <p>
@@ -57,6 +59,8 @@ public final class SynchronousPipeline<T> extends AbstractPipeline<T> {
         ctx = StageContext.next(ctx);
       }
       return Futures.immediateFuture((T) ctx.getUpStream());
+    } catch (ExecutionException e) {
+      return Futures.immediateFailedFuture(e.getCause());
     } catch (Throwable th) {
       return Futures.immediateFailedFuture(th);
     } finally {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -334,10 +334,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig,
         singlePlugin.configurePipeline(pipelineConfigurer);
       }
     } catch (Exception e) {
-      throw new RuntimeException(
-        String.format("Exception while configuring plugin of type %s and name %s for stage %s: %s",
-                      etlPlugin.getType(), etlPlugin.getName(), pluginId, e.getMessage()),
-        e);
+      throw new RuntimeException(String.format("Error configuring stage '%s': %s", pluginId, e.getMessage()), e);
     }
     return new PluginSpec(etlPlugin.getType(),
                           etlPlugin.getName(),


### PR DESCRIPTION
Removed the java exception classname from the error message by
properly unwrapping an ExecutionException in the depolyment code.

Also shortening an error message in the pipeline validation logic
to only include stage name instead of plugin type and name, as
the plugin type and name are not exposed to end users.