### PR TITLE
[CDAP-14799] Implement and test clean semantics for cursors, offsets, limits and total results

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/Cursor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/Cursor.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.metadata.elastic;
+package co.cask.cdap.spi.metadata.dataset;
 
 /**
  * A cursor for an Elasticsearch search session.
@@ -23,12 +23,12 @@ package co.cask.cdap.metadata.elastic;
 class Cursor {
   private final int offset;
   private final int pageSize;
-  private final String scrollId;
+  private final String cursor;
 
-  Cursor(int offset, int pageSize, String scrollId) {
+  Cursor(int offset, int pageSize, String cursor) {
     this.offset = offset;
     this.pageSize = pageSize;
-    this.scrollId = scrollId;
+    this.cursor = cursor;
   }
 
   int getOffset() {
@@ -39,13 +39,13 @@ class Cursor {
     return pageSize;
   }
 
-  String getScrollId() {
-    return scrollId;
+  String getCursor() {
+    return cursor;
   }
 
   @Override
   public String toString() {
-    return String.format("%d:%d:%s", offset, pageSize, scrollId);
+    return String.format("%d:%d:%s", offset, pageSize, cursor);
   }
 
   /**
@@ -56,7 +56,7 @@ class Cursor {
     String[] parts = str.split(":", 3);
     if (parts.length != 3) {
       throw new IllegalArgumentException(
-        String.format("Unable to parse cursor '%s': it must be of the form 'offset:pageSize:scrollId'", str));
+        String.format("Unable to parse cursor '%s': it must be of the form 'offset:pageSize:cursor'", str));
     }
     int offset;
     try {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
@@ -18,6 +18,7 @@ package co.cask.cdap.spi.metadata.dataset;
 
 import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
+import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
@@ -36,13 +37,13 @@ import co.cask.cdap.spi.metadata.ScopedName;
 import co.cask.cdap.spi.metadata.ScopedNameOfKind;
 import co.cask.cdap.spi.metadata.SearchRequest;
 import co.cask.cdap.spi.metadata.SearchResponse;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import org.apache.tephra.TransactionExecutor;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -349,62 +350,103 @@ public class DatasetMetadataStorage implements MetadataStorage {
 
   @Override
   public SearchResponse search(SearchRequest request) {
-    NamespaceId namespace = null;
-    Set<EntityScope> entityScopes;
-    if (request.getNamespaces() == null || request.getNamespaces().isEmpty()) {
-      entityScopes = EnumSet.allOf(EntityScope.class);
-    } else {
-      boolean hasSystem = false;
-      for (String ns : request.getNamespaces()) {
-        if (ns.equals(NamespaceId.SYSTEM.getNamespace())) {
-          hasSystem = true;
-        } else {
-          if (namespace != null) {
-            throw new UnsupportedOperationException(String.format(
-              "This implementation supports at most one non-system namespace, but %s as well as %s were given",
-              namespace.getNamespace(), ns));
-          }
-          namespace = new NamespaceId(ns);
-        }
-      }
-      if (hasSystem) {
-        if (namespace == null) {
-          namespace = NamespaceId.SYSTEM;
-          entityScopes = Collections.singleton(EntityScope.SYSTEM);
-        } else {
-          entityScopes = EnumSet.allOf(EntityScope.class);
-        }
-      } else {
-        entityScopes = Collections.singleton(EntityScope.USER);
-      }
-    }
+    ImmutablePair<NamespaceId, Set<EntityScope>> namespaceAndScopes =
+      determineNamespaceAndScopes(request.getNamespaces());
+    CursorAndOffsetInfo cursorOffsetAndLimits = determineCursorOffsetAndLimits(request);
     MetadataSearchResponse response = searchHelper.search(new co.cask.cdap.data2.metadata.dataset.SearchRequest(
-      namespace,
+      namespaceAndScopes.getFirst(),
       request.getQuery(),
       request.getTypes() == null ? Collections.emptySet() :
         request.getTypes().stream().map(EntityTypeSimpleName::valueOfSerializedForm).collect(Collectors.toSet()),
       request.getSorting() == null ? SortInfo.DEFAULT :
         new SortInfo(request.getSorting().getKey(), SortInfo.SortOrder.valueOf(request.getSorting().getOrder().name())),
-      request.getOffset(),
-      request.getLimit(),
+      cursorOffsetAndLimits.getOffsetToRequest(),
+      cursorOffsetAndLimits.getLimitToRequest(),
       request.isCursorRequested() ? 1 : 0,
-      request.getCursor(),
+      cursorOffsetAndLimits.getCursor(),
       request.isShowHidden(),
-      entityScopes
+      namespaceAndScopes.getSecond()
     ), request.getScope());
-    // translate results back
-    List<MetadataRecord> results = new ArrayList<>(response.getResults().size());
-    response.getResults().forEach(record -> {
-      Metadata metadata = null;
-      for (Map.Entry<MetadataScope, co.cask.cdap.api.metadata.Metadata> entry : record.getMetadata().entrySet()) {
-        Metadata toAdd = new Metadata(entry.getKey(), entry.getValue().getTags(), entry.getValue().getProperties());
-        metadata = metadata == null ? toAdd : mergeDisjointMetadata(metadata, toAdd);
+
+    // translate results back and limit them to at most what was requested (see above where we add 1)
+    int limitToRespond = cursorOffsetAndLimits.getLimitToRespond();
+    int offsetToRespond = cursorOffsetAndLimits.getOffsetToRespond();
+    List<MetadataRecord> results =
+      response.getResults().stream().limit(limitToRespond).map(record -> {
+        Metadata metadata = null;
+        for (Map.Entry<MetadataScope, co.cask.cdap.api.metadata.Metadata> entry : record.getMetadata().entrySet()) {
+          Metadata toAdd = new Metadata(entry.getKey(), entry.getValue().getTags(), entry.getValue().getProperties());
+          metadata = metadata == null ? toAdd : mergeDisjointMetadata(metadata, toAdd);
+        }
+        return new MetadataRecord(record.getMetadataEntity(), metadata);
+      }).collect(Collectors.toList());
+
+    String cursorToReturn = null;
+    if (response.getCursors() != null && !response.getCursors().isEmpty()) {
+      // the new cursor's offset is the previous cursor's offset plus the number of results
+      cursorToReturn = new Cursor(offsetToRespond + results.size(), limitToRespond,
+                                  response.getCursors().get(0)).toString();
+    }
+    // adjust the total results by the difference of requested offset and the true offset that we respond back
+    int totalResults = offsetToRespond - cursorOffsetAndLimits.getOffsetToRequest() + response.getTotal();
+    return new SearchResponse(request, cursorToReturn, offsetToRespond, limitToRespond,
+                              totalResults, results);
+  }
+
+  @VisibleForTesting
+  static CursorAndOffsetInfo determineCursorOffsetAndLimits(SearchRequest request) {
+    // limit and offset will be what we request from the datasets
+    int limit = request.getLimit();
+    int offset = request.getOffset();
+    // limitToRespond and offsetToRespond will be what we return in the response
+    int limitToRespond = limit;
+    int offsetToRespond = offset;
+    // if the request has a cursor, then that supersedes the offset and limit
+    String cursor = null;
+    if (request.getCursor() != null) {
+      // deserialize the cursor
+      Cursor c = Cursor.fromString(request.getCursor());
+      cursor = c.getCursor();
+      // request as many as given by the cursor - and that is also returned in the response
+      limit = c.getPageSize();
+      limitToRespond = limit;
+      // we must request offset zero, because the dataset interprets it relative to the cursor
+      offset = 0;
+      offsetToRespond = c.getOffset();
+    } else if (!request.isCursorRequested() && limit < Integer.MAX_VALUE) {
+      // if no cursor is requested, fetch one extra result to determine if there are more results following
+      limit++;
+    }
+    return new CursorAndOffsetInfo(cursor, offset, offsetToRespond, limit, limitToRespond);
+  }
+
+  @VisibleForTesting
+  static ImmutablePair<NamespaceId, Set<EntityScope>> determineNamespaceAndScopes(Set<String> namespaces) {
+    // if the request does not specify namespaces at all, then it searches all, including system
+    if (namespaces == null || namespaces.isEmpty()) {
+      return ImmutablePair.of(null, EnumSet.allOf(EntityScope.class));
+    }
+    boolean hasSystem = false;
+    Set<String> userNamespaces = namespaces;
+    if (namespaces.contains(NamespaceId.SYSTEM.getNamespace())) {
+      userNamespaces = new HashSet<>(namespaces);
+      userNamespaces.remove(NamespaceId.SYSTEM.getNamespace());
+      // if the request only specifies the system namespace, search that namespace and system scope
+      if (userNamespaces.isEmpty()) {
+        return ImmutablePair.of(NamespaceId.SYSTEM, EnumSet.of(EntityScope.SYSTEM));
       }
-      results.add(new MetadataRecord(record.getMetadataEntity(), metadata));
-    });
-    String cursor =
-      response.getCursors() == null || response.getCursors().isEmpty() ? null : response.getCursors().get(0);
-    return new SearchResponse(request, cursor, response.getTotal(), results);
+      hasSystem = true;
+    }
+    // we have at least one non-system namespace
+    if (userNamespaces.size() > 1) {
+      throw new UnsupportedOperationException(String.format(
+        "This implementation supports at most one non-system namespace, but %s were requested", userNamespaces));
+    }
+    // we have exactly one non-system namespace
+    NamespaceId namespace = new NamespaceId(userNamespaces.iterator().next());
+    return hasSystem
+      ? ImmutablePair.of(namespace, EnumSet.allOf(EntityScope.class))
+      : ImmutablePair.of(namespace, EnumSet.of(EntityScope.USER));
   }
 
   private MetadataChange combineChanges(MetadataEntity entity,
@@ -439,5 +481,55 @@ public class DatasetMetadataStorage implements MetadataStorage {
   @Override
   public void close() {
     // nop-op
+  }
+
+  /**
+   * Helper class to represent adjustments made to the search request parameters
+   * before delegating to the MetadataDataset, based on whether the request has
+   * a cursor and whether it requests a cursor, or not.
+   */
+  static class CursorAndOffsetInfo {
+    private final String cursor;
+    private final int offsetToRequest;
+    private final int offsetToRespond;
+    private final int limitToRequest;
+    private final int limitToRespond;
+
+    /**
+     * @param cursor          the cursor to pass to the metadata dataset
+     * @param offsetToRequest the offset to request from the metadata dataset
+     * @param offsetToRespond the offset to return in the search response
+     * @param limitToRequest  the result limit to request from the metadata dataset
+     * @param limitToRespond  the result limit to return in the search response
+     */
+    CursorAndOffsetInfo(String cursor,
+                        int offsetToRequest, int offsetToRespond,
+                        int limitToRequest, int limitToRespond) {
+      this.cursor = cursor;
+      this.offsetToRequest = offsetToRequest;
+      this.offsetToRespond = offsetToRespond;
+      this.limitToRequest = limitToRequest;
+      this.limitToRespond = limitToRespond;
+    }
+
+    String getCursor() {
+      return cursor;
+    }
+
+    int getOffsetToRequest() {
+      return offsetToRequest;
+    }
+
+    int getOffsetToRespond() {
+      return offsetToRespond;
+    }
+
+    int getLimitToRequest() {
+      return limitToRequest;
+    }
+
+    int getLimitToRespond() {
+      return limitToRespond;
+    }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/noop/NoopMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/noop/NoopMetadataStorage.java
@@ -50,7 +50,7 @@ public class NoopMetadataStorage implements MetadataStorage {
 
   @Override
   public SearchResponse search(SearchRequest request) {
-    return new SearchResponse(request, null, 0, Collections.emptyList());
+    return new SearchResponse(request, null, 0, 0, 0, Collections.emptyList());
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
@@ -20,11 +20,13 @@ import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocalLocationModule;
 import co.cask.cdap.common.guice.NamespaceAdminTestModule;
+import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.StorageModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
@@ -49,10 +51,13 @@ import com.google.inject.util.Modules;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.runtime.TransactionInMemoryModule;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -208,4 +213,64 @@ public class DatasetMetadataStorageTest extends MetadataStorageTest {
       new Drop(ns1app1), new Drop(ns1app2), new Drop(ns1app3), new Drop(ns2app1), new Drop(ns2app2)));
   }
 
+  @Test
+  public void testNsScopes() {
+    // no namespace
+    testNsScopes(null, null, EnumSet.allOf(EntityScope.class), false);
+    testNsScopes(Collections.emptySet(), null, EnumSet.allOf(EntityScope.class), false);
+    // system only
+    testNsScopes(ImmutableSet.of("system"), NamespaceId.SYSTEM, EnumSet.of(EntityScope.SYSTEM), false);
+    // user namespace only
+    testNsScopes(ImmutableSet.of("myns"), new NamespaceId("myns"), EnumSet.of(EntityScope.USER), false);
+    // user and system namespace
+    testNsScopes(ImmutableSet.of("myns", "system"), new NamespaceId("myns"), EnumSet.allOf(EntityScope.class), false);
+    // multiple user namespaces
+    testNsScopes(ImmutableSet.of("myns", "yourns"), null, null, true);
+    testNsScopes(ImmutableSet.of("myns", "system", "yourns"), null, null, true);
+  }
+
+  private void testNsScopes(Set<String> namespaces,
+                            NamespaceId expectedNamespace, Set<EntityScope> expectedScopes,
+                            boolean expectUnsupportedOperation) {
+    if (expectUnsupportedOperation) {
+      try {
+        DatasetMetadataStorage.determineNamespaceAndScopes(namespaces);
+        Assert.fail("Expected unsupported operation");
+      } catch (UnsupportedOperationException e) {
+        return; // expected
+      }
+    }
+    ImmutablePair<NamespaceId, Set<EntityScope>> pair = DatasetMetadataStorage.determineNamespaceAndScopes(namespaces);
+    Assert.assertEquals("namespace does not match for " + namespaces, expectedNamespace, pair.getFirst());
+    Assert.assertEquals("scopes don't match for " + namespaces, expectedScopes, pair.getSecond());
+  }
+
+  @Test
+  public void testCursorOffsetAndLimits() {
+    // search without cursor adds one to the limit to determine if there are more results
+    testCursorsOffsetsAndLimits(null, false, 0, 10, null, 0, 0, 11, 10);
+    testCursorsOffsetsAndLimits(null, false, 5, 10, null, 5, 5, 11, 10);
+    // search with request for a cursor does not need to add one - it can tell by the returned cursor
+    testCursorsOffsetsAndLimits(null, true, 0, 10, null, 0, 0, 10, 10);
+    testCursorsOffsetsAndLimits(null, true, 5, 10, null, 5, 5, 10, 10);
+    // search with cursor supersedes offset and limit
+    testCursorsOffsetsAndLimits(new Cursor(10, 5, "x"), false, 20, 50, "x", 0, 10, 5, 5);
+    testCursorsOffsetsAndLimits(new Cursor(10, 5, "x"), true, 20, 50, "x", 0, 10, 5, 5);
+  }
+
+  private void testCursorsOffsetsAndLimits(Cursor cursor, boolean cursorRequested,
+                                           int offsetRequested, int limitRequested,
+                                           String expectedCursor,
+                                           int expectedOffsetToRequest, int expectedOffsetToRespond,
+                                           int expectedLimitToRequest, int expectedLimitToRespond) {
+    SearchRequest request = SearchRequest.of("*")
+      .setCursor(cursor == null ? null : cursor.toString()).setCursorRequested(cursorRequested)
+      .setOffset(offsetRequested).setLimit(limitRequested).build();
+    DatasetMetadataStorage.CursorAndOffsetInfo info = DatasetMetadataStorage.determineCursorOffsetAndLimits(request);
+    Assert.assertEquals(expectedCursor, info.getCursor());
+    Assert.assertEquals(expectedOffsetToRequest, info.getOffsetToRequest());
+    Assert.assertEquals(expectedOffsetToRespond, info.getOffsetToRespond());
+    Assert.assertEquals(expectedLimitToRequest, info.getLimitToRequest());
+    Assert.assertEquals(expectedLimitToRespond, info.getLimitToRespond());
+  }
 }

--- a/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
+++ b/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
@@ -30,6 +30,7 @@ import co.cask.cdap.spi.metadata.MetadataStorage;
 import co.cask.cdap.spi.metadata.Read;
 import co.cask.cdap.spi.metadata.ScopedName;
 import co.cask.cdap.spi.metadata.ScopedNameOfKind;
+import co.cask.cdap.spi.metadata.SearchRequest;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
@@ -63,7 +64,6 @@ import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.ClearScrollRequest;
-import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.support.WriteRequest;
@@ -354,10 +354,10 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
   }
 
   @Override
-  public co.cask.cdap.spi.metadata.SearchResponse search(co.cask.cdap.spi.metadata.SearchRequest request)
+  public co.cask.cdap.spi.metadata.SearchResponse search(SearchRequest request)
     throws IOException {
     ensureIndexCreated();
-    return request.getCursor() != null ? doScroll(request) : doSearch(request, request.getOffset());
+    return request.getCursor() != null ? doScroll(request) : doSearch(request, request.getOffset(), request.getLimit());
   }
 
   /**
@@ -618,11 +618,10 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
    *
    * @return the search response containing the next page of results.
    */
-  private co.cask.cdap.spi.metadata.SearchResponse doScroll(co.cask.cdap.spi.metadata.SearchRequest request)
+  private co.cask.cdap.spi.metadata.SearchResponse doScroll(SearchRequest request)
     throws IOException {
 
     Cursor cursor = Cursor.fromString(request.getCursor());
-    cursor.validate(request.getOffset(), request.getLimit());
     SearchScrollRequest scrollRequest = new SearchScrollRequest(cursor.getScrollId());
     if (request.isCursorRequested()) {
       scrollRequest.scroll(scrollTimeout);
@@ -631,12 +630,13 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
       client.scroll(scrollRequest, RequestOptions.DEFAULT);
     if (searchResponse.isTimedOut()) {
       // scroll had expired, we have to search again
-      return doSearch(request, cursor.getOffset());
+      return doSearch(request, cursor.getOffset(), cursor.getPageSize());
     }
     SearchHits hits = searchResponse.getHits();
     List<MetadataRecord> results = fromHits(hits);
     String newCursor = computeCursor(searchResponse, cursor.getOffset(), cursor.getPageSize());
-    return new co.cask.cdap.spi.metadata.SearchResponse(request, newCursor, (int) hits.getTotalHits(), results);
+    return new co.cask.cdap.spi.metadata.SearchResponse(request, newCursor, cursor.getOffset(), cursor.getPageSize(),
+                                                        (int) hits.getTotalHits(), results);
   }
 
   /**
@@ -645,12 +645,15 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
    * @param request the search request
    * @param offset the offset for the first result to return. This could be either the offset
    *               from the request, or the offset from a cursor that had expired.
+   * @param limit the limit for the number of results to return. This could be either the limit
+   *              from the request, or the limit from a cursor that had expired.
    */
-  private co.cask.cdap.spi.metadata.SearchResponse doSearch(co.cask.cdap.spi.metadata.SearchRequest request, int offset)
+  private co.cask.cdap.spi.metadata.SearchResponse doSearch(SearchRequest request, int offset, int limit)
     throws IOException {
 
-    SearchRequest searchRequest = new SearchRequest(indexName);
-    searchRequest.source(createSearchSource(request, offset));
+    org.elasticsearch.action.search.SearchRequest searchRequest =
+      new org.elasticsearch.action.search.SearchRequest(indexName);
+    searchRequest.source(createSearchSource(request, offset, limit));
     if (request.isCursorRequested()) {
       searchRequest.scroll(scrollTimeout);
     }
@@ -660,7 +663,8 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
     SearchHits hits = searchResponse.getHits();
     List<MetadataRecord> results = fromHits(hits);
     String newCursor = computeCursor(searchResponse, request.getOffset(), request.getLimit());
-    return new co.cask.cdap.spi.metadata.SearchResponse(request, newCursor, (int) hits.getTotalHits(), results);
+    return new co.cask.cdap.spi.metadata.SearchResponse(request, newCursor, offset, request.getLimit(),
+                                                        (int) hits.getTotalHits(), results);
   }
 
   /**
@@ -696,7 +700,7 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
     client.clearScrollAsync(clearScrollRequest, RequestOptions.DEFAULT, ActionListener.wrap(x -> { }, x -> { }));
   }
 
-  private SearchSourceBuilder createSearchSource(co.cask.cdap.spi.metadata.SearchRequest request, int offset) {
+  private SearchSourceBuilder createSearchSource(SearchRequest request, int offset, int limit) {
     // clients cannot know what the index's max window size is, but any request where offset + limit
     // exceeds that size will fail in ES. Hence we need to adjust the requested number of results to
     // not exceed that window size.
@@ -704,7 +708,7 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
       throw new IllegalArgumentException(String.format("Offset %d is greater than the index's '%s' settings of %d",
                                                        offset, SETTING_MAX_RESULT_WINDOW, maxWindowSize));
     }
-    int limit = Integer.min(maxWindowSize - offset, request.getLimit());
+    limit = Integer.min(maxWindowSize - offset, limit);
 
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     searchSourceBuilder.from(offset);
@@ -743,7 +747,7 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
    *
    * See {@link MetadataDocument} for details about the index mapping.
    */
-  private QueryBuilder createQuery(co.cask.cdap.spi.metadata.SearchRequest request) {
+  private QueryBuilder createQuery(SearchRequest request) {
     // first create a query from the query terms
     QueryBuilder mainQuery = createMainQuery(request);
 
@@ -790,7 +794,7 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
   /**
    * Creates the (sub-)query for Elasticsearch from the terms in the query string.
    */
-  private QueryBuilder createMainQuery(co.cask.cdap.spi.metadata.SearchRequest request) {
+  private QueryBuilder createMainQuery(SearchRequest request) {
     if (request.getQuery().equals("*")) {
       return QueryBuilders.matchAllQuery();
     }
@@ -822,7 +826,7 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
    * @param term the term as it appears in the query, possibly with a field qualifier
    * @param textField the default text field to search if the term does not have a field
    */
-  private QueryBuilder createTermQuery(String term, String textField, co.cask.cdap.spi.metadata.SearchRequest request) {
+  private QueryBuilder createTermQuery(String term, String textField, SearchRequest request) {
     // determine if the term has a field qualifier
     String field = null;
     term = term.trim().toLowerCase();

--- a/cdap-metadata-spi/src/main/java/co.cask.cdap.spi.metadata/SearchResponse.java
+++ b/cdap-metadata-spi/src/main/java/co.cask.cdap.spi.metadata/SearchResponse.java
@@ -27,21 +27,27 @@ public class SearchResponse {
 
   private final SearchRequest request;
   private final String cursor;
+  private final int offset;
+  private final int limit;
   private final int totalResults;
   private final List<MetadataRecord> results;
 
   /**
    * @param request the original request
-   * @param cursor the cursor for the next search, if requested
+   * @param cursor the cursor for the next search, if requested and there are more results
+   * @param offset the offset at which the search results start
+   * @param limit the limit that was applied to this search (the number of results can be less)
    * @param totalResults the total number of results, or an estimate thereof
    * @param results the search results
    */
   public SearchResponse(SearchRequest request,
                         @Nullable String cursor,
-                        int totalResults,
+                        int offset, int limit, int totalResults,
                         List<MetadataRecord> results) {
     this.request = request;
     this.cursor = cursor;
+    this.offset = offset;
+    this.limit = limit;
     this.totalResults = totalResults;
     this.results = results;
   }
@@ -54,18 +60,31 @@ public class SearchResponse {
   }
 
   /**
-   * @return the cursor for the next page of results, if requested
+   * @return the cursor for the next page of results, if requested, or null if there are no more results
    */
-  // TODO (CDAP-14799) clearly explain the semantics of cursors, offsets, and total count
+  @Nullable
   public String getCursor() {
     return cursor;
   }
 
   /**
-   * @return the estimated total number of results
+   * @return the offset at which the results begin
    */
-  // TODO (CDAP-14799) clearly explain the semantics of cursors, offsets, and total count
-  @Nullable
+  public int getOffset() {
+    return offset;
+  }
+
+  /**
+   * @return the limit that was applied to the search (may be greater than the number of results)
+   */
+  public int getLimit() {
+    return limit;
+  }
+
+  /**
+   * @return the estimated total number of results. If this is greater than {@link #getOffset()} plus
+   * the size of {@link #getResults()}, then there are more results.
+   */
   public int getTotalResults() {
     return totalResults;
   }
@@ -82,6 +101,8 @@ public class SearchResponse {
     return "SearchResponse{" +
       "request=" + request +
       ", cursor='" + cursor + '\'' +
+      ", offset=" + offset +
+      ", limit=" + limit +
       ", totalResults=" + totalResults +
       ", results=" + results +
       '}';
@@ -95,15 +116,17 @@ public class SearchResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SearchResponse that = (SearchResponse) o;
-    return totalResults == that.totalResults &&
-      Objects.equals(request, that.request) &&
-      Objects.equals(cursor, that.cursor) &&
-      Objects.equals(results, that.results);
+    SearchResponse response = (SearchResponse) o;
+    return offset == response.offset &&
+      limit == response.limit &&
+      totalResults == response.totalResults &&
+      Objects.equals(request, response.request) &&
+      Objects.equals(cursor, response.cursor) &&
+      Objects.equals(results, response.results);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(request, cursor, totalResults, results);
+    return Objects.hash(request, cursor, offset, limit, totalResults, results);
   }
 }

--- a/cdap-metadata-spi/src/test/java/co.cask.cdap.spi.metadata/MetadataStorageTest.java
+++ b/cdap-metadata-spi/src/test/java/co.cask.cdap.spi.metadata/MetadataStorageTest.java
@@ -42,10 +42,12 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.annotation.Nullable;
 
 import static co.cask.cdap.api.metadata.MetadataScope.SYSTEM;
 import static co.cask.cdap.api.metadata.MetadataScope.USER;
-
 import static co.cask.cdap.spi.metadata.MetadataConstants.CREATION_TIME_KEY;
 import static co.cask.cdap.spi.metadata.MetadataConstants.ENTITY_NAME_KEY;
 import static co.cask.cdap.spi.metadata.MetadataConstants.TTL_KEY;
@@ -1041,6 +1043,69 @@ public abstract class MetadataStorageTest {
                                .setCursorRequested(true).setCursor(response.getCursor()).build(),
                              sorted.subList(8, 10));
     Assert.assertNull(response.getCursor());
+  }
+
+  @Test
+  public void testCursorsOffsetsAndTotals() throws IOException {
+    MetadataStorage mds = getMetadataStorage();
+    List<MetadataRecord> records = IntStream.range(0, 20)
+      .mapToObj(i -> new MetadataRecord(ofDataset(DEFAULT_NAMESPACE, "ds" + i),
+                                        new Metadata(SYSTEM, props(ENTITY_NAME_KEY, "ds" + i))))
+      .collect(Collectors.toList());
+    mds.batch(records.stream()
+                .map(record -> new Update(record.getEntity(), record.getMetadata()))
+                .collect(Collectors.toList()));
+
+    // no cursors
+    validateCursorAndOffset(mds, 0, 10, null, false, 10, 0, 10, true, false);
+    validateCursorAndOffset(mds, 5, 10, null, false, 10, 5, 10, true, false);
+    validateCursorAndOffset(mds, 10, 10, null, false, 10, 10, 10, false, false);
+    validateCursorAndOffset(mds, 15, 10, null, false, 5, 15, 10, false, false);
+    validateCursorAndOffset(mds, 20, 10, null, false, 0, 20, 10, false, false);
+    validateCursorAndOffset(mds, 25, 10, null, false, 0, 25, 10, false, false);
+
+    // request cursors, but don't use them
+    validateCursorAndOffset(mds, 0, 10, null, true, 10, 0, 10, true, true);
+    validateCursorAndOffset(mds, 0, 20, null, true, 20, 0, 20, false, false);
+    validateCursorAndOffset(mds, 0, 30, null, true, 20, 0, 30, false, false);
+
+    // request cursor, and use it
+    String cursor = validateCursorAndOffset(mds, 0, 8, null, true, 8, 0, 8, true, true);
+    cursor = validateCursorAndOffset(mds, 0, 8, cursor, true, 8, 8, 8, true, true);
+    validateCursorAndOffset(mds, 0, 8, cursor, true, 4, 16, 8, false, false);
+
+    // request a cursor that matches evenly with the number of results
+    cursor = validateCursorAndOffset(mds, 0, 10, null, true, 10, 0, 10, true, true);
+    validateCursorAndOffset(mds, 0, 10, cursor, true, 10, 10, 10, false, false);
+
+    // ensure that offset and limit are superseded by cursor
+    cursor = validateCursorAndOffset(mds, 0, 4, null, true, 4, 0, 4, true, true);
+    cursor = validateCursorAndOffset(mds, 0, 0, cursor, true, 4, 4, 4, true, true);
+    cursor = validateCursorAndOffset(mds, 10, 100, cursor, true, 4, 8, 4, true, true);
+    cursor = validateCursorAndOffset(mds, 12, 2, cursor, true, 4, 12, 4, true, true);
+    validateCursorAndOffset(mds, 1, 1, cursor, true, 4, 16, 4, false, false);
+
+    // clean up
+    mds.batch(records.stream().map(MetadataRecord::getEntity).map(Drop::new).collect(Collectors.toList()));
+  }
+
+  @Nullable
+  private String validateCursorAndOffset(MetadataStorage mds,
+                                         int offset, int limit, String cursor, boolean requestCursor,
+                                         int expectedReults, int expectedOffset, int expectedLimit,
+                                         boolean expectMore, boolean expectCursor)
+    throws IOException {
+    SearchResponse response = mds.search(SearchRequest.of("*")
+                                           .setSorting(new Sorting(ENTITY_NAME_KEY, Sorting.Order.ASC))
+                                           .setOffset(offset).setLimit(limit)
+                                           .setCursor(cursor).setCursorRequested(requestCursor)
+                                           .build());
+    Assert.assertEquals(expectedReults, response.getResults().size());
+    Assert.assertEquals(expectedOffset, response.getOffset());
+    Assert.assertEquals(expectedLimit, response.getLimit());
+    Assert.assertEquals(expectMore, response.getTotalResults() > response.getOffset() + response.getResults().size());
+    Assert.assertEquals(expectCursor, null != response.getCursor());
+    return response.getCursor();
   }
 
   private static class NoDupRandom {


### PR DESCRIPTION
See https://issues.cask.co/browse/CDAP-14799 for design.

To make this consistent, a few changes were required in the dataset-based metadata storage:
- cursors must encode the offset and pagesize. The metadata dataset interprets the offset relative to the cursor, and that is not what we need (a search from a cursor always continues where the cursor stands)
- in case no cursor is requested, the dataset does not fetch ahead and we can't tell whether there are more results. Therefore, in that case, fetch an extra result.
- refactored the search() method to move complex determination of parameters into separate methods - and added unit tests for these methods. 
