### PR TITLE
[UI][CDAP-14659] Compile node application to remove node_modules folder

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -994,7 +994,8 @@ cdap_sdk_stop() { cdap_stop_pidfile ${__pidfile} "CDAP Sandbox"; };
 cdap_sdk_check_before_start() {
   cdap_check_pidfile ${__pidfile} Sandbox || return ${?}
   cdap_check_node_version ${CDAP_NODE_VERSION_MINIMUM:-v8.7.0} || return ${?}
-  local __node_pid=$(ps | grep ${CDAP_UI_PATH:-ui/server.js} | grep -v grep | awk '{ print $1 }')
+  local __node_pid=$(ps | grep ${CDAP_UI_PATH:-ui/index.js} | grep -v grep | awk '{ print $1 }')
+  
   if [[ -z ${__node_pid} ]]; then
     : # continue
   else
@@ -1174,7 +1175,7 @@ cdap_ui() {
   fi
   local readonly MAIN_CMD=${MAIN_CMD}
   export NODE_ENV="production"
-  local readonly MAIN_CMD_ARGS="${CDAP_HOME}"/${CDAP_UI_PATH:-ui/server.js}
+  local readonly MAIN_CMD_ARGS="${CDAP_HOME}"/${CDAP_UI_PATH:-ui/index.js}
   cdap_start_bin || die "Failed to start CDAP ${CDAP_SERVICE} service"
 }
 

--- a/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
@@ -83,9 +83,9 @@ final class UserInterfaceService extends AbstractExecutionThreadService {
     generateConfigFile(cConfJsonFile, cConf);
     generateConfigFile(sConfJsonFile, sConf);
 
-    File uiPath = new File("cdap-ui", "server.js");
+    File uiPath = new File("cdap-ui", "index.js");
     if (!uiPath.exists()) {
-      uiPath = new File("ui", "server.js");
+      uiPath = new File("ui", "index.js");
     }
     Preconditions.checkState(uiPath.exists(), "Missing server.js at " + uiPath.getAbsolutePath());
     ProcessBuilder builder = new ProcessBuilder(NODE_JS_EXECUTABLE,

--- a/cdap-ui/.gitignore
+++ b/cdap-ui/.gitignore
@@ -17,3 +17,4 @@ coverage/
 .classpath
 .project
 .settings/
+server_dist/

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -27,7 +27,8 @@
     "build-storybook": "NODE_ENV=development build-storybook",
     "cypress": "cypress run",
     "cypress-open": "cypress open",
-    "test": "run-p jest cypress"
+    "test": "run-p jest cypress",
+    "ncc": "ncc build server.js -o server_dist"
   },
   "repository": {
     "type": "git",
@@ -52,6 +53,7 @@
     "@types/react-input-calendar": "0.0.34",
     "@types/react-router": "4.0.30",
     "@types/storybook__react": "3.0.9",
+    "@zeit/ncc": "0.5.5",
     "autoprefixer": "6.5.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "7.2.3",

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -293,7 +293,9 @@
                 <configuration>
                   <target>
                     <copy todir = "${stage.opt.dir}">
-                      <fileset dir = "server_dist" />
+                      <fileset dir = "server_dist">
+                        <exclude name="node_modules/**" />
+                      </fileset>
                     </copy>
                   </target>
                 </configuration>

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -297,6 +297,9 @@
                         <exclude name="node_modules/**" />
                       </fileset>
                     </copy>
+                    <copy todir = "${stage.opt.dir}/server/config/themes">
+                      <fileset dir = "server/config/themes" />
+                    </copy>
                   </target>
                 </configuration>
               </execution>

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -148,6 +148,7 @@
               <configuration>
                 <excludes>
                   <exclude>**/*.editorconfig</exclude>
+                  <exclude>**/server_dist/**</exclude>
                   <exclude>**/*.babelrc</exclude>
                   <exclude>**/*.jshintrc</exclude>
                   <exclude>**/*.jshintignore</exclude>
@@ -268,42 +269,12 @@
                 </configuration>
               </execution>
               <execution>
-                <id>clean-node-modules</id>
+                <id>build-node-app</id>
                 <goals>
                   <goal>yarn</goal>
                 </goals>
                 <configuration>
-                  <arguments>install --production --frozen-lockfile</arguments>
-                </configuration>
-              </execution>
-              <execution>
-                <id>remove-unnecessary-node-modules</id>
-                <goals>
-                  <goal>yarn</goal>
-                </goals>
-                <configuration>
-                  <arguments>run clean-node-modules</arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>1.3.1</version>
-            <executions>
-              <execution>
-                <id>clean-bower-components</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>rm</executable>
-                  <arguments>
-                    <argument>-rf</argument>
-                    <argument>bower_components</argument>
-                  </arguments>
+                  <arguments>run ncc</arguments>
                 </configuration>
               </execution>
             </executions>
@@ -321,57 +292,8 @@
                 </goals>
                 <configuration>
                   <target>
-                    <copy todir = "${stage.opt.dir}/server">
-                      <fileset dir = "server" />
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/dist">
-                      <fileset dir = "dist" />
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/old_dist">
-                      <fileset dir = "old_dist" />
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/common_dist">
-                      <fileset dir = "common_dist" />
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/cdap_dist">
-                      <fileset dir = "cdap_dist" />
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/dll">
-                      <fileset dir = "dll">
-                        <exclude name="*development*" />
-                      </fileset>
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/login_dist">
-                      <fileset dir = "login_dist" />
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/bin">
-                      <fileset dir = "node">
-                        <include name="node" />
-                      </fileset>
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/node_modules">
-                      <fileset dir = "node_modules" />
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/templates">
-                      <fileset dir = "templates" />
-                    </copy>
                     <copy todir = "${stage.opt.dir}">
-                      <fileset dir = "./">
-                        <include name="LICENSE-node" />
-                      </fileset>
-                    </copy>
-                    <copy todir = "${stage.opt.dir}">
-                      <fileset dir = "./">
-                        <include name="package.json" />
-                      </fileset>
-                    </copy>
-                    <copy todir = "${stage.opt.dir}">
-                      <fileset dir = "./">
-                        <include name="server.js" />
-                      </fileset>
-                    </copy>
-                    <copy todir = "${stage.opt.dir}/cdap-ui-upgrade">
-                      <fileset dir = "cdap-ui-upgrade" />
+                      <fileset dir = "server_dist" />
                     </copy>
                   </target>
                 </configuration>

--- a/cdap-ui/server/config/parser.js
+++ b/cdap-ui/server/config/parser.js
@@ -28,6 +28,7 @@ var promise = require('q'),
   decoder = new StringDecoder('utf8'),
   log4js = require('log4js'),
   cache = {},
+  nodepath = require('path'),
   path,
   buffer = '';
 
@@ -61,7 +62,7 @@ function extractConfig(param) {
 
   if (process.env.NODE_ENV === 'production') {
     buffer = '';
-    tool = spawn(__dirname + '/../../bin/cdap', ['config-tool', '--' + param]);
+    tool = spawn(nodepath.join(__dirname, 'bin', 'cdap'), ['config-tool', '--' + param]);
     tool.stderr.on('data', configReadFail.bind(this));
     tool.stdout.on('data', configRead.bind(this));
     tool.stdout.on('end', onConfigReadEnd.bind(this, deferred, param));

--- a/cdap-ui/yarn.lock
+++ b/cdap-ui/yarn.lock
@@ -1912,6 +1912,10 @@
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
 
+"@zeit/ncc@0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.5.5.tgz#92ab3a89ce5ad393262752be69bbae9a9eb7dff1"
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"


### PR DESCRIPTION
- Compiles Express node app using `ncc` to a build file. This helps in avoiding to cleanup and copying necessary node_modules folders.

Parcel | Before | After
-----|--------|-------
6.0.0-SNAPSHOT SDK | 1.04 GB | 854MB.
ui | 291MB | 97MB

- Tested by building the SDK and starting it. Seemed to work fine. 

**Note:**
- I didn't customize CDAP-BUT to generate a build for a feature branch. A quick standalone build (took 11 minutes consistently across 5-6 builds) should provide a good clarity of the changes.
- The `<sdk>/ui` folder structure hasn't changed. So any existing scripts that drops file in the directory should still function the same.


Build: https://builds.cask.co/browse/CDAP-UDUT163
JIRA: https://issues.cask.co/browse/CDAP-14659
