### PR TITLE
Adds the ability to wrap react components with theme wrapper based on environment (angular vs react)

### DIFF
--- a/cdap-ui/app/cdap/components/AppHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/index.tsx
@@ -21,8 +21,6 @@ import classnames from 'classnames';
 import AppDrawer from 'components/AppHeader/AppDrawer/AppDrawer';
 import AppToolbar from 'components/AppHeader/AppToolBar/AppToolbar';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
-import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';
-import createMuiTheme, { ThemeOptions } from '@material-ui/core/styles/createMuiTheme';
 import { MyNamespaceApi } from 'api/namespace';
 import NamespaceStore from 'services/NamespaceStore';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
@@ -34,6 +32,7 @@ import getLastSelectedNamespace from 'services/get-last-selected-namespace';
 import { SYSTEM_NAMESPACE } from 'services/global-constants';
 import { objectQuery } from 'services/helpers';
 import { NamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
+import ThemeWrapper from 'components/ThemeWrapper';
 
 require('styles/bootstrap_4_patch.scss');
 
@@ -133,58 +132,28 @@ class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderSta
   }
 }
 const AppHeaderWithStyles = withStyles(styles)(MyAppHeader);
-const baseTheme = createMuiTheme({
-  palette: {
-    primary: {
-      main: '#1a73e8',
-    },
-    blue: {
-      50: '#045599',
-      100: '#0076dc',
-      200: '#0099ff',
-      300: '#58b7f6',
-      400: '#7cd2eb',
-      500: '#cae7ef',
-    },
-  },
-  navbarBgColor: 'var(--navbar-color)',
-  buttonLink: {
-    '&:hover': {
-      color: 'inherit',
-      backgroundColor: 'rgba(255, 255, 255, 0.10)',
-    },
-    fontSize: '1rem',
-    color: 'white',
-  },
-  iconButtonFocus: {
-    '&:focus': {
-      outline: 'none',
-      backgroundColor: 'rgba(255, 255, 255, 0.10)',
-    },
-  },
-  grow: {
-    flexGrow: 1,
-  },
-  typography: {
-    fontSize: 13,
-    fontFamily: 'var(--font-family)',
-    useNextVariants: true,
-  },
-} as ThemeOptions);
+
 /**
- *  We are adding the themeing only to the header. Two reasons,
+ * Detecting environment is angular. If angular then add the theme wrapper
+ * as MuiThemeProvider is not available at the root in angular apps
  *
- * 1. Right now only the header is slowly transitioning to material design
- * 2. Header needs to be shared across react and angular and if I add MuiThemeProvider
- *   to main.js angular side won't get the theme. Trying to avoid duplicating theme between angular
- *   and react since we are anways moving away from angular.
+ * In react app we add MuiThemeProvider at main.js which passes on the theme
+ * via context to children down.
+ *
+ * Doing this here to enable us to transition to material design which supports
+ * proper themeing and css modules for any old or new components we write.
+ * As we move slowly everything to react we will remmove this check and
+ * let the root pass on the theme to the children.
  */
 export default function CustomHeader({ nativeLink }) {
-  return (
-    <MuiThemeProvider theme={baseTheme}>
-      <AppHeaderWithStyles nativeLink={nativeLink} />
-    </MuiThemeProvider>
-  );
+  if (typeof window.angular !== 'undefined' && window.angular.version) {
+    return (
+      <ThemeWrapper>
+        <AppHeaderWithStyles nativeLink={nativeLink} />
+      </ThemeWrapper>
+    );
+  }
+  return <AppHeaderWithStyles nativeLink={nativeLink} />;
 }
 // Apparently this is needed for ngReact
 (CustomHeader as any).propTypes = {

--- a/cdap-ui/app/cdap/components/ThemeWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/ThemeWrapper/index.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import * as React from 'react';
+import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';
+import createMuiTheme, { ThemeOptions, Theme } from '@material-ui/core/styles/createMuiTheme';
+
+interface IThemeWraperProps {
+  render?: () => React.ReactNode;
+  component?: React.ReactNode;
+  children?: any;
+}
+
+export default class ThemeWrapper extends React.PureComponent<IThemeWraperProps> {
+  private baseTheme: Theme = createMuiTheme({
+    palette: {
+      primary: {
+        main: '#1a73e8',
+      },
+      blue: {
+        50: '#045599',
+        100: '#0076dc',
+        200: '#0099ff',
+        300: '#58b7f6',
+        400: '#7cd2eb',
+        500: '#cae7ef',
+      },
+    },
+    navbarBgColor: 'var(--navbar-color)',
+    buttonLink: {
+      '&:hover': {
+        color: 'inherit',
+        backgroundColor: 'rgba(255, 255, 255, 0.10)',
+      },
+      fontSize: '1rem',
+      color: 'white',
+    },
+    iconButtonFocus: {
+      '&:focus': {
+        outline: 'none',
+        backgroundColor: 'rgba(255, 255, 255, 0.10)',
+      },
+    },
+    grow: {
+      flexGrow: 1,
+    },
+    typography: {
+      fontSize: 13,
+      fontFamily: 'var(--font-family)',
+      useNextVariants: true,
+    },
+  } as ThemeOptions);
+  public render() {
+    let Component;
+    if (this.props.component) {
+      Component = this.props.component;
+    }
+    if (!this.props.render && !this.props.component && !this.props.children) {
+      return null;
+    }
+    if (this.props.children) {
+      return <MuiThemeProvider theme={this.baseTheme}>{this.props.children}</MuiThemeProvider>;
+    }
+    if (this.props.render) {
+      return <MuiThemeProvider theme={this.baseTheme}>{this.props.render()}</MuiThemeProvider>;
+    }
+    return (
+      <MuiThemeProvider theme={this.baseTheme}>
+        <Component />
+      </MuiThemeProvider>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/globals.ts
+++ b/cdap-ui/app/cdap/globals.ts
@@ -18,6 +18,7 @@ declare global {
   /* tslint:disable:interface-name */
   interface Window {
     getHydratorUrl: ({}) => string;
+    angular;
   }
 }
 

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -52,6 +52,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import OverlayFocus from 'components/OverlayFocus';
 import { Theme } from 'services/ThemeHelper';
 import AuthRefresher from 'components/AuthRefresher';
+import ThemeWrapper from 'components/ThemeWrapper';
 
 import './globals';
 const SampleTSXComponent = Loadable({
@@ -208,4 +209,4 @@ CDAP.propTypes = {
   children: PropTypes.node,
 };
 
-ReactDOM.render(<CDAP />, document.getElementById('app-container'));
+ReactDOM.render(<ThemeWrapper render={() => <CDAP />} />, document.getElementById('app-container'));

--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
@@ -13,4 +13,5 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
+
 <cask-header native-link="params.nativeLink"></cask-header>

--- a/cdap-ui/app/tracker/tracker.html
+++ b/cdap-ui/app/tracker/tracker.html
@@ -31,14 +31,15 @@
 </head>
 
 <body ng-class="bodyClass" class="cdap-body-container" ng-controller="BodyCtrl" ng-keyup="onSearch($event)">
-  <div ng-show="$state.params.namespace">
-    <my-global-navbar ng-if="!$state.params.iframe"></my-global-navbar>
-  </div>
+  
+    <div ng-show="$state.params.namespace">
+      <my-global-navbar ng-if="!$state.params.iframe"></my-global-navbar>
+    </div>
 
-  <main class="container" id="app-container" ng-class="{'iframe': $state.params.iframe}">
-    <div ui-view></div>
-  </main>
-
+    <main class="container" id="app-container" ng-class="{'iframe': $state.params.iframe}">
+      <div ui-view></div>
+    </main>
+  
   <div class="alerts" id="alerts"></div>
   <div ng-if="!$state.params.iframe">
     <loading-icon></loading-icon>


### PR DESCRIPTION
**Reasons for doing this stop gap solution,**

- As we slowly transition to react and material design we need to be able to centralize
   themeing via material-ui context provider.
- For us to be able to use the provider context across everywhere in the app we need to
   have the provider wrapper at the root level.
- This is will be problematic since ng-react doesn't allow angular elements to be children
   for react elements. Meaning this cannot happen,

```
    <theme-wrapper>
      <global-navbar></global-navbar>
      <div ui-view></div>
      <footer></footer>
    </theme-wrapper>
```
   Ng-react doesn't seem to be passing on the angular children down stream.

- Hence the stop gap solution of detecting the envionment and wrapping the component with
   ThemeWrapper to pass on the context down.
- Ideally we should do this only at the root level (which we do in cdap/main.js) since angular
   doesn't allow it we are doing it based on environment

This will enable us to write any new component or re-write any existing component to use theme from
ThemeWrapper for consistency.

Build: https://builds.cask.co/browse/CDAP-UDUT182