### PR TITLE
CDAP-14651 remove incorrect docs on program triggers

### DIFF
--- a/cdap-docs/developer-manual/source/building-blocks/schedules.rst
+++ b/cdap-docs/developer-manual/source/building-blocks/schedules.rst
@@ -208,13 +208,11 @@ to allow additional data to arrive::
 
 To schedule a workflow named "cleanupWorkflow" to run whenever "dataProcessingWorkflow"
 (in the same namespace, application, and application version as "cleanupWorkflow")
-fails, and pass in the `src` directory in the "dataProcessingWorkflow" as the 
-`cleanup_dir` directory::
+fails::
 
   schedule(buildSchedule("onDataProcessingFail", ProgramType.WORKFLOW, "cleanupWorkflow")
-              .withProperties(ImmutableMap.of("triggering.properties.mapping", 
-                                              ImmutableMap.of("cleanup_dir", "src"))
-              .triggerOnProgramStatus(ProgramType.WORKFLOW, "dataProcessingWorkflow");
+              .triggerOnProgramStatus(ProgramType.WORKFLOW, "dataProcessingWorkflow",
+                                      ProgramStatus.FAILED);
 
 To ensure that the workflow runs at least once per hour::
 


### PR DESCRIPTION
The docs give an incorrect example of how to trigger a program
based on the failure of another program. Removed the part about
passing arguments to the next program and added the program
status.