### PR TITLE
update wrangler version upper bound in bootstrap action

### DIFF
--- a/cdap-common/src/main/resources/bootstrap/sandbox.json
+++ b/cdap-common/src/main/resources/bootstrap/sandbox.json
@@ -24,7 +24,7 @@
         "name": "dataprep",
         "artifact": {
           "name": "wrangler-service",
-          "version": "[3.0.0, 4.0.0)",
+          "version": "[3.0.0, 10.0.0)",
           "scope": "SYSTEM"
         }
       }


### PR DESCRIPTION
Updating upperbound of wrangler artifact for automatic dataprep
app creation now that wrangler is at version 4.0.0-SNAPSHOT.