### PR TITLE
CDAP-14515 Handle requirements deserialization on upgrade cluster

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginClass.java
@@ -146,7 +146,10 @@ public class PluginClass {
    * @return the {@link Requirements} which represents the requirements of the plugin
    */
   public Requirements getRequirements() {
-    return requirements;
+    // CDAP-14515 Requirements can be null in the case when the cluster is upgraded and the the Plugin class
+    // is being constructed from a deserialized form and the GSON used to deserialize does not uses
+    // PluginClassDeserializer responsible for handling the absence of requirements in old deserialized form.
+    return requirements == null ? Requirements.EMPTY : requirements;
   }
 
   @Override


### PR DESCRIPTION
- Requirements can be null in the case when the cluster is upgraded and the the Plugin class is being constructed from a deserialized form and the GSON used to deserialize does not uses PluginClassDeserializer responsible for handling the absence of requirements in old deserialized form. 
- After upgrade the cluster starts fine but create pipelines fail since the ArtifactStore does not uses the the above deserializer. 

[Issue](https://issues.cask.co/browse/CDAP-14515)

Build: https://builds.cask.co/browse/CDAP-RUT1639-1