### PR TITLE
(CDAP-14929) Fix remote runtime

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -32,6 +32,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.logging.common.UncaughtExceptionHandler;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.program.StateChangeListener;
 import co.cask.cdap.internal.app.runtime.AbstractListener;
@@ -542,6 +543,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
     services.add(injector.getInstance(TransactionManager.class));
     services.add(injector.getInstance(MessagingHttpService.class));
     services.add(injector.getInstance(RuntimeMonitorServer.class));
+    services.add(injector.getInstance(DatasetOpExecutorService.class));
     services.add(injector.getInstance(DatasetService.class));
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -399,6 +399,9 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
       // Publish CUD (Create, Update, Delete) operations on dataset instance
       result.set(Constants.Dataset.Manager.PUBLISH_CUD, Boolean.TRUE.toString());
 
+      // Always use NoSQL as storage
+      result.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
+
       // The following services will be running in the edge node host.
       // Set the bind addresses for all of them to "${master.services.bind.address}"
       // Which the value of `"master.services.bind.address" will be set in the AbstractProgramTwillRunnable when it


### PR DESCRIPTION
- Starts DatasetOpExecutorService to unblock the DatasetService
- Always use the NoSQL storage implementation in the remote runtime