### PR TITLE
CDAP-14964 stop tx service if using sql

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramContainerModule.java
@@ -30,6 +30,7 @@ import co.cask.cdap.common.namespace.NamespacePathLocator;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NoLookupNamespacePathLocator;
 import co.cask.cdap.common.namespace.guice.NamespaceQueryAdminModule;
+import co.cask.cdap.data.runtime.ConstantTransactionSystemClient;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/master/environment/k8s/AbstractServiceMain.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/master/environment/k8s/AbstractServiceMain.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.master.environment.k8s;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.app.guice.ConstantTransactionSystemClient;
 import co.cask.cdap.common.app.MainClassLoader;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -27,6 +26,7 @@ import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.options.OptionsParser;
 import co.cask.cdap.common.runtime.DaemonMain;
 import co.cask.cdap.common.utils.ProjectInfo;
+import co.cask.cdap.data.runtime.ConstantTransactionSystemClient;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data2.transaction.DelegatingTransactionSystemClientService;
 import co.cask.cdap.data2.transaction.TransactionSystemClientService;

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -393,6 +393,9 @@ public final class Constants {
    * Transactions.
    */
   public static final class Transaction {
+
+    public static final String TX_ENABLED = "data.tx.enabled";
+
     /**
      * Twill Runnable configuration.
      */

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -790,6 +790,14 @@
   </property>
 
   <property>
+    <name>data.tx.enabled</name>
+    <value>true</value>
+    <description>
+      Determines if the transaction service is enabled.
+    </description>
+  </property>
+
+  <property>
     <name>data.tx.bind.address</name>
     <value>0.0.0.0</value>
     <description>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/AbstractTransactionSystemClientProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/AbstractTransactionSystemClientProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.runtime;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import com.google.inject.Provider;
+import org.apache.tephra.TransactionSystemClient;
+
+/**
+ * Class to provide the {@link TransactionSystemClient}.
+ */
+abstract class AbstractTransactionSystemClientProvider implements Provider<TransactionSystemClient> {
+  private final CConfiguration cConf;
+
+  AbstractTransactionSystemClientProvider(CConfiguration cConf) {
+    this.cConf = cConf;
+  }
+
+  @Override
+  public TransactionSystemClient get() {
+    if (cConf.getBoolean(Constants.Transaction.TX_ENABLED)) {
+      return getTransactionSystemClient();
+    }
+
+    // return an constant transation client if tx is disabled
+    return new ConstantTransactionSystemClient();
+  }
+
+  /**
+   * @return the transaction system client for the transaction service
+   */
+  protected abstract TransactionSystemClient getTransactionSystemClient();
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/ConstantTransactionSystemClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/ConstantTransactionSystemClient.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.app.guice;
+package co.cask.cdap.data.runtime;
 
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TransactionSystemClient;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricLevelDBModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricLevelDBModule.java
@@ -21,9 +21,21 @@ import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.data2.transaction.metrics.TransactionManagerMetricsCollector;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
-import com.google.inject.util.Modules;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
+import org.apache.tephra.DefaultTransactionExecutor;
+import org.apache.tephra.TransactionExecutor;
+import org.apache.tephra.TransactionExecutorFactory;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.TxConstants;
 import org.apache.tephra.metrics.MetricsCollector;
-import org.apache.tephra.runtime.TransactionModules;
+import org.apache.tephra.persist.LocalFileTransactionStateStorage;
+import org.apache.tephra.persist.TransactionStateStorage;
+import org.apache.tephra.runtime.TransactionStateStorageProvider;
+import org.apache.tephra.snapshot.SnapshotCodecProvider;
+
+import java.lang.management.ManagementFactory;
 
 /**
  * DataFabricLocalModule defines the Local/HyperSQL bindings for the data fabric.
@@ -36,13 +48,24 @@ public class DataFabricLevelDBModule extends AbstractModule {
 
     // bind transactions
     bind(TransactionSystemClientService.class).to(DelegatingTransactionSystemClientService.class);
-    install(Modules.override(new TransactionModules().getSingleNodeModules()).with(new AbstractModule() {
-      @Override
-      protected void configure() {
-        // Binds the tephra MetricsCollector to the one that emit metrics via MetricsCollectionService
-        bind(MetricsCollector.class).to(TransactionManagerMetricsCollector.class).in(Scopes.SINGLETON);
-      }
-    }));
+
+    bind(SnapshotCodecProvider.class).in(Scopes.SINGLETON);
+    bind(TransactionStateStorage.class).annotatedWith(Names.named("persist"))
+      .to(LocalFileTransactionStateStorage.class).in(Scopes.SINGLETON);
+    bind(TransactionStateStorage.class).toProvider(TransactionStateStorageProvider.class).in(Scopes.SINGLETON);
+    bind(TransactionManager.class).in(Scopes.SINGLETON);
+
+    bindConstant().annotatedWith(Names.named(TxConstants.CLIENT_ID)).to(ManagementFactory.getRuntimeMXBean().getName());
+
+    install(new FactoryModuleBuilder()
+              .implement(TransactionExecutor.class, DefaultTransactionExecutor.class)
+              .build(TransactionExecutorFactory.class));
+
+    // Binds the tephra MetricsCollector to the one that emit metrics via MetricsCollectionService
+    bind(MetricsCollector.class).to(TransactionManagerMetricsCollector.class).in(Scopes.SINGLETON);
+    bind(TransactionSystemClient.class).toProvider(
+      DataFabricInMemoryModule.InMemoryTransactionSystemClientProvider.class).in(Scopes.SINGLETON);
+
     install(new TransactionExecutorModule());
     install(new StorageModule());
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/preview/PreviewDataModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/preview/PreviewDataModules.java
@@ -34,7 +34,7 @@ import co.cask.cdap.data2.registry.UsageWriter;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.cdap.spi.metadata.MetadataStorage;
-import co.cask.cdap.spi.metadata.dataset.DatasetMetadataStorage;
+import co.cask.cdap.spi.metadata.noop.NoopMetadataStorage;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Module;
@@ -70,7 +70,7 @@ public class PreviewDataModules {
         bind(DatasetDefinitionRegistryFactory.class)
           .to(DefaultDatasetDefinitionRegistryFactory.class).in(Scopes.SINGLETON);
 
-        bind(MetadataStorage.class).to(DatasetMetadataStorage.class);
+        bind(MetadataStorage.class).to(NoopMetadataStorage.class);
         expose(MetadataStorage.class);
 
         bind(DatasetFramework.class)

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
@@ -153,16 +153,18 @@ public class MasterTwillApplication implements TwillApplication {
       addMessaging(
         addDatasetOpExecutor(
           addLogSaverService(
-            addTransactionService(
-              addMetricsProcessor (
-                addMetricsService(
-                  TwillSpecification.Builder.with().setName(NAME).withRunnable()
-                )
+            addMetricsProcessor (
+              addMetricsService(
+                TwillSpecification.Builder.with().setName(NAME).withRunnable()
               )
             )
           )
         )
       );
+
+    if (cConf.getBoolean(Constants.Transaction.TX_ENABLED)) {
+      runnableSetter = addTransactionService(runnableSetter);
+    }
 
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       LOG.info("Adding explore runnable.");
@@ -171,10 +173,10 @@ public class MasterTwillApplication implements TwillApplication {
       LOG.info("Explore module disabled - will not launch explore runnable.");
     }
     return runnableSetter
-        .withOrder()
-          .begin(Constants.Service.MESSAGING_SERVICE, Constants.Service.TRANSACTION, Constants.Service.DATASET_EXECUTOR)
-        .withEventHandler(new AbortOnTimeoutEventHandler(noContainerTimeout))
-        .build();
+      .withOrder()
+      .begin(Constants.Service.MESSAGING_SERVICE, Constants.Service.TRANSACTION, Constants.Service.DATASET_EXECUTOR)
+      .withEventHandler(new AbortOnTimeoutEventHandler(noContainerTimeout))
+      .build();
   }
 
   private Builder.RunnableSetter addLogSaverService(Builder.MoreRunnable builder) {

--- a/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/StorageMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/StorageMain.java
@@ -16,11 +16,11 @@
 
 package co.cask.cdap.master.environment.k8s;
 
-import co.cask.cdap.app.guice.ConstantTransactionSystemClient;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DFSLocationModule;
 import co.cask.cdap.common.guice.InMemoryDiscoveryModule;
+import co.cask.cdap.data.runtime.ConstantTransactionSystemClient;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.StorageModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14964
build: https://builds.cask.co/browse/CDAP-DUT6895-1
https://builds.cask.co/browse/IT-ITM-132

Disable the transaction service running if the storage option is sql. Bind a ConstantTransactionSystemClient to provide no-op if a program attempts to start a transaction.