### PR TITLE
CDAP-14961 make sql connection pool size configurable

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -436,14 +436,15 @@ public final class Constants {
     public static final String DATA_STORAGE_IMPLEMENTATION = "data.storage.implementation";
     public static final String DATA_STORAGE_NOSQL = "nosql";
     public static final String DATA_STORAGE_SQL = "postgresql";
-    public static final String DATA_STORAGE_SQL_DRIVER_DIRECTORY = "data.storage.sql.driver.directory";
+    public static final String DATA_STORAGE_SQL_DRIVER_DIRECTORY = "data.storage.sql.jdbc.driver.directory";
     public static final String DATA_STORAGE_SQL_JDBC_DRIVER_NAME = "data.storage.sql.jdbc.driver.name";
 
     // the jdbc connection related properties should be from cdap-security.xml
     public static final String DATA_STORAGE_SQL_JDBC_CONNECTION_URL = "data.storage.sql.jdbc.connection.url";
-    public static final String DATA_STORAGE_SQL_USERNAME = "data.storage.sql.username";
-    public static final String DATA_STORAGE_SQL_PASSWORD = "data.storage.sql.password";
-    public static final String DATA_STORAGE_SQL_PROPERTY_PREFIX = "data.storage.sql.property.";
+    public static final String DATA_STORAGE_SQL_USERNAME = "data.storage.sql.jdbc.username";
+    public static final String DATA_STORAGE_SQL_PASSWORD = "data.storage.sql.jdbc.password";
+    public static final String DATA_STORAGE_SQL_PROPERTY_PREFIX = "data.storage.sql.jdbc.property.";
+    public static final String DATA_STORAGE_SQL_CONNECTION_SIZE = "data.storage.sql.jdbc.connection.pool.size";
 
     // used for Guice named bindings
     public static final String TABLE_TYPE = "table.type";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -735,7 +735,7 @@
   </property>
 
   <property>
-    <name>data.storage.sql.driver.directory</name>
+    <name>data.storage.sql.jdbc.driver.directory</name>
     <value></value>
     <description>
       The sql driver directory which contains the driver jar and
@@ -761,8 +761,16 @@
       The jdbc url to connect to the sql instance. No sensitive information
       should be provided using the jdbc url. The username and password can
       be specified in cdap-security.xml. For non-sensitive properties, it can be
-      specified by adding a property with name prefixed with "data.storage.sql.property.",
+      specified by adding a property with name prefixed with "data.storage.sql.jdbc.property.",
       followed by the sql property name.
+    </description>
+  </property>
+
+  <property>
+    <name>data.storage.sql.jdbc.connection.pool.size</name>
+    <value>800</value>
+    <description>
+      The max number of connections for the sql connection pool.
     </description>
   </property>
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14961
Build: https://builds.cask.co/browse/CDAP-DUT6860-1

The default connection pool only has 8 total connections allowed, which is too small. Changing the config to make the pool size configurable.