### PR TITLE
CDAP-14998 fix DatasetRuntimeContext leak

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/internal/dataset/DatasetRuntimeContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/dataset/DatasetRuntimeContext.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 /**
  * The internal context object used by the Dataset framework to track Dataset methods.
  */
-public abstract class DatasetRuntimeContext {
+public abstract class DatasetRuntimeContext implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(DatasetRuntimeContext.class);
   private static final ThreadLocal<DatasetRuntimeContext> CONTEXT_THREAD_LOCAL = new InheritableThreadLocal<>();
@@ -54,6 +54,11 @@ public abstract class DatasetRuntimeContext {
 
       @Override
       public void onMethodExit() {
+        // no-op
+      }
+
+      @Override
+      public void close() {
         // no-op
       }
     };
@@ -104,4 +109,7 @@ public abstract class DatasetRuntimeContext {
    */
   @SuppressWarnings("unused")
   public abstract void onMethodExit();
+  
+  @Override
+  public abstract void close();
 }


### PR DESCRIPTION
Fixed a memory leak caused by the DefaultDatasetRuntimeContext.
The context uses a ThreadLocal variable, which means every time
an instance is created, another ThreadLocal instance gets added
to the Thread's local map. These variables were never getting
removed, which means long running threads would continually
accumulate these variables until running out of memory.

Made the DatasetRuntimeContext implement Closeable and made sure
datasets always close the runtime context when the dataset is
closed. The DefaultDataRuntimeContext then removes the thread
local variable in its close method, preventing the leak.