### PR TITLE
[CDAP-14291] Exclude storybook-static generated folder from pom ui build

### DIFF
--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -175,6 +175,7 @@
                   <exclude>**/dll/**</exclude>
                   <exclude>**/LICENSE-node</exclude>
                   <exclude>**/cdap-ui-upgrade/**</exclude>
+                  <exclude>**/storybook-static/**</exclude>
                 </excludes>
               </configuration>
             </execution>


### PR DESCRIPTION
Exclude `storybook-static` folder while building UI. This was causing the UI develop build to timeout and fail.

JIRA: https://issues.cask.co/browse/CDAP-14291
Build: https://builds.cask.co/browse/CDAP-UDUT144