### PR TITLE
CDAP-14558 | Realtime/Spark Streaming pipelines ignore config and alw…

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -126,7 +126,7 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
       public JavaStreamingContext call() throws Exception {
         JavaStreamingContext jssc = new JavaStreamingContext(
           new JavaSparkContext(), Durations.milliseconds(pipelineSpec.getBatchIntervalMillis()));
-        SparkStreamingPipelineRunner runner = new SparkStreamingPipelineRunner(sec, jssc, pipelineSpec, false);
+        SparkStreamingPipelineRunner runner = new SparkStreamingPipelineRunner(sec, jssc, pipelineSpec, pipelineSpec.isCheckpointsDisabled());
         PipelinePluginContext pluginContext = new PipelinePluginContext(sec.getPluginContext(), sec.getMetrics(),
                                                                         pipelineSpec.isStageLoggingEnabled(),
                                                                         pipelineSpec.isProcessTimingEnabled());


### PR DESCRIPTION
Realtime/Spark Streaming pipelines ignore config and always run with checkpointing on