### PR TITLE
 [CDAP-14864] Enable and test metadata search on description

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -373,7 +373,7 @@ public class DefaultMetadataStore extends SearchHelper implements MetadataStore 
 
   @Override
   public MetadataSearchResponse search(SearchRequest request) {
-    return super.search(request);
+    return super.search(request, null);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
@@ -391,7 +391,7 @@ public class DatasetMetadataStorage implements MetadataStorage {
       request.getCursor(),
       request.isShowHidden(),
       entityScopes
-    ));
+    ), request.getScope());
     // translate results back
     List<MetadataRecord> results = new ArrayList<>(response.getResults().size());
     response.getResults().forEach(record -> {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/SearchHelper.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/SearchHelper.java
@@ -63,6 +63,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import static co.cask.cdap.api.metadata.MetadataScope.SYSTEM;
 import static co.cask.cdap.api.metadata.MetadataScope.USER;
 
@@ -116,8 +118,8 @@ public class SearchHelper {
     return USER == scope ? BUSINESS_METADATA_INSTANCE_ID : SYSTEM_METADATA_INSTANCE_ID;
   }
 
-  public MetadataSearchResponse search(SearchRequest request) {
-    Set<MetadataScope> searchScopes = EnumSet.allOf(MetadataScope.class);
+  public MetadataSearchResponse search(SearchRequest request, @Nullable MetadataScope scope) {
+    Set<MetadataScope> searchScopes = scope == null ? EnumSet.allOf(MetadataScope.class) : Collections.singleton(scope);
     if ("*".equals(request.getQuery())) {
       if (SortInfo.DEFAULT.equals(request.getSortInfo())) {
         // Can't disallow this completely, because it is required for upgrade, but log a warning to indicate that

--- a/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/MetadataDocument.java
+++ b/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/MetadataDocument.java
@@ -211,7 +211,6 @@ public class MetadataDocument {
       String name = key.getName().toLowerCase();
       value = value.toLowerCase();
       MetadataScope scope = key.getScope();
-      append(scope, name);
       append(scope, value);
       properties.add(new Property(scope.name(), name, value));
     }


### PR DESCRIPTION
- adds tests for search on description
- fixes dataset-based search to search only on requested scope
- fixes elasticsearch-based search not to index property names as plain text

This is relative to the previous feature branch until that is merged. Will rebase then.