### PR TITLE
Add support for CDH 5.15.

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -101,6 +101,7 @@ public class HBaseVersionTest {
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.12.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.13.0");
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.14.0");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.15.0");
 
     // bigtop 1.1.0
     assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.12-hadoop2");

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -49,6 +49,7 @@ public class HBaseVersion {
   private static final String CDH512_CLASSIFIER = "cdh5.12.";
   private static final String CDH513_CLASSIFIER = "cdh5.13.";
   private static final String CDH514_CLASSIFIER = "cdh5.14.";
+  private static final String CDH515_CLASSIFIER = "cdh5.15.";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -308,7 +309,8 @@ public class HBaseVersion {
         ver.getClassifier().startsWith(CDH511_CLASSIFIER) ||
         ver.getClassifier().startsWith(CDH512_CLASSIFIER) ||
         ver.getClassifier().startsWith(CDH513_CLASSIFIER) ||
-        ver.getClassifier().startsWith(CDH514_CLASSIFIER)) {
+        ver.getClassifier().startsWith(CDH514_CLASSIFIER) ||
+        ver.getClassifier().startsWith(CDH515_CLASSIFIER)) {
         return Version.HBASE_12_CDH57;
       }
       return Version.UNKNOWN_CDH;


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-13632

Without this change, cdap master startup fails with:
`[ERROR] Unknown or unsupported HBase version found: unknown-cdh`

https://builds.cask.co/browse/CDAP-DUT6669