### PR TITLE
CDAP-14839 replace usage of NotFound and AlreadyExists exceptions

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -30,7 +30,6 @@ import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -66,6 +65,7 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.scheduler.CoreSchedulerService;
 import co.cask.cdap.scheduler.Scheduler;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.TableAlreadyExistsException;
 import co.cask.cdap.store.StoreDefinition;
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
@@ -156,7 +156,7 @@ public class AppFabricTestHelper {
       StructuredTableAdmin tableAdmin = injector.getInstance(StructuredTableAdmin.class);
       try {
         StoreDefinition.createAllTables(tableAdmin);
-      } catch (IOException | AlreadyExistsException e) {
+      } catch (IOException | TableAlreadyExistsException e) {
         throw new RuntimeException("Failed to create the system tables", e);
       }
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.internal.app.namespace;
 
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.DefaultNamespacePathLocator;
@@ -59,7 +58,7 @@ public class StorageProviderNamespaceAdminTest {
   private static DatasetService datasetService;
 
   @BeforeClass
-  public static void setup() throws IOException, AlreadyExistsException {
+  public static void setup() throws Exception {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
     cConf.setBoolean(Constants.Explore.EXPLORE_ENABLED, true);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/SqlDefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/SqlDefaultStoreTest.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.internal.app.store;
 
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.sql.PostgresSqlStructuredTableAdmin;
@@ -45,7 +44,7 @@ public class SqlDefaultStoreTest extends DefaultStoreTest {
   private static EmbeddedPostgres pg;
 
   @BeforeClass
-  public static void beforeClass() throws IOException, AlreadyExistsException {
+  public static void beforeClass() throws Exception {
     Injector injector = AppFabricTestHelper.getInjector();
     // TODO(CDAP-14770): change this when migrating DefaultStore
     store = injector.getInstance(DefaultStore.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/nosql/NoSqlStructuredTableContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/nosql/NoSqlStructuredTableContext.java
@@ -18,12 +18,12 @@ package co.cask.cdap.data2.nosql;
 
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.spi.data.StructuredTable;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.StructuredTableContext;
 import co.cask.cdap.spi.data.StructuredTableInstantiationException;
+import co.cask.cdap.spi.data.TableNotFoundException;
 import co.cask.cdap.spi.data.table.StructuredTableId;
 import co.cask.cdap.spi.data.table.StructuredTableSchema;
 import co.cask.cdap.spi.data.table.StructuredTableSpecification;
@@ -42,11 +42,11 @@ public class NoSqlStructuredTableContext implements StructuredTableContext {
 
   @Override
   public StructuredTable getTable(
-    StructuredTableId tableId) throws StructuredTableInstantiationException, NotFoundException {
+    StructuredTableId tableId) throws StructuredTableInstantiationException, TableNotFoundException {
     try {
       StructuredTableSpecification specification = tableAdmin.getSpecification(tableId);
       if (specification == null) {
-        throw new NotFoundException(tableId);
+        throw new TableNotFoundException(tableId);
       }
       return new NoSqlStructuredTable(datasetContext.getDataset(NamespaceId.SYSTEM.getNamespace(),
                                                                 NoSqlStructuredTableAdmin.ENTITY_TABLE_NAME),

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/sql/PostgresSqlStructuredTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/sql/PostgresSqlStructuredTableAdmin.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.data2.sql;
 
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.TableAlreadyExistsException;
 import co.cask.cdap.spi.data.table.StructuredTableId;
 import co.cask.cdap.spi.data.table.StructuredTableSpecification;
 import co.cask.cdap.spi.data.table.StructuredTableSpecificationRegistry;
@@ -45,13 +45,13 @@ public class PostgresSqlStructuredTableAdmin implements StructuredTableAdmin {
   }
 
   @Override
-  public void create(StructuredTableSpecification spec) throws IOException, AlreadyExistsException {
+  public void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException {
     try (Connection connection = dataSource.getConnection()) {
       DatabaseMetaData metaData = connection.getMetaData();
       ResultSet rs = metaData.getTables(null, null,
                                         spec.getTableId().getName(), null);
       if (rs.next()) {
-        throw new AlreadyExistsException(spec.getTableId());
+        throw new TableAlreadyExistsException(spec.getTableId());
       }
       Statement statement = connection.createStatement();
       statement.execute(getCreateStatement(spec));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/sql/SqlStructuredTableContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/sql/SqlStructuredTableContext.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.data2.sql;
 
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.spi.data.StructuredTable;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.StructuredTableContext;
 import co.cask.cdap.spi.data.StructuredTableInstantiationException;
+import co.cask.cdap.spi.data.TableNotFoundException;
 import co.cask.cdap.spi.data.table.StructuredTableId;
 import co.cask.cdap.spi.data.table.StructuredTableSchema;
 import co.cask.cdap.spi.data.table.StructuredTableSpecification;
@@ -41,10 +41,10 @@ public class SqlStructuredTableContext implements StructuredTableContext {
 
   @Override
   public StructuredTable getTable(
-    StructuredTableId tableId) throws StructuredTableInstantiationException, NotFoundException {
+    StructuredTableId tableId) throws StructuredTableInstantiationException, TableNotFoundException {
     StructuredTableSpecification specification = admin.getSpecification(tableId);
     if (specification == null) {
-      throw new NotFoundException(tableId);
+      throw new TableNotFoundException(tableId);
     }
     return new PostgresSqlStructuredTable(connection, new StructuredTableSchema(specification));
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/StructuredTableAdmin.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.spi.data;
 
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.spi.data.table.StructuredTableId;
 import co.cask.cdap.spi.data.table.StructuredTableSpecification;
 
@@ -32,9 +31,9 @@ public interface StructuredTableAdmin {
    *
    * @param spec table specification
    * @throws IOException if there is an error creating the table
-   * @throws AlreadyExistsException if the table already exists
+   * @throws TableAlreadyExistsException if the table already exists
    */
-  void create(StructuredTableSpecification spec) throws IOException, AlreadyExistsException;
+  void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException;
 
   /**
    * Get the {@link StructuredTableSpecification} corresponding to the given table id.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/TableAlreadyExistsException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/TableAlreadyExistsException.java
@@ -12,6 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
 package co.cask.cdap.spi.data;
@@ -19,19 +20,17 @@ package co.cask.cdap.spi.data;
 import co.cask.cdap.spi.data.table.StructuredTableId;
 
 /**
- * This interface provides methods that instantiate a {@link StructuredTable} during the runtime.
- * of a program.
+ * Thrown when a table already exists when it is not expected to.
  */
-public interface StructuredTableContext {
+public class TableAlreadyExistsException extends Exception {
+  private final StructuredTableId id;
 
-  /**
-   * Get an instance of the specified Dataset.
-   *
-   * @param tableId the table id
-   * @return An instance of the specified table, never null
-   * @throws StructuredTableInstantiationException if the table cannot be instantiated
-   * @throws TableNotFoundException if the table is not found
-   */
-  StructuredTable getTable(StructuredTableId tableId)
-    throws StructuredTableInstantiationException, TableNotFoundException;
+  public TableAlreadyExistsException(StructuredTableId id) {
+    super(String.format("System table '%s' already exists.", id));
+    this.id = id;
+  }
+
+  public StructuredTableId getId() {
+    return id;
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/TableNotFoundException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/TableNotFoundException.java
@@ -12,6 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
 package co.cask.cdap.spi.data;
@@ -19,19 +20,17 @@ package co.cask.cdap.spi.data;
 import co.cask.cdap.spi.data.table.StructuredTableId;
 
 /**
- * This interface provides methods that instantiate a {@link StructuredTable} during the runtime.
- * of a program.
+ * Thrown when a table does not exist when it is expected to.
  */
-public interface StructuredTableContext {
+public class TableNotFoundException extends Exception {
+  private final StructuredTableId id;
 
-  /**
-   * Get an instance of the specified Dataset.
-   *
-   * @param tableId the table id
-   * @return An instance of the specified table, never null
-   * @throws StructuredTableInstantiationException if the table cannot be instantiated
-   * @throws TableNotFoundException if the table is not found
-   */
-  StructuredTable getTable(StructuredTableId tableId)
-    throws StructuredTableInstantiationException, TableNotFoundException;
+  public TableNotFoundException(StructuredTableId id) {
+    super(String.format("System table '%s' not found.", id));
+    this.id = id;
+  }
+
+  public StructuredTableId getId() {
+    return id;
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/field/FieldType.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/table/field/FieldType.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.spi.data.table.field;
 
-import com.google.common.collect.ImmutableSet;
-
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -37,7 +37,8 @@ public final class FieldType {
     BYTES
   }
 
-  static final Set<Type> PRIMARY_KEY_TYPES = ImmutableSet.of(Type.INTEGER, Type.LONG, Type.STRING);
+  static final Set<Type> PRIMARY_KEY_TYPES = Collections.unmodifiableSet(EnumSet.of(Type.INTEGER, Type.LONG,
+                                                                                    Type.STRING));
 
   private final String name;
   private final Type type;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/DefaultNamespaceStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/DefaultNamespaceStore.java
@@ -16,10 +16,10 @@
 
 package co.cask.cdap.store;
 
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.spi.data.StructuredTableContext;
+import co.cask.cdap.spi.data.TableNotFoundException;
 import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import co.cask.cdap.spi.data.transaction.TransactionRunners;
 import com.google.common.base.Preconditions;
@@ -40,7 +40,7 @@ public class DefaultNamespaceStore implements NamespaceStore {
     this.transactionRunner = transactionRunner;
   }
 
-  private NamespaceTable getNamespaceTable(StructuredTableContext context) throws NotFoundException {
+  private NamespaceTable getNamespaceTable(StructuredTableContext context) throws TableNotFoundException {
     return new NamespaceTable(context);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/NamespaceTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/NamespaceTable.java
@@ -22,6 +22,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.spi.data.StructuredRow;
 import co.cask.cdap.spi.data.StructuredTable;
 import co.cask.cdap.spi.data.StructuredTableContext;
+import co.cask.cdap.spi.data.TableNotFoundException;
 import co.cask.cdap.spi.data.table.field.Field;
 import co.cask.cdap.spi.data.table.field.Fields;
 import co.cask.cdap.spi.data.table.field.Range;
@@ -45,7 +46,7 @@ public final class NamespaceTable {
 
   private StructuredTable table;
 
-  NamespaceTable(StructuredTableContext context) throws NotFoundException {
+  NamespaceTable(StructuredTableContext context) throws TableNotFoundException {
     this.table = context.getTable(StoreDefinition.NamespaceStore.NAMESPACES);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
@@ -18,6 +18,7 @@ package co.cask.cdap.store;
 
 import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.TableAlreadyExistsException;
 import co.cask.cdap.spi.data.table.StructuredTableId;
 import co.cask.cdap.spi.data.table.StructuredTableSpecification;
 import co.cask.cdap.spi.data.table.field.Fields;
@@ -40,7 +41,7 @@ public final class StoreDefinition {
    * @param tableAdmin the table admin to create the table
    */
   public static void createAllTables(StructuredTableAdmin tableAdmin, boolean overWrite)
-    throws IOException, AlreadyExistsException {
+    throws IOException, TableAlreadyExistsException {
     if (overWrite || tableAdmin.getSpecification(ArtifactStore.ARTIFACT_DATA_TABLE) == null) {
       ArtifactStore.createTables(tableAdmin);
     }
@@ -49,7 +50,7 @@ public final class StoreDefinition {
     }
   }
 
-  public static void createAllTables(StructuredTableAdmin tableAdmin) throws IOException, AlreadyExistsException {
+  public static void createAllTables(StructuredTableAdmin tableAdmin) throws IOException, TableAlreadyExistsException {
     createAllTables(tableAdmin, false);
   }
 
@@ -70,7 +71,7 @@ public final class StoreDefinition {
         .withPrimaryKeys(NAMESPACE_FIELD)
         .build();
 
-    public static void createTables(StructuredTableAdmin tableAdmin) throws IOException, AlreadyExistsException {
+    public static void createTables(StructuredTableAdmin tableAdmin) throws IOException, TableAlreadyExistsException {
       tableAdmin.create(NAMESPACE_TABLE_SPEC);
     }
   }
@@ -153,7 +154,7 @@ public final class StoreDefinition {
                          ARTIFACT_NAMESPACE_FIELD, ARTIFACT_NAME_FIELD, ARTIFACT_VER_FIELD)
         .build();
 
-    public static void createTables(StructuredTableAdmin tableAdmin) throws IOException, AlreadyExistsException {
+    public static void createTables(StructuredTableAdmin tableAdmin) throws IOException, TableAlreadyExistsException {
       tableAdmin.create(ARTIFACT_DATA_SPEC);
       tableAdmin.create(APP_DATA_SPEC);
       tableAdmin.create(PLUGIN_DATA_SPEC);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/table/field/FieldTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/table/field/FieldTest.java
@@ -17,10 +17,10 @@
 package co.cask.cdap.spi.data.table.field;
 
 import co.cask.cdap.api.common.Bytes;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -39,13 +39,13 @@ public class FieldTest {
   }
 
   private Set<Field<?>> generateFieldsSet() {
-    return ImmutableSet.of(
-      Fields.bytesField("bytes", Bytes.toBytes("bytesval")),
-      Fields.stringField("string", "strval"),
-      Fields.doubleField("double", 100.0),
-      Fields.intField("int", 30),
-      Fields.bytesField("double-bytes", Bytes.toBytes(100.0)),
-      Fields.bytesField("long-bytes", Bytes.toBytes(600L))
-    );
+    Set<Field<?>> fields = new HashSet<>();
+    fields.add(Fields.bytesField("bytes", Bytes.toBytes("bytesval")));
+    fields.add(Fields.stringField("string", "strval"));
+    fields.add(Fields.doubleField("double", 100.0));
+    fields.add(Fields.intField("int", 30));
+    fields.add(Fields.bytesField("double-bytes", Bytes.toBytes(100.0)));
+    fields.add(Fields.bytesField("long-bytes", Bytes.toBytes(600L)));
+    return fields;
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -23,7 +23,6 @@ import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.guice.TwillModule;
 import co.cask.cdap.app.store.ServiceStore;
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.MasterUtils;
 import co.cask.cdap.common.app.MainClassLoader;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -77,6 +76,7 @@ import co.cask.cdap.security.guice.SecureStoreServerModule;
 import co.cask.cdap.security.impersonation.SecurityUtil;
 import co.cask.cdap.security.store.SecureStoreService;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.TableAlreadyExistsException;
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.store.StoreDefinition;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
@@ -693,7 +693,7 @@ public class MasterServiceMain extends DaemonMain {
       if (tableAdmin.getSpecification(StoreDefinition.ArtifactStore.ARTIFACT_DATA_TABLE) == null) {
         try {
           StoreDefinition.createAllTables(tableAdmin);
-        } catch (IOException | AlreadyExistsException e) {
+        } catch (IOException | TableAlreadyExistsException e) {
           throw new RuntimeException("Unable to create the system tables.", e);
         }
       }


### PR DESCRIPTION
Replaced NotFoundException and AlreadyExistsException with classes
specific to the storage SPI. This was done to prepare to move
the SPI definitions into their own module with minimal dependencies.
NotFoundException and AlreadyExistsException are in cdap-common,
which cannot be used.

Also corrected some exception handling in the ArtifactStore if
getting a StructuredTable throws a TableNotFoundException.
It was not correct to throw a NotFoundException, as that type of
error should not result in a 404, but a 500 response code.

Also removed some guava usage, as the SPI should not depend on
guava either.