### PR TITLE
CDAP-14883 Changes for time queue processor abstraction

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/Checkpoint.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/Checkpoint.java
@@ -19,31 +19,26 @@ package co.cask.cdap.logging.meta;
 import com.google.common.base.Objects;
 
 /**
- * Represents a checkpoint that can be saved when reading from Kafka.
+ * Represents a checkpoint that can be saved when reading logs.
+ * @param <Offset> type of the offset
  */
-public class Checkpoint {
-  private final long nextOffset;
-  private final long nextEventTime;
+public class Checkpoint<Offset> {
+  private final Offset offset;
   private final long maxEventTime;
 
-  public Checkpoint(long nextOffset, long nextEventTime, long maxEventTime) {
-    this.nextOffset = nextOffset;
-    this.nextEventTime = nextEventTime;
+  /**
+   * Checkpoint containing offset and maxEventTime.
+   */
+  public Checkpoint(Offset offset, long maxEventTime) {
+    this.offset = offset;
     this.maxEventTime = maxEventTime;
   }
 
   /**
-   * Returns the next Kafka offset to restart reading from.
+   * Returns the offset.
    */
-  public long getNextOffset() {
-    return nextOffset;
-  }
-
-  /**
-   * Returns the log event time of the message fetched with the previous offset of {@code nextOffset}.
-   */
-  public long getNextEventTime() {
-    return nextEventTime;
+  public Offset getOffset() {
+    return offset;
   }
 
   /**
@@ -56,7 +51,7 @@ public class Checkpoint {
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-      .add("nextOffset", nextOffset)
+      .add("Offset", offset)
       .add("maxEventTime", maxEventTime)
       .toString();
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/CheckpointManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/CheckpointManager.java
@@ -21,25 +21,24 @@ import java.util.Set;
 
 /**
  * Manages reading/writing of checkpoint information for a topic and partition.
+ * @param <Offset> type of the offset
  */
-public interface CheckpointManager {
+public interface CheckpointManager<Offset> {
 
   /**
    * Persists the given map of {@link Checkpoint}s.
    */
-  void saveCheckpoints(Map<Integer, ? extends Checkpoint> checkpoints) throws Exception;
+  void saveCheckpoints(Map<Integer, ? extends Checkpoint<Offset>> checkpoints) throws Exception;
 
   /**
    * Reads the set of {@link Checkpoint}s for the given set of partitions. If there is no checkpoint for the partition,
-   * a {@link Checkpoint} with both {@link Checkpoint#getMaxEventTime()} and
-   * {@link Checkpoint#getNextOffset()} returning {@code -1} will be used.
+   * a {@link Checkpoint} with both {@link Checkpoint#getMaxEventTime()} returning {@code -1} will be used.
    */
-  Map<Integer, Checkpoint> getCheckpoint(Set<Integer> partitions) throws Exception;
+  Map<Integer, Checkpoint<Offset>> getCheckpoint(Set<Integer> partitions) throws Exception;
 
   /**
    * Reads the {@link Checkpoint} for the given partition. If there is no checkpoint for the partition,
-   * a {@link Checkpoint} will be returned with both {@link Checkpoint#getMaxEventTime()} and
-   * {@link Checkpoint#getNextOffset()} returning {@code -1}.
+   * a {@link Checkpoint} will be returned with both {@link Checkpoint#getMaxEventTime()} returning {@code -1}.
    */
-  Checkpoint getCheckpoint(int partition) throws Exception;
+  Checkpoint<Offset> getCheckpoint(int partition) throws Exception;
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/CheckpointManagerFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/CheckpointManagerFactory.java
@@ -34,7 +34,7 @@ public class CheckpointManagerFactory {
     this.txClient = txClient;
   }
 
-  public CheckpointManager create(String topic, byte[] prefix) {
+  public CheckpointManager<KafkaOffset> create(String topic, byte[] prefix) {
     return new DefaultCheckpointManager(datasetFramework, txClient, topic, prefix);
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/KafkaOffset.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/meta/KafkaOffset.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.meta;
+
+/**
+ * Kafka offset for log processing.
+ */
+public class KafkaOffset implements Comparable<KafkaOffset> {
+  private final long nextOffset;
+  private final long nextEventTime;
+
+  /**
+   * Kafka offset containing nextOffset and nextEventTime.
+   */
+  public KafkaOffset(long nextOffset, long nextEventTime) {
+    this.nextOffset = nextOffset;
+    this.nextEventTime = nextEventTime;
+  }
+
+  /**
+   * Returns next offset.
+   */
+  public long getNextOffset() {
+    return nextOffset;
+  }
+
+  /**
+   * Returns next event time.
+   */
+  public long getNextEventTime() {
+    return nextEventTime;
+  }
+
+  @Override
+  public String toString() {
+    return "KafkaOffset{" +
+      "nextOffset=" + nextOffset +
+      ", nextEventTime=" + nextEventTime +
+      '}';
+  }
+
+  @Override
+  public int compareTo(KafkaOffset o) {
+    return Long.compare(this.nextOffset, o.nextOffset);
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/ProcessedEventMetadata.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/ProcessedEventMetadata.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.pipeline.queue;
+
+import co.cask.cdap.logging.meta.Checkpoint;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Holds information about metadata of processed log events.
+ * @param <Offset> type of the offset stored
+ */
+public class ProcessedEventMetadata<Offset> {
+  private final int totalEventsProcessed;
+  private final Map<Integer, Checkpoint<Offset>> checkpoints;
+
+  /**
+   * Processed event metadata containing total events processsed and checkpoints for the partitions
+   */
+  public ProcessedEventMetadata(int totalEventsProcessed, @Nullable Map<Integer, Checkpoint<Offset>> checkpoints) {
+    this.totalEventsProcessed = totalEventsProcessed;
+    this.checkpoints = checkpoints;
+  }
+
+  /**
+   * Returns total events processed.
+   */
+  public int getTotalEventsProcessed() {
+    return totalEventsProcessed;
+  }
+
+  /**
+   * Returns checkpoints for each partition.
+   */
+  @Nullable
+  public Map<Integer, Checkpoint<Offset>> getCheckpoints() {
+    return checkpoints;
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/ProcessedEventMetadata.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/ProcessedEventMetadata.java
@@ -30,7 +30,7 @@ public class ProcessedEventMetadata<Offset> {
   private final Map<Integer, Checkpoint<Offset>> checkpoints;
 
   /**
-   * Processed event metadata containing total events processsed and checkpoints for the partitions
+   * Processed event metadata containing total events processed and checkpoints for the partitions
    */
   public ProcessedEventMetadata(int totalEventsProcessed, @Nullable Map<Integer, Checkpoint<Offset>> checkpoints) {
     this.totalEventsProcessed = totalEventsProcessed;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/ProcessorEvent.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/ProcessorEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.pipeline.queue;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+/**
+ * Processor event containing event, eventSize and offset.
+ * @param <Offset> type of the offset
+ */
+public class ProcessorEvent<Offset> {
+  private final ILoggingEvent event;
+  private final int eventSize;
+  private final Offset offset;
+
+  /**
+   * Processor event containing log event, eventSize and offset
+   */
+  public ProcessorEvent(ILoggingEvent event, int eventSize, Offset offset) {
+    this.event = event;
+    this.eventSize = eventSize;
+    this.offset = offset;
+  }
+
+  /**
+   * Returns log event.
+   */
+  public ILoggingEvent getEvent() {
+    return event;
+  }
+
+  /**
+   * Returns log event size.
+   */
+  public int getEventSize() {
+    return eventSize;
+  }
+
+  /**
+   * Returns offset.
+   */
+  public Offset getOffset() {
+    return offset;
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/TimeEventQueue.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/TimeEventQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.logging.pipeline;
+package co.cask.cdap.logging.pipeline.queue;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -42,7 +42,7 @@ public final class TimeEventQueue<Event, Offset extends Comparable<Offset>> impl
     this.partitionOffsets = new Int2ObjectArrayMap<>();
 
     for (int partition : partitions) {
-      partitionOffsets.put(partition, new TreeSet<Offset>());
+      partitionOffsets.put(partition, new TreeSet<>());
     }
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/TimeEventQueueProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/queue/TimeEventQueueProcessor.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.pipeline.queue;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.logging.meta.Checkpoint;
+import co.cask.cdap.logging.pipeline.LogProcessorPipelineContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * The {@link TimeEventQueue} processor to enqueue the log events to {@link TimeEventQueue}, and process them.
+ * @param <Offset> type of the offset
+ */
+public class TimeEventQueueProcessor<Offset extends Comparable<Offset>> {
+  private static final Logger LOG = LoggerFactory.getLogger(TimeEventQueueProcessor.class);
+  private static final double MIN_FREE_FACTOR = 0.5d;
+  private final TimeEventQueue<ILoggingEvent, Offset> eventQueue;
+  private final LogProcessorPipelineContext context;
+  private final MetricsContext metricsContext;
+  private final long maxBufferSize;
+  private final long eventDelayMillis;
+
+  /**
+   * Time event queue processor.
+   */
+  public TimeEventQueueProcessor(LogProcessorPipelineContext context, long maxBufferSize, long eventDelayMillis,
+                                 Iterable<Integer> partitions) {
+    this.context = context;
+    this.maxBufferSize = maxBufferSize;
+    this.eventDelayMillis = eventDelayMillis;
+    this.metricsContext = context;
+    this.eventQueue = new TimeEventQueue<>(partitions);
+  }
+
+  /**
+   * Processes events provided by event iterator for a given partition.
+   *
+   * @param partition log event partition
+   * @param eventIterator log events iterator
+   * @param eventConverter event converter to convert log event to {@code ProcessorEvent}
+   * @param <T> type of the event provided by the iterator
+   *
+   * @return processed event metadata
+   */
+  public <T> ProcessedEventMetadata<Offset> process(int partition, Iterator<T> eventIterator,
+                                                    Function<T, ProcessorEvent<Offset>> eventConverter) {
+    // iterate through all the events if buffer size has not reached max
+    while (eventIterator.hasNext() && getMaxRetainSize() == Long.MAX_VALUE) {
+      ProcessorEvent<Offset> processorEvent = eventConverter.apply(eventIterator.next());
+      eventQueue.add(processorEvent.getEvent(), processorEvent.getEvent().getTimeStamp(), processorEvent.getEventSize(),
+                     partition, processorEvent.getOffset());
+    }
+
+    // if event queue is full or all the events have been added to the queue, append all the enqueued events to log
+    // appenders.
+    return append();
+  }
+
+  private ProcessedEventMetadata<Offset> append() {
+    long minEventTime = System.currentTimeMillis() - eventDelayMillis;
+    long maxRetainSize = getMaxRetainSize();
+
+    int eventsAppended = 0;
+    long minDelay = Long.MAX_VALUE;
+    long maxDelay = -1;
+    Map<Integer, Checkpoint<Offset>> metadata = new HashMap<>();
+
+    TimeEventQueue.EventIterator<ILoggingEvent, Offset> iterator = eventQueue.iterator();
+    while (iterator.hasNext()) {
+      ILoggingEvent event = iterator.next();
+
+      // If not forced to reduce the event queue size and the current event timestamp is still within the
+      // buffering time, no need to iterate anymore
+      if (eventQueue.getEventSize() <= maxRetainSize && event.getTimeStamp() >= minEventTime) {
+        break;
+      }
+
+      // update delay
+      long delay = System.currentTimeMillis() - event.getTimeStamp();
+      minDelay = delay < minDelay ? delay : minDelay;
+      maxDelay = delay > maxDelay ? delay : maxDelay;
+
+      try {
+        // Otherwise, append the event
+        ch.qos.logback.classic.Logger effectiveLogger = context.getEffectiveLogger(event.getLoggerName());
+        if (event.getLevel().isGreaterOrEqual(effectiveLogger.getEffectiveLevel())) {
+          effectiveLogger.callAppenders(event);
+        }
+      } catch (Exception e) {
+        LOG.warn("Failed to append log event in pipeline {}. Will be retried.", context.getName(), e);
+        break;
+      }
+
+      metadata.put(iterator.getPartition(), new Checkpoint<>(eventQueue.getSmallestOffset(iterator.getPartition()),
+                                                             event.getTimeStamp()));
+      iterator.remove();
+      eventsAppended++;
+    }
+
+    // Always try to call flush, even there was no event written. This is needed so that appender get called
+    // periodically even there is no new events being appended to perform housekeeping work.
+    // Failure to flush is ok and it will be retried by the wrapped appender
+    try {
+      context.flush();
+    } catch (IOException e) {
+      LOG.warn("Failed to flush in pipeline {}. Will be retried.", context.getName(), e);
+    }
+    metricsContext.gauge("event.queue.size.bytes", eventQueue.getEventSize());
+
+    // If no event was appended and the buffer is not full, so just return with 0 events appended.
+    if (eventsAppended == 0) {
+      // nothing has been appended so there is no metadata associated with those events. So return null.
+      return new ProcessedEventMetadata<>(0, null);
+    }
+
+    metricsContext.gauge(Constants.Metrics.Name.Log.PROCESS_MIN_DELAY, minDelay);
+    metricsContext.gauge(Constants.Metrics.Name.Log.PROCESS_MAX_DELAY, maxDelay);
+    metricsContext.increment(Constants.Metrics.Name.Log.PROCESS_MESSAGES_COUNT, eventsAppended);
+
+    return new ProcessedEventMetadata<>(eventsAppended, metadata);
+  }
+
+  /**
+   * Calculates max retain size for event queue.
+   */
+  private long getMaxRetainSize() {
+    long maxRetainSize = eventQueue.getEventSize() >= maxBufferSize ?
+      (long) (maxBufferSize * MIN_FREE_FACTOR) : Long.MAX_VALUE;
+
+    if (maxRetainSize != Long.MAX_VALUE) {
+      LOG.info("Maximum queue size {} reached for pipeline {}.", maxBufferSize, context.getName());
+    }
+    return maxRetainSize;
+  }
+
+  /**
+   * Returns if the queue is empty for a given partition.
+   */
+  public boolean isQueueEmpty(int partition) {
+    return eventQueue.isEmpty(partition);
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestDistributedLogReader.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestDistributedLogReader.java
@@ -31,6 +31,7 @@ import co.cask.cdap.logging.framework.local.LocalLogAppender;
 import co.cask.cdap.logging.meta.Checkpoint;
 import co.cask.cdap.logging.meta.CheckpointManager;
 import co.cask.cdap.logging.meta.CheckpointManagerFactory;
+import co.cask.cdap.logging.meta.KafkaOffset;
 import co.cask.cdap.logging.read.DistributedLogReader;
 import co.cask.cdap.logging.read.FileLogReader;
 import co.cask.cdap.logging.read.LogEvent;
@@ -284,11 +285,11 @@ public class TestDistributedLogReader extends KafkaTestBase {
 
     // Save checkpoint (time of last event)
     CheckpointManagerFactory checkpointManagerFactory = injector.getInstance(CheckpointManagerFactory.class);
-    CheckpointManager checkpointManager =
+    CheckpointManager<KafkaOffset> checkpointManager =
       checkpointManagerFactory.create(kafkaTopic, Constants.Logging.SYSTEM_PIPELINE_CHECKPOINT_PREFIX);
     long checkpointTime = events.get(numExpectedEvents - 1).getLoggingEvent().getTimeStamp();
-    checkpointManager.saveCheckpoints(ImmutableMap.of(stringPartitioner.partition(loggingContext.getLogPartition(), -1),
-                                                      new Checkpoint(numExpectedEvents, checkpointTime,
-                                                                     checkpointTime)));
+    checkpointManager.saveCheckpoints(ImmutableMap.of(
+      stringPartitioner.partition(loggingContext.getLogPartition(), -1),
+      new Checkpoint<>(new KafkaOffset(numExpectedEvents, checkpointTime), checkpointTime)));
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/distributed/DistributedLogFrameworkTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/distributed/DistributedLogFrameworkTest.java
@@ -47,6 +47,7 @@ import co.cask.cdap.logging.guice.DistributedLogFrameworkModule;
 import co.cask.cdap.logging.meta.Checkpoint;
 import co.cask.cdap.logging.meta.CheckpointManagerFactory;
 import co.cask.cdap.logging.meta.FileMetaDataReader;
+import co.cask.cdap.logging.meta.KafkaOffset;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.serialize.LoggingEventSerializer;
 import co.cask.cdap.logging.write.LogLocation;
@@ -188,10 +189,10 @@ public class DistributedLogFrameworkTest {
 
     // Check the checkpoint is persisted correctly. Since all messages are processed,
     // the checkpoint should be the same as the message count.
-    Checkpoint checkpoint = injector.getInstance(CheckpointManagerFactory.class)
+    Checkpoint<KafkaOffset> checkpoint = injector.getInstance(CheckpointManagerFactory.class)
       .create(cConf.get(Constants.Logging.KAFKA_TOPIC), Bytes.toBytes(100))
       .getCheckpoint(0);
-    Assert.assertEquals(msgCount, checkpoint.getNextOffset());
+    Assert.assertEquals(msgCount, checkpoint.getOffset().getNextOffset());
   }
 
   private Injector createInjector() throws IOException {

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/kafka/KafkaOffsetResolverTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/kafka/KafkaOffsetResolverTest.java
@@ -28,7 +28,6 @@ import co.cask.cdap.data.runtime.StorageModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.kafka.KafkaTester;
 import co.cask.cdap.logging.context.GenericLoggingContext;
-import co.cask.cdap.logging.meta.Checkpoint;
 import co.cask.cdap.logging.serialize.LoggingEventSerializer;
 import co.cask.cdap.metrics.collect.LocalMetricsCollectionService;
 import co.cask.cdap.metrics.store.DefaultMetricStore;
@@ -173,7 +172,7 @@ public class KafkaOffsetResolverTest {
     // Use every event's timestamp as target time and assert that found offset is the next offset of the current offset
     for (int i = 0; i < inOrderEvents.size(); i++) {
       long targetTime = inOrderEvents.get(i).getTimeStamp();
-      long offset = offsetResolver.getStartOffset(new Checkpoint(Long.MAX_VALUE, targetTime, 0), 0);
+      long offset = offsetResolver.getStartOffset(Long.MAX_VALUE, targetTime, 0);
       Assert.assertEquals("Failed to find the expected event with the target time: " + targetTime,
                           i + 1, offset);
     }
@@ -210,7 +209,7 @@ public class KafkaOffsetResolverTest {
   private void assertOffsetResolverResult(KafkaOffsetResolver offsetResolver, List<ILoggingEvent> events,
                                           long targetTime, long baseTime) throws IOException {
     long expectedOffset = findExpectedOffsetByTime(events, targetTime);
-    long offset = offsetResolver.getStartOffset(new Checkpoint(Long.MAX_VALUE, targetTime, 0), 0);
+    long offset = offsetResolver.getStartOffset(Long.MAX_VALUE, targetTime, 0);
     Assert.assertEquals(String.format("Failed to find the expected event with the target time %d when basetime is %d ",
                                       targetTime, baseTime), expectedOffset, offset);
   }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/queue/TimeEventQueueProcessorTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/queue/TimeEventQueueProcessorTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.pipeline.queue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.metrics.NoopMetricsContext;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.io.Syncable;
+import co.cask.cdap.logging.meta.Checkpoint;
+import co.cask.cdap.logging.pipeline.LogPipelineConfigurator;
+import co.cask.cdap.logging.pipeline.LogProcessorPipelineContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+/**
+ * Tests for {@link TimeEventQueueProcessor}.
+ */
+public class TimeEventQueueProcessorTest {
+  private static final MetricsContext NO_OP_METRICS_CONTEXT = new NoopMetricsContext();
+
+  @Test
+  public void test() throws Exception {
+    LoggerContext loggerContext = createLoggerContext("WARN", ImmutableMap.of("test.logger", "INFO"),
+                                                      TestAppender.class.getName());
+    LogProcessorPipelineContext context = new LogProcessorPipelineContext(CConfiguration.create(),
+                                                                          "test", loggerContext, NO_OP_METRICS_CONTEXT,
+                                                                          0);
+    context.start();
+    TimeEventQueueProcessor<TestOffset> processor = new TimeEventQueueProcessor<>(context, 50, 1,
+                                                                                  ImmutableList.of(0));
+    long now = System.currentTimeMillis();
+    List<ILoggingEvent> events = ImmutableList.of(
+      createLoggingEvent("test.logger", Level.INFO, "1", now - 1000),
+      createLoggingEvent("test.logger", Level.INFO, "3", now - 700),
+      createLoggingEvent("test.logger", Level.INFO, "5", now - 500),
+      createLoggingEvent("test.logger", Level.INFO, "2", now - 900),
+      createLoggingEvent("test.logger", Level.ERROR, "4", now - 600),
+      createLoggingEvent("test.logger", Level.INFO, "6", now - 100));
+
+    ProcessedEventMetadata<TestOffset> metadata = processor.process(0, events.iterator(), getEventConverter());
+    // only 5 events should be processed because max buffer size is 50 and each event is of size 10
+    Assert.assertEquals(5, metadata.getTotalEventsProcessed());
+    for (Map.Entry<Integer, Checkpoint<TestOffset>> entry : metadata.getCheckpoints().entrySet()) {
+      Checkpoint<TestOffset> value = entry.getValue();
+      // offset should be max offset processed so far
+      Assert.assertEquals(5, value.getOffset().getOffset());
+    }
+  }
+
+  private Function<ILoggingEvent, ProcessorEvent<TestOffset>> getEventConverter() {
+    return event -> new ProcessorEvent<>(event, 10, new TestOffset(Long.parseLong(event.getMessage())));
+  }
+
+  /**
+   * Creates a new {@link ILoggingEvent} with the given information.
+   */
+  private ILoggingEvent createLoggingEvent(String loggerName, Level level, String message, long timestamp) {
+    LoggingEvent event = new LoggingEvent();
+    event.setLevel(level);
+    event.setLoggerName(loggerName);
+    event.setMessage(message);
+    event.setTimeStamp(timestamp);
+    return event;
+  }
+
+  private LoggerContext createLoggerContext(String rootLevel,
+                                            Map<String, String> loggerLevels,
+                                            String appenderClassName) throws Exception {
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    Element configuration = doc.createElement("configuration");
+    doc.appendChild(configuration);
+
+    Element appender = doc.createElement("appender");
+    appender.setAttribute("name", "Test");
+    appender.setAttribute("class", appenderClassName);
+    configuration.appendChild(appender);
+
+    for (Map.Entry<String, String> entry : loggerLevels.entrySet()) {
+      Element logger = doc.createElement("logger");
+      logger.setAttribute("name", entry.getKey());
+      logger.setAttribute("level", entry.getValue());
+      configuration.appendChild(logger);
+    }
+
+    Element rootLogger = doc.createElement("root");
+    rootLogger.setAttribute("level", rootLevel);
+    Element appenderRef = doc.createElement("appender-ref");
+    appenderRef.setAttribute("ref", "Test");
+    rootLogger.appendChild(appenderRef);
+
+    configuration.appendChild(rootLogger);
+
+    Transformer transformer = TransformerFactory.newInstance().newTransformer();
+    StringWriter writer = new StringWriter();
+    transformer.transform(new DOMSource(doc), new StreamResult(writer));
+
+    LoggerContext context = new LoggerContext();
+    JoranConfigurator configurator = new LogPipelineConfigurator(CConfiguration.create());
+    configurator.setContext(context);
+    configurator.doConfigure(new InputSource(new StringReader(writer.toString())));
+
+    return context;
+  }
+
+  /**
+   * Appender for unit-test.
+   */
+  public static final class TestAppender extends AppenderBase<ILoggingEvent> implements Flushable, Syncable {
+
+    private final AtomicInteger flushCount = new AtomicInteger();
+    private Queue<ILoggingEvent> pending;
+    private Queue<ILoggingEvent> persisted;
+
+    @Override
+    protected void append(ILoggingEvent event) {
+      pending.add(event);
+    }
+
+    Queue<ILoggingEvent> getEvents() {
+      return persisted;
+    }
+
+    int getFlushCount() {
+      return flushCount.get();
+    }
+
+    @Override
+    public void start() {
+      persisted = new ConcurrentLinkedQueue<>();
+      pending = new LinkedList<>();
+      super.start();
+    }
+
+    @Override
+    public void stop() {
+      persisted = null;
+      pending = null;
+      super.stop();
+    }
+
+    @Override
+    public void flush() throws IOException {
+      flushCount.incrementAndGet();
+    }
+
+    @Override
+    public void sync() throws IOException {
+      persisted.addAll(pending);
+      pending.clear();
+    }
+  }
+
+  /**
+   * Offset for unit-test.
+   */
+  public static final class TestOffset implements Comparable<TestOffset> {
+    private final long offset;
+
+    public TestOffset(long offset) {
+      this.offset = offset;
+    }
+
+    public long getOffset() {
+      return offset;
+    }
+
+    @Override
+    public int compareTo(TestOffset o) {
+      return Long.compare(this.offset, o.offset);
+    }
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/queue/TimeEventQueueTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/queue/TimeEventQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.logging.pipeline;
+package co.cask.cdap.logging.pipeline.queue;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;


### PR DESCRIPTION
Build: https://builds.cask.co/browse/CDAP-DUT6792-4

Added an abstraction `TimeEventQueueProcessor` responsible for operating on `TimeEventQueue`. 

Currently testing final changes on cluster.