### PR TITLE
CDAP-14596 add profile to mapreduce and spark modes

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/app/ApplicationSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/app/ApplicationSpecification.java
@@ -36,6 +36,7 @@ import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
 
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -134,4 +135,9 @@ public interface ApplicationSpecification {
    * @return An immutable {@link Map} from plugin id to {@link Plugin}
    */
   Map<String, Plugin> getPlugins();
+
+  /**
+   * @return The names of all programs of a given {@link ProgramType}.
+   */
+  Set<String> getProgramsByType(ProgramType programType);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultApplicationSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultApplicationSpecification.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.app.ProgramType;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
@@ -30,8 +31,10 @@ import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
 import co.cask.cdap.proto.id.ApplicationId;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -184,5 +187,25 @@ public final class DefaultApplicationSpecification implements ApplicationSpecifi
   @Override
   public Map<String, Plugin> getPlugins() {
     return plugins;
+  }
+
+  @Override
+  public Set<String> getProgramsByType(ProgramType programType) {
+    switch (programType) {
+      case SPARK:
+        return sparks.keySet();
+      case MAPREDUCE:
+        return mapReduces.keySet();
+      case FLOW:
+        return flows.keySet();
+      case WORKER:
+        return workers.keySet();
+      case SERVICE:
+        return services.keySet();
+      case WORKFLOW:
+        return workflows.keySet();
+      default:
+        return ImmutableSet.of();
+    }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingApplicationSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingApplicationSpecification.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.app.ProgramType;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
@@ -30,6 +31,7 @@ import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.schedule.ScheduleCreationSpec;
 
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -122,5 +124,10 @@ public abstract class ForwardingApplicationSpecification implements ApplicationS
   @Override
   public Map<String, Plugin> getPlugins() {
     return delegate.getPlugins();
+  }
+
+  @Override
+  public Set<String> getProgramsByType(ProgramType programType) {
+    return delegate.getProgramsByType(programType);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SystemArguments.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SystemArguments.java
@@ -357,10 +357,22 @@ public final class SystemArguments {
    * @return the profile id for the program run
    */
   public static ProfileId getProfileIdForProgram(ProgramId programId, Map<String, String> args) {
-    if (programId.getType() == ProgramType.WORKFLOW) {
+    if (isProfileAllowed(programId.getType())) {
       return getProfileIdFromArgs(programId.getNamespaceId(), args).orElse(ProfileId.NATIVE);
     }
     return ProfileId.NATIVE;
+  }
+
+  /**
+   * Determine if compute profile is allowed to be applied on the given program type.
+   *
+   * @param programType programType to check compatibility
+   * @return true if the program type can use profiles, otherwise false
+   */
+  public static boolean isProfileAllowed(ProgramType programType) {
+    return programType == ProgramType.WORKFLOW
+            || programType == ProgramType.MAPREDUCE
+            || programType == ProgramType.SPARK;
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/SystemArgumentsTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/SystemArgumentsTest.java
@@ -55,10 +55,10 @@ public class SystemArgumentsTest {
     ProgramId workerId = appId.worker("worker");
     ProgramId workflowID = appId.workflow("wf");
 
-    Assert.assertEquals(ProfileId.NATIVE, SystemArguments.getProfileIdForProgram(mrId, args));
+    Assert.assertEquals(profileId, SystemArguments.getProfileIdForProgram(mrId, args));
     Assert.assertEquals(ProfileId.NATIVE, SystemArguments.getProfileIdForProgram(serviceId, args));
     Assert.assertEquals(ProfileId.NATIVE, SystemArguments.getProfileIdForProgram(flowId, args));
-    Assert.assertEquals(ProfileId.NATIVE, SystemArguments.getProfileIdForProgram(sparkId, args));
+    Assert.assertEquals(profileId, SystemArguments.getProfileIdForProgram(sparkId, args));
     Assert.assertEquals(ProfileId.NATIVE, SystemArguments.getProfileIdForProgram(workerId, args));
     Assert.assertEquals(profileId, SystemArguments.getProfileIdForProgram(workflowID, args));
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
@@ -45,6 +45,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -181,13 +182,18 @@ public class ProgramLifecycleServiceTest extends AppFabricTestBase {
         NamespaceId.DEFAULT.app(AllProgramsApp.NAME).program(ProgramType.WORKER, AllProgramsApp.NoOpWorker.NAME)
       );
 
+      Set<ProgramType> allowCustomProfiles = EnumSet.of(ProgramType.MAPREDUCE, ProgramType.SPARK, ProgramType.WORKFLOW);
       for (ProgramId programId : programIds) {
         ProgramOptions options = programLifecycleService.createProgramOptions(programId, userArgs,
                                                                               systemArgs, false);
         Optional<ProfileId> opt = SystemArguments.getProfileIdFromArgs(NamespaceId.DEFAULT,
                                                                        options.getArguments().asMap());
         Assert.assertTrue(opt.isPresent());
-        Assert.assertEquals(ProfileId.NATIVE, opt.get());
+        if (allowCustomProfiles.contains(programId.getType())) {
+          Assert.assertEquals(profileId, opt.get());
+        } else {
+          Assert.assertEquals(ProfileId.NATIVE, opt.get());
+        }
       }
     } finally {
       profileService.disableProfile(profileId);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileMetadataTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/profile/ProfileMetadataTest.java
@@ -82,9 +82,12 @@ public class ProfileMetadataTest extends AppFabricTestBase {
     ScheduleId scheduleId1 = defaultAppId.schedule(AppWithSchedule.SCHEDULE);
     ScheduleId scheduleId2 = defaultAppId.schedule(AppWithSchedule.SCHEDULE);
     ProgramId programId = defaultAppId.workflow(AppWithSchedule.WORKFLOW_NAME);
+    ProgramId mapReduceProgramId = defaultAppId.mr(AppWithSchedule.MAPREDUCE);
 
     // Verify the workflow and schedule has been updated to native profile
     Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
+                  10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(mapReduceProgramId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
@@ -99,6 +102,8 @@ public class ProfileMetadataTest extends AppFabricTestBase {
     // Verify the workflow and schedule has been updated to my profile
     Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(mapReduceProgramId).get("profile"),
+                  10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(scheduleId2).get("profile"),
@@ -111,6 +116,8 @@ public class ProfileMetadataTest extends AppFabricTestBase {
     // Verify the workflow and schedule has been updated to my profile 2
     Tasks.waitFor(myProfile2.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(myProfile2.getScopedName(), () -> getMetadataProperties(mapReduceProgramId).get("profile"),
+                  10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(myProfile2.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(myProfile2.getScopedName(), () -> getMetadataProperties(scheduleId2).get("profile"),
@@ -121,6 +128,8 @@ public class ProfileMetadataTest extends AppFabricTestBase {
 
     // Verify the workflow and schedule has been updated to my profile
     Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
+                  10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(mapReduceProgramId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(myProfile.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
@@ -133,6 +142,8 @@ public class ProfileMetadataTest extends AppFabricTestBase {
     // Verify the workflow and schedule has been updated to native profile
     Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(programId).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(mapReduceProgramId).get("profile"),
+                  10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(scheduleId1).get("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(ProfileId.NATIVE.getScopedName(), () -> getMetadataProperties(scheduleId2).get("profile"),
@@ -142,6 +153,8 @@ public class ProfileMetadataTest extends AppFabricTestBase {
 
     // Verify the workflow and schedule has been updated to native profile
     Tasks.waitFor(false, () -> getMetadataProperties(programId).containsKey("profile"),
+                  10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(false, () -> getMetadataProperties(mapReduceProgramId).containsKey("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     Tasks.waitFor(false, () -> getMetadataProperties(scheduleId1).containsKey("profile"),
                   10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
@@ -35,6 +35,7 @@ public enum ProgramType {
     .setCategoryName("flows")
     .setPrettyName("Flow")
     .setListable(true)
+    .setApiProgramType(co.cask.cdap.api.app.ProgramType.FLOW)
     .build()),
 
   @SerializedName("Mapreduce")
@@ -43,6 +44,7 @@ public enum ProgramType {
     .setPrettyName("MapReduce")
     .setListable(true)
     .setSchedulableType(SchedulableProgramType.MAPREDUCE)
+    .setApiProgramType(co.cask.cdap.api.app.ProgramType.MAPREDUCE)
     .build()),
 
   @SerializedName("Workflow")
@@ -51,6 +53,7 @@ public enum ProgramType {
     .setPrettyName("Workflow")
     .setListable(true)
     .setSchedulableType(SchedulableProgramType.WORKFLOW)
+    .setApiProgramType(co.cask.cdap.api.app.ProgramType.WORKFLOW)
     .build()),
 
   @SerializedName("Service")
@@ -58,6 +61,7 @@ public enum ProgramType {
     .setCategoryName("services")
     .setPrettyName("Service")
     .setListable(true)
+    .setApiProgramType(co.cask.cdap.api.app.ProgramType.SERVICE)
     .build()),
 
   @SerializedName("Spark")
@@ -66,6 +70,7 @@ public enum ProgramType {
     .setPrettyName("Spark")
     .setListable(true)
     .setSchedulableType(SchedulableProgramType.SPARK)
+    .setApiProgramType(co.cask.cdap.api.app.ProgramType.SPARK)
     .build()),
 
   @SerializedName("Worker")
@@ -73,6 +78,7 @@ public enum ProgramType {
     .setCategoryName("workers")
     .setPrettyName("Worker")
     .setListable(true)
+    .setApiProgramType(co.cask.cdap.api.app.ProgramType.WORKER)
     .build()),
 
   CUSTOM_ACTION(9, Parameters.builder()
@@ -113,6 +119,10 @@ public enum ProgramType {
 
   public String getScope() {
     return name().toLowerCase();
+  }
+
+  public co.cask.cdap.api.app.ProgramType getApiProgramType() {
+    return parameters.getApiProgramType();
   }
 
   public SchedulableProgramType getSchedulableType() {
@@ -161,9 +171,11 @@ public enum ProgramType {
     private final boolean listable;
     private final String categoryName;
     private final SchedulableProgramType schedulableType;
+    private co.cask.cdap.api.app.ProgramType apiProgramType;
 
     Parameters(String prettyName, Boolean listable, String categoryName,
-                      @Nullable SchedulableProgramType schedulableType) {
+               @Nullable SchedulableProgramType schedulableType,
+               @Nullable co.cask.cdap.api.app.ProgramType apiProgramType) {
       if (prettyName == null) {
         throw new IllegalArgumentException("prettyName cannot be null");
       }
@@ -177,6 +189,7 @@ public enum ProgramType {
       this.listable = listable;
       this.categoryName = categoryName;
       this.schedulableType = schedulableType;
+      this.apiProgramType = apiProgramType;
     }
 
     @Nullable
@@ -196,6 +209,11 @@ public enum ProgramType {
       return categoryName;
     }
 
+    @Nullable
+    public co.cask.cdap.api.app.ProgramType getApiProgramType() {
+      return apiProgramType;
+    }
+
     public static Builder builder() {
       return new Builder();
     }
@@ -208,6 +226,7 @@ public enum ProgramType {
       private Boolean listable;
       private String categoryName;
       private SchedulableProgramType schedulableType;
+      private co.cask.cdap.api.app.ProgramType apiProgramType;
 
       public Builder setSchedulableType(SchedulableProgramType schedulableType) {
         this.schedulableType = schedulableType;
@@ -229,8 +248,13 @@ public enum ProgramType {
         return this;
       }
 
+      public Builder setApiProgramType(co.cask.cdap.api.app.ProgramType apiProgramType) {
+        this.apiProgramType = apiProgramType;
+        return this;
+      }
+
       public Parameters build() {
-        return new Parameters(prettyName, listable, categoryName, schedulableType);
+        return new Parameters(prettyName, listable, categoryName, schedulableType, apiProgramType);
       }
     }
   }


### PR DESCRIPTION
Allow both MAPREDUCE and SPARK program types to use profiles
https://builds.cask.co/browse/CDAP-DUT6679