### PR TITLE
[CDAP-12899] Add link to preview data to each node in preview mode

### DIFF
--- a/cdap-ui/app/cdap/services/PipelineMetricsStore/index.js
+++ b/cdap-ui/app/cdap/services/PipelineMetricsStore/index.js
@@ -53,6 +53,8 @@ const metrics = (state = DEFAULT_METRICS_STATE, action = defaultAction) => {
       };
     case PipelineMetricsActions.RESET:
       return DEFAULT_METRICS_STATE;
+    default:
+      return DEFAULT_METRICS_STATE;
   }
 };
 

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.commons')
-  .controller('DAGPlusPlusCtrl', function MyDAGController(jsPlumb, $scope, $timeout, DAGPlusPlusFactory, GLOBALS, DAGPlusPlusNodesActionsFactory, $window, DAGPlusPlusNodesStore, $rootScope, $popover, uuid, DAGPlusPlusNodesDispatcher, NonStorePipelineErrorFactory, AvailablePluginsStore, myHelpers, HydratorPlusPlusCanvasFactory, HydratorPlusPlusConfigStore) {
+  .controller('DAGPlusPlusCtrl', function MyDAGController(jsPlumb, $scope, $timeout, DAGPlusPlusFactory, GLOBALS, DAGPlusPlusNodesActionsFactory, $window, DAGPlusPlusNodesStore, $rootScope, $popover, uuid, DAGPlusPlusNodesDispatcher, NonStorePipelineErrorFactory, AvailablePluginsStore, myHelpers, HydratorPlusPlusCanvasFactory, HydratorPlusPlusConfigStore, HydratorPlusPlusPreviewActions, HydratorPlusPlusPreviewStore) {
 
     var vm = this;
 
@@ -929,6 +929,12 @@ angular.module(PKG.name + '.commons')
       });
 
     });
+
+    vm.onPreviewData = function(event, node) {
+      event.stopPropagation();
+      HydratorPlusPlusPreviewStore.dispatch(HydratorPlusPlusPreviewActions.setPreviewData());
+      DAGPlusPlusNodesActionsFactory.selectNode(node.name);
+    };
 
     vm.onNodeClick = function(event, node) {
       closeMetricsPopover(node);

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -195,6 +195,9 @@
                 </button>
               </div>
             </div>
+            <div class="node-preview-data-btn" ng-if="previewMode">
+              <a href ng-click="DAGPlusPlusCtrl.onPreviewData($event, node)">Preview Data</a>
+            </div>
             <div class="node-metrics"
                   ng-if="DAGPlusPlusCtrl.isDisabled && ['action', 'sparkprogram', 'condition'].indexOf(node.type) === -1">
               <my-node-metrics

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -20,7 +20,6 @@
 @import "./color-constants.less";
 
 @node-box-width: 200px;
-@node-box-height: 87px;
 @node-box-height-big: 100px;
 @condition-box-width: 105px;
 @condition-box-height: 105px;
@@ -140,10 +139,10 @@ my-dag-plus {
       cursor: move;
       top: 150px;
       padding: 0;
-      height: @node-box-height;
+      height: @node-box-height-big;
       width: @node-box-width;
       z-index: 2;
-      .border-color-hover(@node-box-height);
+      .border-color-hover(@node-box-height-big);
 
       // Setting default node color
       color: @transform-plugins-color;
@@ -168,7 +167,7 @@ my-dag-plus {
           border-radius: 100%;
           position: absolute;
           right: -@endpoint-circle-radius;
-          top: 35px;
+          top: 41px;
           display: flex;
           align-items: center;
           justify-content: center;
@@ -298,6 +297,11 @@ my-dag-plus {
           width: ~"-moz-calc(100% - 24px)";
           width: ~"-webkit-calc(100% - 24px)";
           width: ~"calc(100% - 24px)";
+        }
+        .node-preview-data-btn {
+          position: absolute;
+          bottom: 20px;
+          left: 13px;
         }
 
         .node-alerts-errors {

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorPlusPlusNodeConfigCtrl {
-  constructor($scope, $timeout, $state, HydratorPlusPlusPluginConfigFactory, EventPipe, GLOBALS, HydratorPlusPlusConfigActions, myHelpers, NonStorePipelineErrorFactory, $uibModal, HydratorPlusPlusConfigStore, rPlugin, rDisabled, HydratorPlusPlusHydratorService, myPipelineApi, HydratorPlusPlusPreviewStore, rIsStudioMode, HydratorPlusPlusOrderingFactory, avsc, LogViewerStore, DAGPlusPlusNodesActionsFactory, rNodeMetricsContext, HydratorPlusPlusNodeService) {
+  constructor($scope, $timeout, $state, HydratorPlusPlusPluginConfigFactory, EventPipe, GLOBALS, HydratorPlusPlusConfigActions, myHelpers, NonStorePipelineErrorFactory, $uibModal, HydratorPlusPlusConfigStore, rPlugin, rDisabled, HydratorPlusPlusHydratorService, myPipelineApi, HydratorPlusPlusPreviewStore, rIsStudioMode, HydratorPlusPlusOrderingFactory, avsc, LogViewerStore, DAGPlusPlusNodesActionsFactory, rNodeMetricsContext, HydratorPlusPlusNodeService, HydratorPlusPlusPreviewActions) {
     'ngInject';
     this.$scope = $scope;
     this.$timeout = $timeout;
@@ -34,6 +34,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.HydratorPlusPlusHydratorService = HydratorPlusPlusHydratorService;
     this.myPipelineApi = myPipelineApi;
     this.previewStore = HydratorPlusPlusPreviewStore;
+    this.HydratorPlusPlusPreviewActions = HydratorPlusPlusPreviewActions;
     this.HydratorPlusPlusOrderingFactory = HydratorPlusPlusOrderingFactory;
     this.DAGPlusPlusNodesActionsFactory = DAGPlusPlusNodesActionsFactory;
     this.avsc = avsc;
@@ -89,6 +90,7 @@ class HydratorPlusPlusNodeConfigCtrl {
 
     this.isStudioMode = rIsStudioMode;
     this.isPreviewMode = this.previewStore.getState().preview.isPreviewModeEnabled;
+    this.isPreviewData = this.previewStore.getState().preview.previewData;
 
     if (rIsStudioMode && this.isPreviewMode) {
       this.previewLoading = false;
@@ -98,7 +100,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     }
 
     this.activeTab = 1;
-    if (this.isPreviewMode && !rPlugin.isAction) {
+    if (this.isPreviewMode && this.isPreviewData && !rPlugin.isAction) {
       this.activeTab = 2;
     } else if (this.PipelineMetricsStore.getState().metricsTabActive) {
       this.activeTab = 4;
@@ -108,6 +110,9 @@ class HydratorPlusPlusNodeConfigCtrl {
 
     this.$scope.$on('modal.closing', () => {
       this.updateNodeStateIfDirty();
+      this.previewStore.dispatch(
+        this.HydratorPlusPlusPreviewActions.resetPreviewData()
+      );
     });
 
     // Timeouts

--- a/cdap-ui/app/hydrator/services/create/actions/preview-action-creator.js
+++ b/cdap-ui/app/hydrator/services/create/actions/preview-action-creator.js
@@ -37,6 +37,21 @@ class HydratorPlusPlusPreviewActions {
       });
     };
   }
+  setPreviewData() {
+    return (dispatch) => {
+      dispatch({
+        type: this.previewActions.SET_PREVIEW_DATA
+      });
+    };
+  }
+
+  resetPreviewData() {
+    return (dispatch) => {
+      dispatch({
+        type: this.previewActions.RESET_PREVIEW_DATA
+      });
+    };
+  }
 
   setPreviewId (previewId) {
     return (dispatch) => {

--- a/cdap-ui/app/hydrator/services/create/stores/preview-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/preview-store.js
@@ -20,6 +20,7 @@ let getInitialState = () => {
     isPreviewModeEnabled: false,
     startTime: null,
     previewId: null,
+    previewData: false,
     macros: {},
     userRuntimeArguments: {},
     // `runtimeArgsForDisplay` combines `macros` map and `userRuntimeArguments` map
@@ -52,6 +53,10 @@ var preview = (state = getInitialState(), action = {}) => {
     case previewActions.SET_TIMEOUT_IN_MINUTES:
       let timeoutInMinutes = action.payload.timeoutInMinutes;
       return Object.assign({}, state, {timeoutInMinutes});
+    case previewActions.SET_PREVIEW_DATA:
+      return Object.assign({}, state, {previewData: true});
+    case previewActions.RESET_PREVIEW_DATA:
+      return Object.assign({}, state, {previewData: false});
     case previewActions.PREVIEW_RESET:
       return getInitialState();
     default:
@@ -86,6 +91,8 @@ angular.module(`${PKG.name}.feature.hydrator`)
     'SET_MACROS': 'SET_MACROS',
     'SET_USER_RUNTIME_ARGUMENTS': 'SET_USER_RUNTIME_ARGUMENTS',
     'SET_RUNTIME_ARGS_FOR_DISPLAY': 'SET_RUNTIME_ARGS_FOR_DISPLAY',
-    'SET_TIMEOUT_IN_MINUTES': 'SET_TIMEOUT_IN_MINUTES'
+    'SET_TIMEOUT_IN_MINUTES': 'SET_TIMEOUT_IN_MINUTES',
+    'SET_PREVIEW_DATA': 'SET_PREVIEW_DATA',
+    'RESET_PREVIEW_DATA': 'RESET_PREVIEW_DATA'
   })
   .factory('HydratorPlusPlusPreviewStore', PreviewStore);


### PR DESCRIPTION
- Adds 'Preview data' link to nodes while in preview mode, clicking on which opens preview data directly
- Adds back 'Properties' button to open properties if required.
- Minor fix for pipeline metrics store to have default case to return right default state.

 
JIRA:
https://issues.cask.co/browse/CDAP-12899
Build:
https://builds.cask.co/browse/CDAP-UDUT181