### PR TITLE
[CDAP-14620] New app header implementation

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWizard/index.js
+++ b/cdap-ui/app/cdap/components/AbstractWizard/index.js
@@ -133,9 +133,9 @@ export default function AbstractWizard({
   isOpen,
   onClose,
   wizardType,
-  input,
-  backdrop,
-  displayCTA,
+  input = null,
+  backdrop = true,
+  displayCTA = true,
 }) {
   if (!isOpen) {
     return null;

--- a/cdap-ui/app/cdap/components/Administration/index.js
+++ b/cdap-ui/app/cdap/components/Administration/index.js
@@ -44,7 +44,6 @@ class Administration extends Component {
   componentDidMount() {
     this.getUptime();
     this.getPlatformDetails();
-    document.querySelector('#header-namespace-dropdown').style.display = 'none';
   }
 
   componentWillReceiveProps(nextProps) {
@@ -57,10 +56,6 @@ class Administration extends Component {
         accordionToExpand,
       });
     }
-  }
-
-  componentWillUnmount() {
-    document.querySelector('#header-namespace-dropdown').style.display = 'inline-block';
   }
 
   getUptime() {

--- a/cdap-ui/app/cdap/components/AppHeader/AboutPageModal/AboutPageModal.scss
+++ b/cdap-ui/app/cdap/components/AppHeader/AboutPageModal/AboutPageModal.scss
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@import '~styles/variables.scss';
+
+$modal-padding-left-right: 45px;
+
+.about-page-modal {
+  &.modal-dialog { margin-top: 100px; }
+
+  .modal-body {
+    padding: 50px $modal-padding-left-right;
+
+    .close-section {
+      position: absolute;
+      right: 0.5rem;
+      top: 0.5rem;
+      cursor: pointer;
+      color: #cccccc;
+    }
+
+    .about-title {
+      display: flex;
+      justify-content: center;
+
+      .cdap-version {
+        font-weight: bold;
+        float: right;
+        margin-top: 0.5rem;
+      }
+      .logo-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        img {
+          width: 120px;
+        }
+      }
+    }
+
+    .about-content {
+      margin: 2rem 0;
+
+      .cdap-mode-security {
+        font-size: 14px;
+      }
+    }
+    footer {
+      margin-left: -$modal-padding-left-right;
+      margin-right: -$modal-padding-left-right;
+      border-bottom-left-radius: 6px;
+      border-bottom-right-radius: 6px;
+      // For bootstrap 3
+      > .container {
+        width: 100%;
+      }
+    }
+  }
+}
+
+body.theme-cdap.state-hydrator .about-page-modal .modal-body > footer {
+  position: absolute;
+}

--- a/cdap-ui/app/cdap/components/AppHeader/AboutPageModal/index.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AboutPageModal/index.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import { Modal, ModalBody } from 'reactstrap';
+import T from 'i18n-react';
+import { getModeWithCloudProvider } from 'components/Header/ProductDropdown/helper';
+import Footer from 'components/Footer';
+import { Theme } from 'services/ThemeHelper';
+import IconSVG from 'components/IconSVG';
+import Heading, { HeadingTypes } from 'components/Heading';
+
+require('./AboutPageModal.scss');
+
+declare global {
+  /* tslint:disable:interface-name */
+  interface Window {
+    CDAP_CONFIG: any;
+  }
+}
+
+interface IAboutPageModalProps {
+  cdapVersion: string;
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+const AboutPageModal: React.SFC<IAboutPageModalProps> = ({ cdapVersion, isOpen, toggle }) => {
+  const mode = getModeWithCloudProvider();
+  const productLogoSrc = Theme.productLogoAbout || '/cdap_assets/img/CDAP_darkgray.png';
+  return (
+    <Modal isOpen={isOpen} toggle={toggle} size="md" className="about-page-modal" backdrop="static">
+      <ModalBody>
+        <div className="close-section float-right" onClick={toggle}>
+          <Heading type={HeadingTypes.h3} label={<IconSVG name="icon-close" />} />
+        </div>
+        <div className="about-title">
+          <div className="cdap-logo-with-version">
+            <div className="logo-container">
+              <img src={productLogoSrc} />
+            </div>
+            <span className="cdap-version">
+              {T.translate('features.AboutPage.version', { version: cdapVersion })}
+            </span>
+          </div>
+        </div>
+        <div className="about-content">
+          <div className="cdap-mode-security">
+            <span className="cdap-mode">
+              <strong>{T.translate('features.AboutPage.mode')}</strong>
+              <span>{mode}</span>
+            </span>
+            <br />
+            <span className="cdap-security">
+              <strong>{T.translate('features.AboutPage.security')}</strong>
+              <span>{window.CDAP_CONFIG.securityEnabled ? 'Enabled' : 'Disabled'}</span>
+            </span>
+          </div>
+        </div>
+        <Footer />
+      </ModalBody>
+    </Modal>
+  );
+};
+
+export default AboutPageModal;

--- a/cdap-ui/app/cdap/components/AppHeader/AppDrawer/AppDrawer.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppDrawer/AppDrawer.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import * as React from 'react';
+import List from '@material-ui/core/List';
+import ListItemText from '@material-ui/core/ListItemText';
+import Drawer from '@material-ui/core/Drawer';
+import NamespaceDropdown from 'components/NamespaceDropdown';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+const colorVariables = require('styles/variables.scss');
+import { Link } from 'react-router-dom';
+import { withContext, INamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
+import ListItemLink from 'components/AppHeader/ListItemLink';
+import DrawerFeatureLink from 'components/AppHeader/AppDrawer/DrawerFeatureLink';
+import { Theme } from 'services/ThemeHelper';
+
+const DRAWER_WIDTH = '250px';
+const styles = (theme) => {
+  return {
+    drawer: {
+      zIndex: theme.zIndex.drawer,
+      width: DRAWER_WIDTH,
+    },
+    drawerPaper: {
+      width: DRAWER_WIDTH,
+      backgroundColor: colorVariables.grey08,
+    },
+    listItemText: {
+      fontWeight: 600,
+      fontSize: '1rem',
+    },
+    toolbar: theme.mixins.toolbar,
+  };
+};
+
+interface IAppDrawerProps extends WithStyles<typeof styles> {
+  open: boolean;
+  onClose: () => void;
+  componentDidNavigate: () => void;
+  context: INamespaceLinkContext;
+}
+
+class AppDrawer extends React.PureComponent<IAppDrawerProps> {
+  public state = {
+    onNamespacePreferenceEdit: false,
+  };
+  public toggleonNamespacePreferenceEdit = () => {
+    this.setState({ onNamespacePreferenceEdit: !this.state.onNamespacePreferenceEdit });
+  };
+  public render() {
+    const { classes, open, onClose, componentDidNavigate = () => null } = this.props;
+    const { isNativeLink, namespace } = this.props.context;
+    return (
+      <Drawer
+        open={open}
+        onClose={onClose}
+        className={classes.drawer}
+        disableEnforceFocus={true}
+        disableEscapeKeyDown={this.state.onNamespacePreferenceEdit}
+        ModalProps={{
+          keepMounted: true,
+        }}
+        classes={{
+          paper: classes.drawerPaper,
+        }}
+      >
+        <div className={classes.toolbar} />
+        <NamespaceDropdown
+          onNamespaceCreate={onClose}
+          onNamespacePreferenceEdit={this.toggleonNamespacePreferenceEdit}
+          onNamespaceChange={onClose}
+          tag={isNativeLink ? 'a' : Link}
+        />
+        <List component="nav" dense={true}>
+          <ListItemLink
+            component={isNativeLink ? 'a' : Link}
+            href={`/cdap/ns/${namespace}`}
+            to={`/ns/${namespace}`}
+            onClick={componentDidNavigate}
+          >
+            <ListItemText
+              disableTypography
+              classes={{ root: classes.listItemText }}
+              primary={Theme.featureNames.controlCenter}
+            />
+          </ListItemLink>
+        </List>
+        <List component="nav" dense={true}>
+          <DrawerFeatureLink
+            featureName={Theme.featureNames.pipelines}
+            featureFlag={Theme.showPipelines}
+            featureUrl={`/ns/${namespace}/pipelines`}
+            componentDidNavigate={this.props.componentDidNavigate}
+          />
+          <DrawerFeatureLink
+            featureName={Theme.featureNames.dataPrep}
+            featureFlag={Theme.showDataPrep}
+            featureUrl={`/ns/${namespace}/dataprep`}
+            componentDidNavigate={this.props.componentDidNavigate}
+          />
+          <DrawerFeatureLink
+            featureUrl={`/ns/${namespace}/experiments`}
+            featureFlag={Theme.showAnalytics}
+            featureName={Theme.featureNames.analytics}
+            componentDidNavigate={this.props.componentDidNavigate}
+          />
+          <DrawerFeatureLink
+            featureUrl={`/ns/${namespace}/rulesengine`}
+            featureFlag={Theme.showRulesEngine}
+            featureName={Theme.featureNames.rulesEngine}
+            componentDidNavigate={this.props.componentDidNavigate}
+          />
+          <DrawerFeatureLink
+            featureUrl={`/metadata/ns/${namespace}`}
+            featureFlag={Theme.showMetadata}
+            featureName={Theme.featureNames.metadata}
+            isAngular={true}
+          />
+        </List>
+        <List component="nav" dense={true}>
+          <ListItemLink
+            component={isNativeLink ? 'a' : Link}
+            href="/cdap/administration/configuration"
+            to="/administration/configuration"
+            onClick={componentDidNavigate}
+          >
+            <ListItemText
+              disableTypography
+              classes={{ root: classes.listItemText }}
+              primary={Theme.featureNames.projectAdmin}
+            />
+          </ListItemLink>
+        </List>
+      </Drawer>
+    );
+  }
+}
+
+export default withStyles(styles)(withContext(AppDrawer));

--- a/cdap-ui/app/cdap/components/AppHeader/AppDrawer/DrawerFeatureLink.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppDrawer/DrawerFeatureLink.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+import * as React from 'react';
+import { withContext, INamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemLink from 'components/AppHeader/ListItemLink';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import { Link } from 'react-router-dom';
+
+const styles = () => {
+  return {
+    listItemText: {
+      fontWeight: 600,
+      fontSize: '1rem',
+    },
+  };
+};
+
+interface IDrawerFeatureLinkProps extends WithStyles<typeof styles> {
+  context: INamespaceLinkContext;
+  componentDidNavigate?: () => void;
+  featureFlag: boolean;
+  featureName: string;
+  featureUrl: string;
+  isAngular?: boolean;
+}
+
+class DrawerFeatureLink extends React.PureComponent<IDrawerFeatureLinkProps> {
+  public render() {
+    const {
+      classes,
+      componentDidNavigate = () => null,
+      featureFlag,
+      featureName,
+      featureUrl,
+      isAngular = false,
+    } = this.props;
+    if (featureFlag === false) {
+      return null;
+    }
+
+    const { isNativeLink } = this.props.context;
+
+    return (
+      <ListItemLink
+        component={isNativeLink || isAngular ? 'a' : Link}
+        href={isAngular ? featureUrl : `/cdap${featureUrl}`}
+        to={featureUrl}
+        onClick={componentDidNavigate}
+      >
+        <ListItemText
+          disableTypography
+          classes={{ root: classes.listItemText }}
+          primary={featureName}
+        />
+      </ListItemLink>
+    );
+  }
+}
+
+const DrawerFeatureLinkWithContext = withStyles(styles)(withContext(DrawerFeatureLink));
+
+export default DrawerFeatureLinkWithContext;

--- a/cdap-ui/app/cdap/components/AppHeader/AppToolBar/AppToolbar.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppToolBar/AppToolbar.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+import * as React from 'react';
+import Toolbar from '@material-ui/core/Toolbar';
+import IconButton from '@material-ui/core/IconButton';
+import BrandImage from 'components/AppHeader/BrandImage';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import IconSVG from 'components/IconSVG';
+import MenuIcon from '@material-ui/icons/Menu';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import classnames from 'classnames';
+import ExtendedLinkButton from 'components/AppHeader/ExtendedLinkButton';
+import { withContext, INamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
+import ToolBarFeatureLink from 'components/AppHeader/AppToolBar/ToolBarFeatureLink';
+import HubButton from 'components/AppHeader/HubButton';
+import { Theme } from 'services/ThemeHelper';
+import VersionStore from 'services/VersionStore';
+import T from 'i18n-react';
+import If from 'components/If';
+import AboutPageModal from 'components/AppHeader/AboutPageModal';
+
+const styles = (theme) => {
+  return {
+    grow: theme.grow,
+    iconButton: {
+      marginLeft: '-20px',
+      padding: '10px',
+    },
+    iconButtonFocus: theme.iconButtonFocus,
+    customToolbar: {
+      height: '48px',
+      minHeight: '48px',
+    },
+    buttonLink: theme.buttonLink,
+    cogWheelFontSize: {
+      // This is because the icon is not the same size as it should be.
+      // So beside a normal text this looks small. Hence the bump in font size
+      fontSize: '1.3rem',
+    },
+    anchorMenuItem: {
+      '&:focus': {
+        outline: 'none',
+      },
+      textDecoration: 'none',
+      color: 'inherit',
+    },
+  };
+};
+
+interface IAppToolbarProps extends WithStyles<typeof styles> {
+  onMenuIconClick: () => void;
+  context: INamespaceLinkContext;
+}
+
+interface IAppToolbarState {
+  anchorEl: EventTarget | null;
+  aboutPageOpen: boolean;
+}
+
+class AppToolbar extends React.PureComponent<IAppToolbarProps, IAppToolbarState> {
+  public state = {
+    anchorEl: null,
+    aboutPageOpen: false,
+  };
+
+  public openSettings = (event: React.MouseEvent<HTMLElement>) => {
+    this.setState({
+      anchorEl: event.currentTarget,
+    });
+  };
+
+  public closeSettings = () => {
+    this.setState({
+      anchorEl: null,
+    });
+  };
+
+  private toggleAboutPage = () => {
+    this.setState({
+      aboutPageOpen: !this.state.aboutPageOpen,
+    });
+    this.closeSettings();
+  };
+
+  public render() {
+    const { onMenuIconClick, classes } = this.props;
+    const { anchorEl } = this.state;
+    const { namespace, isNativeLink } = this.props.context;
+    const cdapVersion = VersionStore.getState().version;
+    const docsUrl = `http://docs.cdap.io/cdap/${cdapVersion}/en/index.html`;
+    return (
+      <Toolbar className={classes.customToolbar}>
+        <IconButton
+          onClick={onMenuIconClick}
+          color="inherit"
+          className={classnames(classes.iconButton, classes.iconButtonFocus)}
+        >
+          <MenuIcon />
+        </IconButton>
+        <div className={classes.grow}>
+          <BrandImage />
+        </div>
+        <div>
+          <ToolBarFeatureLink
+            featureFlag={Theme.showDashboard}
+            featureName={Theme.featureNames.dashboard}
+            featureUrl={`/ns/${namespace}/operations`}
+          />
+          <ToolBarFeatureLink
+            featureFlag={Theme.showReports}
+            featureName={Theme.featureNames.reports}
+            featureUrl={`/ns/${namespace}/reports`}
+          />
+          <HubButton />
+          <Button
+            component={isNativeLink ? 'a' : ExtendedLinkButton(`/administration`)}
+            className={classnames(classes.buttonLink)}
+            href={`/cdap/administration`}
+          >
+            {Theme.featureNames.systemAdmin}
+          </Button>
+        </div>
+        <div onClick={this.openSettings}>
+          <IconButton className={classnames(classes.buttonLink, classes.iconButtonFocus)}>
+            <IconSVG name="icon-cogs" className={classes.cogWheelFontSize} />
+          </IconButton>
+        </div>
+        <Menu
+          id="simple-menu"
+          anchorEl={anchorEl as HTMLElement}
+          open={Boolean(anchorEl)}
+          onClose={this.closeSettings}
+          anchorPosition={{
+            left: 0,
+            top: 40,
+          }}
+        >
+          <a
+            className={classes.anchorMenuItem}
+            href={docsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <MenuItem onClick={this.closeSettings}>
+              {T.translate('features.Navbar.ProductDropdown.documentationLabel')}
+            </MenuItem>
+          </a>
+          <If condition={Theme.showAboutProductModal === true}>
+            <MenuItem onClick={this.toggleAboutPage}>
+              <a>
+                {T.translate('features.Navbar.ProductDropdown.aboutLabel', {
+                  productName: Theme.productName,
+                })}
+              </a>
+            </MenuItem>
+          </If>
+        </Menu>
+        <If condition={Theme.showAboutProductModal === true}>
+          <AboutPageModal
+            cdapVersion={cdapVersion}
+            isOpen={this.state.aboutPageOpen}
+            toggle={this.toggleAboutPage}
+          />
+        </If>
+      </Toolbar>
+    );
+  }
+}
+
+export default withStyles(styles)(withContext(AppToolbar));

--- a/cdap-ui/app/cdap/components/AppHeader/AppToolBar/ToolBarFeatureLink.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppToolBar/ToolBarFeatureLink.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+import * as React from 'react';
+import { withContext, INamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
+import ExtendedLinkButton from 'components/AppHeader/ExtendedLinkButton';
+import classnames from 'classnames';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import Button from '@material-ui/core/Button';
+
+interface IToolBarFeatureLinkProps extends WithStyles<typeof styles> {
+  context: INamespaceLinkContext;
+  featureFlag: boolean;
+  featureName: string;
+  featureUrl: string;
+}
+
+const styles = (theme) => {
+  return {
+    buttonLink: theme.buttonLink,
+  };
+};
+
+class ToolBarFeatureLink extends React.PureComponent<IToolBarFeatureLinkProps> {
+  public render() {
+    const { classes, featureFlag, featureName, featureUrl } = this.props;
+    if (featureFlag === false) {
+      return null;
+    }
+    const { isNativeLink } = this.props.context;
+    return (
+      <Button
+        component={isNativeLink ? 'a' : ExtendedLinkButton(featureUrl)}
+        className={classnames(classes.buttonLink)}
+        href={`/cdap${featureUrl}`}
+      >
+        {featureName}
+      </Button>
+    );
+  }
+}
+
+const ToolBarFeatureLinkWithContext = withStyles(styles)(withContext(ToolBarFeatureLink));
+
+export default ToolBarFeatureLinkWithContext;

--- a/cdap-ui/app/cdap/components/AppHeader/BrandImage.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/BrandImage.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import * as React from 'react';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import { withContext, INamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
+import { Theme } from 'services/ThemeHelper';
+import { Link } from 'react-router-dom';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+
+interface IBrandImageProps extends WithStyles<typeof imageStyle> {
+  context: INamespaceLinkContext;
+}
+
+const BrandImage: React.SFC<IBrandImageProps> = ({ classes, context }) => {
+  const brandLogoSrc = Theme.productLogoNavbar || '/cdap_assets/img/company_logo.png';
+  const { isNativeLink } = context;
+  const namespace = getCurrentNamespace();
+  const LinkEl = isNativeLink ? 'a' : Link;
+  return (
+    <LinkEl to={`/ns/${namespace}`} href={`/cdap/ns/${namespace}`}>
+      <img className={classes.img} src={brandLogoSrc} />
+    </LinkEl>
+  );
+};
+
+const imageStyle = {
+  img: {
+    width: '108px',
+    height: '50px',
+  },
+};
+const StyledBrandImage = withStyles(imageStyle)(withContext(BrandImage));
+export default StyledBrandImage;

--- a/cdap-ui/app/cdap/components/AppHeader/ExtendedLinkButton.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/ExtendedLinkButton.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { ButtonProps } from '@material-ui/core/Button';
+
+// This is here because <Button component will not accept `to` prop for Link component
+const ExtendedLinkButton = (toLink: string) => (props: ButtonProps) => (
+  <Link to={toLink} {...props} />
+);
+
+export default ExtendedLinkButton;

--- a/cdap-ui/app/cdap/components/AppHeader/HubButton.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/HubButton.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import { Theme } from 'services/ThemeHelper';
+import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import Loadable from 'react-loadable';
+import classnames from 'classnames';
+import ee from 'event-emitter';
+import globalEvents from 'services/global-events';
+import Button from '@material-ui/core/Button';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+
+const styles = (theme) => {
+  return {
+    buttonLink: theme.buttonLink,
+  };
+};
+
+const PlusButtonModal = Loadable({
+  loader: () => import(/* webpackChunkName: "PlusButtonModal" */ 'components/PlusButtonModal'),
+  loading: LoadingSVGCentered,
+});
+
+interface IHubButtonProps extends WithStyles<typeof styles> {
+  className: string;
+  children: React.ReactNode;
+}
+interface IHubButtonState {
+  showMarketPlace: boolean;
+}
+
+class HubButton extends React.PureComponent<IHubButtonProps, IHubButtonState> {
+  private eventEmitter = ee(ee);
+  public state = {
+    showMarketPlace: false,
+  };
+  constructor(props) {
+    super(props);
+    this.eventEmitter.on(globalEvents.OPENMARKET, this.openHubModal);
+    this.eventEmitter.on(globalEvents.CLOSEMARKET, this.closeHubModal);
+  }
+
+  public componentWillUnmount() {
+    this.eventEmitter.off(globalEvents.OPENMARKET, this.openHubModal);
+    this.eventEmitter.off(globalEvents.CLOSEMARKET, this.closeHubModal);
+  }
+
+  private onClickHandler() {
+    const newState = !this.state.showMarketPlace;
+
+    if (newState === false) {
+      this.eventEmitter.emit(globalEvents.MARKETCLOSING);
+    }
+
+    this.setState({
+      showMarketPlace: newState,
+    });
+  }
+
+  private openHubModal() {
+    this.setState({
+      showMarketPlace: true,
+    });
+  }
+
+  private closeHubModal() {
+    this.eventEmitter.emit(globalEvents.MARKETCLOSING);
+    this.setState({
+      showMarketPlace: false,
+    });
+  }
+
+  public render() {
+    const { classes } = this.props;
+    return (
+      <React.Fragment>
+        <Button className={classnames(classes.buttonLink)} onClick={this.onClickHandler.bind(this)}>
+          <div>
+            <span
+              className={classnames('cask-market-button', this.props.className, {
+                active: this.state.showMarketPlace,
+              })}
+            >
+              {this.props.children}
+            </span>
+          </div>
+        </Button>
+        <PlusButtonModal
+          isOpen={this.state.showMarketPlace}
+          onCloseHandler={this.onClickHandler.bind(this)}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+const HubButtinWithStyles = withStyles(styles)(HubButton);
+
+export default function HubButtonWrapper() {
+  if (Theme.showHub === false) {
+    return null;
+  }
+
+  const featureName = Theme.featureNames.hub;
+
+  return (
+    <HubButtinWithStyles>
+      <span className="hub-text-wrapper">{featureName}</span>
+    </HubButtinWithStyles>
+  );
+}

--- a/cdap-ui/app/cdap/components/AppHeader/ListItemLink.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/ListItemLink.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import * as React from 'react';
+import ListItem from '@material-ui/core/ListItem';
+
+const ListItemLink = ({ component = 'a', ...props }) => (
+  <ListItem button component={component} {...props} />
+);
+export default ListItemLink;

--- a/cdap-ui/app/cdap/components/AppHeader/NamespaceLinkContext.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/NamespaceLinkContext.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+
+export interface INamespaceLinkContext {
+  isNativeLink: boolean;
+  namespace: string;
+}
+const defaultNamespaceLinkContext: INamespaceLinkContext = {
+  isNativeLink: false,
+  namespace: '',
+};
+export const NamespaceLinkContext = React.createContext(defaultNamespaceLinkContext);
+
+export function withContext(Component) {
+  return function ComponentWithContext(props) {
+    return (
+      <NamespaceLinkContext.Consumer>
+        {(context) => <Component {...props} context={context} />}
+      </NamespaceLinkContext.Consumer>
+    );
+  };
+}

--- a/cdap-ui/app/cdap/components/AppHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/index.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import AppBar from '@material-ui/core/AppBar';
+import classnames from 'classnames';
+import AppDrawer from 'components/AppHeader/AppDrawer/AppDrawer';
+import AppToolbar from 'components/AppHeader/AppToolBar/AppToolbar';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';
+import createMuiTheme, { ThemeOptions } from '@material-ui/core/styles/createMuiTheme';
+import { MyNamespaceApi } from 'api/namespace';
+import NamespaceStore from 'services/NamespaceStore';
+import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
+import ee from 'event-emitter';
+import { ISubscription } from 'rxjs/Subscription';
+import { Unsubscribe } from 'redux';
+import globalEvents from 'services/global-events';
+import getLastSelectedNamespace from 'services/get-last-selected-namespace';
+import { SYSTEM_NAMESPACE } from 'services/global-constants';
+import { objectQuery } from 'services/helpers';
+import { NamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
+
+require('styles/bootstrap_4_patch.scss');
+
+interface IMyAppHeaderState {
+  toggleDrawer: boolean;
+  currentNamespace: string;
+}
+const styles = (theme) => {
+  return {
+    grow: theme.grow,
+    appbar: {
+      backgroundColor: theme.navbarBgColor,
+      zIndex: theme.zIndex.drawer + 1,
+    },
+  };
+};
+
+interface IMyAppHeaderProps extends WithStyles<typeof styles> {
+  nativeLink: boolean;
+}
+
+class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderState> {
+  public state: IMyAppHeaderState = {
+    toggleDrawer: false,
+    currentNamespace: '',
+  };
+
+  private namespacesubscription: ISubscription;
+  private nsSubscription: Unsubscribe;
+  private eventEmitter = ee(ee);
+
+  public componentDidMount() {
+    // Polls for namespace data
+    this.namespacesubscription = MyNamespaceApi.pollList().subscribe((res) => {
+      if (res.length > 0) {
+        NamespaceStore.dispatch({
+          type: NamespaceActions.updateNamespaces,
+          payload: {
+            namespaces: res,
+          },
+        });
+      } else {
+        // TL;DR - This is emitted for Authorization in main.js
+        // This means there is no namespace for the user to work on.
+        // which indicates she/he have no authorization for any namesapce in the system.
+        this.eventEmitter.emit(globalEvents.NONAMESPACE);
+      }
+    });
+    this.nsSubscription = NamespaceStore.subscribe(() => {
+      let selectedNamespace: string = getLastSelectedNamespace() as string;
+      const { namespaces } = NamespaceStore.getState();
+      if (selectedNamespace === SYSTEM_NAMESPACE) {
+        selectedNamespace = objectQuery(namespaces, 0, 'name');
+      }
+      if (selectedNamespace !== this.state.currentNamespace) {
+        this.setState({
+          currentNamespace: selectedNamespace,
+        });
+      }
+    });
+  }
+  public componentWillUnmount() {
+    this.nsSubscription();
+    if (this.namespacesubscription) {
+      this.namespacesubscription.unsubscribe();
+    }
+  }
+
+  public toggleDrawer = () => {
+    this.setState({
+      toggleDrawer: !this.state.toggleDrawer,
+    });
+  };
+
+  public render() {
+    const { classes } = this.props;
+    const namespaceLinkContext = {
+      namespace: this.state.currentNamespace,
+      isNativeLink: this.props.nativeLink,
+    };
+    return (
+      <AppBar position="fixed" className={classnames(classes.grow, classes.appbar)}>
+        <NamespaceLinkContext.Provider value={namespaceLinkContext}>
+          <AppToolbar onMenuIconClick={this.toggleDrawer} nativeLink={this.props.nativeLink} />
+          <AppDrawer
+            open={this.state.toggleDrawer}
+            onClose={this.toggleDrawer}
+            componentDidNavigate={this.toggleDrawer}
+          />
+        </NamespaceLinkContext.Provider>
+      </AppBar>
+    );
+  }
+}
+const AppHeaderWithStyles = withStyles(styles)(MyAppHeader);
+const baseTheme = createMuiTheme({
+  palette: {
+    primary: {
+      main: '#1a73e8',
+    },
+    blue: {
+      50: '#045599',
+      100: '#0076dc',
+      200: '#0099ff',
+      300: '#58b7f6',
+      400: '#7cd2eb',
+      500: '#cae7ef',
+    },
+  },
+  navbarBgColor: 'var(--navbar-color)',
+  buttonLink: {
+    '&:hover': {
+      color: 'inherit',
+      backgroundColor: 'rgba(255, 255, 255, 0.10)',
+    },
+    fontSize: '1rem',
+    color: 'white',
+  },
+  iconButtonFocus: {
+    '&:focus': {
+      outline: 'none',
+      backgroundColor: 'rgba(255, 255, 255, 0.10)',
+    },
+  },
+  grow: {
+    flexGrow: 1,
+  },
+  typography: {
+    fontSize: 13,
+    fontFamily: 'var(--font-family)',
+    useNextVariants: true,
+  },
+} as ThemeOptions);
+/**
+ *  We are adding the themeing only to the header. Two reasons,
+ *
+ * 1. Right now only the header is slowly transitioning to material design
+ * 2. Header needs to be shared across react and angular and if I add MuiThemeProvider
+ *   to main.js angular side won't get the theme. Trying to avoid duplicating theme between angular
+ *   and react since we are anways moving away from angular.
+ */
+export default function CustomHeader({ nativeLink }) {
+  return (
+    <MuiThemeProvider theme={baseTheme}>
+      <AppHeaderWithStyles nativeLink={nativeLink} />
+    </MuiThemeProvider>
+  );
+}
+// Apparently this is needed for ngReact
+(CustomHeader as any).propTypes = {
+  nativeLink: PropTypes.bool,
+};
+(CustomHeader as any).defaultProps = {
+  nativeLink: false,
+};

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/ProvisionerSelection/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/ProvisionerSelection/index.js
@@ -54,13 +54,6 @@ class ProfileCreateProvisionerSelection extends Component {
 
   componentDidMount() {
     fetchProvisioners();
-    if (this.state.isSystem) {
-      document.querySelector('#header-namespace-dropdown').style.display = 'none';
-    }
-  }
-
-  componentWillUnmount() {
-    document.querySelector('#header-namespace-dropdown').style.display = 'inline-block';
   }
 
   renderProvisionerBox(provisioner) {

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -80,14 +80,9 @@ class ProfileCreateView extends Component {
   componentDidMount() {
     let { selectedProvisioner } = this.state;
     fetchProvisionerSpec(selectedProvisioner);
-    // FIXME: Since we are already in admin we shouldn't have to do this explicitly from the create profile view.
-    if (this.state.isSystem) {
-      document.querySelector('#header-namespace-dropdown').style.display = 'none';
-    }
   }
 
   componentWillUnmount() {
-    document.querySelector('#header-namespace-dropdown').style.display = 'inline-block';
     resetCreateProfileStore();
   }
 

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/DetailView/index.js
@@ -62,14 +62,6 @@ export default class ProfileDetailView extends Component {
   componentDidMount() {
     this.getProfile();
     this.getProvisioners();
-
-    if (this.state.isSystem) {
-      document.querySelector('#header-namespace-dropdown').style.display = 'none';
-    }
-  }
-
-  componentWillUnmount() {
-    document.querySelector('#header-namespace-dropdown').style.display = 'inline-block';
   }
 
   fetchAggregateMetrics = () => {

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -426,6 +426,7 @@ export default class SetPreferenceModal extends Component {
         className="confirmation-modal set-preference-modal cdap-modal"
         size="lg"
         backdrop="static"
+        zIndex="1201"
       >
         <ModalHeader className="modal-header">
           <div className="float-left">

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -50,7 +50,7 @@ export default class Header extends Component {
     this.namespacesubscription = null;
     this.eventEmitter = ee(ee);
   }
-  componentWillMount() {
+  componentDidMount() {
     // Polls for namespace data
     this.namespacesubscription = MyNamespaceApi.pollList().subscribe((res) => {
       if (res.length > 0) {

--- a/cdap-ui/app/cdap/components/Heading/index.tsx
+++ b/cdap-ui/app/cdap/components/Heading/index.tsx
@@ -31,7 +31,7 @@ interface IHeadingProps {
     | HeadingTypes.h4
     | HeadingTypes.h5
     | HeadingTypes.h6;
-  label: string;
+  label: string | React.ReactNode;
   className?: string;
 }
 const Heading: React.SFC<IHeadingProps> = ({ type, label, className }) => {

--- a/cdap-ui/app/cdap/components/HttpExecutor/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/index.js
@@ -33,14 +33,6 @@ export default class HttpExecutor extends Component {
     super(props);
   }
 
-  componentDidMount() {
-    document.querySelector('#header-namespace-dropdown').style.display = 'none';
-  }
-
-  componentWillUnmount() {
-    document.querySelector('#header-namespace-dropdown').style.display = 'inline-block';
-  }
-
   render() {
     return (
       <Provider store={HttpExecutorStore}>

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.scss
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.scss
@@ -25,6 +25,7 @@ $dark-font: #666666;
 $grey-font: #bbbbbb;
 $success-color: #7ed321;
 $star-color: #373a3c;
+$namespace-card-width: 225px;
 
 #header-namespace-dropdown {
   padding-left: 0;
@@ -32,18 +33,19 @@ $star-color: #373a3c;
   height: 100%;
 }
 .namespace-dropdown {
-  width: 160px;
-  border-left: 1px solid $dark-font;
+  width: 100%;
   padding: 0;
   font-size: 14px;
   user-select: none;
   display: inline-block;
   line-height: 50px;
   cursor: initial;
+  padding-left: 24px;
+  padding-right: 24px;
 
   &.opened,
   &:hover {
-    background: $cdap-white-light;
+    background-color: rgba(0, 0, 0, 0.08);
   }
 
   div[disabled] { cursor: not-allowed; }
@@ -70,7 +72,7 @@ $star-color: #373a3c;
     border: 0;
     text-align: left;
     padding: 0;
-    padding-left: 10px;
+    padding-left: 0;
     color: inherit;
 
     &:hover,
@@ -110,9 +112,7 @@ $star-color: #373a3c;
     }
   }
   .dropdown-menu {
-    position: absolute;
-    width: 220px;
-    left: -60px;
+    width: $namespace-card-width;
     border-bottom-left-radius: 3px;
     outline: none;
     border-top-left-radius: 0;
@@ -270,6 +270,9 @@ $star-color: #373a3c;
             color: $success-color;
           }
         }
+      }
+      a {
+        text-decoration: none;
       }
     }
 

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.tsx
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.tsx
@@ -16,11 +16,10 @@
 
 import PropTypes from 'prop-types';
 
-import React, { Component } from 'react';
+import React from 'react';
 import { Dropdown, DropdownMenu, DropdownToggle } from 'reactstrap';
 import AbstractWizard from 'components/AbstractWizard';
-import NamespaceStore from 'services/NamespaceStore';
-import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
+import NamespaceStore, { INamespace } from 'services/NamespaceStore';
 import SetPreferenceAction from 'components/FastAction/SetPreferenceAction';
 import { PREFERENCES_LEVEL } from 'components/FastAction/SetPreferenceAction/SetPreferenceModal';
 import IconSVG from 'components/IconSVG';
@@ -37,57 +36,119 @@ import { preventPropagation } from 'services/helpers';
 import { Theme } from 'services/ThemeHelper';
 import If from 'components/If';
 import classnames from 'classnames';
+import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
 require('./NamespaceDropdown.scss');
 
-export default class NamespaceDropdown extends Component {
+interface INamespaceDropdownProps {
+  tag?: React.ReactNode;
+  onNamespaceCreate?: () => void;
+  onNamespacePreferenceEdit?: () => void;
+  onNamespaceChange?: () => void;
+}
+interface INamespaceDropdownState {
+  openDropdown: boolean;
+  openWizard: boolean;
+  openPreferenceWizard: boolean;
+  numMetricsLoading: boolean;
+  preferencesSavedMessage: boolean;
+  numApplications: number;
+  numDatasets: number;
+  numStreams: number;
+  namespaceList: INamespace[];
+  defaultNamespace: string;
+  currentNamespace: string;
+  error: string;
+}
+
+const getBaseResolvedUrl = (url: string): string => {
+  const urlparams = window.location.pathname.split('/').filter((a) => a);
+  if (['pipelines', 'metadata', 'logviewer'].indexOf(urlparams[0]) !== -1) {
+    return `/cdap/${url}`;
+  }
+  return `/${url}`;
+};
+
+export default class NamespaceDropdown extends React.PureComponent<
+  INamespaceDropdownProps,
+  INamespaceDropdownState
+> {
   constructor(props) {
     super(props);
-    this.state = {
-      openDropdown: false,
-      openWizard: false,
-      openPreferenceWizard: false,
-      preferencesSavedMessage: false,
-      namespaceList: sortBy(NamespaceStore.getState().namespaces, [this.lowerCaseNamespace]),
-      currentNamespace: NamespaceStore.getState().selectedNamespace,
-      defaultNamespace: localStorage.getItem('DefaultNamespace'),
-    };
 
-    this.subscription = NamespaceStore.subscribe(() => {
-      let selectedNamespace = NamespaceStore.getState().selectedNamespace;
-      let namespaces = NamespaceStore.getState().namespaces.map((ns) => ns.name);
-      if (namespaces.indexOf(selectedNamespace) === -1) {
-        this.setState({
-          currentNamespace: '--',
-          namespaceList: sortBy(NamespaceStore.getState().namespaces, [this.lowerCaseNamespace]),
-        });
-      } else {
-        // have to set this, because the Namespace store gets reset when we visit other apps
-        // e.g. Hydrator or Tracker
-        localStorage.setItem('CurrentNamespace', selectedNamespace);
-        this.setState({
-          currentNamespace: NamespaceStore.getState().selectedNamespace,
-          namespaceList: sortBy(NamespaceStore.getState().namespaces, [this.lowerCaseNamespace]),
-        });
-      }
-    });
-
-    this.toggle = this.toggle.bind(this);
-    this.showNamespaceWizard = this.showNamespaceWizard.bind(this);
-    this.hideNamespaceWizard = this.hideNamespaceWizard.bind(this);
-    this.eventEmitter = ee(ee);
     this.eventEmitter.on(globalEvents.CREATENAMESPACE, () => {
       this.setState({
         openWizard: true,
       });
     });
   }
-  componentWillUnmount() {
+
+  private lowerCaseNamespace = (namespace) => {
+    return namespace.name.toLowerCase();
+  };
+
+  public state: INamespaceDropdownState = {
+    openDropdown: false,
+    openWizard: false,
+    openPreferenceWizard: false,
+    preferencesSavedMessage: false,
+    namespaceList: sortBy(NamespaceStore.getState().namespaces, [
+      this.lowerCaseNamespace,
+    ]) as INamespace[],
+    currentNamespace: NamespaceStore.getState().selectedNamespace,
+    defaultNamespace: localStorage.getItem('DefaultNamespace'),
+    numMetricsLoading: false,
+    numApplications: 0,
+    numDatasets: 0,
+    numStreams: 0,
+    error: '',
+  };
+
+  private eventEmitter = ee(ee);
+
+  private apiSubscription;
+
+  private subscription = NamespaceStore.subscribe(() => {
+    const selectedNamespace = NamespaceStore.getState().selectedNamespace;
+    const namespaces = NamespaceStore.getState().namespaces.map((ns) => ns.name);
+    if (namespaces.indexOf(selectedNamespace) === -1) {
+      this.setState({
+        currentNamespace: '--',
+        namespaceList: sortBy(NamespaceStore.getState().namespaces, [
+          this.lowerCaseNamespace,
+        ]) as INamespace[],
+      });
+    } else {
+      // have to set this, because the Namespace store gets reset when we visit other apps
+      // e.g. Hydrator or Tracker
+      localStorage.setItem('CurrentNamespace', selectedNamespace);
+      this.setState({
+        currentNamespace: NamespaceStore.getState().selectedNamespace,
+        namespaceList: sortBy(NamespaceStore.getState().namespaces, [
+          this.lowerCaseNamespace,
+        ]) as INamespace[],
+      });
+    }
+  });
+  public componentWillUnmount() {
     this.subscription();
     if (this.apiSubscription) {
       this.apiSubscription.unsubscribe();
     }
   }
-  toggle() {
+
+  private selectNamespace = (name) => {
+    NamespaceStore.dispatch({
+      type: NamespaceActions.selectNamespace,
+      payload: {
+        selectedNamespace: name,
+      },
+    });
+    if (this.props.onNamespaceChange) {
+      this.props.onNamespaceChange();
+    }
+  };
+
+  private toggle = () => {
     if (!this.state.openPreferenceWizard) {
       if (this.state.openDropdown === false) {
         this.getNumMetrics();
@@ -97,40 +158,46 @@ export default class NamespaceDropdown extends Component {
       });
       document.querySelector('.namespace-list').scrollTop = 0;
     }
-  }
-  showNamespaceWizard() {
-    this.setState({
-      openWizard: !this.state.openWizard,
-      openDropdown: !this.state.openDropdown,
-    });
-  }
-  hideNamespaceWizard() {
+  };
+
+  private showNamespaceWizard = () => {
+    this.setState(
+      {
+        openWizard: !this.state.openWizard,
+        openDropdown: !this.state.openDropdown,
+      },
+      () => {
+        const { onNamespaceCreate } = this.props;
+        if (onNamespaceCreate && typeof onNamespaceCreate === 'function') {
+          onNamespaceCreate();
+        }
+      }
+    );
+  };
+
+  private hideNamespaceWizard = () => {
     this.setState({
       openWizard: false,
     });
-  }
-  lowerCaseNamespace(namespace) {
-    return namespace.name.toLowerCase();
-  }
-  preferenceWizardIsOpen(openState) {
-    this.setState({ openPreferenceWizard: openState });
-  }
-  selectNamespace(name) {
-    NamespaceStore.dispatch({
-      type: NamespaceActions.selectNamespace,
-      payload: {
-        selectedNamespace: name,
-      },
+  };
+
+  private preferenceWizardIsOpen = (openState) => {
+    this.setState({ openPreferenceWizard: openState }, () => {
+      const { onNamespacePreferenceEdit } = this.props;
+      if (onNamespacePreferenceEdit && typeof onNamespacePreferenceEdit === 'function') {
+        onNamespacePreferenceEdit();
+      }
     });
-    this.toggle();
-  }
-  preferencesAreSaved() {
+  };
+
+  private preferencesAreSaved = () => {
     this.setState({ preferencesSavedMessage: true });
     setTimeout(() => {
       this.setState({ preferencesSavedMessage: false });
     }, 3000);
-  }
-  setDefault(clickedNamespace, event) {
+  };
+
+  private setDefault = (clickedNamespace, event) => {
     event.preventDefault();
     event.stopPropagation();
     event.nativeEvent.stopImmediatePropagation();
@@ -140,10 +207,11 @@ export default class NamespaceDropdown extends Component {
       });
       localStorage.setItem('DefaultNamespace', clickedNamespace);
     }
-  }
-  getNumMetrics() {
+  };
+
+  private getNumMetrics = () => {
     this.setState({ numMetricsLoading: true });
-    let params = {
+    const params = {
       namespace: NamespaceStore.getState().selectedNamespace,
       target: ['app', 'dataset', 'stream'],
       query: '*',
@@ -156,7 +224,7 @@ export default class NamespaceDropdown extends Component {
     this.apiSubscription = MySearchApi.search(params).subscribe(
       (res) => {
         res.results.forEach((entity) => {
-          let entityType = entity.metadataEntity.type;
+          const entityType = entity.metadataEntity.type;
           if (entityType === EntityType.application) {
             numApplications += 1;
           } else if (entityType === EntityType.stream) {
@@ -178,27 +246,16 @@ export default class NamespaceDropdown extends Component {
         });
       }
     );
-  }
-  render() {
-    let LinkEl = Link;
-    let baseurl = '';
-    if (this.props.tag) {
-      let basename = document.querySelector('base');
-      let baseurlname = basename.getAttribute('href');
-      // FIXME: This is a one of thing (an interim solution) and that should go away in subsequent releases.
-      if (baseurlname.indexOf('logviewer') !== -1) {
-        baseurlname = '/cdap/';
-      }
-      basename = baseurlname ? baseurlname : null;
-      LinkEl = this.props.tag;
-      baseurl = `${basename}`;
-    }
+  };
+
+  public render() {
+    const LinkEl = this.props.tag ? this.props.tag : Link;
     const defaultNamespace = this.state.defaultNamespace;
     const currentNamespace = this.state.currentNamespace;
-    let isValidNamespace = NamespaceStore.getState().namespaces.filter(
+    const isValidNamespace = NamespaceStore.getState().namespaces.filter(
       (ns) => ns.name === currentNamespace
     ).length;
-    let currentNamespaceCardHeader = (
+    const currentNamespaceCardHeader = (
       <div>
         <span className="current-namespace-name">{currentNamespace}</span>
         <span className="current-namespace-default">
@@ -216,7 +273,7 @@ export default class NamespaceDropdown extends Component {
         </span>
       </div>
     );
-    let preferenceSpecificCardHeader = (
+    const preferenceSpecificCardHeader = (
       <div className="preferences-saved-message">
         <span>
           {T.translate('features.FastAction.SetPreferences.success', { entityType: 'Namespace' })}
@@ -311,16 +368,14 @@ export default class NamespaceDropdown extends Component {
             ) : null}
             <div className="namespace-list">
               {this.state.namespaceList
-                .filter((item) => item.name !== currentNamespace)
-                .map((item) => {
-                  let starIcon = defaultNamespace === item.name ? 'icon-star' : 'icon-star-o';
+                .filter((item: INamespace) => item.name !== currentNamespace)
+                .map((item: INamespace) => {
+                  const starIcon = defaultNamespace === item.name ? 'icon-star' : 'icon-star-o';
+                  let url = `ns/${item.name}`;
+                  url = `${getBaseResolvedUrl(url)}`;
                   return (
                     <div className="clearfix namespace-container" key={uuidV4()}>
-                      <LinkEl
-                        href={baseurl + `ns/${item.name}`}
-                        to={baseurl + `/ns/${item.name}`}
-                        className="namespace-link"
-                      >
+                      <LinkEl href={url} to={url} className="namespace-link">
                         <span
                           className="namespace-name float-left"
                           onClick={this.selectNamespace.bind(this, item.name)}
@@ -355,11 +410,3 @@ export default class NamespaceDropdown extends Component {
     );
   }
 }
-
-NamespaceDropdown.propTypes = {
-  tag: PropTypes.node,
-};
-
-NamespaceDropdown.defaultProps = {
-  tag: null,
-};

--- a/cdap-ui/app/cdap/components/PipelineList/PipelineList.scss
+++ b/cdap-ui/app/cdap/components/PipelineList/PipelineList.scss
@@ -15,6 +15,7 @@
  */
 
 @import '~styles/colors.scss';
+@import '~styles/variables.scss';
 
 $pipeline-view-header: 55px;
 $pipeline-bg-color: $grey-08;
@@ -23,7 +24,7 @@ $header-link-color: $grey-01;
 
 .pipeline-list-view {
   // substracting the height of global header and footer
-  height: calc(100vh - 50px - 54px);
+  height: calc(100vh - $height-of-header - 54px);
   background-color: $pipeline-bg-color;
 
   .cask-resourcecenter-button { top: 75px; }
@@ -40,6 +41,7 @@ $header-link-color: $grey-01;
     padding-left: 45px;
     line-height: $pipeline-view-header;
     margin-bottom: 0;
+    margin-top: 0;
 
     .option {
       cursor: pointer;

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -28,7 +28,7 @@ require('./styles/main.scss');
 import Loadable from 'react-loadable';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import Home from 'components/Home';
-import Header from 'components/Header';
+import AppHeader from 'components/AppHeader';
 import Footer from 'components/Footer';
 import ConnectionExample from 'components/ConnectionExample';
 import cookie from 'react-cookie';
@@ -113,7 +113,7 @@ class CDAP extends Component {
       <BrowserRouter basename="/cdap">
         <div className="cdap-container">
           <Helmet title={Theme.productName} />
-          <Header />
+          <AppHeader />
           <LoadingIndicator />
           <StatusAlertMessage />
           {this.state.authorizationFailed ? (
@@ -192,8 +192,8 @@ class CDAP extends Component {
                   )}
                 />
                 {/*
-                    Eventually handling 404 should move to the error boundary and all container components will have the error object.
-                    */}
+                      Eventually handling 404 should move to the error boundary and all container components will have the error object.
+                      */}
                 <Route
                   render={(props) => (
                     <ErrorBoundary>

--- a/cdap-ui/app/cdap/services/NamespaceStore/index.ts
+++ b/cdap-ui/app/cdap/services/NamespaceStore/index.ts
@@ -14,14 +14,26 @@
  * the License.
  */
 
-import { combineReducers, createStore } from 'redux';
+import { combineReducers, createStore, Store as InterfaceStore } from 'redux';
 import NamespaceActions from './NamespaceActions';
 import { composeEnhancers, objectQuery, isNilOrEmpty } from 'services/helpers';
 import { SYSTEM_NAMESPACE } from 'services/global-constants';
+import { IAction } from 'services/redux-helpers';
 
+export interface INamespace {
+  name: string;
+  description: string;
+  config: any;
+}
+
+export interface INamespaceStoreState {
+  username: string;
+  selectedNamespace: string;
+  namespaces: INamespace[];
+}
 const defaultAction = {
-  action: '',
-  payload: {},
+  type: '',
+  payload: {} as any,
 };
 
 const defaultInitialState = {
@@ -30,7 +42,7 @@ const defaultInitialState = {
   namespaces: [],
 };
 
-const username = (state = '', action = defaultAction) => {
+const username = (state = '', action: IAction = defaultAction) => {
   switch (action.type) {
     case NamespaceActions.updateUsername:
       return action.payload.username;
@@ -39,7 +51,7 @@ const username = (state = '', action = defaultAction) => {
   }
 };
 
-const selectedNamespace = (state = '', action = defaultAction) => {
+const selectedNamespace = (state = '', action: IAction = defaultAction) => {
   switch (action.type) {
     case NamespaceActions.selectNamespace: {
       if (action.payload.selectedNamespace === SYSTEM_NAMESPACE) {
@@ -48,7 +60,7 @@ const selectedNamespace = (state = '', action = defaultAction) => {
       return action.payload.selectedNamespace;
     }
     case NamespaceActions.updateNamespaces: {
-      let previouslyAccessedNs = localStorage.getItem('CurrentNamespace');
+      const previouslyAccessedNs = localStorage.getItem('CurrentNamespace');
       if (isNilOrEmpty(state) || state === SYSTEM_NAMESPACE) {
         return !isNilOrEmpty(previouslyAccessedNs)
           ? previouslyAccessedNs
@@ -69,8 +81,11 @@ const namespaces = (state = [], action) => {
       return state;
   }
 };
-
-const NamespaceStore = createStore(
+/**
+ * Store to manage namespace globally across CDAP UI.
+ * Stores list of namespaces and current namespace the user is in.
+ */
+const NamespaceStore: InterfaceStore<INamespaceStoreState> = createStore(
   combineReducers({
     username,
     selectedNamespace,
@@ -81,7 +96,7 @@ const NamespaceStore = createStore(
 );
 
 const getCurrentNamespace = () => {
-  let { selectedNamespace: namespace } = NamespaceStore.getState();
+  const { selectedNamespace: namespace } = NamespaceStore.getState();
   return namespace;
 };
 

--- a/cdap-ui/app/cdap/services/ThemeHelper.ts
+++ b/cdap-ui/app/cdap/services/ThemeHelper.ts
@@ -138,6 +138,8 @@ interface IFeatureNames {
   pipelines: string;
   reports: string;
   rulesEngine: string;
+  projectAdmin: string;
+  systemAdmin: string;
 }
 
 interface IThemeObj {
@@ -209,6 +211,8 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
         pipelines: 'Pipelines',
         reports: 'Reports',
         rulesEngine: 'Rules',
+        projectAdmin: 'Project Admin',
+        systemAdmin: 'System Admin',
       },
     };
     if (isNilOrEmpty(contentJson)) {

--- a/cdap-ui/app/cdap/styles/variables.scss
+++ b/cdap-ui/app/cdap/styles/variables.scss
@@ -89,7 +89,7 @@ $success-message-bg: rgb(126, 211, 33);
 
 $streamview-entity-header-bg: #1abc9c;
 $program-entity-header-bg: rgba(41, 177, 159,1);
-$height-of-header: 50px;
+$height-of-header: 48px;
 $height-of-footer: 53px;
 
 // EntityListView variables

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -17,7 +17,6 @@
 import T from 'i18n-react';
 T.setTexts(require('../cdap/text/text-en.yaml'));
 var Store = require('../cdap/services/NamespaceStore').default;
-var Header = require('../cdap/components/Header').default;
 var ResourceCenterButton = require('../cdap/components/ResourceCenterButton').default;
 var DataPrepHome = require('../cdap/components/DataPrepHome').default;
 var DataPrepHelper = require('../cdap/components/DataPrep/helper');
@@ -68,10 +67,11 @@ var IconSVG = require('../cdap/components/IconSVG').default;
 var PipelineConfigConstants = require('../cdap/components/PipelineConfigurations/PipelineConfigConstants');
 var AuthRefresher = require('../cdap/components/AuthRefresher').default;
 var ToggleSwitch = require('../cdap/components/ToggleSwitch').default;
+var PipelineList = require('../cdap/components/PipelineList').default;
+var AppHeader = require('../cdap/components/AppHeader').default;
 
 export {
   Store,
-  Header,
   DataPrepHome,
   DataPrepHelper,
   globalEvents,
@@ -117,4 +117,6 @@ export {
   PipelineConfigConstants,
   AuthRefresher,
   ToggleSwitch,
+  PipelineList,
+  AppHeader,
 };

--- a/cdap-ui/app/directives/react-components/index.js
+++ b/cdap-ui/app/directives/react-components/index.js
@@ -16,7 +16,7 @@
 
 angular.module(PKG.name + '.commons')
   .directive('caskHeader', function(reactDirective) {
-    return reactDirective(window.CaskCommon.Header);
+    return reactDirective(window.CaskCommon.AppHeader);
   })
   .directive('keyValuePairs', function(reactDirective) {
     return reactDirective(window.CaskCommon.KeyValuePairs);

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -171,3 +171,5 @@
 // our fonts look consistent in both React and Angular sides. Make sure to
 // double-check this when/if we upgrade Bootstrap on the React side!
 @bootstrap4-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+
+@height-of-header: 48px;

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -47,6 +47,7 @@
     "@storybook/addon-knobs": "4.0.0-alpha.23",
     "@storybook/addons": "4.0.0-alpha.23",
     "@storybook/react": "4.0.0-alpha.23",
+    "@types/jest": "23.3.10",
     "@types/react": "16.4.6",
     "@types/react-dom": "16.0.6",
     "@types/react-input-calendar": "0.0.34",
@@ -118,6 +119,7 @@
     "style-loader": "0.19.0",
     "stylelint-webpack-plugin": "0.10.5",
     "svg-sprite-loader": "3.9.0",
+    "ts-jest": "23.10.5",
     "ts-loader": "4.4.2",
     "tslint": "5.10.0",
     "tslint-config-prettier": "1.15.0",
@@ -130,6 +132,8 @@
   },
   "dependencies": {
     "@babel/polyfill": "7.0.0-beta.53",
+    "@material-ui/core": "3.6.1",
+    "@material-ui/icons": "3.0.1",
     "body-parser": "1.14.2",
     "bootstrap": "4.1.3",
     "cask-datavoyager": "2.0.0-alpha.12.9",
@@ -206,6 +210,7 @@
     "node": ">= 8.7.0"
   },
   "jest": {
+    "preset": "ts-jest/presets/js-with-babel",
     "testEnvironment": "jsdom",
     "roots": [
       "./app/cdap/"

--- a/cdap-ui/tsconfig.json
+++ b/cdap-ui/tsconfig.json
@@ -8,11 +8,16 @@
     "jsx": "react",
     "skipLibCheck": true,
     "moduleResolution": "node",
+    "sourceMap": true,
     "importHelpers": false,
     "allowSyntheticDefaultImports": true,
     "lib": [
       "es2015",
       "dom"
+    ],
+    "typeRoots": [
+      "./typings",
+      "./node_modules/@types"
     ],
     "baseUrl": ".",
     "paths": {

--- a/cdap-ui/typings/declarations.d.ts
+++ b/cdap-ui/typings/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+  const content: any;
+  export default content;
+}

--- a/cdap-ui/webpack.config.cdap.js
+++ b/cdap-ui/webpack.config.cdap.js
@@ -244,7 +244,7 @@ var webpackConfig = {
     splitChunks: false,
   },
   resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.jsx'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx', '.scss'],
     alias: {
       components: __dirname + '/app/cdap/components',
       services: __dirname + '/app/cdap/services',

--- a/cdap-ui/yarn.lock
+++ b/cdap-ui/yarn.lock
@@ -1245,9 +1245,21 @@
     "@babel/helper-plugin-utils" "7.0.0-beta.53"
     "@babel/plugin-transform-typescript" "7.0.0-beta.53"
 
-"@babel/runtime@^7.0.0":
+"@babel/runtime@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@7.1.2", "@babel/runtime@^7.0.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@babel/runtime@^7.1.2":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
   dependencies:
     regenerator-runtime "^0.12.0"
 
@@ -1417,6 +1429,51 @@
 "@emotion/weak-memoize@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.1.3.tgz#b700d97385fa91affed60c71dfd51c67e9dad762"
+
+"@material-ui/core@3.6.1":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.6.1.tgz#6f8259c64eaa34c9f977165f6b8d175d9eb1858a"
+  dependencies:
+    "@babel/runtime" "7.1.2"
+    "@material-ui/utils" "^3.0.0-alpha.0"
+    "@types/jss" "^9.5.6"
+    "@types/react-transition-group" "^2.0.8"
+    brcast "^3.0.1"
+    classnames "^2.2.5"
+    csstype "^2.5.2"
+    debounce "^1.1.0"
+    deepmerge "^2.0.1"
+    dom-helpers "^3.2.1"
+    hoist-non-react-statics "^3.0.0"
+    is-plain-object "^2.0.4"
+    jss "^9.3.3"
+    jss-camel-case "^6.0.0"
+    jss-default-unit "^8.0.2"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-vendor-prefixer "^7.0.0"
+    keycode "^2.1.9"
+    normalize-scroll-left "^0.1.2"
+    popper.js "^1.14.1"
+    prop-types "^15.6.0"
+    react-event-listener "^0.6.2"
+    react-transition-group "^2.2.1"
+    recompose "0.28.0 - 0.30.0"
+    warning "^4.0.1"
+
+"@material-ui/icons@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.1.tgz#671fb3d04dcaf9351dbbd2bf82ae2ae72e3d93cd"
+  dependencies:
+    "@babel/runtime" "7.0.0"
+    recompose "^0.29.0"
+
+"@material-ui/utils@^3.0.0-alpha.0":
+  version "3.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-3.0.0-alpha.0.tgz#506fcaf531a9a8f58a73ff2d3dfaa36c0f238506"
+  dependencies:
+    "@babel/runtime" "7.1.2"
 
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
@@ -1697,6 +1754,10 @@
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.0.tgz#2fac51050c68f7d6f96c5aafc631132522f4aa3f"
 
+"@types/jest@23.3.10":
+  version "23.3.10"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
+
 "@types/jquery@*":
   version "3.3.22"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.22.tgz#cde55dc8f83207dffd16205b05f97ce824581735"
@@ -1706,6 +1767,13 @@
 "@types/jquery@3.2.16":
   version "3.2.16"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.2.16.tgz#04419c404a3194350e7d3f339a90e72c88db3111"
+
+"@types/jss@^9.5.6":
+  version "9.5.7"
+  resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.7.tgz#fa57a6d0b38a3abef8a425e3eb6a53495cb9d5a0"
+  dependencies:
+    csstype "^2.0.0"
+    indefinite-observable "^1.0.1"
 
 "@types/lodash@4.14.87":
   version "4.14.87"
@@ -1741,6 +1809,12 @@
   resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.0.30.tgz#64bcd886befd1f932779b74d17954adbefb7a3a7"
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/react-transition-group@^2.0.8":
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.14.tgz#afd0cd785a97f070b55765e9f9d76ff568269001"
+  dependencies:
     "@types/react" "*"
 
 "@types/react@*", "@types/react@16.4.6":
@@ -3020,6 +3094,10 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+brcast@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
+
 brfs@^1.3.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/brfs/-/brfs-1.4.3.tgz#db675d6f5e923e6df087fca5859c9090aaed3216"
@@ -3137,6 +3215,12 @@ browserslist@~1.4.0:
   dependencies:
     caniuse-db "^1.0.30000539"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -3151,7 +3235,7 @@ buffer-equal@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
 
-buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
@@ -4211,6 +4295,12 @@ css-vars-ponyfill@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/css-vars-ponyfill/-/css-vars-ponyfill-1.8.0.tgz#09814e6000b364ef5fc5de7591dddf8d1f559814"
 
+css-vendor@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
+  dependencies:
+    is-in-browser "^1.0.2"
+
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
@@ -4281,6 +4371,10 @@ cssstyle@^1.0.0:
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.0.0, csstype@^2.5.2:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.8.tgz#4ce5aa16ea0d562ef9105fa3ae2676f199586a35"
 
 csstype@^2.2.0:
   version "2.5.5"
@@ -4644,6 +4738,10 @@ deap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/deap/-/deap-1.0.0.tgz#b148bf82430a27699b7483a03eb6b67585bfc888"
 
+debounce@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+
 debug@2.6.9, debug@^2.1.0, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -4705,6 +4803,10 @@ deep-is@~0.1.3:
 deepmerge@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.3.2.tgz#1663691629d4dbfe364fa12a2a4f0aa86aa3a050"
+
+deepmerge@^2.0.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -4880,6 +4982,12 @@ dom-converter@~0.1:
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
+
+dom-helpers@^3.2.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-helpers@^3.3.1:
   version "3.3.1"
@@ -5817,7 +5925,7 @@ fast-diff@^1.1.1, fast-diff@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
@@ -7151,6 +7259,12 @@ hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
+hoist-non-react-statics@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -7417,6 +7531,12 @@ imurmurhash@^0.1.4:
 in-publish@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+
+indefinite-observable@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/indefinite-observable/-/indefinite-observable-1.0.2.tgz#0a328793ab2385d4b9dca23eaab4afe6936a73f8"
+  dependencies:
+    symbol-observable "1.2.0"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -7748,6 +7868,10 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
 is-installed-globally@0.1.0:
   version "0.1.0"
@@ -8486,15 +8610,15 @@ json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
-json5@^0.5.0, json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-json5@^2.0.1:
+json5@2.x, json5@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   dependencies:
     minimist "^1.2.0"
+
+json5@^0.5.0, json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
 jsonfile@^3.0.0:
   version "3.0.1"
@@ -8515,13 +8639,51 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jss-camel-case@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-6.1.0.tgz#ccb1ff8d6c701c02a1fed6fb6fb6b7896e11ce44"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
+jss-default-unit@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-8.0.2.tgz#cc1e889bae4c0b9419327b314ab1c8e2826890e6"
+
+jss-global@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-3.0.0.tgz#e19e5c91ab2b96353c227e30aa2cbd938cdaafa2"
+
+jss-nested@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-6.0.1.tgz#ef992b79d6e8f63d939c4397b9d99b5cbbe824ca"
+  dependencies:
+    warning "^3.0.0"
+
+jss-props-sort@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
+
+jss-vendor-prefixer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz#0166729650015ef19d9f02437c73667231605c71"
+  dependencies:
+    css-vendor "^0.3.8"
+
+jss@^9.3.3:
+  version "9.8.7"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
+  dependencies:
+    is-in-browser "^1.1.3"
+    symbol-observable "^1.1.0"
+    warning "^3.0.0"
+
 jsx-ast-utils@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
 
-keycode@^2.2.0:
+keycode@^2.1.9, keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
 
@@ -9152,7 +9314,7 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
-make-error@^1.3.5:
+make-error@1.x, make-error@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
 
@@ -9526,7 +9688,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -9910,6 +10072,10 @@ normalize-path@^2.0.1, normalize-path@^2.1.1:
 normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
+normalize-scroll-left@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
 
 normalize-selector@^0.2.0:
   version "0.2.0"
@@ -11550,6 +11716,14 @@ react-error-overlay@5.0.0-next.2150693d:
   version "5.0.0-next.2150693d"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.0.0-next.2150693d.tgz#72ca7fe78eb3e503060c276105a717c24c87087c"
 
+react-event-listener@^0.6.2:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.4.tgz#d0ea5ed897da1a796616c44b5a8758898140f203"
+  dependencies:
+    "@babel/runtime" "7.0.0"
+    prop-types "^15.6.0"
+    warning "^4.0.1"
+
 react-fuzzy@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-fuzzy/-/react-fuzzy-0.5.2.tgz#fc13bf6f0b785e5fefe908724efebec4935eaefe"
@@ -11574,6 +11748,10 @@ react-inspector@^2.3.0:
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
+
+react-is@^16.3.2:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
 
 react-lifecycles-compat@^1.1.0:
   version "1.1.4"
@@ -11727,7 +11905,7 @@ react-transition-group@2.4.0, react-transition-group@^2.3.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-transition-group@^2.0.0:
+react-transition-group@^2.0.0, react-transition-group@^2.2.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
   dependencies:
@@ -11923,11 +12101,33 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+"recompose@0.28.0 - 0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
+
 recompose@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.27.1.tgz#1a49e931f183634516633bbb4f4edbfd3f38a7ba"
   dependencies:
     babel-runtime "^6.26.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
+
+recompose@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.29.0.tgz#f1a4e20d5f24d6ef1440f83924e821de0b1bccef"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
     hoist-non-react-statics "^2.3.1"
@@ -12561,7 +12761,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.5:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
@@ -13497,13 +13697,13 @@ symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
+symbol-observable@1.2.0, symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+
 symbol-observable@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
-
-symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 symbol-tree@^3.2.2:
   version "3.2.2"
@@ -13813,6 +14013,20 @@ tryit@^1.0.1:
 tryor@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
+
+ts-jest@23.10.5:
+  version "23.10.5"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.10.5.tgz#cdb550df4466a30489bf70ba867615799f388dd5"
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "10.x"
 
 ts-loader@4.4.2:
   version "4.4.2"
@@ -15013,7 +15227,7 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
-yargs-parser@^10.1.0:
+yargs-parser@10.x, yargs-parser@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   dependencies:


### PR DESCRIPTION
- Adds `@material-ui` and `@material-ui/icons` npm packages. This is an effort to transition to material theme for CDAP UI
- Migrates namespace dropdown and namespace store to typescript
- Fixes references of old header across CDAP UI
- Fixes existing tests to run correct in typescript environment 

**Todo:**
- Need to test all flags from theme with a built SDK. Working on this. The code is up for review.
- Add integration test (will create a separate PR)
- Remove old header (will create a separate PR)

JIRA: 
https://issues.cask.co/browse/CDAP-14620
Build:
https://builds.cask.co/browse/CDAP-UDUT161