### PR TITLE
CDAP-13558 Support CDC pipelines on Spark version 2.x

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockSink.java
@@ -96,8 +96,11 @@ public class MockSink extends BatchSink<StructuredRecord, byte[], Put> {
 
   @Override
   public void transform(StructuredRecord input, Emitter<KeyValue<byte[], Put>> emitter) throws Exception {
-    byte[] prefix = Bytes.toBytes(inputCounter.incrementAndGet());
-    byte[] rowkey = Bytes.concat(prefix, Bytes.toBytes(UUID.randomUUID()));
+    byte[] rowkey = Bytes.concat(
+      Bytes.toBytes(System.currentTimeMillis()),
+      Bytes.toBytes(inputCounter.incrementAndGet()),
+      Bytes.toBytes(UUID.randomUUID())
+    );
     Put put = new Put(rowkey);
     put.add(SCHEMA_COL, input.getSchema().toString());
     put.add(RECORD_COL, StructuredRecordStringConverter.toJsonString(input));


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-13558
WIKI - https://wiki.cask.co/display/CE/CDC+Solution+Enhancements

Those changes are needed for all source plugins where message order is important. Such plugins will work only with 1 executor. Currently it is needed for tests in CDC plugin for SQL Server tracking.

In scope of this PR:
- fixed incoming records order for multiple MockSink instances