### PR TITLE
CDAP-14954 create PreviewServiceMain for preview in kubernetes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -168,7 +168,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   @Override
   public Module getStandaloneModules() {
 
-    return Modules.combine(new AppFabricServiceModule(PreviewHttpHandler.class),
+    return Modules.combine(new AppFabricServiceModule(),
                            new NamespaceAdminModule().getStandaloneModules(),
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
@@ -190,7 +190,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                  Multibinder.newSetBinder(binder(), String.class,
                                                           Names.named("appfabric.services.names"));
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.APP_FABRIC_HTTP);
-                               servicesNamesBinder.addBinding().toInstance(Constants.Service.PREVIEW_HTTP);
 
                                // for PingHandler
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.METRICS_PROCESSOR);
@@ -204,7 +203,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                  Multibinder.newSetBinder(binder(), String.class,
                                                           Names.named("appfabric.handler.hooks"));
                                handlerHookNamesBinder.addBinding().toInstance(Constants.Service.APP_FABRIC_HTTP);
-                               handlerHookNamesBinder.addBinding().toInstance(Constants.Service.PREVIEW_HTTP);
 
                                // for PingHandler
                                handlerHookNamesBinder.addBinding().toInstance(Constants.Service.METRICS_PROCESSOR);
@@ -220,7 +218,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   @Override
   public Module getDistributedModules() {
 
-    return Modules.combine(new AppFabricServiceModule(ImpersonationHandler.class, PreviewHttpHandler.class),
+    return Modules.combine(new AppFabricServiceModule(ImpersonationHandler.class),
                            new PreviewHttpModule().getDistributedModules(),
                            new NamespaceAdminModule().getDistributedModules(),
                            new ConfigStoreModule(),
@@ -245,14 +243,12 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                  Multibinder.newSetBinder(binder(), String.class,
                                                           Names.named("appfabric.services.names"));
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.APP_FABRIC_HTTP);
-                               servicesNamesBinder.addBinding().toInstance(Constants.Service.PREVIEW_HTTP);
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.SECURE_STORE_SERVICE);
 
                                Multibinder<String> handlerHookNamesBinder =
                                  Multibinder.newSetBinder(binder(), String.class,
                                                           Names.named("appfabric.handler.hooks"));
                                handlerHookNamesBinder.addBinding().toInstance(Constants.Service.APP_FABRIC_HTTP);
-                               handlerHookNamesBinder.addBinding().toInstance(Constants.Service.PREVIEW_HTTP);
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.SECURE_STORE_SERVICE);
                              }
                            });

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/UnsupportedExploreClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/UnsupportedExploreClient.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
  * A {@link ExploreClient} implementation that throws {@link UnsupportedOperationException} on
  * every method call. This is used in runtime environment that explore is not supported.
  */
-final class UnsupportedExploreClient implements ExploreClient {
+public final class UnsupportedExploreClient implements ExploreClient {
   @Override
   public void ping() throws UnauthenticatedException, ServiceUnavailableException, ExploreException {
     throw new UnsupportedOperationException("Explore is not supported. This method should not be called.");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewHttpServer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.preview;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.ResolvingDiscoverable;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
+import co.cask.cdap.common.logging.LoggingContextAccessor;
+import co.cask.cdap.common.logging.ServiceLoggingContext;
+import co.cask.cdap.common.metrics.MetricsReporterHook;
+import co.cask.cdap.gateway.handlers.preview.PreviewHttpHandler;
+import co.cask.cdap.internal.app.services.AppFabricServer;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.http.NettyHttpService;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+
+/**
+ * HTTP Server for preview.
+ */
+public class PreviewHttpServer extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AppFabricServer.class);
+
+  private final DiscoveryService discoveryService;
+  private final NettyHttpService httpService;
+  private Cancellable cancelHttpService;
+
+  @Inject
+  PreviewHttpServer(CConfiguration cConf, DiscoveryService discoveryService, PreviewHttpHandler previewHttpHandler,
+                    MetricsCollectionService metricsCollectionService) {
+    this.discoveryService = discoveryService;
+    this.httpService = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.PREVIEW_HTTP)
+      .setHost(cConf.get(Constants.Preview.ADDRESS))
+      .setPort(cConf.getInt(Constants.Preview.PORT))
+      .setHttpHandlers(previewHttpHandler)
+      .setConnectionBacklog(cConf.getInt(Constants.Preview.BACKLOG_CONNECTIONS))
+      .setExecThreadPoolSize(cConf.getInt(Constants.Preview.EXEC_THREADS))
+      .setBossThreadPoolSize(cConf.getInt(Constants.Preview.BOSS_THREADS))
+      .setWorkerThreadPoolSize(cConf.getInt(Constants.Preview.WORKER_THREADS))
+      .setHandlerHooks(Collections.singletonList(
+        new MetricsReporterHook(metricsCollectionService, Constants.Service.PREVIEW_HTTP)))
+      .build();
+  }
+
+  /**
+   * Configures the AppFabricService pre-start.
+   */
+  @Override
+  protected void startUp() throws Exception {
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
+                                                                       Constants.Logging.COMPONENT_NAME,
+                                                                       Constants.Service.PREVIEW_HTTP));
+
+    httpService.start();
+    cancelHttpService = discoveryService.register(
+      ResolvingDiscoverable.of(new Discoverable(Constants.Service.PREVIEW_HTTP, httpService.getBindAddress())));
+    LOG.info("Preview HTTP server started on {}", httpService.getBindAddress());
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    try {
+      cancelHttpService.cancel();
+    } finally {
+      httpService.stop();
+    }
+    LOG.info("Preview HTTP server stopped");
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -327,6 +327,11 @@ public final class Constants {
      * Guice named bindings.
      */
     public static final String ADDRESS = "preview.bind.address";
+    public static final String PORT = "preview.bind.port";
+    public static final String BACKLOG_CONNECTIONS = "preview.connection.backlog";
+    public static final String EXEC_THREADS = "preview.exec.threads";
+    public static final String BOSS_THREADS = "preview.boss.threads";
+    public static final String WORKER_THREADS = "preview.worker.threads";
 
     public static final String PREVIEW_CACHE_SIZE = "preview.cache.size";
   }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2802,6 +2802,54 @@
   </property>
 
   <property>
+    <name>preview.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      The bind address for the preview service.
+    </description>
+  </property>
+
+  <property>
+    <name>preview.bind.port</name>
+    <value>0</value>
+    <description>
+      The port to bind the preview service to.
+    </description>
+  </property>
+
+  <property>
+    <name>preview.connection.backlog</name>
+    <value>20000</value>
+    <description>
+      The connection backlog in the CDAP Preview service
+    </description>
+  </property>
+
+  <property>
+    <name>preview.exec.threads</name>
+    <value>10</value>
+    <description>
+      The number of executor threads for the preview service
+    </description>
+  </property>
+
+  <property>
+    <name>preview.boss.threads</name>
+    <value>1</value>
+    <description>
+      The number of boss threads for the preview service
+    </description>
+  </property>
+
+  <property>
+    <name>preview.worker.threads</name>
+    <value>10</value>
+    <description>
+      The number of worker threads in the CDAP Router service
+    </description>
+  </property>
+
+  <property>
     <name>service.retry.policy.base.delay.ms</name>
     <value>100</value>
     <description>

--- a/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/PreviewServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/PreviewServiceMain.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.environment.k8s;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.AuthorizationModule;
+import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
+import co.cask.cdap.app.guice.UnsupportedExploreClient;
+import co.cask.cdap.app.preview.PreviewHttpModule;
+import co.cask.cdap.app.preview.PreviewHttpServer;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.common.logging.ServiceLoggingContext;
+import co.cask.cdap.data.runtime.DataSetServiceModules;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data2.audit.AuditModule;
+import co.cask.cdap.explore.client.ExploreClient;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
+import co.cask.cdap.metadata.MetadataReaderWriterModules;
+import co.cask.cdap.metadata.MetadataServiceModule;
+import co.cask.cdap.metrics.guice.MetricsStoreModule;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.guice.SecureStoreServerModule;
+import com.google.common.util.concurrent.Service;
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * The main class to run the preview service.
+ */
+public class PreviewServiceMain extends AbstractServiceMain {
+
+  /**
+   * Main entry point
+   */
+  public static void main(String[] args) throws Exception {
+    main(PreviewServiceMain.class, args);
+  }
+
+  @Override
+  protected List<Module> getServiceModules() {
+    return Arrays.asList(
+      new PreviewHttpModule().getDistributedModules(),
+      new DataSetServiceModules().getStandaloneModules(),
+      new DataSetsModules().getStandaloneModules(),
+      new AppFabricServiceRuntimeModule().getStandaloneModules(),
+      new ProgramRunnerRuntimeModule().getStandaloneModules(),
+      new MetricsStoreModule(),
+      new MessagingClientModule(),
+      new AuditModule(),
+      new SecureStoreServerModule(),
+      new MetadataReaderWriterModules().getStandaloneModules(),
+      getDataFabricModule(),
+      new MetadataServiceModule(),
+      new AuthorizationModule(),
+      new AuthorizationEnforcementModule().getMasterModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(ExploreClient.class).to(UnsupportedExploreClient.class);
+        }
+      }
+    );
+  }
+
+  @Override
+  protected void addServices(Injector injector, List<? super Service> services,
+                             List<? super AutoCloseable> closeableResources) {
+    services.add(injector.getInstance(MetricsCollectionService.class));
+    services.add(injector.getInstance(PreviewHttpServer.class));
+  }
+
+  @Nullable
+  @Override
+  protected LoggingContext getLoggingContext() {
+    return new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
+                                     Constants.Logging.COMPONENT_NAME,
+                                     Constants.Service.PREVIEW_HTTP);
+  }
+}

--- a/cdap-master/src/test/java/co/cask/cdap/master/environment/app/PreviewTestApp.java
+++ b/cdap-master/src/test/java/co/cask/cdap/master/environment/app/PreviewTestApp.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.environment.app;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.customaction.AbstractCustomAction;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+
+/**
+ * An app with a workflow that just writes a single tracer value. Used to test preview.
+ */
+public class PreviewTestApp extends AbstractApplication {
+  public static final String TRACER_NAME = "trace";
+  public static final String TRACER_KEY = "k";
+  public static final String TRACER_VAL = "v";
+
+  @Override
+  public void configure() {
+    addWorkflow(new TestWorkflow());
+  }
+
+  /**
+   * Workflow that has a single action that writes to a tracer.
+   */
+  public static class TestWorkflow extends AbstractWorkflow {
+    public static final String NAME = TestWorkflow.class.getSimpleName();
+
+    @Override
+    protected void configure() {
+      setName(NAME);
+      addAction(new TracerWriter());
+    }
+  }
+
+  /**
+   * Writes a value to the tracer.
+   */
+  public static class TracerWriter extends AbstractCustomAction {
+
+    @Override
+    public void run() {
+      getContext().getDataTracer(TRACER_NAME).info(TRACER_KEY, TRACER_VAL);
+    }
+  }
+}

--- a/cdap-master/src/test/java/co/cask/cdap/master/environment/k8s/PreviewServiceMainTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/master/environment/k8s/PreviewServiceMainTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.environment.k8s;
+
+import co.cask.cdap.api.artifact.ArtifactSummary;
+import co.cask.cdap.app.preview.PreviewStatus;
+import co.cask.cdap.common.test.AppJarHelper;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
+import co.cask.cdap.master.environment.app.PreviewTestApp;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.preview.PreviewConfig;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.common.ContentProvider;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequestConfig;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit test for {@link AppFabricServiceMain}.
+ */
+public class PreviewServiceMainTest extends MasterServiceMainTestBase {
+  private static final Gson GSON = new Gson();
+
+  @Test
+  public void testPreviewService() throws Exception {
+
+    // Deploy the app artifact
+    LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFolder());
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, PreviewTestApp.class);
+
+    String artifactName = PreviewTestApp.class.getSimpleName();
+    String artifactVersion = "1.0.0-SNAPSHOT";
+
+    HttpRequestConfig requestConfig = new HttpRequestConfig(0, 0);
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", artifactName)).toURL();
+    HttpResponse response = HttpRequests.execute(
+      HttpRequest.post(url)
+        .withBody((ContentProvider<? extends InputStream>) appJar::getInputStream)
+        .addHeader("Artifact-Version", artifactVersion)
+        .build(), requestConfig);
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+
+    // have to stop AppFabric so that Preview can share the same leveldb table
+    AppFabricServiceMain appFabricServiceMain = getServiceMainInstance(AppFabricServiceMain.class);
+    appFabricServiceMain.stop();
+    appFabricServiceMain.getInjector().getInstance(LevelDBTableService.class).close();
+    // start preview service with the same data dir as app-fabric, so that the artifact info is still there.
+    runMain(PreviewServiceMain.class, AppFabricServiceMain.class.getSimpleName());
+
+    // create a preview run
+    url = getRouterBaseURI().resolve("/v3/namespaces/default/previews").toURL();
+    ArtifactSummary artifactSummary = new ArtifactSummary(artifactName, artifactVersion);
+    PreviewConfig previewConfig = new PreviewConfig(PreviewTestApp.TestWorkflow.NAME, ProgramType.WORKFLOW,
+                                                    Collections.emptyMap(), 2);
+    AppRequest appRequest = new AppRequest<>(artifactSummary, null, previewConfig);
+    response = HttpRequests.execute(HttpRequest.post(url).withBody(GSON.toJson(appRequest)).build(), requestConfig);
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    ApplicationId previewId = GSON.fromJson(response.getResponseBodyAsString(), ApplicationId.class);
+
+    URL statusUrl = getRouterBaseURI()
+      .resolve(String.format("/v3/namespaces/default/previews/%s/status", previewId.getApplication())).toURL();
+    Tasks.waitFor(PreviewStatus.Status.COMPLETED, () -> {
+      HttpResponse statusResponse = HttpRequests.execute(HttpRequest.get(statusUrl).build(), requestConfig);
+      PreviewStatus previewStatus = GSON.fromJson(statusResponse.getResponseBodyAsString(), PreviewStatus.class);
+      return previewStatus.getStatus();
+    }, 2, TimeUnit.MINUTES);
+
+    url = getRouterBaseURI()
+      .resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
+                             previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
+    response = HttpRequests.execute(HttpRequest.get(url).build(), requestConfig);
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
+                                                         new TypeToken<Map<String, List<String>>>() { }.getType());
+    Assert.assertEquals(Collections.singletonMap(PreviewTestApp.TRACER_KEY,
+                                                 Collections.singletonList(PreviewTestApp.TRACER_VAL)),
+                        tracerData);
+  }
+}

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -22,6 +22,7 @@ import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.MonitorHandlerModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.preview.PreviewHttpModule;
+import co.cask.cdap.app.preview.PreviewHttpServer;
 import co.cask.cdap.app.store.ServiceStore;
 import co.cask.cdap.common.ServiceBindException;
 import co.cask.cdap.common.app.MainClassLoader;
@@ -138,6 +139,7 @@ public class StandaloneMain {
   private final MetadataSubscriberService metadataSubscriberService;
   private final LevelDBTableService levelDBTableService;
   private final SecureStoreService secureStoreService;
+  private final PreviewHttpServer previewHttpServer;
 
   private ExternalAuthenticationServer externalAuthenticationServer;
   private ExploreExecutorService exploreExecutorService;
@@ -166,6 +168,7 @@ public class StandaloneMain {
     remoteExecutionTwillRunnerService = injector.getInstance(Key.get(TwillRunnerService.class,
                                                                      Constants.AppFabric.RemoteExecution.class));
     metadataSubscriberService = injector.getInstance(MetadataSubscriberService.class);
+    previewHttpServer = injector.getInstance(PreviewHttpServer.class);
 
     if (cConf.getBoolean(DISABLE_UI, false)) {
       userInterfaceService = null;
@@ -255,6 +258,7 @@ public class StandaloneMain {
       throw new Exception("Failed to start Application Fabric");
     }
 
+    previewHttpServer.startAndWait();
     metricsQueryService.startAndWait();
     logQueryService.startAndWait();
     router.startAndWait();
@@ -311,6 +315,7 @@ public class StandaloneMain {
       metadataService.stopAndWait();
       remoteExecutionTwillRunnerService.stop();
       serviceStore.stopAndWait();
+      previewHttpServer.stopAndWait();
       // app fabric will also stop all programs
       appFabricServer.stopAndWait();
       // all programs are stopped: dataset service, metrics, transactions can stop now

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -427,6 +427,7 @@ public class TestBase {
     cConf.set(Constants.Security.AUTH_SERVER_BIND_ADDRESS, localhost);
     cConf.set(Constants.Explore.SERVER_ADDRESS, localhost);
     cConf.set(Constants.Metadata.SERVICE_BIND_ADDRESS, localhost);
+    cConf.set(Constants.Preview.ADDRESS, localhost);
 
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, localDataDir.getAbsolutePath());
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);


### PR DESCRIPTION
Created a PreviewServiceMain that is very similar to AppFabricMain
except it uses standalone program runners instead of the distributed
ones. Created a PreviewHttpServer that runs the PreviewHttpHandler
instead of having AppFabricServer run it.

Distributed CDAP will temporarily not support preview until it is
added back as a master service.