### PR TITLE
CDAP-14690 new method for validation and schema propagation

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/MultiInputPipelineConfigurable.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/MultiInputPipelineConfigurable.java
@@ -17,17 +17,19 @@
 package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.etl.api.validation.SchemaPropagator;
 
 /**
  * Allows the stage with multiple inputs to configure pipeline.
  */
 @Beta
-public interface MultiInputPipelineConfigurable {
+public interface MultiInputPipelineConfigurable extends SchemaPropagator<MultiInputStageConfigurer> {
   /**
-   * Configure an ETL pipeline, adding datasets and streams that the stage needs.
+   * Configure an ETL pipeline, adding datasets and plugins that the stage needs.
    *
-   * @param multiInputPipelineConfigurer the configurer used to add required datasets and streams
+   * @param multiInputPipelineConfigurer the configurer used to add required datasets and plugins
    * @throws IllegalArgumentException if the given config is invalid
    */
   void configurePipeline(MultiInputPipelineConfigurer multiInputPipelineConfigurer) throws IllegalArgumentException;
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/MultiInputPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/MultiInputPipelineConfigurer.java
@@ -18,7 +18,9 @@ package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.DatasetConfigurer;
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.etl.api.validation.SchemaPropagator;
 
 import java.util.Map;
 
@@ -33,8 +35,17 @@ public interface MultiInputPipelineConfigurer extends PluginConfigurer, DatasetC
   /**
    * Get multi input stage configurer for the pipeline stage
    * @return multi input stage configurer
+   * @deprecated schema propagation should be handled by {@link SchemaPropagator#propagateSchema(Object)}
    */
+  @Deprecated
   MultiInputStageConfigurer getMultiInputStageConfigurer();
+
+  /**
+   * Get the map of input stageName to input schema for this stage, or an empty map if its unknown
+   *
+   * @return map of input schemas
+   */
+  Map<String, Schema> getInputSchemas();
 
   /**
    * @return the engine for this pipeline

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/MultiOutputPipelineConfigurable.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/MultiOutputPipelineConfigurable.java
@@ -17,18 +17,20 @@
 package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.etl.api.validation.SchemaPropagator;
 
 /**
  * Allows a stage with multiple outputs to configure the pipeline.
  */
 @Beta
-public interface MultiOutputPipelineConfigurable {
+public interface MultiOutputPipelineConfigurable extends SchemaPropagator<MultiOutputStageConfigurer> {
 
   /**
-   * Configure a pipeline, adding datasets and streams that the stage needs.
+   * Configure a pipeline, adding datasets and plugins that the stage needs.
    *
-   * @param multiOutputPipelineConfigurer the configurer used to add required datasets and streams
+   * @param multiOutputPipelineConfigurer the configurer used to add required datasets and plugins
    * @throws IllegalArgumentException if the given config is invalid
    */
   void configurePipeline(MultiOutputPipelineConfigurer multiOutputPipelineConfigurer);
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/MultiOutputPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/MultiOutputPipelineConfigurer.java
@@ -18,9 +18,12 @@ package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.DatasetConfigurer;
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.etl.api.validation.SchemaPropagator;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Configures a Pipeline. Allows adding datasets and streams, which will be created when a pipeline is created.
@@ -35,8 +38,18 @@ public interface MultiOutputPipelineConfigurer extends PluginConfigurer, Dataset
    * Get multi output stage configurer for the pipeline stage
    *
    * @return multi output stage configurer
+   * @deprecated schema propagation should be handled by {@link SchemaPropagator#propagateSchema(Object)}
    */
+  @Deprecated
   MultiOutputStageConfigurer getMultiOutputStageConfigurer();
+
+  /**
+   * Get the input schema for this stage, or null if its unknown
+   *
+   * @return input schema
+   */
+  @Nullable
+  Schema getInputSchema();
 
   /**
    * @return the engine for this pipeline

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/PipelineConfigurable.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/PipelineConfigurable.java
@@ -17,18 +17,21 @@
 package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.etl.api.validation.SchemaPropagator;
 
 /**
  * Allows the stage to configure pipeline.
  */
 @Beta
-public interface PipelineConfigurable {
+public interface PipelineConfigurable extends SchemaPropagator<StageConfigurer> {
 
   /**
-   * Configure an ETL pipeline, adding datasets and streams that the stage needs.
+   * Configure a pipeline, declaring what datasets and plugins will be needed when the pipeline actually runs.
+   * This is called exactly once, when a pipeline is deployed.
    *
-   * @param pipelineConfigurer the configurer used to add required datasets and streams
+   * @param pipelineConfigurer the configurer used to add required datasets and plugins
    * @throws IllegalArgumentException if the given config is invalid
    */
-  void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException;
+  void configurePipeline(PipelineConfigurer pipelineConfigurer);
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/PipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/PipelineConfigurer.java
@@ -18,9 +18,12 @@ package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.DatasetConfigurer;
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.etl.api.validation.SchemaPropagator;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Configures an ETL Pipeline. Allows adding datasets and streams, which will be created when a pipeline is created.
@@ -32,8 +35,18 @@ public interface PipelineConfigurer extends PluginConfigurer, DatasetConfigurer 
   /**
    * Get stage configurer for the pipeline stage
    * @return stage configurer
+   * @deprecated schema propagation should be done be {@link SchemaPropagator#propagateSchema(Object)}
    */
+  @Deprecated
   StageConfigurer getStageConfigurer();
+
+  /**
+   * Get the input schema for this stage, or null if its unknown
+   *
+   * @return input schema
+   */
+  @Nullable
+  Schema getInputSchema();
 
   /**
    * @return the engine for this pipeline

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/validation/InvalidConfigPropertyException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/validation/InvalidConfigPropertyException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.etl.api.validation;
+
+/**
+ * Thrown when a pipeline stage is invalid because a config property is invalid.
+ */
+public class InvalidConfigPropertyException extends InvalidStageException {
+  private final String field;
+
+  public InvalidConfigPropertyException(String field, String message) {
+    super(message);
+    this.field = field;
+  }
+
+  public InvalidConfigPropertyException(String field, String message, Throwable cause) {
+    super(message, cause);
+    this.field = field;
+  }
+
+  public String getField() {
+    return field;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/validation/InvalidStageException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/validation/InvalidStageException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.etl.api.validation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Thrown when a pipeline stage is invalid. If there are multiple reasons the stage is invalid, they can
+ * all be specified together in this exception. This allows end users to see all errors at once instead of one by one.
+ */
+public class InvalidStageException extends RuntimeException {
+  private final List<Throwable> reasons;
+
+  public InvalidStageException(String message) {
+    super(message);
+    this.reasons = Collections.emptyList();
+  }
+
+  public InvalidStageException(String message, Throwable cause) {
+    super(message, cause);
+    this.reasons = Collections.singletonList(cause);
+  }
+
+  public InvalidStageException(Collection<Throwable> reasons) {
+    this.reasons = Collections.unmodifiableList(new ArrayList<>(reasons));
+  }
+
+  public List<Throwable> getReasons() {
+    return reasons;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/validation/SchemaPropagator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/validation/SchemaPropagator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.etl.api.validation;
+
+/**
+ * Propagates schema and performs validation.
+ *
+ * @param <T> type of stage configurer for getting input schema(s) and setting output schema(s)
+ */
+public interface SchemaPropagator<T> {
+
+  /**
+   * Validate that the pipeline stage is properly configured and propagate schema.
+   * If the stage is invalid, an {@link InvalidStageException} should be thrown containing details about what
+   * is invalid and why.
+   *
+   * Propagation is performed multiple times before a pipeline is deployed, when it is still being constructed.
+   * PluginConfig properties that contain macros will not have actual values at this point. If an InvalidStageException
+   * is thrown, all reasons will be displayed to the user.
+   *
+   * Propagation is also performed once when the pipeline is deployed.
+   * PluginConfig properties that contain macros will not have actual values at this point. If an InvalidStageException
+   * is thrown, pipeline deployment will fail.
+   *
+   * Propagation is also performed once at the start of each pipeline run.
+   * Macros will be evaluated at this point. If an InvalidStageException is thrown, the pipeline run will fail.
+   *
+   * @param stageConfigurer configurer used to get the input schema(s) and set the output schema(s)
+   * @throws InvalidStageException if validation failed
+   */
+  default void propagateSchema(T stageConfigurer) {
+    // no-op by default
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultPipelineConfigurer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.common;
 
 import co.cask.cdap.api.DatasetConfigurer;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
@@ -123,6 +124,12 @@ public class DefaultPipelineConfigurer<C extends PluginConfigurer & DatasetConfi
     return stageConfigurer;
   }
 
+  @Nullable
+  @Override
+  public Schema getInputSchema() {
+    return stageConfigurer.getInputSchema();
+  }
+
   @Override
   public Engine getEngine() {
     return engine;
@@ -137,6 +144,11 @@ public class DefaultPipelineConfigurer<C extends PluginConfigurer & DatasetConfi
   @Override
   public MultiInputStageConfigurer getMultiInputStageConfigurer() {
     return stageConfigurer;
+  }
+
+  @Override
+  public Map<String, Schema> getInputSchemas() {
+    return stageConfigurer.getInputSchemas();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedAction.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedAction.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.common.plugin;
 
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.action.Action;
 import co.cask.cdap.etl.api.action.ActionContext;
 
@@ -39,6 +40,14 @@ public class WrappedAction extends Action {
   public void configurePipeline(final PipelineConfigurer pipelineConfigurer) {
     caller.callUnchecked((Callable<Void>) () -> {
       action.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      action.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedBatchAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedBatchAggregator.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.common.plugin;
 
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchAggregatorContext;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
@@ -50,6 +51,14 @@ public class WrappedBatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> extends BatchAg
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     caller.callUnchecked((Callable<Void>) () -> {
       aggregator.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      aggregator.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedBatchJoiner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedBatchJoiner.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.common.plugin;
 import co.cask.cdap.etl.api.JoinConfig;
 import co.cask.cdap.etl.api.JoinElement;
 import co.cask.cdap.etl.api.MultiInputPipelineConfigurer;
+import co.cask.cdap.etl.api.MultiInputStageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchJoinerContext;
 import co.cask.cdap.etl.api.batch.BatchJoinerRuntimeContext;
@@ -50,6 +51,13 @@ public class WrappedBatchJoiner<JOIN_KEY, INPUT_RECORD, OUT> extends BatchJoiner
   public void configurePipeline(MultiInputPipelineConfigurer multiInputPipelineConfigurer) {
     caller.callUnchecked((Callable<Void>) () -> {
       joiner.configurePipeline(multiInputPipelineConfigurer);
+      return null;
+    });
+  }
+  @Override
+  public void propagateSchema(MultiInputStageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      joiner.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedBatchSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedBatchSink.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.common.plugin;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
@@ -88,6 +89,14 @@ public class WrappedBatchSink<IN, KEY_OUT, VAL_OUT> extends BatchSink<IN, KEY_OU
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     caller.callUnchecked((Callable<Void>) () -> {
       batchSink.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      batchSink.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedBatchSource.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.common.plugin;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
@@ -94,6 +95,14 @@ public class WrappedBatchSource<KEY_IN, VAL_IN, OUT> extends BatchSource<KEY_IN,
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     caller.callUnchecked((Callable<Void>) () -> {
       batchSource.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      batchSource.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedErrorTransform.java
@@ -20,6 +20,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.ErrorRecord;
 import co.cask.cdap.etl.api.ErrorTransform;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;
 
@@ -48,6 +49,14 @@ public class WrappedErrorTransform<IN, OUT> extends ErrorTransform<IN, OUT> {
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     caller.callUnchecked((Callable<Void>) () -> {
       transform.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      transform.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedPostAction.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedPostAction.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.common.plugin;
 
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchActionContext;
 import co.cask.cdap.etl.api.batch.PostAction;
 
@@ -39,6 +40,14 @@ public class WrappedPostAction extends PostAction {
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     caller.callUnchecked((Callable<Void>) () -> {
       postAction.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      postAction.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedSplitterTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedSplitterTransform.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.common.plugin;
 
 import co.cask.cdap.etl.api.MultiOutputEmitter;
 import co.cask.cdap.etl.api.MultiOutputPipelineConfigurer;
+import co.cask.cdap.etl.api.MultiOutputStageConfigurer;
 import co.cask.cdap.etl.api.SplitterTransform;
 import co.cask.cdap.etl.api.TransformContext;
 
@@ -46,6 +47,14 @@ public class WrappedSplitterTransform<T, E> extends SplitterTransform<T, E> {
   public void configurePipeline(MultiOutputPipelineConfigurer multiOutputPipelineConfigurer) {
     caller.callUnchecked((Callable<Void>) () -> {
       transform.configurePipeline(multiOutputPipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void propagateSchema(MultiOutputStageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      transform.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/plugin/WrappedTransform.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.common.plugin;
 
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.StageSubmitterContext;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;
@@ -46,6 +47,14 @@ public class WrappedTransform<IN, OUT> extends Transform<IN, OUT> {
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     caller.callUnchecked((Callable<Void>) () -> {
       transform.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      transform.propagateSchema(stageConfigurer);
       return null;
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -325,12 +325,15 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig,
     try {
       if (type.equals(BatchJoiner.PLUGIN_TYPE)) {
         MultiInputPipelineConfigurable multiPlugin = (MultiInputPipelineConfigurable) plugin;
+        multiPlugin.propagateSchema(pipelineConfigurer.getStageConfigurer());
         multiPlugin.configurePipeline(pipelineConfigurer);
       } else if (type.equals(SplitterTransform.PLUGIN_TYPE)) {
         MultiOutputPipelineConfigurable multiOutputPlugin = (MultiOutputPipelineConfigurable) plugin;
+        multiOutputPlugin.propagateSchema(pipelineConfigurer.getStageConfigurer());
         multiOutputPlugin.configurePipeline(pipelineConfigurer);
       } else if (!type.equals(Constants.SPARK_PROGRAM_PLUGIN_TYPE)) {
         PipelineConfigurable singlePlugin = (PipelineConfigurable) plugin;
+        singlePlugin.propagateSchema(pipelineConfigurer.getStageConfigurer());
         singlePlugin.configurePipeline(pipelineConfigurer);
       }
     } catch (Exception e) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.etl.api.MultiOutputPipelineConfigurer;
 import co.cask.cdap.etl.api.PipelineConfigurable;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.SplitterTransform;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.action.Action;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
@@ -882,13 +883,17 @@ public class PipelineSpecGeneratorTest {
     }
 
     @Override
-    public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    public void propagateSchema(StageConfigurer stageConfigurer) {
       if (outputSchema != null) {
-        pipelineConfigurer.getStageConfigurer().setOutputSchema(outputSchema);
+        stageConfigurer.setOutputSchema(outputSchema);
       }
       if (errorSchema != null) {
-        pipelineConfigurer.getStageConfigurer().setErrorSchema(errorSchema);
+        stageConfigurer.setErrorSchema(errorSchema);
       }
+    }
+
+    @Override
+    public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
       pipelineConfigurer.setPipelineProperties(pipelineProperties);
     }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/plugin/WrappedSparkCompute.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/plugin/WrappedSparkCompute.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.spark.plugin;
 
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.common.plugin.Caller;
@@ -48,6 +49,14 @@ public class WrappedSparkCompute<IN, OUT> extends SparkCompute<IN, OUT> {
         compute.configurePipeline(pipelineConfigurer);
         return null;
       }
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      compute.propagateSchema(stageConfigurer);
+      return null;
     });
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/plugin/WrappedSparkSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/plugin/WrappedSparkSink.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.spark.plugin;
 
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.api.batch.SparkPluginContext;
@@ -49,6 +50,14 @@ public class WrappedSparkSink<IN> extends SparkSink<IN> {
         sink.configurePipeline(pipelineConfigurer);
         return null;
       }
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      sink.propagateSchema(stageConfigurer);
+      return null;
     });
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/plugin/WrappedStreamingSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/plugin/WrappedStreamingSource.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.spark.plugin;
 
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.streaming.StreamingContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.api.streaming.Windower;
@@ -48,6 +49,14 @@ public class WrappedStreamingSource<T> extends StreamingSource<T> {
         source.configurePipeline(pipelineConfigurer);
         return null;
       }
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      source.propagateSchema(stageConfigurer);
+      return null;
     });
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/plugin/WrappedWindower.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/plugin/WrappedWindower.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.spark.plugin;
 
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.streaming.Windower;
 import co.cask.cdap.etl.common.plugin.Caller;
 
@@ -43,6 +44,14 @@ public class WrappedWindower extends Windower {
         windower.configurePipeline(pipelineConfigurer);
         return null;
       }
+    });
+  }
+
+  @Override
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    caller.callUnchecked(() -> {
+      windower.propagateSchema(stageConfigurer);
+      return null;
     });
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/alert/NullAlertTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/alert/NullAlertTransform.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -47,15 +46,14 @@ public class NullAlertTransform extends Transform<StructuredRecord, StructuredRe
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 
   @Override
   public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
     if (input.get(conf.field) == null) {
-      emitter.emitAlert(new HashMap<String, String>());
+      emitter.emitAlert(new HashMap<>());
     } else {
       emitter.emit(input);
     }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/FieldCountAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/FieldCountAggregator.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchAggregatorContext;
@@ -53,15 +52,14 @@ public class FieldCountAggregator extends BatchAggregator<Object, StructuredReco
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     if (!config.containsMacro("fieldType") && !config.containsMacro("fieldName")) {
       stageConfigurer.setOutputSchema(config.getSchema());
     }
   }
 
   @Override
-  public void prepareRun(BatchAggregatorContext context) throws Exception {
+  public void prepareRun(BatchAggregatorContext context) {
     if ("long".equalsIgnoreCase(config.fieldType)) {
       context.setGroupKeyClass(Long.class);
     } else {
@@ -70,7 +68,7 @@ public class FieldCountAggregator extends BatchAggregator<Object, StructuredReco
   }
 
   @Override
-  public void groupBy(StructuredRecord input, Emitter<Object> emitter) throws Exception {
+  public void groupBy(StructuredRecord input, Emitter<Object> emitter) {
     if ("long".equalsIgnoreCase(config.fieldType)) {
       emitter.emit(input.get(config.fieldName));
       emitter.emit(0L);
@@ -82,7 +80,7 @@ public class FieldCountAggregator extends BatchAggregator<Object, StructuredReco
 
   @Override
   public void aggregate(Object groupKey, Iterator<StructuredRecord> groupValues,
-                        Emitter<StructuredRecord> emitter) throws Exception {
+                        Emitter<StructuredRecord> emitter) {
     long count = 0;
     while (groupValues.hasNext()) {
       groupValues.next();

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/GroupFilterAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/GroupFilterAggregator.java
@@ -25,9 +25,9 @@ import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.validation.InvalidConfigPropertyException;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.HashMap;
@@ -44,26 +44,25 @@ public class GroupFilterAggregator extends BatchAggregator<String, StructuredRec
   private Config config;
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     Schema inputSchema = stageConfigurer.getInputSchema();
     if (inputSchema == null) {
       return;
     }
     Schema.Field groupField = inputSchema.getField(config.field);
     if (groupField == null) {
-      throw new IllegalArgumentException(config.field + " is not in the input schema");
+      throw new InvalidConfigPropertyException("field", config.field + " is not in the input schema");
     }
     Schema groupSchema = groupField.getSchema();
     Schema.Type groupType = groupSchema.isNullable() ? groupSchema.getNonNullable().getType() : groupSchema.getType();
     if (groupType != Schema.Type.STRING) {
-      throw new IllegalArgumentException(config.field + " is not of type string");
+      throw new InvalidConfigPropertyException("field", config.field + " is not of type string");
     }
     stageConfigurer.setOutputSchema(inputSchema);
   }
 
   @Override
-  public void groupBy(StructuredRecord input, Emitter<String> emitter) throws Exception {
+  public void groupBy(StructuredRecord input, Emitter<String> emitter) {
     String val = input.get(config.field);
     if (val != null) {
       emitter.emit(val);
@@ -72,7 +71,7 @@ public class GroupFilterAggregator extends BatchAggregator<String, StructuredRec
 
   @Override
   public void aggregate(String groupKey, Iterator<StructuredRecord> groupValues,
-                        Emitter<StructuredRecord> emitter) throws Exception {
+                        Emitter<StructuredRecord> emitter) {
     if (config.value.equals(groupKey)) {
       while (groupValues.hasNext()) {
         emitter.emitError(new InvalidEntry<>(3, "bad val", groupValues.next()));

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/IdentityAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/IdentityAggregator.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -40,19 +39,18 @@ public class IdentityAggregator extends BatchAggregator<StructuredRecord, Struct
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 
   @Override
-  public void groupBy(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+  public void groupBy(StructuredRecord input, Emitter<StructuredRecord> emitter) {
     emitter.emit(input);
   }
 
   @Override
   public void aggregate(StructuredRecord structuredRecord, Iterator<StructuredRecord> groupValues,
-                        Emitter<StructuredRecord> emitter) throws Exception {
+                        Emitter<StructuredRecord> emitter) {
     while (groupValues.hasNext()) {
       emitter.emit(groupValues.next());
     }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/joiner/MockJoiner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/joiner/MockJoiner.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.JoinConfig;
 import co.cask.cdap.etl.api.JoinElement;
-import co.cask.cdap.etl.api.MultiInputPipelineConfigurer;
 import co.cask.cdap.etl.api.MultiInputStageConfigurer;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchJoinerRuntimeContext;
@@ -56,8 +55,7 @@ public class MockJoiner extends BatchJoiner<StructuredRecord, StructuredRecord, 
   }
 
   @Override
-  public void configurePipeline(MultiInputPipelineConfigurer pipelineConfigurer) {
-    MultiInputStageConfigurer stageConfigurer = pipelineConfigurer.getMultiInputStageConfigurer();
+  public void propagateSchema(MultiInputStageConfigurer stageConfigurer) {
     Map<String, Schema> inputSchemas = stageConfigurer.getInputSchemas();
     stageConfigurer.setOutputSchema(getOutputSchema(inputSchemas));
     config.validateConfig();

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockPipelineConfigurer.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * Mock test configurer used to test configure pipeline's validation of input schema and setting of output shcema.
+ * Mock test configurer used to test configure pipeline's validation of input schema and setting of output schema.
  */
 public class MockPipelineConfigurer implements PipelineConfigurer, DatasetConfigurer {
   private final Schema inputSchema;
@@ -50,7 +50,7 @@ public class MockPipelineConfigurer implements PipelineConfigurer, DatasetConfig
   }
 
   public MockPipelineConfigurer(Schema inputSchema) {
-    this(inputSchema, Collections.<String, Object>emptyMap());
+    this(inputSchema, Collections.emptyMap());
   }
 
   @Nullable
@@ -77,6 +77,12 @@ public class MockPipelineConfigurer implements PipelineConfigurer, DatasetConfig
 
       }
     };
+  }
+
+  @Nullable
+  @Override
+  public Schema getInputSchema() {
+    return inputSchema;
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/compute/StringValueFilterCompute.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/compute/StringValueFilterCompute.java
@@ -25,17 +25,14 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.api.spark.dynamic.SparkInterpreter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.rdd.RDD;
-import scala.collection.JavaConversions;
 
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,8 +53,7 @@ public class StringValueFilterCompute extends SparkCompute<StructuredRecord, Str
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/streaming/MockSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/streaming/MockSource.java
@@ -23,9 +23,10 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
-import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.streaming.StreamingContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.cdap.etl.api.validation.InvalidConfigPropertyException;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.format.StructuredRecordStringConverter;
 import com.google.common.collect.ImmutableMap;
@@ -62,11 +63,11 @@ public class MockSource extends StreamingSource<StructuredRecord> {
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     try {
-      pipelineConfigurer.getStageConfigurer().setOutputSchema(Schema.parseJson(conf.schema));
+      stageConfigurer.setOutputSchema(Schema.parseJson(conf.schema));
     } catch (IOException e) {
-      throw new IllegalArgumentException("Could not parse schema " + conf.schema);
+      throw new InvalidConfigPropertyException("schema", "Could not parse schema " + conf.schema);
     }
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/AllErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/AllErrorTransform.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -40,8 +39,7 @@ public class AllErrorTransform extends Transform<StructuredRecord, StructuredRec
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 
@@ -51,7 +49,7 @@ public class AllErrorTransform extends Transform<StructuredRecord, StructuredRec
   }
 
   public static ETLPlugin getPlugin() {
-    return new ETLPlugin("AllError", Transform.PLUGIN_TYPE, new HashMap<String, String>(), null);
+    return new ETLPlugin("AllError", Transform.PLUGIN_TYPE, new HashMap<>(), null);
   }
 
   private static PluginClass getPluginClass() {

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/DoubleTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/DoubleTransform.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -39,8 +38,7 @@ public class DoubleTransform extends Transform<StructuredRecord, StructuredRecor
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 
@@ -51,7 +49,7 @@ public class DoubleTransform extends Transform<StructuredRecord, StructuredRecor
   }
 
   public static ETLPlugin getPlugin() {
-    return new ETLPlugin("Double", Transform.PLUGIN_TYPE, new HashMap<String, String>(), null);
+    return new ETLPlugin("Double", Transform.PLUGIN_TYPE, new HashMap<>(), null);
   }
 
   private static PluginClass getPluginClass() {

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/DropNullTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/DropNullTransform.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -50,8 +49,7 @@ public class DropNullTransform extends Transform<StructuredRecord, StructuredRec
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     Schema inputSchema = stageConfigurer.getInputSchema();
     if (inputSchema != null) {
       stageConfigurer.setOutputSchema(getOutputSchema(inputSchema));

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/ExceptionTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/ExceptionTransform.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;
@@ -46,8 +45,7 @@ public class ExceptionTransform extends Transform<StructuredRecord, StructuredRe
   private Map<String, String> properties;
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FieldsPrefixTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FieldsPrefixTransform.java
@@ -24,9 +24,9 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.validation.InvalidConfigPropertyException;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.ArrayList;
@@ -49,13 +49,12 @@ public class FieldsPrefixTransform extends Transform<StructuredRecord, Structure
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     try {
       Schema outSchema = config.getOutputSchema(Schema.parseJson(config.schemaStr));
       stageConfigurer.setOutputSchema(outSchema);
     } catch (Exception e) {
-      throw new IllegalArgumentException("Invalid output schema: " + e.getMessage(), e);
+      throw new InvalidConfigPropertyException("schemaStr", "Invalid output schema: " + e.getMessage(), e);
     }
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FilterErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FilterErrorTransform.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.ErrorRecord;
 import co.cask.cdap.etl.api.ErrorTransform;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
@@ -42,8 +41,7 @@ public class FilterErrorTransform extends ErrorTransform<StructuredRecord, Struc
   private Config config;
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FlattenErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FlattenErrorTransform.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.ErrorRecord;
 import co.cask.cdap.etl.api.ErrorTransform;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.TransformContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -44,8 +43,7 @@ public class FlattenErrorTransform extends ErrorTransform<StructuredRecord, Stru
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     Schema inputSchema = stageConfigurer.getInputSchema();
     if (inputSchema != null) {
       stageConfigurer.setOutputSchema(getOutputSchema(inputSchema));

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/IdentityTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/IdentityTransform.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.StageSubmitterContext;
 import co.cask.cdap.etl.api.Transform;
@@ -42,8 +41,7 @@ public class IdentityTransform extends Transform<StructuredRecord, StructuredRec
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/IntValueFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/IntValueFilterTransform.java
@@ -24,7 +24,6 @@ import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
@@ -47,8 +46,7 @@ public class IntValueFilterTransform extends Transform<StructuredRecord, Structu
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/SleepTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/SleepTransform.java
@@ -24,11 +24,10 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.StageSubmitterContext;
 import co.cask.cdap.etl.api.Transform;
-import co.cask.cdap.etl.api.TransformContext;
+import co.cask.cdap.etl.api.validation.InvalidConfigPropertyException;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.HashMap;
@@ -50,11 +49,10 @@ public class SleepTransform extends Transform<StructuredRecord, StructuredRecord
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    if (config.millis < 1) {
-      throw new IllegalArgumentException("millis must be at least 1.");
+  public void propagateSchema(StageConfigurer stageConfigurer) {
+    if (config.millis != null && config.millis < 1) {
+      throw new InvalidConfigPropertyException("millis", "millis must be at least 1.");
     }
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/StringValueFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/StringValueFilterTransform.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
-import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.TransformContext;
@@ -51,8 +50,7 @@ public class StringValueFilterTransform extends Transform<StructuredRecord, Stru
   }
 
   @Override
-  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
-    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+  public void propagateSchema(StageConfigurer stageConfigurer) {
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
   }
 


### PR DESCRIPTION
Added a validate method to all pipeline stages that can be used
as a central place for performing validation and schema
propagation. This is done so that plugin developers won't need
to explicitly build validation logic into both their configure
and prepare methods.