### PR TITLE
CDAP-15017 fix flaky MetricsClientTest

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetricsClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetricsClientTestRun.java
@@ -82,7 +82,9 @@ public class MetricsClientTestRun extends ClientTestBase {
       Assert.assertEquals(200, response.getResponseCode());
 
       Tasks.waitFor(true, () ->
-        metricsClient.query(MetricsTags.service(service), Constants.Metrics.Name.Service.SERVICE_INPUT)
+        metricsClient.query(MetricsTags.service(service),
+                            Collections.singletonList(Constants.Metrics.Name.Service.SERVICE_INPUT),
+                            Collections.emptyList(), ImmutableMap.of("start", "now-20s", "end", "now"))
           .getSeries().length > 0, 10, TimeUnit.SECONDS);
 
       MetricQueryResult result = metricsClient.query(MetricsTags.service(service),


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15017
Build: https://builds.cask.co/browse/CDAP-DUT6902-1

The test is flaky because: the write to the second resolution table can be the same time as we query for the metrics(where we specify end = "now"), and the query is exclusive for the end time. I guess the flakiness starts to appear now since we now write to the 4 factTables concurrently, which is faster than before. 