### PR TITLE
[CDAP-14912] Make noSql metadata storage independent of dataset framework

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramContainerModule.java
@@ -34,6 +34,8 @@ import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditModule;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.metadata.writer.FieldLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.MessagingLineageWriter;
@@ -131,6 +133,8 @@ public class DistributedProgramContainerModule extends AbstractModule {
         bind(LineageWriter.class).to(MessagingLineageWriter.class);
         bind(FieldLineageWriter.class).to(MessagingLineageWriter.class);
         bind(UsageWriter.class).to(MessagingUsageWriter.class);
+        // Overrides the metadata store to be no-op (programs never access it directly)
+        bind(MetadataStore.class).to(NoOpMetadataStore.class);
       }
     }));
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2018 Cask Data, Inc.
+ * Copyright © 2015-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,8 @@ package co.cask.cdap.metadata;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.gateway.handlers.CommonHandlers;
+import co.cask.cdap.spi.metadata.MetadataStorage;
+import co.cask.cdap.spi.metadata.dataset.DatasetMetadataStorage;
 import co.cask.http.HttpHandler;
 import com.google.inject.Key;
 import com.google.inject.PrivateModule;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -43,6 +43,7 @@ import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.ProgramTerminator;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
@@ -138,7 +139,6 @@ public class AppFabricTestHelper {
       }
 
       injector.getInstance(TransactionManager.class).startAndWait();
-
       // Register the tables before services will need to use them
       StructuredTableAdmin tableAdmin = injector.getInstance(StructuredTableAdmin.class);
       StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
@@ -151,6 +151,11 @@ public class AppFabricTestHelper {
         StoreDefinition.createAllTables(tableAdmin, structuredTableRegistry);
       } catch (IOException | TableAlreadyExistsException e) {
         throw new RuntimeException("Failed to create the system tables", e);
+      }
+      try {
+        injector.getInstance(MetadataStore.class).createIndex();
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to create the metadata tables.", e);
       }
       injector.getInstance(DatasetOpExecutor.class).startAndWait();
       injector.getInstance(DatasetService.class).startAndWait();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -49,6 +49,7 @@ import co.cask.cdap.common.test.PluginJarHelper;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
 import co.cask.cdap.internal.app.runtime.schedule.store.Schedulers;
@@ -237,6 +238,8 @@ public abstract class AppFabricTestBase {
     // Define all StructuredTable before starting any services that need StructuredTable
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
                                     structuredTableRegistry);
+    injector.getInstance(MetadataStore.class).createIndex();
+
     dsOpService = injector.getInstance(DatasetOpExecutor.class);
     dsOpService.startAndWait();
     datasetService = injector.getInstance(DatasetService.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -54,8 +54,7 @@ public class InMemoryTableService {
 
   public static synchronized void create(String tableName) {
     if (!tables.containsKey(tableName)) {
-      tables.put(tableName, new ConcurrentSkipListMap<byte[],
-        NavigableMap<byte[], NavigableMap<Long, Update>>>(Bytes.BYTES_COMPARATOR));
+      tables.put(tableName, new ConcurrentSkipListMap<>(Bytes.BYTES_COMPARATOR));
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 Cask Data, Inc.
+ * Copyright 2015-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,7 +42,7 @@ public class MetadataDatasetDefinition
 
   private final DatasetDefinition<? extends IndexedTable, ?> indexedTableDef;
 
-  MetadataDatasetDefinition(String name, DatasetDefinition<? extends IndexedTable, ?> indexedTableDef) {
+  public MetadataDatasetDefinition(String name, DatasetDefinition<? extends IndexedTable, ?> indexedTableDef) {
     super(name);
     this.indexedTableDef = indexedTableDef;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.SearchRequest;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
@@ -37,6 +38,16 @@ import java.util.Set;
  * </ul>
  */
 public interface MetadataStore {
+
+  /**
+   * Create all tables or indexes required for operations.
+   */
+  void createIndex() throws IOException;
+
+  /**
+   * Drop all tables or indexes required for operations.
+   */
+  void dropIndex() throws IOException;
 
   /**
    * Replaces the metadata for the given entity: All existing properties and tags are

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -33,6 +33,16 @@ import java.util.Set;
 public class NoOpMetadataStore implements MetadataStore {
 
   @Override
+  public void createIndex() {
+    // no-op
+  }
+
+  @Override
+  public void dropIndex() {
+    // no-op
+  }
+
+  @Override
   public void replaceMetadata(MetadataScope scope, MetadataDataset.Record metadata,
                               Set<String> propertiesToKeep, Set<String> propertiesToPreserve) {
     // NO-OP

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/StorageProviderMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/StorageProviderMetadataStore.java
@@ -85,6 +85,16 @@ public class StorageProviderMetadataStore implements MetadataStore {
   }
 
   @Override
+  public void createIndex() throws IOException {
+    storage.createIndex();
+  }
+
+  @Override
+  public void dropIndex() throws IOException {
+    storage.dropIndex();
+  }
+
+  @Override
   public void replaceMetadata(MetadataScope scope,
                               MetadataDataset.Record metadata,
                               Set<String> propertiesToKeep,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/noop/NoopMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/metadata/noop/NoopMetadataStorage.java
@@ -24,6 +24,7 @@ import co.cask.cdap.spi.metadata.Read;
 import co.cask.cdap.spi.metadata.SearchRequest;
 import co.cask.cdap.spi.metadata.SearchResponse;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,6 +33,16 @@ import java.util.stream.Collectors;
  * Metadata storage provider that does nothing.
  */
 public class NoopMetadataStorage implements MetadataStorage {
+
+  @Override
+  public void createIndex() throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void dropIndex() throws IOException {
+    // no-op
+  }
 
   @Override
   public MetadataChange apply(MetadataMutation mutation) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2018 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,7 +23,6 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.InMemoryDiscoveryModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
-import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
@@ -59,7 +58,6 @@ public class LevelDBTableServiceTest {
       new ConfigModule(conf),
       new NonCustomLocationUnitTestModule(),
       new InMemoryDiscoveryModule(),
-      new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),
       new TransactionMetricsModule(),
       new AuthorizationTestModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2018 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,7 +25,6 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.InMemoryDiscoveryModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
-import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTableTest;
 import co.cask.cdap.data2.dataset2.lib.table.inmemory.PrefixedNamespaces;
@@ -65,7 +64,6 @@ public class LevelDBTableTest extends BufferingTableTest<LevelDBTable> {
       new ConfigModule(cConf),
       new NonCustomLocationUnitTestModule(),
       new InMemoryDiscoveryModule(),
-      new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),
       new TransactionMetricsModule(),
       new AuthorizationTestModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/AbstractMetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/AbstractMetadataStoreTest.java
@@ -47,6 +47,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -71,11 +72,16 @@ public abstract class AbstractMetadataStoreTest {
    * Subclasses must call this after creating the injector and the store.
    * The injector must bind the MetadataStore and InMemoryAuditPublisher.
    */
-  static void commonSetup() {
+  static void commonSetup() throws IOException {
     // injector and store must be set up by subclasses.
     cConf = injector.getInstance(CConfiguration.class);
     store = injector.getInstance(MetadataStore.class);
     auditPublisher = injector.getInstance(InMemoryAuditPublisher.class);
+    store.createIndex();
+  }
+
+  static void commonTearDown() throws IOException {
+    store.dropIndex();
   }
 
   @Before

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStoreTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.audit.AuditTestModule;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
+import co.cask.cdap.spi.metadata.dataset.DatasetMetadataStorage;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.util.Modules;
@@ -34,15 +35,18 @@ import org.apache.tephra.runtime.TransactionInMemoryModule;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.IOException;
+
 /**
  * Tests for {@link DefaultMetadataStore} (which calls MetadataDataset directly).
  */
 public class DefaultMetadataStoreTest extends AbstractMetadataStoreTest {
 
   private static TransactionManager txManager;
+  private static DatasetMetadataStorage storage;
 
   @BeforeClass
-  public static void setupDefaultStore() {
+  public static void setupDefaultStore() throws IOException {
     injector = Guice.createInjector(
       new ConfigModule(),
       Modules.override(
@@ -70,8 +74,12 @@ public class DefaultMetadataStoreTest extends AbstractMetadataStoreTest {
   }
 
   @AfterClass
-  public static void teardown() {
-    txManager.stopAndWait();
+  public static void teardown() throws IOException {
+    try {
+      AbstractMetadataStoreTest.commonTearDown();
+    } finally {
+      txManager.stopAndWait();
+    }
   }
 }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/StorageProviderMetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/StorageProviderMetadataStoreTest.java
@@ -37,6 +37,8 @@ import org.apache.tephra.runtime.TransactionInMemoryModule;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.IOException;
+
 /**
  * Tests for the {@link MetadataStore} that delegates to the metadata storage provider.
  */
@@ -45,7 +47,7 @@ public class StorageProviderMetadataStoreTest extends AbstractMetadataStoreTest 
   private static TransactionManager txManager;
 
   @BeforeClass
-  public static void setupDefaultStore() {
+  public static void setupDefaultStore() throws IOException {
     injector = Guice.createInjector(
       new ConfigModule(),
       Modules.override(
@@ -74,8 +76,12 @@ public class StorageProviderMetadataStoreTest extends AbstractMetadataStoreTest 
   }
 
   @AfterClass
-  public static void teardown() {
-    txManager.stopAndWait();
+  public static void teardown() throws IOException {
+    try {
+      AbstractMetadataStoreTest.commonTearDown();
+    } finally {
+      txManager.stopAndWait();
+    }
   }
 }
 

--- a/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
+++ b/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
@@ -207,8 +207,8 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
     }
   }
 
-  @VisibleForTesting
-  void ensureIndexCreated() throws IOException {
+  @Override
+  public void createIndex() throws IOException {
     if (created) {
       return;
     }
@@ -289,8 +289,8 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
       "}").replace('\'', '"');
   }
 
-  @VisibleForTesting
-  void deleteIndex() throws IOException {
+  @Override
+  public void dropIndex() throws IOException {
     synchronized (this) {
       GetIndexRequest request = new GetIndexRequest();
       request.indices(indexName);
@@ -309,7 +309,6 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
 
   @Override
   public MetadataChange apply(MetadataMutation mutation) throws IOException {
-    ensureIndexCreated();
     MetadataEntity entity = mutation.getEntity();
     Metadata before = readFromIndex(entity);
     Tuple<? extends DocWriteRequest, MetadataChange> intermediary = applyMutation(before, mutation);
@@ -319,7 +318,6 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
 
   @Override
   public List<MetadataChange> batch(List<? extends MetadataMutation> mutations) throws IOException {
-    ensureIndexCreated();
     MultiGetRequest multiGet = new MultiGetRequest();
     for (MetadataMutation mutation : mutations) {
       multiGet.add(indexName, DOC_TYPE, toDocumentId(mutation.getEntity()));
@@ -348,7 +346,6 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
 
   @Override
   public Metadata read(Read read) throws IOException {
-    ensureIndexCreated();
     Metadata metadata = readFromIndex(read.getEntity());
     return filterMetadata(metadata, KEEP, read.getKinds(), read.getScopes(), read.getSelection());
   }
@@ -356,7 +353,6 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
   @Override
   public co.cask.cdap.spi.metadata.SearchResponse search(SearchRequest request)
     throws IOException {
-    ensureIndexCreated();
     return request.getCursor() != null && !request.getCursor().isEmpty()
       ? doScroll(request) : doSearch(request, request.getOffset(), request.getLimit());
   }

--- a/cdap-elastic/src/test/java/co/cask/cdap/metadata/elastic/ElasticConfigurationTest.java
+++ b/cdap-elastic/src/test/java/co/cask/cdap/metadata/elastic/ElasticConfigurationTest.java
@@ -70,7 +70,7 @@ public class ElasticConfigurationTest {
                                @Nullable Integer shards, @Nullable Integer replicas, @Nullable Integer windowSize)
     throws IOException {
     try (ElasticsearchMetadataStorage store = new ElasticsearchMetadataStorage(cConf)) {
-      store.ensureIndexCreated();
+      store.createIndex();
       try {
         try (RestHighLevelClient client = new RestHighLevelClient(
           RestClient.builder(new HttpHost("localhost", Integer.parseInt(elasticPort))))) {
@@ -85,7 +85,7 @@ public class ElasticConfigurationTest {
           Assert.assertEquals(String.valueOf(shards), response.getSetting(indexName, "index.number_of_shards"));
         }
       } finally {
-        store.deleteIndex();
+        store.dropIndex();
       }
     }
   }

--- a/cdap-elastic/src/test/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorageTest.java
+++ b/cdap-elastic/src/test/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorageTest.java
@@ -50,7 +50,7 @@ public class ElasticsearchMetadataStorageTest extends MetadataStorageTest {
   }
 
   @BeforeClass
-  public static void createIndex() {
+  public static void createIndex() throws IOException {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(ElasticsearchMetadataStorage.CONF_ELASTIC_INDEX_NAME,
               "idx" + new Random(System.currentTimeMillis()).nextInt());
@@ -65,13 +65,14 @@ public class ElasticsearchMetadataStorageTest extends MetadataStorageTest {
       cConf.set(ElasticsearchMetadataStorage.CONF_ELASTIC_HOSTS, "localhost:" + elasticPort);
     }
     elasticStore = new ElasticsearchMetadataStorage(cConf);
+    elasticStore.createIndex();
   }
 
   @AfterClass
   public static void dropIndex() throws IOException {
     if (elasticStore != null) {
       try {
-        elasticStore.deleteIndex();
+        elasticStore.dropIndex();
       } finally {
         elasticStore.close();
       }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
@@ -36,6 +36,8 @@ import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.hive.datasets.DatasetSerDe;
 import co.cask.cdap.messaging.guice.MessagingClientModule;
@@ -55,6 +57,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
+import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.zookeeper.ZKClientService;
 
@@ -128,7 +131,12 @@ public class ContextManager {
       new NamespaceQueryAdminModule(),
       new ZKDiscoveryModule(),
       new DataFabricModules("cdap.explore.ContextManager").getDistributedModules(),
-      new DataSetsModules().getDistributedModules(),
+      Modules.override(new DataSetsModules().getDistributedModules()).with(new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetadataStore.class).to(NoOpMetadataStore.class);
+        }
+      }),
       new ExploreClientModule(),
       new KafkaClientModule(),
       new AuditModule(),

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2018 Cask Data, Inc.
+ * Copyright © 2015-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -93,7 +93,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   @BeforeClass
   public static void start() throws Exception {
-    initialize(CConfiguration.create(), tmpFolder, false, false);
+    initialize(CConfiguration.create(), tmpFolder, false);
   }
 
   @After

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/context/ContextManagerTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/context/ContextManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class ContextManagerTest {
 
   @Test
-  public void testInjector() throws Exception {
+  public void testInjector() {
     ContextManager.createInjector(CConfiguration.create(), new Configuration());
   }
 }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.gateway.handlers.log.MockLogReader;
 import co.cask.cdap.gateway.router.NettyRouter;
 import co.cask.cdap.internal.app.services.AppFabricServer;
@@ -179,6 +180,8 @@ public abstract class GatewayTestBase {
     // Define all StructuredTable before starting any services that need StructuredTable
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
                                     injector.getInstance(StructuredTableRegistry.class));
+    injector.getInstance(MetadataStore.class).createIndex();
+
     dsOpService = injector.getInstance(DatasetOpExecutor.class);
     dsOpService.startAndWait();
     datasetService = injector.getInstance(DatasetService.class);

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -48,6 +48,7 @@ import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.writer.MessagingMetadataPublisher;
 import co.cask.cdap.data2.metadata.writer.MetadataPublisher;
 import co.cask.cdap.data2.util.hbase.ConfigurationReader;
@@ -636,6 +637,11 @@ public class MasterServiceMain extends DaemonMain {
                                         injector.getInstance(StructuredTableRegistry.class));
       } catch (IOException | TableAlreadyExistsException e) {
         throw new RuntimeException("Unable to create the system tables.", e);
+      }
+      try {
+        injector.getInstance(MetadataStore.class).createIndex();
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to create the metadata tables.", e);
       }
 
       authorizerInstantiator = injector.getInstance(AuthorizerInstantiator.class);

--- a/cdap-metadata-spi/src/main/java/co.cask.cdap.spi.metadata/MetadataStorage.java
+++ b/cdap-metadata-spi/src/main/java/co.cask.cdap.spi.metadata/MetadataStorage.java
@@ -28,6 +28,16 @@ import java.util.List;
 public interface MetadataStorage extends AutoCloseable {
 
   /**
+   * Create all tables or indexes required for operations.
+   */
+  void createIndex() throws IOException;
+
+  /**
+   * Drop all tables or indexes required for operations.
+   */
+  void dropIndex() throws IOException;
+
+  /**
    * Apply the given mutation to the metadata state.
    *
    * @param mutation the mutation to perform

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -44,6 +44,7 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
@@ -229,6 +230,7 @@ public class StandaloneMain {
     // Define all StructuredTable before starting any services that need StructuredTable
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
                                     injector.getInstance(StructuredTableRegistry.class));
+    injector.getInstance(MetadataStore.class).createIndex();
 
     metricsCollectionService.startAndWait();
     datasetService.startAndWait();

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -53,6 +53,7 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
@@ -280,6 +281,7 @@ public class TestBase {
     // Define all StructuredTable before starting any services that need StructuredTable
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
                                     injector.getInstance(StructuredTableRegistry.class));
+    injector.getInstance(MetadataStore.class).createIndex();
 
     dsOpService = injector.getInstance(DatasetOpExecutor.class);
     dsOpService.startAndWait();


### PR DESCRIPTION
This removes a cyclic dependency that would (due to the way guice injection is done) prevent proper injection. With a dependency on dataset framework, which itself depends on metadata. This should fix that. 