### PR TITLE
Implement strict csp policy for CDAP UI

### DIFF
--- a/cdap-ui/app/cdap/cdap.html
+++ b/cdap-ui/app/cdap/cdap.html
@@ -27,10 +27,13 @@
 </head>
 <body class="cdap-body-container">
   <div id="app-container"></div>
-  <script type="text/javascript" src="/config.js"></script>
-  <script type="text/javascript" src="/ui-config.js"></script>
-  <script type="text/javascript" src="/ui-theme.js"></script>
-  <script type="text/javascript" src="/dll_assets/dll.shared.vendor.<%= htmlWebpackPlugin.options.mode %>js?<%= htmlWebpackPlugin.options.hashId %>"></script>
-  <script type="text/javascript" src="/dll_assets/dll.cdap.vendor.<%= htmlWebpackPlugin.options.mode %>js?<%= htmlWebpackPlugin.options.hashId %>"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/config.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-config.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-theme.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/dll_assets/dll.shared.vendor.<%= htmlWebpackPlugin.options.mode %>js?<%= htmlWebpackPlugin.options.hashId %>"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/dll_assets/dll.cdap.vendor.<%= htmlWebpackPlugin.options.mode %>js?<%= htmlWebpackPlugin.options.hashId %>"></script>
+  <% for (key in htmlWebpackPlugin.files.js) { %>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="<%= htmlWebpackPlugin.files.js[key] %>"></script>
+  <% } %>
 </body>
 </html>

--- a/cdap-ui/app/hydrator/hydrator.html
+++ b/cdap-ui/app/hydrator/hydrator.html
@@ -44,16 +44,16 @@
   <global-footer></global-footer>
   <auth-refresher></auth-refresher>
 
-  <script type="text/javascript" src="/config.js"></script>
-  <script type="text/javascript" src="/ui-config.js"></script>
-  <script type="text/javascript" src="/ui-theme.js"></script>
-  <script type="text/javascript" src="/assets/bundle/polyfill.js"></script>
-  <script type="text/javascript" src="/assets/bundle/lib.js"></script>
-  <script type="text/javascript" src="/common_assets/common-lib-new.js"></script>
-  <script type="text/javascript" src="/common_assets/common-new.js"></script>
-  <script type="text/javascript" src="/assets/bundle/hydrator.js"></script>
-  <script type="text/javascript" src="/assets/bundle/common.es6.js"></script>
-  <script type="text/javascript" src="/assets/bundle/tpl.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/config.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-config.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-theme.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/polyfill.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/lib.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/common_assets/common-lib-new.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/common_assets/common-new.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/hydrator.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/common.es6.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/tpl.js"></script>
 </body>
 
 </html>

--- a/cdap-ui/app/login/login.html
+++ b/cdap-ui/app/login/login.html
@@ -26,7 +26,10 @@
 <body>
   <div id="login-form"></div>
   <div id="footer-container"></div>
-  <script type="text/javascript" src="/dll_assets/dll.shared.vendor.<%= htmlWebpackPlugin.options.mode %>js?<%= htmlWebpackPlugin.options.hashId %>"></script>
-  <script type="text/javascript" src="/login_assets/login.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/dll_assets/dll.shared.vendor.<%= htmlWebpackPlugin.options.mode %>js?<%= htmlWebpackPlugin.options.hashId %>"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/login_assets/login.js"></script>
+  <% for (key in htmlWebpackPlugin.files.js) { %>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="<%= htmlWebpackPlugin.files.js[key] %>"></script>
+  <% } %>
 </body>
 </html>

--- a/cdap-ui/app/logviewer/logviewer.html
+++ b/cdap-ui/app/logviewer/logviewer.html
@@ -45,16 +45,16 @@
     <auth-refresher></auth-refresher>
   </div>
 
-  <script type="text/javascript" src="/config.js"></script>
-  <script type="text/javascript" src="/ui-config.js"></script>
-  <script type="text/javascript" src="/ui-theme.js"></script>
-  <script type="text/javascript" src="/assets/bundle/polyfill.js"></script>
-  <script type="text/javascript" src="/assets/bundle/lib.js"></script>
-  <script type="text/javascript" src="/common_assets/common-lib-new.js"></script>
-  <script type="text/javascript" src="/common_assets/common-new.js"></script>
-  <script type="text/javascript" src="/assets/bundle/logviewer.js"></script>
-  <script type="text/javascript" src="/assets/bundle/common.es6.js"></script>
-  <script type="text/javascript" src="/assets/bundle/tpl.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/config.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-config.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-theme.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/polyfill.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/lib.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/common_assets/common-lib-new.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/common_assets/common-new.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/logviewer.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/common.es6.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/tpl.js"></script>
 </body>
 
 </html>

--- a/cdap-ui/app/tracker/tracker.html
+++ b/cdap-ui/app/tracker/tracker.html
@@ -48,16 +48,16 @@
     <global-footer></global-footer>
     <auth-refresher></auth-refresher>
   </div>
-  <script type="text/javascript" src="/config.js"></script>
-  <script type="text/javascript" src="/ui-config.js"></script>
-  <script type="text/javascript" src="/ui-theme.js"></script>
-  <script type="text/javascript" src="/assets/bundle/polyfill.js"></script>
-  <script type="text/javascript" src="/assets/bundle/lib.js"></script>
-  <script type="text/javascript" src="/common_assets/common-lib-new.js"></script>
-  <script type="text/javascript" src="/common_assets/common-new.js"></script>
-  <script type="text/javascript" src="/assets/bundle/tracker.js"></script>
-  <script type="text/javascript" src="/assets/bundle/common.es6.js"></script>
-  <script type="text/javascript" src="/assets/bundle/tpl.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/config.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-config.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/ui-theme.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/polyfill.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/lib.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/common_assets/common-lib-new.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/common_assets/common-new.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/tracker.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/common.es6.js"></script>
+  <script type="text/javascript" nonce="<_= nonceVal _>" src="/assets/bundle/tpl.js"></script>
 
 </body>
 

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -146,6 +146,7 @@
     "cookie-parser": "1.4.1",
     "css-vars-ponyfill": "1.8.0",
     "d3": "4.12.2",
+    "ejs": "2.6.1",
     "event-emitter": "0.3.4",
     "express": "4.16.2",
     "finalhandler": "0.4.1",

--- a/cdap-ui/webpack.config.cdap.js
+++ b/cdap-ui/webpack.config.cdap.js
@@ -88,6 +88,7 @@ var plugins = [
     template: './cdap.html',
     filename: 'cdap.html',
     hash: true,
+    inject: false,
     hashId: uuidV4(),
     mode: isModeProduction(mode) ? '' : 'development.',
   }),

--- a/cdap-ui/webpack.config.login.js
+++ b/cdap-ui/webpack.config.login.js
@@ -67,6 +67,7 @@ var plugins = [
     title: 'CDAP',
     template: './login.html',
     filename: 'login.html',
+    inject: false,
     hash: true,
     hashId: uuidV4(),
     mode: isModeProduction(mode) ? '' : 'development.',

--- a/cdap-ui/yarn.lock
+++ b/cdap-ui/yarn.lock
@@ -5547,7 +5547,7 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ejs@^2.6.1:
+ejs@2.6.1, ejs@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 


### PR DESCRIPTION
- Adds `strict-dynamic, unsafe-inline, unsafe-eval` to csp policy. This is to make sure only the statically added script tag contain nonce and whatever script tags injected dynamically during the course of bootstrapping the app in the browser is implicitly trusted. (the `unsafe-inline and unsafe-eval` is for browsers that don't support `strict-dynamic`)
- Removes `style-src` from csp policy.
- For now have added `report-uri` to csp policy. Need to configure it to receive right requests from UI.

Build: https://builds.cask.co/browse/CDAP-UDUT211