### PR TITLE
CDAP-14931 return the actual status of the app fabric services

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AppFabricServiceManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AppFabricServiceManager.java
@@ -21,6 +21,7 @@ import ch.qos.logback.classic.LoggerContext;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.MasterServiceManager;
 import co.cask.cdap.common.zookeeper.election.LeaderElectionInfoService;
+import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.proto.Containers;
 import co.cask.cdap.proto.SystemServiceLiveInfo;
 import com.google.inject.Inject;
@@ -49,14 +50,18 @@ public class AppFabricServiceManager implements MasterServiceManager {
   private static final long ELECTION_PARTICIPANTS_TIMEOUT_MS = 2000L;
 
   private final InetAddress hostname;
-  private LeaderElectionInfoService electionInfoService;
   private final Map<String, LogEntry.Level> oldLogLevels;
+  private final AppFabricServer appFabricServer;
+
+  private LeaderElectionInfoService electionInfoService;
 
   @Inject
-  public AppFabricServiceManager(@Named(Constants.Service.MASTER_SERVICES_BIND_ADDRESS) InetAddress hostname) {
+  public AppFabricServiceManager(@Named(Constants.Service.MASTER_SERVICES_BIND_ADDRESS) InetAddress hostname,
+                                 AppFabricServer appFabricServer) {
     this.hostname = hostname;
     // this is to remember old log levels, will be used during reset
-    this.oldLogLevels = Collections.synchronizedMap(new HashMap<String, LogEntry.Level>());
+    this.oldLogLevels = Collections.synchronizedMap(new HashMap<>());
+    this.appFabricServer = appFabricServer;
   }
 
   @Inject(optional = true)
@@ -127,7 +132,7 @@ public class AppFabricServiceManager implements MasterServiceManager {
 
   @Override
   public boolean isServiceAvailable() {
-    return true;
+    return appFabricServer.isServiceAvailable();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/CoreSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/CoreSchedulerService.java
@@ -208,7 +208,7 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
    *
    * @throws ServiceUnavailableException if the scheduler is not yet functional
    */
-  private void checkStarted() {
+  public void checkStarted() {
     if (!Uninterruptibles.awaitUninterruptibly(startedLatch, 0, TimeUnit.SECONDS)) {
       throw new ServiceUnavailableException("Core scheduler");
     }


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-14931
Build: https://builds.cask.co/browse/CDAP-DUT6840-1

The recent integration test is flaky because the core scheduler service is not available even the system service endpoint returns OK for app fabric service. The CoreSchedulerService uses an internal RetryOnStartFailureService so the status will be running after the start() call, but the service may not be functional.