### PR TITLE
CDAP-13650 allow updates to stored keys on secure store

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStoreManager.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStoreManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -36,7 +36,7 @@ public interface SecureStoreManager {
    * @param description User provided description of the entry.
    * @param properties associated with this element.
    * @throws IOException If the attempt to store the element failed.
-   * @throws Exception If the specified namespace does not exist or the name already exists. Updating is not supported.
+   * @throws Exception If the specified namespace does not exist.
    */
   void putSecureData(String namespace, String name, String data, String description, Map<String, String> properties)
     throws Exception;

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/DefaultSecureStoreService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/DefaultSecureStoreService.java
@@ -19,7 +19,6 @@ package co.cask.cdap.security.store;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreData;
 import co.cask.cdap.api.security.store.SecureStoreManager;
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
@@ -39,10 +38,8 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Default implementation of the service that manages access to the Secure Store,
@@ -112,7 +109,6 @@ public class DefaultSecureStoreService implements SecureStore, SecureStoreManage
    * @throws BadRequestException If the request does not contain the value to be stored.
    * @throws UnauthorizedException If the user does not have write permissions on the namespace.
    * @throws NamespaceNotFoundException If the specified namespace does not exist.
-   * @throws AlreadyExistsException If the key already exists in the namespace. Updating is not supported.
    * @throws IOException If there was a problem storing the key to underlying provider.
    */
   @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/FileSecureStore.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/FileSecureStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,6 @@ import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreData;
 import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.security.store.SecureStoreMetadata;
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -109,15 +108,13 @@ public class FileSecureStore implements SecureStore, SecureStoreManager {
   }
 
   /**
-   * Stores an element in the secure store. Although JCEKS supports overwriting keys the interface currently does not
-   * support it. If the key already exists then this method throws an AlreadyExistsException.
+   * Stores an element in the secure store. If the element already exists, it will get overwritten.
    * @param namespace The namespace this key belongs to.
    * @param name Name of the element to store.
    * @param data The data that needs to be securely stored.
    * @param description User provided description of the entry.
    * @param properties Metadata associated with the data.
    * @throws NamespaceNotFoundException If the specified namespace does not exist.
-   * @throws AlreadyExistsException If the key already exists in the namespace. Updating is not supported.
    * @throws IOException If there was a problem storing the key to the in memory keystore
    * or if there was problem persisting the keystore.
    */
@@ -130,9 +127,6 @@ public class FileSecureStore implements SecureStore, SecureStoreManager {
     SecureStoreData secureStoreData = new SecureStoreData(meta, data.getBytes(Charsets.UTF_8));
     writeLock.lock();
     try {
-      if (keyStore.containsAlias(keyName)) {
-        throw new AlreadyExistsException(new SecureKeyId(namespace, name));
-      }
       keyStore.setKeyEntry(keyName, new SecretKeySpec(serialize(secureStoreData), "none"), password, null);
       // Attempt to persist the store.
       flush();

--- a/cdap-security/src/test/java/co/cask/cdap/security/store/FileSecureStoreTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/store/FileSecureStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -129,13 +130,17 @@ public class FileSecureStoreTest {
     Assert.assertEquals(metadata2.getName(), secureStore.getSecureData(NAMESPACE1, KEY2).getMetadata().getName());
   }
 
-  @Test(expected = Exception.class)
+  @Test
   public void testOverwrite() throws Exception {
     secureStoreManager.putSecureData(NAMESPACE1, KEY1, VALUE1, DESCRIPTION1, PROPERTIES_1);
     SecureStoreData oldData = secureStore.getSecureData(NAMESPACE1, KEY1);
     Assert.assertArrayEquals(VALUE1.getBytes(Charsets.UTF_8), oldData.get());
     String newVal = "New value";
-    secureStoreManager.putSecureData(NAMESPACE1, KEY1, newVal, DESCRIPTION1, PROPERTIES_1);
+    secureStoreManager.putSecureData(NAMESPACE1, KEY1, newVal, DESCRIPTION2, PROPERTIES_1);
+
+    SecureStoreData updated = secureStore.getSecureData(NAMESPACE1, KEY1);
+    Assert.assertArrayEquals(newVal.getBytes(StandardCharsets.UTF_8), updated.get());
+    Assert.assertEquals(DESCRIPTION2, updated.getMetadata().getDescription());
   }
 
   @Test(expected = NotFoundException.class)


### PR DESCRIPTION
`SecureStoreManager` api exposes hadoop kms implementation details by not allowing updates at api level. Changing that to allow secure key updates at api level. That means for standalone and cloud, updates are allowed, but for hadoop kms, updates are still not allowed. 

Also fixed a bug in` KMSSecureStore` implementation where each get request was updating creationtime to system current time. Updated `KMSSecureStore` implementation to throw `AlreadyExistsException` when key is present in kms.

Could not find any usage of client in integration tests repo. 

Build: https://builds.cask.co/browse/CDAP-DUT6721-6