### PR TITLE
[CDAP-14572] Adds toggle plugin widget

### DIFF
--- a/cdap-docs/developer-manual/source/pipelines/developing-plugins/presentation-plugins.rst
+++ b/cdap-docs/developer-manual/source/pipelines/developing-plugins/presentation-plugins.rst
@@ -687,6 +687,34 @@ CDAP pipelines as of version |version|.
             }
           }
 
+   * - ``toggle``
+     - - ``on``: 'On' state of the toggle, defined by ``value`` - value to be set for the plugin property, and
+         ``label`` - a label to be rendered in UI, limited to 64 characters.
+       - ``off``: 'Off' state of the toggle, defined by ``value`` - value to be set for the plugin property, and
+         ``label`` - a label to be rendered in UI, limited to 64 characters.
+       - ``default``: default value for the widget
+     - ``string``
+     - A toggle widget that allows toggling between 'on' and 'off' states
+     - .. container:: copyable copyable-text
+
+         ::
+
+          {
+            "name": "property-toggle",
+            "widget-type": "toggle",
+            "widget-attributes": {
+              "on": {
+                "value": "on",
+                "label": "On"
+              },
+              "off": {
+                "value": "off",
+                "label": "Off"
+              },
+              "default": "on"
+            }
+          }
+
 
 .. _plugins-presentation-plugin-function:
 

--- a/cdap-ui/app/cdap/components/ToggleSwitch/ToggleSwitch.scss
+++ b/cdap-ui/app/cdap/components/ToggleSwitch/ToggleSwitch.scss
@@ -18,8 +18,8 @@
 $switch-btn-width: 14px;
 $widget-height: 32px;
 $switch-button-margin-top: 2px;
-$on-color: $green-02;
-$off-color: $blue-02;
+$on-color: $blue-02;
+$off-color: $grey-04;
 
 .toggle-switch-container {
   display: inline-block;
@@ -54,13 +54,11 @@ $off-color: $blue-02;
 
     &.on {
       background-color: $on-color;
-      .switch-button {
-        order: 2;
-      }
     }
 
     &.off {
       background-color: $off-color;
+      flex-direction: row-reverse;
     }
   }
 

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -67,6 +67,7 @@ var cdapavscwrapper = require('../cdap/services/cdapavscwrapper').default;
 var IconSVG = require('../cdap/components/IconSVG').default;
 var PipelineConfigConstants = require('../cdap/components/PipelineConfigurations/PipelineConfigConstants');
 var AuthRefresher = require('../cdap/components/AuthRefresher').default;
+var ToggleSwitch = require('../cdap/components/ToggleSwitch').default;
 
 export {
   Store,
@@ -115,4 +116,5 @@ export {
   IconSVG,
   PipelineConfigConstants,
   AuthRefresher,
+  ToggleSwitch,
 };

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
@@ -164,14 +164,14 @@ class MyBatchPipelineConfigCtrl {
     this.executorResources.memoryMB = value;
     this.updatePipelineEditStatus();
   }
-  onToggleInstrumentationChange() {
+  onToggleInstrumentationChange = () => {
     this.instrumentation = !this.instrumentation;
     this.updatePipelineEditStatus();
-  }
-  onStageLoggingChange() {
+  };
+  onStageLoggingChange = () => {
     this.stageLogging = !this.stageLogging;
     this.updatePipelineEditStatus();
-  }
+  };
   updatePipelineEditStatus() {
     const isResourcesEqual = (oldvalue, newvalue) => {
       return oldvalue.memoryMB === newvalue.memoryMB && oldvalue.virtualCores === newvalue.virtualCores;

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
@@ -115,10 +115,10 @@
         <div class="label-with-toggle instrumentation row">
           <span class="toggle-label col-xs-4">Instrumentation</span>
           <div class="col-xs-7 toggle-container">
-            <my-toggle-switch-widget
+            <toggle-switch
               is-on="BatchPipelineConfigCtrl.instrumentation"
-              on-toggle="BatchPipelineConfigCtrl.onToggleInstrumentationChange()"
-            ></my-toggle-switch-widget>
+              on-toggle="BatchPipelineConfigCtrl.onToggleInstrumentationChange"
+            ></toggle-switch>
             <i class="fa fa-info-circle"
                 uib-tooltip="Emits timing metrics such as total time, mean, standard deviation for pipeline stages. It is recommended to always have this setting on, unless the environment is short on resources."
                 tooltip-placement="right">
@@ -128,10 +128,10 @@
         <div class="label-with-toggle stageLogging row">
           <span class="toggle-label col-xs-4">Stage level logging</span>
           <div class="col-xs-7 toggle-container">
-            <my-toggle-switch-widget
+            <toggle-switch
               is-on="BatchPipelineConfigCtrl.stageLogging"
-              on-toggle="BatchPipelineConfigCtrl.onStageLoggingChange()"
-            ></my-toggle-switch-widget>
+              on-toggle="BatchPipelineConfigCtrl.onStageLoggingChange"
+            ></toggle-switch>
             <i class="fa fa-info-circle"
                 uib-tooltip="Allows logs from each stage in the pipeline to be queried individually. It is recommended to always have this setting on, unless the environment is short on resources."
                 tooltip-placement="right">

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config-ctrl.js
@@ -205,20 +205,24 @@ class MyRealtimePipelineConfigCtrl {
     this.updatePipelineEditStatus();
   }
 
-  onCheckPointingChange() {
+  onCheckPointingChange = () => {
     this.checkpointing = !this.checkpointing;
     this.updatePipelineEditStatus();
-  }
+  };
 
-  onInstrumentationChange() {
+  onInstrumentationChange = () => {
     this.instrumentation = !this.instrumentation;
     this.updatePipelineEditStatus();
-  }
+  };
 
-  onStageLoggingChange() {
+  onStageLoggingChange = () => {
     this.stageLogging = !this.stageLogging;
     this.updatePipelineEditStatus();
-  }
+  };
+
+  onBackpressureChange = () => {
+    this.backpressure = !this.backpressure;
+  };
 
   getUpdatedPipelineConfig() {
     let pipelineconfig = _.cloneDeep(this.store.getCloneConfig());

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-realtime-pipeline-config/my-realtime-pipeline-config.html
@@ -126,10 +126,10 @@
         <div class="label-with-toggle checkpointing row">
           <span class="toggle-label col-xs-4">Checkpointing</span>
           <div class="col-xs-7 toggle-container">
-            <my-toggle-switch-widget
+            <toggle-switch
               is-on="!RealtimePipelineConfigCtrl.checkpointing"
-              on-toggle="RealtimePipelineConfigCtrl.onCheckPointingChange()"
-            ></my-toggle-switch-widget>
+              on-toggle="RealtimePipelineConfigCtrl.onCheckPointingChange"
+            ></toggle-switch>
             <i class="fa fa-info-circle"
                 uib-tooltip="Allows Apache Spark Streaming to checkpoint data (RDDs) to persistent storage so that the pipeline can recover from failures."
                 tooltip-placement="right">
@@ -139,10 +139,10 @@
         <div class="label-with-toggle instrumentation row">
           <span class="toggle-label col-xs-4">Instrumentation</span>
           <div class="col-xs-7 toggle-container">
-            <my-toggle-switch-widget
+            <toggle-switch
               is-on="RealtimePipelineConfigCtrl.instrumentation"
-              on-toggle="RealtimePipelineConfigCtrl.onInstrumentationChange()"
-            ></my-toggle-switch-widget>
+              on-toggle="RealtimePipelineConfigCtrl.onInstrumentationChange"
+            ></toggle-switch>
             <i class="fa fa-info-circle"
                 uib-tooltip="Emits timing metrics such as total time, mean, and and standard deviation for pipeline stages. It is recommended to always have this setting on, unless the environment is short on resources."
                 tooltip-placement="right">
@@ -152,10 +152,10 @@
         <div class="label-with-toggle stage-logging row">
           <span class="toggle-label col-xs-4">Stage level logging</span>
           <div class="col-xs-7 toggle-container">
-            <my-toggle-switch-widget
+            <toggle-switch
               is-on="RealtimePipelineConfigCtrl.stageLogging"
-              on-toggle="RealtimePipelineConfigCtrl.onStageLoggingChange()"
-            ></my-toggle-switch-widget>
+              on-toggle="RealtimePipelineConfigCtrl.onStageLoggingChange"
+            ></toggle-switch>
             <i class="fa fa-info-circle"
                 uib-tooltip="Allows logs from each stage in the pipeline to be queried individually. It is recommended to always have this setting on, unless the environment is short on resources."
                 tooltip-placement="right">
@@ -244,11 +244,11 @@
           <div class="label-with-toggle backpressure row">
             <span class="toggle-label col-xs-4">Backpressure</span>
             <div class="col-xs-7 toggle-container">
-              <my-toggle-switch-widget
+              <toggle-switch
                 is-on="RealtimePipelineConfigCtrl.backpressure"
                 is-disabled="RealtimePipelineConfigCtrl.isDeployed"
-                on-toggle="RealtimePipelineConfigCtrl.backpressure = !RealtimePipelineConfigCtrl.backpressure"
-              ></my-toggle-switch-widget>
+                on-toggle="RealtimePipelineConfigCtrl.onBackpressureChange"
+              ></toggle-switch>
               <i class="fa fa-info-circle"
                  uib-tooltip="Allows the Apache Spark Streaming engine to control the receiving rate based on the current batch scheduling delays and processing times so that the system receives only as fast as the system can process."
                  tooltip-placement="right">

--- a/cdap-ui/app/directives/react-components/index.js
+++ b/cdap-ui/app/directives/react-components/index.js
@@ -60,6 +60,9 @@ angular.module(PKG.name + '.commons')
   .directive('iconSvg', function(reactDirective) {
     return reactDirective(window.CaskCommon.IconSVG);
   })
-  .directive('authRefresher', function (reactDirective) {
+  .directive('authRefresher', function(reactDirective) {
     return reactDirective(window.CaskCommon.AuthRefresher);
+  })
+  .directive('toggleSwitch', function(reactDirective) {
+    return reactDirective(window.CaskCommon.ToggleSwitch);
   });

--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -261,7 +261,15 @@ angular.module(PKG.name + '.commons')
           'ng-model': 'model',
           'config': 'myconfig'
         }
-      }
+      },
+      'toggle': {
+        element: '<my-toggle-switch></my-toggle-switch>',
+        attributes: {
+          'ng-model': 'model',
+          'config': 'myconfig',
+          'disabled': 'disabled',
+        }
+      },
     };
     this.registry['__default__'] = this.registry['textbox'];
   });

--- a/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.html
+++ b/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.html
@@ -14,15 +14,11 @@
   the License.
 -->
 
-<div class="ng-toggle-switch-container"
-    ng-class="{'disabled': isDisabled}">
-  <div class="toggle-switch"
-       ng-class="{'on': isOn, 'off': !isOn }"
-       ng-click="onToggle()">
-      <div class="switch-button"></div>
-      <div class="label"
-           ng-class="{'on-label': isOn, 'off-label': !isOn }">
-        <span ng-if="isOn">On</span>
-        <span ng-if="!isOn">Off</span>
-  </div>
-</div>
+<toggle-switch
+  is-on="isOn"
+  on-toggle="onToggle"
+  on-label="onLabel"
+  off-label="offLabel"
+  disabled="disabled"
+>
+</toggle-switch>

--- a/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.js
+++ b/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,15 +14,34 @@
  * the License.
  */
 
+ const CHAR_LIMIT = 64;
+
 angular.module(PKG.name + '.commons')
-  .directive('myToggleSwitchWidget', function() {
+  .directive('myToggleSwitch', function() {
     return {
       restrict: 'E',
       scope: {
-        isOn: '=',
-        isDisabled: '=',
-        onToggle: '&'
+        model: '=ngModel',
+        config: '=',
+        disabled: '=',
       },
-      templateUrl: 'widget-container/widget-toggle-switch/widget-toggle-switch.html'
+      templateUrl: 'widget-container/widget-toggle-switch/widget-toggle-switch.html',
+      controller: function($scope, myHelpers) {
+        const onValue = myHelpers.objectQuery($scope.config, 'widget-attributes', 'on', 'value') || 'on';
+        const offValue = myHelpers.objectQuery($scope.config, 'widget-attributes', 'off', 'value') || 'off';
+        const defaultValue = myHelpers.objectQuery($scope.config, 'widget-attributes', 'default') || onValue;
+        const onLabel = myHelpers.objectQuery($scope.config, 'widget-attributes', 'on', 'label') || 'On';
+        const offLabel = myHelpers.objectQuery($scope.config, 'widget-attributes', 'off', 'label') || 'Off';
+
+        $scope.onLabel = onLabel.slice(0, CHAR_LIMIT);
+        $scope.offLabel = offLabel.slice(0, CHAR_LIMIT);
+        $scope.model = $scope.model || defaultValue;
+        $scope.isOn = $scope.model === onValue;
+        $scope.onToggle = () => ($scope.isOn = !$scope.isOn);
+
+        $scope.$watch('isOn', () => {
+          $scope.model = $scope.isOn ? onValue : offValue;
+        });
+      }
     };
   });

--- a/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.less
+++ b/cdap-ui/app/directives/widget-container/widget-toggle-switch/widget-toggle-switch.less
@@ -14,73 +14,8 @@
  * the License.
  */
 
-@import "../../../styles/variables.less";
-@container-width: 50px;
-@switch-btn-width: 14px;
 @widget-height: 32px;
-@switch-button-margin-top: 2px;
-@on-color: @green-02;
-@off-color: @blue-02;
 
-.ng-toggle-switch-container {
-  display: inline-block;
+toggle-switch {
   height: @widget-height;
-  width: @container-width;
-
-  .toggle-switch {
-    height: 100%;
-    width: 100%;
-    position: relative;
-    vertical-align: middle;
-    border-radius: 5px;
-    font-weight: 500;
-    color: white;
-    user-select: none;
-    cursor: pointer;
-
-    .switch-button {
-      position: absolute;
-      top: @switch-button-margin-top;
-      width: @switch-btn-width;
-      height: @widget-height - (@switch-button-margin-top * 2);
-      background-color: white;
-      border-radius: 5px;
-    }
-
-    .label {
-      height: 100%;
-      width: @container-width - @switch-btn-width;
-      font-size: 11px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      &.off-label {
-        margin-left: @switch-btn-width;
-      }
-    }
-
-    &.on {
-      background-color: @on-color;
-      .switch-button {
-        right: 2px;
-      }
-    }
-
-    &.off {
-      background-color: @off-color;
-      .switch-button {
-        left: 2px;
-      }
-    }
-  }
-
-  &.disabled {
-    cursor: not-allowed;
-
-    .toggle-switch {
-      pointer-events: none;
-      opacity: 0.5;
-    }
-  }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14572
UI builds: https://builds.cask.co/browse/CDAP-UDUT149
Docs builds: https://builds.cask.co/browse/CDAP-DQB442

This PR:
- Adds `toggle` widget that can be used when building pipeline plugins. This is based on the existing `ToggleSwitch` React component. The user can specify the 'On'/'Off' labels, and the value to send to the backend for each state. Currently we set a limit of 64 characters for the labels.
- Modifies Configure modeless in Studio to use `toggle-switch` directive based on React component, instead of legacy `my-toggle-switch-widget` Angular directive.