### PR TITLE
[CDAP-14659] Adds back node binary to be copied while building SDK

### DIFF
--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -292,6 +292,16 @@
                 </goals>
                 <configuration>
                   <target>
+                   <copy todir = "${stage.opt.dir}/bin">
+                      <fileset dir = "node">
+                        <include name="node" />
+                      </fileset>
+                    </copy>
+                    <copy todir = "${stage.opt.dir}">
+                      <fileset dir = "./">
+                        <include name="LICENSE-node" />
+                      </fileset>
+                    </copy>
                     <copy todir = "${stage.opt.dir}">
                       <fileset dir = "server_dist">
                         <exclude name="node_modules/**" />


### PR DESCRIPTION
- Copies back nodejs binary to make sure CDAP uses the binary we ship rather than the system node.

**JIRA:**
https://issues.cask.co/browse/CDAP-14659
https://issues.cask.co/browse/CDAP-14137

**Build:** 
https://builds.cask.co/browse/CDAP-UDUT166

