### PR TITLE
[CDAP-14834] Remove dependency on dataset framework

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/NoSqlArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/NoSqlArtifactStoreTest.java
@@ -21,9 +21,6 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespacePathLocator;
-import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.nosql.NoSqlStructuredTableAdmin;
-import co.cask.cdap.data2.nosql.NoSqlTransactionRunner;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.security.impersonation.Impersonator;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
@@ -31,7 +28,6 @@ import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import co.cask.cdap.store.StoreDefinition;
 import com.google.common.base.Joiner;
 import com.google.inject.Injector;
-import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.BeforeClass;
 
@@ -42,13 +38,10 @@ public class NoSqlArtifactStoreTest extends ArtifactStoreTest {
     CConfiguration cConf = CConfiguration.create();
     // any plugin which requires transaction will be excluded
     cConf.set(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE, Joiner.on(",").join(Table.TYPE, KeyValueTable.TYPE));
-    artifactStore = AppFabricTestHelper.getInjector(cConf).getInstance(ArtifactStore.class);
+    cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
     Injector injector = AppFabricTestHelper.getInjector(cConf);
-    DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
-    StructuredTableAdmin structuredTableAdmin = new NoSqlStructuredTableAdmin(datasetFramework);
-    TransactionSystemClient txClient = injector.getInstance(TransactionSystemClient.class);
-
-    TransactionRunner transactionRunner = new NoSqlTransactionRunner(datasetFramework, txClient);
+    StructuredTableAdmin structuredTableAdmin = injector.getInstance(StructuredTableAdmin.class);
+    TransactionRunner transactionRunner = injector.getInstance(TransactionRunner.class);
     artifactStore = new ArtifactStore(cConf,
                                       injector.getInstance(NamespacePathLocator.class),
                                       injector.getInstance(LocationFactory.class),

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -430,8 +430,11 @@ public final class Constants {
     public static final String DATA_EVENT_TOPIC = "data.event.topic";
 
     public static final String DATA_STORAGE_IMPLEMENTATION = "data.storage.implementation";
-    public static final String DATA_STROAGE_NOSQL = "nosql";
+    public static final String DATA_STORAGE_NOSQL = "nosql";
     public static final String DATA_STORAGE_SQL = "postgressql";
+
+    // used for Guice named bindings
+    public static final String TABLE_TYPE = "table.type";
 
     /**
      * Constants for PartitionedFileSet's DynamicPartitioner

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
@@ -53,7 +53,7 @@ public class DataFabricDistributedModule extends AbstractModule {
   @Override
   public void configure() {
     bind(ThriftClientProvider.class).toProvider(ThriftClientProviderSupplier.class);
-    bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
+    bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class).in(Scopes.SINGLETON);
 
     // bind transactions
     bind(TransactionSystemClientService.class).to(DistributedTransactionSystemClientService.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/StorageModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/StorageModule.java
@@ -20,7 +20,6 @@ package co.cask.cdap.data.runtime;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
-import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.nosql.NoSqlStructuredTableAdmin;
 import co.cask.cdap.data2.nosql.NoSqlTransactionRunner;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
@@ -70,8 +69,8 @@ public class StorageModule extends PrivateModule {
       }
 
       storageImpl = storageImpl.toLowerCase();
-      if (storageImpl.equals(Constants.Dataset.DATA_STROAGE_NOSQL)) {
-        return new NoSqlTransactionRunner(injector.getInstance(DatasetFramework.class),
+      if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+        return new NoSqlTransactionRunner(injector.getInstance(NoSqlStructuredTableAdmin.class),
                                           injector.getInstance(TransactionSystemClient.class));
       }
 
@@ -107,20 +106,20 @@ public class StorageModule extends PrivateModule {
     public StructuredTableAdmin get() {
       String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
       if (storageImpl == null) {
-        throw new IllegalStateException("No storage implentation is specified in the configuration file");
+        throw new IllegalStateException("No storage implementation is specified in the configuration file");
       }
 
       storageImpl = storageImpl.toLowerCase();
-      if (storageImpl.equals(Constants.Dataset.DATA_STROAGE_NOSQL)) {
-        return new NoSqlStructuredTableAdmin(injector.getInstance(DatasetFramework.class));
+      if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+        return injector.getInstance(NoSqlStructuredTableAdmin.class);
       }
       if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
         // TODO: CDAP-14780, connect to the sql using the connection, user name and password from the sConf
         return null;
       }
-      throw new UnsupportedOperationException(String.format("%s is not a supported storage implementation, the " +
-                                                              "supported implementations are NoSql and PostgresSql.",
-                                                            storageImpl));
+      throw new UnsupportedOperationException(
+        String.format("%s is not a supported storage implementation, the supported implementations are %s and %s",
+                      storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data.runtime;
 
+import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.lib.ObjectMappedTable;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
@@ -34,6 +35,9 @@ import co.cask.cdap.data2.dataset2.lib.partitioned.TimePartitionedFileSetModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.lib.table.CubeModule;
 import co.cask.cdap.data2.dataset2.lib.table.ObjectMappedTableModule;
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableDefinition;
+import co.cask.cdap.data2.dataset2.lib.table.inmemory.InMemoryTableDefinition;
+import co.cask.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableDefinition;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseMetricsTableModule;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseTableModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryMetricsTableModule;
@@ -50,6 +54,7 @@ import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.MapBinder;
+import com.google.inject.name.Names;
 
 /**
  * Provides guice bindings for {@link DatasetModule} that are by default available in the system.
@@ -71,6 +76,11 @@ public class SystemDatasetRuntimeModule extends RuntimeModule {
         mapBinder.addBinding("orderedTable-memory").toInstance(new InMemoryTableModule());
         mapBinder.addBinding("metricsTable-memory").toInstance(new InMemoryMetricsTableModule());
         bindDefaultModules(mapBinder);
+
+        bind(String.class)
+          .annotatedWith(Names.named(Constants.Dataset.TABLE_TYPE)).toInstance("table");
+        bind(DatasetDefinition.class)
+          .annotatedWith(Names.named(Constants.Dataset.TABLE_TYPE)).to(InMemoryTableDefinition.class);
       }
     };
   }
@@ -86,6 +96,11 @@ public class SystemDatasetRuntimeModule extends RuntimeModule {
         mapBinder.addBinding("orderedTable-leveldb").toInstance(new LevelDBTableModule());
         mapBinder.addBinding("metricsTable-leveldb").toInstance(new LevelDBMetricsTableModule());
         bindDefaultModules(mapBinder);
+
+        bind(String.class)
+          .annotatedWith(Names.named(Constants.Dataset.TABLE_TYPE)).toInstance("table");
+        bind(DatasetDefinition.class)
+          .annotatedWith(Names.named(Constants.Dataset.TABLE_TYPE)).to(LevelDBTableDefinition.class);
       }
     };
   }
@@ -127,6 +142,11 @@ public class SystemDatasetRuntimeModule extends RuntimeModule {
         mapBinder.addBinding("orderedTable-hbase").toProvider(OrderedTableModuleProvider.class).in(Singleton.class);
         mapBinder.addBinding("metricsTable-hbase").toInstance(new HBaseMetricsTableModule());
         bindDefaultModules(mapBinder);
+
+        bind(String.class)
+          .annotatedWith(Names.named(Constants.Dataset.TABLE_TYPE)).toInstance("table");
+        bind(DatasetDefinition.class)
+          .annotatedWith(Names.named(Constants.Dataset.TABLE_TYPE)).to(HBaseTableDefinition.class);
       }
     };
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/AbstractTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/AbstractTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -43,6 +43,11 @@ public abstract class AbstractTableDefinition<D extends Dataset, A extends Datas
 
   protected AbstractTableDefinition(String name) {
     super(name);
+  }
+
+  protected AbstractTableDefinition(String name, CConfiguration cConf) {
+    super(name);
+    this.cConf = cConf;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,9 +19,12 @@ package co.cask.cdap.data2.dataset2.lib.table.hbase;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.AbstractTableDefinition;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.filesystem.LocationFactory;
 
@@ -36,23 +39,24 @@ public class HBaseTableDefinition extends AbstractTableDefinition<Table, HBaseTa
   @Inject
   private Configuration hConf;
   @Inject
-  private HBaseTableUtil hBaseTableUtil;
+  private Provider<HBaseTableUtil> hBaseTableUtilProvider;
   @Inject
   private LocationFactory locationFactory;
 
-  public HBaseTableDefinition(String name) {
+  @Inject
+  public HBaseTableDefinition(@Named(Constants.Dataset.TABLE_TYPE) String name) {
     super(name);
   }
 
   @Override
   public Table getDataset(DatasetContext datasetContext, DatasetSpecification spec,
                           Map<String, String> arguments, ClassLoader classLoader) throws IOException {
-    return new HBaseTable(datasetContext, spec, arguments, cConf, hConf, hBaseTableUtil);
+    return new HBaseTable(datasetContext, spec, arguments, cConf, hConf, hBaseTableUtilProvider.get());
   }
 
   @Override
   public HBaseTableAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
                                   ClassLoader classLoader) throws IOException {
-    return new HBaseTableAdmin(datasetContext, spec, hConf, hBaseTableUtil, cConf, locationFactory);
+    return new HBaseTableAdmin(datasetContext, spec, hConf, hBaseTableUtilProvider.get(), cConf, locationFactory);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,10 @@ package co.cask.cdap.data2.dataset2.lib.table.inmemory;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.AbstractTableDefinition;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 import java.io.IOException;
 import java.util.Map;
@@ -29,7 +32,8 @@ import java.util.Map;
  */
 public class InMemoryTableDefinition extends AbstractTableDefinition<Table, InMemoryTableAdmin> {
 
-  public InMemoryTableDefinition(String name) {
+  @Inject
+  public InMemoryTableDefinition(@Named(Constants.Dataset.TABLE_TYPE) String name) {
     super(name);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,8 +19,10 @@ package co.cask.cdap.data2.dataset2.lib.table.leveldb;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.AbstractTableDefinition;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 import java.io.IOException;
 import java.util.Map;
@@ -33,7 +35,8 @@ public class LevelDBTableDefinition extends AbstractTableDefinition<Table, Level
   @Inject
   private LevelDBTableService service;
 
-  public LevelDBTableDefinition(String name) {
+  @Inject
+  public LevelDBTableDefinition(@Named(Constants.Dataset.TABLE_TYPE) String name) {
     super(name);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/nosql/NoSqlStructuredTableContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/nosql/NoSqlStructuredTableContext.java
@@ -18,9 +18,7 @@ package co.cask.cdap.data2.nosql;
 
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
-import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.spi.data.StructuredTable;
-import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.StructuredTableContext;
 import co.cask.cdap.spi.data.StructuredTableInstantiationException;
 import co.cask.cdap.spi.data.TableNotFoundException;
@@ -32,28 +30,27 @@ import co.cask.cdap.spi.data.table.StructuredTableSpecification;
  * The nosql context to get the table.
  */
 public class NoSqlStructuredTableContext implements StructuredTableContext {
+  private final NoSqlStructuredTableAdmin tableAdmin;
   private final DatasetContext datasetContext;
-  private final StructuredTableAdmin tableAdmin;
 
-  public NoSqlStructuredTableContext(DatasetContext datasetContext, StructuredTableAdmin tableAdmin) {
-    this.datasetContext = datasetContext;
+  NoSqlStructuredTableContext(NoSqlStructuredTableAdmin tableAdmin, DatasetContext datasetContext) {
     this.tableAdmin = tableAdmin;
+    this.datasetContext = datasetContext;
   }
 
   @Override
-  public StructuredTable getTable(
-    StructuredTableId tableId) throws StructuredTableInstantiationException, TableNotFoundException {
+  public StructuredTable getTable(StructuredTableId tableId)
+    throws StructuredTableInstantiationException, TableNotFoundException {
     try {
       StructuredTableSpecification specification = tableAdmin.getSpecification(tableId);
       if (specification == null) {
         throw new TableNotFoundException(tableId);
       }
-      return new NoSqlStructuredTable(datasetContext.getDataset(NamespaceId.SYSTEM.getNamespace(),
-                                                                NoSqlStructuredTableAdmin.ENTITY_TABLE_NAME),
+      return new NoSqlStructuredTable(datasetContext.getDataset(NoSqlStructuredTableAdmin.ENTITY_TABLE_NAME),
                                       new StructuredTableSchema(specification));
     } catch (DatasetInstantiationException e) {
-      throw new StructuredTableInstantiationException(tableId,
-                                                      String.format("Error instantiating table %s", tableId), e);
+      throw new StructuredTableInstantiationException(
+        tableId, String.format("Error instantiating table %s", tableId), e);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/nosql/NoSqlTransactionRunner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/nosql/NoSqlTransactionRunner.java
@@ -17,46 +17,146 @@
 package co.cask.cdap.data2.nosql;
 
 import co.cask.cdap.api.Transactional;
-import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
-import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
-import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.data2.transaction.Transactions;
-import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.transaction.TransactionException;
 import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import co.cask.cdap.spi.data.transaction.TxRunnable;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import org.apache.tephra.RetryStrategies;
+import org.apache.tephra.TransactionAware;
+import org.apache.tephra.TransactionContext;
 import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionSystemClient;
 
-import java.util.Collections;
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * No sql transaction runner to start a transaction
  */
 public class NoSqlTransactionRunner implements TransactionRunner {
-  private final StructuredTableAdmin tableAdmin;
+  private final NoSqlStructuredTableAdmin tableAdmin;
   private final Transactional transactional;
 
-  public NoSqlTransactionRunner(DatasetFramework dsFramework, TransactionSystemClient txClient) {
-    this.tableAdmin = new NoSqlStructuredTableAdmin(dsFramework);
-    this.transactional = Transactions.createTransactionalWithRetry(
-      Transactions.createTransactional(new MultiThreadDatasetCache(
-        new SystemDatasetInstantiator(dsFramework), new TransactionSystemClientAdapter(txClient),
-        NamespaceId.SYSTEM, Collections.emptyMap(), null, null)),
-      org.apache.tephra.RetryStrategies.retryOnConflict(20, 100)
-    );
+  @Inject
+  public NoSqlTransactionRunner(NoSqlStructuredTableAdmin tableAdmin, TransactionSystemClient txClient) {
+    this.tableAdmin = tableAdmin;
+    this.transactional = Transactions.createTransactionalWithRetry(createTransactional(txClient),
+                                                                   RetryStrategies.retryOnConflict(20, 100));
+  }
+
+  private Transactional createTransactional(TransactionSystemClient txClient) {
+    return new Transactional() {
+      @Override
+      public void execute(co.cask.cdap.api.TxRunnable runnable) throws TransactionFailureException {
+        TransactionContext txContext = new TransactionContext(txClient);
+        try (EntityTableDatasetContext datasetContext = new EntityTableDatasetContext(txContext)) {
+          txContext.start();
+          finishExecute(txContext, datasetContext, runnable);
+        } catch (Exception e) {
+          Throwables.propagateIfPossible(e, TransactionFailureException.class);
+        }
+      }
+
+      @Override
+      public void execute(int timeout, co.cask.cdap.api.TxRunnable runnable) throws TransactionFailureException {
+        TransactionContext txContext = new TransactionContext(txClient);
+        try (EntityTableDatasetContext datasetContext = new EntityTableDatasetContext(txContext)) {
+          txContext.start(timeout);
+          finishExecute(txContext, datasetContext, runnable);
+        } catch (Exception e) {
+          Throwables.propagateIfPossible(e, TransactionFailureException.class);
+        }
+      }
+
+      private void finishExecute(TransactionContext txContext, DatasetContext dsContext,
+                                 co.cask.cdap.api.TxRunnable runnable)
+        throws TransactionFailureException {
+        try {
+          runnable.run(dsContext);
+        } catch (Exception e) {
+          txContext.abort(new TransactionFailureException("Exception raised from TxRunnable.run() " + runnable, e));
+        }
+        // The call the txContext.abort above will always have exception thrown
+        // Hence we'll only reach here if and only if the runnable.run() returns normally.
+        txContext.finish();
+      }
+    };
   }
 
   @Override
   public void run(TxRunnable runnable) throws TransactionException {
     try {
       transactional.execute(
-        datasetContext -> runnable.run(new NoSqlStructuredTableContext(datasetContext, tableAdmin))
+        datasetContext -> runnable.run(new NoSqlStructuredTableContext(tableAdmin, datasetContext))
       );
     } catch (TransactionFailureException e) {
       throw new TransactionException("Failure executing NoSql transaction:", e.getCause() == null ? e : e.getCause());
+    }
+  }
+
+  private class EntityTableDatasetContext implements DatasetContext, AutoCloseable {
+
+    private final TransactionContext txContext;
+    private Dataset entityTable = null;
+
+    private EntityTableDatasetContext(TransactionContext txContext) {
+      this.txContext = txContext;
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (entityTable != null) {
+        entityTable.close();
+        entityTable = null;
+      }
+    }
+
+    @Override
+    public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+      // this is the only method that gets called on this dataset context (see NoSqlStructuredTableContext)
+      if (NoSqlStructuredTableAdmin.ENTITY_TABLE_NAME.equals(name)) {
+        if (entityTable == null) {
+          try {
+            entityTable = tableAdmin.getEntityTable();
+            txContext.addTransactionAware((TransactionAware) entityTable);
+          } catch (IOException e) {
+            throw new DatasetInstantiationException("Cannot instantiate entity table", e);
+          }
+        }
+        //noinspection unchecked
+        return (T) entityTable;
+      }
+      throw new DatasetInstantiationException("Trying to access dataset other than entity table: " + name);
+    }
+
+    @Override
+    public <T extends Dataset> T getDataset(String namespace, String name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends Dataset> T getDataset(String name, Map<String, String> arguments) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments)  {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void releaseDataset(Dataset dataset) {
+      // no-op
+    }
+
+    @Override
+    public void discardDataset(Dataset dataset) {
+      // no-op
     }
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/nosql/NoSqlStructuredTableTest.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
-import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.StructuredTableTest;
 import co.cask.cdap.spi.data.table.StructuredTableSchema;
@@ -30,8 +29,6 @@ import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.tephra.TransactionManager;
-import org.apache.tephra.TransactionSystemClient;
-import org.apache.tephra.inmemory.InMemoryTxSystemClient;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -74,10 +71,8 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     Configuration txConf = HBaseConfiguration.create();
     txManager = new TransactionManager(txConf);
     txManager.startAndWait();
-    TransactionSystemClient txClient = new InMemoryTxSystemClient(txManager);
-    noSqlTableAdmin = new NoSqlStructuredTableAdmin(dsFrameworkUtil.getFramework());
-    transactionRunner = new NoSqlTransactionRunner(dsFrameworkUtil.getFramework(),
-                                                   new TransactionSystemClientAdapter(txClient));
+    noSqlTableAdmin = dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableAdmin.class);
+    transactionRunner = dsFrameworkUtil.getInjector().getInstance(NoSqlTransactionRunner.class);
   }
 
   @AfterClass

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/JobQueueDebugger.java
@@ -44,8 +44,6 @@ import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.metadata.writer.NoOpMetadataPublisher;
 import co.cask.cdap.data2.transaction.Transactions;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.runtime.schedule.constraint.ConstraintCodec;
 import co.cask.cdap.internal.app.runtime.schedule.queue.Job;
@@ -369,7 +367,6 @@ public class JobQueueDebugger extends AbstractIdleService {
       new AbstractModule() {
         @Override
         protected void configure() {
-          bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
           bind(Store.class).annotatedWith(Names.named("defaultStore")).to(DefaultStore.class).in(Singleton.class);
 
           // This is needed because the LocalApplicationManager

--- a/cdap-storage-spi/src/main/java/co/cask/cdap/spi/data/table/StructuredTableSpecificationRegistry.java
+++ b/cdap-storage-spi/src/main/java/co/cask/cdap/spi/data/table/StructuredTableSpecificationRegistry.java
@@ -43,4 +43,8 @@ public final class StructuredTableSpecificationRegistry {
   public static void removeSpecification(StructuredTableId tableId) {
     specMap.remove(tableId);
   }
+
+  public static boolean isEmpty() {
+    return specMap.isEmpty();
+  }
 }


### PR DESCRIPTION
Instead of going through DatasetFramework, uses the table's dataset definition directly to instantiate tables.