### PR TITLE
(CDAP-14569) LevelDB performance improvement

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/LevelDBKVTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/LevelDBKVTableDefinition.java
@@ -156,7 +156,7 @@ public class LevelDBKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyV
     }
 
     private static byte[] createKey(byte[] rowKey) {
-      return new KeyValue(rowKey, DATA_COLFAM, DEFAULT_COLUMN, 1, KeyValue.Type.Put).getKey();
+      return KeyValue.getKey(rowKey, DATA_COLFAM, DEFAULT_COLUMN, 1, KeyValue.Type.Put);
     }
 
     @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -547,11 +547,11 @@ public class LevelDBTableCore {
   // ------- helpers to create the keys for writes and scans ----------
 
   private static byte[] createPutKey(byte[] rowKey, byte[] columnKey, long version) {
-    return new KeyValue(rowKey, DATA_COLFAM, columnKey, version, KeyValue.Type.Put).getKey();
+    return KeyValue.getKey(rowKey, DATA_COLFAM, columnKey, version, KeyValue.Type.Put);
   }
 
   private static byte[] createStartKey(byte[] row) { // the first possible key of a row
-    return new KeyValue(row, DATA_COLFAM, null, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum).getKey();
+    return KeyValue.getKey(row, DATA_COLFAM, null, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum);
   }
 
   private static byte[] createEndKey(byte[] row) {
@@ -559,16 +559,16 @@ public class LevelDBTableCore {
   }
 
   private static byte[] createStartKey(byte[] row, byte[] column) {
-    return new KeyValue(row, DATA_COLFAM, column, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum).getKey();
+    return KeyValue.getKey(row, DATA_COLFAM, column, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum);
   }
 
   private static byte[] createEndKey(byte[] row, byte[] column) {
     if (column != null) {
       // we have a stop column and can use that as an upper bound
-      return new KeyValue(row, DATA_COLFAM, column, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum).getKey();
+      return KeyValue.getKey(row, DATA_COLFAM, column, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum);
     } else {
       // no stop column - use next column family as upper bound
-      return new KeyValue(row, NEXT_COLFAM, null, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum).getKey();
+      return KeyValue.getKey(row, NEXT_COLFAM, null, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum);
     }
   }
 }


### PR DESCRIPTION
Improvement on the LevelDB table implementation to provide better improvements. There are two commits in this PR.

1. Use Unsafe Bytes comparer if possible.
2. Reduce amount of intermediate array creation and array copying.