### PR TITLE
Fix WorkflowStatsSLAHttpHandlerTest 

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/WorkflowTable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/WorkflowTable.java
@@ -258,7 +258,7 @@ public class WorkflowTable {
       // This only works since the all keys but the last primary key are the same, so we can scan for a range in the
       // last primary key which is numeric.
       try (CloseableIterator<StructuredRow> iterator =
-        table.scan(Range.create(lowerBoundFields, Range.Bound.INCLUSIVE, upperBoundFields, Range.Bound.EXCLUSIVE),
+        table.scan(Range.create(lowerBoundFields, Range.Bound.INCLUSIVE, upperBoundFields, Range.Bound.INCLUSIVE),
                    1)) {
         if (!iterator.hasNext()) {
           return workflowRunRecords;


### PR DESCRIPTION
Fix WorkflowStatsSLAHttpHandlerTest by allowing upper bound in the scan. Previous code was doing scan `[startTime - (limit * timeInterval), startTime + (limit * timeInterval)]`, while current code does scan `[startTime - (limit * timeInterval), startTime + (limit * timeInterval))`

Build: https://builds.cask.co/browse/CDAP-DUT6784-1