### PR TITLE
CDAP-14524 fix single input output

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -87,7 +87,7 @@ public final class MapReduceContextConfig {
   }
 
   /**
-   * Updates the {@link Configuration} of this class with the given paramters.
+   * Updates the {@link Configuration} of this class with the given parameters.
    *
    * @param context the context for the MapReduce program
    * @param conf the CDAP configuration

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.Transactionals;
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
-import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduce;
@@ -50,10 +49,8 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.internal.app.runtime.LocalizationUtils;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.SystemArguments;
-import co.cask.cdap.internal.app.runtime.batch.dataset.UnsupportedOutputFormat;
 import co.cask.cdap.internal.app.runtime.batch.dataset.input.MapperInput;
 import co.cask.cdap.internal.app.runtime.batch.dataset.input.MultipleInputs;
-import co.cask.cdap.internal.app.runtime.batch.dataset.output.MultipleOutputs;
 import co.cask.cdap.internal.app.runtime.batch.dataset.output.MultipleOutputsMainOutputWrapper;
 import co.cask.cdap.internal.app.runtime.batch.dataset.output.ProvidedOutput;
 import co.cask.cdap.internal.app.runtime.batch.distributed.ContainerLauncherGenerator;
@@ -121,7 +118,6 @@ import java.net.URL;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -747,35 +743,8 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     List<ProvidedOutput> outputsMap = context.getOutputs();
     fixOutputPermissions(job, outputsMap);
     LOG.debug("Using as output for MapReduce Job: {}", outputsMap);
-    OutputFormatProvider rootOutputFormatProvider;
-    if (outputsMap.isEmpty()) {
-      // user is not going through our APIs to add output; propagate the job's output format
-      rootOutputFormatProvider =
-        new BasicOutputFormatProvider(job.getOutputFormatClass().getName(), Collections.<String, String>emptyMap());
-    } else if (outputsMap.size() == 1) {
-      // If only one output is configured through the context, then set it as the root OutputFormat
-      rootOutputFormatProvider = outputsMap.get(0).getOutputFormatProvider();
-    } else {
-      // multiple output formats configured via the context. We should use a RecordWriter that doesn't support writing
-      // as the root output format in this case to disallow writing directly on the context.
-      // the OutputCommitter is effectively a no-op, as it runs as the RootOutputCommitter in MultipleOutputsCommitter
-      rootOutputFormatProvider =
-        new BasicOutputFormatProvider(UnsupportedOutputFormat.class.getName(), Collections.<String, String>emptyMap());
-    }
-
-    MultipleOutputsMainOutputWrapper.setRootOutputFormat(job,
-                                                         rootOutputFormatProvider.getOutputFormatClassName(),
-                                                         rootOutputFormatProvider.getOutputFormatConfiguration());
+    MultipleOutputsMainOutputWrapper.setOutputs(job, outputsMap);
     job.setOutputFormatClass(MultipleOutputsMainOutputWrapper.class);
-
-    for (ProvidedOutput output : outputsMap) {
-      String outputName = output.getOutput().getAlias();
-      String outputFormatClassName = output.getOutputFormatClassName();
-      Map<String, String> outputConfig = output.getOutputFormatConfiguration();
-      MultipleOutputs.addNamedOutput(job, outputName, outputFormatClassName,
-                                     job.getOutputKeyClass(), job.getOutputValueClass(), outputConfig);
-
-    }
   }
 
   private void fixOutputPermissions(JobContext job, List<ProvidedOutput> outputs) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/AppWithSingleInputOutput.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/AppWithSingleInputOutput.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.output;
+
+import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.batch.InputFormatProvider;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * App used to test whether map reduce task context has correct config values.
+ */
+public class AppWithSingleInputOutput extends AbstractApplication {
+  static final String ADDITIONAL_CONFIG = "additionalConfig";
+  static final String SINK_CONFIG = "sinkConfig";
+  static final String SOURCE_CONFIG = "sinkConfig";
+
+
+  @Override
+  public void configure() {
+    setName("AppWithSingleInputOutput");
+    setDescription("Application with MapReduce job");
+    addMapReduce(new SimpleMapReduce());
+  }
+
+  /**
+   * Simple map-only MR.
+   */
+  public static class SimpleMapReduce extends AbstractMapReduce {
+    @Override
+    protected void configure() {
+      setName("SimpleMapReduce");
+    }
+
+    @Override
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
+
+      Map<String, String> sourceConf = new HashMap<>();
+      sourceConf.put(ADDITIONAL_CONFIG, SOURCE_CONFIG);
+
+      context.addInput(Input.of("input", new InputFormatProvider() {
+        @Override
+        public String getInputFormatClassName() {
+          return ConfigVerifyingInputFormat.class.getName();
+        }
+
+        @Override
+        public Map<String, String> getInputFormatConfiguration() {
+          return sourceConf;
+        }
+      }), SimpleMapper.class);
+
+      Map<String, String> sinkConf = new HashMap<>();
+      sinkConf.put(ADDITIONAL_CONFIG, SINK_CONFIG);
+      context.addOutput(Output.of("test", new OutputFormatProvider() {
+        @Override
+        public String getOutputFormatClassName() {
+          return ConfigVerifyingOutputFormat.class.getName();
+        }
+
+        @Override
+        public Map<String, String> getOutputFormatConfiguration() {
+          return sinkConf;
+        }
+      }));
+
+      Job job = context.getHadoopJob();
+      job.setMapperClass(SimpleMapper.class);
+      job.setNumReduceTasks(0);
+    }
+  }
+
+  public static class SimpleMapper extends Mapper<LongWritable, Text, LongWritable, Text>
+    implements ProgramLifecycle<MapReduceTaskContext<LongWritable, Text>> {
+
+    @Override
+    public void initialize(MapReduceTaskContext<LongWritable, Text> context) throws Exception {
+      // no-op
+    }
+
+    @Override
+    public void map(LongWritable key, Text data, Context context) throws IOException, InterruptedException {
+      context.write(new LongWritable(1L), data);
+    }
+
+    @Override
+    public void destroy() {
+      // no-op
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ConfigVerifyingInputFormat.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ConfigVerifyingInputFormat.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.output;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Noop inputformat that generates mock input splits and verifies if correct configuration values are available in
+ * job and task context.
+ */
+public class ConfigVerifyingInputFormat extends InputFormat<LongWritable, Text> {
+
+  /**
+   * Get noop splits
+   */
+  @Override
+  public List<InputSplit> getSplits(JobContext jobContext) throws IOException, InterruptedException {
+    String config = jobContext.getConfiguration().get(AppWithSingleInputOutput.ADDITIONAL_CONFIG);
+    // CDAP-14531 validate the correct conf values are present in the context for the input splits
+    if (!config.equals(AppWithSingleInputOutput.SOURCE_CONFIG)) {
+      throw new RuntimeException(String.format("Configuration value for key: %s should be %s, instead it was %s",
+                                               AppWithSingleInputOutput.ADDITIONAL_CONFIG,
+                                               AppWithSingleInputOutput.SOURCE_CONFIG, config));
+    }
+
+    List<InputSplit> splits = new ArrayList<>();
+    for (int i = 0; i < 1; i++) {
+      splits.add(new MockInputSplit());
+    }
+    return splits;
+  }
+
+  /**
+   * Noop record reader
+   */
+  @Override
+  public RecordReader<LongWritable, Text> createRecordReader(
+    InputSplit inputSplit, TaskAttemptContext context) throws IOException, InterruptedException {
+    String config = context.getConfiguration().get(AppWithSingleInputOutput.ADDITIONAL_CONFIG);
+    // CDAP-14531 validate the correct conf values are present in the context for the input
+    if (!config.equals(AppWithSingleInputOutput.SOURCE_CONFIG)) {
+      throw new RuntimeException(String.format("Configuration value for key: %s should be %s, instead it was %s",
+                                               AppWithSingleInputOutput.ADDITIONAL_CONFIG,
+                                               AppWithSingleInputOutput.SOURCE_CONFIG, config));
+    }
+
+    return new RecordReader<LongWritable, Text>() {
+      @Override
+      public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        // no-op
+      }
+
+      @Override
+      public boolean nextKeyValue() throws IOException, InterruptedException {
+        return false;
+      }
+
+      @Override
+      public LongWritable getCurrentKey() throws IOException, InterruptedException {
+        return new LongWritable();
+      }
+
+      @Override
+      public Text getCurrentValue() throws IOException, InterruptedException {
+        return new Text();
+      }
+
+      @Override
+      public float getProgress() throws IOException, InterruptedException {
+        return 0;
+      }
+
+      @Override
+      public void close() throws IOException {
+        // no-op
+      }
+    };
+  }
+
+
+  public static class MockInputSplit extends InputSplit implements Writable {
+
+    @Override
+    public long getLength() throws IOException, InterruptedException {
+      return 0L;
+    }
+
+    @Override
+    public String[] getLocations() throws IOException, InterruptedException {
+      return new String[0];
+    }
+
+    @Override
+    public void readFields(DataInput arg0) throws IOException {
+      // no-op
+    }
+
+    @Override
+    public void write(DataOutput arg0) throws IOException {
+      // no-op
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ConfigVerifyingOutputFormat.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ConfigVerifyingOutputFormat.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.output;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * Noop output format to test correct configurations are available in task context
+ */
+public class ConfigVerifyingOutputFormat extends OutputFormat<LongWritable, Text> {
+
+  /**
+   * Noop record writer
+   */
+  @Override
+  public RecordWriter<LongWritable, Text> getRecordWriter(TaskAttemptContext context) throws IOException {
+    String config = context.getConfiguration().get(AppWithSingleInputOutput.ADDITIONAL_CONFIG);
+    // CDAP-14531 validate the correct conf values are present in the context for the output
+    if (!config.equals(AppWithSingleInputOutput.SINK_CONFIG)) {
+      throw new RuntimeException(String.format("Configuration value for key: %s should be %s, instead it was %s",
+                                               AppWithSingleInputOutput.ADDITIONAL_CONFIG,
+                                               AppWithSingleInputOutput.SINK_CONFIG, config));
+    }
+
+    return new RecordWriter<LongWritable, Text>() {
+      @Override
+      public void write(LongWritable key, Text value) throws IOException, InterruptedException {
+        // no-op
+      }
+
+      @Override
+      public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+        // no-op
+      }
+    };
+  }
+
+  /**
+   * Noop spec check
+   */
+  @Override
+  public void checkOutputSpecs(JobContext jobContext) {
+  }
+
+  /**
+   * Noop output committer
+   */
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext context) {
+    String config = context.getConfiguration().get(AppWithSingleInputOutput.ADDITIONAL_CONFIG);
+    // CDAP-14531 validate the correct conf values are present in the context for the output committer
+    if (!config.equals(AppWithSingleInputOutput.SINK_CONFIG)) {
+      throw new RuntimeException(String.format("Configuration value for key: %s should be %s, instead it was %s",
+                                               AppWithSingleInputOutput.ADDITIONAL_CONFIG,
+                                               AppWithSingleInputOutput.SINK_CONFIG, config));
+    }
+
+    return new OutputCommitter() {
+      @Override
+      public void setupJob(JobContext jobContext) {
+
+      }
+
+      @Override
+      public void setupTask(TaskAttemptContext taskAttemptContext) {
+
+      }
+
+      @Override
+      public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) {
+        return false;
+      }
+
+      @Override
+      public void commitTask(TaskAttemptContext taskAttemptContext) {
+
+      }
+
+      @Override
+      public void abortTask(TaskAttemptContext taskAttemptContext) {
+
+      }
+    };
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/MapReduceConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/MapReduceConfigTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.output;
+
+import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.batch.MapReduceRunnerTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests correct configuration for map task context
+ */
+public class MapReduceConfigTest extends MapReduceRunnerTestBase {
+
+  @Test
+  public void testConfigIsolation() throws Exception {
+    ApplicationWithPrograms app = deployApp(AppWithSingleInputOutput.class);
+    Assert.assertTrue(runProgram(app, AppWithSingleInputOutput.SimpleMapReduce.class, new BasicArguments()));
+  }
+}


### PR DESCRIPTION
**Summary**
`MultiInputFormat` is used for single source mapreduce job. When pipeline has single source and sink and if both source and sink has same configuration key, all the hadoop conf keys are changed to use source configuration. That means, sink uses config values from source. This works for multiple output case because for multiple outputs, we use namedKeys. 

The fix simply uses copy of configuration in `MultipleInputFormat` to avoid overwriting sink keys.

**Edit**
The previous approach had an issue. If configuration is modified in `inputFormat.createRecordReader` (which can happen in CombineFileRecordReader), those properties wont be available in copied configuration.

The PR is now using another approach where single and multiple outputs use named properties. 

Issues: 
https://issues.cask.co/browse/CDAP-10250
https://issues.cask.co/browse/CDAP-14524

Build: 
https://builds.cask.co/browse/CDAP-RUT1640-3