### PR TITLE
CDAP-14882 Adding concurrent writer to handle concurrent writes to lo…

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/ConcurrentLogBufferWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/ConcurrentLogBufferWriter.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.logbuffer;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.base.Throwables;
+import com.google.common.collect.AbstractIterator;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Class to support writing to log buffer and log processing pipeline(s) with high concurrency.
+ *
+ * It uses a non-blocking algorithm to batch writes from concurrent threads. The algorithm is the same as
+ * the one used in ConcurrentMessageWriter.
+ *
+ * The algorithm is like this:
+ *
+ * When a thread that received a request, performs the following:
+ *
+ * <pre>
+ * 1. Constructs a PendingLogBufferRequest locally and enqueue it to a ConcurrentLinkedQueue.
+ * 2. Use CAS to set an AtomicBoolean flag to true.
+ * 3. If successfully set the flag to true, this thread becomes the writer and proceed to run step 4-7.
+ * 4. Provides an Iterator of PendingLogBufferRequest to log buffer writer, which consumes from the
+ * ConcurrentLinkedQueue.
+ * 5. Log buffer writer returns list of log events with file offset. These events are sent to log processor pipeline
+ * for further processing.
+ * 6. Set the state of each PendingLogBufferRequest that are written to COMPLETED (succeed/failure).
+ * 7. Set the AtomicBoolean flag back to false.
+ * 8. If the PendingLogBufferRequest enqueued by this thread is NOT COMPLETED, go back to step 2.
+ * </pre>
+ *
+ * TODO: CDAP-14882 Send log events to log pipeline for further processing.
+ * TODO: CDAP-14882 Restore unprocessed log events from LogBuffer(WAL).
+ */
+@ThreadSafe
+public class ConcurrentLogBufferWriter implements Closeable {
+  // concurrent queue to write pending log buffer requests
+  private final PendingRequestQueue pendingRequestQueue;
+  // WAL writer to buffer log events
+  private final LogBufferWriter logBufferWriter;
+  private final AtomicBoolean writerFlag;
+  private final AtomicBoolean closed;
+
+  public ConcurrentLogBufferWriter(CConfiguration cConf) throws IOException {
+    this.pendingRequestQueue = new PendingRequestQueue();
+    this.logBufferWriter = new LogBufferWriter(cConf.get(Constants.LogBuffer.LOG_BUFFER_BASE_DIR),
+                                               cConf.getLong(Constants.LogBuffer.LOG_BUFFER_MAX_FILE_SIZE_BYTES));
+    this.writerFlag = new AtomicBoolean();
+    this.closed = new AtomicBoolean();
+  }
+
+  public void process(LogBufferRequest request) throws IOException {
+    if (closed.get()) {
+      throw new IOException("Concurrent log writer is already closed.");
+    }
+
+    PendingLogBufferRequest pendingLogBufferRequest = new PendingLogBufferRequest(request);
+    pendingRequestQueue.enqueue(pendingLogBufferRequest);
+
+    while (!pendingLogBufferRequest.isCompleted()) {
+      if (!tryWrite()) {
+        Thread.yield();
+      }
+    }
+
+    if (!pendingLogBufferRequest.isSuccess()) {
+      Throwables.propagateIfInstanceOf(pendingLogBufferRequest.getFailureCause(), IOException.class);
+      throw new IOException("Unable to write log event to log buffer", pendingLogBufferRequest.getFailureCause());
+    }
+  }
+
+  /**
+   * Tries to acquire the writer flag and processes the pending requests.
+   *
+   * @return {@code true} if acquired the writer flag and called {@link PendingRequestQueue#process(LogBufferRequest)};
+   *         otherwise {@code false} will be returned.
+   */
+  private boolean tryWrite() {
+    if (!writerFlag.compareAndSet(false, true)) {
+      return false;
+    }
+    try {
+      pendingRequestQueue.process(logBufferWriter);
+    } finally {
+      writerFlag.set(false);
+    }
+    return true;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    // Flush everything in the queue.
+    // When this thread can grab the writer flag, all pending write requests must be completed since the closed
+    // flag was already set to false.
+    while (!tryWrite()) {
+      Thread.yield();
+    }
+    logBufferWriter.close();
+  }
+
+  /**
+   * An in memory queue to hold concurrent log requests. Except the {@link #enqueue(PendingLogBufferRequest)} method,
+   * all methods on this class can only be called while holding the writer flag.
+   */
+  private static final class PendingRequestQueue {
+
+    private final Queue<PendingLogBufferRequest> writeQueue;
+    private final List<PendingLogBufferRequest> inflightRequests;
+
+    private PendingRequestQueue() {
+      this.writeQueue = new ConcurrentLinkedQueue<>();
+      this.inflightRequests = new ArrayList<>(100);
+    }
+
+    void enqueue(PendingLogBufferRequest bufferRequest) {
+      writeQueue.add(bufferRequest);
+    }
+
+    void process(LogBufferWriter writer) {
+      // Capture all current events.
+      // The reason for capturing instead of using a live iterator is to avoid the possible case of infinite write
+      // time. The number of requests in the queue is bounded by the number of threads that call this method.
+      // Since this method is expected to be called from a http handler thread, that is bounded by
+      // the thread pool size used by the http service.
+      inflightRequests.clear();
+      PendingLogBufferRequest request = writeQueue.poll();
+      while (request != null) {
+        inflightRequests.add(request);
+        request = writeQueue.poll();
+      }
+
+      try {
+        if (!inflightRequests.isEmpty()) {
+          // persist logs in append only WAL
+          Iterable<LogBufferEvent> events = writer.write(new PendingEventIterator(inflightRequests.iterator()));
+          // TODO: CDAP-14882 send the LogBufferEvent(s) to each log pipeline for processing
+        }
+        // after log events have been sent to log buffer pipeline for processing, set the pending requests to complete
+        completeAll(null);
+      } catch (Throwable t) {
+        completeAll(t);
+      }
+    }
+
+    /**
+     * Marks all inflight requests as collected through the {@link Iterator#next()} method as completed.
+     * This method must be called while holding the writer flag.
+     */
+    void completeAll(@Nullable Throwable failureCause) {
+      Iterator<PendingLogBufferRequest> iterator = inflightRequests.iterator();
+      while (iterator.hasNext()) {
+        iterator.next().completed(failureCause);
+        iterator.remove();
+      }
+    }
+
+    /**
+     * Pending log events iterator.
+     */
+    static final class PendingEventIterator extends AbstractIterator<byte[]> {
+      Iterator<PendingLogBufferRequest> requestIterator;
+      Iterator<byte[]> currentRequestIterator;
+
+      PendingEventIterator(Iterator<PendingLogBufferRequest> requestIterator) {
+        this.requestIterator = requestIterator;
+        this.currentRequestIterator = requestIterator.next().getIterator();
+      }
+
+      @Override
+      protected byte[] computeNext() {
+        if (currentRequestIterator.hasNext()) {
+          return currentRequestIterator.next();
+        }
+
+        while (!currentRequestIterator.hasNext()) {
+          if (!requestIterator.hasNext()) {
+            return endOfData();
+          }
+          currentRequestIterator = requestIterator.next().getIterator();
+        }
+
+        return currentRequestIterator.next();
+      }
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferRequest.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.logbuffer;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Represents log events to be persisted.
+ */
+public class LogBufferRequest implements Iterable<byte[]> {
+  private final List<byte[]> logEvents;
+  private final int logPartition;
+
+  public LogBufferRequest(int logPartition, List<byte[]> logEvents) {
+    this.logPartition = logPartition;
+    this.logEvents = logEvents;
+  }
+
+  @Override
+  public Iterator<byte[]> iterator() {
+    return logEvents.iterator();
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/PendingLogBufferRequest.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/PendingLogBufferRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.logbuffer;
+
+import java.util.Iterator;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a pending {@link LogBufferRequest} that is yet to be processed by log processor pipelines.
+ */
+public class PendingLogBufferRequest {
+  private final LogBufferRequest originalRequest;
+  private boolean completed;
+  private Throwable failureCause;
+
+  PendingLogBufferRequest(LogBufferRequest originalRequest) {
+    this.originalRequest = originalRequest;
+  }
+
+  boolean isCompleted() {
+    return completed;
+  }
+
+  boolean isSuccess() {
+    if (!isCompleted()) {
+      throw new IllegalStateException("Write is not yet completed");
+    }
+    return failureCause == null;
+  }
+
+  @Nullable
+  Throwable getFailureCause() {
+    return failureCause;
+  }
+
+  void completed(@Nullable Throwable failureCause) {
+    completed = true;
+    this.failureCause = failureCause;
+  }
+
+  public Iterator<byte[]> getIterator() {
+    return originalRequest.iterator();
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/ConcurrentLogBufferWriterTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/ConcurrentLogBufferWriterTest.java
@@ -19,7 +19,8 @@ package co.cask.cdap.logging.logbuffer;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
-import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.logging.appender.LogMessage;
 import co.cask.cdap.logging.context.WorkerLoggingContext;
@@ -29,43 +30,40 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.DataInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Iterator;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Tests for {@link LogBufferWriter}.
+ * Tests for {@link ConcurrentLogBufferWriter}.
  */
-public class LogBufferWriterTest {
-  private final LoggingEventSerializer serializer = new LoggingEventSerializer();
+public class ConcurrentLogBufferWriterTest {
+  private static final Logger LOG = LoggerFactory.getLogger(ConcurrentLogBufferWriterTest.class);
+  private static final LoggingEventSerializer serializer = new LoggingEventSerializer();
 
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
   @Test
-  public void testLogBufferWriter() throws Exception {
+  public void testWrites() throws IOException {
+    CConfiguration cConf = CConfiguration.create();
     String absolutePath = TMP_FOLDER.newFolder().getAbsolutePath();
+    cConf.set(Constants.LogBuffer.LOG_BUFFER_BASE_DIR, absolutePath);
+    cConf.setLong(Constants.LogBuffer.LOG_BUFFER_MAX_FILE_SIZE_BYTES, 100000);
 
-    LogBufferWriter writer = new LogBufferWriter(absolutePath, 100000);
+    ConcurrentLogBufferWriter writer = new ConcurrentLogBufferWriter(cConf);
     ImmutableList<byte[]> events = getLoggingEvents();
-    Iterator<LogBufferEvent> writtenEvents = writer.write(events.iterator()).iterator();
-    writer.close();
+    writer.process(new LogBufferRequest(0, events));
 
-    int i = 0;
-    int startPos = 0;
-    // verify if correct offsets were set without file rotation
-    while (writtenEvents.hasNext()) {
-      LogBufferEvent bufferEvent = writtenEvents.next();
-      Assert.assertEquals(bufferEvent.getLogEvent().getMessage(), "" + i++);
-      // There will not be any rotation.
-      Assert.assertEquals(bufferEvent.getOffset().getFilePos(), startPos);
-      startPos = startPos + Bytes.SIZEOF_INT + serializer.toBytes(bufferEvent.getLogEvent()).length;
-    }
-
-    // verify if the events were serialized and written correctly
+    // verify if the events were written to log buffer
     try (DataInputStream dis = new DataInputStream(new FileInputStream(absolutePath + "/0.buf"))) {
       for (byte[] eventBytes : events) {
         ILoggingEvent event = serializer.fromBytes(ByteBuffer.wrap(eventBytes));
@@ -75,33 +73,43 @@ public class LogBufferWriterTest {
   }
 
   @Test
-  public void testFileRotation() throws Exception {
-    // Make sure rotation happens after every event is written
-    LogBufferWriter writer = new LogBufferWriter(TMP_FOLDER.newFolder().getAbsolutePath(), 10);
+  public void testConcurrentWrites() throws Exception {
+    int threadCount = 20;
+
+    CConfiguration cConf = CConfiguration.create();
+    String absolutePath = TMP_FOLDER.newFolder().getAbsolutePath();
+    cConf.set(Constants.LogBuffer.LOG_BUFFER_BASE_DIR, absolutePath);
+    cConf.setLong(Constants.LogBuffer.LOG_BUFFER_MAX_FILE_SIZE_BYTES, 100000);
+
+    ConcurrentLogBufferWriter writer = new ConcurrentLogBufferWriter(cConf);
     ImmutableList<byte[]> events = getLoggingEvents();
-    Iterator<LogBufferEvent> writtenEvents = writer.write(events.iterator()).iterator();
-    writer.close();
 
-    int i = 0;
-    // verify if correct offsets and file id were set with file rotation
-    while (writtenEvents.hasNext()) {
-      LogBufferEvent bufferEvent = writtenEvents.next();
-      Assert.assertEquals(bufferEvent.getLogEvent().getMessage(), "" + i++);
-      // There will be one rotation per event.
-      Assert.assertEquals(bufferEvent.getOffset().getFileId(), i + ".buf");
-      Assert.assertEquals(bufferEvent.getOffset().getFilePos(), 0);
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    final CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          barrier.await();
+          writer.process(new LogBufferRequest(0, events));
+        } catch (Exception e) {
+          LOG.error("Exception raised when processing log events.", e);
+        }
+      });
     }
-  }
 
-  @Test (expected = IOException.class)
-  public void testWritesOnClosedWriter() throws IOException {
-    LogBufferWriter writer = new LogBufferWriter(TMP_FOLDER.newFolder().getAbsolutePath(), 100000);
-    writer.close();
-    // should throw IOException
-    writer.write(ImmutableList.of(
-      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "0", 1,
-                                            new WorkerLoggingContext("default", "app1", "worker1", "run1",
-                                                                     "instance1")))).iterator());
+    barrier.await();
+    executor.shutdown();
+    Assert.assertTrue(executor.awaitTermination(1, TimeUnit.MINUTES));
+
+    // verify if the events were written to log buffer
+    try (DataInputStream dis = new DataInputStream(new FileInputStream(absolutePath + "/0.buf"))) {
+      for (int i = 0; i < threadCount; i++) {
+        for (byte[] eventBytes : events) {
+          ILoggingEvent event = serializer.fromBytes(ByteBuffer.wrap(eventBytes));
+          Assert.assertEquals(event.getMessage(), getEvent(dis, serializer.toBytes(event).length).getMessage());
+        }
+      }
+    }
   }
 
   private ImmutableList<byte[]> getLoggingEvents() {


### PR DESCRIPTION
…g buffer

Adding concurrent Writer that handles concurrent log event writes. It uses `LogBufferWriter` to write log buffer events.

Build: https://builds.cask.co/browse/CDAP-DUT6828-2