### PR TITLE
CDAP-14708 fix a provisioning error for firewall deny rules

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -312,7 +312,7 @@ public class DataprocClient implements AutoCloseable {
       }
 
       String direction = firewall.getDirection();
-      if (!"INGRESS".equals(direction)) {
+      if (!"INGRESS".equals(direction) || firewall.getAllowed() == null) {
         continue;
       }
 


### PR DESCRIPTION
Fixed a bug in the dataproc provisioner that would cause
provisioning to fail if the project has a firewall rule that
denies traffic, regardless of whether that rule is relevant or not.
The fix is to check for null instead of assuming an empty list
is returned from the allowed list.