### PR TITLE
CDAP-13648 Change SecureStore list api to use List<SecureStoreMetadata>

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStore.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStore.java
@@ -19,33 +19,31 @@ package co.cask.cdap.api.security.store;
 import co.cask.cdap.api.annotation.Beta;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 
 /**
  * Provides read access to the secure store.
- * For write access use {@link SecureStoreManager}
+ * For write access use {@link SecureStoreManager}.
  */
 @Beta
 public interface SecureStore {
 
   /**
-   * List of all the entries in the secure store.
-   * @param namespace The namespace that this key belongs to.
-   * @return A list of {@link SecureStoreMetadata} objects representing the data stored in the store.
-   * @throws IOException If there was a problem reading from the keystore.
-   * @throws Exception If the specified namespace does not exist.
+   * List of metadata stored in the secure store.
+   * @param namespace The namespace that this key belongs to
+   * @return A list of {@link SecureStoreMetadata} objects representing the data stored in the store
+   * @throws IOException If there was a problem reading from the keystore
+   * @throws Exception If the specified namespace does not exist
    */
-  // TODO CDAP-13648 change this api to return list of SecureStoreMetadata. Also change names of the methods to list,
-  // get as `SecureData` in method names are redundant
-  Map<String, String> listSecureData(String namespace) throws Exception;
+  List<SecureStoreMetadata> list(String namespace) throws Exception;
 
   /**
    * Returns the data stored in the secure store.
-   * @param namespace The namespace that this key belongs to.
-   * @param name Name of the data element.
-   * @return An object representing the securely stored data associated with the name.
-   * @throws IOException If there was a problem reading from the store.
-   * @throws Exception if the specified namespace or name does not exist.
+   * @param namespace The namespace that this key belongs to
+   * @param name Name of the data element
+   * @return An object representing the securely stored data associated with the name
+   * @throws IOException If there was a problem reading from the store
+   * @throws Exception if the specified namespace or name does not exist
    */
-  SecureStoreData getSecureData(String namespace, String name) throws Exception;
+  SecureStoreData get(String namespace, String name) throws Exception;
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStoreData.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStoreData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api.security.store;
 
+import java.util.Arrays;
+
 /**
  * This represents the entity stored in the Secure Store.
  * The data is stored as UTF8 encoded byte array.
@@ -29,7 +31,7 @@ public final class SecureStoreData {
 
   public SecureStoreData(SecureStoreMetadata metadata, byte[] data) {
     this.metadata = metadata;
-    this.data = data;
+    this.data =  Arrays.copyOf(data, data.length);
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStoreManager.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStoreManager.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Beta;
 
 import java.io.IOException;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Provides write access to the secure store.
@@ -30,23 +31,23 @@ public interface SecureStoreManager {
 
   /**
    * Stores an element in the secure store.
-   * @param namespace The namespace that this key belongs to.
-   * @param name This is the identifier that will be used to retrieve this element.
+   * @param namespace The namespace that this key belongs to
+   * @param name This is the identifier that will be used to retrieve this element
    * @param data The sensitive data that has to be securely stored
-   * @param description User provided description of the entry.
-   * @param properties associated with this element.
-   * @throws IOException If the attempt to store the element failed.
-   * @throws Exception If the specified namespace does not exist.
+   * @param description User provided description of the entry
+   * @param properties associated with this element
+   * @throws IOException If the attempt to store the element failed
+   * @throws Exception If the specified namespace does not exist
    */
-  void putSecureData(String namespace, String name, String data, String description, Map<String, String> properties)
-    throws Exception;
+  void put(String namespace, String name, String data, @Nullable String description,
+           Map<String, String> properties) throws Exception;
 
   /**
    * Deletes the element with the given name.
-   * @param namespace The namespace that this key belongs to.
-   * @param name of the element to delete.
-   * @throws IOException If the store is not initialized or if the key could not be removed.
-   * @throws Exception If the specified namespace or name does not exist.
+   * @param namespace The namespace that this key belongs to
+   * @param name of the element to delete
+   * @throws IOException If the store is not initialized or if the key could not be removed
+   * @throws Exception If the specified namespace or name does not exist
    */
-  void deleteSecureData(String namespace, String name) throws Exception;
+  void delete(String namespace, String name) throws Exception;
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStoreMetadata.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/security/store/SecureStoreMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Represents the metadata for the data stored in the Secure Store.
@@ -31,16 +32,11 @@ public final class SecureStoreMetadata {
   private final long createdEpochMs;
   private final Map<String, String> properties;
 
-  public SecureStoreMetadata(String name, String description, long created, Map<String, String> properties) {
+  public SecureStoreMetadata(String name, @Nullable String description, long created, Map<String, String> properties) {
     this.name = name;
     this.description = description;
     this.createdEpochMs = created;
-    this.properties = properties;
-  }
-
-  public static SecureStoreMetadata of(String name, String description, Map<String, String> properties) {
-    return new SecureStoreMetadata(name, description, System.currentTimeMillis(),
-                                   Collections.unmodifiableMap(new HashMap<>(properties)));
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
   }
 
   /**
@@ -64,6 +60,7 @@ public final class SecureStoreMetadata {
     return properties;
   }
 
+  @Nullable
   public String getDescription() {
     return description;
   }
@@ -74,7 +71,6 @@ public final class SecureStoreMetadata {
       "name='" + name + '\'' +
       ", description='" + description + '\'' +
       ", createdEpochMs=" + createdEpochMs +
-      ", properties=" + properties +
       '}';
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2018 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,6 +55,7 @@ import co.cask.cdap.api.schedule.TriggeringScheduleInfo;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreData;
 import co.cask.cdap.api.security.store.SecureStoreManager;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
@@ -123,6 +124,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -506,13 +508,13 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
-    return secureStore.listSecureData(namespace);
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
+    return secureStore.list(namespace);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
-    return secureStore.getSecureData(namespace, name);
+  public SecureStoreData get(String namespace, String name) throws Exception {
+    return secureStore.get(namespace, name);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2018 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -67,14 +67,14 @@ public class DefaultAdmin extends DefaultDatasetManager implements Admin {
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data,
-                            String description, Map<String, String> properties) throws Exception {
-    secureStoreManager.putSecureData(namespace, name, data, description, properties);
+  public void put(String namespace, String name, String data,
+                  @Nullable String description, Map<String, String> properties) throws Exception {
+    secureStoreManager.put(namespace, name, data, description, properties);
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
-    secureStoreManager.deleteSecureData(namespace, name);
+  public void delete(String namespace, String name) throws Exception {
+    secureStoreManager.delete(namespace, name);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,6 +42,7 @@ import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo;
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.api.workflow.WorkflowInfo;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import org.apache.tephra.TransactionFailureException;
@@ -55,6 +56,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -287,13 +289,13 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
-    return delegate.listSecureData(namespace);
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
+    return delegate.list(namespace);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
-    return delegate.getSecureData(namespace, name);
+  public SecureStoreData get(String namespace, String name) throws Exception {
+    return delegate.get(namespace, name);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerMacroEvaluator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/ProvisionerMacroEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -52,7 +52,7 @@ public class ProvisionerMacroEvaluator implements MacroEvaluator {
       throw new InvalidMacroException("Secure store macro function only supports 1 argument.");
     }
     try {
-      return Bytes.toString(secureStore.getSecureData(namespace, arguments[0]).get());
+      return Bytes.toString(secureStore.get(namespace, arguments[0]).get());
     } catch (Exception e) {
       throw new InvalidMacroException("Failed to resolve macro '" + macroFunction + "(" + arguments[0] + ")'", e);
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -39,6 +39,7 @@ import co.cask.cdap.api.metrics.NoopMetricsContext;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpContentConsumer;
 import co.cask.cdap.api.service.http.HttpContentProducer;
@@ -765,12 +766,12 @@ public class HttpHandlerGeneratorTest {
     }
 
     @Override
-    public Map<String, String> listSecureData(String namespace) throws Exception {
+    public List<SecureStoreMetadata> list(String namespace) throws Exception {
       return null;
     }
 
     @Override
-    public SecureStoreData getSecureData(String namespace, String name) throws Exception {
+    public SecureStoreData get(String namespace, String name) throws Exception {
       return null;
     }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2018 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.services;
 
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
@@ -61,7 +62,7 @@ import org.junit.rules.TemporaryFolder;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -150,8 +151,8 @@ public class DefaultSecureStoreServiceTest {
     final SecureKeyId secureKeyId1 = NamespaceId.DEFAULT.secureKey(KEY1);
     SecurityRequestContext.setUserId(ALICE.getName());
     try {
-      secureStoreManager.putSecureData(NamespaceId.DEFAULT.getNamespace(), KEY1, VALUE1, DESCRIPTION1,
-                                       Collections.<String, String>emptyMap());
+      secureStoreManager.put(NamespaceId.DEFAULT.getNamespace(), KEY1, VALUE1, DESCRIPTION1,
+                             Collections.<String, String>emptyMap());
       Assert.fail("Alice should not be able to store a key since she does not have WRITE privileges on the namespace");
     } catch (UnauthorizedException expected) {
       // expected
@@ -160,18 +161,18 @@ public class DefaultSecureStoreServiceTest {
     // Grant ALICE admin access to the secure key
     grantAndAssertSuccess(secureKeyId1, ALICE, EnumSet.of(Action.ADMIN));
     // Write should succeed
-    secureStoreManager.putSecureData(NamespaceId.DEFAULT.getNamespace(), KEY1, VALUE1, DESCRIPTION1,
-                                     Collections.<String, String>emptyMap());
+    secureStoreManager.put(NamespaceId.DEFAULT.getNamespace(), KEY1, VALUE1, DESCRIPTION1,
+                           Collections.<String, String>emptyMap());
     // Listing should return the value just written
-    Map<String, String> secureKeyListEntries = secureStore.listSecureData(NamespaceId.DEFAULT.getNamespace());
-    Assert.assertEquals(1, secureKeyListEntries.size());
-    Assert.assertTrue(secureKeyListEntries.containsKey(KEY1));
-    Assert.assertEquals(DESCRIPTION1, secureKeyListEntries.get(KEY1));
+    List<SecureStoreMetadata> metadatas = secureStore.list(NamespaceId.DEFAULT.getNamespace());
+    Assert.assertEquals(1, metadatas.size());
+    Assert.assertEquals(KEY1, metadatas.get(0).getName());
+    Assert.assertEquals(DESCRIPTION1, metadatas.get(0).getDescription());
     revokeAndAssertSuccess(secureKeyId1, ALICE, EnumSet.allOf(Action.class));
 
     // Should not be able to list the keys since ALICE does not have privilege on the secure key
     try {
-      secureStore.listSecureData(NamespaceId.DEFAULT.getNamespace());
+      secureStore.list(NamespaceId.DEFAULT.getNamespace());
     } catch (UnauthorizedException e) {
       // expected
     }
@@ -180,14 +181,14 @@ public class DefaultSecureStoreServiceTest {
     SecurityRequestContext.setUserId(BOB.getName());
     grantAndAssertSuccess(NamespaceId.DEFAULT, BOB, EnumSet.of(Action.READ));
     grantAndAssertSuccess(secureKeyId1, BOB, EnumSet.of(Action.READ));
-    Assert.assertEquals(VALUE1, new String(secureStore.getSecureData(NamespaceId.DEFAULT.getNamespace(), KEY1).get(),
+    Assert.assertEquals(VALUE1, new String(secureStore.get(NamespaceId.DEFAULT.getNamespace(), KEY1).get(),
                                            Charsets.UTF_8));
-    secureKeyListEntries = secureStore.listSecureData(NamespaceId.DEFAULT.getNamespace());
-    Assert.assertEquals(1, secureKeyListEntries.size());
+    metadatas = secureStore.list(NamespaceId.DEFAULT.getNamespace());
+    Assert.assertEquals(1, metadatas.size());
 
     // BOB should not be able to delete the key
     try {
-      secureStoreManager.deleteSecureData(NamespaceId.DEFAULT.getNamespace(), KEY1);
+      secureStoreManager.delete(NamespaceId.DEFAULT.getNamespace(), KEY1);
       Assert.fail("Bob should not be able to delete a key since he does not have ADMIN privileges on the key");
     } catch (UnauthorizedException expected) {
       // expected
@@ -195,8 +196,8 @@ public class DefaultSecureStoreServiceTest {
 
     // Grant Bob ADMIN access and he should be able to delete the key
     grantAndAssertSuccess(secureKeyId1, BOB, ImmutableSet.of(Action.ADMIN));
-    secureStoreManager.deleteSecureData(NamespaceId.DEFAULT.getNamespace(), KEY1);
-    Assert.assertEquals(0, secureStore.listSecureData(NamespaceId.DEFAULT.getNamespace()).size());
+    secureStoreManager.delete(NamespaceId.DEFAULT.getNamespace(), KEY1);
+    Assert.assertEquals(0, secureStore.list(NamespaceId.DEFAULT.getNamespace()).size());
     Predicate<Privilege> secureKeyIdFilter = new Predicate<Privilege>() {
       @Override
       public boolean apply(Privilege input) {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -2627,10 +2627,10 @@ public class DataPipelineTest extends HydratorTestBase {
       .build();
 
     // place dataset names into secure storage
-    getSecureStoreManager().putSecureData("default", prefix + "source", prefix + "MockSecureSourceDataset",
-                                          "secure source dataset name", new HashMap<>());
-    getSecureStoreManager().putSecureData("default", prefix + "sink", prefix + "MockSecureSinkDataset",
-                                          "secure dataset name", new HashMap<>());
+    getSecureStoreManager().put("default", prefix + "source", prefix + "MockSecureSourceDataset",
+                                "secure source dataset name", new HashMap<>());
+    getSecureStoreManager().put("default", prefix + "sink", prefix + "MockSecureSinkDataset",
+                                "secure dataset name", new HashMap<>());
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
     ApplicationId appId = NamespaceId.DEFAULT.app("App-" + engine);

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/condition/BasicConditionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/condition/BasicConditionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.batch.condition;
 
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.api.workflow.NodeValue;
 import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.api.workflow.WorkflowToken;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Default implementation of the {@link ConditionContext}.
@@ -109,24 +111,24 @@ public class BasicConditionContext extends AbstractStageContext implements Condi
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
-    return context.listSecureData(namespace);
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
+    return context.list(namespace);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
-    return context.getSecureData(namespace, name);
+  public SecureStoreData get(String namespace, String name) throws Exception {
+    return context.get(namespace, name);
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws Exception {
-    context.getAdmin().putSecureData(namespace, name, data, description, properties);
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws Exception {
+    context.getAdmin().put(namespace, name, data, description, properties);
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
-    context.getAdmin().deleteSecureData(namespace, name);
+  public void delete(String namespace, String name) throws Exception {
+    context.getAdmin().delete(namespace, name);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/BasicActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/BasicActionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.batch.customaction;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.customaction.CustomActionContext;
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.etl.api.action.ActionContext;
 import co.cask.cdap.etl.api.lineage.field.FieldOperation;
 import co.cask.cdap.etl.common.AbstractStageContext;
@@ -27,6 +28,7 @@ import org.apache.tephra.TransactionFailureException;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Default implementation for the {@link ActionContext}.
@@ -51,24 +53,24 @@ public class BasicActionContext extends AbstractStageContext implements ActionCo
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
-    return context.listSecureData(namespace);
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
+    return context.list(namespace);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
-    return context.getSecureData(namespace, name);
+  public SecureStoreData get(String namespace, String name) throws Exception {
+    return context.get(namespace, name);
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws Exception {
-    context.getAdmin().putSecureData(namespace, name, data, description, properties);
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws Exception {
+    context.getAdmin().put(namespace, name, data, description, properties);
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
-    context.getAdmin().deleteSecureData(namespace, name);
+  public void delete(String namespace, String name) throws Exception {
+    context.getAdmin().delete(namespace, name);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultMacroEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,12 +20,8 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.macro.InvalidMacroException;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.security.store.SecureStore;
-import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.etl.common.macro.LogicalStartTimeMacro;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -70,7 +66,7 @@ public class DefaultMacroEvaluator implements MacroEvaluator {
         throw new InvalidMacroException("Secure store macro function only supports 1 argument.");
       }
       try {
-        return Bytes.toString(secureStore.getSecureData(namespace, arguments[0]).get());
+        return Bytes.toString(secureStore.get(namespace, arguments[0]).get());
       } catch (Exception e) {
         throw new InvalidMacroException("Failed to resolve macro '" + macroFunction + "(" + arguments[0] + ")'", e);
       }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockActionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockActionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,6 +23,7 @@ import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.action.ActionContext;
 import co.cask.cdap.etl.api.action.SettableArguments;
@@ -134,23 +135,23 @@ public class MockActionContext implements ActionContext {
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) {
+  public List<SecureStoreMetadata> list(String namespace) {
     return null;
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) {
+  public SecureStoreData get(String namespace, String name) {
     return null;
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) {
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) {
     // no-op; unused
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) {
+  public void delete(String namespace, String name) {
     // no-op; unused
   }
 

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/SecureStoreClientTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/SecureStoreClientTest.java
@@ -33,6 +33,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -104,7 +105,7 @@ public class SecureStoreClientTest extends AbstractClientTest {
   @Test
   public void testSecureKeys() throws Exception {
     // no secure keys to begin with
-    Map<String, String> secureKeys = client.listKeys(NamespaceId.DEFAULT);
+    List<SecureStoreMetadata> secureKeys = client.listKeys(NamespaceId.DEFAULT);
     Assert.assertTrue(secureKeys.isEmpty());
 
     // create a key

--- a/cdap-client/src/main/java/co/cask/cdap/client/SecureStoreClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/SecureStoreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2018 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -38,7 +38,7 @@ import com.google.inject.Inject;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Map;
+import java.util.List;
 
 /**
  * Provides ways to get/set Secure keys.
@@ -150,7 +150,7 @@ public class SecureStoreClient {
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NamespaceNotFoundException if the given namespace is not found
    */
-  public Map<String, String> listKeys(NamespaceId namespaceId) throws IOException, UnauthenticatedException,
+  public List<SecureStoreMetadata> listKeys(NamespaceId namespaceId) throws IOException, UnauthenticatedException,
     NamespaceNotFoundException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3(namespaceId, SECURE_KEYS);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
@@ -158,7 +158,7 @@ public class SecureStoreClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NamespaceNotFoundException(namespaceId);
     }
-    return ObjectResponse.fromJsonBody(response, new TypeToken<Map<String, String>>() { }).getResponseObject();
+    return ObjectResponse.fromJsonBody(response, new TypeToken<List<SecureStoreMetadata>>() { }).getResponseObject();
   }
 
   private static String getSecureKeyPath(SecureKeyId secureKeyId) {

--- a/cdap-common/src/test/java/co/cask/cdap/common/test/NoopAdmin.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/test/NoopAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,6 +26,7 @@ import co.cask.cdap.api.messaging.TopicNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * A {@link Admin} that performs no-operation on all methods.
@@ -69,13 +70,13 @@ public class NoopAdmin implements Admin {
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws Exception {
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws Exception {
     // no-op
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
+  public void delete(String namespace, String name) throws Exception {
     // no-op
   }
 

--- a/cdap-kms/src/main/java/co/cask/cdap/security/store/KMSSecureStoreService.java
+++ b/cdap-kms/src/main/java/co/cask/cdap/security/store/KMSSecureStoreService.java
@@ -43,9 +43,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Secure Store implementation backed by Hadoop KMS. This assumes that KMS is setup and running.
@@ -114,8 +114,8 @@ public class KMSSecureStoreService extends AbstractIdleService implements Secure
   // Unfortunately KeyProvider does not specify
   // the underlying cause except in the message, so we can not throw a more specific exception.
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws Exception {
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws Exception {
     checkNamespaceExists(namespace);
     String keyName = getKeyName(namespace, name);
     if (provider.getMetadata(keyName) != null) {
@@ -144,7 +144,7 @@ public class KMSSecureStoreService extends AbstractIdleService implements Secure
    * the underlying cause except in the message, so we can not throw a more specific exception.
    */
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
+  public void delete(String namespace, String name) throws Exception {
     checkNamespaceExists(namespace);
     try {
       provider.deleteKey(getKeyName(namespace, name));
@@ -168,7 +168,7 @@ public class KMSSecureStoreService extends AbstractIdleService implements Secure
   // Unfortunately KeyProvider does not specify the underlying cause except in the message, so we can not throw a
   // more specific exception.
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
     checkNamespaceExists(namespace);
     String prefix = namespace + NAME_SEPARATOR;
     List<String> keysInNamespace = new ArrayList<>();
@@ -188,10 +188,12 @@ public class KMSSecureStoreService extends AbstractIdleService implements Secure
       throw new ConcurrentModificationException("A key was deleted while listing was in progress. Please try again.");
     }
 
-    Map<String, String> secureStoreMetadatas = new HashMap<>(metadatas.length);
+    List<SecureStoreMetadata> secureStoreMetadatas = new ArrayList<>(metadatas.length);
     for (int i = 0; i < metadatas.length; i++) {
       KeyProvider.Metadata metadata = metadatas[i];
-      secureStoreMetadatas.put(keysInNamespace.get(i).substring(prefix.length()), metadata.getDescription());
+      secureStoreMetadatas.add(new SecureStoreMetadata(keysInNamespace.get(i).substring(prefix.length()),
+                                                       metadata.getDescription(),
+                                                       metadata.getCreated().getTime(), metadata.getAttributes()));
     }
     return secureStoreMetadatas;
   }
@@ -208,7 +210,7 @@ public class KMSSecureStoreService extends AbstractIdleService implements Secure
   // Unfortunately KeyProvider does not specify the underlying cause except in the message, so we can not throw a
   // more specific exception.
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
+  public SecureStoreData get(String namespace, String name) throws Exception {
     checkNamespaceExists(namespace);
     String keyName = getKeyName(namespace, name);
     KeyProvider.Metadata metadata = provider.getMetadata(keyName);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/SecureKeyCreateRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/SecureKeyCreateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package co.cask.cdap.proto.security;
 
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Request for creating a new entry in the secure store
@@ -27,12 +28,13 @@ public class SecureKeyCreateRequest {
   private final String data;
   private final Map<String, String> properties;
 
-  public SecureKeyCreateRequest(String description, String data, Map<String, String> properties) {
+  public SecureKeyCreateRequest(@Nullable String description, String data, Map<String, String> properties) {
     this.description = description;
     this.data = data;
     this.properties = properties;
   }
 
+  @Nullable
   public String getDescription() {
     return description;
   }
@@ -42,15 +44,13 @@ public class SecureKeyCreateRequest {
   }
 
   public Map<String, String> getProperties() {
-    return properties == null ? Collections.<String, String>emptyMap() : properties;
+    return properties == null ? Collections.emptyMap() : properties;
   }
 
   @Override
   public String toString() {
     return "SecureKeyCreateRequest{" +
       "description='" + description + '\'' +
-      ", data='" + data + '\'' +
-      ", properties=" + properties +
       '}';
   }
 }

--- a/cdap-securestore-ext-cloudkms/src/main/java/co/cask/cdap/securestore/gcp/cloudkms/SecretInfo.java
+++ b/cdap-securestore-ext-cloudkms/src/main/java/co/cask/cdap/securestore/gcp/cloudkms/SecretInfo.java
@@ -19,6 +19,7 @@ package co.cask.cdap.securestore.gcp.cloudkms;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Class used to serialize and deserialize the secret and associated metadata. Used by {@link SecretInfoCodec}.
@@ -33,7 +34,7 @@ public final class SecretInfo {
   /**
    * Creates SecretInfo instance with provided name, description, secretData, creationTimeMs and properties.
    */
-  public SecretInfo(String name, String description, byte[] secretData, long creationTimeMs,
+  public SecretInfo(String name, @Nullable String description, byte[] secretData, long creationTimeMs,
                     Map<String, String> properties) {
     this.name = name;
     this.description = description;
@@ -52,6 +53,7 @@ public final class SecretInfo {
   /**
    * Returns description of the secret
    */
+  @Nullable
   public String getDescription() {
     return description;
   }

--- a/cdap-securestore-ext-cloudkms/src/main/java/co/cask/cdap/securestore/gcp/cloudkms/SecretInfoCodec.java
+++ b/cdap-securestore-ext-cloudkms/src/main/java/co/cask/cdap/securestore/gcp/cloudkms/SecretInfoCodec.java
@@ -36,7 +36,8 @@ public class SecretInfoCodec implements Encoder<SecretInfo>, Decoder<SecretInfo>
   public SecretInfo decode(byte[] data) throws IOException {
     try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
       String name = dis.readUTF();
-      String description = dis.readUTF();
+      boolean descriptionExists = dis.readBoolean();
+      String description = descriptionExists ? dis.readUTF() : null;
       long creationTimeMs = dis.readLong();
 
       Map<String, String> properties = new HashMap<>();
@@ -56,7 +57,10 @@ public class SecretInfoCodec implements Encoder<SecretInfo>, Decoder<SecretInfo>
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     try (DataOutputStream dos = new DataOutputStream(bos)) {
       dos.writeUTF(secretInfo.getName());
-      dos.writeUTF(secretInfo.getDescription());
+      dos.writeBoolean(secretInfo.getDescription() != null);
+      if (secretInfo.getDescription() != null) {
+        dos.writeUTF(secretInfo.getDescription());
+      }
       dos.writeLong(secretInfo.getCreationTimeMs());
 
       Map<String, String> properties = secretInfo.getProperties();

--- a/cdap-securestore-ext-cloudkms/src/test/java/co/cask/cdap/securestore/spi/SecretInfoCodecTest.java
+++ b/cdap-securestore-ext-cloudkms/src/test/java/co/cask/cdap/securestore/spi/SecretInfoCodecTest.java
@@ -48,4 +48,23 @@ public class SecretInfoCodecTest {
     Assert.assertEquals(secretInfo.getDescription(), decodedSecretInfo.getDescription());
     Assert.assertEquals(secretInfo.getProperties().size(), decodedSecretInfo.getProperties().size());
   }
+
+  @Test
+  public void encodeDecodeSecretInfoWithNull() throws Exception {
+    SecretInfoCodec encoderDecoder = new SecretInfoCodec();
+    String secretData = "secretData";
+    long creationTime = System.currentTimeMillis();
+    Map<String, String> properties = new HashMap<>();
+    SecretInfo secretInfo = new SecretInfo("secretName", null, secretData.getBytes(StandardCharsets.UTF_8),
+                                           creationTime, properties);
+    byte[] encodedSecretInfo = encoderDecoder.encode(secretInfo);
+    SecretInfo decodedSecretInfo = encoderDecoder.decode(encodedSecretInfo);
+
+    Assert.assertArrayEquals(secretInfo.getSecretData(), decodedSecretInfo.getSecretData());
+    Assert.assertEquals(secretInfo.getName(), decodedSecretInfo.getName());
+    Assert.assertEquals(secretInfo.getDescription(), decodedSecretInfo.getDescription());
+    Assert.assertEquals(secretInfo.getCreationTimeMs(), decodedSecretInfo.getCreationTimeMs());
+    Assert.assertEquals(secretInfo.getDescription(), decodedSecretInfo.getDescription());
+    Assert.assertEquals(secretInfo.getProperties().size(), decodedSecretInfo.getProperties().size());
+  }
 }

--- a/cdap-securestore-spi/pom.xml
+++ b/cdap-securestore-spi/pom.xml
@@ -34,6 +34,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cdap-securestore-spi/src/main/java/co/cask/cdap/securestore/spi/secret/SecretMetadata.java
+++ b/cdap-securestore-spi/src/main/java/co/cask/cdap/securestore/spi/secret/SecretMetadata.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Represents metadata for the sensitive data to be stored.
@@ -38,7 +39,8 @@ public class SecretMetadata {
    * @param creationTimeMs creation time of the secret in milli seconds
    * @param properties properties of the secret
    */
-  public SecretMetadata(String name, String description, long creationTimeMs, Map<String, String> properties) {
+  public SecretMetadata(String name, @Nullable String description, long creationTimeMs,
+                        Map<String, String> properties) {
     this.name = name;
     this.description = description;
     this.creationTimeMs = creationTimeMs;
@@ -55,6 +57,7 @@ public class SecretMetadata {
   /**
    * @return description of the secret
    */
+  @Nullable
   public String getDescription() {
     return description;
   }

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,6 +28,7 @@ import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
 import co.cask.cdap.api.messaging.TopicNotFoundException;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
@@ -37,8 +38,10 @@ import com.google.inject.assistedinject.Assisted;
 import org.apache.tephra.TransactionFailureException;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /**
  * An {@link AuthorizationContext} that delegates to the provided {@link DatasetContext}, {@link Admin} and
@@ -149,14 +152,14 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws Exception {
-    delegateAdmin.putSecureData(namespace, name, data, description, properties);
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws Exception {
+    delegateAdmin.put(namespace, name, data, description, properties);
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
-    delegateAdmin.deleteSecureData(namespace, name);
+  public void delete(String namespace, String name) throws Exception {
+    delegateAdmin.delete(namespace, name);
   }
 
 
@@ -192,13 +195,13 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
-    return delegateSecureStore.listSecureData(namespace);
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
+    return delegateSecureStore.list(namespace);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
-    return delegateSecureStore.getSecureData(namespace, name);
+  public SecureStoreData get(String namespace, String name) throws Exception {
+    return delegateSecureStore.get(namespace, name);
   }
 
   @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/preview/PreviewSecureStore.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/preview/PreviewSecureStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,8 +18,11 @@ package co.cask.cdap.security.guice.preview;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreData;
 import co.cask.cdap.api.security.store.SecureStoreManager;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 
+import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Secure store to be used for preview. Reads are delegated but writes should happen in memory
@@ -33,23 +36,23 @@ public class PreviewSecureStore implements SecureStore, SecureStoreManager {
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
-    return delegate.listSecureData(namespace);
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
+    return delegate.list(namespace);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
-    return delegate.getSecureData(namespace, name);
+  public SecureStoreData get(String namespace, String name) throws Exception {
+    return delegate.get(namespace, name);
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws Exception {
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws Exception {
     //TODO put data in in-mempry map
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
+  public void delete(String namespace, String name) throws Exception {
     // TODO delete the data from in-memory map if its present otherwise it would be no-op since we do not want to
     // delegate it
   }

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/DefaultSecureStoreService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/DefaultSecureStoreService.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.security.store;
 
 import co.cask.cdap.api.security.store.SecureStoreData;
-import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -29,14 +29,14 @@ import co.cask.cdap.security.guice.SecureStoreServerModule;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
-import com.google.common.base.Strings;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Default implementation of the service that manages access to the Secure Store,
@@ -66,12 +66,11 @@ public class DefaultSecureStoreService extends AbstractIdleService implements Se
    *
    */
   @Override
-  public final Map<String, String> listSecureData(final String namespace) throws Exception {
+  public final List<SecureStoreMetadata> list(final String namespace) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
-    Map<String, String> metadatas = new HashMap<>(secureStoreService.listSecureData(namespace));
-    metadatas.keySet().retainAll(AuthorizationUtil.isVisible(metadatas.keySet(), authorizationEnforcer, principal,
-                                                             input -> new SecureKeyId(namespace, input), null));
-    return metadatas;
+    List<SecureStoreMetadata> metadatas = secureStoreService.list(namespace);
+    return AuthorizationUtil.isVisible(metadatas, authorizationEnforcer, principal,
+                                       input -> new SecureKeyId(namespace, input.getName()), null);
   }
 
   /**
@@ -85,35 +84,28 @@ public class DefaultSecureStoreService extends AbstractIdleService implements Se
    * @throws UnauthorizedException If the user does not have READ permissions on the secure key.
    */
   @Override
-  public final SecureStoreData getSecureData(String namespace, String name) throws Exception {
+  public final SecureStoreData get(String namespace, String name) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     SecureKeyId secureKeyId = new SecureKeyId(namespace, name);
     authorizationEnforcer.enforce(secureKeyId, principal, Action.READ);
-    return secureStoreService.getSecureData(namespace, name);
+    return secureStoreService.get(namespace, name);
   }
 
   /**
    * Puts the user provided data in the secure store, if the user has admin access to the key.
    *
-   * @throws BadRequestException If the request does not contain the value to be stored.
    * @throws UnauthorizedException If the user does not have write permissions on the namespace.
    * @throws NamespaceNotFoundException If the specified namespace does not exist.
    * @throws IOException If there was a problem storing the key to underlying provider.
    */
   @Override
-  public final synchronized void putSecureData(String namespace, String name, String value, String description,
-                                               Map<String, String> properties) throws Exception {
+  public final synchronized void put(String namespace, String name, String value, @Nullable String description,
+                                     Map<String, String> properties) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     NamespaceId namespaceId = new NamespaceId(namespace);
     SecureKeyId secureKeyId = namespaceId.secureKey(name);
     authorizationEnforcer.enforce(secureKeyId, principal, Action.ADMIN);
-
-    if (Strings.isNullOrEmpty(value)) {
-      throw new BadRequestException("The data field should not be empty. This is the data that will be stored " +
-                                      "securely.");
-    }
-
-    secureStoreService.putSecureData(namespace, name, value, description, properties);
+    secureStoreService.put(namespace, name, value, description, properties);
   }
 
   /**
@@ -125,11 +117,11 @@ public class DefaultSecureStoreService extends AbstractIdleService implements Se
    * @throws IOException If there was a problem deleting it from the underlying provider.
    */
   @Override
-  public final void deleteSecureData(String namespace, String name) throws Exception {
+  public final void delete(String namespace, String name) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     SecureKeyId secureKeyId = new SecureKeyId(namespace, name);
     authorizationEnforcer.enforce(secureKeyId, principal, Action.ADMIN);
-    secureStoreService.deleteSecureData(namespace, name);
+    secureStoreService.delete(namespace, name);
   }
 
   @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/DummySecureStoreService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/DummySecureStoreService.java
@@ -17,10 +17,13 @@
 package co.cask.cdap.security.store;
 
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * A dummy class that is loaded when the user has set the provider to "none".
@@ -32,23 +35,23 @@ public class DummySecureStoreService extends AbstractIdleService implements Secu
     "\"security.store.provider\" property in cdap-site.xml.";
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws IOException {
+  public List<SecureStoreMetadata> list(String namespace) throws IOException {
     throw new UnsupportedOperationException(SECURE_STORE_SETUP);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws IOException {
+  public SecureStoreData get(String namespace, String name) throws IOException {
     throw new UnsupportedOperationException(SECURE_STORE_SETUP);
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws IOException {
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws IOException {
     throw new UnsupportedOperationException(SECURE_STORE_SETUP);
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) throws IOException {
+  public void delete(String namespace, String name) throws IOException {
     throw new UnsupportedOperationException(SECURE_STORE_SETUP);
   }
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/FileSecureStoreService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/FileSecureStoreService.java
@@ -50,12 +50,15 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.Nullable;
 import javax.crypto.spec.SecretKeySpec;
 
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
@@ -118,11 +121,11 @@ public class FileSecureStoreService extends AbstractIdleService implements Secur
    * or if there was problem persisting the keystore.
    */
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws Exception {
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws Exception {
     checkNamespaceExists(namespace);
     String keyName = getKeyName(namespace, name);
-    SecureStoreMetadata meta = SecureStoreMetadata.of(name, description, properties);
+    SecureStoreMetadata meta = new SecureStoreMetadata(name, description, System.currentTimeMillis(), properties);
     SecureStoreData secureStoreData = new SecureStoreData(meta, data.getBytes(Charsets.UTF_8));
     writeLock.lock();
     try {
@@ -153,7 +156,7 @@ public class FileSecureStoreService extends AbstractIdleService implements Secur
    * or if there was a problem persisting the keystore after deleting the element.
    */
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
+  public void delete(String namespace, String name) throws Exception {
     checkNamespaceExists(namespace);
     String keyName = getKeyName(namespace, name);
     Key key = null;
@@ -188,21 +191,21 @@ public class FileSecureStoreService extends AbstractIdleService implements Secur
    * @throws IOException If there was a problem reading from the keystore.
    */
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
     checkNamespaceExists(namespace);
     readLock.lock();
     try {
       Enumeration<String> aliases = keyStore.aliases();
-      Map<String, String> data = new HashMap<>();
+      List<SecureStoreMetadata> metadataList = new ArrayList<>();
       String prefix = namespace + NAME_SEPARATOR;
       while (aliases.hasMoreElements()) {
         String alias = aliases.nextElement();
         // Filter out elements not in this namespace.
         if (alias.startsWith(prefix)) {
-          data.put(alias.substring(prefix.length()), getSecureStoreMetadata(alias).getDescription());
+          metadataList.add(getSecureStoreMetadata(alias));
         }
       }
-      return data;
+      return metadataList;
     } catch (KeyStoreException e) {
       throw new IOException("Failed to get the list of elements from the secure store.", e);
     } finally {
@@ -220,7 +223,7 @@ public class FileSecureStoreService extends AbstractIdleService implements Secur
    * @throws IOException If there was a problem reading from the store.
    */
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
+  public SecureStoreData get(String namespace, String name) throws Exception {
     checkNamespaceExists(namespace);
     String keyName = getKeyName(namespace, name);
     readLock.lock();
@@ -370,7 +373,10 @@ public class FileSecureStoreService extends AbstractIdleService implements Secur
       // Writing the metadata
       SecureStoreMetadata meta = data.getMetadata();
       dos.writeUTF(meta.getName());
-      dos.writeUTF(meta.getDescription());
+      dos.writeBoolean(meta.getDescription() != null);
+      if (meta.getDescription() != null) {
+        dos.writeUTF(meta.getDescription());
+      }
       dos.writeLong(meta.getLastModifiedTime());
 
       Map<String, String> properties = meta.getProperties();
@@ -392,7 +398,8 @@ public class FileSecureStoreService extends AbstractIdleService implements Secur
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data));
 
     String name = dis.readUTF();
-    String description = dis.readUTF();
+    boolean descriptionExists = dis.readBoolean();
+    String description = descriptionExists ? dis.readUTF() : null;
     long lastModified = dis.readLong();
 
     Map<String, String> properties = new HashMap<>();

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/secretmanager/SecretManagerSecureStoreService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/secretmanager/SecretManagerSecureStoreService.java
@@ -40,8 +40,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Secret manager based secure store service to call {@link SecretManager} methods.
@@ -85,18 +87,18 @@ public class SecretManagerSecureStoreService extends AbstractIdleService impleme
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
     validate(namespace);
-    Map<String, String> map = new HashMap<>();
+    List<SecureStoreMetadata> metadataList = new ArrayList<>();
     for (SecretMetadata metadata : secretManager.list(namespace)) {
-      map.put(metadata.getName(), metadata.getDescription());
+      metadataList.add(new SecureStoreMetadata(metadata.getName(), metadata.getDescription(),
+                                               metadata.getCreationTimeMs(), metadata.getProperties()));
     }
-
-    return map;
+    return metadataList;
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
+  public SecureStoreData get(String namespace, String name) throws Exception {
     validate(namespace);
     try {
       Secret secret = secretManager.get(namespace, name);
@@ -110,8 +112,8 @@ public class SecretManagerSecureStoreService extends AbstractIdleService impleme
   }
 
   @Override
-  public void putSecureData(String namespace, String name, String data, String description,
-                            Map<String, String> properties) throws Exception {
+  public void put(String namespace, String name, String data, @Nullable String description,
+                  Map<String, String> properties) throws Exception {
     validate(namespace);
     secretManager.store(namespace, new Secret(data.getBytes(StandardCharsets.UTF_8),
                                               new SecretMetadata(name, description, System.currentTimeMillis(),
@@ -119,7 +121,7 @@ public class SecretManagerSecureStoreService extends AbstractIdleService impleme
   }
 
   @Override
-  public void deleteSecureData(String namespace, String name) throws Exception {
+  public void delete(String namespace, String name) throws Exception {
     validate(namespace);
     try {
       secretManager.delete(namespace, name);

--- a/cdap-security/src/test/java/co/cask/cdap/security/store/FileSecureStoreServiceTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/store/FileSecureStoreServiceTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.conf.SConfiguration;
 import co.cask.cdap.common.namespace.InMemoryNamespaceAdmin;
 import co.cask.cdap.proto.NamespaceMeta;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.UnmodifiableIterator;
 import org.apache.commons.io.Charsets;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,7 +38,9 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class FileSecureStoreServiceTest {
@@ -90,73 +93,78 @@ public class FileSecureStoreServiceTest {
   }
 
   private void populateStore() throws Exception {
-    secureStoreManager.putSecureData(NAMESPACE1, KEY1, VALUE1, DESCRIPTION1, PROPERTIES_1);
-    secureStoreManager.putSecureData(NAMESPACE1, KEY2, VALUE2, DESCRIPTION2, PROPERTIES_2);
+    secureStoreManager.put(NAMESPACE1, KEY1, VALUE1, DESCRIPTION1, PROPERTIES_1);
+    secureStoreManager.put(NAMESPACE1, KEY2, VALUE2, DESCRIPTION2, PROPERTIES_2);
   }
 
   @Test
   public void testListEmpty() throws Exception {
-    Assert.assertEquals(Collections.<String, String>emptyMap(), secureStore.listSecureData(NAMESPACE1));
+    Assert.assertEquals(Collections.emptyList(), secureStore.list(NAMESPACE1));
   }
 
   @Test
   public void testList() throws Exception {
     populateStore();
-    Map<String, String> expected = ImmutableMap.of(KEY1, DESCRIPTION1, KEY2, DESCRIPTION2);
-    Assert.assertEquals(expected, secureStore.listSecureData(NAMESPACE1));
+    List<SecureStoreMetadata> metadatas = secureStore.list(NAMESPACE1);
+    metadatas.sort(Comparator.comparing(SecureStoreMetadata::getName));
+    verifyList(metadatas, ImmutableMap.of(KEY1, DESCRIPTION1, KEY2, DESCRIPTION2));
   }
 
   @Test
   public void testGet() throws Exception {
     populateStore();
-    SecureStoreMetadata metadata = SecureStoreMetadata.of(KEY1, DESCRIPTION1, PROPERTIES_1);
+    SecureStoreMetadata metadata = new SecureStoreMetadata(KEY1, DESCRIPTION1, System.currentTimeMillis(),
+                                                           PROPERTIES_1);
     SecureStoreData secureStoreData = new SecureStoreData(metadata, VALUE1.getBytes(Charsets.UTF_8));
-    Assert.assertArrayEquals(secureStoreData.get(), secureStore.getSecureData(NAMESPACE1, KEY1).get());
+    Assert.assertArrayEquals(secureStoreData.get(), secureStore.get(NAMESPACE1, KEY1).get());
     Assert.assertEquals(metadata.getDescription(),
-                        secureStore.getSecureData(NAMESPACE1, KEY1).getMetadata().getDescription());
-    Assert.assertEquals(metadata.getName(), secureStore.getSecureData(NAMESPACE1, KEY1).getMetadata().getName());
+                        secureStore.get(NAMESPACE1, KEY1).getMetadata().getDescription());
+    Assert.assertEquals(metadata.getName(), secureStore.get(NAMESPACE1, KEY1).getMetadata().getName());
   }
 
   @Test
   public void testGetMetadata() throws Exception {
     populateStore();
-    SecureStoreMetadata metadata = SecureStoreMetadata.of(KEY1, DESCRIPTION1, PROPERTIES_1);
+    SecureStoreMetadata metadata = new SecureStoreMetadata(KEY1, DESCRIPTION1, System.currentTimeMillis(),
+                                                           PROPERTIES_1);
     Assert.assertEquals(metadata.getDescription(),
-                        secureStore.getSecureData(NAMESPACE1, KEY1).getMetadata().getDescription());
-    Assert.assertEquals(metadata.getName(), secureStore.getSecureData(NAMESPACE1, KEY1).getMetadata().getName());
-    SecureStoreMetadata metadata2 = SecureStoreMetadata.of(KEY2, DESCRIPTION2, PROPERTIES_2);
+                        secureStore.get(NAMESPACE1, KEY1).getMetadata().getDescription());
+    Assert.assertEquals(metadata.getName(), secureStore.get(NAMESPACE1, KEY1).getMetadata().getName());
+    SecureStoreMetadata metadata2 = new SecureStoreMetadata(KEY2, DESCRIPTION2, System.currentTimeMillis(),
+                                                            PROPERTIES_2);
     Assert.assertEquals(metadata2.getDescription(),
-                        secureStore.getSecureData(NAMESPACE1, KEY2).getMetadata().getDescription());
-    Assert.assertEquals(metadata2.getName(), secureStore.getSecureData(NAMESPACE1, KEY2).getMetadata().getName());
+                        secureStore.get(NAMESPACE1, KEY2).getMetadata().getDescription());
+    Assert.assertEquals(metadata2.getName(), secureStore.get(NAMESPACE1, KEY2).getMetadata().getName());
   }
 
   @Test
   public void testOverwrite() throws Exception {
-    secureStoreManager.putSecureData(NAMESPACE1, KEY1, VALUE1, DESCRIPTION1, PROPERTIES_1);
-    SecureStoreData oldData = secureStore.getSecureData(NAMESPACE1, KEY1);
+    secureStoreManager.put(NAMESPACE1, KEY1, VALUE1, DESCRIPTION1, PROPERTIES_1);
+    SecureStoreData oldData = secureStore.get(NAMESPACE1, KEY1);
     Assert.assertArrayEquals(VALUE1.getBytes(Charsets.UTF_8), oldData.get());
     String newVal = "New value";
-    secureStoreManager.putSecureData(NAMESPACE1, KEY1, newVal, DESCRIPTION2, PROPERTIES_1);
+    secureStoreManager.put(NAMESPACE1, KEY1, newVal, DESCRIPTION2, PROPERTIES_1);
 
-    SecureStoreData updated = secureStore.getSecureData(NAMESPACE1, KEY1);
+    SecureStoreData updated = secureStore.get(NAMESPACE1, KEY1);
     Assert.assertArrayEquals(newVal.getBytes(StandardCharsets.UTF_8), updated.get());
     Assert.assertEquals(DESCRIPTION2, updated.getMetadata().getDescription());
   }
 
   @Test(expected = NotFoundException.class)
   public void testGetNonExistent() throws Exception {
-    secureStore.getSecureData(NAMESPACE1, "Dummy");
+    secureStore.get(NAMESPACE1, "Dummy");
   }
 
   @Test(expected = NotFoundException.class)
   public void testDelete() throws Exception {
     populateStore();
-    SecureStoreMetadata metadata = SecureStoreMetadata.of(KEY1, DESCRIPTION1, PROPERTIES_1);
+    SecureStoreMetadata metadata = new SecureStoreMetadata(KEY1, DESCRIPTION1, System.currentTimeMillis(),
+                                                           PROPERTIES_1);
     SecureStoreData secureStoreData = new SecureStoreData(metadata, VALUE1.getBytes(Charsets.UTF_8));
-    Assert.assertArrayEquals(secureStoreData.get(), secureStore.getSecureData(NAMESPACE1, KEY1).get());
-    secureStoreManager.deleteSecureData(NAMESPACE1, KEY1);
+    Assert.assertArrayEquals(secureStoreData.get(), secureStore.get(NAMESPACE1, KEY1).get());
+    secureStoreManager.delete(NAMESPACE1, KEY1);
     try {
-      secureStore.getSecureData(NAMESPACE1, KEY1);
+      secureStore.get(NAMESPACE1, KEY1);
     } catch (IOException ioe) {
       Assert.assertTrue(ioe.getMessage().contains("not found in the secure store"));
       throw ioe;
@@ -166,13 +174,34 @@ public class FileSecureStoreServiceTest {
   @Test
   public void testMultipleNamespaces() throws Exception {
     populateStore();
-    String ns = "namespace2";
-    secureStoreManager.putSecureData(ns, KEY1, VALUE1, DESCRIPTION1, PROPERTIES_1);
-    Map<String, String> expected = ImmutableMap.of(KEY1, DESCRIPTION1, KEY2, DESCRIPTION2);
-    Assert.assertEquals(expected, secureStore.listSecureData(NAMESPACE1));
-    Assert.assertNotEquals(expected, secureStore.listSecureData(NAMESPACE2));
-    Map<String, String> expected2 = ImmutableMap.of(KEY1, DESCRIPTION1);
-    Assert.assertEquals(expected2, secureStore.listSecureData(NAMESPACE2));
-    Assert.assertNotEquals(expected2, secureStore.listSecureData(NAMESPACE1));
+    secureStoreManager.put(NAMESPACE2, "ns2-" + KEY1, VALUE1, DESCRIPTION1, PROPERTIES_1);
+    secureStoreManager.put(NAMESPACE2, "ns2-" + KEY2, VALUE2, DESCRIPTION2, PROPERTIES_2);
+
+    List<SecureStoreMetadata> metadatas = secureStore.list(NAMESPACE1);
+    metadatas.sort(Comparator.comparing(SecureStoreMetadata::getName));
+    verifyList(metadatas, ImmutableMap.of(KEY1, DESCRIPTION1, KEY2, DESCRIPTION2));
+
+    metadatas = secureStore.list(NAMESPACE2);
+    metadatas.sort(Comparator.comparing(SecureStoreMetadata::getName));
+    verifyList(metadatas, ImmutableMap.of("ns2-" + KEY1, DESCRIPTION1, "ns2-" + KEY2, DESCRIPTION2));
+  }
+
+  private void verifyList(List<SecureStoreMetadata> metadatas, ImmutableMap<String, String> map) {
+    Assert.assertEquals(metadatas.size(), map.size());
+    UnmodifiableIterator<Map.Entry<String, String>> iterator = map.entrySet().iterator();
+    for (SecureStoreMetadata metadata : metadatas) {
+      Map.Entry<String, String> expected = iterator.next();
+      Assert.assertEquals(expected.getKey(), metadata.getName());
+      Assert.assertEquals(expected.getValue(), metadata.getDescription());
+    }
+  }
+
+  @Test
+  public void testNullDescription() throws Exception {
+    secureStoreManager.put(NAMESPACE1, KEY1, VALUE1, null, PROPERTIES_1);
+    List<SecureStoreMetadata> metadatas = secureStore.list(NAMESPACE1);
+    metadatas.sort(Comparator.comparing(SecureStoreMetadata::getName));
+    Assert.assertEquals(KEY1, metadatas.get(0).getName());
+    Assert.assertNull(metadatas.get(0).getDescription());
   }
 }

--- a/cdap-security/src/test/java/co/cask/cdap/security/store/client/RemoteSecureStoreTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/store/client/RemoteSecureStoreTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
+import java.util.List;
 
 /**
  * Tests for {@link RemoteSecureStore}.
@@ -93,27 +93,27 @@ public class RemoteSecureStoreTest {
                                                           "value".getBytes(StandardCharsets.UTF_8));
 
     // test put and get
-    remoteSecureStore.putSecureData(NAMESPACE1, "key", "value", "description", ImmutableMap.of("prop1", "value1"));
-    SecureStoreData actual = remoteSecureStore.getSecureData(NAMESPACE1, "key");
+    remoteSecureStore.put(NAMESPACE1, "key", "value", "description", ImmutableMap.of("prop1", "value1"));
+    SecureStoreData actual = remoteSecureStore.get(NAMESPACE1, "key");
     Assert.assertEquals(secureStoreMetadata.getName(), actual.getMetadata().getName());
     Assert.assertArrayEquals(secureStoreData.get(), actual.get());
     Assert.assertEquals(secureStoreMetadata.getDescription(), actual.getMetadata().getDescription());
     Assert.assertEquals(secureStoreMetadata.getProperties().size(), actual.getMetadata().getProperties().size());
 
     // test list
-    Map<String, String> secureData = remoteSecureStore.listSecureData(NAMESPACE1);
+    List<SecureStoreMetadata> secureData = remoteSecureStore.list(NAMESPACE1);
     Assert.assertEquals(1, secureData.size());
-    Map.Entry<String, String> entry = secureData.entrySet().iterator().next();
-    Assert.assertEquals("key", entry.getKey());
-    Assert.assertEquals("description", entry.getValue());
+    SecureStoreMetadata metadata = secureData.get(0);
+    Assert.assertEquals("key", metadata.getName());
+    Assert.assertEquals("description", metadata.getDescription());
 
     // test delete
-    remoteSecureStore.deleteSecureData(NAMESPACE1, "key");
-    Assert.assertEquals(0, remoteSecureStore.listSecureData(NAMESPACE1).size());
+    remoteSecureStore.delete(NAMESPACE1, "key");
+    Assert.assertEquals(0, remoteSecureStore.list(NAMESPACE1).size());
   }
 
   @Test(expected = SecureKeyNotFoundException.class)
   public void testKeyNotFound() throws Exception {
-    remoteSecureStore.getSecureData(NAMESPACE1, "nonexistingkey");
+    remoteSecureStore.get(NAMESPACE1, "nonexistingkey");
   }
 }

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -38,6 +38,7 @@ import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo;
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.workflow.WorkflowInfo;
@@ -303,13 +304,13 @@ final class BasicSparkClientContext implements SparkClientContext {
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
-    return sparkRuntimeContext.listSecureData(namespace);
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
+    return sparkRuntimeContext.list(namespace);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
-    return sparkRuntimeContext.getSecureData(namespace, name);
+  public SecureStoreData get(String namespace, String name) throws Exception {
+    return sparkRuntimeContext.get(namespace, name);
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkSecureStore.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/SparkSecureStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,12 +18,13 @@ package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.Map;
+import java.util.List;
 
 /**
  * A {@link Externalizable} implementation of {@link SecureStore} used in Spark program execution.
@@ -49,13 +50,13 @@ public class SparkSecureStore implements SecureStore, Externalizable {
   }
 
   @Override
-  public Map<String, String> listSecureData(String namespace) throws Exception {
-    return delegate.listSecureData(namespace);
+  public List<SecureStoreMetadata> list(String namespace) throws Exception {
+    return delegate.list(namespace);
   }
 
   @Override
-  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
-    return delegate.getSecureData(namespace, name);
+  public SecureStoreData get(String namespace, String name) throws Exception {
+    return delegate.get(namespace, name);
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -33,8 +33,7 @@ import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.preview.DataTracer
 import co.cask.cdap.api.schedule.TriggeringScheduleInfo
-import co.cask.cdap.api.security.store.SecureStore
-import co.cask.cdap.api.security.store.SecureStoreData
+import co.cask.cdap.api.security.store.{SecureStore, SecureStoreData, SecureStoreMetadata}
 import co.cask.cdap.api.spark.JavaSparkExecutionContext
 import co.cask.cdap.api.spark.SparkExecutionContext
 import co.cask.cdap.api.spark.SparkSpecification
@@ -131,13 +130,13 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
   override def getTriggeringScheduleInfo: TriggeringScheduleInfo = sec.getTriggeringScheduleInfo.getOrElse(null)
 
   @throws[IOException]
-  override def listSecureData(namespace: String): util.Map[String, String] = {
-    return sec.getSecureStore.listSecureData(namespace)
+  override def list(namespace: String): util.List[SecureStoreMetadata] = {
+    return sec.getSecureStore.list(namespace)
   }
 
   @throws[IOException]
-  override def getSecureData(namespace: String, name: String): SecureStoreData = {
-    return sec.getSecureStore.getSecureData(namespace, name)
+  override def get(namespace: String, name: String): SecureStoreData = {
+    return sec.getSecureStore.get(namespace, name)
   }
 
   /**


### PR DESCRIPTION
Build: https://builds.cask.co/browse/CDAP-DUT6740-3

PR Changes:

- Modified `SecureStore` and `SecureStoreManager` api method names to get, list, put and delete and removed redundant `SecureData` from method names.
- Changed `SecureStore` list api to return `List<SecureStoreMetadata>` instead of `Map<String,String`.
- Made changes to `FileSecureStoreService` and `SecretInfoCodec` to handle null description. 
- Also marked description as `Nullable` in api and spi.
- Removed `of` method in `SecureStoreMetadata`, instead using constructor.
- Moved secure data validation to `SecureStoreHandler`.

No usage of existing apis were found in integration tests repo and hydrator plugins repo.