### PR TITLE
[CDAP-14641] Refactor Profile Metadata Processor

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
@@ -195,7 +195,7 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
           case PROFILE_UNASSIGNMENT:
           case ENTITY_CREATION:
           case ENTITY_DELETION:
-            return new ProfileMetadataMessageProcessor(cConf, datasetContext, datasetFramework);
+            return new ProfileMetadataMessageProcessor(cConf, datasetContext, datasetFramework, metadataStore);
           default:
             return null;
         }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataAuditPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataAuditPublishTest.java
@@ -35,8 +35,6 @@ import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.audit.payload.metadata.MetadataPayload;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.scheduler.Scheduler;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
@@ -92,13 +90,13 @@ public class SystemMetadataAuditPublishTest {
     AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, AllProgramsApp.class, null, cConf);
     Set<String> addedMetadata = new HashSet<>();
     // TODO (CDAP-14670): this test is brittle, find a better condition to wait on
-    Tasks.waitFor(25, () -> addAllSystemMetadata(addedMetadata), 10, TimeUnit.SECONDS);
+    Tasks.waitFor(26, () -> addAllSystemMetadata(addedMetadata), 10, TimeUnit.SECONDS);
     namespaceAdmin.delete(NamespaceId.DEFAULT);
     Set<String> removedMetadata = new HashSet<>();
-    // TODO (CDAP-14666): deletions have one additional key: "profile". This is because of named bug.
-    Tasks.waitFor(addedMetadata.size() + 1, () -> addAllSystemMetadata(removedMetadata), 5, TimeUnit.SECONDS);
+    // expect the same number of changes when namespace is deleted
+    Tasks.waitFor(addedMetadata.size(), () -> addAllSystemMetadata(removedMetadata), 5, TimeUnit.SECONDS);
     // Assert that the exact same system properties and tags got added upon app deployment and removed upon deletion
-    Assert.assertEquals(ImmutableSet.of("profile"), Sets.difference(removedMetadata, addedMetadata).immutableCopy());
+    Assert.assertEquals(addedMetadata, removedMetadata);
   }
 
   private int addAllSystemMetadata(Set<String> allMetadata) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -47,6 +47,14 @@ public interface MetadataStore {
   void setProperties(MetadataScope scope, MetadataEntity metadataEntity, Map<String, String> properties);
 
   /**
+   * Adds/updates properties for each specified {@link MetadataEntity} in the specified {@link MetadataScope}.
+   *
+   * @param scope the {@link MetadataScope} to add/update the properties in
+   * @param toUpdate the properties to add/update, for each entity in the map
+   */
+  void setProperties(MetadataScope scope, Map<MetadataEntity, Map<String, String>> toUpdate);
+
+  /**
    * Sets the specified property for the specified {@link MetadataEntity} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope} to set/update the property in
@@ -138,6 +146,14 @@ public interface MetadataStore {
    * @param keys the keys to remove
    */
   void removeProperties(MetadataScope scope, MetadataEntity metadataEntity, Set<String> keys);
+
+  /**
+   * Removes the specified properties for each {@link MetadataEntity} in the specified {@link MetadataScope}.
+   *
+   * @param scope the {@link MetadataScope}
+   * @param toRemove a map specifying the set of keys to remove for each metadata entity.
+   */
+  void removeProperties(MetadataScope scope, Map<MetadataEntity, Set<String>> toRemove);
 
   /**
    * Removes tags of the {@link MetadataEntity} in the specified {@link MetadataScope}.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -38,6 +38,11 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
+  public void setProperties(MetadataScope scope, Map<MetadataEntity, Map<String, String>> toUpdate) {
+    // NO-OP
+  }
+
+  @Override
   public void setProperty(MetadataScope scope, MetadataEntity metadataEntity, String key, String value) {
     // NO-OP
   }
@@ -100,6 +105,11 @@ public class NoOpMetadataStore implements MetadataStore {
 
   @Override
   public void removeProperties(MetadataScope scope, MetadataEntity metadataEntity, Set<String> keys) {
+    // NO-OP
+  }
+
+  @Override
+  public void removeProperties(MetadataScope scope, Map<MetadataEntity, Set<String>> toRemove) {
     // NO-OP
   }
 


### PR DESCRIPTION
Before introducing an SPI for Metadata, we must make sure that no code directly accesses the MetadataDataset (except for DefaultMetadataStore). The ProfileMetadataMessageProcessor is one such place. 

It currently consumes a message from TMS, then scans preferences and entity store to determine the new profile for each program and schedule, and updates the corresponding property in the metadata dataset, all in one transaction. 

This changes it to collect all the changes instead of directly applying them to the MetadataDataset, and then calls a new batch method in MetadataStore to apply all changes in a separate transaction. This is safe because these changes are idempotent, and even if the TMS transaction fails and is retried, it will only re-apply the same metadata changes again. 

This also optimizes the access to the preferences dataset. Previously, or each program, it was resolving all preferences for the program, then getting the profile from the resolved preferences. That has two drawbacks:
- it resolves all preferences instead of just the profile preference that we're interested in
- many preferences are read multiple times: for each program in an app, the preferences are resolved, reading the preferences for the app over and over again.

This is improved by 
- adding a new method to preference dataset to resolve only one property
- passing the profile property down from the parent entity when processing its children.
 
 