### PR TITLE
[CDAP-15007] Make MetadataAdmin and HttpHandler uniformly return Metadata objects

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataReader.java
@@ -56,7 +56,7 @@ public class DefaultMetadataReader implements MetadataReader {
   @Override
   public Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) throws MetadataException {
     try {
-      return MetadataCompatibility.toV5Metadata(metadataAdmin.getMetadata(scope, metadataEntity), scope);
+      return MetadataCompatibility.toV5Metadata(metadataAdmin.getMetadata(metadataEntity, scope), scope);
     } catch (IOException e) {
       throw new MetadataException(e);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/FieldLineageAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/FieldLineageAdmin.java
@@ -107,9 +107,8 @@ public class FieldLineageAdmin {
     Set<Field> result = createFields(lineageFields, true);
     if (includeCurrent) {
       // get the system properties of this dataset
-      Map<String, String> properties = metadataAdmin.getProperties(MetadataScope.SYSTEM,
-                                                                   MetadataEntity.ofDataset(endPoint.getNamespace(),
-                                                                                            endPoint.getName()));
+      Map<String, String> properties = metadataAdmin
+        .getProperties(MetadataScope.SYSTEM, MetadataEntity.ofDataset(endPoint.getNamespace(), endPoint.getName()));
       // the system metadata contains the schema of the dataset which is written by the DatasetSystemMetadataWriter
       if (properties.containsKey(MetadataConstants.SCHEMA_KEY)) {
         String schema = properties.get(MetadataConstants.SCHEMA_KEY);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -20,12 +20,14 @@ import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.common.InvalidMetadataException;
 import co.cask.cdap.spi.metadata.Metadata;
+import co.cask.cdap.spi.metadata.MetadataKind;
 import co.cask.cdap.spi.metadata.SearchRequest;
 import co.cask.cdap.spi.metadata.SearchResponse;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Interface that the {@link MetadataHttpHandler} uses to interact with Metadata.
@@ -64,7 +66,17 @@ public interface MetadataAdmin {
    * Returns the metadata (including properties and tags) for the specified {@link MetadataEntity}
    * in the specified {@link MetadataScope}.
    */
-  Metadata getMetadata(MetadataScope scope, MetadataEntity metadataEntity) throws IOException;
+  Metadata getMetadata(MetadataEntity metadataEntity, MetadataScope scope) throws IOException;
+
+  /**
+   * Returns the metadata of specified kind (properties or tags) for the specified {@link MetadataEntity}
+   * in the specified {@link MetadataScope}.
+   *
+   * @param scope the scope to address, or null for all scopes
+   * @param kind the kind of metadata to select, or null for all metadata
+   */
+  Metadata getMetadata(MetadataEntity entity, @Nullable MetadataScope scope, @Nullable MetadataKind kind)
+    throws IOException;
 
   /**
    * @return a {@link Map} representing the metadata of the specified {@link MetadataEntity} in both

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -2929,7 +2929,8 @@ public class DataPipelineTest extends HydratorTestBase {
 
     // verify metadata written by the pipeline
     Metadata actual =
-      metadataAdmin.getMetadata(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"));
+      metadataAdmin.getMetadata(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"),
+                                MetadataScope.USER);
 
     Assert.assertNotNull(actual);
     Assert.assertTrue(!actual.isEmpty());
@@ -2946,7 +2947,8 @@ public class DataPipelineTest extends HydratorTestBase {
 
     waitForMetadataProcessing(metadataAdmin, 1);
 
-    actual = metadataAdmin.getMetadata(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"));
+    actual = metadataAdmin.getMetadata(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"),
+                                       MetadataScope.USER);
 
     Assert.assertNotNull(actual);
     Assert.assertTrue(!actual.isEmpty());
@@ -2957,11 +2959,10 @@ public class DataPipelineTest extends HydratorTestBase {
 
   private void waitForMetadataProcessing(MetadataAdmin metadataAdmin, int expectedTagSize)
     throws TimeoutException, InterruptedException, java.util.concurrent.ExecutionException {
-    Tasks.waitFor(true, () -> {
-      Metadata metadata =
-        metadataAdmin.getMetadata(MetadataEntity.ofDataset(NamespaceId.DEFAULT.getNamespace(), "singleInput"));
-      return metadata.getTags(MetadataScope.USER).size() == expectedTagSize;
-    }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    Tasks.waitFor(expectedTagSize, () ->
+                    metadataAdmin.getTags(MetadataScope.USER, MetadataEntity.ofDataset(
+                      NamespaceId.DEFAULT.getNamespace(), "singleInput")).size(),
+                  10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
   }
 
   private void runPipelineForMetadata(MetadataAdmin metadataAdmin,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/MetadataCompatibility.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/MetadataCompatibility.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.metadata;
 
+import co.cask.cdap.api.metadata.MetadataEntity;
 import co.cask.cdap.api.metadata.MetadataScope;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.EntityScope;
@@ -99,13 +100,13 @@ public final class MetadataCompatibility {
    * Convert a {@link Metadata} to a 5.x map from scope to {@link co.cask.cdap.api.metadata.Metadata}.
    */
   public static Set<co.cask.cdap.common.metadata.MetadataRecord>
-  toV5MetadataRecords(MetadataRecord record, @Nullable String requestedScope) {
+  toV5MetadataRecords(MetadataEntity entity, Metadata metadata, @Nullable String requestedScope) {
     Set<co.cask.cdap.common.metadata.MetadataRecord> result = new HashSet<>();
     for (MetadataScope scope : MetadataScope.ALL) {
-      Set<String> tags = record.getMetadata().getTags(scope);
-      Map<String, String> properties = record.getMetadata().getProperties(scope);
       if (requestedScope == null || scope.name().equalsIgnoreCase(requestedScope)) {
-        result.add(new co.cask.cdap.common.metadata.MetadataRecord(record.getEntity(), scope, properties, tags));
+        Set<String> tags = metadata.getTags(scope);
+        Map<String, String> properties = metadata.getProperties(scope);
+        result.add(new co.cask.cdap.common.metadata.MetadataRecord(entity, scope, properties, tags));
       }
     }
     return result;

--- a/cdap-metadata-spi/src/main/java/co.cask.cdap.spi.metadata/Read.java
+++ b/cdap-metadata-spi/src/main/java/co.cask.cdap.spi.metadata/Read.java
@@ -70,8 +70,8 @@ public class Read {
   }
 
   private Read(MetadataEntity entity,
-               MetadataScope scope,
-               MetadataKind kind,
+               @Nullable MetadataScope scope,
+               @Nullable MetadataKind kind,
                Set<ScopedNameOfKind> selection) {
     this.entity = entity;
     this.scopes = scope == null ? MetadataScope.ALL : Collections.singleton(scope);


### PR DESCRIPTION
This streamlines the metadata processing in the UI. The REST API change is only effective for requests that have &responseFormat=v6 and won't affect stability of other clients (such as MetadataClient, CLI, ITN)