### PR TITLE
[CDAP-14937] Adding log buffer recovery upon restart

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -789,10 +789,14 @@ public final class Constants {
    * Configurations for log buffer.
    */
   public static final class LogBuffer {
+    // log buffer writer configs
     public static final String LOG_BUFFER_BASE_DIR = "log.buffer.base.dir";
     public static final String LOG_BUFFER_MAX_FILE_SIZE_BYTES = "log.buffer.max.file.size.bytes";
+    // log buffer recovery configs
+    public static final String LOG_BUFFER_RECOVERY_BATCH_SIZE = "log.buffer.recovery.batch.size";
     // number of events to be sent to time event queue processor from incoming queue
-    public static final String LOG_BUFFER_PIPELINE_BATCHSIZE = "log.buffer.pipeline.batch.size";
+    public static final String LOG_BUFFER_PIPELINE_BATCH_SIZE = "log.buffer.pipeline.batch.size";
+    // log buffer server configs
     public static final String LOG_BUFFER_SERVER_BIND_ADDRESS = "log.buffer.server.bind.address";
     public static final String LOG_BUFFER_SERVER_BIND_PORT = "log.buffer.server.bind.port";
   }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1492,6 +1492,14 @@
   </property>
 
   <property>
+    <name>log.buffer.recovery.batch.size</name>
+    <value>1000</value>
+    <description>
+      Log buffer recovery batch size to recover log buffer files in batches
+    </description>
+  </property>
+
+  <property>
     <name>log.kafka.topic</name>
     <value>logs.user-v2</value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="cd20658fb29ded81b47eef4e0e6779a1"
+DEFAULT_XML_MD5_HASH="301c88929bcdab5018eca429dae36888"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/ConcurrentLogBufferWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/ConcurrentLogBufferWriter.java
@@ -55,8 +55,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * 7. Set the AtomicBoolean flag back to false.
  * 8. If the PendingLogBufferRequest enqueued by this thread is NOT COMPLETED, go back to step 2.
  * </pre>
- *
- * TODO: CDAP-14937 Restore unprocessed log events from LogBuffer(WAL).
  */
 @ThreadSafe
 public class ConcurrentLogBufferWriter implements Closeable {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferFileOffset.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferFileOffset.java
@@ -57,8 +57,7 @@ public class LogBufferFileOffset implements Comparable<LogBufferFileOffset> {
     }
 
     LogBufferFileOffset that = (LogBufferFileOffset) o;
-
-    return filePos == that.filePos && Objects.equals(fileId, that.fileId);
+    return fileId == that.fileId && filePos == that.filePos;
   }
 
   @Override
@@ -68,8 +67,8 @@ public class LogBufferFileOffset implements Comparable<LogBufferFileOffset> {
 
   @Override
   public String toString() {
-    return "FileOffset{" +
-      "fileId='" + fileId + '\'' +
+    return "LogBufferFileOffset{" +
+      "fileId=" + fileId +
       ", filePos=" + filePos +
       '}';
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferReader.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.logbuffer;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.logging.serialize.LoggingEventSerializer;
+import com.google.common.io.Closeables;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Reader to read log buffer files.
+ */
+public class LogBufferReader implements Closeable {
+  private static final String FILE_SUFFIX = ".buf";
+  private final int batchSize;
+  private final String baseDir;
+  private final long maxFileId;
+
+  private long currFileId;
+  private LogBufferInputStream inputStream;
+  private boolean skipFirstEvent;
+
+  public LogBufferReader(String baseDir, int batchSize, long currFileId, long currPos) throws IOException {
+    this.baseDir = baseDir;
+    this.batchSize = batchSize;
+    // if no checkpoints are written, start from 0th position from first file. Also in that case do not skip first event
+    this.currFileId = currFileId < 0 ? 0 : currFileId;
+    this.skipFirstEvent = currFileId >= 0;
+    this.maxFileId = getMaxFileId(baseDir);
+    this.inputStream = new LogBufferInputStream(baseDir, this.currFileId, currPos < 0 ? 0 : currPos);
+  }
+
+  /**
+   * Reads next batch of events from log buffer.
+   *
+   * @param eventList events list to which events will be added
+   * @return number of events added to eventList
+   * @throws IOException error while reading events from buffer files
+   */
+  public int readEvents(List<LogBufferEvent> eventList) throws IOException {
+    // there are no files in the log buffer directory. So return 0.
+    if (maxFileId < 0) {
+      return 0;
+    }
+
+    // iterate over all the remaining events.
+    while (eventList.size() < batchSize && currFileId < (maxFileId + 1)) {
+      try {
+        if (inputStream == null) {
+          inputStream = new LogBufferInputStream(baseDir, currFileId);
+        }
+
+        // skip the first event if skipFirstEvent is true. This is needed because log buffer offset represents offset
+        // till which log events have been processed. Meaning current event is already processed by log buffer pipeline.
+        if (skipFirstEvent) {
+          inputStream.read();
+          skipFirstEvent = false;
+        }
+
+        eventList.add(inputStream.read());
+      } catch (FileNotFoundException e) {
+        // move to next file in case file pointed by currFileId was not found
+        currFileId++;
+      } catch (EOFException e) {
+        // reached eof on this input stream. So close it, move to next file
+        inputStream.close();
+        inputStream = null;
+        currFileId++;
+      }
+    }
+
+    return eventList.size();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (inputStream != null) {
+      inputStream.close();
+    }
+  }
+
+  private long getMaxFileId(String baseDir) {
+    long maxFileId = -1;
+    File[] files = new File(baseDir).listFiles();
+    if (files != null) {
+      for (File file : files) {
+        String[] splitted = file.getName().split("\\.");
+        long fileId = Long.parseLong(splitted[0]);
+        if (maxFileId < fileId) {
+          maxFileId = fileId;
+        }
+      }
+    }
+
+    return maxFileId;
+  }
+
+  /**
+   * Input stream to interact with log buffer files.
+   */
+  private static final class LogBufferInputStream {
+    private long fileId;
+    private long pos;
+    private DataInputStream inputStream;
+    private boolean skipFirstEvent;
+    private final LoggingEventSerializer serializer;
+
+    LogBufferInputStream(String baseDir, long fileId) throws IOException {
+      this(baseDir, fileId, 0);
+    }
+
+    LogBufferInputStream(String baseDir, long fileId, long pos) throws IOException {
+      this.fileId = fileId;
+      this.pos = pos;
+      FileInputStream fis = new FileInputStream(new File(baseDir, fileId + FILE_SUFFIX));
+      // seek to the position if the position is not zero
+      if (pos != 0) {
+        fis.getChannel().position(pos);
+        this.skipFirstEvent = true;
+      }
+      this.inputStream = new DataInputStream(fis);
+      this.serializer = new LoggingEventSerializer();
+    }
+
+    /**
+     * Reads next event from log buffer file pointed by this input stream.
+     *
+     * @return log buffer event
+     * @throws IOException error while reading log buffer file
+     */
+    LogBufferEvent read() throws IOException {
+      int length = inputStream.readInt();
+      byte[] eventBytes = new byte[length];
+      inputStream.read(eventBytes);
+      LogBufferEvent event = new LogBufferEvent(serializer.fromBytes(ByteBuffer.wrap(eventBytes)),
+                                                eventBytes.length, new LogBufferFileOffset(fileId, pos));
+      // update curr position to point to next event
+      pos = pos + Bytes.SIZEOF_INT + length;
+      return event;
+    }
+
+    /**
+     * Closes this input stream.
+     */
+    void close() {
+      // close current input stream
+      Closeables.closeQuietly(inputStream);
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferRecoveryService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferRecoveryService.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.logbuffer;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.logging.LogSamplers;
+import co.cask.cdap.common.logging.Loggers;
+import co.cask.cdap.logging.meta.CheckpointManager;
+import co.cask.cdap.logging.pipeline.logbuffer.LogBufferProcessorPipeline;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Log buffer recovery service which recovers logs upon log saver restart and sends them to log buffer pipeline for
+ * further processing.
+ */
+class LogBufferRecoveryService extends AbstractExecutionThreadService {
+  private static final Logger LOG = LoggerFactory.getLogger(LogBufferRecoveryService.class);
+  // For outage, only log once per 60 seconds per message.
+  private static final Logger OUTAGE_LOG =
+    Loggers.sampling(LOG, LogSamplers.perMessage(() -> LogSamplers.limitRate(60000)));
+  private static final String SERVICE_NAME = "log.buffer.recovery";
+
+  private final List<LogBufferProcessorPipeline> pipelines;
+  private final List<CheckpointManager<LogBufferFileOffset>> checkpointManagers;
+  private final String baseLogDir;
+  private final int batchSize;
+  private final CountDownLatch stopLatch;
+
+  private LogBufferReader reader;
+  private volatile boolean stopped;
+
+  LogBufferRecoveryService(CConfiguration cConf, List<LogBufferProcessorPipeline> pipelines,
+                           List<CheckpointManager<LogBufferFileOffset>> checkpointManagers) {
+    this(pipelines, checkpointManagers, cConf.get(Constants.LogBuffer.LOG_BUFFER_BASE_DIR),
+         cConf.getInt(Constants.LogBuffer.LOG_BUFFER_RECOVERY_BATCH_SIZE));
+  }
+
+  @VisibleForTesting
+  LogBufferRecoveryService(List<LogBufferProcessorPipeline> pipelines,
+                           List<CheckpointManager<LogBufferFileOffset>> checkpointManager,
+                           String baseLogDir, int batchSize) {
+    this.pipelines = pipelines;
+    this.checkpointManagers = checkpointManager;
+    this.baseLogDir = baseLogDir;
+    this.batchSize = batchSize;
+    this.stopLatch = new CountDownLatch(1);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    // get the smallest offset of all the log pipelines
+    LogBufferFileOffset minOffset = getSmallestOffset(checkpointManagers);
+    this.reader = new LogBufferReader(baseLogDir, batchSize, minOffset.getFileId(), minOffset.getFilePos());
+  }
+
+  @Override
+  protected void run() throws Exception {
+    // check if the log buffer dir exists, this could happen if log saver is starting for the first time.
+    if (!exists(baseLogDir)) {
+      return;
+    }
+
+    List<LogBufferEvent> logBufferEvents = new LinkedList<>();
+    boolean hasReadEvents = true;
+    while (!stopped && hasReadEvents) {
+      try {
+        hasReadEvents = reader.readEvents(logBufferEvents) > 0;
+        processLogs(logBufferEvents, pipelines);
+      } catch (IOException e) {
+        // even though error occurred while reading, whatever logs were read, those should be processed.
+        processLogs(logBufferEvents, pipelines);
+        OUTAGE_LOG.warn("Failed to recover logs from log buffer. Read will be retried.", e);
+        // in case of failure to read, sleep and then retry
+        stopLatch.await(500, TimeUnit.MILLISECONDS);
+      }
+    }
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (reader != null) {
+      reader.close();
+    }
+  }
+
+  @Override
+  protected void triggerShutdown() {
+    stopped = true;
+    stopLatch.countDown();
+  }
+
+  @Override
+  protected String getServiceName() {
+    return SERVICE_NAME;
+  }
+
+  @Override
+  protected Executor executor() {
+    return MoreExecutors.sameThreadExecutor();
+  }
+
+  private LogBufferFileOffset getSmallestOffset(List<CheckpointManager<LogBufferFileOffset>> checkpointManagers)
+    throws IOException {
+    // there will be atleast one log pipeline
+    LogBufferFileOffset minOffset = checkpointManagers.get(0).getCheckpoint(0).getOffset();
+
+    for (int i = 1; i < checkpointManagers.size(); i++) {
+      LogBufferFileOffset offset = checkpointManagers.get(i).getCheckpoint(0).getOffset();
+      // keep track of minimum offset
+      minOffset = minOffset.compareTo(offset) > 0 ? offset : minOffset;
+    }
+
+    return minOffset;
+  }
+
+  private boolean exists(String baseLogDir) {
+    File baseDir = new File(baseLogDir);
+    return baseDir.exists();
+  }
+
+  private void processLogs(List<LogBufferEvent> logBufferEvents, List<LogBufferProcessorPipeline> pipelines) {
+    for (LogBufferProcessorPipeline pipeline : pipelines) {
+      pipeline.processLogEvents(logBufferEvents.iterator());
+    }
+    logBufferEvents.clear();
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/LogBufferWriter.java
@@ -103,7 +103,9 @@ public class LogBufferWriter implements Flushable, Closeable {
    * @throws IOException if there is any problem while writing to log buffer
    */
   private LogBufferFileOffset write(byte[] eventBytes) throws IOException {
+    long startFileId = currFileId;
     long startOffset = currOffset;
+
     // write size of the log event
     currOutputStream.write(Bytes.toBytes(eventBytes.length));
     currOffset = currOffset + Bytes.SIZEOF_INT;
@@ -119,7 +121,8 @@ public class LogBufferWriter implements Flushable, Closeable {
       currOutputStream = new BufferedOutputStream(rotateFile(currOutputStream).getOutputStream());
     }
 
-    return new LogBufferFileOffset(currFileId, startOffset);
+    // the file id and file pos in offset is where current event is written.
+    return new LogBufferFileOffset(startFileId, startOffset);
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/handler/LogBufferHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/logbuffer/handler/LogBufferHandler.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.io.ByteBuffers;
 import co.cask.cdap.logging.logbuffer.ConcurrentLogBufferWriter;
 import co.cask.cdap.logging.logbuffer.LogBufferRequest;
 import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HandlerContext;
 import co.cask.http.HttpResponder;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -31,6 +32,7 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,5 +73,14 @@ public class LogBufferHandler extends AbstractHttpHandler {
     //return new LogBufferRequest(partitionId, events);
     return new LogBufferRequest(partitionId,
                                 events.stream().map(ByteBuffers::getByteArray).collect(Collectors.toList()));
+  }
+
+  @Override
+  public void destroy(HandlerContext context) {
+    try {
+      writer.close();
+    } catch (IOException e) {
+      // close quietly
+    }
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/logbuffer/LogBufferProcessorPipeline.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/logbuffer/LogBufferProcessorPipeline.java
@@ -166,24 +166,6 @@ public class LogBufferProcessorPipeline extends AbstractExecutionThreadService {
   }
 
   /**
-   * Pushes log events to blocking queue to be processed by processor pipeline.
-   *
-   * @param events log events to be processed
-   */
-  public void processLogEvents(Iterator<LogBufferEvent> events) {
-    // Don't accept any log events if the pipeline is not running
-    while (!stopped && events.hasNext()) {
-      try {
-        // This call will block caller thread until the queue has free space.
-        incomingEventQueue.put(events.next());
-      } catch (InterruptedException e) {
-        // Just ignore the exception and reset the flag
-        Thread.currentThread().interrupt();
-      }
-    }
-  }
-
-  /**
    * Persists the checkpoints.
    */
   private void persistCheckpoints() {
@@ -224,6 +206,24 @@ public class LogBufferProcessorPipeline extends AbstractExecutionThreadService {
       OUTAGE_LOG.warn("Failed to sync in pipeline {}. Will be retried.", name, e);
     }
     return config.getCheckpointIntervalMillis();
+  }
+
+  /**
+   * Pushes log events to blocking queue to be processed by processor pipeline.
+   *
+   * @param events log events to be processed
+   */
+  public void processLogEvents(Iterator<LogBufferEvent> events) {
+    // Don't accept any log events if the pipeline is not running
+    while (!stopped && events.hasNext()) {
+      try {
+        // This call will block caller thread until the queue has free space.
+        incomingEventQueue.put(events.next());
+      } catch (InterruptedException e) {
+        // Just ignore the exception and reset the flag
+        Thread.currentThread().interrupt();
+      }
+    }
   }
 
   /**

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/ConcurrentLogBufferWriterTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/ConcurrentLogBufferWriterTest.java
@@ -99,6 +99,7 @@ public class ConcurrentLogBufferWriterTest {
     // verify if the pipeline has processed the messages.
     Tasks.waitFor(5, () -> appender.getEvents().size(), 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     pipeline.stopAndWait();
+    loggerContext.stop();
   }
 
   @Test
@@ -157,6 +158,7 @@ public class ConcurrentLogBufferWriterTest {
     // verify if the pipeline has processed the messages.
     Tasks.waitFor(100, () -> appender.getEvents().size(), 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     pipeline.stopAndWait();
+    loggerContext.stop();
   }
 
   private ImmutableList<byte[]> getLoggingEvents() {

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/LogBufferRecoveryServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/LogBufferRecoveryServiceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.logbuffer;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.metrics.NoopMetricsContext;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.logging.appender.LogMessage;
+import co.cask.cdap.logging.context.WorkerLoggingContext;
+import co.cask.cdap.logging.pipeline.LogPipelineTestUtil;
+import co.cask.cdap.logging.pipeline.LogProcessorPipelineContext;
+import co.cask.cdap.logging.pipeline.MockAppender;
+import co.cask.cdap.logging.pipeline.logbuffer.LogBufferPipelineConfig;
+import co.cask.cdap.logging.pipeline.logbuffer.LogBufferProcessorPipeline;
+import co.cask.cdap.logging.serialize.LoggingEventSerializer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for {@link LogBufferRecoveryService}.
+ */
+public class LogBufferRecoveryServiceTest {
+  private static final LoggingEventSerializer serializer = new LoggingEventSerializer();
+  private static final MetricsContext NO_OP_METRICS_CONTEXT = new NoopMetricsContext();
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testLogBufferRecoveryService() throws Exception {
+    String absolutePath = TMP_FOLDER.newFolder().getAbsolutePath();
+
+    // create and start pipeline
+    LoggerContext loggerContext = LogPipelineTestUtil.createLoggerContext("WARN",
+                                                                          ImmutableMap.of("test.logger", "INFO"),
+                                                                          MockAppender.class.getName());
+    final MockAppender appender = LogPipelineTestUtil.getAppender(loggerContext.getLogger(Logger.ROOT_LOGGER_NAME),
+                                                                  "Test", MockAppender.class);
+    MockCheckpointManager checkpointManager = new MockCheckpointManager();
+    LogBufferPipelineConfig config = new LogBufferPipelineConfig(1024L, 300L, 500L, 4);
+    loggerContext.start();
+    LogBufferProcessorPipeline pipeline = new LogBufferProcessorPipeline(
+      new LogProcessorPipelineContext(CConfiguration.create(), "test", loggerContext, NO_OP_METRICS_CONTEXT, 0),
+      config, checkpointManager, 0);
+
+    // start the pipeline
+    pipeline.startAndWait();
+
+    // write directly to log buffer
+    LogBufferWriter writer = new LogBufferWriter(absolutePath, 250);
+    ImmutableList<byte[]> events = getLoggingEvents();
+    writer.write(events.iterator()).iterator();
+    writer.close();
+
+    // start log buffer reader to read log events from files. keep the batch size as 2 so that there are more than 1
+    // iterations
+    LogBufferRecoveryService service = new LogBufferRecoveryService(ImmutableList.of(pipeline),
+                                                                    ImmutableList.of(checkpointManager),
+                                                                    absolutePath, 2);
+    service.startAndWait();
+
+    Tasks.waitFor(5, () -> appender.getEvents().size(), 120, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+    service.stopAndWait();
+    pipeline.stopAndWait();
+    loggerContext.stop();
+  }
+
+  private ImmutableList<byte[]> getLoggingEvents() {
+    WorkerLoggingContext loggingContext =
+      new WorkerLoggingContext("default", "app1", "worker1", "run1", "instance1");
+    long now = System.currentTimeMillis();
+    return ImmutableList.of(
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "0", now - 1000, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "1", now - 900, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "2", now - 700, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.DEBUG, "3", now - 600, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "4", now - 500, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "5", now - 100, loggingContext)));
+  }
+
+  private ILoggingEvent createLoggingEvent(String loggerName, Level level, String message, long timestamp,
+                                           LoggingContext loggingContext) {
+    LoggingEvent event = new LoggingEvent();
+    event.setLevel(level);
+    event.setLoggerName(loggerName);
+    event.setMessage(message);
+    event.setTimeStamp(timestamp);
+    return new LogMessage(event, loggingContext);
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/LogBufferWriterTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/LogBufferWriterTest.java
@@ -59,10 +59,10 @@ public class LogBufferWriterTest {
     // verify if correct offsets were set without file rotation
     while (writtenEvents.hasNext()) {
       LogBufferEvent bufferEvent = writtenEvents.next();
-      Assert.assertEquals(bufferEvent.getLogEvent().getMessage(), "" + i++);
+      Assert.assertEquals("" + i++, bufferEvent.getLogEvent().getMessage());
+      startPos = startPos + Bytes.SIZEOF_INT + serializer.toBytes(bufferEvent.getLogEvent()).length;
       // There will not be any rotation.
       Assert.assertEquals(bufferEvent.getOffset().getFilePos(), startPos);
-      startPos = startPos + Bytes.SIZEOF_INT + serializer.toBytes(bufferEvent.getLogEvent()).length;
     }
 
     // verify if the events were serialized and written correctly
@@ -87,9 +87,9 @@ public class LogBufferWriterTest {
     while (writtenEvents.hasNext()) {
       LogBufferEvent bufferEvent = writtenEvents.next();
       Assert.assertEquals(bufferEvent.getLogEvent().getMessage(), "" + i++);
-      // There will be one rotation per event.
-      Assert.assertEquals(bufferEvent.getOffset().getFileId() + ".buf", i + ".buf");
-      Assert.assertEquals(bufferEvent.getOffset().getFilePos(), 0);
+      // There will be 2 events in one file.
+      Assert.assertEquals(i + ".buf", bufferEvent.getOffset().getFileId() + ".buf");
+      Assert.assertEquals(0, bufferEvent.getOffset().getFilePos());
     }
   }
 

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/MockCheckpointManager.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/logbuffer/MockCheckpointManager.java
@@ -21,6 +21,7 @@ import co.cask.cdap.logging.meta.CheckpointManager;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,10 +29,13 @@ import java.util.Set;
  * Checkpoint manager for unit tests.
  */
 public class MockCheckpointManager implements CheckpointManager<LogBufferFileOffset> {
-  @Override
-  public void saveCheckpoints(Map<Integer, ? extends Checkpoint<LogBufferFileOffset>> checkpoints)
-    throws IOException {
+  private final Map<Integer, Checkpoint<LogBufferFileOffset>> map = new HashMap<>();
 
+  @Override
+  public void saveCheckpoints(Map<Integer, ? extends Checkpoint<LogBufferFileOffset>> checkpoints) throws IOException {
+    for (Map.Entry<Integer, ? extends Checkpoint<LogBufferFileOffset>> entry : checkpoints.entrySet()) {
+      map.put(entry.getKey(), entry.getValue());
+    }
   }
 
   @Override
@@ -41,6 +45,10 @@ public class MockCheckpointManager implements CheckpointManager<LogBufferFileOff
 
   @Override
   public Checkpoint<LogBufferFileOffset> getCheckpoint(int partition) throws IOException {
-    return new Checkpoint<>(new LogBufferFileOffset(-1, -1), -1);
+    if (!map.containsKey(partition)) {
+      return new Checkpoint<>(new LogBufferFileOffset(-1, -1), -1);
+    }
+
+    return map.get(partition);
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/logbuffer/LogBufferProcessorPipelineTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/logbuffer/LogBufferProcessorPipelineTest.java
@@ -75,7 +75,7 @@ public class LogBufferProcessorPipelineTest {
     AtomicInteger i = new AtomicInteger(0);
     List<LogBufferEvent> bufferEvents = events.stream().map(event -> {
       LogBufferEvent lbe = new LogBufferEvent(event, serializer.toBytes(event).length,
-                         new LogBufferFileOffset(0, i.get()));
+                                              new LogBufferFileOffset(0, i.get()));
       i.incrementAndGet();
       return lbe;
     }).collect(Collectors.toList());
@@ -97,6 +97,7 @@ public class LogBufferProcessorPipelineTest {
     Tasks.waitFor(200, () -> appender.getEvents().size(), 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     executorService.shutdown();
     pipeline.stopAndWait();
+    loggerContext.stop();
   }
 
   private ImmutableList<ILoggingEvent> getLoggingEvents() {

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/logbuffer/LogBufferReaderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/pipeline/logbuffer/LogBufferReaderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.pipeline.logbuffer;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.logging.appender.LogMessage;
+import co.cask.cdap.logging.context.WorkerLoggingContext;
+import co.cask.cdap.logging.logbuffer.LogBufferEvent;
+import co.cask.cdap.logging.logbuffer.LogBufferReader;
+import co.cask.cdap.logging.logbuffer.LogBufferWriter;
+import co.cask.cdap.logging.serialize.LoggingEventSerializer;
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Tests for {@link LogBufferReader}.
+ */
+public class LogBufferReaderTest {
+  private final LoggingEventSerializer serializer = new LoggingEventSerializer();
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testLogReader() throws Exception {
+    String absolutePath = TMP_FOLDER.newFolder().getAbsolutePath();
+
+    LogBufferWriter writer = new LogBufferWriter(absolutePath, 250);
+    ImmutableList<byte[]> events = getLoggingEvents();
+    Iterable<LogBufferEvent> writtenEvents = writer.write(events.iterator());
+    writer.close();
+
+    List<LogBufferEvent> logBufferEvents = new LinkedList<>();
+    // read from start positions, tests case where no checkpoints are persisted
+    LogBufferReader reader = new LogBufferReader(absolutePath, 2, -1, -1);
+    Iterator<LogBufferEvent> iterator = writtenEvents.iterator();
+    verifyEvents(logBufferEvents, reader, iterator);
+    reader.close();
+
+    // this should skip first and second event, this is because log buffer offsets are offset for event that is
+    // already stored. so in this case, skip first event and skip second event as second event is the last stored event
+    reader = new LogBufferReader(absolutePath, 2, 0, 145);
+    iterator = writtenEvents.iterator();
+    iterator.next();
+    iterator.next();
+    verifyEvents(logBufferEvents, reader, iterator);
+    reader.close();
+  }
+
+  private void verifyEvents(List<LogBufferEvent> logBufferEvents, LogBufferReader reader,
+                            Iterator<LogBufferEvent> iterator) throws IOException {
+    while (reader.readEvents(logBufferEvents) > 0) {
+      for (LogBufferEvent event : logBufferEvents) {
+        LogBufferEvent next = iterator.next();
+        Assert.assertEquals(next.getOffset(), event.getOffset());
+        Assert.assertEquals(next.getEventSize(), event.getEventSize());
+        Assert.assertEquals(next.getLogEvent().getMessage(), event.getLogEvent().getMessage());
+      }
+      logBufferEvents.clear();
+    }
+  }
+
+  private ImmutableList<byte[]> getLoggingEvents() {
+    WorkerLoggingContext loggingContext =
+      new WorkerLoggingContext("default", "app1", "worker1", "run1", "instance1");
+    long now = System.currentTimeMillis();
+    return ImmutableList.of(
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "0", now - 1000, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "1", now - 900, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "2", now - 700, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.DEBUG, "3", now - 600, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "4", now - 500, loggingContext)),
+      serializer.toBytes(createLoggingEvent("test.logger", Level.INFO, "5", now - 100, loggingContext)));
+  }
+
+  private ILoggingEvent createLoggingEvent(String loggerName, Level level, String message, long timestamp,
+                                           LoggingContext loggingContext) {
+    LoggingEvent event = new LoggingEvent();
+    event.setLevel(level);
+    event.setLoggerName(loggerName);
+    event.setMessage(message);
+    event.setTimeStamp(timestamp);
+    return new LogMessage(event, loggingContext);
+  }
+}


### PR DESCRIPTION
Adding a log service to read logs from log buffer and send them to log processor pipelines upon log saver restart. 

DUT: https://builds.cask.co/browse/CDAP-DUT-2530
ITM: 