### PR TITLE
CDAP-14894 migrate config store to use new SPI

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -135,7 +135,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   public Module getInMemoryModules() {
     return Modules.combine(new AppFabricServiceModule(),
                            new NamespaceAdminModule().getInMemoryModules(),
-                           new ConfigStoreModule().getInMemoryModule(),
+                           new ConfigStoreModule(),
                            new EntityVerifierModule(),
                            new AuthenticationContextModules().getMasterModule(),
                            BootstrapModules.getInMemoryModule(),
@@ -174,7 +174,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
     return Modules.combine(new AppFabricServiceModule(PreviewHttpHandler.class),
                            new NamespaceAdminModule().getStandaloneModules(),
-                           new ConfigStoreModule().getStandaloneModule(),
+                           new ConfigStoreModule(),
                            new EntityVerifierModule(),
                            new AuthenticationContextModules().getMasterModule(),
                            new ProvisionerModule(),
@@ -227,7 +227,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
     return Modules.combine(new AppFabricServiceModule(ImpersonationHandler.class, PreviewHttpHandler.class),
                            new PreviewHttpModule().getDistributedModules(),
                            new NamespaceAdminModule().getDistributedModules(),
-                           new ConfigStoreModule().getDistributedModule(),
+                           new ConfigStoreModule(),
                            new EntityVerifierModule(),
                            new AuthenticationContextModules().getMasterModule(),
                            new MetadataServiceModule(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/Config.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/Config.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * Configuration Class that holds an Id and properties as a Map.
  */
 public final class Config {
-  private final String id;
+  private final String name;
   private final Map<String, String> properties;
 
   /**
@@ -37,12 +37,12 @@ public final class Config {
   public Config(String name, Map<String, String> properties) {
     Preconditions.checkNotNull(name);
     Preconditions.checkNotNull(properties);
-    this.id = name;
+    this.name = name;
     this.properties = ImmutableMap.copyOf(properties);
   }
 
-  public String getId() {
-    return id;
+  public String getName() {
+    return name;
   }
 
   public Map<String, String> getProperties() {
@@ -56,11 +56,11 @@ public final class Config {
     }
 
     Config config = (Config) o;
-    return Objects.equal(this.id, config.id) && Objects.equal(this.properties, config.properties);
+    return Objects.equal(this.name, config.name) && Objects.equal(this.properties, config.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.id, this.properties);
+    return Objects.hashCode(this.name, this.properties);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/ConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/ConfigStore.java
@@ -44,10 +44,10 @@ public interface ConfigStore {
    * Delete a Configuration.
    * @param namespace namespace
    * @param type configuration type
-   * @param id name of the configuration
+   * @param name name of the configuration
    * @throws ConfigNotFoundException if configuration is not found
    */
-  void delete(String namespace, String type, String id) throws ConfigNotFoundException;
+  void delete(String namespace, String type, String name) throws ConfigNotFoundException;
 
   /**
    * List all Configurations which are of a specific type.
@@ -61,11 +61,11 @@ public interface ConfigStore {
    * Read a Configuration.
    * @param namespace namespace
    * @param type configuration type
-   * @param id name of the configuration
+   * @param name name of the configuration
    * @return {@link Config}
    * @throws ConfigNotFoundException if configuration is not found
    */
-  Config get(String namespace, String type, String id) throws ConfigNotFoundException;
+  Config get(String namespace, String type, String name) throws ConfigNotFoundException;
 
   /**
    * Update a Configuration.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/ConsoleSettingsStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/ConsoleSettingsStore.java
@@ -59,9 +59,9 @@ public class ConsoleSettingsStore {
     List<Config> configList = configStore.list(CONSOLE_NAMESPACE, CONFIG_TYPE);
     for (Config config : configList) {
       try {
-        configStore.delete(CONSOLE_NAMESPACE, CONFIG_TYPE, config.getId());
+        configStore.delete(CONSOLE_NAMESPACE, CONFIG_TYPE, config.getName());
       } catch (ConfigNotFoundException e) {
-        LOG.warn("ConsoleSettings for {} not found", config.getId());
+        LOG.warn("ConsoleSettings for {} not found", config.getName());
       }
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
@@ -16,92 +16,138 @@
 
 package co.cask.cdap.config;
 
-import co.cask.cdap.api.Transactional;
-import co.cask.cdap.api.Transactionals;
-import co.cask.cdap.api.data.DatasetContext;
-import co.cask.cdap.api.dataset.DatasetManagementException;
-import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
-import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
-import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
-import co.cask.cdap.data2.transaction.Transactions;
-import co.cask.cdap.proto.id.NamespaceId;
-import com.google.common.collect.ImmutableMap;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.spi.data.StructuredRow;
+import co.cask.cdap.spi.data.StructuredTable;
+import co.cask.cdap.spi.data.table.field.Field;
+import co.cask.cdap.spi.data.table.field.Fields;
+import co.cask.cdap.spi.data.table.field.Range;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import co.cask.cdap.spi.data.transaction.TransactionRunners;
+import co.cask.cdap.store.StoreDefinition;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
 import com.google.inject.Inject;
-import org.apache.tephra.RetryStrategies;
-import org.apache.tephra.TransactionSystemClient;
 
-import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
- * Default Configuration Store.
+ * Default Configuration Store. A "configuration" consists of a namespace, type, name, and properties map
+ * The primary key is namespace, type, and name.
+ *
+ * For example, the ConsoleSettingsStore uses this to store user-specific configurations.
+ * The type is "usersettings", and name is the user name.
+ * "
  */
 public class DefaultConfigStore implements ConfigStore {
-  private final DatasetFramework datasetFramework;
-  private final Transactional transactional;
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private final TransactionRunner transactionRunner;
 
   @Inject
-  public DefaultConfigStore(DatasetFramework datasetFramework, TransactionSystemClient txClient) {
-    this.datasetFramework = datasetFramework;
-    this.transactional = Transactions.createTransactionalWithRetry(
-      Transactions.createTransactional(new MultiThreadDatasetCache(
-        new SystemDatasetInstantiator(datasetFramework), new TransactionSystemClientAdapter(txClient),
-        NamespaceId.SYSTEM, ImmutableMap.of(), null, null)),
-      RetryStrategies.retryOnConflict(20, 100)
-    );
-  }
-
-  public static void setupDatasets(DatasetFramework dsFramework) throws DatasetManagementException, IOException {
-    dsFramework.addInstance(Table.class.getName(), ConfigDataset.CONFIG_STORE_DATASET_INSTANCE_ID,
-                            DatasetProperties.EMPTY);
+  public DefaultConfigStore(TransactionRunner transactionRunner) {
+    this.transactionRunner = transactionRunner;
   }
 
   @Override
   public void create(String namespace, String type, Config config) throws ConfigExistsException {
-    Transactionals.execute(transactional, context -> {
-      getConfigDataset(context).create(namespace, type, config);
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.ConfigStore.CONFIGS);
+      List<Field<?>> primaryKey = getPrimaryKey(namespace, type, config.getName());
+      Optional<StructuredRow> row = table.read(primaryKey);
+      if (row.isPresent()) {
+        throw new ConfigExistsException(namespace, type, config.getName());
+      }
+      table.upsert(toFields(namespace, type, config));
     }, ConfigExistsException.class);
   }
 
   @Override
   public void createOrUpdate(String namespace, String type, Config config) {
-    Transactionals.execute(transactional, context -> {
-      getConfigDataset(context).createOrUpdate(namespace, type, config);
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.ConfigStore.CONFIGS);
+      table.upsert(toFields(namespace, type, config));
     });
   }
 
   @Override
-  public void delete(String namespace, String type, String id) throws ConfigNotFoundException {
-    Transactionals.execute(transactional, context -> {
-      getConfigDataset(context).delete(namespace, type, id);
+  public void delete(String namespace, String type, String name) throws ConfigNotFoundException {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.ConfigStore.CONFIGS);
+      List<Field<?>> primaryKey = getPrimaryKey(namespace, type, name);
+      Optional<StructuredRow> row = table.read(primaryKey);
+      if (!row.isPresent()) {
+        throw new ConfigNotFoundException(namespace, type, name);
+      }
+      table.delete(primaryKey);
     }, ConfigNotFoundException.class);
   }
 
   @Override
   public List<Config> list(String namespace, String type) {
-    return Transactionals.execute(transactional, context -> {
-      return getConfigDataset(context).list(namespace, type);
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.ConfigStore.CONFIGS);
+
+      List<Field<?>> scanStart = new ArrayList<>(2);
+      scanStart.add(Fields.stringField(StoreDefinition.ConfigStore.NAMESPACE_FIELD, namespace));
+      scanStart.add(Fields.stringField(StoreDefinition.ConfigStore.TYPE_FIELD, type));
+      Range range = Range.singleton(scanStart);
+      try (CloseableIterator<StructuredRow> iter = table.scan(range, Integer.MAX_VALUE)) {
+        List<Config> result = new ArrayList<>();
+        while (iter.hasNext()) {
+          StructuredRow row = iter.next();
+          result.add(fromRow(row));
+        }
+        return result;
+      }
     });
   }
 
   @Override
-  public Config get(String namespace, String type, String id) throws ConfigNotFoundException {
-    return Transactionals.execute(transactional, context -> {
-      return getConfigDataset(context).get(namespace, type, id);
+  public Config get(String namespace, String type, String name) throws ConfigNotFoundException {
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.ConfigStore.CONFIGS);
+      List<Field<?>> primaryKey = getPrimaryKey(namespace, type, name);
+      Optional<StructuredRow> row = table.read(primaryKey);
+      return row.map(this::fromRow).orElseThrow(() -> new ConfigNotFoundException(namespace, type, name));
     }, ConfigNotFoundException.class);
   }
 
   @Override
   public void update(String namespace, String type, Config config) throws ConfigNotFoundException {
-    Transactionals.execute(transactional, context -> {
-      getConfigDataset(context).update(namespace, type, config);
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(StoreDefinition.ConfigStore.CONFIGS);
+      List<Field<?>> primaryKey = getPrimaryKey(namespace, type, config.getName());
+      Optional<StructuredRow> row = table.read(primaryKey);
+      if (!row.isPresent()) {
+        throw new ConfigNotFoundException(namespace, type, config.getName());
+      }
+      table.upsert(toFields(namespace, type, config));
     }, ConfigNotFoundException.class);
   }
 
-  private ConfigDataset getConfigDataset(DatasetContext context) {
-    return ConfigDataset.get(context, datasetFramework);
+  private Config fromRow(StructuredRow row) {
+    String name = row.getString(StoreDefinition.ConfigStore.NAME_FIELD);
+    Map<String, String> properties =
+      GSON.fromJson(row.getString(StoreDefinition.ConfigStore.PROPERTIES_FIELD), MAP_TYPE);
+    return new Config(name, properties);
+  }
+
+  private List<Field<?>> toFields(String namespace, String type, Config config) {
+    List<Field<?>> fields = getPrimaryKey(namespace, type, config.getName());
+    fields.add(Fields.stringField(StoreDefinition.ConfigStore.PROPERTIES_FIELD, GSON.toJson(config.getProperties())));
+    return fields;
+  }
+
+  private List<Field<?>> getPrimaryKey(String namespace, String type, String name) {
+    List<Field<?>> primaryKey = new ArrayList<>();
+    primaryKey.add(Fields.stringField(StoreDefinition.ConfigStore.NAMESPACE_FIELD, namespace));
+    primaryKey.add(Fields.stringField(StoreDefinition.ConfigStore.TYPE_FIELD, type));
+    primaryKey.add(Fields.stringField(StoreDefinition.ConfigStore.NAME_FIELD, name));
+    return primaryKey;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/PreferencesDataset.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/PreferencesDataset.java
@@ -33,7 +33,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
- * This class is responsible for Perferences operations. It uses {@link ConfigDataset} as the underlying storage.
+ * This class is responsible for Perferences operations.
+ * It uses {@link InternalPreferencesDataset} as the underlying storage.
  * It does not wrap its operations in a transaction. It is up to the caller to decide what operations belong
  * in a transaction.
  */
@@ -44,17 +45,17 @@ public class PreferencesDataset {
   // Id for Properties config stored at the instance level
   private static final String INSTANCE_PROPERTIES = "instance";
 
-  private final ConfigDataset configDataset;
+  private final InternalPreferencesDataset internalPreferencesDataset;
 
-  private PreferencesDataset(ConfigDataset configDataset) {
-    this.configDataset = configDataset;
+  private PreferencesDataset(InternalPreferencesDataset internalPreferencesDataset) {
+    this.internalPreferencesDataset = internalPreferencesDataset;
   }
 
   /**
    * Get the PreferenceDataset
    */
   public static PreferencesDataset get(DatasetContext datasetContext, DatasetFramework dsFramework) {
-    return new PreferencesDataset(ConfigDataset.get(datasetContext, dsFramework));
+    return new PreferencesDataset(InternalPreferencesDataset.get(datasetContext, dsFramework));
   }
 
   /**
@@ -194,7 +195,7 @@ public class PreferencesDataset {
   private Map<String, String> getConfigProperties(String namespace, String id) {
     Map<String, String> value = new HashMap<>();
     try {
-      Config config = configDataset.get(namespace, PREFERENCES_CONFIG_TYPE, id);
+      Config config = internalPreferencesDataset.get(namespace, PREFERENCES_CONFIG_TYPE, id);
       value.putAll(config.getProperties());
     } catch (ConfigNotFoundException e) {
       //no-op - return empty map
@@ -204,12 +205,12 @@ public class PreferencesDataset {
 
   private void setConfig(String namespace, String id, Map<String, String> propertyMap) {
     Config config = new Config(id, propertyMap);
-    configDataset.createOrUpdate(namespace, PREFERENCES_CONFIG_TYPE, config);
+    internalPreferencesDataset.createOrUpdate(namespace, PREFERENCES_CONFIG_TYPE, config);
   }
 
   private void deleteConfig(String namespace, String id) {
     try {
-      configDataset.delete(namespace, PREFERENCES_CONFIG_TYPE, id);
+      internalPreferencesDataset.delete(namespace, PREFERENCES_CONFIG_TYPE, id);
     } catch (ConfigNotFoundException e) {
       //no-op
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/guice/ConfigStoreModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/guice/ConfigStoreModule.java
@@ -19,31 +19,14 @@ package co.cask.cdap.config.guice;
 import co.cask.cdap.config.ConfigStore;
 import co.cask.cdap.config.DefaultConfigStore;
 import com.google.inject.AbstractModule;
-import com.google.inject.Module;
 
 /**
  * Configuration Store Guice Modules.
  */
-public class ConfigStoreModule {
+public class ConfigStoreModule extends AbstractModule {
 
-  public Module getInMemoryModule() {
-    return getModule();
-  }
-
-  public Module getStandaloneModule() {
-    return getModule();
-  }
-
-  public Module getDistributedModule() {
-    return getModule();
-  }
-
-  private Module getModule() {
-    return new AbstractModule() {
-      @Override
-      protected void configure() {
-        bind(ConfigStore.class).to(DefaultConfigStore.class);
-      }
-    };
+  @Override
+  protected void configure() {
+    bind(ConfigStore.class).to(DefaultConfigStore.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ConsoleSettingsHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ConsoleSettingsHttpHandler.java
@@ -73,7 +73,7 @@ public class ConsoleSettingsHttpHandler extends AbstractHttpHandler {
     }
 
     JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty(ID, userConfig.getId());
+    jsonObject.addProperty(ID, userConfig.getName());
 
     //We store the serialized JSON string of the properties in ConfigStore and we return a JsonObject back
     jsonObject.add(CONFIG_PROPERTY, JSON_PARSER.parse(userConfig.getProperties().get(CONFIG_PROPERTY)));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -209,7 +209,7 @@ public class DefaultPreviewManager implements PreviewManager {
       new PreviewSecureStoreModule(secureStore),
       new PreviewDiscoveryRuntimeModule(discoveryService),
       new LocalLocationModule(),
-      new ConfigStoreModule().getStandaloneModule(),
+      new ConfigStoreModule(),
       new PreviewRunnerModule(artifactRepository, artifactStore, authorizerInstantiator, authorizationEnforcer,
                               privilegesManager, preferencesService),
       new ProgramRunnerRuntimeModule().getStandaloneModules(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/config/NoSqlUserConfigStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/config/NoSqlUserConfigStoreTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.config;
+
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import com.google.common.base.Joiner;
+import com.google.inject.Injector;
+import org.junit.BeforeClass;
+
+public class NoSqlUserConfigStoreTest extends UserConfigStoreTest {
+
+  @BeforeClass
+  public static void setup() {
+    CConfiguration cConf = CConfiguration.create();
+    // any plugin which requires transaction will be excluded
+    cConf.set(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE, Joiner.on(",").join(Table.TYPE, KeyValueTable.TYPE));
+    cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
+    Injector injector = AppFabricTestHelper.getInjector(cConf);
+    TransactionRunner transactionRunner = injector.getInstance(TransactionRunner.class);
+    configStore = new DefaultConfigStore(transactionRunner);
+    admin = injector.getInstance(StructuredTableAdmin.class);
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/config/PreferencesServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/config/PreferencesServiceTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.config;
+
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.ProfileConflictException;
+import co.cask.cdap.internal.app.runtime.SystemArguments;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.internal.profile.ProfileService;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProfileId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.profile.Profile;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for PreferencesService.
+ */
+public class PreferencesServiceTest extends AppFabricTestBase {
+
+  // Testing PreferencesStore
+  @Test
+  public void testCleanSlate() throws Exception {
+    Map<String, String> emptyMap = ImmutableMap.of();
+    PreferencesService store = getInjector().getInstance(PreferencesService.class);
+    Assert.assertEquals(emptyMap, store.getProperties());
+    Assert.assertEquals(emptyMap, store.getProperties(new NamespaceId("somenamespace")));
+    Assert.assertEquals(emptyMap, store.getProperties(NamespaceId.DEFAULT));
+    Assert.assertEquals(emptyMap, store.getResolvedProperties());
+    Assert.assertEquals(emptyMap, store.getResolvedProperties(new ProgramId("a", "b", ProgramType.WORKFLOW, "d")));
+    // should not throw any exception if try to delete properties without storing anything
+    store.deleteProperties();
+    store.deleteProperties(NamespaceId.DEFAULT);
+    store.deleteProperties(new ProgramId("a", "x", ProgramType.WORKFLOW, "z"));
+  }
+
+  @Test
+  public void testBasicProperties() throws Exception {
+    Map<String, String> propMap = Maps.newHashMap();
+    propMap.put("key", "instance");
+    PreferencesService store = getInjector().getInstance(PreferencesService.class);
+    store.setProperties(propMap);
+    Assert.assertEquals(propMap, store.getProperties());
+    Assert.assertEquals(propMap, store.getResolvedProperties(new ProgramId("a", "b", ProgramType.WORKFLOW, "d")));
+    Assert.assertEquals(propMap, store.getResolvedProperties(new NamespaceId("myspace")));
+    Assert.assertEquals(ImmutableMap.<String, String>of(), store.getProperties(new NamespaceId("myspace")));
+    store.deleteProperties();
+    propMap.clear();
+    Assert.assertEquals(propMap, store.getProperties());
+    Assert.assertEquals(propMap, store.getResolvedProperties(new ProgramId("a", "b", ProgramType.WORKFLOW, "d")));
+    Assert.assertEquals(propMap, store.getResolvedProperties(new NamespaceId("myspace")));
+  }
+
+  @Test
+  public void testMultiLevelProperties() throws Exception {
+    Map<String, String> propMap = Maps.newHashMap();
+    propMap.put("key", "namespace");
+    PreferencesService store = getInjector().getInstance(PreferencesService.class);
+    store.setProperties(new NamespaceId("myspace"), propMap);
+    propMap.put("key", "application");
+    store.setProperties(new ApplicationId("myspace", "app"), propMap);
+    Assert.assertEquals(propMap, store.getProperties(new ApplicationId("myspace", "app")));
+    Assert.assertEquals("namespace", store.getProperties(new NamespaceId("myspace")).get("key"));
+    Assert.assertTrue(store.getProperties(new ApplicationId("myspace", "notmyapp")).isEmpty());
+    Assert.assertEquals("namespace", store.getResolvedProperties(new ApplicationId("myspace", "notmyapp")).get("key"));
+    Assert.assertTrue(store.getProperties(new NamespaceId("notmyspace")).isEmpty());
+    store.deleteProperties(new NamespaceId("myspace"));
+    Assert.assertTrue(store.getProperties(new NamespaceId("myspace")).isEmpty());
+    Assert.assertTrue(store.getResolvedProperties(new ApplicationId("myspace", "notmyapp")).isEmpty());
+    Assert.assertEquals(propMap, store.getProperties(new ApplicationId("myspace", "app")));
+    store.deleteProperties(new ApplicationId("myspace", "app"));
+    Assert.assertTrue(store.getProperties(new ApplicationId("myspace", "app")).isEmpty());
+    propMap.put("key", "program");
+    store.setProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog"), propMap);
+    Assert.assertEquals(propMap, store.getProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog")));
+    store.setProperties(ImmutableMap.of("key", "instance"));
+    Assert.assertEquals(propMap, store.getProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog")));
+    store.deleteProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog"));
+    Assert.assertTrue(store.getProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog")).isEmpty());
+    Assert.assertEquals("instance", store.getResolvedProperties(
+      new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog")).get("key"));
+    store.deleteProperties();
+    Assert.assertEquals(ImmutableMap.<String, String>of(), store.getProperties(
+      new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog")));
+  }
+
+  @Test
+  public void testAddProfileInProperties() throws Exception {
+    PreferencesService prefStore = getInjector().getInstance(PreferencesService.class);
+    ProfileService profileStore = getInjector().getInstance(ProfileService.class);
+
+    // put a profile unrelated property should not affect the write
+    Map<String, String> expected = new HashMap<>();
+    expected.put("unRelatedKey", "unRelatedValue");
+    prefStore.setProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog"), expected);
+    Assert.assertEquals(expected, prefStore.getProperties(
+      new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog")));
+
+    // put something related to profile
+    Map<String, String> profileMap = new HashMap<>();
+    profileMap.put(SystemArguments.PROFILE_NAME, "userProfile");
+
+    // this set call should fail since the profile does not exist
+    try {
+      prefStore.setProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog"), profileMap);
+      Assert.fail();
+    } catch (NotFoundException e) {
+      // expected
+    }
+    // the pref store should remain unchanged
+    Assert.assertEquals(expected, prefStore.getProperties(
+      new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog")));
+
+    // add the profile and disable it
+    ProfileId profileId = new ProfileId("myspace", "userProfile");
+    profileStore.saveProfile(profileId, Profile.NATIVE);
+    profileStore.disableProfile(profileId);
+
+    // this set call should fail since the profile is disabled
+    try {
+      prefStore.setProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog"), profileMap);
+      Assert.fail();
+    } catch (ProfileConflictException e) {
+      // expected
+    }
+    // the pref store should remain unchanged
+    Assert.assertEquals(expected, prefStore.getProperties(
+      new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog")));
+
+    // enable the profile
+    profileStore.enableProfile(profileId);
+    expected = profileMap;
+    prefStore.setProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog"), profileMap);
+    Map<String, String> properties = prefStore.getProperties(
+      new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog"));
+    Assert.assertEquals(expected, properties);
+
+    prefStore.deleteProperties(new ProgramId("myspace", "app", ProgramType.WORKFLOW, "prog"));
+    profileStore.disableProfile(profileId);
+    profileStore.deleteProfile(profileId);
+  }
+
+  @Test
+  public void testAddUserProfileToPreferencesInstanceLevel() throws Exception {
+    PreferencesService prefStore = getInjector().getInstance(PreferencesService.class);
+
+    // use profile in USER scope at instance level should fail
+    try {
+      prefStore.setProperties(Collections.singletonMap(SystemArguments.PROFILE_NAME, "userProfile"));
+      Assert.fail();
+    } catch (BadRequestException e) {
+      // expected
+    }
+
+    try {
+      prefStore.setProperties(Collections.singletonMap(SystemArguments.PROFILE_NAME, "USER:userProfile"));
+      Assert.fail();
+    } catch (BadRequestException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testProfileAssignment() throws Exception {
+    PreferencesService preferencesService = getInjector().getInstance(PreferencesService.class);
+    ProfileService profileService = getInjector().getInstance(ProfileService.class);
+    ProfileId myProfile = NamespaceId.DEFAULT.profile("myProfile");
+    profileService.saveProfile(myProfile, Profile.NATIVE);
+
+    // add properties with profile information
+    Map<String, String> prop = new HashMap<>();
+    prop.put(SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
+    ApplicationId myApp = NamespaceId.DEFAULT.app("myApp");
+    ProgramId myProgram = myApp.workflow("myProgram");
+    preferencesService.setProperties(prop);
+    preferencesService.setProperties(NamespaceId.DEFAULT, prop);
+    preferencesService.setProperties(myApp, prop);
+    preferencesService.setProperties(myProgram, prop);
+
+    // the assignment should be there for these entities
+    Set<EntityId> expected = new HashSet<>();
+    expected.add(new InstanceId(""));
+    expected.add(NamespaceId.DEFAULT);
+    expected.add(myApp);
+    expected.add(myProgram);
+    Assert.assertEquals(expected, profileService.getProfileAssignments(ProfileId.NATIVE));
+
+    // setting an empty property is actually deleting the assignment
+    prop.clear();
+    preferencesService.setProperties(myApp, prop);
+    expected.remove(myApp);
+    Assert.assertEquals(expected, profileService.getProfileAssignments(ProfileId.NATIVE));
+
+    // set my program to use a different profile, should update both profiles
+    prop.put(SystemArguments.PROFILE_NAME, myProfile.getScopedName());
+    preferencesService.setProperties(myProgram, prop);
+    expected.remove(myProgram);
+    Assert.assertEquals(expected, profileService.getProfileAssignments(ProfileId.NATIVE));
+    Assert.assertEquals(Collections.singleton(myProgram), profileService.getProfileAssignments(myProfile));
+
+    // delete all preferences
+    preferencesService.deleteProperties();
+    preferencesService.deleteProperties(NamespaceId.DEFAULT);
+    preferencesService.deleteProperties(myApp);
+    preferencesService.deleteProperties(myProgram);
+    Assert.assertEquals(Collections.emptySet(), profileService.getProfileAssignments(ProfileId.NATIVE));
+    Assert.assertEquals(Collections.emptySet(), profileService.getProfileAssignments(myProfile));
+
+    profileService.disableProfile(myProfile);
+    profileService.deleteProfile(myProfile);
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/config/SqlUserConfigStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/config/SqlUserConfigStoreTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.config;
+
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.sql.PostgresSqlStructuredTableAdmin;
+import co.cask.cdap.data2.sql.SqlStructuredTableRegistry;
+import co.cask.cdap.data2.sql.SqlTransactionRunner;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import com.google.common.base.Joiner;
+import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import javax.sql.DataSource;
+
+public class SqlUserConfigStoreTest extends UserConfigStoreTest {
+
+  private static EmbeddedPostgres pg;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    // any plugin which requires transaction will be excluded
+    cConf.set(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE, Joiner.on(",").join(Table.TYPE, KeyValueTable.TYPE));
+
+    pg = EmbeddedPostgres.start();
+    DataSource dataSource = pg.getPostgresDatabase();
+    admin = new PostgresSqlStructuredTableAdmin(new SqlStructuredTableRegistry(), dataSource);
+    TransactionRunner transactionRunner = new SqlTransactionRunner(admin, dataSource);
+    configStore = new DefaultConfigStore(transactionRunner);
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    pg.close();
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -90,7 +90,7 @@ public class DefaultPreviewManagerTest {
       new LogReaderRuntimeModules().getInMemoryModules(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
-      new ConfigStoreModule().getInMemoryModule(),
+      new ConfigStoreModule(),
       new MetadataServiceModule(),
       new MetadataReaderWriterModules().getInMemoryModules(),
       new AuthorizationModule(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -97,7 +97,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new MetricsHandlerModule());
     install(new MetricsClientRuntimeModule().getInMemoryModules());
     install(new ExploreClientModule());
-    install(new ConfigStoreModule().getInMemoryModule());
+    install(new ConfigStoreModule());
     install(new MetadataServiceModule());
     install(new AuthorizationModule());
     install(new AuthorizationEnforcementModule().getStandaloneModules());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
@@ -55,6 +55,9 @@ public final class StoreDefinition {
     if (overWrite || tableAdmin.getSpecification(WorkflowStore.WORKFLOW_STATISTICS) == null) {
       WorkflowStore.createTables(tableAdmin);
     }
+    if (overWrite || tableAdmin.getSpecification(ConfigStore.CONFIGS) == null) {
+      ConfigStore.createTable(tableAdmin);
+    }
   }
 
   public static void createAllTables(StructuredTableAdmin tableAdmin, StructuredTableRegistry registry)
@@ -81,6 +84,31 @@ public final class StoreDefinition {
 
     public static void createTable(StructuredTableAdmin tableAdmin) throws IOException, TableAlreadyExistsException {
       tableAdmin.create(NAMESPACE_TABLE_SPEC);
+    }
+  }
+
+  /**
+   * Schema for ConfigStore
+   */
+  public static final class ConfigStore {
+    public static final StructuredTableId CONFIGS = new StructuredTableId("configs");
+
+    public static final String NAMESPACE_FIELD = "namespace";
+    public static final String TYPE_FIELD = "type";
+    public static final String NAME_FIELD = "name";
+    public static final String PROPERTIES_FIELD = "properties";
+
+    public static final StructuredTableSpecification CONFIG_TABLE_SPEC = new StructuredTableSpecification.Builder()
+      .withId(CONFIGS)
+      .withFields(Fields.stringType(NAMESPACE_FIELD),
+                  Fields.stringType(TYPE_FIELD),
+                  Fields.stringType(NAME_FIELD),
+                  Fields.stringType(PROPERTIES_FIELD))
+      .withPrimaryKeys(NAMESPACE_FIELD, TYPE_FIELD, NAME_FIELD)
+      .build();
+
+    public static void createTable(StructuredTableAdmin tableAdmin) throws IOException, TableAlreadyExistsException {
+      tableAdmin.create(CONFIG_TABLE_SPEC);
     }
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -484,8 +484,6 @@ public class UpgradeTool {
     FieldLineageDataset.setupDatasets(datasetFramework);
     // app metadata
     DefaultStore.setupDatasets(datasetFramework);
-    // config store
-    DefaultConfigStore.setupDatasets(datasetFramework);
     // logs metadata
     LoggingStoreTableUtil.setupDatasets(datasetFramework);
     // scheduler metadata


### PR DESCRIPTION
The ConfigDataset used to be used for the DefaultConfigStore
and the PreferencesService. However, the PreferencesService
has a bug that makes it impossible to move it to a sql backed
implementation without changing the way preferences are stored.
Preferences are also tied together with profile and other stores.

To workaround this, renamed the ConfigDataset to
InternalPreferencesDataset and made it only used by the
PreferencesService. The DefaultConfigStore was moved to use the new SPI,
so config and preferences no longer share the same underlying storage.