### PR TITLE
Implement checkpointing on GCS.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsApp.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableSet;
  * Data Streams Application.
  */
 public class DataStreamsApp extends AbstractApplication<DataStreamsConfig> {
-  public static final String CHECKPOINT_FILESET = "dataStreamsCheckpoints";
 
   @Override
   public void configure() {
@@ -48,9 +47,5 @@ public class DataStreamsApp extends AbstractApplication<DataStreamsConfig> {
       throw new IllegalArgumentException(String.format("Failed to configure pipeline: %s", e.getMessage()), e);
     }
     addSpark(new DataStreamsSparkLauncher(spec));
-
-    if (!config.checkpointsDisabled()) {
-      createDataset(CHECKPOINT_FILESET, FileSet.class);
-    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpec.java
@@ -36,13 +36,15 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
   private final boolean checkpointsDisabled;
   private final boolean isUnitTest;
   private final String checkpointDirectory;
+  private final String pipelineId;
 
   private DataStreamsPipelineSpec(Set<StageSpec> stages, Set<Connection> connections,
                                   Resources resources, Resources driverResources, Resources clientResources,
                                   boolean stageLoggingEnabled, boolean processTimingEnabled, long batchIntervalMillis,
                                   String extraJavaOpts, int numOfRecordsPreview,
                                   boolean stopGracefully, Map<String, String> properties,
-                                  boolean checkpointsDisabled, boolean isUnitTest, String checkpointDirectory) {
+                                  boolean checkpointsDisabled, boolean isUnitTest, String checkpointDirectory,
+                                  String pipelineId) {
     super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, processTimingEnabled,
           numOfRecordsPreview, properties);
     this.batchIntervalMillis = batchIntervalMillis;
@@ -51,6 +53,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     this.checkpointsDisabled = checkpointsDisabled;
     this.isUnitTest = isUnitTest;
     this.checkpointDirectory = checkpointDirectory;
+    this.pipelineId = pipelineId;
   }
 
   public long getBatchIntervalMillis() {
@@ -77,6 +80,10 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     return checkpointDirectory;
   }
 
+  public String getPipelineId() {
+    return pipelineId;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -96,13 +103,14 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       stopGracefully == that.stopGracefully &&
       checkpointsDisabled == that.checkpointsDisabled &&
       isUnitTest == that.isUnitTest &&
-      Objects.equals(checkpointDirectory, that.checkpointDirectory);
+      Objects.equals(checkpointDirectory, that.checkpointDirectory) &&
+      Objects.equals(pipelineId, that.pipelineId);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), batchIntervalMillis, extraJavaOpts,
-                        stopGracefully, checkpointsDisabled, isUnitTest, checkpointDirectory);
+                        stopGracefully, checkpointsDisabled, isUnitTest, checkpointDirectory, pipelineId);
   }
 
   @Override
@@ -114,6 +122,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       ", checkpointsDisabled=" + checkpointsDisabled +
       ", isUnitTest=" + isUnitTest +
       ", checkpointDirectory='" + checkpointDirectory + '\'' +
+      ", pipelineId='" + pipelineId + '\'' +
       "} " + super.toString();
   }
 
@@ -131,13 +140,15 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     private boolean checkpointsDisabled;
     private boolean isUnitTest;
     private String checkpointDirectory;
+    private String pipelineId;
 
     public Builder(long batchIntervalMillis) {
       this.batchIntervalMillis = batchIntervalMillis;
       this.stopGracefully = false;
       this.checkpointsDisabled = false;
       this.isUnitTest = false;
-      this.checkpointDirectory = UUID.randomUUID().toString();
+      this.checkpointDirectory = "";
+      this.pipelineId = UUID.randomUUID().toString();
     }
 
     public Builder setExtraJavaOpts(String extraJavaOpts) {
@@ -170,7 +181,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       return new DataStreamsPipelineSpec(stages, connections, resources, driverResources, clientResources,
                                          stageLoggingEnabled, processTimingEnabled, batchIntervalMillis, extraJavaOpts,
                                          numOfRecordsPreview, stopGracefully, properties,
-                                         checkpointsDisabled, isUnitTest, checkpointDirectory);
+                                         checkpointsDisabled, isUnitTest, checkpointDirectory, pipelineId);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -23,6 +23,7 @@ import co.cask.cdap.etl.common.macro.TimeParser;
 import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
 import co.cask.cdap.etl.spec.PipelineSpecGenerator;
 import co.cask.cdap.etl.validation.InvalidPipelineException;
+import org.apache.hadoop.fs.Path;
 
 import java.util.Set;
 
@@ -53,8 +54,15 @@ public class DataStreamsPipelineSpecGenerator<T extends PluginConfigurer & Datas
       .setStopGracefully(config.getStopGracefully())
       .setIsUnitTest(config.isUnitTest())
       .setCheckpointsDisabled(config.checkpointsDisabled());
-    if (config.getCheckpointDir() != null) {
-      specBuilder.setCheckpointDirectory(config.getCheckpointDir());
+    if (!config.checkpointsDisabled()) {
+      String checkpointDir = config.getCheckpointDir();
+      try {
+        new Path(checkpointDir);
+      } catch (Exception e) {
+        throw new IllegalArgumentException(
+          String.format("Checkpoint directory '%s' is not a valid Path: %s", checkpointDir, e.getMessage()), e);
+      }
+      specBuilder.setCheckpointDirectory(checkpointDir);
     }
     configureStages(config, specBuilder);
     return specBuilder.build();

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,6 @@ import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.spark.AbstractSpark;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
@@ -35,11 +34,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.SparkConf;
-import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -124,39 +121,6 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     }
     context.setSparkConf(sparkConf);
 
-    if (!spec.isCheckpointsDisabled()) {
-      // Each pipeline has its own checkpoint directory within the checkpoint fileset.
-      // Ideally, when a pipeline is deleted, we would be able to delete that checkpoint directory.
-      // This is because we don't want another pipeline created with the same name to pick up the old checkpoint.
-      // Since CDAP has no way to run application logic on deletion, we instead generate a unique pipeline id
-      // and use that as the checkpoint directory as a subdirectory inside the pipeline name directory.
-      // On start, we check for any other pipeline ids for that pipeline name, and delete them if they exist.
-      FileSet checkpointFileSet = context.getDataset(DataStreamsApp.CHECKPOINT_FILESET);
-      String pipelineName = context.getApplicationSpecification().getName();
-      String checkpointDir = spec.getCheckpointDirectory();
-      Location pipelineCheckpointBase = checkpointFileSet.getBaseLocation().append(pipelineName);
-      Location pipelineCheckpointDir = pipelineCheckpointBase.append(checkpointDir);
-
-      if (!ensureDirExists(pipelineCheckpointBase)) {
-        throw new IOException(
-          String.format("Unable to create checkpoint base directory '%s' for the pipeline.", pipelineCheckpointBase));
-      }
-
-      try {
-        for (Location child : pipelineCheckpointBase.list()) {
-          if (!child.equals(pipelineCheckpointDir) && !child.delete(true)) {
-            LOG.warn("Unable to delete checkpoint directory {} from an old pipeline.", child);
-          }
-        }
-      } catch (Exception e) {
-        LOG.warn("Unable to clean up old checkpoint directories from old pipelines.", e);
-      }
-
-      if (!ensureDirExists(pipelineCheckpointDir)) {
-        throw new IOException(
-          String.format("Unable to create checkpoint directory '%s' for the pipeline.", pipelineCheckpointDir));
-      }
-    }
     WRAPPERLOGGER.info("Pipeline '{}' running", context.getApplicationSpecification().getName());
   }
 
@@ -169,9 +133,4 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
                        status == ProgramStatus.COMPLETED ? "succeeded" : status.name().toLowerCase());
 
   }
-
-  private boolean ensureDirExists(Location location) throws IOException {
-    return location.isDirectory() || location.mkdirs() || location.isDirectory();
-  }
-
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,11 +16,7 @@
 
 package co.cask.cdap.datastreams;
 
-import co.cask.cdap.api.Transactionals;
-import co.cask.cdap.api.TxRunnable;
-import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.JavaSparkMain;
 import co.cask.cdap.etl.api.AlertPublisher;
@@ -43,21 +39,27 @@ import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function0;
 import org.apache.spark.streaming.Durations;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
-import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
  * Driver for running pipelines using Spark Streaming.
  */
 public class SparkStreamingPipelineDriver implements JavaSparkMain {
+  private static final Logger LOG = LoggerFactory.getLogger(SparkStreamingPipelineDriver.class);
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
@@ -68,7 +70,6 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
 
   @Override
   public void run(final JavaSparkExecutionContext sec) throws Exception {
-
     final DataStreamsPipelineSpec pipelineSpec = GSON.fromJson(sec.getSpecification().getProperty(Constants.PIPELINEID),
                                                                DataStreamsPipelineSpec.class);
 
@@ -80,26 +81,52 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
     boolean checkpointsDisabled = pipelineSpec.isCheckpointsDisabled();
 
     String checkpointDir = null;
+    JavaSparkContext context = null;
     if (!checkpointsDisabled) {
-      // Get the location of the checkpoint directory.
       String pipelineName = sec.getApplicationSpecification().getName();
-      String relativeCheckpointDir = pipelineSpec.getCheckpointDirectory();
+      Path baseCheckpointDir = new Path(new Path(pipelineSpec.getCheckpointDirectory()), pipelineName);
+      Path checkpointDirPath = new Path(baseCheckpointDir, pipelineSpec.getPipelineId());
+      checkpointDir = checkpointDirPath.toString();
 
-      // there isn't any way to instantiate the fileset except in a TxRunnable, so need to use a reference.
-      final AtomicReference<Location> checkpointBaseRef = new AtomicReference<>();
-      Transactionals.execute(sec, new TxRunnable() {
-        @Override
-        public void run(DatasetContext context) throws Exception {
-          FileSet checkpointFileSet = context.getDataset(DataStreamsApp.CHECKPOINT_FILESET);
-          checkpointBaseRef.set(checkpointFileSet.getBaseLocation());
+      context = new JavaSparkContext();
+      Configuration configuration = context.hadoopConfiguration();
+      // Set the filesystem to whatever the checkpoint directory uses. This is necessary since spark will override
+      // the URI schema with what is set in this config. This needs to happen before StreamingCompat.getOrCreate
+      // is called, since StreamingCompat.getOrCreate will attempt to parse the checkpointDir before calling
+      // context function.
+      configuration.set("fs.defaultFS", checkpointDir);
+      FileSystem fileSystem = FileSystem.get(configuration);
+
+      // Checkpoint directory structure: [directory]/[pipelineName]/[pipelineId]
+      // Ideally, when a pipeline is deleted, we would be able to delete [directory]/[pipelineName].
+      // This is because we don't want another pipeline created with the same name to pick up the old checkpoint.
+      // Since CDAP has no way to run application logic on deletion, we instead generate a unique pipeline id
+      // and use that as the checkpoint directory as a subdirectory inside the pipeline name directory.
+      // On start, we check for any other pipeline ids for that pipeline name, and delete them if they exist.
+      if (!ensureDirExists(fileSystem, baseCheckpointDir)) {
+        throw new IOException(
+          String.format("Unable to create checkpoint base directory '%s' for the pipeline.", baseCheckpointDir));
+      }
+
+      try {
+        for (FileStatus child : fileSystem.listStatus(baseCheckpointDir)) {
+          if (child.isDirectory()) {
+            if (!child.getPath().equals(checkpointDirPath) && !fileSystem.delete(child.getPath(), true)) {
+              LOG.warn("Unable to delete checkpoint directory {} from an old pipeline.", child);
+            }
+          }
         }
-      }, Exception.class);
+      } catch (Exception e) {
+        LOG.warn("Unable to clean up old checkpoint directories from old pipelines.", e);
+      }
 
-      Location pipelineCheckpointDir = checkpointBaseRef.get().append(pipelineName).append(relativeCheckpointDir);
-      checkpointDir = pipelineCheckpointDir.toURI().toString();
+      if (!ensureDirExists(fileSystem, checkpointDirPath)) {
+        throw new IOException(
+          String.format("Unable to create checkpoint directory '%s' for the pipeline.", checkpointDir));
+      }
     }
 
-    JavaStreamingContext jssc = run(pipelineSpec, pipelinePhase, sec, checkpointDir);
+    JavaStreamingContext jssc = run(pipelineSpec, pipelinePhase, sec, checkpointDir, context);
     jssc.start();
 
     boolean stopped = false;
@@ -119,14 +146,15 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
   private JavaStreamingContext run(final DataStreamsPipelineSpec pipelineSpec,
                                    final PipelinePhase pipelinePhase,
                                    final JavaSparkExecutionContext sec,
-                                   @Nullable final String checkpointDir) throws Exception {
-
+                                   @Nullable final String checkpointDir,
+                                   @Nullable final JavaSparkContext context) throws Exception {
     Function0<JavaStreamingContext> contextFunction = new Function0<JavaStreamingContext>() {
       @Override
       public JavaStreamingContext call() throws Exception {
+        JavaSparkContext javaSparkContext = context == null ? new JavaSparkContext() : context;
         JavaStreamingContext jssc = new JavaStreamingContext(
-          new JavaSparkContext(), Durations.milliseconds(pipelineSpec.getBatchIntervalMillis()));
-        SparkStreamingPipelineRunner runner = new SparkStreamingPipelineRunner(sec, jssc, pipelineSpec, 
+          javaSparkContext, Durations.milliseconds(pipelineSpec.getBatchIntervalMillis()));
+        SparkStreamingPipelineRunner runner = new SparkStreamingPipelineRunner(sec, jssc, pipelineSpec,
                                                                                pipelineSpec.isCheckpointsDisabled());
         PipelinePluginContext pluginContext = new PipelinePluginContext(sec.getPluginContext(), sec.getMetrics(),
                                                                         pipelineSpec.isStageLoggingEnabled(),
@@ -142,10 +170,17 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
         }
         if (checkpointDir != null) {
           jssc.checkpoint(checkpointDir);
+          jssc.sparkContext().hadoopConfiguration().set("fs.defaultFS", checkpointDir);
         }
         return jssc;
       }
     };
-    return checkpointDir == null ? contextFunction.call() : StreamingCompat.getOrCreate(checkpointDir, contextFunction);
+    return checkpointDir == null
+      ? contextFunction.call()
+      : StreamingCompat.getOrCreate(checkpointDir, contextFunction, context.hadoopConfiguration());
+  }
+
+  private boolean ensureDirExists(FileSystem fileSystem, Path dir) throws IOException {
+    return fileSystem.isDirectory(dir) || fileSystem.mkdirs(dir) || fileSystem.isDirectory(dir);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsSparkSinkTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsSparkSinkTest.java
@@ -96,6 +96,7 @@ public class DataStreamsSparkSinkTest  extends HydratorTestBase {
       .addStage(new ETLStage("source", MockSource.getPlugin(schema, input)))
       .addStage(new ETLStage("sink", co.cask.cdap.etl.mock.spark.streaming.MockSink.getPlugin("${tablename}")))
       .addConnection("source", "sink")
+      .setCheckpointDir("file://" + TMP_FOLDER.getRoot().toPath().toString())
       .setBatchInterval("1s")
       .build();
 

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
@@ -83,6 +83,7 @@ public class DataStreamsTest extends HydratorTestBase {
   private static final Gson GSON = new Gson();
   private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("app", "1.0.0");
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
+  private static String checkpointDir;
   private static int startCount = 0;
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
@@ -96,6 +97,7 @@ public class DataStreamsTest extends HydratorTestBase {
     }
 
     setupStreamingArtifacts(APP_ARTIFACT_ID, DataStreamsApp.class);
+    checkpointDir = "file://" + TMP_FOLDER.getRoot().toPath().toString();
   }
 
   @Test
@@ -125,6 +127,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("sleep", "filter1")
       .addConnection("filter1", "filter2")
       .addConnection("filter2", "sink")
+      .setCheckpointDir(checkpointDir)
       .setBatchInterval("1s")
       .build();
 
@@ -225,6 +228,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("users1", "dupeFlagger")
       .addConnection("users2", "dupeFlagger")
       .addConnection("dupeFlagger", "sink2")
+      .setCheckpointDir(checkpointDir)
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, pipelineConfig);
@@ -375,6 +379,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("source2", "agg2")
       .addConnection("agg1", "sink1")
       .addConnection("agg2", "sink2")
+      .setCheckpointDir(checkpointDir)
       .disableCheckpoints()
       .build();
 
@@ -477,6 +482,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("agg", "filter")
       .addConnection("filter", "sink")
       .setBatchInterval("1s")
+      .setCheckpointDir(checkpointDir)
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
@@ -606,6 +612,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("t4", "outerjoin")
       .addConnection("outerjoin", "multijoinSink")
       .setBatchInterval("5s")
+      .setCheckpointDir(checkpointDir)
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
@@ -715,6 +722,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("agg2", "errorfilter")
       .addConnection("errorflatten", "sink1")
       .addConnection("errorfilter", "sink2")
+      .setCheckpointDir(checkpointDir)
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
@@ -810,6 +818,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("splitter1", "sink2", "non-null")
       .addConnection("splitter2", "sink1", "null")
       .addConnection("splitter2", "sink2", "non-null")
+      .setCheckpointDir(checkpointDir)
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
@@ -895,6 +904,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("source", "nullAlert")
       .addConnection("nullAlert", "sink")
       .addConnection("nullAlert", "tms")
+      .setCheckpointDir(checkpointDir)
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/preview/PreviewDataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/preview/PreviewDataStreamsTest.java
@@ -115,6 +115,7 @@ public class PreviewDataStreamsTest extends HydratorTestBase {
       .addConnection("transform", "sink")
       .setNumOfRecordsPreview(100)
       .setBatchInterval("1s")
+      .setCheckpointDir("file://" + TMP_FOLDER.getRoot().toPath().toString())
       .build();
 
     // Construct the preview config with the program name and program type.

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/StreamingCompat.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/StreamingCompat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.spark;
 
 import com.google.common.base.Optional;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function0;
 import org.apache.spark.api.java.function.Function2;
@@ -44,8 +45,9 @@ public final class StreamingCompat {
 
   }
 
-  public static JavaStreamingContext getOrCreate(String checkpointDir, Function0<JavaStreamingContext> contextFunc) {
-    return JavaStreamingContext.getOrCreate(checkpointDir, contextFunc);
+  public static JavaStreamingContext getOrCreate(String checkpointDir, Function0<JavaStreamingContext> contextFunc,
+                                                 Configuration configuration) {
+    return JavaStreamingContext.getOrCreate(checkpointDir, contextFunc, configuration);
   }
 
   public static <T> void foreachRDD(JavaDStream<T> stream, final Function2<JavaRDD<T>, Time, Void> func) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/co/cask/cdap/etl/spark/StreamingCompat.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/co/cask/cdap/etl/spark/StreamingCompat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,8 @@
 package co.cask.cdap.etl.spark;
 
 import com.google.common.base.Optional;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function0;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.VoidFunction2;
@@ -46,8 +46,9 @@ public final class StreamingCompat {
 
   }
 
-  public static JavaStreamingContext getOrCreate(String checkpointDir, Function0<JavaStreamingContext> contextFunc) {
-    return JavaStreamingContext.getOrCreate(checkpointDir, contextFunc);
+  public static JavaStreamingContext getOrCreate(String checkpointDir, Function0<JavaStreamingContext> contextFunc,
+                                                 Configuration configuration) {
+    return JavaStreamingContext.getOrCreate(checkpointDir, contextFunc, configuration);
   }
 
   public static <T> void foreachRDD(JavaDStream<T> stream, final Function2<JavaRDD<T>, Time, Void> func) {


### PR DESCRIPTION
Implementing checkpointing for GCS. The old implementation relied on creating a fileset and then reading from that directory. Change the logic to have spark use a directory directly.

The old checkpointDir parameter was really used as a ID field. Introduce a new field in the spec pipelineId for that purpose. CheckpointDir will now be passed in through the UI.

Tested that this works upon creating a new pipeline, re-running that pipeline to pick up the checkpoint files, and then deleting the pipeline and creating a new pipeline with the same name to see the old pipelineId directory deleted.

Setting the fs.defaultFS conf is necessary since there is some bug in spark such that this conf overrides whatever the connector establishes as a fs, and thus will attempt to parse a "gs://..." as "hdfs://..."

Builds:
https://builds.cask.co/browse/CDAP-DUT6876-5