### PR TITLE
Add actual storage implementation for SecretStore

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -30,6 +30,7 @@ import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.common.twill.MasterServiceManager;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.config.guice.ConfigStoreModule;
+import co.cask.cdap.data.security.DefaultSecretStore;
 import co.cask.cdap.data2.datafabric.dataset.DatasetExecutorServiceManager;
 import co.cask.cdap.data2.datafabric.dataset.MetadataServiceManager;
 import co.cask.cdap.explore.service.ExploreServiceManager;
@@ -110,6 +111,7 @@ import co.cask.cdap.route.store.RouteStore;
 import co.cask.cdap.route.store.ZKRouteStore;
 import co.cask.cdap.scheduler.CoreSchedulerService;
 import co.cask.cdap.scheduler.Scheduler;
+import co.cask.cdap.securestore.spi.SecretStore;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.impersonation.DefaultOwnerAdmin;
 import co.cask.cdap.security.impersonation.DefaultUGIProvider;
@@ -365,6 +367,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       datasetModuleBinder.addBinding("app-fabric").toInstance(new AppFabricDatasetModule());
 
       bind(Store.class).to(DefaultStore.class);
+      bind(SecretStore.class).to(DefaultSecretStore.class).in(Scopes.SINGLETON);
 
       // In App-Fabric, we can write directly, hence bind to the basic implementation
       bind(WorkflowStateWriter.class).to(BasicWorkflowStateWriter.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunnerModule.java
@@ -23,6 +23,7 @@ import co.cask.cdap.app.store.preview.PreviewStore;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.config.PreferencesService;
+import co.cask.cdap.data.security.DefaultSecretStore;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.MockExploreClient;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
@@ -48,6 +49,7 @@ import co.cask.cdap.route.store.LocalRouteStore;
 import co.cask.cdap.route.store.RouteStore;
 import co.cask.cdap.scheduler.NoOpScheduler;
 import co.cask.cdap.scheduler.Scheduler;
+import co.cask.cdap.securestore.spi.SecretStore;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.impersonation.DefaultOwnerAdmin;
 import co.cask.cdap.security.impersonation.DefaultUGIProvider;
@@ -113,6 +115,7 @@ public class PreviewRunnerModule extends PrivateModule {
     );
 
     bind(Store.class).to(DefaultStore.class);
+    bind(SecretStore.class).to(DefaultSecretStore.class).in(Scopes.SINGLETON);
     bind(RouteStore.class).to(LocalRouteStore.class).in(Scopes.SINGLETON);
 
     bind(UGIProvider.class).to(DefaultUGIProvider.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/SqlDefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/SqlDefaultStoreTest.java
@@ -65,7 +65,7 @@ public class SqlDefaultStoreTest extends DefaultStoreTest {
       injector.getProvider(NamespaceResourceDeleter.class), injector.getProvider(StorageProviderNamespaceAdmin.class),
       injector.getInstance(CConfiguration.class), injector.getInstance(Impersonator.class),
       injector.getInstance(AuthorizationEnforcer.class), injector.getInstance(AuthenticationContext.class));
-    StoreDefinition.NamespaceStore.createTables(structuredTableAdmin);
+    StoreDefinition.NamespaceStore.createTable(structuredTableAdmin);
     StoreDefinition.WorkflowStore.createTables(structuredTableAdmin);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/security/DefaultSecretStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/security/DefaultSecretStoreTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security;
+
+import co.cask.cdap.data.security.DefaultSecretStore;
+import co.cask.cdap.securestore.spi.SecretNotFoundException;
+import co.cask.cdap.securestore.spi.SecretStore;
+import co.cask.cdap.securestore.spi.secret.Decoder;
+import co.cask.cdap.securestore.spi.secret.Encoder;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Tests for {@link DefaultSecretStore}.
+ */
+public abstract class DefaultSecretStoreTest {
+  protected static SecretStore store;
+
+  @Test
+  public void testSecretStore() throws Exception {
+    String namespace = "ns1";
+    String name = "secretKey";
+    String description = "description";
+    String data = "password";
+    long now = System.currentTimeMillis();
+    Map<String, String> map = ImmutableMap.of("p1", "v1");
+    FakeEncoder fakeEncoder = new FakeEncoder();
+    FakeDecoder fakeDecoder = new FakeDecoder();
+    TestSecret expected = new TestSecret(name, description,
+                                         data.getBytes(StandardCharsets.UTF_8), now, map);
+
+    store.store(namespace, name, fakeEncoder, expected);
+    TestSecret actual = store.get(namespace, name, fakeDecoder);
+    Assert.assertEquals(expected, actual);
+
+    store.delete(namespace, name);
+    try {
+      store.get(name, name, fakeDecoder);
+      Assert.fail("Expected SecretNotFoundException");
+    } catch (SecretNotFoundException e) {
+      // expected
+    }
+
+    try {
+      store.delete(namespace, name);
+      Assert.fail("Expected SecretNotFoundException");
+    } catch (SecretNotFoundException e) {
+      // expected
+    }
+
+    List<TestSecret> expectedList = new ArrayList<>();
+    expected = new TestSecret(name, description,
+                              data.getBytes(StandardCharsets.UTF_8), now, map);
+    expectedList.add(expected);
+    store.store(namespace, name, fakeEncoder, expected);
+    expected = new TestSecret("secretKey2", description,
+                              data.getBytes(StandardCharsets.UTF_8), now, map);
+    expectedList.add(expected);
+    store.store(namespace, "secretKey2", fakeEncoder, expected);
+
+    store.store("ns2", name, fakeEncoder, expected);
+
+    List<TestSecret> actualList = new ArrayList<>(store.list(namespace, fakeDecoder));
+
+    Assert.assertEquals(expectedList, actualList);
+  }
+
+  private static class TestSecret {
+    private final String name;
+    private final String description;
+    private final byte[] secretData;
+    private final long creationTimeMs;
+    private final Map<String, String> properties;
+
+    TestSecret(String name, String description, byte[] secretData, long creationTimeMs,
+               Map<String, String> properties) {
+      this.name = name;
+      this.description = description;
+      this.secretData = secretData;
+      this.creationTimeMs = creationTimeMs;
+      this.properties = properties;
+    }
+
+    String getName() {
+      return name;
+    }
+
+    String getDescription() {
+      return description;
+    }
+
+    byte[] getSecretData() {
+      return secretData;
+    }
+
+    long getCreationTimeMs() {
+      return creationTimeMs;
+    }
+
+    Map<String, String> getProperties() {
+      return properties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      TestSecret secret = (TestSecret) o;
+
+      return creationTimeMs == secret.creationTimeMs &&
+        Objects.equals(name, secret.name) &&
+        Objects.equals(description, secret.description) &&
+        Arrays.equals(secretData, secret.secretData) &&
+        Objects.equals(properties, secret.properties);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Objects.hash(name, description, creationTimeMs, properties);
+      result = 31 * result + Arrays.hashCode(secretData);
+      return result;
+    }
+  }
+
+  private static class FakeEncoder implements Encoder<TestSecret> {
+    @Override
+    public byte[] encode(TestSecret data) throws IOException {
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      try (DataOutputStream dos = new DataOutputStream(bos)) {
+        dos.writeUTF(data.getName());
+        dos.writeBoolean(data.getDescription() != null);
+        if (data.getDescription() != null) {
+          dos.writeUTF(data.getDescription());
+        }
+        dos.writeLong(data.getCreationTimeMs());
+
+        Map<String, String> properties = data.getProperties();
+        dos.writeInt(properties.size());
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+          dos.writeUTF(entry.getKey());
+          dos.writeUTF(entry.getValue());
+        }
+
+        byte[] secret = data.getSecretData();
+        dos.writeInt(secret.length);
+        dos.write(secret);
+      }
+      return bos.toByteArray();
+    }
+  }
+
+  private static class FakeDecoder implements Decoder<TestSecret> {
+    @Override
+    public TestSecret decode(byte[] data) throws IOException {
+      try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
+        String name = dis.readUTF();
+        boolean descriptionExists = dis.readBoolean();
+        String description = descriptionExists ? dis.readUTF() : null;
+        long creationTimeMs = dis.readLong();
+
+        Map<String, String> properties = new HashMap<>();
+        int len = dis.readInt();
+        for (int i = 0; i < len; i++) {
+          properties.put(dis.readUTF(), dis.readUTF());
+        }
+
+        byte[] secret = new byte[dis.readInt()];
+        dis.readFully(secret);
+        return new TestSecret(name, description, secret, creationTimeMs, properties);
+      }
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/security/DefaultSecretStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/security/DefaultSecretStoreTest.java
@@ -158,47 +158,47 @@ public abstract class DefaultSecretStoreTest {
   private static class FakeEncoder implements Encoder<TestSecret> {
     @Override
     public byte[] encode(TestSecret data) throws IOException {
-      ByteArrayOutputStream bos = new ByteArrayOutputStream();
-      try (DataOutputStream dos = new DataOutputStream(bos)) {
-        dos.writeUTF(data.getName());
-        dos.writeBoolean(data.getDescription() != null);
+      ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+      try (DataOutputStream dataOutputStream = new DataOutputStream(byteOutputStream)) {
+        dataOutputStream.writeUTF(data.getName());
+        dataOutputStream.writeBoolean(data.getDescription() != null);
         if (data.getDescription() != null) {
-          dos.writeUTF(data.getDescription());
+          dataOutputStream.writeUTF(data.getDescription());
         }
-        dos.writeLong(data.getCreationTimeMs());
+        dataOutputStream.writeLong(data.getCreationTimeMs());
 
         Map<String, String> properties = data.getProperties();
-        dos.writeInt(properties.size());
+        dataOutputStream.writeInt(properties.size());
         for (Map.Entry<String, String> entry : properties.entrySet()) {
-          dos.writeUTF(entry.getKey());
-          dos.writeUTF(entry.getValue());
+          dataOutputStream.writeUTF(entry.getKey());
+          dataOutputStream.writeUTF(entry.getValue());
         }
 
         byte[] secret = data.getSecretData();
-        dos.writeInt(secret.length);
-        dos.write(secret);
+        dataOutputStream.writeInt(secret.length);
+        dataOutputStream.write(secret);
       }
-      return bos.toByteArray();
+      return byteOutputStream.toByteArray();
     }
   }
 
   private static class FakeDecoder implements Decoder<TestSecret> {
     @Override
     public TestSecret decode(byte[] data) throws IOException {
-      try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
-        String name = dis.readUTF();
-        boolean descriptionExists = dis.readBoolean();
-        String description = descriptionExists ? dis.readUTF() : null;
-        long creationTimeMs = dis.readLong();
+      try (DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(data))) {
+        String name = dataInputStream.readUTF();
+        boolean descriptionExists = dataInputStream.readBoolean();
+        String description = descriptionExists ? dataInputStream.readUTF() : null;
+        long creationTimeMs = dataInputStream.readLong();
 
         Map<String, String> properties = new HashMap<>();
-        int len = dis.readInt();
+        int len = dataInputStream.readInt();
         for (int i = 0; i < len; i++) {
-          properties.put(dis.readUTF(), dis.readUTF());
+          properties.put(dataInputStream.readUTF(), dataInputStream.readUTF());
         }
 
-        byte[] secret = new byte[dis.readInt()];
-        dis.readFully(secret);
+        byte[] secret = new byte[dataInputStream.readInt()];
+        dataInputStream.readFully(secret);
         return new TestSecret(name, description, secret, creationTimeMs, properties);
       }
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/security/NoSqlDefaultSecureStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/security/NoSqlDefaultSecureStoreTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data.security.DefaultSecretStore;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import co.cask.cdap.store.StoreDefinition;
+import com.google.inject.Injector;
+import org.junit.BeforeClass;
+
+/**
+ * Tests for {@link DefaultSecretStore} with NoSql storage implementation.
+ */
+public class NoSqlDefaultSecureStoreTest extends DefaultSecretStoreTest {
+  @BeforeClass
+  public static void setup() throws Exception {
+    Injector injector = AppFabricTestHelper.getInjector(CConfiguration.create());
+
+    TransactionRunner transactionRunner = injector.getInstance(TransactionRunner.class);
+    store = new DefaultSecretStore(transactionRunner);
+
+    StructuredTableAdmin structuredTableAdmin = injector.getInstance(StructuredTableAdmin.class);
+    StoreDefinition.ArtifactStore.createTables(structuredTableAdmin);
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/security/SqlDefaultSecureStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/security/SqlDefaultSecureStoreTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security;
+
+import co.cask.cdap.data.security.DefaultSecretStore;
+import co.cask.cdap.data2.sql.PostgresSqlStructuredTableAdmin;
+import co.cask.cdap.data2.sql.SqlTransactionRunner;
+import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import co.cask.cdap.store.StoreDefinition;
+import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import javax.sql.DataSource;
+
+/**
+ * Tests {@link DefaultSecretStore} with Sql storage implementation.
+ */
+public class SqlDefaultSecureStoreTest extends DefaultSecretStoreTest {
+  private static EmbeddedPostgres pg;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    pg = EmbeddedPostgres.start();
+    DataSource dataSource = pg.getPostgresDatabase();
+    StructuredTableAdmin structuredTableAdmin = new PostgresSqlStructuredTableAdmin(dataSource);
+    TransactionRunner transactionRunner = new SqlTransactionRunner(structuredTableAdmin, dataSource);
+    store = new DefaultSecretStore(transactionRunner);
+    StoreDefinition.SecretStore.createTable(structuredTableAdmin);
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    pg.close();
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/security/SqlDefaultSecureStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/security/SqlDefaultSecureStoreTest.java
@@ -33,12 +33,12 @@ import javax.sql.DataSource;
  * Tests {@link DefaultSecretStore} with Sql storage implementation.
  */
 public class SqlDefaultSecureStoreTest extends DefaultSecretStoreTest {
-  private static EmbeddedPostgres pg;
+  private static EmbeddedPostgres postgres;
 
   @BeforeClass
   public static void setup() throws Exception {
-    pg = EmbeddedPostgres.start();
-    DataSource dataSource = pg.getPostgresDatabase();
+    postgres = EmbeddedPostgres.start();
+    DataSource dataSource = postgres.getPostgresDatabase();
     StructuredTableAdmin structuredTableAdmin = new PostgresSqlStructuredTableAdmin(dataSource);
     TransactionRunner transactionRunner = new SqlTransactionRunner(structuredTableAdmin, dataSource);
     store = new DefaultSecretStore(transactionRunner);
@@ -47,6 +47,6 @@ public class SqlDefaultSecureStoreTest extends DefaultSecretStoreTest {
 
   @AfterClass
   public static void afterClass() throws IOException {
-    pg.close();
+    postgres.close();
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/security/DefaultSecretStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/security/DefaultSecretStore.java
@@ -75,10 +75,6 @@ public class DefaultSecretStore implements SecretStore {
                                                                                        .SecretStore.NAMESPACE_FIELD,
                                                                                      namespace));
       try (CloseableIterator<StructuredRow> iterator = table.scan(Range.singleton(partialKey), Integer.MAX_VALUE)) {
-        if (!iterator.hasNext()) {
-          return Collections.emptyList();
-        }
-
         List<T> list = new ArrayList<>();
         while (iterator.hasNext()) {
           StructuredRow row = iterator.next();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/security/DefaultSecretStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/security/DefaultSecretStore.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.security;
+
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.securestore.spi.SecretNotFoundException;
+import co.cask.cdap.securestore.spi.SecretStore;
+import co.cask.cdap.securestore.spi.secret.Decoder;
+import co.cask.cdap.securestore.spi.secret.Encoder;
+import co.cask.cdap.spi.data.StructuredRow;
+import co.cask.cdap.spi.data.StructuredTable;
+import co.cask.cdap.spi.data.table.field.Field;
+import co.cask.cdap.spi.data.table.field.Fields;
+import co.cask.cdap.spi.data.table.field.Range;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import co.cask.cdap.spi.data.transaction.TransactionRunners;
+import co.cask.cdap.store.StoreDefinition;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Default implementation of secret store to persist secrets.
+ */
+public class DefaultSecretStore implements SecretStore {
+  private final TransactionRunner transactionRunner;
+
+  @Inject
+  public DefaultSecretStore(TransactionRunner transactionRunner) {
+    this.transactionRunner = transactionRunner;
+  }
+
+  @Override
+  public <T> T get(String namespace, String name, Decoder<T> decoder) throws SecretNotFoundException, IOException {
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.SecretStore.SECRET_STORE_TABLE);
+      List<Field<?>> keyFields = ImmutableList.<Field<?>>builder()
+        .addAll(getKeyFields(namespace, name))
+        .build();
+      Optional<StructuredRow> optionalRow = table.read(keyFields);
+      if (!optionalRow.isPresent()) {
+        throw new SecretNotFoundException(namespace, name);
+      }
+      StructuredRow row = optionalRow.get();
+      return decoder.decode(row.getBytes(StoreDefinition.SecretStore.SECRET_DATA_FIELD));
+    }, SecretNotFoundException.class, IOException.class);
+  }
+
+  @Override
+  public <T> Collection<T> list(String namespace, Decoder<T> decoder) throws IOException {
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.SecretStore.SECRET_STORE_TABLE);
+      Collection<Field<?>> partialKey = Collections.singletonList(Fields.stringField(StoreDefinition
+                                                                                       .SecretStore.NAMESPACE_FIELD,
+                                                                                     namespace));
+      try (CloseableIterator<StructuredRow> iterator = table.scan(Range.singleton(partialKey), Integer.MAX_VALUE)) {
+        if (!iterator.hasNext()) {
+          return Collections.emptyList();
+        }
+
+        List<T> list = new ArrayList<>();
+        while (iterator.hasNext()) {
+          StructuredRow row = iterator.next();
+          list.add(decoder.decode(row.getBytes(StoreDefinition.SecretStore.SECRET_DATA_FIELD)));
+        }
+
+        return Collections.unmodifiableList(list);
+      }
+    }, IOException.class);
+  }
+
+  @Override
+  public <T> void store(String namespace, String name, Encoder<T> encoder, T data) throws IOException {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.SecretStore.SECRET_STORE_TABLE);
+      List<Field<?>> fields = ImmutableList.<Field<?>>builder()
+        .addAll(getKeyFields(namespace, name))
+        .add(Fields.bytesField(StoreDefinition.SecretStore.SECRET_DATA_FIELD, encoder.encode(data)))
+        .build();
+      table.upsert(fields);
+    }, IOException.class);
+  }
+
+  @Override
+  public void delete(String namespace, String name) throws SecretNotFoundException, IOException {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.SecretStore.SECRET_STORE_TABLE);
+      List<Field<?>> keyFields = ImmutableList.<Field<?>>builder()
+        .addAll(getKeyFields(namespace, name))
+        .build();
+      if (!table.read(keyFields).isPresent()) {
+        throw new SecretNotFoundException(namespace, name);
+      }
+      table.delete(keyFields);
+    }, SecretNotFoundException.class, IOException.class);
+  }
+
+  private Collection<Field<?>> getKeyFields(String namespace, String name) {
+    return Arrays.asList(Fields.stringField(StoreDefinition.SecretStore.NAMESPACE_FIELD, namespace),
+                         Fields.stringField(StoreDefinition.SecretStore.SECRET_NAME_FIELD, name));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
@@ -45,7 +45,10 @@ public final class StoreDefinition {
       ArtifactStore.createTables(tableAdmin);
     }
     if (overWrite || tableAdmin.getSpecification(NamespaceStore.NAMESPACES) == null) {
-      NamespaceStore.createTables(tableAdmin);
+      NamespaceStore.createTable(tableAdmin);
+    }
+    if (overWrite || tableAdmin.getSpecification(SecretStore.SECRET_STORE_TABLE) == null) {
+      SecretStore.createTable(tableAdmin);
     }
     if (overWrite || tableAdmin.getSpecification(WorkflowStore.WORKFLOW_STATISTICS) == null) {
       WorkflowStore.createTables(tableAdmin);
@@ -73,7 +76,7 @@ public final class StoreDefinition {
         .withPrimaryKeys(NAMESPACE_FIELD)
         .build();
 
-    public static void createTables(StructuredTableAdmin tableAdmin) throws IOException, TableAlreadyExistsException {
+    public static void createTable(StructuredTableAdmin tableAdmin) throws IOException, TableAlreadyExistsException {
       tableAdmin.create(NAMESPACE_TABLE_SPEC);
     }
   }
@@ -194,6 +197,28 @@ public final class StoreDefinition {
       tableAdmin.create(APP_DATA_SPEC);
       tableAdmin.create(PLUGIN_DATA_SPEC);
       tableAdmin.create(UNIV_PLUGIN_DATA_SPEC);
+    }
+  }
+
+  /**
+   * Schema for {@link SecretStore}.
+   */
+  public static final class SecretStore {
+    public static final StructuredTableId SECRET_STORE_TABLE = new StructuredTableId("secret_store");
+    public static final String NAMESPACE_FIELD = "namespace";
+    public static final String SECRET_NAME_FIELD = "secret_name";
+    public static final String SECRET_DATA_FIELD = "secret_data";
+
+    public static final StructuredTableSpecification SECRET_STORE_SPEC = new StructuredTableSpecification.Builder()
+      .withId(SECRET_STORE_TABLE)
+      .withFields(Fields.stringType(NAMESPACE_FIELD),
+                  Fields.stringType(SECRET_NAME_FIELD),
+                  Fields.bytesType(SECRET_DATA_FIELD))
+      .withPrimaryKeys(NAMESPACE_FIELD, SECRET_NAME_FIELD)
+      .build();
+
+    public static void createTable(StructuredTableAdmin tableAdmin) throws IOException, TableAlreadyExistsException {
+      tableAdmin.create(SECRET_STORE_SPEC);
     }
   }
 }

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -636,7 +636,7 @@
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration combine.self="override">
-                  <outputDirectory>${stage.securestores.ext.dir}/cloudkms</outputDirectory>
+                  <outputDirectory>${stage.securestores.ext.dir}/gcp-cloudkms</outputDirectory>
                   <resources>
                     <resource>
                       <directory>

--- a/cdap-securestore-ext-cloudkms/src/main/java/co/cask/cdap/securestore/gcp/cloudkms/CloudSecretManager.java
+++ b/cdap-securestore-ext-cloudkms/src/main/java/co/cask/cdap/securestore/gcp/cloudkms/CloudSecretManager.java
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public class CloudSecretManager implements SecretManager {
   private static final Logger LOG = LoggerFactory.getLogger(CloudSecretManager.class);
-  private static final String CLOUD_KMS_NAME = "cloudkms";
+  private static final String CLOUD_KMS_NAME = "gcp-cloudkms";
   private static final String CRYPTO_KEY_PREFIX = "cdap_key_";
   private final SecretInfoCodec encoderDecoder;
   private SecretStore store;

--- a/cdap-securestore-spi/src/main/java/co/cask/cdap/securestore/spi/SecretManager.java
+++ b/cdap-securestore-spi/src/main/java/co/cask/cdap/securestore/spi/SecretManager.java
@@ -28,8 +28,6 @@ import java.util.Collection;
  *
  * The implementation of this class must be thread safe as store and retrieve methods can be called from multiple
  * threads.
- *
- * TODO CDAP-14699 Expose dataset through context in initialize method.
  */
 public interface SecretManager {
   /**

--- a/cdap-securestore-spi/src/main/java/co/cask/cdap/securestore/spi/SecretStore.java
+++ b/cdap-securestore-spi/src/main/java/co/cask/cdap/securestore/spi/SecretStore.java
@@ -28,7 +28,6 @@ import java.util.Collection;
  *
  * The implementation of this class must be thread safe as store and retrieve methods can be called from multiple
  * threads.
- *
  */
 public interface SecretStore {
 

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationEnforcer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationEnforcer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -60,7 +60,7 @@ public interface AuthorizationEnforcer {
    * @param entityIds the entities on which the visibility check is to be performed
    * @param principal the principal to check the visibility for
    * @return a set of entities that are visible to the principal
-   * @throws Exception if any errors occured while performing the check
+   * @throws Exception if any errors occurred while performing the check
    */
   Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) throws Exception;
 

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -49,6 +49,11 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-storage-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-security-spi</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/secretmanager/SecretManagerSecureStoreService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/secretmanager/SecretManagerSecureStoreService.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.id.SecureKeyId;
 import co.cask.cdap.securestore.spi.SecretManager;
 import co.cask.cdap.securestore.spi.SecretManagerContext;
 import co.cask.cdap.securestore.spi.SecretNotFoundException;
+import co.cask.cdap.securestore.spi.SecretStore;
 import co.cask.cdap.securestore.spi.secret.Secret;
 import co.cask.cdap.securestore.spi.secret.SecretMetadata;
 import co.cask.cdap.security.store.SecureStoreService;
@@ -54,12 +55,12 @@ public class SecretManagerSecureStoreService extends AbstractIdleService impleme
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final SecretManagerContext context;
   private final String type;
-  private final SecretManager secretManager;
+  private SecretManager secretManager;
 
   @Inject
-  SecretManagerSecureStoreService(CConfiguration cConf, NamespaceQueryAdmin namespaceQueryAdmin) {
+  SecretManagerSecureStoreService(CConfiguration cConf, NamespaceQueryAdmin namespaceQueryAdmin, SecretStore store) {
     this(namespaceQueryAdmin,
-         new DefaultSecretManagerContext(cConf),
+         new DefaultSecretManagerContext(cConf, store),
          cConf.get(Constants.Security.Store.PROVIDER),
          new SecretManagerExtensionLoader(cConf.get(Constants.Security.Store.EXTENSIONS_DIR))
            .get(cConf.get(Constants.Security.Store.PROVIDER)));
@@ -155,6 +156,7 @@ public class SecretManagerSecureStoreService extends AbstractIdleService impleme
       LOG.info("Initialized secure store of type {}.", type);
     } catch (IOException e) {
       LOG.error(String.format("Error occurred while initializing secure store of type %s.", type), e);
+      this.secretManager = null;
     }
   }
 

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -647,7 +647,7 @@
                     <!-- copy secure store extensions -->
                     <resource>
                       <directory>${project.parent.basedir}/cdap-securestore-ext-cloudkms/target/libexec</directory>
-                      <targetPath>ext/securestores/cloudkms</targetPath>
+                      <targetPath>ext/securestores/gcp-cloudkms</targetPath>
                       <includes>
                         <include>*.jar</include>
                       </includes>


### PR DESCRIPTION
Changes:
- Added DefaultSecureStore implementation using storage spis. The store is added in data fabric and injected to `SecretManagerSecureStoreService` through injection. Also added tests for Sql and NoSql implementations.
- Renamed `NamespaceStore#createTables` to `NamespaceStore#createTable` as it only creates 1 table.
- Fixed a NPE bug when secret manager is not initialized.
- Renamed `cloudkms` type to `gcp-cloudkms` to be consistent with other extensions such as runtime providers.

Build: https://builds.cask.co/browse/CDAP-DUT6776