### PR TITLE
CDAP-15023 fix nested transactions in subscriber service

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AbstractNotificationSubscriberService.java
@@ -33,7 +33,8 @@ import com.google.gson.Gson;
 import org.apache.tephra.TxConstants;
 
 /**
- * Abstract class that fetches notifications from TMS
+ * Abstract class that fetches notifications from TMS.
+ * No transactions should be started in any of the overrided methods since they are already wrapped in a transaction.
  */
 public abstract class AbstractNotificationSubscriberService extends AbstractMessagingSubscriberService<Notification> {
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/DeprovisionTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/DeprovisionTask.java
@@ -19,12 +19,12 @@ package co.cask.cdap.internal.provision.task;
 
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.internal.provision.ProvisionerNotifier;
-import co.cask.cdap.internal.provision.ProvisionerStore;
 import co.cask.cdap.internal.provision.ProvisioningOp;
 import co.cask.cdap.internal.provision.ProvisioningTaskInfo;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerContext;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
@@ -57,11 +57,11 @@ public class DeprovisionTask extends ProvisioningTask {
   private final ProvisionerNotifier provisionerNotifier;
   private final Location keysDir;
 
-  public DeprovisionTask(ProvisioningTaskInfo initialTaskInfo, ProvisionerStore provisionerStore,
+  public DeprovisionTask(ProvisioningTaskInfo initialTaskInfo, TransactionRunner transactionRunner,
                          int retryTimeLimitSecs, Provisioner provisioner,
                          ProvisionerContext provisionerContext, ProvisionerNotifier provisionerNotifier,
                          LocationFactory locationFactory) {
-    super(initialTaskInfo, provisionerStore, retryTimeLimitSecs);
+    super(initialTaskInfo, transactionRunner, retryTimeLimitSecs);
     this.provisioner = provisioner;
     this.provisionerContext = provisionerContext;
     this.provisionerNotifier = provisionerNotifier;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisionTask.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/provision/task/ProvisionTask.java
@@ -19,12 +19,12 @@ package co.cask.cdap.internal.provision.task;
 
 import co.cask.cdap.app.runtime.ProgramStateWriter;
 import co.cask.cdap.internal.provision.ProvisionerNotifier;
-import co.cask.cdap.internal.provision.ProvisionerStore;
 import co.cask.cdap.internal.provision.ProvisioningOp;
 import co.cask.cdap.internal.provision.ProvisioningTaskInfo;
 import co.cask.cdap.runtime.spi.provisioner.ClusterStatus;
 import co.cask.cdap.runtime.spi.provisioner.Provisioner;
 import co.cask.cdap.runtime.spi.provisioner.ProvisionerContext;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,11 +68,11 @@ public class ProvisionTask extends ProvisioningTask {
   private final ProvisionerNotifier provisionerNotifier;
   private final ProgramStateWriter programStateWriter;
 
-  public ProvisionTask(ProvisioningTaskInfo initialTaskInfo, ProvisionerStore provisionerStore,
+  public ProvisionTask(ProvisioningTaskInfo initialTaskInfo, TransactionRunner transactionRunner,
                        Provisioner provisioner, ProvisionerContext provisionerContext,
                        ProvisionerNotifier provisionerNotifier, ProgramStateWriter programStateWriter,
                        int retryTimeLimitSecs) {
-    super(initialTaskInfo, provisionerStore, retryTimeLimitSecs);
+    super(initialTaskInfo, transactionRunner, retryTimeLimitSecs);
     this.provisioner = provisioner;
     this.provisionerContext = provisionerContext;
     this.provisionerNotifier = provisionerNotifier;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataSubscriberService.java
@@ -83,6 +83,7 @@ import javax.annotation.Nullable;
  * Service responsible for consuming metadata messages from TMS and persist it to metadata store.
  * This is a wrapping service to host multiple {@link AbstractMessagingSubscriberService}s for lineage, usage
  * and metadata subscriptions.
+ * No transactions should be started in any of the overrided methods since they are already wrapped in a transaction.
  */
 public class MetadataSubscriberService extends AbstractMessagingSubscriberService<MetadataMessage> {
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ScheduleNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ScheduleNotificationSubscriberService.java
@@ -116,6 +116,7 @@ public class ScheduleNotificationSubscriberService extends AbstractIdleService {
 
   /**
    * Abstract base class for implementing job queue logic for various kind of notifications.
+   * No transactions should be started in any of the overrided methods since they are already wrapped in a transaction.
    */
   private abstract class AbstractSchedulerSubscriberService extends AbstractNotificationSubscriberService {
 


### PR DESCRIPTION
This pr fixes CDAP-15023, CDAP-15021, CDAP-14909
Build: https://builds.cask.co/browse/CDAP-DUT6900-2/

Fix the nested transaction in subscriber classes. This is mainly in `ProgramNotificationSubcriberService`, when we start a tx in `processMessages`, and the `ProvisioningTask` should have get and put in one transaction, not in separate. 
The `MetadataSubcriberService` already had this fixed.