### PR TITLE
CDAP-14795 add namespaced create classloader method

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactManager.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactManager.java
@@ -56,4 +56,19 @@ public interface ArtifactManager {
    */
   CloseableClassLoader createClassLoader(ArtifactInfo artifactInfo,
                                          @Nullable ClassLoader parentClassLoader) throws IOException;
+
+  /**
+   * Create a class loader using the artifact represented by artifactInfo with parent as parentClassloader
+   * Call to this method might take a long time based on the size of the artifact.
+   * If called from short transactions, it is possible this call will timeout if the artifact size is large
+   *
+   * @param namespace the namespace of the specified artifact. This should be the same namespace that was used when
+   *  calling {@link #listArtifacts(String)}
+   * @param artifactInfo artifact info
+   * @param parentClassLoader parent class loader, if null bootstrap classLoader shall be used as parent
+   * @throws IOException if there were any exception while creating the class loader or if the artifact is not found
+   * @return Closeable class loader, calling close on this does the necessary cleanup.
+   */
+  CloseableClassLoader createClassLoader(String namespace, ArtifactInfo artifactInfo,
+                                         @Nullable ClassLoader parentClassLoader) throws IOException;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/AbstractArtifactManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/AbstractArtifactManager.java
@@ -57,10 +57,12 @@ public abstract class AbstractArtifactManager implements ArtifactManager {
    * Returns the {@link Location} of the give artifact.
    *
    * @param artifactInfo information of the artifact
+   * @param namespace artifact namespace, or null if the program namespace should not be used
    * @return the {@link Location} of the artifact
    * @throws IOException if failed to locate the {@link Location} of the artifact
    */
-  protected abstract Location getArtifactLocation(ArtifactInfo artifactInfo) throws IOException;
+  protected abstract Location getArtifactLocation(ArtifactInfo artifactInfo,
+                                                  @Nullable String namespace) throws IOException;
 
   /**
    * Create a class loader with artifact jar unpacked contents and parent for this classloader is the supplied
@@ -76,8 +78,14 @@ public abstract class AbstractArtifactManager implements ArtifactManager {
   @Override
   public CloseableClassLoader createClassLoader(ArtifactInfo artifactInfo,
                                                 @Nullable ClassLoader parentClassLoader) throws IOException {
+    return createClassLoader(null, artifactInfo, parentClassLoader);
+  }
+
+  @Override
+  public CloseableClassLoader createClassLoader(@Nullable String namespace, ArtifactInfo artifactInfo,
+                                                @Nullable ClassLoader parentClassLoader) throws IOException {
     File unpackedDir = DirUtils.createTempDir(tmpDir);
-    BundleJarUtil.unJar(getArtifactLocation(artifactInfo), unpackedDir);
+    BundleJarUtil.unJar(getArtifactLocation(artifactInfo, namespace), unpackedDir);
     DirectoryClassLoader directoryClassLoader =
       new DirectoryClassLoader(unpackedDir,
                                parentClassLoader == null ? bootstrapClassLoader : parentClassLoader, "lib");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/LocalArtifactManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/LocalArtifactManager.java
@@ -32,6 +32,7 @@ import org.apache.twill.filesystem.Location;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * An implementation of {@link ArtifactManager} that talks to {@link ArtifactRepository} directly.
@@ -79,8 +80,16 @@ public final class LocalArtifactManager extends AbstractArtifactManager {
   }
 
   @Override
-  protected Location getArtifactLocation(ArtifactInfo artifactInfo) throws IOException {
-    NamespaceId namespace = ArtifactScope.SYSTEM.equals(artifactInfo.getScope()) ? NamespaceId.SYSTEM : namespaceId;
+  protected Location getArtifactLocation(ArtifactInfo artifactInfo,
+                                         @Nullable String artifactNamespace) throws IOException {
+    NamespaceId namespace;
+    if (ArtifactScope.SYSTEM.equals(artifactInfo.getScope())) {
+      namespace = NamespaceId.SYSTEM;
+    } else if (artifactNamespace != null) {
+      namespace = new NamespaceId(artifactNamespace);
+    } else {
+      namespace = namespaceId;
+    }
     ArtifactId artifactId = namespace.artifact(artifactInfo.getName(), artifactInfo.getVersion());
 
     return Retries.callWithRetries(() -> {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/RemoteArtifactManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/RemoteArtifactManager.java
@@ -45,6 +45,7 @@ import org.apache.twill.filesystem.LocationFactory;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Implementation for {@link co.cask.cdap.api.artifact.ArtifactManager}
@@ -129,9 +130,16 @@ public final class RemoteArtifactManager extends AbstractArtifactManager {
   }
 
   @Override
-  protected Location getArtifactLocation(ArtifactInfo artifactInfo) throws IOException {
-    String namespace = ArtifactScope.SYSTEM.equals(artifactInfo.getScope()) ?
-      NamespaceId.SYSTEM.getNamespace() : namespaceId.getEntityName();
+  protected Location getArtifactLocation(ArtifactInfo artifactInfo,
+                                         @Nullable String artifactNamespace) throws IOException {
+    String namespace;
+    if (ArtifactScope.SYSTEM.equals(artifactInfo.getScope())) {
+      namespace = NamespaceId.SYSTEM.getNamespace();
+    } else if (artifactNamespace != null) {
+      namespace = artifactNamespace;
+    } else {
+      namespace = namespaceId.getNamespace();
+    }
 
     HttpRequest.Builder requestBuilder =
       remoteClient.requestBuilder(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -134,8 +134,14 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
   }
 
   @Override
-  public CloseableClassLoader createClassLoader(final ArtifactInfo artifactInfo,
-                                                @Nullable  final ClassLoader parentClassLoader) throws IOException {
+  public CloseableClassLoader createClassLoader(ArtifactInfo artifactInfo,
+                                                @Nullable ClassLoader parentClassLoader) throws IOException {
     return artifactManager.createClassLoader(artifactInfo, parentClassLoader);
+  }
+
+  @Override
+  public CloseableClassLoader createClassLoader(String namespace, ArtifactInfo artifactInfo,
+                                                @Nullable ClassLoader parentClassLoader) throws IOException {
+    return artifactManager.createClassLoader(namespace, artifactInfo, parentClassLoader);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -857,6 +857,12 @@ public class HttpHandlerGeneratorTest {
     }
 
     @Override
+    public CloseableClassLoader createClassLoader(String namespace, ArtifactInfo artifactInfo,
+                                                  @Nullable ClassLoader parentClassLoader) throws IOException {
+      return null;
+    }
+
+    @Override
     public Map<MetadataScope, Metadata> getMetadata(MetadataEntity metadataEntity) {
       return null;
     }


### PR DESCRIPTION
Added a namespaced version of the create classloader method in
ArtifactManager to mirror the namespaced version of the list
artifacts method.

This is required when an app in one namespace lists artifacts
in another namespace and wants to create a classloader. If the
namespace is not provided in the method, the namespace of the app
will be used, which will not be the true namespace of the artifact,
resulting in that artifact not being found.