### PR TITLE
CDAP-14780 add logic to actually connect to sql

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -436,7 +436,15 @@ public final class Constants {
 
     public static final String DATA_STORAGE_IMPLEMENTATION = "data.storage.implementation";
     public static final String DATA_STORAGE_NOSQL = "nosql";
-    public static final String DATA_STORAGE_SQL = "postgressql";
+    public static final String DATA_STORAGE_SQL = "postgresql";
+    public static final String DATA_STORAGE_SQL_DRIVER_DIRECTORY = "data.storage.sql.driver.directory";
+    public static final String DATA_STORAGE_SQL_JDBC_DRIVER_NAME = "data.storage.sql.jdbc.driver.name";
+
+    // the jdbc connection related properties should be from cdap-security.xml
+    public static final String DATA_STORAGE_SQL_JDBC_CONNECTION_URL = "data.storage.sql.jdbc.connection.url";
+    public static final String DATA_STORAGE_SQL_USERNAME = "data.storage.sql.username";
+    public static final String DATA_STORAGE_SQL_PASSWORD = "data.storage.sql.password";
+    public static final String DATA_STORAGE_SQL_PROPERTY_PREFIX = "data.storage.sql.property.";
 
     // used for Guice named bindings
     public static final String TABLE_TYPE = "table.type";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -735,6 +735,38 @@
   </property>
 
   <property>
+    <name>data.storage.sql.driver.directory</name>
+    <value></value>
+    <description>
+      The sql driver directory which contains the driver jar and
+      other necessary jars to connect to the sql instance.
+      This config can only be used when the stroage implementation is sql.
+    </description>
+  </property>
+
+  <property>
+    <name>data.storage.sql.jdbc.driver.name</name>
+    <value></value>
+    <description>
+      The jdbc driver name to connect to the sql instance. The jdbc url,
+      username, password, connection properties can be set using
+      cdap-security.xml.
+    </description>
+  </property>
+
+  <property>
+    <name>data.storage.sql.jdbc.connection.url</name>
+    <value></value>
+    <description>
+      The jdbc url to connect to the sql instance. No sensitive information
+      should be provided using the jdbc url. The username and password can
+      be specified in cdap-security.xml. For non-sensitive properties, it can be
+      specified by adding a property with name prefixed with "data.storage.sql.property.",
+      followed by the sql property name.
+    </description>
+  </property>
+
+  <property>
     <name>data.tx.bind.address</name>
     <value>0.0.0.0</value>
     <description>

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -181,6 +181,10 @@
       <artifactId>hbase-client</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/jdbc/DataSourceInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/jdbc/DataSourceInstantiator.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.sql.jdbc;
+
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.conf.SConfiguration;
+import co.cask.cdap.common.lang.DirectoryClassLoader;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import org.apache.commons.dbcp2.ConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp2.PoolableConnection;
+import org.apache.commons.dbcp2.PoolableConnectionFactory;
+import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+
+/**
+ * Class to instantiate the {@link DataSource} for the sql related structured table.
+ */
+public class DataSourceInstantiator implements Supplier<DataSource> {
+  private static final Logger LOG = LoggerFactory.getLogger(DataSourceInstantiator.class);
+
+  private final CConfiguration cConf;
+  private final SConfiguration sConf;
+
+  private volatile DataSource dataSource;
+
+  @Inject
+  public DataSourceInstantiator(CConfiguration cConf, SConfiguration sConf) {
+    this.cConf = cConf;
+    this.sConf = sConf;
+  }
+
+  @Override
+  public DataSource get() {
+    if (dataSource != null) {
+      return dataSource;
+    }
+    return constructDataSource();
+  }
+
+  private synchronized DataSource constructDataSource() {
+    // this is needed to prevent recreation of the DataSource if the get() method is called concurrently
+    if (dataSource != null) {
+      return dataSource;
+    }
+    if (!cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION).equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      throw new IllegalArgumentException("Cannot instantiate the data source if the storage implementation is nosql.");
+    }
+
+    loadJDBCDriver();
+
+    String jdbcUrl = cConf.get(Constants.Dataset.DATA_STORAGE_SQL_JDBC_CONNECTION_URL);
+    if (jdbcUrl == null) {
+      throw new IllegalArgumentException("The jdbc connection url is not specified.");
+    }
+    Properties properties = retrieveJDBCConnectionProperties();
+    LOG.info("Creating the DataSource with jdbc url: {}", jdbcUrl);
+
+    ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(jdbcUrl, properties);
+    PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
+    // The GenericObjectPool is thread safe according to the javadoc,
+    // the PoolingDataSource will be thread safe as long as the connectin pool is thread-safe
+    ObjectPool<PoolableConnection> connectionPool = new GenericObjectPool<>(poolableConnectionFactory);
+    poolableConnectionFactory.setPool(connectionPool);
+    dataSource = new PoolingDataSource<>(connectionPool);
+    return dataSource;
+  }
+
+  private Properties retrieveJDBCConnectionProperties() {
+    Properties properties = new Properties();
+    String username = sConf.get(Constants.Dataset.DATA_STORAGE_SQL_USERNAME);
+    String password = sConf.get(Constants.Dataset.DATA_STORAGE_SQL_PASSWORD);
+    if ((username == null) != (password == null)) {
+      throw new IllegalArgumentException("The username and password for the jdbc connection must both be set" +
+                                           " or both not be set.");
+    }
+
+    if (username != null) {
+      properties.setProperty("user", username);
+      properties.setProperty("password", password);
+    }
+
+    for (Map.Entry<String, String> cConfEntry : cConf) {
+      if (cConfEntry.getKey().startsWith(Constants.Dataset.DATA_STORAGE_SQL_PROPERTY_PREFIX)) {
+        properties.put(cConfEntry.getKey().substring(Constants.Dataset.DATA_STORAGE_SQL_PROPERTY_PREFIX.length()),
+                       cConfEntry.getValue());
+      }
+    }
+    return properties;
+  }
+
+  private void loadJDBCDriver() {
+    String driverExtensionPath = cConf.get(Constants.Dataset.DATA_STORAGE_SQL_DRIVER_DIRECTORY);
+    String driverName = cConf.get(Constants.Dataset.DATA_STORAGE_SQL_JDBC_DRIVER_NAME);
+    if (driverExtensionPath == null || driverName == null) {
+      throw new IllegalArgumentException("The JDBC driver directory and driver name must be specified.");
+    }
+    DirectoryClassLoader directoryClassLoader =
+      new DirectoryClassLoader(new File(driverExtensionPath), DataSourceInstantiator.class.getClassLoader());
+    try {
+      Driver driver = (Driver) Class.forName(driverName, true, directoryClassLoader).newInstance();
+
+      // wrap the driver class and register it ourselves since the driver manager will not use driver from other
+      // classloader
+      JDBCDriverShim driverShim = new JDBCDriverShim(driver);
+      DriverManager.registerDriver(driverShim);
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | SQLException e) {
+      Throwables.propagate(e);
+    }
+
+    LOG.info("Successfully loaded {} from {}", driverName, driverExtensionPath);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/jdbc/JDBCDriverShim.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/jdbc/JDBCDriverShim.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.sql.jdbc;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Shim for JDBC driver as a better alternative to mere Class.forName to load the JDBC Driver class.
+ *
+ * From http://www.kfu.com/~nsayer/Java/dyn-jdbc.html
+ * One problem with using <pre>{@code Class.forName()}</pre> to find and load the JDBC Driver class is that it
+ * presumes that your driver is in the classpath. This means either packaging the driver in your jar, or having to
+ * stick the driver somewhere (probably unpacking it too), or modifying your classpath.
+ * But why not use something like URLClassLoader and the overload of Class.forName() that lets you specify the
+ * ClassLoader?" Because the DriverManager will refuse to use a driver not loaded by the system ClassLoader.
+ * The workaround for this is to create a shim class that implements java.sql.Driver.
+ * This shim class will do nothing but call the methods of an instance of a JDBC driver that we loaded dynamically.
+ *
+ */
+public class JDBCDriverShim implements Driver {
+
+  private final Driver delegate;
+
+  public JDBCDriverShim(Driver delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean acceptsURL(String url) throws SQLException {
+    return delegate.acceptsURL(url);
+  }
+
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
+    return delegate.connect(url, info);
+  }
+
+  @Override
+  public int getMajorVersion() {
+    return delegate.getMajorVersion();
+  }
+
+  @Override
+  public int getMinorVersion() {
+    return delegate.getMinorVersion();
+  }
+
+  @Override
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+    return delegate.getPropertyInfo(url, info);
+  }
+
+  @Override
+  public boolean jdbcCompliant() {
+    return delegate.jdbcCompliant();
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    return delegate.getParentLogger();
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/sql/jdbc/DataSourceInstantiatorTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/sql/jdbc/DataSourceInstantiatorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.sql.jdbc;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.conf.SConfiguration;
+import co.cask.cdap.common.test.AppJarHelper;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+public class DataSourceInstantiatorTest {
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testInstantiate() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_SQL);
+    cConf.set(Constants.Dataset.DATA_STORAGE_SQL_DRIVER_DIRECTORY, TEMP_FOLDER.getRoot().getPath());
+    cConf.set(Constants.Dataset.DATA_STORAGE_SQL_JDBC_DRIVER_NAME, NoopDriver.class.getName());
+    cConf.set(Constants.Dataset.DATA_STORAGE_SQL_JDBC_CONNECTION_URL, "jdbc:noop://");
+    AppJarHelper.createDeploymentJar(new LocalLocationFactory(TEMP_FOLDER.getRoot()), NoopDriver.class);
+
+    SConfiguration sConf = SConfiguration.create();
+
+    DataSourceInstantiator instantiator = new DataSourceInstantiator(cConf, sConf);
+    DataSource dataSource = instantiator.get();
+    Assert.assertNotNull(dataSource);
+    Enumeration<Driver> drivers = DriverManager.getDrivers();
+    Driver loadedDriver = null;
+
+    // the DriverManager can contain the postgres driver since we use embedded postgres, the DriverManager will load
+    // that driver initially.
+    int count = 0;
+    while (drivers.hasMoreElements()) {
+      Driver driver = drivers.nextElement();
+      // we will wrap the driver
+      if (driver instanceof JDBCDriverShim) {
+        loadedDriver = driver;
+      }
+      count++;
+    }
+    Assert.assertEquals(2, count);
+    Assert.assertNotNull(loadedDriver);
+  }
+
+  public static final class NoopDriver implements Driver {
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+      return null;
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+      return false;
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+      return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+      return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+      return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+      return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+      return null;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <opentable.version>0.12.6</opentable.version>
+    <dbcp.version>2.6.0</dbcp.version>
 
     <cask.packages.snapshot.repo>http://cask.invalid.snapshot.repo.co</cask.packages.snapshot.repo>
     <cask.packages.release.repo>http://cask.invalid.release.repo.co</cask.packages.release.repo>
@@ -1651,6 +1652,17 @@
         <artifactId>otj-pg-embedded</artifactId>
         <version>${opentable.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-dbcp2</artifactId>
+        <version>${dbcp.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14780
Build: https://builds.cask.co/browse/CDAP-DUT6856-1

Instantiate the data source using the given jars in the directory from the cConf. We use a PoolingDataSource from apache common dbcp. Still need to figure out how to use injector to get the datasource in the unit test since the embedded postgres is in the test scope and it will load the driver itself.