### PR TITLE
CDAP-13554 fix variable substitution limit bug when getting spec

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -66,10 +66,10 @@ public final class MapReduceContextConfig {
   private static final Type PLUGIN_MAP_TYPE = new TypeToken<Map<String, Plugin>>() { }.getType();
   private static final Type OUTPUT_LIST_TYPE = new TypeToken<List<Output.DatasetOutput>>() { }.getType();
 
+  static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
   private static final String HCONF_ATTR_APP_SPEC = "cdap.mapreduce.app.spec";
   private static final String HCONF_ATTR_PROGRAM_ID = "cdap.mapreduce.program.id";
   private static final String HCONF_ATTR_WORKFLOW_INFO = "cdap.mapreduce.workflow.info";
-  private static final String HCONF_ATTR_PLUGINS = "cdap.mapreduce.plugins";
   private static final String HCONF_ATTR_PROGRAM_JAR_URI = "cdap.mapreduce.program.jar.uri";
   private static final String HCONF_ATTR_CCONF = "cdap.mapreduce.cconf";
   private static final String HCONF_ATTR_LOCAL_FILES = "cdap.mapreduce.local.files";
@@ -180,7 +180,7 @@ public final class MapReduceContextConfig {
    * Returns the plugins being used in the MapReduce program.
    */
   public Map<String, Plugin> getPlugins() {
-    String spec = hConf.get(HCONF_ATTR_PLUGINS);
+    String spec = hConf.getRaw(HCONF_ATTR_PLUGINS);
     if (spec == null) {
       return ImmutableMap.of();
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
@@ -20,26 +20,25 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
-import co.cask.cdap.api.data.stream.StreamSpecification;
-import co.cask.cdap.api.flow.FlowSpecification;
-import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.plugin.Plugin;
-import co.cask.cdap.api.service.ServiceSpecification;
-import co.cask.cdap.api.spark.SparkSpecification;
-import co.cask.cdap.api.worker.WorkerSpecification;
-import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.internal.app.DefaultApplicationSpecification;
-import co.cask.cdap.internal.dataset.DatasetCreationSpec;
-import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
+import com.google.gson.Gson;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  */
 public class MapReduceContextConfigTest {
+  private static final Gson GSON = new Gson();
 
   @Test
   public void testManyMacrosInAppSpec() {
@@ -53,19 +52,47 @@ public class MapReduceContextConfigTest {
     ApplicationSpecification appSpec = new DefaultApplicationSpecification(
       "name", "desc", appCfg.toString(),
       new ArtifactId("artifact", new ArtifactVersion("1.0.0"), ArtifactScope.USER),
-      Collections.<String, StreamSpecification>emptyMap(),
-      Collections.<String, String>emptyMap(),
-      Collections.<String, DatasetCreationSpec>emptyMap(),
-      Collections.<String, FlowSpecification>emptyMap(),
-      Collections.<String, MapReduceSpecification>emptyMap(),
-      Collections.<String, SparkSpecification>emptyMap(),
-      Collections.<String, WorkflowSpecification>emptyMap(),
-      Collections.<String, ServiceSpecification>emptyMap(),
-      Collections.<String, ScheduleCreationSpec>emptyMap(),
-      Collections.<String, WorkerSpecification>emptyMap(),
-      Collections.<String, Plugin>emptyMap()
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      Collections.emptyMap()
     );
     cfg.setApplicationSpecification(appSpec);
     Assert.assertEquals(appSpec.getConfiguration(), cfg.getApplicationSpecification().getConfiguration());
+  }
+
+  @Test
+  public void testGetPluginsWithMacrosMoreThan20() {
+    Configuration hConf = new Configuration();
+    MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
+    Map<String, Plugin> mockPlugins = new HashMap<>();
+    ArtifactId artifactId = new ArtifactId("plugins", new ArtifactVersion("1.0.0"), ArtifactScope.SYSTEM);
+    Map<String, String> properties = new HashMap<>();
+    properties.put("path",
+                   "${input.directory}/${a}${b}${c}${d}${e}${f}${g}${h}${i}${j}"
+                     + "${k}${l}${m}${n}${o}${p}${q}${r}${s}${t}${u}${v}${w}${x}${y}${z}.txt");
+    hConf.set("input.directory", "/dummy/path");
+    String[] alphabetsArr = {"a", "b", "c", "d", "e", "f", "g", "h",
+      "i", "j", "k", "l", "m", "n", "o", "p", "q",
+      "r", "s", "t", "u", "v", "w", "x", "y", "z"};
+    for (String alphabet : alphabetsArr) {
+      hConf.set(alphabet, alphabet);
+    }
+    Set<ArtifactId> parents = new LinkedHashSet<>();
+    Plugin filePlugin1 = new Plugin(parents, artifactId,
+                                    new PluginClass("type", "name", "desc", "clsname", "cfgfield",
+                                                    Collections.emptyMap()),
+                                    PluginProperties.builder().addAll(properties).build());
+    mockPlugins.put("File1", filePlugin1);
+    hConf.set(MapReduceContextConfig.HCONF_ATTR_PLUGINS, GSON.toJson(mockPlugins));
+    Map<String, Plugin> plugins = cfg.getPlugins();
+    Assert.assertEquals(plugins, mockPlugins);
   }
 }


### PR DESCRIPTION
Use getRaw() instead of get() to prevent variable substitution
when getting plugin information from the Hadoop Configuration.
This prevents macros from getting replaced when they shouldn't
and also prevents the substitution limit hardcoded by Hadoop.