### PR TITLE
CDAP-14581 try to fix flaky testExternalDatasetTrackingSpark

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -2722,8 +2722,8 @@ public class DataPipelineTest extends HydratorTestBase {
     Assert.assertEquals(ProgramRunStatus.COMPLETED, history.get(0).getStatus());
 
     // Assert output
-    Assert.assertEquals(allInput, MockExternalSink.readOutput(outputSubDir1.getAbsolutePath()));
-    Assert.assertEquals(allInput, MockExternalSink.readOutput(outputSubDir2.getAbsolutePath()));
+    Assert.assertEquals(allInput, MockExternalSink.readOutput(outputSubDir1.getAbsolutePath(), schema));
+    Assert.assertEquals(allInput, MockExternalSink.readOutput(outputSubDir2.getAbsolutePath(), schema));
 
     if (!backwardsCompatible) {
       // Assert that external datasets got created


### PR DESCRIPTION
The pipeline somehow fails with gson serialization errors, so
changing the sink to use a different way to serialize and
deserialize a StructuredRecord.