### PR TITLE
CDAP-14840 add system app api

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/service/AbstractService.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/AbstractService.java
@@ -26,12 +26,15 @@ import java.util.Arrays;
  * An abstract implementation of {@link Service}. Users may extend this to write a {@link Service}.
  *
  * The default no-op constructor must be implemented.
+ *
+ * @param <T> type of service configurer
  */
-public abstract class AbstractService extends AbstractPluginConfigurable<ServiceConfigurer> implements Service {
-  private ServiceConfigurer configurer;
+public abstract class AbstractService<T extends ServiceConfigurer> extends AbstractPluginConfigurable<T>
+  implements Service<T> {
+  private T configurer;
 
   @Override
-  public final void configure(ServiceConfigurer serviceConfigurer) {
+  public final void configure(T serviceConfigurer) {
     this.configurer = serviceConfigurer;
     configure();
   }
@@ -88,7 +91,7 @@ public abstract class AbstractService extends AbstractPluginConfigurable<Service
    * Returns the {@link ServiceConfigurer}, only available at configuration time.
    */
   @Override
-  protected final ServiceConfigurer getConfigurer() {
+  protected final T getConfigurer() {
     return configurer;
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/AbstractHttpServiceHandler.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/AbstractHttpServiceHandler.java
@@ -23,11 +23,14 @@ import java.util.Map;
 /**
  * An abstract implementation of {@link HttpServiceHandler}. Classes that extend this class only
  * have to implement a configure method which can be used to add optional arguments.
+ *
+ * @param <T> type of service context
+ * @param <V> type of service configurer
  */
-public abstract class AbstractHttpServiceHandler extends AbstractPluginConfigurable<HttpServiceConfigurer>
-  implements HttpServiceHandler {
-  private HttpServiceConfigurer configurer;
-  private HttpServiceContext context;
+public abstract class AbstractHttpServiceHandler<T extends HttpServiceContext, V extends HttpServiceConfigurer>
+  extends AbstractPluginConfigurable<V> implements HttpServiceHandler<T, V> {
+  private V configurer;
+  private T context;
 
   /**
    * This can be overridden in child classes to add custom user properties during configure time.
@@ -43,7 +46,7 @@ public abstract class AbstractHttpServiceHandler extends AbstractPluginConfigura
    * @param configurer the {@link HttpServiceConfigurer} which is used to configure this Handler
    */
   @Override
-  public final void configure(HttpServiceConfigurer configurer) {
+  public final void configure(V configurer) {
     this.configurer = configurer;
     configure();
   }
@@ -56,7 +59,7 @@ public abstract class AbstractHttpServiceHandler extends AbstractPluginConfigura
    * @throws Exception
    */
   @Override
-  public void initialize(HttpServiceContext context) throws Exception {
+  public void initialize(T context) throws Exception {
     this.context = context;
   }
 
@@ -71,7 +74,7 @@ public abstract class AbstractHttpServiceHandler extends AbstractPluginConfigura
   /**
    * @return the {@link HttpServiceContext} which was used when this class was initialized
    */
-  protected final HttpServiceContext getContext() {
+  protected final T getContext() {
     return context;
   }
 
@@ -79,7 +82,7 @@ public abstract class AbstractHttpServiceHandler extends AbstractPluginConfigura
    * @return the {@link HttpServiceConfigurer} used to configure this class
    */
   @Override
-  protected final HttpServiceConfigurer getConfigurer() {
+  protected final V getConfigurer() {
     return configurer;
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandler.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandler.java
@@ -78,8 +78,11 @@ import javax.ws.rs.Path;
  *
  * @see HttpContentConsumer
  * @see HttpContentProducer
+ * @param <T> type of service context
+ * @param <V> type of service configurer
  */
-public interface HttpServiceHandler extends ProgramLifecycle<HttpServiceContext> {
+public interface HttpServiceHandler<T extends HttpServiceContext, V extends HttpServiceConfigurer>
+  extends ProgramLifecycle<T> {
 
   /**
    * Configures this HttpServiceHandler with the given {@link HttpServiceConfigurer}.
@@ -87,7 +90,7 @@ public interface HttpServiceHandler extends ProgramLifecycle<HttpServiceContext>
    *
    * @param configurer the HttpServiceConfigurer which is used to configure this Handler
    */
-  void configure(HttpServiceConfigurer configurer);
+  void configure(V configurer);
 
   /**
    * Invoked whenever a new instance of this HttpServiceHandler is created. Note that this
@@ -98,7 +101,7 @@ public interface HttpServiceHandler extends ProgramLifecycle<HttpServiceContext>
    */
   @Override
   @TransactionPolicy(TransactionControl.IMPLICIT)
-  void initialize(HttpServiceContext context) throws Exception;
+  void initialize(T context) throws Exception;
 
   /**
    * Invoked whenever an instance of this HttpServiceHandler is destroyed. This may happen

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -55,6 +55,11 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-system-app-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-watchdog</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/AppSpecInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/AppSpecInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.deploy.pipeline;
+
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
+
+import java.util.Collection;
+
+/**
+ * ApplicationSpecification and associated system tables. This is used because the StructuredTableSpecifications
+ * can't be stored in the ApplicationSpecification since the class is not in cdap-api.
+ */
+public class AppSpecInfo {
+  private final ApplicationSpecification appSpec;
+  private final Collection<StructuredTableSpecification> systemTables;
+
+  public AppSpecInfo(ApplicationSpecification appSpec,
+                     Collection<StructuredTableSpecification> systemTables) {
+    this.appSpec = appSpec;
+    this.systemTables = systemTables;
+  }
+
+  public ApplicationSpecification getAppSpec() {
+    return appSpec;
+  }
+
+  public Collection<StructuredTableSpecification> getSystemTables() {
+    return systemTables;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -20,9 +20,12 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.KerberosPrincipalId;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
 import com.google.gson.annotations.SerializedName;
 import org.apache.twill.filesystem.Location;
 
+import java.util.Collection;
+import java.util.Collections;
 import javax.annotation.Nullable;
 
 /**
@@ -36,6 +39,7 @@ public class ApplicationDeployable {
   private final ApplicationSpecification specification;
   private final ApplicationSpecification existingAppSpec;
   private final ApplicationDeployScope applicationDeployScope;
+  private final Collection<StructuredTableSpecification> systemTables;
   @SerializedName("principal")
   private final KerberosPrincipalId ownerPrincipal;
   @SerializedName("update-schedules")
@@ -46,7 +50,7 @@ public class ApplicationDeployable {
                                @Nullable ApplicationSpecification existingAppSpec,
                                ApplicationDeployScope applicationDeployScope) {
     this(artifactId, artifactLocation, applicationId, specification, existingAppSpec, applicationDeployScope,
-         null, true);
+         null, true, Collections.emptyList());
   }
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
@@ -54,7 +58,8 @@ public class ApplicationDeployable {
                                @Nullable ApplicationSpecification existingAppSpec,
                                ApplicationDeployScope applicationDeployScope,
                                @Nullable KerberosPrincipalId ownerPrincipal,
-                               boolean updateSchedules) {
+                               boolean updateSchedules,
+                               Collection<StructuredTableSpecification> systemTables) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.applicationId = applicationId;
@@ -63,6 +68,7 @@ public class ApplicationDeployable {
     this.applicationDeployScope = applicationDeployScope;
     this.ownerPrincipal = ownerPrincipal;
     this.updateSchedules = updateSchedules;
+    this.systemTables = systemTables;
   }
 
   /**
@@ -115,6 +121,10 @@ public class ApplicationDeployable {
   @Nullable
   public KerberosPrincipalId getOwnerPrincipal() {
     return ownerPrincipal;
+  }
+
+  public Collection<StructuredTableSpecification> getSystemTables() {
+    return systemTables;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
@@ -33,7 +33,8 @@ public class ApplicationWithPrograms extends ApplicationDeployable {
     super(applicationDeployable.getArtifactId(), applicationDeployable.getArtifactLocation(),
           applicationDeployable.getApplicationId(), applicationDeployable.getSpecification(),
           applicationDeployable.getExistingAppSpec(), applicationDeployable.getApplicationDeployScope(),
-          applicationDeployable.getOwnerPrincipal(), applicationDeployable.canUpdateSchedules());
+          applicationDeployable.getOwnerPrincipal(), applicationDeployable.canUpdateSchedules(),
+          applicationDeployable.getSystemTables());
     this.programDescriptors = ImmutableList.copyOf(programDescriptors);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateSystemTablesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateSystemTablesStage.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.deploy.pipeline;
+
+import co.cask.cdap.pipeline.AbstractStage;
+import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.TableAlreadyExistsException;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
+import com.google.common.reflect.TypeToken;
+
+import java.io.IOException;
+
+/**
+ * This {@link co.cask.cdap.pipeline.Stage} is responsible for creating system tables
+ */
+public class CreateSystemTablesStage extends AbstractStage<ApplicationDeployable> {
+  private final StructuredTableAdmin structuredTableAdmin;
+
+  public CreateSystemTablesStage(StructuredTableAdmin structuredTableAdmin) {
+    super(TypeToken.of(ApplicationDeployable.class));
+    this.structuredTableAdmin = structuredTableAdmin;
+  }
+
+  /**
+   * Deploys dataset modules specified in the given application spec.
+   *
+   * @param input An instance of {@link ApplicationDeployable}
+   */
+  @Override
+  public void process(ApplicationDeployable input) throws IOException, TableAlreadyExistsException {
+    for (StructuredTableSpecification spec : input.getSystemTables()) {
+      StructuredTableSpecification existing = structuredTableAdmin.getSpecification(spec.getTableId());
+      if (existing == null) {
+        // it's possible this throws TableAlreadyExistsException if two apps are deployed at the same time and there
+        // is a race. In that case, fail deployment. On re-deployment, the existing spec will get checked with the
+        // desired spec here. If they are the same, things will continue. If they differ, deployment will fail again.
+        structuredTableAdmin.create(spec);
+      } else if (!existing.equals(spec)) {
+        // don't allow deploying the app if the app expects a specification different than the one that exists
+        throw new IllegalArgumentException(
+          String.format("System table '%s' already exists, but with a different specification.",
+                        spec.getTableId().getName()));
+      }
+    }
+
+    // Emit the input to next stage.
+    emit(input);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/AuthorizationArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/AuthorizationArtifactRepository.java
@@ -204,11 +204,7 @@ public class AuthorizationArtifactRepository implements ArtifactRepository {
                                     @Nullable Set<ArtifactRange> parentArtifacts,
                                     @Nullable Set<PluginClass> additionalPlugins,
                                     Map<String, String> properties) throws Exception {
-    if (artifactId.getNamespace().toEntityId().equals(NamespaceId.SYSTEM)) {
-      throw new IllegalArgumentException("Cannot add artifact in system namespace");
-    }
     // To add an artifact, a user must have ADMIN privilege on the artifact is being added
-    // This method is used to add user app artifacts, so enforce authorization on the specified, non-system namespace
     Principal principal = authenticationContext.getPrincipal();
     authorizationEnforcer.enforce(artifactId.toEntityId(), principal, Action.ADMIN);
     return delegate.addArtifact(artifactId, artifactFile, parentArtifacts, additionalPlugins, properties);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillRunnable.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.distributed;
 import co.cask.cdap.app.guice.DistributedArtifactManagerModule;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.internal.app.runtime.service.ServiceProgramRunner;
 import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.inject.Module;
@@ -38,6 +39,8 @@ public class ServiceTwillRunnable extends AbstractProgramTwillRunnable<ServicePr
   protected Module createModule(CConfiguration cConf, Configuration hConf,
                                 ProgramOptions programOptions, ProgramRunId programRunId) {
     Module module = super.createModule(cConf, hConf, programOptions, programRunId);
-    return Modules.combine(module, new DistributedArtifactManagerModule());
+    return Modules.combine(module,
+                           new DistributedArtifactManagerModule(),
+                           new SystemDatasetRuntimeModule().getDistributedModules());
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -47,6 +47,7 @@ import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Closeables;
 import com.google.inject.Inject;
@@ -77,6 +78,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MetadataPublisher metadataPublisher;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final PluginFinder pluginFinder;
+  private final TransactionRunner transactionRunner;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -86,7 +88,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               MessagingService messagingService,
                               ArtifactManagerFactory artifactManagerFactory,
                               MetadataReader metadataReader, MetadataPublisher metadataPublisher,
-                              NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder) {
+                              NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder,
+                              TransactionRunner transactionRunner) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -101,6 +104,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.metadataPublisher = metadataPublisher;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.pluginFinder = pluginFinder;
+    this.transactionRunner = transactionRunner;
   }
 
   @Override
@@ -142,7 +146,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           txClient, discoveryServiceClient,
                                                           pluginInstantiator, secureStore, secureStoreManager,
                                                           messagingService, artifactManager, metadataReader,
-                                                          metadataPublisher, namespaceQueryAdmin, pluginFinder);
+                                                          metadataPublisher, namespaceQueryAdmin, pluginFinder,
+                                                          transactionRunner);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton((Closeable) pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultSystemTableConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultSystemTableConfigurer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.api.SystemTableConfigurer;
+import co.cask.cdap.spi.data.table.StructuredTableId;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Configures system tables and prefixes all table ids to prevent clashes with CDAP platform tables.
+ */
+public class DefaultSystemTableConfigurer implements SystemTableConfigurer {
+  public static final String PREFIX = "app_";
+  private final List<StructuredTableSpecification> specs;
+
+  public DefaultSystemTableConfigurer() {
+    this.specs = new ArrayList<>();
+  }
+
+  @Override
+  public void createTable(StructuredTableSpecification tableSpecification) {
+    // prefix table ids to prevent clashes with the CDAP system.
+    specs.add(new StructuredTableSpecification.Builder(tableSpecification)
+                .withId(new StructuredTableId(PREFIX + tableSpecification.getTableId().getName()))
+                .build());
+  }
+
+  public Collection<StructuredTableSpecification> getTableSpecs() {
+    return Collections.unmodifiableList(specs);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -53,6 +53,7 @@ import co.cask.cdap.logging.context.UserServiceLoggingContext;
 import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import co.cask.http.NettyHttpService;
 import com.google.common.reflect.TypeToken;
 import org.apache.tephra.TransactionSystemClient;
@@ -87,7 +88,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                            MessagingService messagingService,
                            ArtifactManager artifactManager, MetadataReader metadataReader,
                            MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
-                           PluginFinder pluginFinder) {
+                           PluginFinder pluginFinder, TransactionRunner transactionRunner) {
     super(host, program, programOptions, instanceId, serviceAnnouncer, TransactionControl.IMPLICIT);
 
     this.cConf = cConf;
@@ -97,7 +98,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
-                                               pluginFinder);
+                                               pluginFinder, transactionRunner);
     this.context = contextFactory.create(null);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
@@ -151,12 +152,13 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                               ArtifactManager artifactManager,
                                                               MetadataReader metadataReader,
                                                               MetadataPublisher metadataPublisher,
-                                                              PluginFinder pluginFinder) {
+                                                              PluginFinder pluginFinder,
+                                                              TransactionRunner transactionRunner) {
     return spec -> new BasicHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
-                                               namespaceQueryAdmin, pluginFinder);
+                                               namespaceQueryAdmin, pluginFinder, transactionRunner);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.id.Id;
 import co.cask.cdap.common.test.AppJarHelper;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.deploy.pipeline.AppSpecInfo;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.AuthorizationArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
@@ -43,6 +44,7 @@ import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.twill.filesystem.LocalLocationFactory;
@@ -68,7 +70,7 @@ public class ConfiguratorTest {
 
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
-
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
   private static CConfiguration conf;
   private static AuthorizationEnforcer authEnforcer;
   private static AuthenticationContext authenticationContext;
@@ -112,8 +114,8 @@ public class ConfiguratorTest {
       Assert.assertNotNull(response);
 
       // Deserialize the JSON spec back into Application object.
-      ApplicationSpecificationAdapter adapter = ApplicationSpecificationAdapter.create();
-      ApplicationSpecification specification = adapter.fromJson(response.getResponse());
+      AppSpecInfo appSpecInfo = GSON.fromJson(response.getResponse(), AppSpecInfo.class);
+      ApplicationSpecification specification = appSpecInfo.getAppSpec();
       Assert.assertNotNull(specification);
       Assert.assertEquals(AllProgramsApp.NAME, specification.getName()); // Simple checks.
 
@@ -151,8 +153,8 @@ public class ConfiguratorTest {
       ConfigResponse response = result.get(10, TimeUnit.SECONDS);
       Assert.assertNotNull(response);
 
-      ApplicationSpecificationAdapter adapter = ApplicationSpecificationAdapter.create();
-      ApplicationSpecification specification = adapter.fromJson(response.getResponse());
+      AppSpecInfo appSpecInfo = GSON.fromJson(response.getResponse(), AppSpecInfo.class);
+      ApplicationSpecification specification = appSpecInfo.getAppSpec();
       Assert.assertNotNull(specification);
       Assert.assertEquals(1, specification.getDatasets().size());
       Assert.assertTrue(specification.getDatasets().containsKey("myTable"));
@@ -164,7 +166,7 @@ public class ConfiguratorTest {
       response = result.get(10, TimeUnit.SECONDS);
       Assert.assertNotNull(response);
 
-      specification = adapter.fromJson(response.getResponse());
+      specification = GSON.fromJson(response.getResponse(), AppSpecInfo.class).getAppSpec();
       Assert.assertNotNull(specification);
       Assert.assertEquals(1, specification.getDatasets().size());
       Assert.assertTrue(specification.getDatasets().containsKey(ConfigTestApp.DEFAULT_TABLE));

--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-system-app-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-watchdog-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.common.lang;
 
 import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.service.SystemServiceConfigurer;
 import co.cask.cdap.common.internal.guava.ClassPath;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -86,6 +87,7 @@ public final class ProgramResources {
     // Add everything in cdap-api as visible resources
     // Trace dependencies for cdap-api classes
     Set<String> result = ClassPathResources.getResourcesWithDependencies(classLoader, Application.class);
+    result.addAll(ClassPathResources.getResourcesWithDependencies(classLoader, SystemServiceConfigurer.class));
 
     // Gather resources for javax.ws.rs classes. They are not traceable from the api classes.
     Iterables.addAll(result, Iterables.transform(ClassPathResources.getClassPathResources(classLoader, Path.class),

--- a/cdap-storage-spi/src/main/java/co/cask/cdap/spi/data/table/StructuredTableSpecification.java
+++ b/cdap-storage-spi/src/main/java/co/cask/cdap/spi/data/table/StructuredTableSpecification.java
@@ -21,6 +21,7 @@ import co.cask.cdap.spi.data.StructuredTable;
 import co.cask.cdap.spi.data.table.field.FieldType;
 import co.cask.cdap.spi.data.table.field.Fields;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -122,12 +123,29 @@ public final class StructuredTableSpecification {
    * Builder used to create {@link StructuredTableSpecification}
    */
   public static final class Builder {
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
-
     private StructuredTableId tableId;
-    private FieldType[] fieldTypes;
-    private String[] primaryKeys;
-    private String[] indexes = EMPTY_STRING_ARRAY;
+    private List<FieldType> fieldTypes;
+    private List<String> primaryKeys;
+    private List<String> indexes;
+
+    /**
+     * Create a builder that is initialized with all the information from an existing specification.
+     */
+    public Builder() {
+      this.fieldTypes = new ArrayList<>();
+      this.primaryKeys = new ArrayList<>();
+      this.indexes = new ArrayList<>();
+    }
+
+    /**
+     * Create a builder that is initialized with all the information from an existing specification.
+     */
+    public Builder(StructuredTableSpecification existing) {
+      this.tableId = existing.getTableId();
+      this.fieldTypes = new ArrayList<>(existing.getFieldTypes());
+      this.primaryKeys = new ArrayList<>(existing.getPrimaryKeys());
+      this.indexes = new ArrayList<>(existing.getIndexes());
+    }
 
     /**
      * Set the table id. A table should have an id.
@@ -145,7 +163,7 @@ public final class StructuredTableSpecification {
      * @return Builder instance
      */
     public Builder withFields(FieldType ...fieldTypes) {
-      this.fieldTypes = fieldTypes;
+      this.fieldTypes = Arrays.asList(fieldTypes);
       return this;
     }
 
@@ -155,7 +173,7 @@ public final class StructuredTableSpecification {
      * @return Builder instance
      */
     public Builder withPrimaryKeys(String ...primaryKeys) {
-      this.primaryKeys = primaryKeys;
+      this.primaryKeys = Arrays.asList(primaryKeys);
       return this;
     }
 
@@ -166,7 +184,7 @@ public final class StructuredTableSpecification {
      */
     public Builder withIndexes(String ...indexes) {
       if (indexes != null) {
-        this.indexes = indexes;
+        this.indexes = Arrays.asList(indexes);
       }
       return this;
     }
@@ -177,8 +195,7 @@ public final class StructuredTableSpecification {
      */
     public StructuredTableSpecification build() throws InvalidFieldException {
       validate();
-      return new StructuredTableSpecification(tableId, Arrays.asList(fieldTypes), Arrays.asList(primaryKeys),
-                                              Arrays.asList(indexes));
+      return new StructuredTableSpecification(tableId, fieldTypes, primaryKeys, indexes);
     }
 
     private void validate() throws InvalidFieldException {
@@ -194,11 +211,11 @@ public final class StructuredTableSpecification {
             tableId.getName()));
       }
 
-      if (fieldTypes == null || fieldTypes.length == 0) {
+      if (fieldTypes == null || fieldTypes.size() == 0) {
         throw new IllegalArgumentException("No fieldTypes specified for the table " + tableId);
       }
 
-      if (primaryKeys == null || primaryKeys.length == 0) {
+      if (primaryKeys == null || primaryKeys.size() == 0) {
         throw new IllegalArgumentException("No primary keys specified for the table " + tableId);
       }
 
@@ -213,8 +230,8 @@ public final class StructuredTableSpecification {
       }
 
       // Validate that the primary key is part of fields defined and of valid type
-      Map<String, FieldType.Type> typeMap =
-        Arrays.stream(fieldTypes).collect(Collectors.toMap(FieldType::getName, FieldType::getType));
+      Map<String, FieldType.Type> typeMap = fieldTypes.stream()
+        .collect(Collectors.toMap(FieldType::getName, FieldType::getType));
       for (String primaryKey : primaryKeys) {
         FieldType.Type type = typeMap.get(primaryKey);
         if (type == null) {

--- a/cdap-system-app-api/pom.xml
+++ b/cdap-system-app-api/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2019 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>co.cask.cdap</groupId>
+    <version>6.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-system-app-api</artifactId>
+  <name>CDAP System Application API</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-storage-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/cdap-system-app-api/src/main/java/co/cask/cdap/api/SystemTableConfigurer.java
+++ b/cdap-system-app-api/src/main/java/co/cask/cdap/api/SystemTableConfigurer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
+
+/**
+ * Allows registering system tables for creation.
+ */
+@Beta
+public interface SystemTableConfigurer {
+
+  /**
+   * Create a system table that conforms to the given table specification when the
+   * application is deployed. If the table already exists, nothing happens.
+   *
+   * @throws UnsupportedOperationException if the application is not a system application
+   */
+  void createTable(StructuredTableSpecification tableSpecification);
+
+}

--- a/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/AbstractSystemService.java
+++ b/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/AbstractSystemService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.service;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
+
+/**
+ * Abstract class for system services. System services can only be used in applications that are deployed in the
+ * system namespace.
+ */
+@Beta
+public abstract class AbstractSystemService extends AbstractService<SystemServiceConfigurer> {
+
+  /**
+   * Create a system table that conforms to the given table specification when the
+   * application is deployed. If the table already exists, nothing happens.
+   *
+   * @throws UnsupportedOperationException if the application is not a system application
+   */
+  protected void createTable(StructuredTableSpecification tableSpecification) {
+    getConfigurer().createTable(tableSpecification);
+  }
+
+}

--- a/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/SystemServiceConfigurer.java
+++ b/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/SystemServiceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,19 +16,13 @@
 
 package co.cask.cdap.api.service;
 
-import co.cask.cdap.api.service.http.HttpServiceHandler;
+import co.cask.cdap.api.SystemTableConfigurer;
+import co.cask.cdap.api.annotation.Beta;
 
 /**
- * Defines a custom user Service. Services are custom applications that run in program containers and provide
- * endpoints to serve requests.
- *
- * @param <T> type of service configurer
+ * Configurer for system application services, allowing additional capabilities beyond those available to user services.
+ * System configurers can only be used by applications that are deployed in the system namespace.
  */
-public interface Service<T extends ServiceConfigurer> {
-
-  /**
-   * Configure the Service by adding {@link HttpServiceHandler}s to handle requests.
-   * @param configurer to use to add handlers to the Service.
-   */
-  void configure(T configurer);
+@Beta
+public interface SystemServiceConfigurer extends ServiceConfigurer, SystemTableConfigurer {
 }

--- a/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/http/AbstractSystemHttpServiceHandler.java
+++ b/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/http/AbstractSystemHttpServiceHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.service.http;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
+
+/**
+ * Abstract class for system http service handlers. System handlers can only be used in applications that are deployed
+ * in the system namespace.
+ */
+@Beta
+public class AbstractSystemHttpServiceHandler extends
+  AbstractHttpServiceHandler<SystemHttpServiceContext, SystemHttpServiceConfigurer> {
+
+  /**
+   * Create a system table that conforms to the given table specification when the
+   * application is deployed. If the table already exists, nothing happens.
+   *
+   * @throws UnsupportedOperationException if the application is not a system application
+   */
+  protected void createTable(StructuredTableSpecification tableSpecification) {
+    getConfigurer().createTable(tableSpecification);
+  }
+}

--- a/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/http/SystemHttpServiceConfigurer.java
+++ b/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/http/SystemHttpServiceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,21 +14,18 @@
  * the License.
  */
 
-package co.cask.cdap.api.service;
+package co.cask.cdap.api.service.http;
 
-import co.cask.cdap.api.service.http.HttpServiceHandler;
+import co.cask.cdap.api.SystemTableConfigurer;
+import co.cask.cdap.api.annotation.Beta;
+
+import java.util.Map;
 
 /**
- * Defines a custom user Service. Services are custom applications that run in program containers and provide
- * endpoints to serve requests.
- *
- * @param <T> type of service configurer
+ * System HttpServiceConfigurer that provides capabilities beyond those available to user configurers.
+ * A system configurer can only be used by applications that are deployed in the system namespace.
  */
-public interface Service<T extends ServiceConfigurer> {
+@Beta
+public interface SystemHttpServiceConfigurer extends HttpServiceConfigurer, SystemTableConfigurer {
 
-  /**
-   * Configure the Service by adding {@link HttpServiceHandler}s to handle requests.
-   * @param configurer to use to add handlers to the Service.
-   */
-  void configure(T configurer);
 }

--- a/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/http/SystemHttpServiceContext.java
+++ b/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/http/SystemHttpServiceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,21 +14,15 @@
  * the License.
  */
 
-package co.cask.cdap.api.service;
+package co.cask.cdap.api.service.http;
 
-import co.cask.cdap.api.service.http.HttpServiceHandler;
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
 
 /**
- * Defines a custom user Service. Services are custom applications that run in program containers and provide
- * endpoints to serve requests.
- *
- * @param <T> type of service configurer
+ * A System HttpServiceContext that exposes capabilities beyond those available to service contexts for user services.
  */
-public interface Service<T extends ServiceConfigurer> {
+@Beta
+public interface SystemHttpServiceContext extends HttpServiceContext, TransactionRunner {
 
-  /**
-   * Configure the Service by adding {@link HttpServiceHandler}s to handle requests.
-   * @param configurer to use to add handlers to the Service.
-   */
-  void configure(T configurer);
 }

--- a/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/http/SystemHttpServiceHandler.java
+++ b/cdap-system-app-api/src/main/java/co/cask/cdap/api/service/http/SystemHttpServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,21 +14,16 @@
  * the License.
  */
 
-package co.cask.cdap.api.service;
+package co.cask.cdap.api.service.http;
 
-import co.cask.cdap.api.service.http.HttpServiceHandler;
+import co.cask.cdap.api.annotation.Beta;
 
 /**
- * Defines a custom user Service. Services are custom applications that run in program containers and provide
- * endpoints to serve requests.
- *
- * @param <T> type of service configurer
+ * A System HttpServiceHandler that exposes capabilities beyond those that are not available to user service handlers.
+ * System handlers can only be run by applications that run in the system namespace.
  */
-public interface Service<T extends ServiceConfigurer> {
+@Beta
+public interface SystemHttpServiceHandler
+  extends HttpServiceHandler<SystemHttpServiceContext, SystemHttpServiceConfigurer> {
 
-  /**
-   * Configure the Service by adding {@link HttpServiceHandler}s to handle requests.
-   * @param configurer to use to add handlers to the Service.
-   */
-  void configure(T configurer);
 }

--- a/cdap-system-app-unit-test/pom.xml
+++ b/cdap-system-app-unit-test/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2019 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap</artifactId>
+    <version>6.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-system-app-unit-test</artifactId>
+  <name>CDAP System Application Unit Test Framework</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-unit-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-storage-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/cdap-system-app-unit-test/src/main/java/co/cask/cdap/test/SystemAppTestBase.java
+++ b/cdap-system-app-unit-test/src/main/java/co/cask/cdap/test/SystemAppTestBase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import org.junit.BeforeClass;
+
+/**
+ * Base class to inherit from for system application unit-tests.
+ *
+ * @see TestBase
+ */
+public class SystemAppTestBase extends TestBase {
+  private static TransactionRunner transactionRunner;
+  private static StructuredTableAdmin tableAdmin;
+
+  @BeforeClass
+  public static void setupClass() {
+    if (isFirstInit()) {
+      transactionRunner = injector.getInstance(TransactionRunner.class);
+      tableAdmin = injector.getInstance(StructuredTableAdmin.class);
+    }
+  }
+
+  public TransactionRunner getTransactionRunner() {
+    return transactionRunner;
+  }
+
+  public StructuredTableAdmin getStructuredTableAdmin() {
+    return tableAdmin;
+  }
+}

--- a/cdap-system-app-unit-test/src/test/java/co/cask/cdap/test/SystemAppTestBaseTest.java
+++ b/cdap-system-app-unit-test/src/test/java/co/cask/cdap/test/SystemAppTestBaseTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.spi.data.StructuredRow;
+import co.cask.cdap.spi.data.StructuredTable;
+import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.table.StructuredTableId;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
+import co.cask.cdap.spi.data.table.field.Field;
+import co.cask.cdap.spi.data.table.field.FieldType;
+import co.cask.cdap.spi.data.table.field.Fields;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import co.cask.cdap.test.app.SystemTestApp;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for system app.
+ */
+public class SystemAppTestBaseTest extends SystemAppTestBase {
+
+  @Test
+  public void testTableOperations() throws Exception {
+    StructuredTableAdmin tableAdmin = getStructuredTableAdmin();
+    StructuredTableId id = new StructuredTableId("t0");
+    Assert.assertNull(tableAdmin.getSpecification(id));
+
+    String keyCol = "key";
+    String valCol = "val";
+    tableAdmin.create(new StructuredTableSpecification.Builder()
+                        .withId(id)
+                        .withFields(new FieldType(keyCol, FieldType.Type.STRING),
+                                    new FieldType(valCol, FieldType.Type.STRING))
+                        .withPrimaryKeys(keyCol)
+                        .build());
+
+    try {
+      TransactionRunner transactionRunner = getTransactionRunner();
+
+      String key = "k0";
+      String val = "v0";
+      transactionRunner.run(context -> {
+        StructuredTable table = context.getTable(id);
+        List<Field<?>> fields = new ArrayList<>();
+        fields.add(Fields.stringField(keyCol, key));
+
+        Optional<StructuredRow> row = table.read(fields);
+        Assert.assertFalse(row.isPresent());
+
+        fields.add(Fields.stringField(valCol, val));
+        table.upsert(fields);
+      });
+
+      transactionRunner.run(context -> {
+        StructuredTable table = context.getTable(id);
+        List<Field<?>> keyField = Collections.singletonList(Fields.stringField(keyCol, key));
+        Optional<StructuredRow> row = table.read(keyField);
+        Assert.assertTrue(row.isPresent());
+        Assert.assertEquals(val, row.get().getString(valCol));
+      });
+    } finally {
+      tableAdmin.drop(id);
+    }
+  }
+
+  @Test
+  public void testSystemServiceInUserNamespaceFails() {
+    try {
+      deployApplication(NamespaceId.DEFAULT, SystemTestApp.class);
+      Assert.fail("Should not have been able to deploy a system service in a user namespace.");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testSystemService() throws Exception {
+    ApplicationManager applicationManager = deployApplication(NamespaceId.SYSTEM, SystemTestApp.class);
+
+    ServiceManager serviceManager = applicationManager.getServiceManager(SystemTestApp.SERVICE_NAME);
+    serviceManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
+    URI serviceURI = serviceManager.getServiceURL(1, TimeUnit.MINUTES).toURI();
+
+    String key = "k0";
+    String val = "v0";
+    URL url = serviceURI.resolve(key).toURL();
+
+    HttpRequest request = HttpRequest.get(url).build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(404, response.getResponseCode());
+
+    request = HttpRequest.put(url).withBody(val).build();
+    response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+
+    request = HttpRequest.get(url).build();
+    response = HttpRequests.execute(request);
+    Assert.assertEquals(val, response.getResponseBodyAsString());
+  }
+}

--- a/cdap-system-app-unit-test/src/test/java/co/cask/cdap/test/app/SystemTestApp.java
+++ b/cdap-system-app-unit-test/src/test/java/co/cask/cdap/test/app/SystemTestApp.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.service.AbstractSystemService;
+import co.cask.cdap.api.service.http.AbstractSystemHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import co.cask.cdap.spi.data.StructuredRow;
+import co.cask.cdap.spi.data.StructuredTable;
+import co.cask.cdap.spi.data.table.StructuredTableId;
+import co.cask.cdap.spi.data.table.StructuredTableSpecification;
+import co.cask.cdap.spi.data.table.field.Field;
+import co.cask.cdap.spi.data.table.field.FieldType;
+import co.cask.cdap.spi.data.table.field.Fields;
+import co.cask.cdap.spi.data.transaction.TransactionException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * Application to test system application services.
+ */
+public class SystemTestApp extends AbstractApplication {
+  public static final StructuredTableId TABLE_ID = new StructuredTableId("kv");
+  public static final String SERVICE_NAME = "kv";
+  public static final String KEY_COL = "key";
+  public static final String VAL_COL = "val";
+
+  @Override
+  public void configure() {
+    addService(new TableService());
+  }
+
+  /**
+   * Service for accessing the table.
+   */
+  public static class TableService extends AbstractSystemService {
+
+    @Override
+    protected void configure() {
+      setName(SERVICE_NAME);
+      createTable(new StructuredTableSpecification.Builder()
+                    .withId(TABLE_ID)
+                    .withFields(new FieldType(KEY_COL, FieldType.Type.STRING),
+                                new FieldType(VAL_COL, FieldType.Type.STRING))
+                    .withPrimaryKeys(KEY_COL).build());
+      addHandler(new TableHandler());
+    }
+  }
+
+  /**
+   * Service handler for accessing the table.
+   */
+  public static class TableHandler extends AbstractSystemHttpServiceHandler {
+
+    @PUT
+    @Path("{key}")
+    public void put(HttpServiceRequest request, HttpServiceResponder responder,
+                    @PathParam("key") String key) throws TransactionException {
+      String val = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      getContext().run(context -> {
+        StructuredTable table = context.getTable(TABLE_ID);
+        List<Field<?>> fields = new ArrayList<>(2);
+        fields.add(Fields.stringField(KEY_COL, key));
+        fields.add(Fields.stringField(VAL_COL, val));
+        table.upsert(fields);
+        responder.sendStatus(200);
+      });
+    }
+
+    @GET
+    @Path("{key}")
+    public void get(HttpServiceRequest request, HttpServiceResponder responder,
+                    @PathParam("key") String key) throws TransactionException {
+      getContext().run(context -> {
+        StructuredTable table = context.getTable(TABLE_ID);
+        List<Field<?>> keyField = Collections.singletonList(Fields.stringField(KEY_COL, key));
+        Optional<StructuredRow> row = table.read(keyField);
+        if (!row.isPresent()) {
+          responder.sendStatus(404);
+        } else {
+          responder.sendString(row.get().getString(VAL_COL));
+        }
+      });
+    }
+
+  }
+}

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -165,6 +165,7 @@ public class TestBase {
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
+  static Injector injector;
   private static CConfiguration cConf;
   private static int nestedStartCount;
   private static boolean firstInit = true;
@@ -221,7 +222,7 @@ public class TestBase {
       System.load(new File(tmpDir, "hadoop.dll").getAbsolutePath());
     }
 
-    Injector injector = Guice.createInjector(
+    injector = Guice.createInjector(
       createDataFabricModule(),
       new TransactionExecutorModule(),
       new DataSetsModules().getStandaloneModules(),
@@ -342,7 +343,17 @@ public class TestBase {
     provisioningService = injector.getInstance(ProvisioningService.class);
     provisioningService.startAndWait();
     metadataSubscriberService.startAndWait();
+  }
 
+  /**
+   * If a subclass has a {@link BeforeClass} method, this can be called within that method to determine whether this
+   * is the first time it was called. This is useful in test suites, where most initialization should only happen once
+   * at the very first init.
+   *
+   * @return whether this is the first time the class has been initialized.
+   */
+  protected static boolean isFirstInit() {
+    return nestedStartCount == 1;
   }
 
   private static TestManager getTestManager() {

--- a/pom.xml
+++ b/pom.xml
@@ -2734,6 +2734,8 @@
         <module>cdap-security-spi</module>
         <module>cdap-security</module>
         <module>cdap-storage-spi</module>
+        <module>cdap-system-app-api</module>
+        <module>cdap-system-app-unit-test</module>
         <module>cdap-tms</module>
         <module>cdap-gateway</module>
         <module>cdap-explore-client</module>


### PR DESCRIPTION
Introduced a new cdap-system-app-api module and corresponding
cdap-system-app-unit-test module for unit tests.

The new system-app-api module contains additional configurers
and contexts that are available to CDAP Services. These
classes allow applications to create system tables and use
them at runtime. Only applications deployed in the system
namespace are allowed to use the new classes. Attempts to
deploy an app in a user namespace will result in deployment
failure.

As part of this work, the restriction that system artifacts
cannot be added through the REST API was removed. This is because
unit tests require a way to add artifacts to the system namespace,
and also because the restriction is no long required now that
artifact authorization exists.