### PR TITLE
[CDAP-14963] Test and fix behavior when Elasticsearch scroll times out

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2018 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2018 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchResults.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Cask Data, Inc.
+ * Copyright 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/AuditMetadataStorageTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/AuditMetadataStorageTest.java
@@ -150,6 +150,11 @@ public class AuditMetadataStorageTest extends MetadataStorageTest {
     return storage;
   }
 
+  @Override
+  protected void validateCursor(String cursor, int expectedOffset, int expectedPageSize) {
+    // no-op - this is tested in DatasetMetadataStorageTest
+  }
+
   @Test
   public void testPublishing() throws IOException {
     generateMetadataUpdates();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
@@ -112,6 +112,13 @@ public class DatasetMetadataStorageTest extends MetadataStorageTest {
     return storage;
   }
 
+  @Override
+  protected void validateCursor(String cursor, int expectedOffset, int expectedPageSize) {
+    Cursor c = Cursor.fromString(cursor);
+    Assert.assertEquals(expectedOffset, c.getOffset());
+    Assert.assertEquals(expectedPageSize, c.getPageSize());
+  }
+
   // this tests is not in MetadataStorageTest,
   // because it tests result scoring and sorting specific to the dataset-based implementation
   @Test

--- a/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
+++ b/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
@@ -44,6 +44,7 @@ import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import org.apache.http.HttpHost;
 import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -624,8 +625,13 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
     if (request.isCursorRequested()) {
       scrollRequest.scroll(scrollTimeout);
     }
-    SearchResponse searchResponse =
-      client.scroll(scrollRequest, RequestOptions.DEFAULT);
+    SearchResponse searchResponse;
+    try {
+      searchResponse = client.scroll(scrollRequest, RequestOptions.DEFAULT);
+    } catch (ElasticsearchStatusException e) {
+      // scroll invalid or timed out
+      return doSearch(request, cursor.getOffset(), cursor.getPageSize());
+    }
     if (searchResponse.isTimedOut()) {
       // scroll had expired, we have to search again
       return doSearch(request, cursor.getOffset(), cursor.getPageSize());
@@ -660,8 +666,8 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
       client.search(searchRequest, RequestOptions.DEFAULT);
     SearchHits hits = searchResponse.getHits();
     List<MetadataRecord> results = fromHits(hits);
-    String newCursor = computeCursor(searchResponse, request.getOffset(), request.getLimit());
-    return new co.cask.cdap.spi.metadata.SearchResponse(request, newCursor, offset, request.getLimit(),
+    String newCursor = computeCursor(searchResponse, offset, limit);
+    return new co.cask.cdap.spi.metadata.SearchResponse(request, newCursor, offset, limit,
                                                         (int) hits.getTotalHits(), results);
   }
 

--- a/cdap-metadata-spi/src/test/java/co.cask.cdap.spi.metadata/MetadataStorageTest.java
+++ b/cdap-metadata-spi/src/test/java/co.cask.cdap.spi.metadata/MetadataStorageTest.java
@@ -1223,7 +1223,7 @@ public abstract class MetadataStorageTest {
   @Nullable
   private String validateCursorAndOffset(MetadataStorage mds,
                                          int offset, int limit, String cursor, boolean requestCursor,
-                                         int expectedReults, int expectedOffset, int expectedLimit,
+                                         int expectedResults, int expectedOffset, int expectedLimit,
                                          boolean expectMore, boolean expectCursor)
     throws IOException {
     SearchResponse response = mds.search(SearchRequest.of("*")
@@ -1231,13 +1231,25 @@ public abstract class MetadataStorageTest {
                                            .setOffset(offset).setLimit(limit)
                                            .setCursor(cursor).setCursorRequested(requestCursor)
                                            .build());
-    Assert.assertEquals(expectedReults, response.getResults().size());
+    Assert.assertEquals(expectedResults, response.getResults().size());
     Assert.assertEquals(expectedOffset, response.getOffset());
     Assert.assertEquals(expectedLimit, response.getLimit());
     Assert.assertEquals(expectMore, response.getTotalResults() > response.getOffset() + response.getResults().size());
     Assert.assertEquals(expectCursor, null != response.getCursor());
+    if (expectCursor) {
+      validateCursor(response.getCursor(), expectedOffset + expectedLimit, expectedLimit);
+    }
     return response.getCursor();
   }
+
+  /**
+   * Subclasses must override this with implementation-specific code
+   * to validate that the new cursor reflects the correct offset and page size:
+   *
+   * @param expectedOffset the expected offset of the cursor
+   * @param expectedPageSize the expected pagesize/limit of the cursor
+   */
+  protected abstract void validateCursor(String cursor, int expectedOffset, int expectedPageSize);
 
   private static class NoDupRandom {
     private final Random random = new Random(System.currentTimeMillis());

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithMetadataPrograms.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithMetadataPrograms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
adds a test and fixes the failure. Contrary to its documentation, ElasticSearch throws an exception when a scroll has timed out. So we have to handle that in the code. 