### PR TITLE
(CDAP-14569) Improve increments performance on LevelDB

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/common/Bytes.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/common/Bytes.java
@@ -1075,7 +1075,7 @@ public class Bytes {
    * @param right right operand
    * @return True if equal
    */
-  public static boolean equals(final byte [] left, final byte [] right) {
+  public static boolean equals(@Nullable byte[] left, @Nullable byte[] right) {
     // Could use Arrays.equals?
     //noinspection SimplifiableConditionalExpression
     if (left == right) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTable.java
@@ -18,13 +18,11 @@ package co.cask.cdap.data2.dataset2.lib.table.leveldb;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DataSetException;
-import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.inmemory.PrefixedNamespaces;
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
@@ -39,27 +37,12 @@ import javax.annotation.Nullable;
  */
 public class LevelDBMetricsTable implements MetricsTable {
 
-  private static final Function<Long, byte[]> LONG_TO_BYTES = new Function<Long, byte[]>() {
-    @Override
-    public byte[] apply(Long input) {
-      return Bytes.toBytes(input);
-    }
-  };
-  private static final Function<SortedMap<byte[], Long>, SortedMap<byte[], byte[]>>
-    TRANSFORM_MAP_LONG_TO_BYTE_ARRAY = new Function<SortedMap<byte[], Long>, SortedMap<byte[], byte[]>>() {
-    @Override
-    public SortedMap<byte[], byte[]> apply(SortedMap<byte[], Long> input) {
-      return Maps.transformValues(input, LONG_TO_BYTES);
-    }
-  };
-
   private final String tableName;
   private final LevelDBTableCore core;
 
-  public LevelDBMetricsTable(DatasetContext datasetContext, String tableName,
-                             LevelDBTableService service, CConfiguration cConf) throws IOException {
-    this.core = new LevelDBTableCore(PrefixedNamespaces.namespace(cConf, datasetContext.getNamespaceId(), tableName),
-                                     service);
+  public LevelDBMetricsTable(String namespace, String tableName,
+                             LevelDBTableService service, CConfiguration cConf) {
+    this.core = new LevelDBTableCore(PrefixedNamespaces.namespace(cConf, namespace, tableName), service);
     this.tableName = tableName;
   }
 
@@ -79,9 +62,9 @@ public class LevelDBMetricsTable implements MetricsTable {
   @Override
   public void put(SortedMap<byte[], ? extends SortedMap<byte[], Long>> updates) {
     SortedMap<byte[], ? extends SortedMap<byte[], byte[]>> convertedUpdates =
-      Maps.transformValues(updates, TRANSFORM_MAP_LONG_TO_BYTE_ARRAY);
+      Maps.transformValues(updates, input -> Maps.transformValues(input, Bytes::toBytes));
     try {
-      core.persist(convertedUpdates, System.currentTimeMillis());
+      core.persist(convertedUpdates, Long.MAX_VALUE);
     } catch (IOException e) {
       throw new DataSetException("Put failed on table " + tableName, e);
     }
@@ -90,7 +73,7 @@ public class LevelDBMetricsTable implements MetricsTable {
   @Override
   public void putBytes(SortedMap<byte[], ? extends SortedMap<byte[], byte[]>> updates) {
     try {
-      core.persist(updates, System.currentTimeMillis());
+      core.persist(updates, Long.MAX_VALUE);
     } catch (IOException e) {
       throw new DataSetException("Put failed on table " + tableName, e);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableDefinition.java
@@ -41,7 +41,7 @@ public class LevelDBMetricsTableDefinition extends AbstractTableDefinition<Metri
   @Override
   public MetricsTable getDataset(DatasetContext datasetContext, DatasetSpecification spec,
                                  Map<String, String> arguments, ClassLoader classLoader) throws IOException {
-    return new LevelDBMetricsTable(datasetContext, spec.getName(), service, cConf);
+    return new LevelDBMetricsTable(datasetContext.getNamespaceId(), spec.getName(), service, cConf);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTable.java
@@ -96,9 +96,7 @@ public class LevelDBTable extends BufferingTable {
   @WriteOnly
   private void persist(NavigableMap<byte[], NavigableMap<byte[], Long>> increments,
                        NavigableMap<byte[], NavigableMap<byte[], byte[]>> puts) throws IOException {
-    for (Map.Entry<byte[], NavigableMap<byte[], Long>> incEntry : increments.entrySet()) {
-      core.increment(incEntry.getKey(), incEntry.getValue());
-    }
+    core.increment(increments);
     core.persist(puts, persistedVersion);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -22,14 +22,12 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Maps;
 import org.apache.tephra.Transaction;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.ReadOptions;
+import org.iq80.leveldb.Snapshot;
 import org.iq80.leveldb.WriteBatch;
 import org.iq80.leveldb.WriteOptions;
 import org.slf4j.Logger;
@@ -42,6 +40,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 
 /**
@@ -54,7 +53,7 @@ public class LevelDBTableCore {
   private static final Scanner EMPTY_SCANNER = createEmptyScanner();
 
   // this represents deleted values
-  protected static final byte[] DELETE_MARKER = { };
+  private static final byte[] DELETE_MARKER = { };
 
   // we use the empty column family for all data
   private static final byte[] DATA_COLFAM = { };
@@ -69,16 +68,10 @@ public class LevelDBTableCore {
     return Bytes.add(column, ONE_ZERO);
   }
 
-  // empty immutable row's column->value map constant
-  // Using ImmutableSortedMap instead of Maps.unmodifiableNavigableMap to avoid conflicts with
-  // Hadoop, which uses an older version of guava without that method.
-  static final NavigableMap<byte[], byte[]> EMPTY_ROW_MAP =
-    ImmutableSortedMap.<byte[], byte[]>orderedBy(Bytes.BYTES_COMPARATOR).build();
-
   private final String tableName;
   private final LevelDBTableService service;
 
-  public LevelDBTableCore(String tableName, LevelDBTableService service) throws IOException {
+  public LevelDBTableCore(String tableName, LevelDBTableService service) {
     this.tableName = tableName;
     this.service = service;
   }
@@ -106,55 +99,65 @@ public class LevelDBTableCore {
       // to-do
       deleteColumn(row, column);
     } else {
-      persist(Collections.singletonMap(row, Collections.singletonMap(column, newValue)), System.currentTimeMillis());
+      persist(Collections.singletonMap(row, Collections.singletonMap(column, newValue)), Long.MAX_VALUE);
     }
     return true;
   }
 
   public synchronized Map<byte[], Long> increment(byte[] row, Map<byte[], Long> increments) throws IOException {
-    Map<byte[], Long> result = getResultMap(row, increments);
-    Map<byte[], byte[]> replacing = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-    for (Map.Entry<byte[], Long> entry : result.entrySet()) {
-      replacing.put(entry.getKey(), Bytes.toBytes(entry.getValue()));
+    Map<byte[], Long> result = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+
+    DB db = getDB();
+    WriteBatch writeBatch = db.createWriteBatch();
+    try (Snapshot snapshot = db.getSnapshot()) {
+      ReadOptions readOptions = new ReadOptions().snapshot(snapshot);
+
+      for (Map.Entry<byte[], Long> entry : increments.entrySet()) {
+        byte[] rowKey = createPutKey(row, entry.getKey(), Long.MAX_VALUE);
+        byte[] existingValue = db.get(rowKey, readOptions);
+        long newValue = incrementValue(entry.getValue(), existingValue, row, entry.getKey());
+        result.put(entry.getKey(), newValue);
+        writeBatch.put(rowKey, Bytes.toBytes(newValue));
+      }
+      db.write(writeBatch, service.getWriteOptions());
     }
-    persist(ImmutableMap.of(row, replacing), System.currentTimeMillis());
+
     return result;
   }
 
 
   public synchronized void increment(NavigableMap<byte[], NavigableMap<byte[], Long>> updates) throws IOException {
-    Map<byte[], Map<byte[], byte[]>> resultMap = Maps.newHashMap();
-    for (NavigableMap.Entry<byte[], NavigableMap<byte[], Long>> row : updates.entrySet()) {
-      NavigableMap<byte[], Long> increments = row.getValue();
-      Map<byte[], byte[]> replacing = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-      Map<byte[], Long> result = getResultMap(row.getKey(), increments);
-      for (Map.Entry<byte[], Long> entry : result.entrySet()) {
-        replacing.put(entry.getKey(), Bytes.toBytes(entry.getValue()));
-      }
-      resultMap.put(row.getKey(), replacing);
+    if (updates.isEmpty()) {
+      return;
     }
-    persist(resultMap, System.currentTimeMillis());
+
+    DB db = getDB();
+    WriteBatch writeBatch = db.createWriteBatch();
+    try (Snapshot snapshot = db.getSnapshot()) {
+      ReadOptions readOptions = new ReadOptions().snapshot(snapshot);
+
+      for (Map.Entry<byte[], NavigableMap<byte[], Long>> updateEntry : updates.entrySet()) {
+        for (Map.Entry<byte[], Long> entry : updateEntry.getValue().entrySet()) {
+          byte[] rowKey = createPutKey(updateEntry.getKey(), entry.getKey(), Long.MAX_VALUE);
+          byte[] existingValue = db.get(rowKey, readOptions);
+          long newValue = incrementValue(entry.getValue(), existingValue, updateEntry.getKey(), entry.getKey());
+          writeBatch.put(rowKey, Bytes.toBytes(newValue));
+        }
+      }
+      db.write(writeBatch, service.getWriteOptions());
+    }
   }
 
-  private Map<byte[], Long> getResultMap(byte[] row, Map<byte[], Long> increments) throws IOException {
-    NavigableMap<byte[], byte[]> existing =
-      getRow(row, increments.keySet().toArray(new byte[increments.size()][]), null, null, -1, null);
-    Map<byte[], Long> result = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-    for (Map.Entry<byte[], Long> increment : increments.entrySet()) {
-      long existingValue = 0L;
-      byte[] existingBytes = existing.get(increment.getKey());
-      if (existingBytes != null) {
-        if (existingBytes.length != Bytes.SIZEOF_LONG) {
-          throw new NumberFormatException("Attempted to increment a value that is not convertible to long," +
-                                            " row: " + Bytes.toStringBinary(row) +
-                                            " column: " + Bytes.toStringBinary(increment.getKey()));
-        }
-        existingValue = Bytes.toLong(existingBytes);
-      }
-      long newValue = existingValue + increment.getValue();
-      result.put(increment.getKey(), newValue);
+  private long incrementValue(long value, @Nullable byte[] existingValue, byte[] row, byte[] col) {
+    if (existingValue == null) {
+      return value;
     }
-    return result;
+    if (existingValue.length != Bytes.SIZEOF_LONG) {
+      throw new NumberFormatException("Attempted to increment a value that is not convertible to long," +
+                                        " row: " + Bytes.toStringBinary(row) +
+                                        " column: " + Bytes.toStringBinary(col));
+    }
+    return value + Bytes.toLong(existingValue);
   }
 
   public void persist(Map<byte[], ? extends Map<byte[], byte[]>> changes, long version) throws IOException {
@@ -210,11 +213,11 @@ public class LevelDBTableCore {
    * if columns are not null, then limit param is ignored and limit is columns.length
    */
   public NavigableMap<byte[], byte[]> getRow(byte[] row, @Nullable byte[][] columns,
-                                             byte[] startCol, byte[] stopCol,
-                                             int limit, Transaction tx) throws IOException {
+                                             @Nullable byte[] startCol, @Nullable byte[] stopCol,
+                                             int limit, @Nullable Transaction tx) throws IOException {
     if (columns != null) {
       if (columns.length == 0) {
-        return EMPTY_ROW_MAP;
+        return Collections.emptyNavigableMap();
       }
       columns = Arrays.copyOf(columns, columns.length);
       Arrays.sort(columns, Bytes.BYTES_COMPARATOR);
@@ -258,14 +261,15 @@ public class LevelDBTableCore {
    * @return a pair consisting of the row key of the next non-empty row and the column map for that row. If multiRow
    *         is false, null is returned for row key because the caller already knows it.
    */
-  private static ImmutablePair<byte[], NavigableMap<byte[], byte[]>>
-  getRow(DBIterator iterator, byte[] endKey, Transaction tx, boolean multiRow, byte[][] columns, int limit)
-    throws IOException {
-
+  private static ImmutablePair<byte[], NavigableMap<byte[], byte[]>> getRow(DBIterator iterator,
+                                                                            @Nullable byte[] endKey,
+                                                                            @Nullable Transaction tx,
+                                                                            boolean multiRow,
+                                                                            @Nullable byte[][] columns, int limit) {
     byte[] rowBeingRead = null;
     byte[] previousRow = null;
     byte[] previousCol = null;
-    NavigableMap<byte[], byte[]> map = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    NavigableMap<byte[], byte[]> map = new TreeMap<>(Bytes.BYTES_COMPARATOR);
 
     while (iterator.hasNext()) {
       Map.Entry<byte[], byte[]> entry = iterator.peekNext();
@@ -326,24 +330,6 @@ public class LevelDBTableCore {
     return new ImmutablePair<>(rowBeingRead, map);
   }
 
-  public void deleteRows(byte[] prefix) throws IOException {
-    Preconditions.checkNotNull(prefix, "prefix must not be null");
-    DB db = getDB();
-    WriteBatch batch = db.createWriteBatch();
-    try (DBIterator iterator = db.iterator()) {
-      iterator.seek(createStartKey(prefix));
-      while (iterator.hasNext()) {
-        Map.Entry<byte[], byte[]> entry = iterator.next();
-        if (!Bytes.startsWith(KeyValue.fromKey(entry.getKey()).getRow(), prefix)) {
-          // iterator is past prefix
-          break;
-        }
-        batch.delete(entry.getKey());
-      }
-      db.write(batch);
-    }
-  }
-
   /**
    * Delete a list of rows from the table entirely, disregarding transactions.
    * @param toDelete the row keys to delete
@@ -376,7 +362,7 @@ public class LevelDBTableCore {
         } else if (comp > 0) {
           // read past current row -> move to next row
           currentRow = rows.hasNext() ? rows.next() : null;
-        } else if (comp < 0) {
+        } else {
           // iterator must seek to current row
           iterator.seek(createStartKey(currentRow));
           entry = iterator.hasNext() ? iterator.next() : null;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTable.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 
 /**
@@ -113,8 +114,8 @@ public final class FactTable implements Closeable {
 
   public void add(List<Fact> facts) {
     // Simply collecting all rows/cols/values that need to be put to the underlying table.
-    NavigableMap<byte[], NavigableMap<byte[], byte[]>> gaugesTable = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-    NavigableMap<byte[], NavigableMap<byte[], byte[]>> incrementsTable = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    NavigableMap<byte[], NavigableMap<byte[], Long>> gaugesTable = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    NavigableMap<byte[], NavigableMap<byte[], Long>> incrementsTable = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     for (Fact fact : facts) {
       for (Measurement measurement : fact.getMeasurements()) {
         byte[] rowKey = codec.createRowKey(fact.getDimensionValues(), measurement.getName(), fact.getTimestamp());
@@ -123,23 +124,19 @@ public final class FactTable implements Closeable {
         if (MeasureType.COUNTER == measurement.getType()) {
           inc(incrementsTable, rowKey, column, measurement.getValue());
         } else {
-          set(gaugesTable, rowKey, column, Bytes.toBytes(measurement.getValue()));
+          gaugesTable
+            .computeIfAbsent(rowKey, k -> Maps.newTreeMap(Bytes.BYTES_COMPARATOR))
+            .put(column, measurement.getValue());
         }
       }
     }
 
-    NavigableMap<byte[], NavigableMap<byte[], Long>> convertedIncrementsTable =
-      Maps.transformValues(incrementsTable, TRANSFORM_MAP_BYTE_ARRAY_TO_LONG);
-
-    NavigableMap<byte[], NavigableMap<byte[], Long>> convertedGaugesTable =
-      Maps.transformValues(gaugesTable, TRANSFORM_MAP_BYTE_ARRAY_TO_LONG);
-
     // todo: replace with single call, to be able to optimize rpcs in underlying table
-    timeSeriesTable.put(convertedGaugesTable);
-    timeSeriesTable.increment(convertedIncrementsTable);
+    timeSeriesTable.put(gaugesTable);
+    timeSeriesTable.increment(incrementsTable);
     if (metrics != null) {
-      metrics.increment(putCountMetric, convertedGaugesTable.size());
-      metrics.increment(incrementCountMetric, convertedIncrementsTable.size());
+      metrics.increment(putCountMetric, gaugesTable.size());
+      metrics.increment(incrementCountMetric, incrementsTable.size());
     }
   }
 
@@ -442,35 +439,16 @@ public final class FactTable implements Closeable {
 
   // todo: shouldn't we aggregate "before" writing to FactTable? We could do it really efficient outside
   //       also: the underlying datasets will do aggregation in memory anyways
-  private static void inc(NavigableMap<byte[], NavigableMap<byte[], byte[]>> incrementsTable,
-                   byte[] rowKey, byte[] column, long value) {
-    byte[] oldValue = get(incrementsTable, rowKey, column);
+  private static void inc(NavigableMap<byte[], NavigableMap<byte[], Long>> incrementsTable,
+                          byte[] rowKey, byte[] column, long value) {
+    NavigableMap<byte[], Long> values = incrementsTable.computeIfAbsent(rowKey,
+                                                                        k -> new TreeMap<>(Bytes.BYTES_COMPARATOR));
+    Long oldValue = values.get(column);
     long newValue = value;
     if (oldValue != null) {
-      if (Bytes.SIZEOF_LONG == oldValue.length) {
-        newValue = Bytes.toLong(oldValue) + value;
-      } else if (Bytes.SIZEOF_INT == oldValue.length) {
-        // In 2.4 and older versions we stored it as int
-        newValue = Bytes.toInt(oldValue) + value;
-      } else {
-        // should NEVER happen, unless the table is screwed up manually
-        throw new IllegalStateException(
-          String.format("Could not parse measure @row %s @column %s value %s as int or long",
-                        Bytes.toStringBinary(rowKey), Bytes.toStringBinary(column), Bytes.toStringBinary(oldValue)));
-      }
-
+      newValue += oldValue;
     }
-    set(incrementsTable, rowKey, column, Bytes.toBytes(newValue));
-  }
 
-  private static byte[] get(NavigableMap<byte[], NavigableMap<byte[], byte[]>> table, byte[] row, byte[] column) {
-    NavigableMap<byte[], byte[]> rowMap = table.get(row);
-    return rowMap == null ? null : rowMap.get(column);
-  }
-
-  private static void set(NavigableMap<byte[], NavigableMap<byte[], byte[]>> table,
-                          byte[] row, byte[] column, byte[] value) {
-    NavigableMap<byte[], byte[]> rowMap = table.computeIfAbsent(row, k -> Maps.newTreeMap(Bytes.BYTES_COMPARATOR));
-    rowMap.put(column, value);
+    values.put(column, newValue);
   }
 }


### PR DESCRIPTION
- Use direct get on the underlying LevelDB object for increment
- Reduce unnecessary array creation and byte encode/decode
- No need to use current time for writing increments and swapping
  - Usage are non-transactional, hence older values are never needed.
- Code cleanup + refactoring