### PR TITLE
use https for market.cask.co

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1675,7 +1675,7 @@
 
   <property>
     <name>market.base.url</name>
-    <value>http://market.cask.co/v2</value>
+    <value>https://market.cask.co/v2</value>
     <description>
       The base URL of the Cask Market used by the CDAP UI for the Cask
       Market RESTful API. The default value shown is that of the public Cask

--- a/cdap-docs/user-guide/source/mmds/example.rst
+++ b/cdap-docs/user-guide/source/mmds/example.rst
@@ -13,7 +13,7 @@ Example Walk-Through
 This example walks you through using CDAP Sandbox to train a model that predicts the home sale prices for unsold homes on the market.
 
 The data source for this example is 2017 real estate sales for a few cities in the San Francisco Bay Area,
-which you can download `here <http://market.cask.co/v2/packages/datapack-realestate-sales/1.0.0/sales.tsv>`__.
+which you can download `here <https://market.cask.co/v2/packages/datapack-realestate-sales/1.0.0/sales.tsv>`__.
 Place the file on your local machine.
 
 Creating an Experiment
@@ -146,7 +146,7 @@ Making Predicitons
 ------------------
 
 You will be making predictions on sample real estate listings.
-Download the `listing file <http://market.cask.co/v2/packages/datapack-realestate-listings/1.0.0/listings.tsv>`__ and place it on your local machine.
+Download the `listing file <https://market.cask.co/v2/packages/datapack-realestate-listings/1.0.0/listings.tsv>`__ and place it on your local machine.
 
 Now click the `Creating a scoring pipeline` button to use the model we just trained to create a scoring pipeline.
 This brings you to the Pipeline Studio with part of a pipeline preconfigured for you.

--- a/cdap-ui/server/config/development/cdap.json
+++ b/cdap-ui/server/config/development/cdap.json
@@ -10,6 +10,6 @@
   "dashboard.bind.port": "11011",
   "enable.preview": "true",
   "dashboard.router.check.timeout.secs": "0",
-  "market.base.url": "http://market.cask.co/dev/v2",
+  "market.base.url": "https://market.cask.co/dev/v2",
   "ui.theme.file": "cdap-ui/server/config/themes/default.json"
 }


### PR DESCRIPTION
Use ssl for http://market.cask.co.

market.cask.co has also been updated to redirect http to https