### PR TITLE
[CDAP-14753] Add a dataset-based implementation for the Metadata SPI

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -58,7 +58,7 @@ public class DefaultMetadataAdmin extends MetadataValidator implements MetadataA
   public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties)
     throws InvalidMetadataException {
     validateProperties(metadataEntity, properties);
-    metadataStore.setProperties(MetadataScope.USER, metadataEntity, properties);
+    metadataStore.addProperties(MetadataScope.USER, metadataEntity, properties);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
@@ -372,7 +372,7 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
               hasTags = put.getTags() != null && !put.getTags().isEmpty();
             }
             if (hasProperties) {
-              metadataStore.setProperties(put.getScope(), entity, put.getProperties());
+              metadataStore.addProperties(put.getScope(), entity, put.getProperties());
             }
             if (hasTags) {
               metadataStore.addTags(put.getScope(), entity, put.getTags());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -118,7 +118,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
   private void updateProfileMetadata(EntityId entityId, MetadataMessage message) {
     Map<MetadataEntity, Map<String, String>> toUpdate = new HashMap<>();
     collectProfileMetadata(entityId, message, toUpdate);
-    metadataStore.setProperties(MetadataScope.SYSTEM, toUpdate);
+    metadataStore.addProperties(MetadataScope.SYSTEM, toUpdate);
   }
 
   private void collectProfileMetadata(EntityId entityId, MetadataMessage message,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -123,17 +123,17 @@ public class LineageAdminTest extends AppFabricTestBase {
                                                       toMap("dk2", "dk2"), toSet("dt2"));
 
     // Add metadata
-    metadataStore.setProperties(MetadataScope.USER, program1.getParent().toMetadataEntity(),
+    metadataStore.addProperties(MetadataScope.USER, program1.getParent().toMetadataEntity(),
                                 run1AppMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, program1.getParent().toMetadataEntity(), run1AppMeta.getTags());
-    metadataStore.setProperties(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getProperties());
+    metadataStore.addProperties(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getTags());
-    metadataStore.setProperties(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getProperties());
+    metadataStore.addProperties(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getTags());
-    metadataStore.setProperties(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getProperties());
+    metadataStore.addProperties(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getTags());
 
@@ -557,17 +557,17 @@ public class LineageAdminTest extends AppFabricTestBase {
                                                       toMap("dk2", "dk2"), toSet("dt2"));
 
     // Add metadata
-    metadataStore.setProperties(MetadataScope.USER, program1.getParent().toMetadataEntity(),
+    metadataStore.addProperties(MetadataScope.USER, program1.getParent().toMetadataEntity(),
                                 run1AppMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, program1.getParent().toMetadataEntity(), run1AppMeta.getTags());
-    metadataStore.setProperties(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getProperties());
+    metadataStore.addProperties(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, program1.toMetadataEntity(), run1ProgramMeta.getTags());
-    metadataStore.setProperties(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getProperties());
+    metadataStore.addProperties(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, dataset1.toMetadataEntity(), run1Data1Meta.getTags());
-    metadataStore.setProperties(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getProperties());
+    metadataStore.addProperties(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, dataset2.toMetadataEntity(), run1Data2Meta.getTags());
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataSubscriberServiceTest.java
@@ -593,7 +593,7 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
     ApplicationSpecification appSpec = Specifications.from(new AllProgramsApp());
 
     // need to put metadata on workflow since we currently only set or delete workflow metadata
-    mds.setProperties(MetadataScope.SYSTEM, workflowId.toMetadataEntity(),
+    mds.addProperties(MetadataScope.SYSTEM, workflowId.toMetadataEntity(),
                       Collections.singletonMap("profile", ProfileId.NATIVE.getScopedName()));
     Assert.assertEquals(ProfileId.NATIVE.getScopedName(),
                         mds.getProperties(workflowId.toMetadataEntity()).get("profile"));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -1269,7 +1269,7 @@ public class MetadataDataset extends AbstractDataset {
     private final Record existing;
     private final Record latest;
 
-    Change(Record existing, Record latest) {
+    public Change(Record existing, Record latest) {
       this.existing = existing;
       this.latest = latest;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -246,34 +246,38 @@ public class MetadataDataset extends AbstractDataset {
   }
 
   /**
-   * Sets a metadata property for the specified {@link MetadataEntity}.
-   * @param metadataEntity the metadata entity for whch the property needs to be updated
+   * Adds a metadata property for the specified {@link MetadataEntity}.
+   * Overwrites the property if it already exists.
+   *
+   * @param metadataEntity the metadata entity for which the property needs to be updated
    * @param key The metadata key to be added
    * @param value The metadata value to be added
    */
-  public Change setProperty(MetadataEntity metadataEntity, String key, String value) {
-    return setMetadata(new MetadataEntry(metadataEntity, key, value));
+  public Change addProperty(MetadataEntity metadataEntity, String key, String value) {
+    return addMetadata(new MetadataEntry(metadataEntity, key, value));
   }
 
   /**
-   * Adds the given properties the given metadataEntity
+   * Adds the given properties the given metadataEntity.
+   * Overwrites properties that already exist.
+   *
    * @param metadataEntity the metadataEntity to which properties needs to be added
-   * @param properties the propeties to add (note if the property key exist and new value is different it will be
+   * @param properties the properties to add (note if the property key exist and new value is different it will be
    * overwritten)
    * @return {@link Change} representing the change in metadata for the metadataEntity
    */
-  public Change setProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
+  public Change addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
     Record previousMetadata, finalMetadata;
     Iterator<Map.Entry<String, String>> iterator = properties.entrySet().iterator();
     // properties can have none, one or more than one entry to be updated
     if (iterator.hasNext()) {
       // if there is at least one entry then we need to process that entry to update metadata and at that point we want
-      // to store what was the previousMetadata before we called setMetadata
+      // to store what was the previousMetadata before we called addMetadata
       Map.Entry<String, String> first = iterator.next();
-      Change metadataChange = setMetadata(new MetadataEntry(metadataEntity, first.getKey(), first.getValue()));
-      // metadata before setMetadata was applied
+      Change metadataChange = addMetadata(new MetadataEntry(metadataEntity, first.getKey(), first.getValue()));
+      // metadata before addMetadata was applied
       previousMetadata = metadataChange.getExisting();
-      // metadata after setMetadata was applied
+      // metadata after addMetadata was applied
       finalMetadata = metadataChange.getLatest();
     } else {
       // if properties was empty then we do need to the existing metadata as it is and also the final state is
@@ -284,7 +288,7 @@ public class MetadataDataset extends AbstractDataset {
     // if there are more key-value properties then process them updating the final metadata state
     while (iterator.hasNext()) {
       Map.Entry<String, String> next = iterator.next();
-      finalMetadata = setMetadata(new MetadataEntry(metadataEntity, next.getKey(), next.getValue())).getLatest();
+      finalMetadata = addMetadata(new MetadataEntry(metadataEntity, next.getKey(), next.getValue())).getLatest();
     }
     return new Change(previousMetadata, finalMetadata);
   }
@@ -295,7 +299,7 @@ public class MetadataDataset extends AbstractDataset {
    * @param tagsToAdd the tags to add
    */
   public Change addTags(MetadataEntity metadataEntity, Set<String> tagsToAdd) {
-    return setMetadata(new MetadataEntry(metadataEntity, MetadataConstants.TAGS_KEY,
+    return addMetadata(new MetadataEntry(metadataEntity, MetadataConstants.TAGS_KEY,
                                          Joiner.on(TAGS_SEPARATOR).join(tagsToAdd)));
   }
 
@@ -960,7 +964,7 @@ public class MetadataDataset extends AbstractDataset {
    * @param metadataEntry The value of the metadata to be saved
    * @return {@link Change} representing the metadata before the change and after
    */
-  private Change setMetadata(MetadataEntry metadataEntry) {
+  private Change addMetadata(MetadataEntry metadataEntry) {
     // get existing metadata
     Record existingMetadata = getMetadata(metadataEntry.getMetadataEntity());
     // existingMetadata is a Metadata object containing key-value properties and list of tags. We need to determine if

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -178,7 +178,7 @@ public class DefaultMetadataStore implements MetadataStore {
         changed = mds.removeProperties(entity, propertiesToDelete);
       }
       if (!propertiesToSet.isEmpty()) {
-        changed = mds.setProperties(entity, propertiesToSet);
+        changed = mds.addProperties(entity, propertiesToSet);
       }
       previous.set(existing);
       addedTags.set(tagsToAdd);
@@ -208,9 +208,9 @@ public class DefaultMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void setProperties(final MetadataScope scope, final MetadataEntity metadataEntity,
+  public void addProperties(final MetadataScope scope, final MetadataEntity metadataEntity,
                             final Map<String, String> properties) {
-    MetadataDataset.Change metadataChange = execute(mds -> mds.setProperties(metadataEntity, properties), scope);
+    MetadataDataset.Change metadataChange = execute(mds -> mds.addProperties(metadataEntity, properties), scope);
     publishAudit(scope, metadataEntity, properties, metadataChange);
   }
 
@@ -242,13 +242,13 @@ public class DefaultMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void setProperties(MetadataScope scope, Map<MetadataEntity, Map<String, String>> toUpdate) {
+  public void addProperties(MetadataScope scope, Map<MetadataEntity, Map<String, String>> toUpdate) {
     Map<MetadataEntity, ImmutablePair<Map<String, String>, MetadataDataset.Change>> changeLog = execute(mds -> {
       Map<MetadataEntity, ImmutablePair<Map<String, String>, MetadataDataset.Change>> changes = new HashMap<>();
       for (Map.Entry<MetadataEntity, Map<String, String>> entry : toUpdate.entrySet()) {
         MetadataEntity metadataEntity = entry.getKey();
         Map<String, String> properties = entry.getValue();
-        MetadataDataset.Change metadataChange = mds.setProperties(metadataEntity, properties);
+        MetadataDataset.Change metadataChange = mds.addProperties(metadataEntity, properties);
         changes.put(metadataEntity, ImmutablePair.of(properties, metadataChange));
       }
       return changes;
@@ -260,9 +260,9 @@ public class DefaultMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void setProperty(final MetadataScope scope, final MetadataEntity metadataEntity, final String key,
+  public void addProperty(final MetadataScope scope, final MetadataEntity metadataEntity, final String key,
                           final String value) {
-    MetadataDataset.Change change = execute(mds -> mds.setProperty(metadataEntity, key, value), scope);
+    MetadataDataset.Change change = execute(mds -> mds.addProperty(metadataEntity, key, value), scope);
     publishAudit(new MetadataRecord(metadataEntity, scope, change.getExisting().getProperties(),
                                     change.getExisting().getTags()),
                  new MetadataRecord(metadataEntity, scope, ImmutableMap.of(key, value), EMPTY_TAGS),

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -61,7 +61,7 @@ public interface MetadataStore {
    * @param metadataEntity the {@link MetadataEntity} to add the properties to
    * @param properties the properties to add/update
    */
-  void setProperties(MetadataScope scope, MetadataEntity metadataEntity, Map<String, String> properties);
+  void addProperties(MetadataScope scope, MetadataEntity metadataEntity, Map<String, String> properties);
 
   /**
    * Adds/updates properties for each specified {@link MetadataEntity} in the specified {@link MetadataScope}.
@@ -69,17 +69,17 @@ public interface MetadataStore {
    * @param scope the {@link MetadataScope} to add/update the properties in
    * @param toUpdate the properties to add/update, for each entity in the map
    */
-  void setProperties(MetadataScope scope, Map<MetadataEntity, Map<String, String>> toUpdate);
+  void addProperties(MetadataScope scope, Map<MetadataEntity, Map<String, String>> toUpdate);
 
   /**
-   * Sets the specified property for the specified {@link MetadataEntity} in the specified {@link MetadataScope}.
+   * Adds the specified property for the specified {@link MetadataEntity} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope} to set/update the property in
    * @param metadataEntity the {@link MetadataEntity} to set the property for
    * @param key the property key
    * @param value the property value
    */
-  void setProperty(MetadataScope scope, MetadataEntity metadataEntity, String key, String value);
+  void addProperty(MetadataScope scope, MetadataEntity metadataEntity, String key, String value);
 
   /**
    * Adds tags for the specified {@link MetadataEntity} in the specified {@link MetadataScope}.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -39,18 +39,18 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void setProperties(MetadataScope scope, MetadataEntity metadataEntity,
+  public void addProperties(MetadataScope scope, MetadataEntity metadataEntity,
                             Map<String, String> properties) {
     // NO-OP
   }
 
   @Override
-  public void setProperties(MetadataScope scope, Map<MetadataEntity, Map<String, String>> toUpdate) {
+  public void addProperties(MetadataScope scope, Map<MetadataEntity, Map<String, String>> toUpdate) {
     // NO-OP
   }
 
   @Override
-  public void setProperty(MetadataScope scope, MetadataEntity metadataEntity, String key, String value) {
+  public void addProperty(MetadataScope scope, MetadataEntity metadataEntity, String key, String value) {
     // NO-OP
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/MetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/MetadataStorage.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.spi.metadata;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
 
 /**
  * The Storage Provider API for Metadata.
@@ -35,10 +35,10 @@ public interface MetadataStorage {
   /**
    * Apply a batch of mutations to the metadata state.
    *
-   * @param mutations the mutations to perform
-   * @return the changes effected by each of the mutations
+   * @param mutations the mutations to perform. They are applied in the order given by the list.
+   * @return the changes effected by each of the mutations, in the same order as the batch of mutations.
    */
-  Collection<MetadataChange> batch(Collection<? extends MetadataMutation> mutations) throws IOException;
+  List<MetadataChange> batch(List<? extends MetadataMutation> mutations) throws IOException;
 
   /**
    * Retrieve the metadata for an entity.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
@@ -204,7 +204,7 @@ public class DatasetMetadataStorage implements MetadataStorage {
         after = change.getLatest();
       }
       if (!propertiesToAdd.isEmpty()) {
-        MetadataDataset.Change change = dataset.setProperties(entity, propertiesToAdd);
+        MetadataDataset.Change change = dataset.addProperties(entity, propertiesToAdd);
         before = before != null ? before : change.getExisting();
         after = change.getLatest();
       }
@@ -283,7 +283,7 @@ public class DatasetMetadataStorage implements MetadataStorage {
       after = dataset.removeProperties(entity, propertiesToRemove).getLatest();
     }
     if (!propertiesToAdd.isEmpty()) {
-      after = dataset.setProperties(entity, propertiesToAdd).getLatest();
+      after = dataset.addProperties(entity, propertiesToAdd).getLatest();
     }
     return new MetadataDataset.Change(before, after);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.metadata.dataset;
+
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.proto.EntityScope;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.metadata.MetadataSearchResponse;
+import co.cask.cdap.spi.metadata.Metadata;
+import co.cask.cdap.spi.metadata.MetadataChange;
+import co.cask.cdap.spi.metadata.MetadataDirective;
+import co.cask.cdap.spi.metadata.MetadataKind;
+import co.cask.cdap.spi.metadata.MetadataMutation;
+import co.cask.cdap.spi.metadata.MetadataRecord;
+import co.cask.cdap.spi.metadata.MetadataStorage;
+import co.cask.cdap.spi.metadata.Read;
+import co.cask.cdap.spi.metadata.ScopedName;
+import co.cask.cdap.spi.metadata.ScopedNameOfKind;
+import co.cask.cdap.spi.metadata.SearchRequest;
+import co.cask.cdap.spi.metadata.SearchResponse;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import org.apache.tephra.TransactionExecutor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static co.cask.cdap.api.metadata.MetadataScope.SYSTEM;
+import static co.cask.cdap.api.metadata.MetadataScope.USER;
+import static co.cask.cdap.spi.metadata.MetadataKind.PROPERTY;
+import static co.cask.cdap.spi.metadata.MetadataKind.TAG;
+
+/**
+ * A dataset-based implementation of the Metadata SPI.
+ */
+public class DatasetMetadataStorage implements MetadataStorage {
+
+  private final SearchHelper searchHelper;
+
+  @Inject
+  DatasetMetadataStorage(SearchHelper searchHelper) {
+    this.searchHelper = searchHelper;
+  }
+
+  private <T> T execute(TransactionExecutor.Function<MetadataDatasetContext, T> func) {
+    return searchHelper.execute(func);
+  }
+
+  @Override
+  public MetadataChange apply(MetadataMutation mutation) {
+    return execute(context -> apply(context, mutation));
+  }
+
+  private MetadataChange apply(MetadataDatasetContext context, MetadataMutation mutation) {
+    switch (mutation.getType()) {
+      case CREATE:
+        MetadataMutation.Create create = (MetadataMutation.Create) mutation;
+        return create(context, create.getEntity(), create.getMetadata(), create.getDirectives());
+      case DROP:
+        MetadataMutation.Drop drop = (MetadataMutation.Drop) mutation;
+        return drop(context, drop.getEntity());
+      case UPDATE:
+        MetadataMutation.Update update = (MetadataMutation.Update) mutation;
+        return update(context, update.getEntity(), update.getUpdates());
+      case REMOVE:
+        MetadataMutation.Remove remove = (MetadataMutation.Remove) mutation;
+        return remove(context, remove);
+      default:
+        throw new IllegalStateException(
+          String.format("Unknown MetadataMutation type %s for %s", mutation.getType(), mutation.getEntity()));
+    }
+  }
+
+  @Override
+  public Collection<MetadataChange> batch(Collection<? extends MetadataMutation> mutations) {
+    return execute(context -> mutations.stream().map(mutation -> apply(context, mutation)).collect(Collectors.toSet()));
+  }
+
+  private MetadataChange remove(MetadataDatasetContext context, MetadataMutation.Remove remove) {
+    MetadataEntity entity = remove.getEntity();
+    MetadataDataset.Change userChange, systemChange;
+    if (remove.getRemovals() != null) {
+      Set<String> userTagsToRemove = new HashSet<>();
+      Set<String> systemTagsToRemove = new HashSet<>();
+      Set<String> userPropertiesToRemove = new HashSet<>();
+      Set<String> systemPropertiesToRemove = new HashSet<>();
+      remove.getRemovals().forEach(removal -> (TAG == removal.getKind()
+        ? USER == removal.getScope() ? userTagsToRemove : systemTagsToRemove
+        : USER == removal.getScope() ? userPropertiesToRemove : systemPropertiesToRemove)
+        .add(removal.getName()));
+      userChange = removeInScope(context, USER, entity, userTagsToRemove, userPropertiesToRemove);
+      systemChange = removeInScope(context, SYSTEM, entity, systemTagsToRemove, systemPropertiesToRemove);
+    } else {
+      Set<MetadataScope> scopes = remove.getScopes();
+      Set<MetadataKind> kinds = remove.getKinds();
+      userChange = removeScope(context, USER, entity, scopes, kinds);
+      systemChange = removeScope(context, SYSTEM, entity, scopes, kinds);
+    }
+    return combineChanges(entity, userChange, systemChange);
+
+  }
+
+  private MetadataDataset.Change removeScope(MetadataDatasetContext context,
+                                             MetadataScope scope, MetadataEntity entity,
+                                             Set<MetadataScope> scopesToRemoves, Set<MetadataKind> kindsToRemove) {
+    MetadataDataset dataset = context.getDataset(scope);
+    if (scopesToRemoves.contains(scope)) {
+      if (MetadataKind.ALL.equals(kindsToRemove)) {
+        return dataset.removeMetadata(entity);
+      }
+      if (kindsToRemove.contains(PROPERTY)) {
+        return dataset.removeProperties(entity);
+      }
+      if (kindsToRemove.contains(TAG)) {
+        return dataset.removeTags(entity);
+      }
+    }
+    // nothing to remove - return identity change
+    MetadataDataset.Record existing = dataset.getMetadata(entity);
+    return new MetadataDataset.Change(existing, existing);
+  }
+
+  private MetadataDataset.Change removeInScope(MetadataDatasetContext context,
+                                               MetadataScope scope, MetadataEntity entity,
+                                               Set<String> tagsToRemove, Set<String> propertiesToRemove) {
+    MetadataDataset dataset = context.getDataset(scope);
+    MetadataDataset.Record before = null, after = null;
+    if (tagsToRemove.isEmpty() && propertiesToRemove.isEmpty()) {
+      before = dataset.getMetadata(entity);
+      after = before;
+    } else {
+      if (!tagsToRemove.isEmpty()) {
+        MetadataDataset.Change change = dataset.removeTags(entity, tagsToRemove);
+        before = change.getExisting();
+        after = change.getLatest();
+      }
+      if (!propertiesToRemove.isEmpty()) {
+        MetadataDataset.Change change = dataset.removeProperties(entity, propertiesToRemove);
+        before = before != null ? before : change.getExisting();
+        after = change.getLatest();
+      }
+    }
+    return new MetadataDataset.Change(before, after);
+  }
+
+  private MetadataChange update(MetadataDatasetContext context,
+                                MetadataEntity entity, Metadata updates) {
+    Set<String> userTagsToAdd = new HashSet<>();
+    Set<String> systemTagsToAdd = new HashSet<>();
+    Map<String, String> userPropertiesToAdd = new HashMap<>();
+    Map<String, String> systemPropertiesToAdd = new HashMap<>();
+    updates.getTags().forEach(tag -> (USER == tag.getScope() ? userTagsToAdd : systemTagsToAdd).add(tag.getName()));
+    updates.getProperties().forEach(
+      (key, value) -> (USER == key.getScope() ? userPropertiesToAdd : systemPropertiesToAdd).put(key.getName(), value));
+    MetadataDataset.Change userChange =
+      addInScope(context, USER, entity, userTagsToAdd, userPropertiesToAdd);
+    MetadataDataset.Change systemChange =
+      addInScope(context, SYSTEM, entity, systemTagsToAdd, systemPropertiesToAdd);
+    return combineChanges(entity, userChange, systemChange);
+  }
+
+  private MetadataDataset.Change addInScope(MetadataDatasetContext context,
+                                            MetadataScope scope, MetadataEntity entity,
+                                            Set<String> tagsToAdd, Map<String, String> propertiesToAdd) {
+
+    MetadataDataset dataset = context.getDataset(scope);
+    MetadataDataset.Record before = null, after = null;
+    if (tagsToAdd.isEmpty() && propertiesToAdd.isEmpty()) {
+      before = dataset.getMetadata(entity);
+      after = before;
+    } else {
+      if (!tagsToAdd.isEmpty()) {
+        MetadataDataset.Change change = dataset.addTags(entity, tagsToAdd);
+        before = change.getExisting();
+        after = change.getLatest();
+      }
+      if (!propertiesToAdd.isEmpty()) {
+        MetadataDataset.Change change = dataset.setProperties(entity, propertiesToAdd);
+        before = before != null ? before : change.getExisting();
+        after = change.getLatest();
+      }
+    }
+    return new MetadataDataset.Change(before, after);
+  }
+
+  private MetadataChange drop(MetadataDatasetContext context, MetadataEntity entity) {
+    MetadataDataset.Change userChange = context.getDataset(USER).removeMetadata(entity);
+    MetadataDataset.Change systemChange = context.getDataset(SYSTEM).removeMetadata(entity);
+    return combineChanges(entity, userChange, systemChange);
+  }
+
+  private MetadataChange create(MetadataDatasetContext context, MetadataEntity entity,
+                                Metadata metadata, Map<ScopedNameOfKind, MetadataDirective> directives) {
+    Set<String> newUserTags = new HashSet<>();
+    Set<String> newSystemTags = new HashSet<>();
+    Map<String, String> newUserProperties = new HashMap<>();
+    Map<String, String> newSystemProperties = new HashMap<>();
+    metadata.getTags().forEach(tag -> (USER == tag.getScope() ? newUserTags : newSystemTags).add(tag.getName()));
+    metadata.getProperties().forEach(
+      (key, value) -> (USER == key.getScope() ? newUserProperties : newSystemProperties).put(key.getName(), value));
+    MetadataDataset.Change userChange =
+      replaceInScope(context, USER, entity, newUserTags, newUserProperties, directives);
+    MetadataDataset.Change systemChange =
+      replaceInScope(context, SYSTEM, entity, newSystemTags, newSystemProperties, directives);
+    return combineChanges(entity, userChange, systemChange);
+  }
+
+  private MetadataDataset.Change replaceInScope(MetadataDatasetContext context,
+                                                MetadataScope scope, MetadataEntity entity,
+                                                Set<String> newTags, Map<String, String> newProperties,
+                                                Map<ScopedNameOfKind, MetadataDirective> directives) {
+    MetadataDataset dataset = context.getDataset(scope);
+    final MetadataDataset.Record before = dataset.getMetadata(entity);
+    if (newTags.isEmpty() && newProperties.isEmpty()) {
+      // this scope remains unchanged
+      return new MetadataDataset.Change(before, before);
+    }
+    Set<String> existingTags = before.getTags();
+    Set<String> tagsToKeepOrPreserve = directives.entrySet().stream()
+      .filter(entry -> entry.getKey().getScope() == scope && entry.getKey().getKind() == TAG
+        && (entry.getValue() == MetadataDirective.KEEP || entry.getValue() == MetadataDirective.PRESERVE))
+      .map(Map.Entry::getKey)
+      .map(ScopedName::getName)
+      .filter(existingTags::contains)
+      .collect(Collectors.toSet());
+    newTags = Sets.union(newTags, tagsToKeepOrPreserve);
+
+    Map<String, String> existingProperties = before.getProperties();
+    Map<String, String> propertiesToKeepOrPreserve = directives.entrySet().stream()
+      .filter(entry -> entry.getKey().getScope() == scope && entry.getKey().getKind() == PROPERTY)
+      .filter(entry -> existingProperties.containsKey(entry.getKey().getName()))
+      .filter(entry -> entry.getValue() == MetadataDirective.PRESERVE
+        || entry.getValue() == MetadataDirective.KEEP && !newProperties.containsKey(entry.getKey().getName()))
+      .map(Map.Entry::getKey)
+      .map(ScopedName::getName)
+      .collect(Collectors.toMap(name -> name, existingProperties::get));
+    newProperties.putAll(propertiesToKeepOrPreserve);
+
+    Set<String> tagsToRemove = Sets.difference(before.getTags(), newTags);
+    Set<String> tagsToAdd = Sets.difference(newTags, before.getTags());
+    Set<String> propertiesToRemove = Sets.difference(before.getProperties().keySet(), newProperties.keySet());
+    @SuppressWarnings("ConstantConditions")
+    Map<String, String> propertiesToAdd = Maps.filterEntries(
+      newProperties, entry -> !entry.getValue().equals(existingProperties.get(entry.getKey())));
+
+    MetadataDataset.Record after = before;
+    if (!tagsToRemove.isEmpty()) {
+      after = dataset.removeTags(entity, tagsToRemove).getLatest();
+    }
+    if (!tagsToAdd.isEmpty()) {
+      after = dataset.addTags(entity, tagsToAdd).getLatest();
+    }
+    if (!propertiesToRemove.isEmpty()) {
+      after = dataset.removeProperties(entity, propertiesToRemove).getLatest();
+    }
+    if (!propertiesToAdd.isEmpty()) {
+      after = dataset.setProperties(entity, propertiesToAdd).getLatest();
+    }
+    return new MetadataDataset.Change(before, after);
+  }
+
+  @Override
+  public Metadata read(Read read) {
+    return execute(context -> read(context, read));
+  }
+
+  private Metadata read(MetadataDatasetContext context, Read read) {
+    MetadataDataset.Record userMetadata = readScope(context, MetadataScope.USER, read);
+    MetadataDataset.Record systemMetadata = readScope(context, MetadataScope.SYSTEM, read);
+    return union(new Metadata(USER, userMetadata.getTags(), userMetadata.getProperties()),
+                 new Metadata(SYSTEM, systemMetadata.getTags(), systemMetadata.getProperties()));
+  }
+
+  private MetadataDataset.Record readScope(MetadataDatasetContext context,
+                                           MetadataScope scope, Read read) {
+    MetadataEntity entity = read.getEntity();
+    if (read.getSelection() == null && (!read.getScopes().contains(scope) || read.getKinds().isEmpty())) {
+      return new MetadataDataset.Record(entity);
+    }
+    Set<ScopedNameOfKind> selectionForScope = null;
+    if (read.getSelection() != null) {
+      //noinspection ConstantConditions
+      selectionForScope = Sets.filter(read.getSelection(), entry -> entry.getScope() == scope);
+      if (selectionForScope.isEmpty()) {
+        return new MetadataDataset.Record(entity);
+      }
+    }
+    // now we know we must read from the dataset
+    MetadataDataset dataset = context.getDataset(scope);
+    if (selectionForScope != null) {
+      // request is for a specific set of tags and properties
+      Set<String> tagsToRead = selectionForScope.stream()
+        .filter(entry -> TAG == entry.getKind())
+        .map(ScopedName::getName)
+        .collect(Collectors.toSet());
+      Set<String> propertiesToRead = selectionForScope.stream()
+        .filter(entry -> PROPERTY == entry.getKind())
+        .map(ScopedName::getName)
+        .collect(Collectors.toSet());
+      Set<String> tags = tagsToRead.isEmpty() ? Collections.emptySet()
+        : Sets.intersection(tagsToRead, dataset.getTags(entity));
+      Map<String, String> properties = propertiesToRead.isEmpty() ? Collections.emptyMap()
+        : Maps.filterKeys(dataset.getProperties(entity), propertiesToRead::contains);
+      return new MetadataDataset.Record(entity, properties, tags);
+    }
+    if (MetadataKind.ALL.equals(read.getKinds())) {
+      // all metadata kinds requested
+      return dataset.getMetadata(entity);
+    }
+    // exactly one kind is requested
+    MetadataKind requestKind = read.getKinds().iterator().next();
+    if (requestKind == TAG) {
+      return new MetadataDataset.Record(entity, Collections.emptyMap(), dataset.getTags(entity));
+    }
+    if (requestKind == PROPERTY) {
+      return new MetadataDataset.Record(entity, dataset.getProperties(entity), Collections.emptySet());
+    }
+    throw new IllegalStateException("Encountered metadata read request for unknown kind " + requestKind);
+  }
+
+  @Override
+  public SearchResponse search(SearchRequest request) {
+    NamespaceId namespace = null;
+    Set<EntityScope> entityScopes;
+    if (request.getNamespaces() == null || request.getNamespaces().isEmpty()) {
+      entityScopes = EnumSet.allOf(EntityScope.class);
+    } else {
+      boolean hasSystem = false;
+      for (String ns : request.getNamespaces()) {
+        if (ns.equals(NamespaceId.SYSTEM.getNamespace())) {
+          hasSystem = true;
+        } else {
+          if (namespace != null) {
+            throw new UnsupportedOperationException(String.format(
+              "This implementation supports at most one non-system namespace, but %s as well as %s were given",
+              namespace.getNamespace(), ns));
+          }
+          namespace = new NamespaceId(ns);
+        }
+      }
+      if (hasSystem) {
+        if (namespace == null) {
+          namespace = NamespaceId.SYSTEM;
+          entityScopes = Collections.singleton(EntityScope.SYSTEM);
+        } else {
+          entityScopes = EnumSet.allOf(EntityScope.class);
+        }
+      } else {
+        entityScopes = Collections.singleton(EntityScope.USER);
+      }
+    }
+    MetadataSearchResponse response = searchHelper.search(new co.cask.cdap.data2.metadata.dataset.SearchRequest(
+      namespace,
+      request.getQuery(),
+      request.getTypes() == null ? Collections.emptySet() :
+        request.getTypes().stream().map(EntityTypeSimpleName::valueOf).collect(Collectors.toSet()),
+      request.getSorting() == null ? SortInfo.DEFAULT :
+        new SortInfo(request.getSorting().getKey(), SortInfo.SortOrder.valueOf(request.getSorting().getOrder().name())),
+      request.getOffset(),
+      request.getLimit(),
+      request.isCursorRequested() ? 1 : 0,
+      request.getCursor(),
+      request.isShowHidden(),
+      entityScopes
+    ));
+    // translate results back
+    List<MetadataRecord> results = new ArrayList<>(response.getResults().size());
+    response.getResults().forEach(record -> {
+      Metadata metadata = null;
+      for (Map.Entry<MetadataScope, co.cask.cdap.api.metadata.Metadata> entry : record.getMetadata().entrySet()) {
+        Metadata toAdd = new Metadata(entry.getKey(), entry.getValue().getTags(), entry.getValue().getProperties());
+        metadata = metadata == null ? toAdd : union(metadata, toAdd);
+      }
+      results.add(new MetadataRecord(record.getMetadataEntity(), metadata));
+    });
+    String cursor =
+      response.getCursors() == null || response.getCursors().isEmpty() ? null : response.getCursors().get(0);
+    return new SearchResponse(request, cursor, response.getTotal(), results);
+  }
+
+  private MetadataChange combineChanges(MetadataEntity entity,
+                                        MetadataDataset.Change userChange,
+                                        MetadataDataset.Change sysChange) {
+
+    Metadata userBefore = new Metadata(USER, userChange.getExisting().getTags(),
+                                       userChange.getExisting().getProperties());
+    Metadata sysBefore = new Metadata(SYSTEM, sysChange.getExisting().getTags(),
+                                      sysChange.getExisting().getProperties());
+    Metadata before = union(userBefore, sysBefore);
+
+    Metadata userAfter = new Metadata(USER, userChange.getLatest().getTags(), userChange.getLatest().getProperties());
+    Metadata sysAfter = new Metadata(SYSTEM, sysChange.getLatest().getTags(), sysChange.getLatest().getProperties());
+    Metadata after = union(userAfter, sysAfter);
+
+    return new MetadataChange(entity, before, after);
+  }
+
+  private static Metadata union(Metadata meta, Metadata other) {
+    return new Metadata(Sets.union(meta.getTags(), other.getTags()),
+                        ImmutableMap.<ScopedName, String>builder()
+                          .putAll(meta.getProperties())
+                          .putAll(other.getProperties()).build());
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/MetadataDatasetContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/MetadataDatasetContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.metadata.dataset;
+
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+
+/**
+ * Provides a metadata dataset for a given scope.
+ */
+public interface MetadataDatasetContext {
+
+  MetadataDataset getDataset(MetadataScope scope);
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/SearchHelper.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/SearchHelper.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.metadata.dataset;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.Transactionals;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.metadata.Metadata;
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.MetadataDatasetDefinition;
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.SearchRequest;
+import co.cask.cdap.data2.metadata.dataset.SearchResults;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.metadata.MetadataSearchResponse;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import org.apache.tephra.RetryStrategies;
+import org.apache.tephra.TransactionExecutor;
+import org.apache.tephra.TransactionSystemClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static co.cask.cdap.api.metadata.MetadataScope.SYSTEM;
+import static co.cask.cdap.api.metadata.MetadataScope.USER;
+
+/**
+ * Implements the metadata search over metadata datasets.
+ */
+public class SearchHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SearchHelper.class);
+
+  public static final DatasetId BUSINESS_METADATA_INSTANCE_ID = NamespaceId.SYSTEM.dataset("meta.business");
+  public static final DatasetId SYSTEM_METADATA_INSTANCE_ID = NamespaceId.SYSTEM.dataset("meta.system");
+
+  private static final Comparator<Map.Entry<MetadataEntity, Integer>> SEARCH_RESULT_DESC_SCORE_COMPARATOR =
+    // sort in descending order
+    (o1, o2) -> o2.getValue() - o1.getValue();
+
+  private final Transactional transactional;
+  private final DatasetFramework dsFramework;
+
+  @Inject
+  public SearchHelper(TransactionSystemClient txClient, DatasetFramework dsFramework) {
+    DynamicDatasetCache datasetCache = new MultiThreadDatasetCache(
+      new SystemDatasetInstantiator(dsFramework), new TransactionSystemClientAdapter(txClient),
+      NamespaceId.SYSTEM, Collections.emptyMap(), null, null);
+    this.transactional = Transactions.createTransactionalWithRetry(
+      Transactions.createTransactional(datasetCache),
+      RetryStrategies.retryOnConflict(20, 100)
+    );
+    this.dsFramework = dsFramework;
+  }
+
+  public SearchHelper(Transactional transactional, DatasetFramework dsFramework) {
+    this.transactional = transactional;
+    this.dsFramework = dsFramework;
+  }
+
+  <T> T execute(TransactionExecutor.Function<MetadataDatasetContext, T> func) {
+    return Transactionals.execute(transactional, context -> {
+      return func.apply(scope -> getMetadataDataset(context, dsFramework, scope));
+    });
+  }
+
+  public static MetadataDataset getMetadataDataset(DatasetContext context, DatasetFramework dsFramework,
+                                                   MetadataScope scope) {
+    try {
+      return DatasetsUtil.getOrCreateDataset(
+        context, dsFramework, getMetadataDatasetInstance(scope), MetadataDataset.class.getName(),
+        DatasetProperties.builder().add(MetadataDatasetDefinition.SCOPE_KEY, scope.name()).build());
+    } catch (DatasetManagementException | IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private static DatasetId getMetadataDatasetInstance(MetadataScope scope) {
+    return USER == scope ? BUSINESS_METADATA_INSTANCE_ID : SYSTEM_METADATA_INSTANCE_ID;
+  }
+
+  public MetadataSearchResponse search(SearchRequest request) {
+    Set<MetadataScope> searchScopes = EnumSet.allOf(MetadataScope.class);
+    if ("*".equals(request.getQuery())) {
+      if (SortInfo.DEFAULT.equals(request.getSortInfo())) {
+        // Can't disallow this completely, because it is required for upgrade, but log a warning to indicate that
+        // a full index search should not be done in production.
+        LOG.warn("Attempt to search through all indexes. This query can have an adverse effect on performance and is " +
+                   "not recommended for production use. It is only meant to be used for administrative purposes " +
+                   "such as upgrade. To improve the performance of such queries, please specify sort parameters " +
+                   "as well.");
+      } else {
+        // when it is a known sort (stored sorted in the metadata dataset already), restrict it to system scope only
+        searchScopes = EnumSet.of(SYSTEM);
+      }
+    }
+    return search(searchScopes, request);
+  }
+
+  private MetadataSearchResponse search(Set<MetadataScope> scopes, SearchRequest request) {
+    List<MetadataEntry> results = new LinkedList<>();
+    List<String> cursors = new LinkedList<>();
+    for (MetadataScope scope : scopes) {
+      SearchResults searchResults = execute(context -> context.getDataset(scope).search(request));
+      results.addAll(searchResults.getResults());
+      cursors.addAll(searchResults.getCursors());
+    }
+
+    int offset = request.getOffset();
+    int limit = request.getLimit();
+    SortInfo sortInfo = request.getSortInfo();
+    // sort if required
+    Set<MetadataEntity> sortedEntities = getSortedEntities(results, sortInfo);
+    int total = sortedEntities.size();
+
+    // pagination is not performed at the dataset level, because:
+    // 1. scoring is needed for DEFAULT sort info. So perform it here for now.
+    // 2. Even when using custom sorting, we need to remove elements from the beginning to the offset and the cursors
+    //    at the end
+    // TODO: Figure out how all of this can be done server (HBase) side
+    int startIndex = Math.min(request.getOffset(), sortedEntities.size());
+    // Account for overflow
+    int endIndex = (int) Math.min(Integer.MAX_VALUE, (long) offset + limit);
+    endIndex = Math.min(endIndex, sortedEntities.size());
+
+    // add 1 to maxIndex because end index is exclusive
+    Set<MetadataEntity> subSortedEntities = new LinkedHashSet<>(
+      ImmutableList.copyOf(sortedEntities).subList(startIndex, endIndex)
+    );
+
+    // Fetch metadata for entities in the result list
+    // Note: since the fetch is happening in a different transaction, the metadata for entities may have been
+    // removed. It is okay not to have metadata for some results in case this happens.
+    Set<MetadataSearchResultRecord> finalResults = execute(
+      context -> addMetadataToEntities(subSortedEntities,
+                                       fetchMetadata(context.getDataset(SYSTEM), subSortedEntities),
+                                       fetchMetadata(context.getDataset(USER), subSortedEntities)));
+
+    return new MetadataSearchResponse(
+      sortInfo.getSortBy() + " " + sortInfo.getSortOrder(), offset, limit, request.getNumCursors(), total,
+      finalResults, cursors, request.shouldShowHidden(), request.getEntityScopes());
+  }
+
+  private Set<MetadataEntity> getSortedEntities(List<MetadataEntry> results, SortInfo sortInfo) {
+    // if sort order is not weighted, return entities in the order received.
+    // in this case, the backing storage is expected to return results in the expected order.
+    if (SortInfo.SortOrder.WEIGHTED != sortInfo.getSortOrder()) {
+      Set<MetadataEntity> entities = new LinkedHashSet<>(results.size());
+      for (MetadataEntry metadataEntry : results) {
+        entities.add(metadataEntry.getMetadataEntity());
+      }
+      return entities;
+    }
+    // if sort order is weighted, score results by weight, and return in descending order of weights
+    // Score results
+    final Map<MetadataEntity, Integer> weightedResults = new HashMap<>();
+    for (MetadataEntry metadataEntry : results) {
+      weightedResults.put(metadataEntry.getMetadataEntity(),
+                          weightedResults.getOrDefault(metadataEntry.getMetadataEntity(), 0) + 1);
+    }
+
+    // Sort the results by score
+    List<Map.Entry<MetadataEntity, Integer>> resultList = new ArrayList<>(weightedResults.entrySet());
+    resultList.sort(SEARCH_RESULT_DESC_SCORE_COMPARATOR);
+    Set<MetadataEntity> result = new LinkedHashSet<>(resultList.size());
+    for (Map.Entry<MetadataEntity, Integer> entry : resultList) {
+      result.add(entry.getKey());
+    }
+    return result;
+  }
+
+  private Map<MetadataEntity, MetadataDataset.Record> fetchMetadata(MetadataDataset mds,
+                                                                    final Set<MetadataEntity> metadataEntities) {
+    Set<MetadataDataset.Record> metadataSet = mds.getMetadata(metadataEntities);
+    Map<MetadataEntity, MetadataDataset.Record> metadataMap = new HashMap<>();
+    for (MetadataDataset.Record m : metadataSet) {
+      metadataMap.put(m.getMetadataEntity(), m);
+    }
+    return metadataMap;
+  }
+
+  private Set<MetadataSearchResultRecord>
+  addMetadataToEntities(Set<MetadataEntity> entities,
+                        Map<MetadataEntity, MetadataDataset.Record> systemMetadata,
+                        Map<MetadataEntity, MetadataDataset.Record> userMetadata) {
+    Set<MetadataSearchResultRecord> result = new LinkedHashSet<>();
+    for (MetadataEntity entity : entities) {
+      ImmutableMap.Builder<MetadataScope, Metadata> builder = ImmutableMap.builder();
+      // Add system metadata
+      MetadataDataset.Record metadata = systemMetadata.get(entity);
+      if (metadata != null) {
+        builder.put(SYSTEM, new Metadata(metadata.getProperties(), metadata.getTags()));
+      }
+
+      // Add user metadata
+      metadata = userMetadata.get(entity);
+      if (metadata != null) {
+        builder.put(MetadataScope.USER, new Metadata(metadata.getProperties(), metadata.getTags()));
+      }
+
+      // Create result
+      result.add(new MetadataSearchResultRecord(entity, builder.build()));
+    }
+    return result;
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -119,19 +119,19 @@ public class MetadataDatasetTest {
     });
     // Set some properties
     txnl.execute(() -> {
-      dataset.setProperty(app1, "akey1", "avalue1");
-      MetadataDataset.Change metadataChange = dataset.setProperties(program1, Collections.emptyMap());
+      dataset.addProperty(app1, "akey1", "avalue1");
+      MetadataDataset.Change metadataChange = dataset.addProperties(program1, Collections.emptyMap());
       Assert.assertEquals(metadataChange.getExisting(), new MetadataDataset.Record(program1, Collections.emptyMap(),
                                                                                    Collections.emptySet()));
       Assert.assertEquals(metadataChange.getLatest(), new MetadataDataset.Record(program1, Collections.emptyMap(),
                                                                                  Collections.emptySet()));
-      metadataChange = dataset.setProperty(program1, "fkey1", "fvalue1");
+      metadataChange = dataset.addProperty(program1, "fkey1", "fvalue1");
       // assert the metadata change which happens on setting property for the first time
       Assert.assertEquals(new MetadataDataset.Record(program1), metadataChange.getExisting());
       Assert.assertEquals(new MetadataDataset.Record(program1,
                                                      ImmutableMap.of("fkey1", "fvalue1"), Collections.emptySet()),
                           metadataChange.getLatest());
-      metadataChange = dataset.setProperty(program1, "fK", "fV");
+      metadataChange = dataset.addProperty(program1, "fK", "fV");
       // assert the metadata change which happens when setting property with existing property
       Assert.assertEquals(new MetadataDataset.Record(program1,
                                                      ImmutableMap.of("fkey1", "fvalue1"), Collections.emptySet()),
@@ -140,14 +140,14 @@ public class MetadataDatasetTest {
                                                      ImmutableMap.of("fkey1", "fvalue1", "fK", "fV"),
                                                      Collections.emptySet()),
                           metadataChange.getLatest());
-      dataset.setProperty(dataset1, "dkey1", "dvalue1");
-      dataset.setProperty(dataset2, "skey1", "svalue1");
-      dataset.setProperty(dataset2, "skey2", "svalue2");
-      dataset.setProperty(artifact1, "rkey1", "rvalue1");
-      dataset.setProperty(artifact1, "rkey2", "rvalue2");
-      dataset.setProperty(fileEntity, "fkey2", "fvalue2");
-      dataset.setProperty(partitionFileEntity, "pfkey2", "pfvalue2");
-      dataset.setProperty(jarEntity, "jkey2", "jvalue2");
+      dataset.addProperty(dataset1, "dkey1", "dvalue1");
+      dataset.addProperty(dataset2, "skey1", "svalue1");
+      dataset.addProperty(dataset2, "skey2", "svalue2");
+      dataset.addProperty(artifact1, "rkey1", "rvalue1");
+      dataset.addProperty(artifact1, "rkey2", "rvalue2");
+      dataset.addProperty(fileEntity, "fkey2", "fvalue2");
+      dataset.addProperty(partitionFileEntity, "pfkey2", "pfvalue2");
+      dataset.addProperty(jarEntity, "jkey2", "jvalue2");
     });
     // verify
     txnl.execute(() -> {
@@ -194,7 +194,7 @@ public class MetadataDatasetTest {
       Assert.assertEquals(expected, result);
     });
     // reset a property
-    txnl.execute(() -> dataset.setProperty(dataset2, "skey1", "sv1"));
+    txnl.execute(() -> dataset.addProperty(dataset2, "skey1", "sv1"));
     txnl.execute(() -> Assert.assertEquals(ImmutableMap.of("skey1", "sv1", "skey2", "svalue2"),
                                            dataset.getProperties(dataset2)));
     // cleanup
@@ -443,8 +443,8 @@ public class MetadataDatasetTest {
     final MetadataEntry myFieldEntry1 = new MetadataEntry(myField1, "testKey1", "testValue1");
     final MetadataEntry myFieldEntry2 = new MetadataEntry(myField2, "testKey2", "testValue2");
     txnl.execute(() -> {
-      dataset.setProperty(myField1, "testKey1", "testValue1");
-      dataset.setProperty(myField2, "testKey2", "testValue2");
+      dataset.addProperty(myField1, "testKey1", "testValue1");
+      dataset.addProperty(myField2, "testKey2", "testValue2");
     });
 
     // Search for it based on value
@@ -472,9 +472,9 @@ public class MetadataDatasetTest {
     final MetadataEntry multiWordEntry = new MetadataEntry(program1, "multiword", multiWordValue);
 
     txnl.execute(() -> {
-      dataset.setProperty(program1, "key1", "value1");
-      dataset.setProperty(program1, "key2", "value2");
-      dataset.setProperty(program1, "multiword", multiWordValue);
+      dataset.addProperty(program1, "key1", "value1");
+      dataset.addProperty(program1, "key2", "value2");
+      dataset.addProperty(program1, "multiword", multiWordValue);
     });
 
     // Search for it based on value
@@ -509,7 +509,7 @@ public class MetadataDatasetTest {
 
     });
     // Search based on value
-    txnl.execute(() -> dataset.setProperty(program1, "key3", "value1"));
+    txnl.execute(() -> dataset.addProperty(program1, "key3", "value1"));
     txnl.execute(() -> {
       List<MetadataEntry> results =
         searchByDefaultIndex("ns1", "value1", ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
@@ -520,7 +520,7 @@ public class MetadataDatasetTest {
     });
 
     // Search based on value prefix
-    txnl.execute(() -> dataset.setProperty(dataset2, "key21", "value21"));
+    txnl.execute(() -> dataset.addProperty(dataset2, "key21", "value21"));
     txnl.execute(() -> {
       List<MetadataEntry> results =
         searchByDefaultIndex("ns1", "value2*", ImmutableSet.of(EntityTypeSimpleName.ALL));
@@ -546,12 +546,12 @@ public class MetadataDatasetTest {
 
     txnl.execute(() -> {
       // Add some properties to program1
-      dataset.setProperty(program1, "key1", "value1");
-      dataset.setProperty(program1, "key2", "value2");
+      dataset.addProperty(program1, "key1", "value1");
+      dataset.addProperty(program1, "key2", "value2");
       // add a multi word value
-      dataset.setProperty(program1, multiWordKey, multiWordValue);
-      dataset.setProperty(dataset2, "sKey1", "sValue1");
-      dataset.setProperty(dataset2, "Key1", "Value1");
+      dataset.addProperty(program1, multiWordKey, multiWordValue);
+      dataset.addProperty(dataset2, "sKey1", "sValue1");
+      dataset.addProperty(dataset2, "Key1", "Value1");
     });
 
     txnl.execute(() -> {
@@ -616,9 +616,9 @@ public class MetadataDatasetTest {
     final String multiWordValue = "aV1 av2 ,  -  ,  av3 - av4_av5 av6";
 
     txnl.execute(() -> {
-      dataset.setProperty(program1, multiWordKey, multiWordValue);
-      dataset.setProperty(sysArtifact, multiWordKey, multiWordValue);
-      dataset.setProperty(ns2Artifact, multiWordKey, multiWordValue);
+      dataset.addProperty(program1, multiWordKey, multiWordValue);
+      dataset.addProperty(sysArtifact, multiWordKey, multiWordValue);
+      dataset.addProperty(ns2Artifact, multiWordKey, multiWordValue);
     });
     // perform the exact same multiword search in the 'ns1' namespace. It should return the system artifact along with
     // matched entities in the 'ns1' namespace
@@ -708,8 +708,8 @@ public class MetadataDatasetTest {
     String multiWordValue = "aV1 av2 ,  -  ,  av3 - av4_av5 av6";
 
     txnl.execute(() -> {
-      dataset.setProperty(nsArtifact, multiWordKey, multiWordValue);
-      dataset.setProperty(sysArtifact, multiWordKey, multiWordValue);
+      dataset.addProperty(nsArtifact, multiWordKey, multiWordValue);
+      dataset.addProperty(sysArtifact, multiWordKey, multiWordValue);
     });
 
     MetadataEntry systemArtifactEntry = new MetadataEntry(sysArtifact, multiWordKey, multiWordValue);
@@ -755,8 +755,8 @@ public class MetadataDatasetTest {
   @Test
   public void testUpdateSearch() throws Exception {
     txnl.execute(() -> {
-      dataset.setProperty(program1, "key1", "value1");
-      dataset.setProperty(program1, "key2", "value2");
+      dataset.addProperty(program1, "key1", "value1");
+      dataset.addProperty(program1, "key2", "value2");
       dataset.addTags(program1, "tag1", "tag2");
     });
     txnl.execute(() -> {
@@ -773,7 +773,7 @@ public class MetadataDatasetTest {
 
     // Update key1
     txnl.execute(() -> {
-      dataset.setProperty(program1, "key1", "value3");
+      dataset.addProperty(program1, "key1", "value3");
       dataset.removeProperties(program1, "key2");
       dataset.removeTags(program1, "tag2");
     });
@@ -827,7 +827,7 @@ public class MetadataDatasetTest {
       for (Map.Entry<MetadataEntity, MetadataDataset.Record> entry : allMetadata.entrySet()) {
         MetadataDataset.Record metadata = entry.getValue();
         for (Map.Entry<String, String> props : metadata.getProperties().entrySet()) {
-          dataset.setProperty(metadata.getMetadataEntity(), props.getKey(), props.getValue());
+          dataset.addProperty(metadata.getMetadataEntity(), props.getKey(), props.getValue());
         }
         dataset.addTags(metadata.getMetadataEntity(),
                         metadata.getTags().toArray(new String[0]));
@@ -864,12 +864,12 @@ public class MetadataDatasetTest {
   @Test
   public void testDelete() throws Exception {
     txnl.execute(() -> {
-      dataset.setProperty(program1, "key1", "value1");
-      dataset.setProperty(program1, "key2", "value2");
+      dataset.addProperty(program1, "key1", "value1");
+      dataset.addProperty(program1, "key2", "value2");
       dataset.addTags(program1, "tag1", "tag2");
 
-      dataset.setProperty(app1, "key10", "value10");
-      dataset.setProperty(app1, "key12", "value12");
+      dataset.addProperty(app1, "key10", "value10");
+      dataset.addProperty(app1, "key12", "value12");
       dataset.addTags(app1, "tag11", "tag12");
     });
 
@@ -916,10 +916,10 @@ public class MetadataDatasetTest {
     final String name = "dataset1";
     final long creationTime = System.currentTimeMillis();
     txnl.execute(() -> {
-      dataset.setProperty(program1, "key", value);
-      dataset.setProperty(program1, AbstractSystemMetadataWriter.SCHEMA_KEY, schema);
-      dataset.setProperty(dataset1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, name);
-      dataset.setProperty(dataset1, AbstractSystemMetadataWriter.CREATION_TIME_KEY, String.valueOf(creationTime));
+      dataset.addProperty(program1, "key", value);
+      dataset.addProperty(program1, AbstractSystemMetadataWriter.SCHEMA_KEY, schema);
+      dataset.addProperty(dataset1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, name);
+      dataset.addProperty(dataset1, AbstractSystemMetadataWriter.CREATION_TIME_KEY, String.valueOf(creationTime));
     });
     final String namespaceId = program1.getValue(MetadataEntity.NAMESPACE);
     txnl.execute(() -> {
@@ -966,9 +966,9 @@ public class MetadataDatasetTest {
     MetadataEntity ns1App = new NamespaceId("ns1").app("a").toMetadataEntity();
     MetadataEntity ns2App = new NamespaceId("ns2").app("a").toMetadataEntity();
     txnl.execute(() -> {
-      dataset.setProperty(ns1App, "k1", "v1");
-      dataset.setProperty(ns1App, "k2", "v2");
-      dataset.setProperty(ns2App, "k1", "v1");
+      dataset.addProperty(ns1App, "k1", "v1");
+      dataset.addProperty(ns1App, "k2", "v2");
+      dataset.addProperty(ns2App, "k1", "v1");
     });
 
     SearchRequest request1 = new SearchRequest(null, "v1", EnumSet.allOf(EntityTypeSimpleName.class), SortInfo.DEFAULT,
@@ -1005,11 +1005,11 @@ public class MetadataDatasetTest {
     ApplicationId ns2app2 = new NamespaceId("ns2").app("a2");
     String key = AbstractSystemMetadataWriter.ENTITY_NAME_KEY;
     txnl.execute(() -> {
-      dataset.setProperty(ns1app1.toMetadataEntity(), key, ns1app1.getApplication());
-      dataset.setProperty(ns1app2.toMetadataEntity(), key, ns1app2.getApplication());
-      dataset.setProperty(ns1app3.toMetadataEntity(), key, ns1app3.getApplication());
-      dataset.setProperty(ns2app1.toMetadataEntity(), key, ns2app1.getApplication());
-      dataset.setProperty(ns2app2.toMetadataEntity(), key, ns2app2.getApplication());
+      dataset.addProperty(ns1app1.toMetadataEntity(), key, ns1app1.getApplication());
+      dataset.addProperty(ns1app2.toMetadataEntity(), key, ns1app2.getApplication());
+      dataset.addProperty(ns1app3.toMetadataEntity(), key, ns1app3.getApplication());
+      dataset.addProperty(ns2app1.toMetadataEntity(), key, ns2app1.getApplication());
+      dataset.addProperty(ns2app2.toMetadataEntity(), key, ns2app2.getApplication());
     });
 
     MetadataEntry ns1app1Entry = new MetadataEntry(ns1app1.toMetadataEntity(), key, ns1app1.getApplication());
@@ -1067,8 +1067,8 @@ public class MetadataDatasetTest {
     MetadataEntity ns1App = new NamespaceId("ns1").app(appName).toMetadataEntity();
     MetadataEntity ns2App = new NamespaceId("ns2").app(appName).toMetadataEntity();
     txnl.execute(() -> {
-      dataset.setProperty(ns2App, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
-      dataset.setProperty(ns1App, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
+      dataset.addProperty(ns2App, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
+      dataset.addProperty(ns1App, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
     });
 
     SortInfo nameAsc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.ASC);
@@ -1092,9 +1092,9 @@ public class MetadataDatasetTest {
     String dsName = "name21 name22";
     String appName = "name31 name32 name33";
     txnl.execute(() -> {
-      dataset.setProperty(program1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, flowName);
-      dataset.setProperty(dataset1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, dsName);
-      dataset.setProperty(app1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
+      dataset.addProperty(program1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, flowName);
+      dataset.addProperty(dataset1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, dsName);
+      dataset.addProperty(app1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
     });
     NamespaceId namespaceId = new NamespaceId(program1.getValue(MetadataEntity.NAMESPACE));
     EnumSet<EntityTypeSimpleName> targets = EnumSet.allOf(EntityTypeSimpleName.class);
@@ -1247,7 +1247,7 @@ public class MetadataDatasetTest {
 
     txnl.execute(() -> {
       // Add a new property and a tag
-      dataset.setProperty(targetId, prefix + "k2", "v2");
+      dataset.addProperty(targetId, prefix + "k2", "v2");
       dataset.addTags(targetId, prefix + "t3");
     });
     // Save the complete metadata record at this point
@@ -1269,7 +1269,7 @@ public class MetadataDatasetTest {
 
     txnl.execute(() -> {
       // Add another property and a tag
-      dataset.setProperty(targetId, prefix + "k3", "v3");
+      dataset.addProperty(targetId, prefix + "k3", "v3");
       dataset.addTags(targetId, prefix + "t4");
     });
     txnl.execute(() -> {
@@ -1292,7 +1292,7 @@ public class MetadataDatasetTest {
 
     txnl.execute(() -> {
       // Add the same property and tag as second time
-      dataset.setProperty(targetId, prefix + "k2", "v2");
+      dataset.addProperty(targetId, prefix + "k2", "v2");
       dataset.addTags(targetId, prefix + "t3");
     });
     txnl.execute(() -> {
@@ -1360,7 +1360,7 @@ public class MetadataDatasetTest {
 
     // Add one more property and a tag
     txnl.execute(() -> {
-      dataset.setProperty(targetId, prefix + "k2", "v2");
+      dataset.addProperty(targetId, prefix + "k2", "v2");
       dataset.addTags(targetId, prefix + "t2");
     });
     final MetadataDataset.Record lastCompleteRecord = new MetadataDataset.Record(targetId, toProps(prefix, "k2", "v2"),
@@ -1399,7 +1399,7 @@ public class MetadataDatasetTest {
 
   private void addMetadataHistory(MetadataDataset dataset, MetadataDataset.Record record) {
     for (Map.Entry<String, String> entry : record.getProperties().entrySet()) {
-      dataset.setProperty(record.getMetadataEntity(), entry.getKey(), entry.getValue());
+      dataset.addProperty(record.getMetadataEntity(), entry.getKey(), entry.getValue());
     }
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     dataset.addTags(record.getMetadataEntity(), record.getTags().toArray(new String[0]));

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStoreTest.java
@@ -305,22 +305,22 @@ public class DefaultMetadataStoreTest {
     Set<String> userTags = ImmutableSet.of("tag1", "tag2");
     Set<String> streamUserTags = ImmutableSet.of("tag3", "tag4");
     Set<String> sysTags = ImmutableSet.of("sysTag1");
-    store.setProperties(MetadataScope.USER, service1.toMetadataEntity(), userProps);
-    store.setProperties(MetadataScope.SYSTEM, service1.toMetadataEntity(), systemProps);
+    store.addProperties(MetadataScope.USER, service1.toMetadataEntity(), userProps);
+    store.addProperties(MetadataScope.SYSTEM, service1.toMetadataEntity(), systemProps);
     store.addTags(MetadataScope.USER, service1.toMetadataEntity(), userTags);
     store.addTags(MetadataScope.SYSTEM, service1.toMetadataEntity(), sysTags);
     store.addTags(MetadataScope.USER, dataset2.toMetadataEntity(), streamUserTags);
     store.removeTags(MetadataScope.USER, dataset2.toMetadataEntity(), streamUserTags);
-    store.setProperties(MetadataScope.USER, dataset2.toMetadataEntity(), userProps);
+    store.addProperties(MetadataScope.USER, dataset2.toMetadataEntity(), userProps);
     store.removeProperties(MetadataScope.USER, dataset2.toMetadataEntity(),
                            ImmutableSet.of("key1", "key2", "multiword"));
 
     Map<String, String> streamUserProps = ImmutableMap.of("sKey1", "sValue1 sValue2",
                                                           "Key1", "Value1");
-    store.setProperties(MetadataScope.USER, dataset2.toMetadataEntity(), streamUserProps);
+    store.addProperties(MetadataScope.USER, dataset2.toMetadataEntity(), streamUserProps);
 
     Map<String, String> datasetUserProps = ImmutableMap.of("sKey1", "sValuee1 sValuee2");
-    store.setProperties(MetadataScope.USER, dataset1.toMetadataEntity(), datasetUserProps);
+    store.addProperties(MetadataScope.USER, dataset1.toMetadataEntity(), datasetUserProps);
 
     // Test score and metadata match
     MetadataSearchResponse response = search("ns1", "value1 multiword:av2");
@@ -373,25 +373,25 @@ public class DefaultMetadataStoreTest {
     MetadataEntity ns2app1 = ns2.app("a1").toMetadataEntity();
     MetadataEntity ns2app2 = ns2.app("a2").toMetadataEntity();
 
-    store.setProperty(MetadataScope.USER, ns1app1, "k1", "v1");
+    store.addProperty(MetadataScope.USER, ns1app1, "k1", "v1");
     store.addTags(MetadataScope.USER, ns1app1, Collections.singleton("v1"));
     Metadata meta = new Metadata(Collections.singletonMap("k1", "v1"), Collections.singleton("v1"));
     MetadataSearchResultRecord ns1app1Record =
       new MetadataSearchResultRecord(ns1app1, Collections.singletonMap(MetadataScope.USER, meta));
 
-    store.setProperty(MetadataScope.USER, ns1app2, "k1", "v1");
-    store.setProperty(MetadataScope.USER, ns1app2, "k2", "v2");
+    store.addProperty(MetadataScope.USER, ns1app2, "k1", "v1");
+    store.addProperty(MetadataScope.USER, ns1app2, "k2", "v2");
     meta = new Metadata(ImmutableMap.of("k1", "v1", "k2", "v2"), Collections.emptySet());
     MetadataSearchResultRecord ns1app2Record =
       new MetadataSearchResultRecord(ns1app2, Collections.singletonMap(MetadataScope.USER, meta));
 
-    store.setProperty(MetadataScope.USER, ns1app3, "k1", "v1");
-    store.setProperty(MetadataScope.USER, ns1app3, "k3", "v3");
+    store.addProperty(MetadataScope.USER, ns1app3, "k1", "v1");
+    store.addProperty(MetadataScope.USER, ns1app3, "k3", "v3");
     meta = new Metadata(ImmutableMap.of("k1", "v1", "k3", "v3"), Collections.emptySet());
     MetadataSearchResultRecord ns1app3Record =
       new MetadataSearchResultRecord(ns1app3, Collections.singletonMap(MetadataScope.USER, meta));
 
-    store.setProperties(MetadataScope.USER, ImmutableMap.of(
+    store.addProperties(MetadataScope.USER, ImmutableMap.of(
       ns2app1, ImmutableMap.of("k1", "v1", "k2", "v2"),
       ns2app2, ImmutableMap.of("k1", "v1")));
     store.addTags(MetadataScope.USER, ns2app2, ImmutableSet.of("v2", "v3"));
@@ -621,7 +621,7 @@ public class DefaultMetadataStoreTest {
 
   private void generateMetadataUpdates() {
     store.addTags(MetadataScope.USER, dataset.toMetadataEntity(), datasetTags);
-    store.setProperties(MetadataScope.USER, app.toMetadataEntity(), appProperties);
+    store.addProperties(MetadataScope.USER, app.toMetadataEntity(), appProperties);
     store.addTags(MetadataScope.USER, app.toMetadataEntity(), appTags);
     store.addTags(MetadataScope.USER, service.toMetadataEntity(), tags);
     store.removeTags(MetadataScope.USER, service.toMetadataEntity());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/MetadataStorageTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/MetadataStorageTest.java
@@ -371,7 +371,7 @@ public abstract class MetadataStorageTest {
 
     mds.batch(ImmutableList.of(app1Record, app2Record, program1Record, dataset1Record, dataset2Record, file1Record)
                 .stream().map(record -> new Update(record.getEntity(), record.getMetadata()))
-                .collect(Collectors.toSet()));
+                .collect(Collectors.toList()));
 
     // Try to search on all tags
     assertResults(mds, SearchRequest.of("tags:*").addNamespace(ns1).build(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.metadata.dataset;
+
+import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.LocalLocationModule;
+import co.cask.cdap.common.guice.NamespaceAdminTestModule;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
+import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
+import co.cask.cdap.spi.metadata.Metadata;
+import co.cask.cdap.spi.metadata.MetadataMutation.Drop;
+import co.cask.cdap.spi.metadata.MetadataMutation.Remove;
+import co.cask.cdap.spi.metadata.MetadataMutation.Update;
+import co.cask.cdap.spi.metadata.MetadataRecord;
+import co.cask.cdap.spi.metadata.MetadataStorage;
+import co.cask.cdap.spi.metadata.MetadataStorageTest;
+import co.cask.cdap.spi.metadata.ScopedNameOfKind;
+import co.cask.cdap.spi.metadata.SearchRequest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.util.Modules;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.runtime.TransactionInMemoryModule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static co.cask.cdap.api.metadata.MetadataScope.SYSTEM;
+import static co.cask.cdap.api.metadata.MetadataScope.USER;
+import static co.cask.cdap.spi.metadata.MetadataKind.PROPERTY;
+import static co.cask.cdap.spi.metadata.MetadataKind.TAG;
+
+public class DatasetMetadataStorageTest extends MetadataStorageTest {
+
+  private static TransactionManager txManager;
+  private static DatasetMetadataStorage storage;
+
+  @BeforeClass
+  public static void setup() {
+    Injector injector = Guice.createInjector(
+      new ConfigModule(),
+      Modules.override(
+        new DataSetsModules().getInMemoryModules()).with(new AbstractModule() {
+        @Override
+        protected void configure() {
+          // Need the distributed metadata store.
+          bind(MetadataStore.class).to(DefaultMetadataStore.class);
+        }
+      }),
+      new LocalLocationModule(),
+      new TransactionInMemoryModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new NamespaceAdminTestModule(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterModule()
+    );
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+    storage = injector.getInstance(DatasetMetadataStorage.class);
+  }
+
+  @AfterClass
+  public static void teardown() {
+    txManager.stopAndWait();
+  }
+
+  @Override
+  protected MetadataStorage getMetadataStorage() {
+    return storage;
+  }
+
+  // this tests is not in MetadataStorageTest,
+  // because it tests result scoring and sorting specific to the dataset-based implementation
+  @Test
+  public void testSearchWeight() throws IOException {
+    MetadataStorage mds = getMetadataStorage();
+
+    String ns = "ns1";
+    NamespaceId nsId = new NamespaceId(ns);
+    MetadataEntity service1 = nsId.app("app1").service("service1").toMetadataEntity();
+    MetadataEntity dataset1 = nsId.dataset("ds1").toMetadataEntity();
+    MetadataEntity dataset2 = nsId.dataset("ds2").toMetadataEntity();
+
+    // Add metadata
+    String multiWordValue = "aV1 av2 ,  -  ,  av3 - av4_av5 av6";
+    Map<String, String> userProps = ImmutableMap.of("key1", "value1", "key2", "value2", "multiword", multiWordValue);
+    Map<String, String> systemProps = ImmutableMap.of("sysKey1", "sysValue1");
+    Set<String> userTags = ImmutableSet.of("tag1", "tag2");
+    Set<String> temporaryUserTags = ImmutableSet.of("tag3", "tag4");
+    Map<String, String> dataset1UserProps = ImmutableMap.of("sKey1", "sValuee1 sValuee2");
+    Map<String, String> dataset2UserProps = ImmutableMap.of("sKey1", "sValue1 sValue2", "Key1", "Value1");
+    Set<String> sysTags = ImmutableSet.of("sysTag1");
+
+    MetadataRecord service1Record = new MetadataRecord(
+      service1, union(new Metadata(USER, userTags, userProps), new Metadata(SYSTEM, sysTags, systemProps)));
+    mds.apply(new Update(service1Record.getEntity(), service1Record.getMetadata()));
+
+    // dd and then remove some metadata for dataset2
+    mds.apply(new Update(dataset2, new Metadata(USER, temporaryUserTags, userProps)));
+    mds.apply(new Remove(dataset2, temporaryUserTags.stream()
+      .map(tag -> new ScopedNameOfKind(TAG, USER, tag)).collect(Collectors.toSet())));
+    mds.apply(new Remove(dataset2, userProps.keySet().stream()
+      .map(tag -> new ScopedNameOfKind(PROPERTY, USER, tag)).collect(Collectors.toSet())));
+
+    MetadataRecord dataset1Record = new MetadataRecord(dataset1, new Metadata(USER, tags(), dataset1UserProps));
+    MetadataRecord dataset2Record = new MetadataRecord(dataset2, new Metadata(USER, tags(), dataset2UserProps));
+
+    mds.batch(ImmutableList.of(new Update(dataset1Record.getEntity(), dataset1Record.getMetadata()),
+                               new Update(dataset2Record.getEntity(), dataset2Record.getMetadata())));
+
+    // Test score and metadata match
+    assertInOrder(mds, SearchRequest.of("value1 multiword:av2").addNamespace(ns).build(),
+                  service1Record, dataset2Record);
+    assertInOrder(mds, SearchRequest.of("value1 sValue*").addNamespace(ns).setLimit(Integer.MAX_VALUE).build(),
+                  dataset2Record, dataset1Record, service1Record);
+    assertResults(mds, SearchRequest.of("*").addNamespace(ns).setLimit(Integer.MAX_VALUE).build(),
+                  dataset2Record, dataset1Record, service1Record);
+
+    // clean up
+    mds.batch(ImmutableList.of(new Drop(service1), new Drop(dataset1), new Drop(dataset2)));
+  }
+}


### PR DESCRIPTION
- adds an implementation of the metadata SPI based on the existing MetadataDataset.
- adds a specific test for the scoring, that is specific to this implementation.
- adds a class "SearchHelper" that is shared between this implementation and the (still) existing DefaultMetadataStore, to avoid duplication of this non-trivial code to score and sort results.

