### PR TITLE
CDAP-14523: Introducing flag to switch off caching in the pipeline when compute engine is spark

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/Constants.java
@@ -40,6 +40,7 @@ public final class Constants {
   );
   public static final String MDC_STAGE_KEY = "pipeline.stage";
   public static final String FIELD_OPERATION_KEY_IN_WORKFLOW_TOKEN = "field.operations";
+  public static final String SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG = "spark.cdap.pipeline.autocache.enable";
 
   private Constants() {
     throw new AssertionError("Suppress default constructor for noninstantiability");

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
@@ -48,6 +48,7 @@ import co.cask.cdap.etl.spark.function.TransformFunction;
 import co.cask.cdap.etl.spec.StageSpec;
 import com.google.common.base.Throwables;
 import com.google.gson.Gson;
+import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -88,7 +89,12 @@ public class RDDCollection<T> implements SparkCollection<T> {
 
   @Override
   public SparkCollection<T> cache() {
-    return wrap(rdd.cache());
+    SparkConf sparkconf = jsc.getConf();
+    if (sparkconf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
+      return wrap(rdd.cache());
+    } else {
+      return wrap(rdd);
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -25,6 +25,7 @@ import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.Windower;
+import co.cask.cdap.etl.common.Constants;
 import co.cask.cdap.etl.common.NoopStageStatisticsCollector;
 import co.cask.cdap.etl.common.PipelineRuntime;
 import co.cask.cdap.etl.common.RecordInfo;
@@ -44,6 +45,7 @@ import co.cask.cdap.etl.spark.streaming.function.StreamingAlertPublishFunction;
 import co.cask.cdap.etl.spark.streaming.function.StreamingBatchSinkFunction;
 import co.cask.cdap.etl.spark.streaming.function.StreamingSparkSinkFunction;
 import co.cask.cdap.etl.spec.StageSpec;
+import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
@@ -76,7 +78,12 @@ public class DStreamCollection<T> implements SparkCollection<T> {
 
   @Override
   public SparkCollection<T> cache() {
-    return wrap(stream.cache());
+    SparkConf sparkconf = stream.context().sparkContext().getConf();
+    if (sparkconf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
+      return wrap(stream.cache());
+    } else {
+      return wrap(stream);
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Current Problem : In Spark Compute and Sink plugins rdd is being cached automatically, the more compute plugins i have in my pipeline , all rdd's get cached , hence the pipeline is exhausting system resources. And therefore leading to increased pipeline execution time. 
Caching is automatically build in the cdap pipeline and advance spark users don't have any means to control this caching in their pipelines, so a boolean property is being introduced, which can be passed in the Custom properties when the spark Engine is selected. 

**"spark.cdap.pipeline.autocache.enable"**

The default value of this flag is **true** , which means that the caching remains enabled as default. But when this flag is set to false below are the cases where rdd is not cached automatically. 
Below where caching is switched off:
1) Forking 
2) Joining
3) Compute
4) Sink 

Notes for the User : In case of Forking and joining 
There are 2 ways 
1) Not recommended to use this flag. 
2) Developer has to change the code and explicitly put rdd caching in the spark code in pipeline.  