### PR TITLE
[CDAP-14862] Add tests for search on TTL 

### DIFF
--- a/cdap-elastic/src/main/resources/index.mapping.json
+++ b/cdap-elastic/src/main/resources/index.mapping.json
@@ -33,6 +33,9 @@
     "created": {
       "type": "date"
     },
+    "ttl": {
+      "type": "long"
+    },
     "namespace": {
       "type": "keyword"
     },

--- a/cdap-elastic/src/test/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorageTest.java
+++ b/cdap-elastic/src/test/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorageTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.spi.metadata.MetadataStorage;
 import co.cask.cdap.spi.metadata.MetadataStorageTest;
 import co.cask.cdap.spi.metadata.ScopedName;
 import co.cask.cdap.spi.metadata.ScopedNameOfKind;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 
 public class ElasticsearchMetadataStorageTest extends MetadataStorageTest {
@@ -294,6 +296,10 @@ public class ElasticsearchMetadataStorageTest extends MetadataStorageTest {
                           Collections.singleton(MetadataKind.PROPERTY),
                           Collections.singleton(MetadataScope.USER),
                           null));
+  }
 
+  @Override
+  protected List<String> getAdditionalTTLQueries() {
+    return ImmutableList.of("ttl:0003600", "TtL:03600", "TtL:03600.00");
   }
 }


### PR DESCRIPTION
and prepare Elasticsearch metadata for more advanced search. In addition to indexing it as a property, also index it as a long field. This will allow to do numeric (range, or comparison) search in the future. 

The elasticsearch test adds a few extra queries to test for that. 