### PR TITLE
[CDAP-14757] Add an Elasticsearch module that allows testing via 'mvn verify'

### DIFF
--- a/cdap-elastic/pom.xml
+++ b/cdap-elastic/pom.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2019 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap</artifactId>
+    <version>6.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-elastic</artifactId>
+  <name>CDAP Elasticsearch Metadata Storage Provider</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <elasticsearch.version>6.5.3</elasticsearch.version>
+    <httpclient.version>4.5.2</httpclient.version>
+    <httpcore.version>4.4.4</httpcore.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common-unit-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!--- ElasticSearch dependencies -->
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-high-level-client</artifactId>
+      <version>${elasticsearch.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>${httpcore.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Shouldn't deploy test module -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14.1</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.15</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <argLine>-Delastic.http.port=${elasticHttpPort}</argLine>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>reserve-ports</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <configuration>
+              <portNames>
+                <portName>elasticHttpPort</portName>
+                <portName>elasticTransportPort</portName>
+              </portNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.github.alexcojocaru</groupId>
+        <artifactId>elasticsearch-maven-plugin</artifactId>
+        <version>6.9</version>
+        <configuration>
+          <version>${elasticsearch.version}</version>
+          <clusterName>test</clusterName>
+          <transportPort>${elasticTransportPort}</transportPort>
+          <httpPort>${elasticHttpPort}</httpPort>
+        </configuration>
+        <executions>
+          <!--
+              The elasticsearch maven plugin goals are by default bound to the
+              pre-integration-test and post-integration-test phases
+          -->
+          <execution>
+            <id>start-elasticsearch</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>runforked</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop-elasticsearch</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/cdap-elastic/src/test/java/co/cask/cdap/metadata/elastic/ElasticClientTest.java
+++ b/cdap-elastic/src/test/java/co/cask/cdap/metadata/elastic/ElasticClientTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata.elastic;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * Tests the way Elasticsearch is set up for "integration" tests (mvn verify).
+ */
+public class ElasticClientTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ElasticClientTest.class);
+
+  @Test
+  public void testCreateDelete() throws IOException {
+    int elasticPort = Integer.valueOf(System.getProperty("elastic.http.port", "9200"));
+    LOG.info("Elasticsearch port is {}", System.getProperty("elastic.http.port"));
+    try (RestHighLevelClient client =
+           new RestHighLevelClient(RestClient.builder(new HttpHost("localhost", elasticPort)))) {
+
+      String indexName = "test" + new Random(System.currentTimeMillis()).nextInt();
+      CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
+      createIndexRequest.settings(Settings.builder()
+                                    .put("index.number_of_shards", 1)
+                                    .put("index.number_of_replicas", 1));
+      Assert.assertTrue(client.indices().create(createIndexRequest, RequestOptions.DEFAULT).isAcknowledged());
+      try {
+        GetIndexRequest request = new GetIndexRequest().indices(indexName);
+        Assert.assertTrue(client.indices().exists(request, RequestOptions.DEFAULT));
+      } finally {
+        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexName);
+        Assert.assertTrue(client.indices().delete(deleteIndexRequest, RequestOptions.DEFAULT).isAcknowledged());
+      }
+      GetIndexRequest request = new GetIndexRequest().indices(indexName);
+      Assert.assertFalse(client.indices().exists(request, RequestOptions.DEFAULT));
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2710,6 +2710,7 @@
         <module>cdap-api-spark</module>
         <module>cdap-api-spark2_2.11</module>
         <module>cdap-formats</module>
+        <module>cdap-elastic</module>
         <module>cdap-hbase-compat-base</module>
         <module>cdap-hbase-compat-0.96</module>
         <module>cdap-hbase-compat-0.98</module>


### PR DESCRIPTION
This uses the elasticsearch maven plugin to start an ES instance in the pre-integration-test stage, then runs the integration tests (mvn verify, not ITN), and tears down ES in the post-integration-test. 

There is no way to configure 0 as the port number for ES and make it bind to a random port. Therefore, this uses the reserve-ports plugin to find a free port immediately before starting ES. There is a very small chance that the port is taken by something else before ES comes up, and that would fail the test, but there does not seem to be a way around this. 

The elasticsearch port is then passed to the test using a system property.