### PR TITLE
fix flaky preview test due to recent metrics change

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/LocalMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/LocalMetricsCollectionService.java
@@ -28,7 +28,9 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.twill.common.Threads;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -69,9 +71,11 @@ public final class LocalMetricsCollectionService extends AggregatedMetricsCollec
 
   @Override
   protected void publish(Iterator<MetricValues> metrics) {
+    List<MetricValues> metricValues = new ArrayList<>();
     while (metrics.hasNext()) {
-      metricStore.add(metrics.next());
+      metricValues.add(metrics.next());
     }
+    metricStore.add(metricValues);
   }
 
   @Override


### PR DESCRIPTION
The recent change for concurrent write in metric store introduced flaky preview tests because: The `LocalMetricCollectionService` do not perform a batch write. Once the preview run finishes, it will try to shutdown the service, but the InterruptedException might get caught by `future.get()` and then a RuntimeException will be thrown, causing the rest of the metrics getting ignored. The metric collection service will not able to stop gracefully since the interrupt flag is ignored. 
Changing to do batch write in the service and ignore the InterruptedException in DefaultCube