### PR TITLE
Update Cypress and Jest test configs

### DIFF
--- a/cdap-ui/cypress.json
+++ b/cdap-ui/cypress.json
@@ -3,7 +3,6 @@
   "env": {
     "host": "localhost"
   },
-  "projectId": "nekuf8",
   "video": false,
   "pluginsFile": false,
   "supportFile": false,

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -19,7 +19,7 @@
     "build-dev-common-w": "NODE_ENV=development parallel-webpack --config=webpack.config.common.js -d --watch",
     "build-prod-dlls": "NODE_ENV=production parallel-webpack --config=webpack.config.dlls.js",
     "build-dev-dlls": "NODE_ENV=development parallel-webpack --config=webpack.config.dlls.js",
-    "jest": "jest",
+    "jest": "jest --coverage",
     "jest-w": "jest --watch",
     "karma-test": "node ./node_modules/karma/bin/karma start test/karma-conf.js",
     "karma-test-single-run": "node ./node_modules/karma/bin/karma start test/karma-conf.js --no-auto-watch --single-run",


### PR DESCRIPTION
This PR:
- Removes projectId from `cypress.json`. Since we don't want to continue using Cypress's Dashboard service, we don't need this configuration anymore.
- Adds --coverage flag to `yarn jest` command, to show coverage report whenever we run locally or in CI.