### PR TITLE
CDAP-14793 add ability to instantiate plugins at service runtime

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
@@ -21,9 +21,11 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.artifact.ArtifactManager;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metadata.MetadataReader;
 import co.cask.cdap.api.metadata.MetadataWriter;
+import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -48,4 +50,18 @@ public interface HttpServiceContext extends RuntimeContext, DatasetContext, Serv
    * @return instance id of this handler.
    */
   int getInstanceId();
+
+  /**
+   * Create a {@link PluginConfigurer} that can be used to instantiate plugins at runtime that were not registered
+   * at configure time. Plugins registered by the dynamic configurer live in their own scope and will not
+   * conflict with any plugins that were registered by the service when it was configured. Plugins registered by
+   * the returned configurer will also not be available through {@link #newPluginInstance(String)} or
+   * {@link #newPluginInstance(String, MacroEvaluator)}.
+   *
+   * The dynamic configurer is meant to be used to create plugins for the lifetime of a single service call and
+   * then to be forgotten.
+   *
+   * @return an dynamic plugin configurer that must be closed
+   */
+  PluginConfigurer createPluginConfigurer();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -40,6 +40,7 @@ import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.SystemArguments;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
+import co.cask.cdap.internal.app.runtime.artifact.PluginFinder;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.services.ServiceHttpServer;
 import co.cask.cdap.messaging.MessagingService;
@@ -75,6 +76,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MetadataReader metadataReader;
   private final MetadataPublisher metadataPublisher;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final PluginFinder pluginFinder;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -84,7 +86,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               MessagingService messagingService,
                               ArtifactManagerFactory artifactManagerFactory,
                               MetadataReader metadataReader, MetadataPublisher metadataPublisher,
-                              NamespaceQueryAdmin namespaceQueryAdmin) {
+                              NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -98,6 +100,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.metadataReader = metadataReader;
     this.metadataPublisher = metadataPublisher;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.pluginFinder = pluginFinder;
   }
 
   @Override
@@ -139,7 +142,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           txClient, discoveryServiceClient,
                                                           pluginInstantiator, secureStore, secureStoreManager,
                                                           messagingService, artifactManager, metadataReader,
-                                                          metadataPublisher, namespaceQueryAdmin);
+                                                          metadataPublisher, namespaceQueryAdmin, pluginFinder);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton((Closeable) pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BodyConsumerAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BodyConsumerAdapter.java
@@ -100,6 +100,7 @@ final class BodyConsumerAdapter extends BodyConsumer {
     try {
       BodyConsumerAdapter.this.responder.execute();
     } finally {
+      taskExecutor.releaseCallResources();
       if (!this.responder.hasContentProducer()) {
         contextReleaser.cancel();
       }
@@ -156,6 +157,7 @@ final class BodyConsumerAdapter extends BodyConsumer {
       try {
         responder.execute(false);
       } finally {
+        taskExecutor.releaseCallResources();
         if (!responder.hasContentProducer()) {
           contextReleaser.cancel();
         }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/ServiceTaskExecutor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/ServiceTaskExecutor.java
@@ -46,6 +46,11 @@ public interface ServiceTaskExecutor {
   <T> T execute(Callable<T> callable, boolean transactional) throws Exception;
 
   /**
+   * Release resources that are no longer needed after an endpoint has been executed.
+   */
+  void releaseCallResources();
+
+  /**
    * Returns a {@link Transactional} used by this task executor for executing transactional tasks directly.
    */
   Transactional getTransactional();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -36,6 +36,7 @@ import co.cask.cdap.api.metadata.Metadata;
 import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.api.metrics.NoopMetricsContext;
+import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.api.security.store.SecureStoreData;
@@ -625,6 +626,11 @@ public class HttpHandlerGeneratorTest {
         }
 
         @Override
+        public void releaseCallResources() {
+          // no-op
+        }
+
+        @Override
         public Transactional getTransactional() {
           return context;
         }
@@ -660,6 +666,11 @@ public class HttpHandlerGeneratorTest {
     @Override
     public int getInstanceId() {
       return 1;
+    }
+
+    @Override
+    public PluginConfigurer createPluginConfigurer() {
+      return null;
     }
 
     @Override

--- a/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/service/SparkHttpServiceServer.java
+++ b/cdap-spark-core-base/src/main/java/co/cask/cdap/app/runtime/spark/service/SparkHttpServiceServer.java
@@ -159,6 +159,11 @@ public class SparkHttpServiceServer extends AbstractServiceHttpServer<SparkHttpS
         }
 
         @Override
+        public void releaseCallResources() {
+          // no-op
+        }
+
+        @Override
         public Transactional getTransactional() {
           return context;
         }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/DynamicPluginServiceApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/DynamicPluginServiceApp.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.service;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.service.AbstractService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpContentConsumer;
+import co.cask.cdap.api.service.http.HttpContentProducer;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
+import com.google.gson.Gson;
+
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * App for testing plugin instantiating at service runtime without registering any plugins at configure time.
+ */
+public class DynamicPluginServiceApp extends AbstractApplication {
+  public static final String PLUGIN_TYPE = "supplier";
+  public static final String SERVICE_NAME = "service";
+
+  @Override
+  public void configure() {
+    addService(new DynamicPluginService());
+  }
+
+  /**
+   * Dynamic plugin service
+   */
+  public static class DynamicPluginService extends AbstractService {
+
+    @Override
+    protected void configure() {
+      setName(SERVICE_NAME);
+      addHandler(new DynamicPluginHandler());
+    }
+  }
+
+  /**
+   * Dynamic plugin handler
+   */
+  public static class DynamicPluginHandler extends AbstractHttpServiceHandler {
+    private static final Gson GSON = new Gson();
+    private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+    private boolean onFinishSuccessful = false;
+    private boolean onErrorSuccessful = false;
+
+    @POST
+    @Path("plugins/{name}/apply")
+    public void callPluginFunction(HttpServiceRequest request, HttpServiceResponder responder,
+                                   @PathParam("name") String name) {
+      Map<String, String> properties = GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(),
+                                                     MAP_TYPE);
+      PluginProperties pluginProperties = PluginProperties.builder()
+        .addAll(properties)
+        .build();
+
+      PluginConfigurer pluginConfigurer = getContext().createPluginConfigurer();
+      Function<PluginConfigurer, String> plugin =
+        pluginConfigurer.usePlugin(PLUGIN_TYPE, name, UUID.randomUUID().toString(), pluginProperties);
+      if (plugin == null) {
+        responder.sendError(404, "Plugin " + name + " not found.");
+        return;
+      }
+
+      responder.sendString(plugin.apply(pluginConfigurer));
+    }
+
+    // used to test that plugins can be used within a BodyProducer
+    @POST
+    @Path("producer")
+    public void producePluginFunction(HttpServiceRequest request, HttpServiceResponder responder) {
+      PluginRequest pluginRequest = GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(),
+                                                  PluginRequest.class);
+      PluginConfigurer pluginConfigurer = getContext().createPluginConfigurer();
+
+      HttpContentProducer producer = new HttpContentProducer() {
+        private boolean done = false;
+
+        @Override
+        public ByteBuffer nextChunk(Transactional transactional) {
+          if (done) {
+            return ByteBuffer.allocate(0);
+          }
+
+          PluginProperties pluginProperties = PluginProperties.builder()
+            .addAll(pluginRequest.goodProperties)
+            .build();
+          Function<PluginConfigurer, String> plugin = pluginConfigurer.usePlugin(PLUGIN_TYPE, pluginRequest.goodName,
+                                                                                 UUID.randomUUID().toString(),
+                                                                                 pluginProperties);
+          if (plugin == null) {
+            return ByteBuffer.allocate(0);
+          }
+
+          done = true;
+          String result = plugin.apply(pluginConfigurer);
+          return ByteBuffer.wrap(Bytes.toBytes(result));
+        }
+
+        @Override
+        public void onFinish() {
+          // check instantiating in onFinish()
+          PluginProperties pluginProperties = PluginProperties.builder()
+            .addAll(pluginRequest.goodProperties)
+            .build();
+          Function<PluginConfigurer, String> plugin = pluginConfigurer.usePlugin(PLUGIN_TYPE, pluginRequest.goodName,
+                                                                                 UUID.randomUUID().toString(),
+                                                                                 pluginProperties);
+          onFinishSuccessful = plugin != null;
+        }
+
+        @Override
+        public void onError(Throwable failureCause) {
+          // no-op
+        }
+
+      };
+      responder.send(200, producer, "text/plain");
+    }
+
+    // used to check if the plugin was instantiated successfully in the ContentProducer's onFinish method
+    @GET
+    @Path("onFinishSuccessful")
+    public void onFinishSuccessful(HttpServiceRequest request, HttpServiceResponder responder) {
+      responder.sendString(Boolean.toString(onFinishSuccessful));
+    }
+
+    // used to test that plugins can be used within an HttpContentConsumer
+    // the PluginRequest is read using the content consumer
+    @POST
+    @Path("consumer")
+    public HttpContentConsumer callWithConsumer(HttpServiceRequest request, HttpServiceResponder responder) {
+      PluginConfigurer pluginConfigurer = getContext().createPluginConfigurer();
+      return new HttpContentConsumer() {
+        private byte[] body = new byte[0];
+        private PluginRequest pluginRequest;
+
+        @Override
+        public void onReceived(ByteBuffer chunk, Transactional transactional) {
+          body = Bytes.concat(body, Bytes.toBytes(chunk));
+        }
+
+        @Override
+        public void onFinish(HttpServiceResponder responder) {
+          pluginRequest = GSON.fromJson(Bytes.toString(body), PluginRequest.class);
+          PluginProperties pluginProperties = PluginProperties.builder()
+            .addAll(pluginRequest.goodProperties)
+            .build();
+          Function<PluginConfigurer, String> plugin = pluginConfigurer.usePlugin(PLUGIN_TYPE, pluginRequest.goodName,
+                                                                                 UUID.randomUUID().toString(),
+                                                                                 pluginProperties);
+          if (plugin == null) {
+            // throw an
+            throw new IllegalArgumentException("Plugin does not exist");
+          }
+          responder.sendString(plugin.apply(pluginConfigurer));
+        }
+
+        @Override
+        public void onError(HttpServiceResponder responder, Throwable failureCause) {
+          PluginProperties pluginProperties = PluginProperties.builder()
+            .addAll(pluginRequest.errorProperties)
+            .build();
+          Function<PluginConfigurer, String> plugin = pluginConfigurer.usePlugin(PLUGIN_TYPE, pluginRequest.errorName,
+                                                                                 UUID.randomUUID().toString(),
+                                                                                 pluginProperties);
+          if (plugin == null) {
+            responder.sendError(404, "error plugin not found");
+            return;
+          }
+          responder.sendError(400, plugin.apply(pluginConfigurer));
+        }
+      };
+    }
+
+  }
+
+  /**
+   * Request body of the 'contentconsumer' endpoint
+   */
+  public static class PluginRequest {
+    private final String goodName;
+    private final String errorName;
+    private final Map<String, String> goodProperties;
+    private final Map<String, String> errorProperties;
+
+    public PluginRequest(String goodName, Map<String, String> goodProperties,
+                         String errorName, Map<String, String> errorProperties) {
+      this.goodName = goodName;
+      this.errorName = errorName;
+      this.goodProperties = goodProperties;
+      this.errorProperties = errorProperties;
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/DynamicPluginServiceTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/DynamicPluginServiceTestRun.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.service;
+
+import co.cask.cdap.api.artifact.ArtifactManager;
+import co.cask.cdap.api.artifact.ArtifactSummary;
+import co.cask.cdap.api.service.Service;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.service.function.ConstantFunction;
+import co.cask.cdap.service.function.DelegatingFunction;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.ServiceManager;
+import co.cask.cdap.test.TestConfiguration;
+import co.cask.cdap.test.base.TestFrameworkTestBase;
+import co.cask.common.http.HttpMethod;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import com.google.gson.Gson;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit test for the {@link ArtifactManager} from {@link Service}.
+ */
+public class DynamicPluginServiceTestRun extends TestFrameworkTestBase {
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+  private static final Gson GSON = new Gson();
+
+  private ServiceManager serviceManager;
+  private URI baseURI;
+
+
+  @Before
+  public void initTest() throws Exception {
+    ArtifactId appArtifactId = NamespaceId.DEFAULT.artifact("dynamicPlugin", "1.0.0");
+    addAppArtifact(appArtifactId, DynamicPluginServiceApp.class);
+
+    ArtifactId pluginArtifactId = NamespaceId.DEFAULT.artifact("plugins", "1.0.0");
+    addPluginArtifact(pluginArtifactId, appArtifactId, ConstantFunction.class, DelegatingFunction.class);
+    ApplicationId appId = NamespaceId.DEFAULT.app("dynamicPluginService");
+    ArtifactSummary summary = new ArtifactSummary(appArtifactId.getArtifact(), appArtifactId.getVersion());
+    AppRequest<Void> appRequest = new AppRequest<>(summary);
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+    serviceManager = appManager.getServiceManager(DynamicPluginServiceApp.SERVICE_NAME);
+    serviceManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
+
+    baseURI = serviceManager.getServiceURL(1, TimeUnit.MINUTES).toURI();
+  }
+
+  @After
+  public void cleanupTest() throws Exception {
+    serviceManager.stop();
+    serviceManager.waitForStopped(2, TimeUnit.MINUTES);
+  }
+
+  @Test
+  public void testDynamicPluginSimple() throws Exception {
+    // test a single plugin
+    Map<String, String> properties = new HashMap<>();
+    properties.put("value", "x");
+    URL url = baseURI.resolve(String.format("plugins/%s/apply", ConstantFunction.NAME)).toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.POST, url)
+      .withBody(GSON.toJson(properties))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+    Assert.assertEquals("x", response.getResponseBodyAsString());
+
+    // test plugin that uses a plugin
+    Map<String, String> delegateProperties = new HashMap<>();
+    delegateProperties.put("value", "y");
+
+    properties = new HashMap<>();
+    properties.put("delegateName", ConstantFunction.NAME);
+    properties.put("properties", GSON.toJson(delegateProperties));
+    url = baseURI.resolve(String.format("plugins/%s/apply", DelegatingFunction.NAME)).toURL();
+    request = HttpRequest.builder(HttpMethod.POST, url)
+      .withBody(GSON.toJson(properties))
+      .build();
+    response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+    Assert.assertEquals("y", response.getResponseBodyAsString());
+  }
+
+  @Test
+  public void testDynamicPluginBodyProducer() throws Exception {
+    // test that a plugin can be instantiated in the body producer chunk() and onFinish() methods
+    // the good plugin should be found, so the response should be 'x'
+    DynamicPluginServiceApp.PluginRequest requestBody =
+      new DynamicPluginServiceApp.PluginRequest(ConstantFunction.NAME, Collections.singletonMap("value", "x"),
+                                                ConstantFunction.NAME, Collections.singletonMap("value", "y"));
+    URL producerUrl = baseURI.resolve("producer").toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.POST, producerUrl)
+      .withBody(GSON.toJson(requestBody))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+    Assert.assertEquals("x", response.getResponseBodyAsString());
+
+    URL onFinishUrl = baseURI.resolve("onFinishSuccessful").toURL();
+    request = HttpRequest.builder(HttpMethod.GET, onFinishUrl).build();
+    response = HttpRequests.execute(request);
+    Assert.assertTrue(Boolean.valueOf(response.getResponseBodyAsString()));
+  }
+
+  @Test
+  public void testDynamicPluginContentConsumer() throws Exception {
+    // test that a plugin can be instantiated in the content consumer finish method
+    // the good plugin should be found, so the response should be 'x'
+    DynamicPluginServiceApp.PluginRequest requestBody =
+      new DynamicPluginServiceApp.PluginRequest(ConstantFunction.NAME, Collections.singletonMap("value", "x"),
+                                                ConstantFunction.NAME, Collections.singletonMap("value", "y"));
+    URL url = baseURI.resolve("consumer").toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.POST, url)
+      .withBody(GSON.toJson(requestBody))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+    Assert.assertEquals("x", response.getResponseBodyAsString());
+
+    // test that a plugin can be instantiated in the content consumer error method
+    // the "good" plugin should not be found, so the response should be 'y'
+    requestBody =
+      new DynamicPluginServiceApp.PluginRequest("non-existent", Collections.singletonMap("value", "x"),
+                                                ConstantFunction.NAME, Collections.singletonMap("value", "y"));
+    request = HttpRequest.builder(HttpMethod.POST, url)
+      .withBody(GSON.toJson(requestBody))
+      .build();
+    response = HttpRequests.execute(request);
+    Assert.assertEquals(400, response.getResponseCode());
+    Assert.assertEquals("y", response.getResponseBodyAsString());
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/function/ConstantFunction.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/function/ConstantFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.service.function;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.service.DynamicPluginServiceApp;
+
+import java.util.function.Function;
+
+/**
+ * Plugin Function that just returns whatever value it was configured to return.
+ */
+@Plugin(type = DynamicPluginServiceApp.PLUGIN_TYPE)
+@Name(ConstantFunction.NAME)
+public class ConstantFunction implements Function<PluginConfigurer, String> {
+  public static final String NAME = "constant";
+  private final Conf conf;
+
+  public ConstantFunction(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public String apply(PluginConfigurer pluginConfigurer) {
+    return conf.value;
+  }
+
+  /**
+   * Config for the supplier
+   */
+  public static class Conf extends PluginConfig {
+    private String value;
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/function/DelegatingFunction.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/function/DelegatingFunction.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package co.cask.cdap.service.function;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
+import co.cask.cdap.service.DynamicPluginServiceApp;
+import com.google.gson.Gson;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * Plugin Function that tests a plugin using another plugin.
+ */
+@Plugin(type = DynamicPluginServiceApp.PLUGIN_TYPE)
+@Name(DelegatingFunction.NAME)
+public class DelegatingFunction implements Function<PluginConfigurer, String> {
+  public static final String NAME = "delegating";
+  private final Conf conf;
+
+  public DelegatingFunction(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public String apply(PluginConfigurer pluginConfigurer) {
+    Function<PluginConfigurer, String> delegate = pluginConfigurer.usePlugin(DynamicPluginServiceApp.PLUGIN_TYPE,
+                                                                             conf.delegateName,
+                                                                             UUID.randomUUID().toString(),
+                                                                             conf.getPluginProperties());
+    return delegate.apply(pluginConfigurer);
+  }
+
+  /**
+   * Config for the supplier
+   */
+  public static class Conf extends PluginConfig {
+    private static final Gson GSON = new Gson();
+    private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+
+    private String delegateName;
+
+    private String properties;
+
+    private PluginProperties getPluginProperties() {
+      Map<String, String> propertiesMap = GSON.fromJson(properties, MAP_TYPE);
+      return PluginProperties.builder()
+        .addAll(propertiesMap)
+        .build();
+    }
+  }
+
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
@@ -20,6 +20,7 @@ import co.cask.cdap.admin.AdminAppTestRun;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.test.TestSuite;
 import co.cask.cdap.mapreduce.service.MapReduceServiceIntegrationTestRun;
+import co.cask.cdap.service.DynamicPluginServiceTestRun;
 import co.cask.cdap.service.FileUploadServiceTestRun;
 import co.cask.cdap.service.ServiceArtifactTestRun;
 import co.cask.cdap.service.ServiceLifeCycleTestRun;
@@ -44,6 +45,7 @@ import org.junit.runners.Suite;
 @RunWith(TestSuite.class)
 @Suite.SuiteClasses({
   AdminAppTestRun.class,
+  DynamicPluginServiceTestRun.class,
   FileUploadServiceTestRun.class,
   MapReduceServiceIntegrationTestRun.class,
   MessagingAppTestRun.class,


### PR DESCRIPTION
Added a DynamicPluginConfigurer that can be created by services
at runtime to instantiate plugins that were not registered at
configure time. This is required by the pipeline system service
for validation and schema propagation.

Plugins registered by the DynamicPluginConfigurer live in their
own space and will not conflict with any already registered by
the service at configure time. They also will not be accessible
through the PluginContext, as the program should just use the
plugin instance returned by the configurer.