### PR TITLE
(CDAP-14645) Fix the dependency copy for Hadoop yarn classes

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -82,7 +82,7 @@ case ${1} in
   config-tool) shift; cdap_config_tool ${@}; __ret=${?} ;;
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   version) shift; cdap_version_command ${@}; __ret=${?} ;;
-  run) shift; cdap_run_class ${@}; __ret=${?} ;;
+  run) shift; cdap_exec_class ${@}; __ret=${?} ;;
   sandbox) shift; cdap_sdk ${@}; __ret=${?} ;;
   setup) shift; cdap_setup ${@}; __ret=${?} ;;
   debug) shift; cdap_debug ${@}; __ret=${?} ;;

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -144,10 +144,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -771,6 +767,31 @@
           <artifactId>cdap-kubernetes</artifactId>
           <version>${project.version}</version>
           <scope>provided</scope>
+        </dependency>
+
+        <!--
+          Couple hadoop dependencies in non provided scope in order for copy-dependencies.
+          They are needed in K8s environment
+        -->
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-auth</artifactId>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-api</artifactId>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-client</artifactId>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-common</artifactId>
+          <scope>compile</scope>
         </dependency>
       </dependencies>
 


### PR DESCRIPTION
- Also added a cdap_exec_class() to the shell script to support graceful shutdown