### PR TITLE
CDAP-14724 fix action only workflows on cloud runtimes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -157,6 +158,12 @@ public final class DistributedWorkflowProgramRunner extends DistributedProgramRu
           Closeables.closeQuietly((Closeable) runner);
         }
       }
+    }
+
+    if (clusterMode == ClusterMode.ISOLATED) {
+      // For isolated mode, the hadoop classes comes from the hadoop classpath in the target cluster directly
+      // Without this, the remote process will fail to start due to missing zookeeper classes (see CDAP-14724)
+      launchConfig.addExtraClasspath(Collections.singletonList("$HADOOP_CLASSPATH"));
     }
 
     // Set the class acceptor


### PR DESCRIPTION
Fixed a bug where workflows that do not contain mapreduce or
spark would not have the hadoop classpath added to their classpath,
which would result in zookeeper classes not being found and the
remote process failing.