### PR TITLE
CDAP-14515 Update doc to drop java 7 from requirements

### DIFF
--- a/cdap-docs/admin-manual/source/system-requirements.rst
+++ b/cdap-docs/admin-manual/source/system-requirements.rst
@@ -99,7 +99,7 @@ You'll need this software installed:
 
 Java Runtime
 ------------
-The latest `JDK or JRE version 1.7.xx or 1.8.xx <http://www.java.com/en/download/manual.jsp>`__
+The latest `JDK or JRE version 1.8.xx <http://www.java.com/en/download/manual.jsp>`__
 for Linux, Windows, or Mac OS X must be installed in your environment; we recommend the Oracle JDK.
 
 .. highlight:: console

--- a/cdap-docs/developer-manual/source/getting-started/sandbox/index.rst
+++ b/cdap-docs/developer-manual/source/getting-started/sandbox/index.rst
@@ -27,7 +27,7 @@ CDAP Sandbox
 The CDAP Sandbox runs on Linux, MacOS, and Windows, and has these
 requirements:
 
-- `JDK 7 or 8 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__
+- `JDK 8 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__
   (required to run CDAP; note that $JAVA_HOME should be set)
 - `Node.js <https://nodejs.org>`__ (required to run the CDAP UI; we recommend any
   version beginning with |node-js-min-version|.

--- a/cdap-docs/faqs/source/general.rst
+++ b/cdap-docs/faqs/source/general.rst
@@ -33,7 +33,7 @@ CDAP currently supports Java for developing applications.
 
 What version of Java SDK is required by CDAP?
 ---------------------------------------------
-The latest version of the JDK or JRE version 7 or version 8 must be installed in your
+The latest version of the JDK or JRE version 8 must be installed in your
 environment. CDAP is tested on both the `Oracle JDK <http://www.java.com/en/download/manual.jsp>`__
 and the `OpenJDK <http://openjdk.java.net/>`__.
 

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -37,7 +37,7 @@ GIT_EMR_VERSIONS="4.6 through 4.8"
 GIT_PREVIOUS_SHORT_VERSION="4.2"
 GIT_PREVIOUS_VERSION="4.2.0"
 
-GIT_NODE_JS_MIN_VERSION="v4.5.0"
+GIT_NODE_JS_MIN_VERSION="v8.7.0"
 # GIT_NODE_JS_MAX_VERSION="" # not currently known
 
 # This needs to be explicitly set as Git has trouble identifying it


### PR DESCRIPTION
Should be ported back to 5.0 docs too. 

Note: Merge pending on version bump to 5.1.1-SNAPSHOT if needed.