### PR TITLE
[CDAP-14989] Add a way to search metadata for property names

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/MetadataConstants.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/MetadataConstants.java
@@ -22,6 +22,7 @@ package co.cask.cdap.data2.metadata;
 public class MetadataConstants {
 
   public static final String TAGS_KEY = "tags";
+  public static final String PROPERTIES_KEY = "properties";
   public static final String KEYVALUE_SEPARATOR = ":";
 
   public static final String SCHEMA_KEY = "schema";

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2018 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,10 +35,11 @@ public class DefaultValueIndexer implements Indexer {
   /**
    * Generates a set of tokens based on the metadata values. Splits values on whitespace, '-', '_', ':', and ',' to
    * generate multiple tokens. Also generates an additional token that has the metadata key prefixed to it.
+   * Also adds a token that allows searching the property name, that is, properties:key, except if the key is "tags".
    *
    * For example, when given property 'owner'='foo bar', six tokens will be generated:
    *
-   * 'foo bar', 'foo', 'bar', 'owner:foo bar', 'owner:foo', and 'owner:bar'.
+   * 'foo bar', 'foo', 'bar', 'owner:foo bar', 'owner:foo', 'owner:bar', and 'properties:owner'.
    *
    * If 'tags'='foo,bar baz' is given, six tokens will be generated:
    *
@@ -79,6 +80,9 @@ public class DefaultValueIndexer implements Indexer {
     Set<String> indexesWithKeyValue = new HashSet<>(indexes);
     for (String index : indexes) {
       indexesWithKeyValue.add(key + MetadataConstants.KEYVALUE_SEPARATOR + index);
+    }
+    if (!key.equalsIgnoreCase(MetadataConstants.TAGS_KEY)) {
+      indexesWithKeyValue.add(MetadataConstants.PROPERTIES_KEY + MetadataConstants.KEYVALUE_SEPARATOR + key);
     }
     return indexesWithKeyValue;
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexerTest.java
@@ -38,6 +38,7 @@ public class DefaultValueIndexerTest {
     Set<String> expected = new HashSet<>();
     expected.add("val");
     expected.add("key:val");
+    expected.add("properties:key");
     Assert.assertEquals(expected, indexer.getIndexes(entry));
   }
 
@@ -52,6 +53,7 @@ public class DefaultValueIndexerTest {
     expected.add("key:foo bar");
     expected.add("key:foo");
     expected.add("key:bar");
+    expected.add("properties:key");
     Assert.assertEquals(expected, indexer.getIndexes(entry));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/MetadataStorageTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/MetadataStorageTest.java
@@ -563,14 +563,20 @@ public abstract class MetadataStorageTest {
 
     // add properties for program and dataset
     final String multiWordValue = "aV1 av2 ,  -  ,  av3 - av4_av5 av6";
-    MetadataRecord programRecord = new MetadataRecord(
-      program, new Metadata(USER, props("key1", "value1", "key2", "value2", "multiword", multiWordValue)));
+    MetadataRecord programRecord = new MetadataRecord(program, new Metadata(USER, props("key1", "value1",
+                                                                                        "key2", "value2",
+                                                                                        "multiword", multiWordValue)));
     MetadataRecord datasetRecord = new MetadataRecord(dataset,
       new Metadata(ImmutableSet.of(), ImmutableMap.of(new ScopedName(SYSTEM, "sKey1"), "sValue1",
                                                       new ScopedName(USER, "Key1"), "Value1")));
 
     mds.batch(batch(new Update(program, programRecord.getMetadata()),
                     new Update(dataset, datasetRecord.getMetadata())));
+
+    // search based on the names of properties
+    assertResults(mds, SearchRequest.of("properties:key1").build(), programRecord, datasetRecord);
+    assertResults(mds, SearchRequest.of("properties:skey1").setScope(SYSTEM).build(), datasetRecord);
+    assertResults(mds, SearchRequest.of("properties:multi*").setScope(USER).build(), programRecord);
 
     // Search for it based on key and value
     assertResults(mds, SearchRequest.of("key1:value1").addType(TYPE_PROGRAM).build(), programRecord);

--- a/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/MetadataDocument.java
+++ b/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/MetadataDocument.java
@@ -181,6 +181,8 @@ public class MetadataDocument {
     private Long created;
     private final List<String> userTags = new ArrayList<>();
     private final List<String> systemTags = new ArrayList<>();
+    private final List<String> userPropertyNames = new ArrayList<>();
+    private final List<String> systemPropertyNames = new ArrayList<>();
     private final StringBuilder userText = new StringBuilder();
     private final StringBuilder systemText = new StringBuilder();
     private final Set<Property> properties = new HashSet<>();
@@ -214,6 +216,7 @@ public class MetadataDocument {
       append(scope, name);
       append(scope, value);
       properties.add(new Property(scope.name(), name, value));
+      (MetadataScope.USER == key.getScope() ? userPropertyNames : systemPropertyNames).add(name);
     }
 
     Builder addMetadata(Metadata metadata) {
@@ -234,9 +237,17 @@ public class MetadataDocument {
 
     MetadataDocument build() {
       properties.add(
-        new Property(MetadataScope.USER.name(), "tags", Strings.collectionToDelimitedString(userTags, " ")));
+        new Property(MetadataScope.USER.name(), MetadataConstants.TAGS_KEY,
+                     Strings.collectionToDelimitedString(userTags, " ")));
       properties.add(
-        new Property(MetadataScope.SYSTEM.name(), "tags", Strings.collectionToDelimitedString(systemTags, " ")));
+        new Property(MetadataScope.SYSTEM.name(), MetadataConstants.TAGS_KEY,
+                     Strings.collectionToDelimitedString(systemTags, " ")));
+      properties.add(
+        new Property(MetadataScope.USER.name(), MetadataConstants.PROPERTIES_KEY,
+                     Strings.collectionToDelimitedString(userPropertyNames, " ")));
+      properties.add(
+        new Property(MetadataScope.SYSTEM.name(), MetadataConstants.PROPERTIES_KEY,
+                     Strings.collectionToDelimitedString(systemPropertyNames, " ")));
       return
         new MetadataDocument(entity, metadata, namespace, type, name, created,
                              userText.toString(), systemText.toString(), properties);


### PR DESCRIPTION
Similar to searching tags:explore, this allows to search properties:ttl, which matches all property names.