### PR TITLE
Fix broken unit tests 

### DIFF
--- a/cdap-master/src/test/java/co/cask/cdap/master/environment/k8s/MasterServiceMainTestBase.java
+++ b/cdap-master/src/test/java/co/cask/cdap/master/environment/k8s/MasterServiceMainTestBase.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.master.environment.k8s;
 
 import co.cask.cdap.api.dataset.DatasetDefinition;
-import co.cask.cdap.app.guice.ConstantTransactionSystemClient;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -127,7 +126,7 @@ public class MasterServiceMainTestBase {
       new SystemDatasetRuntimeModule().getStandaloneModules()
     );
     DatasetDefinition tableDef = injector.getInstance(Key.get(DatasetDefinition.class,
-                                                              Names.named(Constants.Dataset.TABLE_TYPE)));
+                                                              Names.named(Constants.Dataset.TABLE_TYPE_NO_TX)));
     StructuredTableRegistry tableRegistry = new NoSqlStructuredTableRegistry(tableDef);
     StructuredTableAdmin tableAdmin = new NoSqlStructuredTableAdmin(tableDef, tableRegistry);
     StoreDefinition.createAllTables(tableAdmin, tableRegistry);


### PR DESCRIPTION
Two PRs were independently branched off from develop but were dependent on each other was merged 
Make schema registry non tx: https://github.com/cdapio/cdap/pull/11039 
and 
Introduce AppFabricMain: https://github.com/cdapio/cdap/pull/11040 

This resulted in a problem with creating tableregistry class which was incorrectly fixed by the 
PR: 
https://github.com/cdapio/cdap/pull/11047

The fix should have used a non transactional dataset definition and this PR fixes the same