### PR TITLE
CDAP-14549 fix macros in plugins of plugins

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/plugin/PluggableFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/plugin/PluggableFilterTransform.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.datapipeline.plugin;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.TransformContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+
+/**
+ * A Transform that delegates its logic to a plugin. Used to test plugins created by other plugins.
+ */
+@Plugin(type = Transform.PLUGIN_TYPE)
+@Name(PluggableFilterTransform.NAME)
+public class PluggableFilterTransform extends Transform<StructuredRecord, StructuredRecord> {
+  public static final String NAME = "PluggableTransform";
+  static final String FILTER_PLUGIN_TYPE = "filter";
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private final Conf conf;
+  private Predicate<StructuredRecord> filter;
+
+  public PluggableFilterTransform(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    Map<String, String> filterProperties = GSON.fromJson(conf.filterProperties, MAP_TYPE);
+    PluginProperties pluginProperties = PluginProperties.builder().addAll(filterProperties).build();
+    filter = pipelineConfigurer.usePlugin(FILTER_PLUGIN_TYPE, conf.filterPlugin, "id", pluginProperties);
+    if (filter == null) {
+      throw new IllegalArgumentException("Could not find filter plugin " + conf.filterPlugin);
+    }
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws Exception {
+    filter = context.newPluginInstance("id");
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) {
+    if (!filter.test(input)) {
+      emitter.emit(input);
+    }
+  }
+
+  /**
+   * Configuration for the transform
+   */
+  public static class Conf extends PluginConfig {
+    private String filterPlugin;
+
+    @Nullable
+    private String filterProperties;
+
+    public Conf() {
+      filterPlugin = null;
+      filterProperties = GSON.toJson(Collections.emptyMap());
+    }
+  }
+
+  public static ETLPlugin getPlugin(String filterPlugin, Map<String, String> filterProperties) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("filterPlugin", filterPlugin);
+    properties.put("filterProperties", GSON.toJson(filterProperties));
+    return new ETLPlugin(NAME, Transform.PLUGIN_TYPE, properties, null);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/plugin/ValueFilter.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/plugin/ValueFilter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.datapipeline.plugin;
+
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Filters out records where a field has a specific value. Used to test plugins created by other plugins.
+ */
+@Plugin(type = PluggableFilterTransform.FILTER_PLUGIN_TYPE)
+@Name(ValueFilter.NAME)
+public class ValueFilter implements Predicate<StructuredRecord> {
+  public static final String NAME = "ValueFilter";
+  private final Conf conf;
+
+  public ValueFilter(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public boolean test(StructuredRecord input) {
+    return conf.value.equals(input.get(conf.field));
+  }
+
+  public static class Conf extends PluginConfig {
+    @Macro
+    private String field;
+
+    @Macro
+    private String value;
+  }
+
+  public static Map<String, String> getProperties(String field, String value) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("field", field);
+    properties.put("value", value);
+    return properties;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultPipelineConfigurer.java
@@ -108,7 +108,7 @@ public class DefaultPipelineConfigurer<C extends PluginConfigurer & DatasetConfi
   @Override
   public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                          PluginSelector selector) {
-    return configurer.usePlugin(pluginType, pluginName, pluginId, properties, selector);
+    return configurer.usePlugin(pluginType, pluginName, getPluginId(pluginId), properties, selector);
   }
 
   @Nullable
@@ -122,7 +122,7 @@ public class DefaultPipelineConfigurer<C extends PluginConfigurer & DatasetConfi
   @Override
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                                      PluginSelector selector) {
-    return configurer.usePluginClass(pluginType, pluginName, pluginId, properties, selector);
+    return configurer.usePluginClass(pluginType, pluginName, getPluginId(pluginId), properties, selector);
   }
   
   private String getPluginId(String childPluginId) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineRuntime.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineRuntime.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metadata.MetadataWriter;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.etl.api.StageContext;
@@ -45,36 +46,37 @@ public class PipelineRuntime {
   private final ServiceDiscoverer serviceDiscoverer;
   private final MetadataReader metadataReader;
   private final MetadataWriter metadataWriter;
+  private final SecureStore secureStore;
 
   public PipelineRuntime(SparkClientContext context) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-         new BasicArguments(context), context.getMetrics(), context, context, context, context);
+         new BasicArguments(context), context.getMetrics(), context, context, context, context, context);
   }
 
   public PipelineRuntime(CustomActionContext context, Metrics metrics) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-         new BasicArguments(context), metrics, context, context, context, context);
+         new BasicArguments(context), metrics, context, context, context, context, context);
   }
 
   public PipelineRuntime(MapReduceTaskContext context, Metrics metrics, BasicArguments arguments) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-         arguments, metrics, context, context);
+         arguments, metrics, context, context, context);
   }
 
   public PipelineRuntime(MapReduceContext context, Metrics metrics) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-         new BasicArguments(context), metrics, context, context, context, context);
+         new BasicArguments(context), metrics, context, context, context, context, context);
   }
 
   public PipelineRuntime(WorkflowContext context, Metrics metrics) {
     this(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
          new BasicArguments(context.getToken(), context.getRuntimeArguments()), metrics, context, context, context,
-         context);
+         context, context);
   }
 
   public PipelineRuntime(String namespace, String pipelineName, long logicalStartTime, BasicArguments arguments,
                          Metrics metrics, PluginContext pluginContext, ServiceDiscoverer serviceDiscoverer,
-                         MetadataReader metadataReader, MetadataWriter metadataWriter) {
+                         SecureStore secureStore, MetadataReader metadataReader, MetadataWriter metadataWriter) {
     this.namespace = namespace;
     this.pipelineName = pipelineName;
     this.logicalStartTime = logicalStartTime;
@@ -84,11 +86,14 @@ public class PipelineRuntime {
     this.serviceDiscoverer = serviceDiscoverer;
     this.metadataReader = metadataReader;
     this.metadataWriter = metadataWriter;
+    this.secureStore = secureStore;
   }
 
   public PipelineRuntime(String namespace, String pipelineName, long logicalStartTime, BasicArguments arguments,
-                         Metrics metrics, PluginContext pluginContext, ServiceDiscoverer serviceDiscoverer) {
-    this(namespace, pipelineName, logicalStartTime, arguments, metrics, pluginContext, serviceDiscoverer, null, null);
+                         Metrics metrics, PluginContext pluginContext, ServiceDiscoverer serviceDiscoverer,
+                         SecureStore secureStore) {
+    this(namespace, pipelineName, logicalStartTime, arguments, metrics, pluginContext, serviceDiscoverer,
+         secureStore, null, null);
   }
 
   public String getNamespace() {
@@ -117,6 +122,10 @@ public class PipelineRuntime {
 
   public ServiceDiscoverer getServiceDiscoverer() {
     return serviceDiscoverer;
+  }
+
+  public SecureStore getSecureStore() {
+    return secureStore;
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/SparkPipelineRuntime.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/SparkPipelineRuntime.java
@@ -28,7 +28,7 @@ public class SparkPipelineRuntime extends PipelineRuntime {
 
   public SparkPipelineRuntime(SparkClientContext context) {
     super(context.getNamespace(), context.getApplicationSpecification().getName(), context.getLogicalStartTime(),
-          new BasicArguments(context), context.getMetrics(), context, context, context, context);
+          new BasicArguments(context), context.getMetrics(), context, context, context, context, context);
   }
 
   public SparkPipelineRuntime(JavaSparkExecutionContext sec) {
@@ -37,6 +37,7 @@ public class SparkPipelineRuntime extends PipelineRuntime {
 
   public SparkPipelineRuntime(JavaSparkExecutionContext sec, long batchTime) {
     super(sec.getNamespace(), sec.getApplicationSpecification().getName(), batchTime,
-          new BasicArguments(sec), sec.getMetrics(), sec.getPluginContext(), sec.getServiceDiscoverer());
+          new BasicArguments(sec), sec.getMetrics(), sec.getPluginContext(), sec.getServiceDiscoverer(),
+          sec.getSecureStore());
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/PluginFunctionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/function/PluginFunctionContext.java
@@ -113,7 +113,7 @@ public class PluginFunctionContext implements Serializable {
   public SparkBatchRuntimeContext createBatchRuntimeContext() {
     PipelineRuntime pipelineRuntime = new PipelineRuntime(namespace, pipelineName, logicalStartTime,
                                                           arguments, metrics, pluginContext,
-                                                          serviceDiscoverer);
+                                                          serviceDiscoverer, secureStore);
     return new SparkBatchRuntimeContext(pipelineRuntime, stageSpec);
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -51,7 +51,7 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
   public DefaultStreamingContext(StageSpec stageSpec, JavaSparkExecutionContext sec, JavaStreamingContext jsc) {
     super(new PipelineRuntime(sec.getNamespace(), sec.getApplicationSpecification().getName(),
                               sec.getLogicalStartTime(), new BasicArguments(sec), sec.getMetrics(),
-                              sec.getPluginContext(), sec.getServiceDiscoverer(), sec, sec), stageSpec);
+                              sec.getPluginContext(), sec.getServiceDiscoverer(), sec, sec, sec), stageSpec);
     this.sec = sec;
     this.jsc = jsc;
     this.admin = sec.getAdmin();


### PR DESCRIPTION
Use a macro evaluator when a plugin instantiates another plugin.
Also correctly scope the plugin id when a plugin is registered
using the plugin selector APIs.