### PR TITLE
[CDAP-14553] [CDAP-14599] Adds generic plugin function widget

### DIFF
--- a/cdap-docs/developer-manual/source/pipelines/developing-plugins/presentation-plugins.rst
+++ b/cdap-docs/developer-manual/source/pipelines/developing-plugins/presentation-plugins.rst
@@ -228,7 +228,6 @@ different properties are defined; three use a *textbox* widget, while one uses a
             "plugin-function": {
               "method": "POST",
               "widget": "outputSchema",
-              "output-property": "schema",
               "plugin-method": "outputSchema",
               "required-fields": ["groupByFields", "aggregates"],
               "missing-required-fields-message":
@@ -728,8 +727,6 @@ These fields need to be configured to use the plugin functions in the CDAP UI:
 - **method:** Type of request to make when calling the plugin function from the CDAP UI
   (for example: GET or POST)
 - **widget:** Type of widget to use to import output schema
-- **output-property:** Property to update once the CDAP UI receives the data from the
-  plugin method
 - **plugin-method:** Name of the plugin method to call (as exposed by the plugin)
 - **required-fields:** Fields required to call the plugin method
 - **missing-required-fields-message:** A message for the user as to why the action is
@@ -741,6 +738,83 @@ fields are required fields to use a plugin method of the plugin in the CDAP UI.
 
 With plugin functions, if the widget is not supported in the CDAP UI or the
 plugin function map is not supplied, the user will not see the widget in the CDAP UI.
+
+.. highlight:: json-ellipsis
+
+.. list-table::
+   :widths: 15 20 20 30
+   :header-rows: 1
+
+   * - Widget Type
+     - Widget attributes
+     - Description
+     - Example Widget JSON
+  
+   * - ``outputSchema``
+     - - ``label``: Label for the button 
+       - ``btnClass``: bootstrap css class to add to the button
+       - ``multiple-inputs``: boolean to indicate if there are multiple input schemas
+     - Widget to populate output schema for a plugin. 
+       This is specifically used to populate output schema and not any other property.
+     - .. container:: copyable copyable-text
+
+         ::
+
+          {
+            "widget-type": "csv",
+            "label": "Group by fields",
+            "name": "groupByFields",
+            "widget-attributes": {
+              "delimiter": ",",
+              "value-placeholder": "Field Name"
+            },
+            "plugin-function": {
+              "method": "POST",
+              "widget": "outputSchema",
+              "label": "Get output schema",
+              "button-class": "btn-primary",
+              "plugin-method": "outputSchema",
+              "required-fields": ["groupByFields", "aggregates"],
+              "missing-required-fields-message": "'Group By Fields' & 'Aggregates' properties are required to fetch schema."
+            }
+          }
+
+   * - ``getPropertyValue``
+     - ``label``: Label for the button
+     - Widget to populate any property in a plugin. This widget should be used in the property which needs to
+       fetch its value from a plugin function implemented in the plugin backend
+     - .. container:: copyable copyable-text
+
+         ::
+
+          {
+            "widget-type": "select",
+            "label": "Format",
+            "name": "format",
+            "widget-attributes": {
+              "values": [
+                "avro",
+                "blob",
+                "csv",
+                "delimited",
+                "json",
+                "parquet",
+                "text",
+                "tsv"
+              ],
+              "default": "text"
+            },
+            "plugin-function": {
+              "method": "POST",
+              "widget": "getPropertyValue",
+              "widget-attributes": {
+                "label": "Get Schema Value"
+              },
+              "required-fields": ["path"],
+              "missing-required-fields-message": "Please provide path field",
+              "plugin-method": "getSchema"
+            }
+          }
 
 Example Plugin
 --------------
@@ -767,7 +841,6 @@ plugin-function, could be represented by::
             "plugin-function": {
               "method": "POST",
               "widget": "outputSchema",
-              "output-property": "schema",
               "plugin-method": "outputSchema",
               "required-fields": ["groupByFields", "aggregates"],
               "missing-required-fields-message":
@@ -999,7 +1072,6 @@ Based on the above specification, we can write a widget JSON for a *Batch Source
             "plugin-function": {
               "method": "POST",
               "widget": "outputSchema",
-              "output-property": "schema",
               "plugin-method": "outputSchema",
               "required-fields": ["groupByFields", "aggregates"],
               "missing-required-fields-message":

--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -479,7 +479,7 @@ gulp.task('default', ['lint', 'build', 'rev:replace:dev']);
 /*
   watch
  */
-gulp.task('watch', ['jshint', 'build', 'rev:replace:dev'], function() {
+gulp.task('watch', ['jshint', 'build'], function() {
   plug.livereload.listen({ port: 35728 });
 
   var jsAppSource = [

--- a/cdap-ui/app/cdap/components/EntityListView/EntityListHeader/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/EntityListHeader/index.js
@@ -218,11 +218,7 @@ export default class EntityListHeader extends Component {
         <CustomDropdownMenu onClick={(e) => e.stopPropagation()}>
           {this.state.filterOptions.map((option) => {
             return (
-              <DropdownItem
-                tag="li"
-                key={option.id}
-                onClick={this.onFilterClick.bind(this, option)}
-              >
+              <DropdownItem tag="li" key={option.id}>
                 <div className="form-group form-check">
                   <input
                     type="checkbox"

--- a/cdap-ui/app/cdap/components/Modal/Modal.stories.tsx
+++ b/cdap-ui/app/cdap/components/Modal/Modal.stories.tsx
@@ -43,7 +43,7 @@ storiesOf('Modals', module)
         >
           <ModalHeader>
             {text('Modal title', 'Default Modal')}
-            <div className="close-section float-xs-right" onClick={action('modal closed')}>
+            <div className="close-section float-right" onClick={action('modal closed')}>
               <IconSVG name="icon-close" />
             </div>
           </ModalHeader>

--- a/cdap-ui/app/directives/plugin-functions/functions/get-property-value/get-property-value-modal.html
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-property-value/get-property-value-modal.html
@@ -1,0 +1,49 @@
+<!--
+  Copyright © 2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="modal-header clearfix">
+  <h3 class="modal-title pull-left">Property Value</h3>
+  <div class="btn-group pull-right">
+    <a class="btn" ng-click="$dismiss()">
+      <span class="fa fa-times"></span>
+    </a>
+  </div>
+</div>
+
+<div class="modal-body">
+  <div ng-if="GetPropertyValueModalController.showLoading">
+    <h3 class="fa fa-spin fa-refresh"></h3>
+  </div>
+
+  <fieldset disabled="true" ng-if="GetPropertyValueModalController.propertyValue">
+    <my-json-textbox
+      ng-model="GetPropertyValueModalController.propertyValue"
+      disabled="true"
+    >
+    </my-json-textbox>
+  </fieldset>
+
+  <p class="text-danger" ng-if="GetPropertyValueModalController.error">
+    Error: {{ GetPropertyValueModalController.error }}
+  </p>
+  </div>
+</div>
+
+<div class="modal-footer" ng-if="GetPropertyValueModalController.propertyValue">
+  <button class="btn btn-blue" ng-disabled="!GetPropertyValueModalController.propertyValue" ng-click="GetPropertyValueModalController.apply()">
+    Apply
+  </button>
+</div>

--- a/cdap-ui/app/directives/plugin-functions/functions/get-property-value/get-property-value.html
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-property-value/get-property-value.html
@@ -1,0 +1,31 @@
+<!--
+  Copyright © 2018 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<button
+  class="btn btn-default pull-right"
+  type="button"
+  ng-disabled="GetPropertyValueController.requiredProperties.indexOf('') !== -1"
+  ng-click="GetPropertyValueController.openModal()"
+>
+  <span
+    ng-if="GetPropertyValueController.requiredProperties.indexOf('') !== -1"
+    uib-tooltip="{{OutputSchemaController.missingFieldsWarningMessage}}"
+    tooltip-append-to-body="true"
+  >
+    <i class="fa fa-exclamation-triangle text-warning"></i>
+  </span>
+  {{GetPropertyValueController.label}}
+</button>

--- a/cdap-ui/app/directives/plugin-functions/functions/get-property-value/get-property-value.js
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-property-value/get-property-value.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.commons')
+  .directive('getPropertyValue', function() {
+    return {
+      restrict: 'E',
+      templateUrl: 'plugin-functions/functions/get-property-value/get-property-value.html',
+      scope: {
+        node: '=',
+        fnConfig: '=',
+        nodeConfig: '='
+      },
+      controller: function ($scope, $uibModal, myPipelineApi, myHelpers) {
+        var vm = this;
+        var fnConfig = $scope.fnConfig;
+        var methodName = fnConfig['plugin-method'] || 'getSchema';
+        vm.label = myHelpers.objectQuery(fnConfig, 'widget-attributes', 'label') || 'Get value';
+        vm.node = $scope.node;
+        var getRequiredFields = function () {
+          if (!fnConfig['required-fields']) { return []; }
+          return fnConfig['required-fields'].map(function (field) {
+            if ($scope.node.plugin.properties.hasOwnProperty(field)) {
+              return $scope.node.plugin.properties[field];
+            }
+            return '';
+          });
+        };
+        vm.requiredProperties = getRequiredFields();
+        vm.requiredFieldsWatch = $scope.$watch('GetPropertyValueController.node.plugin.properties', function () {
+          vm.requiredProperties = getRequiredFields();
+        }, true);
+        vm.missingFieldsWarningMessage = fnConfig['missing-required-fields-message'] || '';
+        var methodType = fnConfig.method || 'GET';
+        var getPluginMethodApi = function (methodType) {
+          switch (methodType) {
+            case 'POST':
+              return myPipelineApi.postPluginMethod;
+            case 'GET':
+              return myPipelineApi.getPluginMethod;
+            case 'PUT':
+              return myPipelineApi.putPluginMethod;
+            case 'DELETE':
+              return myPipelineApi.deletePluginMethod;
+          }
+        };
+        var pluginMethodApi = getPluginMethodApi(methodType);
+
+        // @ts-ignore
+        vm.openModal = function () {
+          var modal = $uibModal.open({
+            templateUrl: 'plugin-functions/functions/get-property-value/get-property-value-modal.html',
+            windowClass: 'hydrator-modal layered-modal get-property-value-modal',
+            keyboard: true,
+            controller: function ($scope, nodeInfo, $state) {
+              var mvm = this;
+              mvm.showLoading = true;
+              mvm.node = angular.copy(nodeInfo);
+              mvm.fetchValue = function () {
+                var config = mvm.node.plugin.properties;
+                var params = {
+                  namespace: $state.params.namespace,
+                  artifactName: mvm.node.plugin.artifact.name,
+                  version: mvm.node.plugin.artifact.version,
+                  pluginType: mvm.node.type,
+                  pluginName: mvm.node.plugin.name,
+                  methodName: methodName,
+                  scope: mvm.node.plugin.artifact.scope
+                };
+
+
+                pluginMethodApi(params, config)
+                  .$promise
+                  .then(function (res) {
+                    mvm.error = null;
+                    mvm.propertyValue = res;
+                    mvm.showLoading = false;
+                  }, function (err) {
+                    mvm.propertyValue = null;
+                    mvm.error = err.data;
+                    mvm.showLoading = false;
+                  });
+              };
+
+              mvm.apply = function () {
+                $scope.$close(JSON.stringify(mvm.propertyValue));
+              };
+
+              mvm.fetchValue();
+
+            },
+            controllerAs: 'GetPropertyValueModalController',
+            resolve: {
+              nodeInfo: function () {
+                return $scope.node;
+              }
+            }
+          });
+
+          modal.result.then(function (value) {
+            let outputProperty = $scope.nodeConfig.name;
+            $scope.node.plugin.properties[outputProperty] = value;
+          });
+        };
+      },
+      controllerAs: 'GetPropertyValueController'
+    };
+  });

--- a/cdap-ui/app/directives/plugin-functions/functions/get-property-value/get-property-value.less
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-property-value/get-property-value.less
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+.modal.hydrator-modal.get-property-value-modal {
+  .modal-dialog > .modal-content .modal-body > fieldset > my-json-textbox textarea {
+    height: 200px;
+    resize: vertical;
+  }
+}

--- a/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.js
+++ b/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.js
@@ -47,7 +47,12 @@ angular.module(PKG.name + '.commons')
         vm.node = $scope.node;
         var getRequiredFields = function() {
           if (!fnConfig['required-fields']) { return []; }
-          return fnConfig['required-fields'].map( function(field) { return $scope.node.plugin.properties[field]; } );
+          return fnConfig['required-fields'].map( function(field) {
+            if ($scope.node.plugin.properties.hasOwnProperty(field)) {
+              return $scope.node.plugin.properties[field];
+            }
+            return '';
+          });
         };
         vm.requiredProperties = getRequiredFields();
         vm.requiredFieldsWatch = $scope.$watch('OutputSchemaController.node.plugin.properties', function() {

--- a/cdap-ui/app/directives/plugin-functions/plugin-functions-factory.js
+++ b/cdap-ui/app/directives/plugin-functions/plugin-functions-factory.js
@@ -32,6 +32,14 @@ angular.module(PKG.name + '.commons')
           'fn-config': 'fnConfig',
           'class': 'pull-right'
         }
+      },
+      'getPropertyValue': {
+        element: '<get-property-value></get-property-value>',
+        attributes: {
+          'node': 'node',
+          'fn-config': 'fnConfig',
+          'class': 'pull-right'
+        },
       }
     };
 

--- a/cdap-ui/app/directives/plugin-functions/plugin-functions.js
+++ b/cdap-ui/app/directives/plugin-functions/plugin-functions.js
@@ -21,6 +21,7 @@ angular.module(PKG.name + '.commons')
       scope: {
         fnConfig: '=',
         node: '=',
+        nodeConfig: '=',
         isDisabled: '='
       },
       replace: false,

--- a/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.html
+++ b/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.html
@@ -46,7 +46,7 @@
     <label>
       <input
         type="radio"
-        id="{{option.id}}"
+        id="{{option.elementid}}"
         value="{{option.id}}"
         name="{{groupName}}"
         ng-model="$parent.model"

--- a/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.js
+++ b/cdap-ui/app/directives/widget-container/widget-radio-group/widget-radio-group.js
@@ -26,15 +26,16 @@ angular.module(PKG.name + '.commons')
       controller: function(myHelpers, $scope, uuid) {
         $scope.groupName = 'radio-group-'+ uuid.v4();
         $scope.options = myHelpers.objectQuery($scope.config, 'widget-attributes', 'options') || [];
+        $scope.propertyName = myHelpers.objectQuery($scope.config, 'name');
         if (!Array.isArray($scope.options) || (Array.isArray($scope.options) && !$scope.options.length)) {
-          $scope.error = 'Missing options for ' + myHelpers.objectQuery($scope.config, 'name');
+          $scope.error = 'Missing options for ' + $scope.propertyName;
         }
         let defaultValue = myHelpers.objectQuery($scope.config, 'widget-attributes', 'default') || '';
         $scope.layout = myHelpers.objectQuery($scope.config, 'widget-attributes', 'layout') || 'block';
         $scope.model = $scope.model || defaultValue;
         let isModelValid = $scope.options.find(option => option.id === $scope.model);
         if (!isModelValid) {
-          $scope.error = 'Unknown value for ' + myHelpers.objectQuery($scope.config, 'name') + ' specified.';
+          $scope.error = 'Unknown value for ' + $scope.propertyName + ' specified.';
         }
         $scope.$watch('model', () => {
           let isModelValid = $scope.options.find(option => option.id === $scope.model);
@@ -44,6 +45,7 @@ angular.module(PKG.name + '.commons')
         });
         $scope.options = $scope.options.map(option => ({
           id: option.id,
+          elementid: $scope.propertyName + '-' + option.id,
           label: option.label || option.id
         }));
       }

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html
@@ -44,7 +44,11 @@
           <div class="form-group">
             <div class="col-xs-offset-8 col-xs-4">
                 <span ng-if="field['plugin-function'] && (!field['plugin-function']['position'] || field['plugin-function']['position'] === 'top') && !isDisabled">
-                  <plugin-functions fn-config="field['plugin-function']" node="HydratorPlusPlusNodeConfigCtrl.state.node">
+                  <plugin-functions
+                    fn-config="field['plugin-function']"
+                    node="HydratorPlusPlusNodeConfigCtrl.state.node"
+                    nodeConfig="field"
+                  >
                   </plugin-functions>
                 </span>
               </div>
@@ -59,7 +63,11 @@
             <div class="col-xs-offset-8 col-xs-4">
               <span class="plugin-function-bottom"
                 ng-if="field['plugin-function'] && field['plugin-function']['position'] === 'bottom' && !isDisabled">
-                <plugin-functions fn-config="field['plugin-function']" node="HydratorPlusPlusNodeConfigCtrl.state.node">
+                <plugin-functions
+                  fn-config="field['plugin-function']"
+                  node="HydratorPlusPlusNodeConfigCtrl.state.node"
+                  nodeConfig="field"
+                >
                 </plugin-functions>
               </span>
             </div>


### PR DESCRIPTION
**Feature**
- Adds a generic plugin function widget to make a request to backend and update a specific property in the plugin.
- This is different than schema updates which needs to be broadcasted.

**Bugfixes**
- Fixes filer in control center to properly update store.
- Fixes radio-group widget to have proper unique html ids.
- Removes replace:dev from gulp watch. This will result in caching during development. A workaround is to disable cache in browser we are developing.
With replace:dev dist folder was exploding and the html files were not properly updated with changed script tags. 
This change just simplifies for dev workflow. The distribute will still have all hashes added to files.

**Note**:
Docs for the plugin function widgets are still pending. Will either add to this PR or will create a separate PR for it.

**JIRA**: 
https://issues.cask.co/browse/CDAP-14553
https://issues.cask.co/browse/CDAP-14599

**Build**:
https://builds.cask.co/browse/CDAP-UDUT155

**Docs:**
https://builds.cask.co/artifact/CDAP-DQB450/shared/build-1/Docs-HTML/html/developer-manual/pipelines/developing-plugins/presentation-plugins.html#H3270