### PR TITLE
CDAP-14779 filter hadoop from action only workflow twill jar

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -121,6 +121,7 @@ public final class DistributedWorkflowProgramRunner extends DistributedProgramRu
 
     WorkflowSpecification spec = program.getApplicationSpecification().getWorkflows().get(program.getName());
     List<ClassAcceptor> acceptors = new ArrayList<>();
+    acceptors.add(launchConfig.getClassAcceptor());
 
     // Only interested in MapReduce and Spark nodes.
     // This is because CUSTOM_ACTION types are running inside the driver


### PR DESCRIPTION
This fixes an issue where all cloud runs can fail if the very
first program run for CDAP happens to be an action only workflow.
The twill jar created was not filtering out hadoop jars. The twill
jar is also cached, which means it would get used for subsequent
program runs, causing class conflict issues for those runs.