### PR TITLE
CDAP-14916 fix TransactionRunners runtime exception propagation

### DIFF
--- a/cdap-storage-spi/src/main/java/co/cask/cdap/spi/data/transaction/TransactionRunners.java
+++ b/cdap-storage-spi/src/main/java/co/cask/cdap/spi/data/transaction/TransactionRunners.java
@@ -196,6 +196,18 @@ public class TransactionRunners {
   }
 
   /**
+   * Propagates the given {@link TransactionException}. If the {@link TransactionException#getCause()}
+   * doesn't return {@code null}, the cause will be used instead for the propagation. This method will
+   * throw the failure exception as-is the given propagated type if the type matches or as {@link RuntimeException}.
+   *
+   * @param e the {@link TransactionException} to propagate
+   * @return nothing will ever be returned. This return type is only for convenience.
+   */
+  private static RuntimeException propagate(TransactionException e) {
+    throw propagateThrowable(firstNonNull(e.getCause(), e));
+  }
+
+  /**
    * Propagates {@code throwable} as-is if it is an instance of
    * {@link RuntimeException} or {@link Error}, or else as a last resort, wraps
    * it in a {@code RuntimeException} then propagates.
@@ -203,7 +215,7 @@ public class TransactionRunners {
    * @param throwable the Throwable to propagate
    * @return nothing will ever be returned. This return type is only for convenience.
    */
-  private static RuntimeException propagate(Throwable throwable) {
+  private static RuntimeException propagateThrowable(Throwable throwable) {
     propagateIfPossible(requireNonNull(throwable));
     throw new RuntimeException(throwable);
   }
@@ -220,7 +232,7 @@ public class TransactionRunners {
   public static <X extends Throwable> X propagate(TransactionException e, Class<X> propagateType) throws X {
     Throwable cause = firstNonNull(e.getCause(), e);
     propagateIfPossible(cause, propagateType);
-    throw propagate(cause);
+    throw propagateThrowable(cause);
   }
 
   /**
@@ -239,7 +251,7 @@ public class TransactionRunners {
                                                                           Class<X2> propagateType2) throws X1, X2 {
     Throwable cause = firstNonNull(e.getCause(), e);
     propagateIfPossible(cause, propagateType1, propagateType2);
-    throw propagate(cause);
+    throw propagateThrowable(cause);
   }
 
   /**
@@ -263,7 +275,7 @@ public class TransactionRunners {
     Throwable cause = firstNonNull(e.getCause(), e);
     propagateIfPossible(cause, propagateType1, propagateType2);
     propagateIfPossible(cause, propagateType3);
-    throw propagate(cause);
+    throw propagateThrowable(cause);
   }
 
   /**

--- a/cdap-storage-spi/src/test/java/co/cask/cdap/spi/data/transaction/TransactionRunnersTest.java
+++ b/cdap-storage-spi/src/test/java/co/cask/cdap/spi/data/transaction/TransactionRunnersTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.transaction;
+
+import co.cask.cdap.spi.data.TableAlreadyExistsException;
+import co.cask.cdap.spi.data.TableNotFoundException;
+import co.cask.cdap.spi.data.table.StructuredTableId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Tests exception propagation.
+ */
+public class TransactionRunnersTest {
+  private static final TransactionRunner MOCK = runnable -> {
+    try {
+      runnable.run(null);
+    } catch (Exception e) {
+      throw new TransactionException(e.getMessage(), e);
+    }
+  };
+
+  @Test
+  public void testRuntimeExceptionPropagation() {
+    try {
+      TransactionRunners.run(MOCK, (TxRunnable) context -> {
+        throw new IllegalArgumentException();
+      });
+      Assert.fail("runnable should have thrown an exception");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+
+    try {
+      TransactionRunners.run(MOCK, (TxCallable<Object>) context -> {
+        throw new IllegalArgumentException();
+      });
+      Assert.fail("runnable should have thrown an exception");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testSingleExceptionCheckedPropagation() {
+    try {
+      TransactionRunners.run(MOCK, (TxRunnable) context -> {
+        throw new TableNotFoundException(new StructuredTableId("id"));
+      }, TableNotFoundException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (TableNotFoundException e) {
+      // expected
+    }
+
+
+    try {
+      TransactionRunners.run(MOCK, (TxCallable<Object>) context -> {
+        throw new TableNotFoundException(new StructuredTableId("id"));
+      }, TableNotFoundException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (TableNotFoundException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testSingleExceptionRuntimePropagation() throws Exception {
+    try {
+      TransactionRunners.run(MOCK, (TxRunnable) context -> {
+        throw new IllegalArgumentException();
+      }, TableNotFoundException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+
+    try {
+      TransactionRunners.run(MOCK, (TxCallable<Object>) context -> {
+        throw new IllegalArgumentException();
+      }, TableNotFoundException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testTwoExceptionCheckedPropagation() throws Exception {
+    try {
+      TransactionRunners.run(MOCK, (TxRunnable) context -> {
+        throw new TableAlreadyExistsException(new StructuredTableId("id"));
+      }, TableNotFoundException.class, TableAlreadyExistsException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (TableAlreadyExistsException e) {
+      // expected
+    }
+
+
+    try {
+      TransactionRunners.run(MOCK, (TxCallable<Object>) context -> {
+        throw new TableAlreadyExistsException(new StructuredTableId("id"));
+      }, TableNotFoundException.class, TableAlreadyExistsException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (TableAlreadyExistsException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testTwoExceptionRuntimePropagation() throws Exception {
+    try {
+      TransactionRunners.run(MOCK, (TxRunnable) context -> {
+        throw new IllegalArgumentException();
+      }, TableNotFoundException.class, TableAlreadyExistsException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+
+    try {
+      TransactionRunners.run(MOCK, (TxCallable<Object>) context -> {
+        throw new IllegalArgumentException();
+      }, TableNotFoundException.class, TableAlreadyExistsException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testThreeExceptionCheckedPropagation() throws Exception {
+    try {
+      TransactionRunners.run(MOCK, context -> {
+        throw new IOException("io");
+      }, TableNotFoundException.class, TableAlreadyExistsException.class, IOException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (IOException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testThreeExceptionRuntimePropagation() throws Exception {
+    try {
+      TransactionRunners.run(MOCK, context -> {
+        throw new IllegalArgumentException();
+      }, TableNotFoundException.class, TableAlreadyExistsException.class, IOException.class);
+      Assert.fail("runnable should have thrown an exception");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
Fixed a bug with the TransactionRunners.run() methods that take a
single runnable and no exception classes. These methods used to
throw a RuntimeException around the TransactionException around
the actual RuntimeException thrown by the TxRunnable.