### PR TITLE
CDAP-14929 Define all tables before starting services in Cloud Runtime.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -47,6 +47,10 @@ import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
 import co.cask.cdap.messaging.server.MessagingHttpService;
 import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.spi.data.StructuredTableAdmin;
+import co.cask.cdap.spi.data.TableAlreadyExistsException;
+import co.cask.cdap.spi.data.table.StructuredTableRegistry;
+import co.cask.cdap.store.StoreDefinition;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.io.Closeables;
@@ -507,6 +511,13 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
         addOnPremiseServices(injector, programOptions, metricsCollectionService, services);
         break;
       case ISOLATED:
+        try {
+          // Define the relevant StructuredTable before starting any services that need StructuredTable
+          StoreDefinition.createDatasetServiceTables(injector.getInstance(StructuredTableAdmin.class),
+                                                     injector.getInstance(StructuredTableRegistry.class), false);
+        } catch (IOException | TableAlreadyExistsException e) {
+          throw new RuntimeException("Unable to create the system tables.", e);
+        }
         addIsolatedServices(injector, services);
         break;
       default:

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
@@ -90,6 +90,22 @@ public final class StoreDefinition {
   }
 
   /**
+   * Create system tables used by Dataset Service.
+   *
+   * @param tableAdmin the table admin to create the table
+   */
+  public static void createDatasetServiceTables(StructuredTableAdmin tableAdmin, StructuredTableRegistry registry,
+                                                boolean overWrite) throws IOException, TableAlreadyExistsException {
+    registry.initialize();
+    if (overWrite || tableAdmin.getSpecification(DatasetInstanceStore.DATASET_INSTANCES) == null) {
+      DatasetInstanceStore.createTables(tableAdmin);
+    }
+    if (overWrite || tableAdmin.getSpecification(DatasetTypeStore.DATASET_TYPES) == null) {
+      DatasetTypeStore.createTables(tableAdmin);
+    }
+  }
+
+  /**
    * Namespace store schema
    */
   public static final class NamespaceStore {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-14929

Cloud integration tests: https://builds.cask.co/browse/IT-CLD-208
Unit tests: https://builds.cask.co/browse/CDAP-DUT6836-4