### PR TITLE
Storage spi update

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/AlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/AlreadyExistsException.java
@@ -32,13 +32,13 @@ public class AlreadyExistsException extends ConflictException {
     this.objectId = null;
   }
 
-  public AlreadyExistsException(EntityId entityId) {
-    this(entityId, String.format("'%s' already exists", entityId));
+  public AlreadyExistsException(Object objectId) {
+    this(objectId, String.format("'%s' already exists", objectId));
   }
 
-  public AlreadyExistsException(EntityId entityId, String errorMessage) {
+  public AlreadyExistsException(Object objectId, String errorMessage) {
     super(errorMessage);
-    this.objectId = entityId;
+    this.objectId = objectId;
   }
 
   @Nullable

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/InvalidFieldException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/InvalidFieldException.java
@@ -20,16 +20,19 @@ import co.cask.cdap.spi.data.table.StructuredTableId;
 import co.cask.cdap.spi.data.table.field.FieldType;
 
 /**
- * Exception thrown when a field is not part of the table schema.
+ * Exception thrown when a field is invalid. The field is invalid on the following conditions: 1. it is not part of
+ * the table schema, 2. the field is not a primary key or an index, but it is used as one, 3. the field is part of
+ * schema but its value is incompatible with what is in the schema.
  */
-public class InvalidFieldException extends IllegalArgumentException {
+public class InvalidFieldException extends Exception {
   private final String fieldName;
   private final StructuredTableId tableId;
 
   /**
-   * Create an exception when a field is not part of a table schema
+   * Create an exception when a field is not part of a table schema.
+   *
    * @param tableId table
-   * @param fieldName missing field name
+   * @param fieldName the field name that is not part of the schema
    */
   public InvalidFieldException(StructuredTableId tableId, String fieldName) {
     super(String.format("Field %s is not part of the schema of table %s",
@@ -39,20 +42,21 @@ public class InvalidFieldException extends IllegalArgumentException {
   }
 
   /**
-   * Create an exception when a field is not defined as a primary key or an index, but is used as one
+   * Create an exception when a field is not defined as a primary key or an index, but is used as one.
+   *
    * @param tableId table
    * @param fieldName wrongly used field name
-   * @param definition the message which specifies the wrong usage
+   * @param message the message which specifies the wrong usage
    */
-  public InvalidFieldException(StructuredTableId tableId, String fieldName, String definition) {
-    super(String.format("Field %s is not defined as %s of table %s",
-                        fieldName, definition, tableId.getName()));
+  public InvalidFieldException(StructuredTableId tableId, String fieldName, String message) {
+    super(String.format("Field %s of table %s %s", fieldName, tableId.getName(), message));
     this.tableId = tableId;
     this.fieldName = fieldName;
   }
 
   /**
    * Create an exception when a field is needs conversion to an incompatible type than what is defined.
+   *
    * @param tableId table
    * @param fieldName field name
    * @param expected expected type of the field

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredRow.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredRow.java
@@ -23,14 +23,14 @@ import javax.annotation.Nullable;
  */
 public interface StructuredRow {
   /**
-   * @return the value of the field named fieldName as integer, or null if the field value is not defined.
-   * @throws InvalidFieldException if the fieldName is not part of the table schema, or is of incompatible type.
+   * @return the value of the field named fieldName as integer, or null if the field value is not defined
+   * @throws InvalidFieldException if the fieldName is not part of the table schema, or is of incompatible type
    */
   @Nullable
   Integer getInteger(String fieldName) throws InvalidFieldException;
 
   /**
-   * @return the value of the field named fieldName as long, or null if the field value is not defined.
+   * @return the value of the field named fieldName as long, or null if the field value is not defined
    * @throws InvalidFieldException if the fieldName is not part of the table schema,
    * or is of incompatible type. Integer field will be automatically widened to Long.
    */
@@ -38,7 +38,7 @@ public interface StructuredRow {
   Long getLong(String fieldName) throws InvalidFieldException;
 
   /**
-   * @return the value of the field named fieldName as string, or null if the field value is not defined.
+   * @return the value of the field named fieldName as string, or null if the field value is not defined
    * @throws InvalidFieldException if the fieldName is not part of the table schema,
    * or is of incompatible type. Numeric to string conversion will not be done.
    */
@@ -46,14 +46,14 @@ public interface StructuredRow {
   String getString(String fieldName) throws InvalidFieldException;
 
   /**
-   * @return the value of the field named fieldName as float, or null if the field value is not defined.
-   * @throws InvalidFieldException if the fieldName is not part of the table schema, or is of incompatible type.
+   * @return the value of the field named fieldName as float, or null if the field value is not defined
+   * @throws InvalidFieldException if the fieldName is not part of the table schema, or is of incompatible type
    */
   @Nullable
   Float getFloat(String fieldName) throws InvalidFieldException;
 
   /**
-   * @return the value of the field named fieldName as double, or null if the field value is not defined.
+   * @return the value of the field named fieldName as double, or null if the field value is not defined
    * @throws InvalidFieldException if the fieldName is not part of the table schema,
    * or is of incompatible type. Float field will be automatically widened to Double.
    */

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredTableAdmin.java
@@ -16,16 +16,41 @@
 
 package co.cask.cdap.spi.data;
 
+import co.cask.cdap.common.AlreadyExistsException;
+import co.cask.cdap.spi.data.table.StructuredTableId;
 import co.cask.cdap.spi.data.table.StructuredTableSpecification;
 
+import java.io.IOException;
+import javax.annotation.Nullable;
+
 /**
- * Defines admin operations on a {@link StructuredTable}
+ * Defines admin operations on a {@link StructuredTable}.
  */
 public interface StructuredTableAdmin {
   /**
    * Create a StructuredTable using the {@link StructuredTableSpecification}.
    *
    * @param spec table specification
+   * @throws IOException if there is an error creating the table
+   * @throws AlreadyExistsException if the table already exists
    */
-  void create(StructuredTableSpecification spec);
+  void create(StructuredTableSpecification spec) throws IOException, AlreadyExistsException;
+
+  /**
+   * Get the {@link StructuredTableSpecification} corresponding to the given table id.
+   *
+   * @param tableId the table id
+   * @return the specification for the table
+   */
+  @Nullable
+  StructuredTableSpecification getSpecification(StructuredTableId tableId);
+
+  /**
+   * Drop the StructuredTable synchronously. After this method is called, the existing table will get deleted. If the
+   * table does not exist, no operation will be done.
+   *
+   * @param tableId the table id
+   * @throws IOException if there is an error dropping the table
+   */
+  void drop(StructuredTableId tableId) throws IOException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredTableContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredTableContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data;
+
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.spi.data.table.StructuredTableId;
+
+/**
+ * This interface provides methods that instantiate a {@link StructuredTable} during the runtime.
+ * of a program.
+ */
+public interface StructuredTableContext {
+
+  /**
+   * Get an instance of the specified Dataset.
+   *
+   * @param tableId the table id
+   * @return An instance of the specified table, never null
+   * @throws StructuredTableInstantiationException if the table cannot be instantiated
+   * @throws NotFoundException if the table is not found
+   */
+  StructuredTable getTable(StructuredTableId tableId) throws StructuredTableInstantiationException, NotFoundException;
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredTableInstantiationException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredTableInstantiationException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data;
+
+import co.cask.cdap.spi.data.table.StructuredTableId;
+
+/**
+ * Exception thrown when table instantiation fails.
+ */
+public class StructuredTableInstantiationException extends RuntimeException {
+  private final StructuredTableId tableId;
+
+  public StructuredTableInstantiationException(StructuredTableId tableId, String message, Throwable cause) {
+    super(message, cause);
+    this.tableId = tableId;
+  }
+
+  public StructuredTableId getTableId() {
+    return tableId;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/StructuredTableSchema.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/StructuredTableSchema.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.table;
+
+import co.cask.cdap.spi.data.table.field.FieldType;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Class for the table schema, which provides convenient way to fetch for fields, primary key and index.
+ */
+public class StructuredTableSchema {
+  private final StructuredTableId tableId;
+  private final Map<String, FieldType.Type> fields;
+  // primary keys have to be ordered as defined in the table schema
+  private final Set<String> primaryKeys;
+  private final Set<String> indexes;
+
+  public StructuredTableSchema(StructuredTableSpecification spec) {
+    this.tableId = spec.getTableId();
+    this.fields = Collections.unmodifiableMap(spec.getFieldTypes().stream().collect(
+      Collectors.toMap(FieldType::getName, FieldType::getType)));
+    this.primaryKeys = Collections.unmodifiableSet(new LinkedHashSet<>(spec.getPrimaryKeys()));
+    this.indexes = Collections.unmodifiableSet(new HashSet<>(spec.getIndexes()));
+  }
+
+  public StructuredTableId getTableId() {
+    return tableId;
+  }
+
+  public Set<String> getPrimaryKeys() {
+    return primaryKeys;
+  }
+
+  /**
+   * Check if the given field name is a column of the primary keys.
+   *
+   * @param fieldName the field name to be checked
+   * @return true if this field name is a column of primary keys, false otherwise
+   */
+  public boolean isPrimaryKeyColumn(String fieldName) {
+    return primaryKeys.contains(fieldName);
+  }
+
+  /**
+   * Check if the given field name is an index column.
+   *
+   * @param fieldName the field name to be checked
+   * @return true if this field name is an index column, false otherwise
+   */
+  public boolean isIndexColumn(String fieldName) {
+    return indexes.contains(fieldName);
+  }
+
+  /**
+   * Get the field type of the given field name.
+   *
+   * @param fieldName the field name
+   * @return optional containing the field type, empty if the field name is not part of the schema
+   */
+  public Optional<FieldType.Type> getType(String fieldName) {
+    return Optional.ofNullable(fields.get(fieldName));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/StructuredTableSpecification.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/StructuredTableSpecification.java
@@ -175,13 +175,13 @@ public final class StructuredTableSpecification {
      * Build the table specification
      * @return the table specification
      */
-    public StructuredTableSpecification build() {
+    public StructuredTableSpecification build() throws InvalidFieldException {
       validate();
       return new StructuredTableSpecification(tableId, Arrays.asList(fieldTypes), Arrays.asList(primaryKeys),
                                               Arrays.asList(indexes));
     }
 
-    private void validate() {
+    private void validate() throws InvalidFieldException {
       if (tableId == null) {
         throw new IllegalArgumentException("StructuredTableId cannot be empty");
       }
@@ -221,7 +221,7 @@ public final class StructuredTableSpecification {
           throw new InvalidFieldException(tableId, primaryKey);
         }
         if (!Fields.isPrimaryKeyType(type)) {
-          throw new InvalidFieldException(tableId, primaryKey, "primary key");
+          throw new InvalidFieldException(tableId, primaryKey, "is not defined as primary key column");
         }
       }
 
@@ -229,7 +229,7 @@ public final class StructuredTableSpecification {
       for (String index : indexes) {
         FieldType.Type type = typeMap.get(index);
         if (type == null) {
-          throw new InvalidFieldException(tableId, index, "index");
+          throw new InvalidFieldException(tableId, index, "is not defined as an index column");
         }
       }
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/field/FieldType.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/field/FieldType.java
@@ -42,7 +42,8 @@ public final class FieldType {
   private final Type type;
 
   /**
-   * Construct a field type with the given field name and type
+   * Construct a field type with the given field name and type.
+   *
    * @param name field name
    * @param type field type
    */

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/field/Fields.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/field/Fields.java
@@ -26,42 +26,42 @@ public final class Fields {
   }
 
   /**
-   * @return the FieldType of INTEGER with the given name.
+   * @return the FieldType of INTEGER with the given name
    */
   public static FieldType intType(String name) {
     return new FieldType(name, FieldType.Type.INTEGER);
   }
 
   /**
-   * @return the FieldType of LONG with the given name.
+   * @return the FieldType of LONG with the given name
    */
   public static FieldType longType(String name) {
     return new FieldType(name, FieldType.Type.LONG);
   }
 
   /**
-   * @return the FieldType of STRING with the given name.
+   * @return the FieldType of STRING with the given name
    */
   public static FieldType stringType(String name) {
     return new FieldType(name, FieldType.Type.STRING);
   }
 
   /**
-   * @return the FieldType of FLOAT with the given name.
+   * @return the FieldType of FLOAT with the given name
    */
   public static FieldType floatType(String name) {
     return new FieldType(name, FieldType.Type.FLOAT);
   }
 
   /**
-   * @return the FieldType of DOUBLE with the given name.
+   * @return the FieldType of DOUBLE with the given name
    */
   public static FieldType doubleType(String name) {
     return new FieldType(name, FieldType.Type.DOUBLE);
   }
 
   /**
-   * @return true if the type is allowed to be part of a primary key, false otherwise.
+   * @return true if the type is allowed to be part of a primary key, false otherwise
    */
   public static boolean isPrimaryKeyType(FieldType.Type type) {
     return FieldType.PRIMARY_KEY_TYPES.contains(type);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TransactionException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TransactionException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.transaction;
+
+/**
+ * Exception thrown when a transaction fails to execute.
+ */
+public class TransactionException extends Exception {
+  public TransactionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TransactionRunner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TransactionRunner.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.transaction;
+
+import co.cask.cdap.spi.data.StructuredTable;
+import co.cask.cdap.spi.data.StructuredTableContext;
+
+/**
+ * An object that executes submitted {@link TxRunnable} tasks. Each task submitted will be executed inside
+ * a transaction.
+ */
+public interface TransactionRunner {
+
+  /**
+   * Executes a set of operations via a {@link TxRunnable} that are committed as a single transaction.
+   * The {@link TxRunnable} can gain access to a {@link StructuredTable} through the
+   * provided {@link StructuredTableContext}.
+   *
+   * @param runnable the runnable to be executed in the transaction
+   * @throws TransactionException if failed to execute the given {@link TxRunnable} in a transaction
+   */
+  void run(TxRunnable runnable) throws TransactionException;
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TransactionRunners.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TransactionRunners.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.transaction;
+
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Helper class for interacting with {@link TransactionRunner}.
+ * TODO: Figure out better way to propagate the exception: https://issues.cask.co/browse/CDAP-14736
+ */
+public class TransactionRunners {
+
+  // private constructor to prevent instantiation of this class.
+  private TransactionRunners() {
+  }
+
+  /**
+   * Executes the given {@link TxRunnable} using the given {@link TransactionRunner}.
+   *
+   * @param txRunner the {@link TransactionRunner} to use for txRunner execution
+   * @param runnable the {@link TxRunnable} to be executed inside a transaction
+   * @throws RuntimeException where the cause is wrapped with {@link RuntimeException} if it is not already a
+   * {@link RuntimeException}
+   */
+  public static void run(TransactionRunner txRunner, TxRunnable runnable) {
+    try {
+      txRunner.run(runnable);
+    } catch (TransactionException e) {
+      throw propagate(e);
+    }
+  }
+
+  /**
+   * Executes the given {@link TxRunnable} using the given {@link TransactionRunner}.
+   *
+   * @param txRunner the {@link TransactionRunner} to use for txRunner execution
+   * @param runnable the {@link TxRunnable} to be executed inside a transaction
+   * @param <X> exception type of propagate type
+   * @throws X if failed to execute the given {@link co.cask.cdap.api.TxRunnable} in a transaction.
+   * If the TransactionException has a cause in it, the cause is thrown as-is if it is an instance of X.
+   * @throws RuntimeException if cause is not an instance of X. The cause is wrapped with {@link RuntimeException}
+   * if it is not already a {@link RuntimeException}.
+   */
+  public static <X extends Throwable> void run(TransactionRunner txRunner,
+                                               TxRunnable runnable, Class<X> exception) throws X {
+    try {
+      txRunner.run(runnable);
+    } catch (TransactionException e) {
+      throw propagate(e, exception);
+    }
+  }
+
+  /**
+   * Executes the given {@link TxRunnable} using the given {@link TransactionRunner}.
+   *
+   * @param txRunner the {@link TransactionRunner} to use for txRunner execution
+   * @param runnable the {@link TxRunnable} to be executed inside a transaction
+   * @param <X1> exception type of first propagate type
+   * @param <X2> exception type of second propagate type
+   * @throws X1 if failed to execute the given {@link TxRunnable} in a transaction. If the
+   * TransactionException has a cause in it, the cause is thrown as-is if it is an instance of X1.
+   * @throws X2 if failed to execute the given {@link TxRunnable} in a transaction. If the
+   * TransactionException has a cause in it, the cause is thrown as-is if it is an instance of X2.
+   * @throws RuntimeException if cause is not an instance of X1 or X2. The cause is wrapped with
+   * {@link RuntimeException} if it is not already a {@link RuntimeException}.
+   */
+  public static <X1 extends Throwable, X2 extends Throwable> void run(TransactionRunner txRunner,
+                                                                      TxRunnable runnable,
+                                                                      Class<X1> exception1,
+                                                                      Class<X2> exception2) throws X1, X2 {
+    try {
+      txRunner.run(runnable);
+    } catch (TransactionException e) {
+      throw propagate(e, exception1, exception2);
+    }
+  }
+
+  /**
+   * Executes the given {@link TxCallable} using the given {@link TransactionRunner}.
+   *
+   * @param txRunner the {@link TransactionRunner} to use for txRunner execution
+   * @param callable the {@link TxCallable} to be executed inside a transaction
+   * @param <V> type of the result
+   * @return value returned by the given {@link TxCallable}
+   * @throws  RuntimeException if failed to execute the given {@link TxRunnable} in a transaction.
+   * If the TransactionException has a cause in it, the cause is propagated.
+   */
+  public static <V> V run(TransactionRunner txRunner, TxCallable<V> callable) {
+    try {
+      AtomicReference<V> result = new AtomicReference<>();
+      txRunner.run(context -> result.set(callable.call(context)));
+      return result.get();
+    } catch (TransactionException e) {
+      throw propagate(e);
+    }
+  }
+
+  /**
+   * Executes the given {@link TxCallable} using the given {@link TransactionRunner}.
+   *
+   * @param txRunner the {@link TransactionRunner} to use for the transaction execution
+   * @param callable the {@link TxCallable} to be executed inside a transaction
+   * @param <V> type of the result
+   * @param <X> exception type of propagate type
+   * @return value returned by the given {@link TxCallable}
+   * @throws X if failed to execute the given {@link TxRunnable} in a transaction. If the TransactionException
+   * has a cause in it, the cause is thrown as-is if it is an instance of X.
+   * @throws RuntimeException if cause is not an instance of X. The cause is wrapped with {@link RuntimeException}
+   * if it is not already a {@link RuntimeException}.
+   */
+  public static <V, X extends Throwable> V run(TransactionRunner txRunner,
+                                               TxCallable<V> callable, Class<X> exception) throws X {
+    try {
+      AtomicReference<V> result = new AtomicReference<>();
+      txRunner.run(c -> result.set(callable.call(c)));
+      return result.get();
+    } catch (TransactionException e) {
+      throw propagate(e, exception);
+    }
+  }
+
+  /**
+   * Executes the given {@link TxCallable} using the given {@link TransactionRunner}.
+   *
+   * @param txRunner the {@link TransactionRunner} to use for txRunner execution
+   * @param callable the {@link TxCallable} to be executed inside a transaction
+   * @param <V> type of the result
+   * @param <X1> exception type of first propagate type
+   * @param <X2> exception type of second propagate type
+   * @return value returned by the given {@link TxCallable}
+   * @throws X1 if failed to execute the given {@link TxRunnable} in a transaction. If the
+   * TransactionException has a cause in it, the cause is thrown as-is if it is an instance of X1.
+   * @throws X2 if failed to execute the given {@link TxRunnable} in a transaction. If the
+   * TransactionException has a cause in it, the cause is thrown as-is if it is an instance of X2.
+   * @throws RuntimeException if cause is not an instance of X1 or X2. The cause is wrapped with
+   * {@link RuntimeException} if it is not already a {@link RuntimeException}.
+   */
+  public static <V, X1 extends Throwable, X2 extends Throwable> V run(TransactionRunner txRunner,
+                                                                      TxCallable<V> callable,
+                                                                      Class<X1> exception1,
+                                                                      Class<X2> exception2) throws X1, X2 {
+    try {
+      AtomicReference<V> result = new AtomicReference<>();
+      txRunner.run(context -> result.set(callable.call(context)));
+      return result.get();
+    } catch (TransactionException e) {
+      throw propagate(e, exception1, exception2);
+    }
+  }
+
+  /**
+   * Propagates {@code throwable} as-is if it is an instance of
+   * {@link RuntimeException} or {@link Error}, or else as a last resort, wraps
+   * it in a {@code RuntimeException} then propagates.
+   *
+   * @param throwable the Throwable to propagate
+   * @return nothing will ever be returned. This return type is only for convenience.
+   */
+  private static RuntimeException propagate(Throwable throwable) {
+    propagateIfPossible(requireNonNull(throwable));
+    throw new RuntimeException(throwable);
+  }
+
+  /**
+   * Propagates the given {@link TransactionException}. If the {@link TransactionException#getCause()}
+   * doesn't return {@code null}, the cause will be used instead for the propagation. This method will
+   * throw the failure exception as-is the given propagated type if the type matches or as {@link RuntimeException}.
+   * This method will always throw exception and the returned exception is for satisfying Java static analysis only.
+   *
+   * @param e the {@link TransactionException} to propagate
+   * @param propagateType if the exception is an instance of this type, it will be rethrown as is
+   * @param <X> exception type of propagate type
+   * @return a exception of type X
+   */
+  public static <X extends Throwable> X propagate(TransactionException e, Class<X> propagateType) throws X {
+    Throwable cause = firstNonNull(e.getCause(), e);
+    propagateIfPossible(cause, propagateType);
+    throw propagate(cause);
+  }
+
+  /**
+   * Propagates the given {@link TransactionException}. If the {@link TransactionException#getCause()}
+   * doesn't return {@code null}, the cause will be used instead for the propagation. This method will
+   * throw the failure exception as-is the given propagated types if the type matches or as {@link RuntimeException}.
+   * This method will always throw and the returned exception is for satisfying Java static analysis only.
+   *
+   * @param e the {@link TransactionException} to propagate
+   * @param propagateType1 if the exception is an instance of this type, it will be rethrown as is
+   * @param propagateType2 if the exception is an instance of this type, it will be rethrown as is
+   * @param <X1> exception type of first propagate type
+   * @param <X2> exception type of second propagate type
+   * @return a exception of type X1,X2
+   */
+  public static <X1 extends Throwable, X2 extends Throwable> X1 propagate(TransactionException e,
+                                                                          Class<X1> propagateType1,
+                                                                          Class<X2> propagateType2) throws X1, X2 {
+    Throwable cause = firstNonNull(e.getCause(), e);
+    propagateIfPossible(cause, propagateType1, propagateType2);
+    throw propagate(cause);
+  }
+
+  /**
+   * Propagates {@code throwable} exactly as-is, if and only if it is an
+   * instance of {@link RuntimeException} or {@link Error}.
+   */
+  private static void propagateIfPossible(@Nullable Throwable throwable) {
+    propagateIfInstanceOf(throwable, Error.class);
+    propagateIfInstanceOf(throwable, RuntimeException.class);
+  }
+
+  /**
+   * Propagates {@code throwable} exactly as-is, if and only if it is an
+   * instance of {@link RuntimeException}, {@link Error}, or
+   * {@code declaredType}.
+   *
+   * @param throwable the Throwable to possibly propagate
+   * @param declaredType the single checked exception type declared by the calling method
+   */
+  private static <X extends Throwable> void propagateIfPossible(
+    @Nullable Throwable throwable, Class<X> declaredType) throws X {
+    propagateIfInstanceOf(throwable, declaredType);
+    propagateIfPossible(throwable);
+  }
+
+  /**
+   * Propagates {@code throwable} exactly as-is, if and only if it is an
+   * instance of {@link RuntimeException}, {@link Error}, {@code declaredType1},
+   * or {@code declaredType2}.
+   *
+   * @param throwable the Throwable to possibly propagate
+   * @param declaredType1 any checked exception type declared by the calling
+   *     method
+   * @param declaredType2 any other checked exception type declared by the
+   *     calling method
+   */
+  private static <X1 extends Throwable, X2 extends Throwable>
+  void propagateIfPossible(@Nullable Throwable throwable,
+                           Class<X1> declaredType1, Class<X2> declaredType2) throws X1, X2 {
+    requireNonNull(declaredType2);
+    propagateIfInstanceOf(throwable, declaredType1);
+    propagateIfPossible(throwable, declaredType2);
+  }
+
+  /**
+   * Propagates {@code throwable} exactly as-is, if and only if it is an
+   * instance of {@code declaredType}.
+   */
+  private static <X extends Throwable> void propagateIfInstanceOf(
+    @Nullable Throwable throwable, Class<X> declaredType) throws X {
+    if (declaredType.isInstance(throwable)) {
+      throw declaredType.cast(throwable);
+    }
+  }
+
+  /**
+   * Returns the first of two given parameters that is not {@code null}, if
+   * either is, or otherwise throws a {@link NullPointerException}.
+   */
+  private static <T> T firstNonNull(@Nullable T first, @Nullable T second) {
+    return first != null ? first : requireNonNull(second);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TxCallable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TxCallable.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.transaction;
+
+import co.cask.cdap.spi.data.StructuredTable;
+import co.cask.cdap.spi.data.StructuredTableContext;
+
+/**
+ * A callable that provides a {@link StructuredTableContext} to programs which may be used to get
+ * access to and use tables.
+ *
+ * @param <V> type of the return value from the {@link #call(StructuredTableContext)}.
+ *
+ */
+public interface TxCallable<V> {
+  /**
+   * Provides a {@link StructuredTableContext} to get instances of {@link StructuredTable}s.
+   *
+   * <p>
+   *   Operations executed on a table within the execution of this method are committed as a single transaction.
+   *   The transaction is started before this method is invoked and is committed upon successful execution.
+   *   Exceptions thrown while committing the transaction or thrown by user-code result in a rollback of the
+   *   transaction.
+   * </p>
+   *
+   * @param context to get tables from
+   * @return return value of the call method
+   */
+  V call(StructuredTableContext context) throws Exception;
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TxRunnable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/transaction/TxRunnable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.transaction;
+
+import co.cask.cdap.spi.data.StructuredTable;
+import co.cask.cdap.spi.data.StructuredTableContext;
+
+/**
+ * A runnable that provides a {@link StructuredTableContext} to programs which may be used to get
+ * access to and use tables.
+ */
+public interface TxRunnable {
+  /**
+   * Provides a {@link StructuredTableContext} to get instances of {@link StructuredTable}s.
+   *
+   * <p>
+   *   Operations executed on a table within the execution of this method are committed as a single transaction.
+   *   The transaction is started before this method is invoked and is committed upon successful execution.
+   *   Exceptions thrown while committing the transaction or thrown by user-code result in a rollback of the
+   *   transaction.
+   * </p>
+   *
+   * @param context to get table from
+   */
+  void run(StructuredTableContext context) throws Exception;
+}


### PR DESCRIPTION
The addition to the spi is mainly about transaction. The logic is similar to the current transaction logic using DatasetContext. There is also some update in the method StructuredTableAdmin to support retrieve the spec and drop the table.