### PR TITLE
CDAP-14813 fix flaky explore service tests

### DIFF
--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -212,7 +212,8 @@ public class BaseHiveExploreServiceTest {
     NamespaceMeta namespaceMeta = new NamespaceMeta.Builder().setName(namespaceId).build();
     namespaceAdmin.create(namespaceMeta);
     if (!NamespaceId.DEFAULT.equals(namespaceId)) {
-      exploreService.createNamespace(namespaceMeta);
+      QueryHandle handle = exploreService.createNamespace(namespaceMeta);
+      waitForCompletionStatus(handle, 50, TimeUnit.MILLISECONDS, 40);
     }
   }
 
@@ -222,7 +223,8 @@ public class BaseHiveExploreServiceTest {
   protected static void deleteNamespace(NamespaceId namespaceId) throws Exception {
     namespacePathLocator.get(namespaceId).delete(true);
     if (!NamespaceId.DEFAULT.equals(namespaceId)) {
-      exploreService.deleteNamespace(namespaceId);
+      QueryHandle handle = exploreService.deleteNamespace(namespaceId);
+      waitForCompletionStatus(handle, 50, TimeUnit.MILLISECONDS, 40);
     }
     namespaceAdmin.delete(namespaceId);
   }


### PR DESCRIPTION
The queries used to create and drop databases were being treated
as blocking calls in the unit tests even though they are not.
Changed them to wait until the query is done before moving on.

This fixes one particular test that would create namespace 'foo',
check for TableNotFoundExceptions on two tables in 'foo', then delete
namespace 'foo'. The exceptions can be thrown if the namespace
does not exist, and the deletion of the namespace can fail if
it is run before the creation of the namespace completes. This
leaves namespace 'foo' hanging around for the lifetime of the
test, which causes a subsequent namespace test case to fail.