### PR TITLE
(CDAP-14645) Couple fixes for the Kubernetes runtime

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -802,27 +802,6 @@
                   </resources>
                 </configuration>
               </execution>
-              <!-- Copy Spark 2, and includes the spark-assembly -->
-              <execution>
-                <id>copy-spark2-assembly</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration combine.self="override">
-                  <outputDirectory>${stage.runtime.ext.dir}/${spark2.artifacts.dir}</outputDirectory>
-                  <resources>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-spark-core2_2.11/target/libexec
-                      </directory>
-                      <includes>
-                        <include>co.cask.cdap.spark-assembly*.jar</include>
-                      </includes>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
           <plugin>
@@ -830,22 +809,18 @@
             <artifactId>maven-dependency-plugin</artifactId>
             <version>2.8</version>
             <executions>
-              <!-- Copy Hadoop dependencies -->
+              <!--
+                Need to override the copy-dependencies to exclude Kafka and Scala in K8s build, but to include Hadoop
+              -->
               <execution>
-                <id>copy-hadoop-dependencies</id>
+                <id>copy-dependencies</id>
                 <phase>prepare-package</phase>
                 <goals>
                   <goal>copy-dependencies</goal>
                 </goals>
-                <configuration>
-                  <outputDirectory>${stage.hadoop.lib.dir}</outputDirectory>
-                  <overWriteReleases>false</overWriteReleases>
-                  <overWriteSnapshots>false</overWriteSnapshots>
-                  <overWriteIfNewer>true</overWriteIfNewer>
-                  <includeGroupIds>org.apache.hadoop</includeGroupIds>
-                  <prependGroupId>true</prependGroupId>
-                  <silent>true</silent>
-                  <includeScope>compile</includeScope>
+                <configuration combine.self="append">
+                  <excludeGroupIds>org.apache.hbase,org.apache.hive,com.google.protobuf,\
+                    org.datanucleus,asm,org.apache.spark,slf4j-log4j12,org.scala-lang,org.apache.kafka</excludeGroupIds>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/AbstractServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/AbstractServiceMain.java
@@ -59,6 +59,7 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -121,6 +122,9 @@ public abstract class AbstractServiceMain extends DaemonMain {
   @Override
   public final void init(String[] args) throws MalformedURLException {
     LOG.info("Initializing master service class {}", getClass().getName());
+
+    // Intercept JUL loggers
+    SLF4JBridgeHandler.install();
 
     ConfigOptions opts = new ConfigOptions();
     OptionsParser.init(opts, args, getClass().getSimpleName(), ProjectInfo.getVersion().toString(), System.out);

--- a/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/StorageMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/StorageMain.java
@@ -88,7 +88,9 @@ public class StorageMain {
     }
 
     // Create metadata tables
-    injector.getInstance(MetadataStorage.class).createIndex();
+    try (MetadataStorage metadataStorage = injector.getInstance(MetadataStorage.class)) {
+      metadataStorage.createIndex();
+    }
     injector.getInstance(LevelDBTableService.class).close();
 
     LOG.info("Storage creation completed");


### PR DESCRIPTION
- Change cdap-master packaging to not to include spark-assembly jar
- Exclude Kafka and Scala in k8s build
- Fix StorageMain to have MetadataStorage closed after used