### PR TITLE
CDAP-14577 - Google Cloud Platform Provisioner - Dataproc - Add ability to use and existing Dataproc cluster

### DIFF
--- a/cdap-runtime-ext-remote-hadoop/pom.xml
+++ b/cdap-runtime-ext-remote-hadoop/pom.xml
@@ -42,10 +42,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-      <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-      </dependency>
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-runtime-ext-remote-hadoop/pom.xml
+++ b/cdap-runtime-ext-remote-hadoop/pom.xml
@@ -42,6 +42,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+      <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+      </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-runtime-ext-remote-hadoop/src/main/java/co/cask/cdap/runtime/spi/provisioner/remote/RemoteHadoopConf.java
+++ b/cdap-runtime-ext-remote-hadoop/src/main/java/co/cask/cdap/runtime/spi/provisioner/remote/RemoteHadoopConf.java
@@ -29,10 +29,12 @@ import java.util.Map;
 public class RemoteHadoopConf {
   private final SSHKeyPair sshKeyPair;
   private final String host;
+  private final String initializationAction;
 
-  private RemoteHadoopConf(SSHKeyPair sshKeyPair, String host) {
+  private RemoteHadoopConf(SSHKeyPair sshKeyPair, String host, String initializationAction) {
     this.sshKeyPair = sshKeyPair;
     this.host = host;
+    this.initializationAction = initializationAction;
   }
 
   public SSHKeyPair getKeyPair() {
@@ -43,6 +45,10 @@ public class RemoteHadoopConf {
     return host;
   }
 
+  public String getInitializationAction() {
+    return initializationAction;
+  }
+
   /**
    * Create the conf from a property map while also performing validation.
    */
@@ -50,10 +56,11 @@ public class RemoteHadoopConf {
     String host = getString(properties, "host");
     String user = getString(properties, "user");
     String privateKey = getString(properties, "sshKey");
+    String initializationAction = getString(properties, "initializationAction");
 
     SSHKeyPair keyPair = new SSHKeyPair(new SSHPublicKey(user, ""),
                                         () -> privateKey.getBytes(StandardCharsets.UTF_8));
-    return new RemoteHadoopConf(keyPair, host);
+    return new RemoteHadoopConf(keyPair, host, initializationAction);
   }
 
   private static String getString(Map<String, String> properties, String key) {

--- a/cdap-runtime-ext-remote-hadoop/src/main/java/co/cask/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
+++ b/cdap-runtime-ext-remote-hadoop/src/main/java/co/cask/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
@@ -81,9 +81,9 @@ public class RemoteHadoopProvisioner implements Provisioner {
     } catch (IOException ioe) {
       if (Throwables.getRootCause(ioe) instanceof ConnectException) {
         throw new IOException(String.format(
-                "Failed to connect to host %s. Ensure that firewall rules exist that allow ssh " +
-                        "on port 22.", host),
-                ioe);
+          "Failed to connect to host %s. Ensure that firewall rules exist that allow ssh " +
+            "on port 22.", host),
+          ioe);
       }
       throw ioe;
     }
@@ -91,14 +91,14 @@ public class RemoteHadoopProvisioner implements Provisioner {
 
   private String getMasterExternalIp(Cluster cluster) {
     Node masterNode = cluster.getNodes().stream()
-            .filter(node -> Node.Type.MASTER == node.getType())
-            .findFirst().orElseThrow(() ->
-                    new IllegalArgumentException("Cluster has no node of master type: " + cluster));
+      .filter(node -> Node.Type.MASTER == node.getType())
+      .findFirst().orElseThrow(() ->
+        new IllegalArgumentException("Cluster has no node of master type: " + cluster));
 
     String ip = masterNode.getIpAddress();
     if (ip == null) {
       throw new IllegalArgumentException(String.format("External IP is not defined for node '%s' in cluster %s",
-              masterNode.getId(), cluster));
+        masterNode.getId(), cluster));
     }
     return ip;
   }

--- a/cdap-runtime-ext-remote-hadoop/src/main/resources/remote-hadoop.json
+++ b/cdap-runtime-ext-remote-hadoop/src/main/resources/remote-hadoop.json
@@ -47,7 +47,7 @@
       "properties": [
         {
           "widget-type": "textarea",
-          "label": "Initialization Action (optional)",
+          "label": "Initialization Action",
           "name": "initializationAction",
           "description": "Initialization action to be executed during initialization of the cluster. For example: sudo zookeeper-server start",
           "widget-attributes": {

--- a/cdap-runtime-ext-remote-hadoop/src/main/resources/remote-hadoop.json
+++ b/cdap-runtime-ext-remote-hadoop/src/main/resources/remote-hadoop.json
@@ -41,6 +41,20 @@
           }
         }
       ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
+          "widget-type": "textarea",
+          "label": "Initialization Action (optional)",
+          "name": "initializationAction",
+          "description": "Initialization action to be executed during initialization of the cluster. For example: sudo zookeeper-server start",
+          "widget-attributes": {
+            "default": ""
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-14577
Currently the Dataproc cloud provisioner is lunching a new Dataproc instance each time.

In my org production the Dataproc is created by Terraform in order to apply comprehensive company security policy.

I need to ability to run the workflow on an existing cluster, and I'll use Apache airflow to control the cluster creation