### PR TITLE
[CDAP-15584] Implement creation/replacement of system metadata in a single MetadataStore method

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataChange.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Cask Data, Inc.
+ * Copyright 2018-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,7 @@ public class MetadataChange {
   private final Metadata existing;
   private final Metadata latest;
 
-  MetadataChange(Metadata existing, Metadata latest) {
+  public MetadataChange(Metadata existing, Metadata latest) {
     this.existing = existing;
     this.latest = latest;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -286,7 +286,7 @@ public class MetadataDataset extends AbstractDataset {
     // if there are more key-value properties then process them updating the final metadata state
     while (iterator.hasNext()) {
       Map.Entry<String, String> next = iterator.next();
-      finalMetadata = setMetadata(new MetadataEntry(metadataEntity, next.getKey(), next.getValue())).getExisting();
+      finalMetadata = setMetadata(new MetadataEntry(metadataEntity, next.getKey(), next.getValue())).getLatest();
     }
     return new MetadataChange(previousMetadata, finalMetadata);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.metadata.store;
 import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.data2.metadata.dataset.Metadata;
 import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 
@@ -36,6 +37,22 @@ import java.util.Set;
  * </ul>
  */
 public interface MetadataStore {
+
+  /**
+   * Replaces the metadata for the given entity: All existing properties and tags are
+   * replaced with the given Metadata, with these exceptions: some existing properties
+   * are kept even if the new properties do not contain them, and some properties are
+   * left unchanged even if the new properties contain a new value.
+   *
+   * @param scope the {@link MetadataScope} to add/update the properties in
+   * @param metadata the new metadata, including the entity, properties and tags
+   * @param propertiesToKeep the names of properties that should be kept even if the
+   *                         new metadata does not contain them
+   * @param propertiesToPreserve the names of properties to leave unchanged even if
+   *                             the new metadata contains no or new values for them
+   */
+  void replaceMetadata(MetadataScope scope, Metadata metadata,
+                       Set<String> propertiesToKeep, Set<String> propertiesToPreserve);
 
   /**
    * Adds/updates properties for the specified {@link MetadataEntity} in the specified {@link MetadataScope}.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.metadata.store;
 import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.metadata.MetadataRecord;
+import co.cask.cdap.data2.metadata.dataset.Metadata;
 import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import com.google.common.collect.ImmutableSet;
@@ -30,6 +31,12 @@ import java.util.Set;
  * Implementation of {@link MetadataStore} used in memory mode.
  */
 public class NoOpMetadataStore implements MetadataStore {
+
+  @Override
+  public void replaceMetadata(MetadataScope scope, Metadata metadata,
+                              Set<String> propertiesToKeep, Set<String> propertiesToPreserve) {
+    // NO-OP
+  }
 
   @Override
   public void setProperties(MetadataScope scope, MetadataEntity metadataEntity,


### PR DESCRIPTION
This is in preparation for introducing the metadata SPI, which will have a similar method. 