### PR TITLE
CDAP-13326 consolidate prepare logic into a common class

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReducePreparer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReducePreparer.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.mapreduce;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchConfigurable;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.api.lineage.field.FieldOperation;
+import co.cask.cdap.etl.batch.BatchPhaseSpec;
+import co.cask.cdap.etl.batch.DefaultAggregatorContext;
+import co.cask.cdap.etl.batch.DefaultJoinerContext;
+import co.cask.cdap.etl.batch.PipelinePhasePreparer;
+import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
+import co.cask.cdap.etl.batch.conversion.WritableConversion;
+import co.cask.cdap.etl.batch.conversion.WritableConversions;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.PipelineRuntime;
+import co.cask.cdap.etl.common.TypeChecker;
+import co.cask.cdap.etl.common.submit.AggregatorContextProvider;
+import co.cask.cdap.etl.common.submit.ContextProvider;
+import co.cask.cdap.etl.common.submit.Finisher;
+import co.cask.cdap.etl.common.submit.JoinerContextProvider;
+import co.cask.cdap.etl.common.submit.SubmitterPlugin;
+import co.cask.cdap.etl.proto.v2.spec.StageSpec;
+import com.google.gson.Gson;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.tephra.TransactionFailureException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * For each stage, call prepareRun() in topological order.
+ * prepareRun will setup the input/output of the pipeline phase and set any arguments that should be visible
+ * to subsequent stages. These configure and prepare operations must be performed in topological order
+ * to ensure that arguments set by one stage are available to subsequent stages.
+ *
+ */
+public class MapReducePreparer extends PipelinePhasePreparer {
+  private static final Gson GSON = new Gson();
+  private final MapReduceContext context;
+  private final Set<String> connectorDatasets;
+  private Job job;
+  private Configuration hConf;
+  private Map<String, SinkOutput> sinkOutputs;
+  private Map<String, String> inputAliasToStage;
+  private Map<String, List<FieldOperation>> stageOperations;
+
+
+  public MapReducePreparer(MapReduceContext context, Metrics metrics, MacroEvaluator macroEvaluator,
+                           PipelineRuntime pipelineRuntime, Set<String> connectorDatasets) {
+    super(context, metrics, macroEvaluator, pipelineRuntime);
+    this.context = context;
+    this.connectorDatasets = connectorDatasets;
+  }
+
+  public List<Finisher> prepare(BatchPhaseSpec phaseSpec,
+                                Job job) throws TransactionFailureException, InstantiationException, IOException {
+    this.job = job;
+    this.hConf = job.getConfiguration();
+    hConf.setBoolean("mapreduce.map.speculative", false);
+    hConf.setBoolean("mapreduce.reduce.speculative", false);
+
+    sinkOutputs = new HashMap<>();
+    inputAliasToStage = new HashMap<>();
+    // Collect field operations emitted by various stages in this MapReduce program
+    stageOperations = new HashMap<>();
+
+    List<Finisher> finishers = prepare(phaseSpec);
+
+    hConf.set(ETLMapReduce.SINK_OUTPUTS_KEY, GSON.toJson(sinkOutputs));
+    hConf.set(ETLMapReduce.INPUT_ALIAS_KEY, GSON.toJson(inputAliasToStage));
+
+    WorkflowToken token = context.getWorkflowToken();
+    if (token != null) {
+      for (Map.Entry<String, String> entry : pipelineRuntime.getArguments().getAddedArguments().entrySet()) {
+        token.put(entry.getKey(), entry.getValue());
+      }
+
+      // Put the collected field operations in workflow token
+      token.put(Constants.FIELD_OPERATION_KEY_IN_WORKFLOW_TOKEN, GSON.toJson(stageOperations));
+    }
+    // token is null when just the mapreduce job is run but not the entire workflow
+    // we still want things to work in that case.
+    hConf.set(ETLMapReduce.RUNTIME_ARGS_KEY, GSON.toJson(pipelineRuntime.getArguments().asMap()));
+
+    return finishers;
+  }
+
+  @Override
+  protected SubmitterPlugin create(PipelinePluginInstantiator pluginInstantiator, StageSpec stageSpec) {
+    return null;
+  }
+
+  @Override
+  protected SubmitterPlugin createSource(BatchConfigurable<BatchSourceContext> batchSource, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<MapReduceBatchContext> contextProvider =
+      new MapReduceBatchContextProvider(context, pipelineRuntime, stageSpec, connectorDatasets);
+    return new SubmitterPlugin<>(stageName, context, batchSource, contextProvider, sourceContext -> {
+      for (String inputAlias : sourceContext.getInputNames()) {
+        inputAliasToStage.put(inputAlias, stageName);
+      }
+      stageOperations.put(stageName, sourceContext.getFieldOperations());
+    });
+  }
+
+  @Override
+  protected SubmitterPlugin createSink(BatchConfigurable<BatchSinkContext> batchSink, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<MapReduceBatchContext> contextProvider =
+      new MapReduceBatchContextProvider(context, pipelineRuntime, stageSpec, connectorDatasets);
+    return new SubmitterPlugin<>(stageName, context, batchSink, contextProvider, sinkContext -> {
+      sinkOutputs.put(stageName, new SinkOutput(sinkContext.getOutputNames()));
+      stageOperations.put(stageName, sinkContext.getFieldOperations());
+    });
+  }
+
+  @Override
+  protected SubmitterPlugin createTransform(Transform<?, ?> transform, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<MapReduceBatchContext> contextProvider =
+      new MapReduceBatchContextProvider(context, pipelineRuntime, stageSpec, connectorDatasets);
+    return new SubmitterPlugin<>(stageName, context, transform, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createAggregator(BatchAggregator<?, ?, ?> aggregator, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultAggregatorContext> contextProvider =
+      new AggregatorContextProvider(pipelineRuntime, stageSpec, context.getAdmin());
+    return new SubmitterPlugin<>(stageName, context, aggregator, contextProvider, aggregatorContext -> {
+      if (aggregatorContext.getNumPartitions() != null) {
+        job.setNumReduceTasks(aggregatorContext.getNumPartitions());
+      }
+      Class<?> outputKeyClass = aggregatorContext.getGroupKeyClass();
+      Class<?> outputValClass = aggregatorContext.getGroupValueClass();
+
+      if (outputKeyClass == null) {
+        outputKeyClass = TypeChecker.getGroupKeyClass(aggregator);
+      }
+      if (outputValClass == null) {
+        outputValClass = TypeChecker.getGroupValueClass(aggregator);
+      }
+      hConf.set(ETLMapReduce.MAP_KEY_CLASS, outputKeyClass.getName());
+      hConf.set(ETLMapReduce.MAP_VAL_CLASS, outputValClass.getName());
+      job.setMapOutputKeyClass(getOutputKeyClass(stageName, outputKeyClass));
+      job.setMapOutputValueClass(getOutputValClass(stageName, outputValClass));
+      stageOperations.put(stageName, aggregatorContext.getFieldOperations());
+    });
+  }
+
+  @Override
+  protected SubmitterPlugin createJoiner(BatchJoiner<?, ?, ?> batchJoiner, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultJoinerContext> contextProvider =
+      new JoinerContextProvider(pipelineRuntime, stageSpec, context.getAdmin());
+    return new SubmitterPlugin<>(stageName, context, batchJoiner, contextProvider, joinerContext -> {
+      if (joinerContext.getNumPartitions() != null) {
+        job.setNumReduceTasks(joinerContext.getNumPartitions());
+      }
+      Class<?> outputKeyClass = joinerContext.getJoinKeyClass();
+      Class<?> inputRecordClass = joinerContext.getJoinInputRecordClass();
+
+      if (outputKeyClass == null) {
+        outputKeyClass = TypeChecker.getJoinKeyClass(batchJoiner);
+      }
+      if (inputRecordClass == null) {
+        inputRecordClass = TypeChecker.getJoinInputRecordClass(batchJoiner);
+      }
+      hConf.set(ETLMapReduce.MAP_KEY_CLASS, outputKeyClass.getName());
+      hConf.set(ETLMapReduce.MAP_VAL_CLASS, inputRecordClass.getName());
+      job.setMapOutputKeyClass(getOutputKeyClass(stageName, outputKeyClass));
+      getOutputValClass(stageName, inputRecordClass);
+      // for joiner plugin map output is tagged with stageName
+      job.setMapOutputValueClass(TaggedWritable.class);
+      stageOperations.put(stageName, joinerContext.getFieldOperations());
+    });
+  }
+
+  private Class<?> getOutputKeyClass(String reducerName, Class<?> outputKeyClass) {
+    // in case the classes are not a WritableComparable, but is some common type we support
+    // for example, a String or a StructuredRecord
+    WritableConversion writableConversion = WritableConversions.getConversion(outputKeyClass.getName());
+    // if the conversion is null, it means the user is using their own object.
+    if (writableConversion != null) {
+      outputKeyClass = writableConversion.getWritableClass();
+    }
+    // check classes here instead of letting mapreduce do it, since mapreduce throws a cryptic error
+    if (!WritableComparable.class.isAssignableFrom(outputKeyClass)) {
+      throw new IllegalArgumentException(String.format(
+        "Invalid reducer %s. The key class %s must implement Hadoop's WritableComparable.",
+        reducerName, outputKeyClass));
+    }
+    return outputKeyClass;
+  }
+
+  private Class<?> getOutputValClass(String reducerName, Class<?> outputValClass) {
+    WritableConversion writableConversion;
+    writableConversion = WritableConversions.getConversion(outputValClass.getName());
+    if (writableConversion != null) {
+      outputValClass = writableConversion.getWritableClass();
+    }
+    if (!Writable.class.isAssignableFrom(outputValClass)) {
+      throw new IllegalArgumentException(String.format(
+        "Invalid reducer %s. The value class %s must implement Hadoop's Writable.",
+        reducerName, outputValClass));
+    }
+    return outputValClass;
+  }
+
+  /**
+   * Context provider for mapreduce.
+   */
+  private static class MapReduceBatchContextProvider implements ContextProvider<MapReduceBatchContext> {
+    private final MapReduceContext context;
+    private final PipelineRuntime pipelineRuntime;
+    private final StageSpec stageSpec;
+    private final Set<String> connectorDatasets;
+
+    MapReduceBatchContextProvider(MapReduceContext context, PipelineRuntime pipelineRuntime,
+                                  StageSpec stageSpec, Set<String> connectorDatasets) {
+      this.context = context;
+      this.pipelineRuntime = pipelineRuntime;
+      this.stageSpec = stageSpec;
+      this.connectorDatasets = connectorDatasets;
+    }
+
+    @Override
+    public MapReduceBatchContext getContext(DatasetContext datasetContext) {
+      return new MapReduceBatchContext(context, pipelineRuntime, stageSpec, connectorDatasets, datasetContext);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/PipelinePhasePreparer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/PipelinePhasePreparer.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.AlertPublisher;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchConfigurable;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.batch.connector.MultiConnectorFactory;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.common.PipelineRuntime;
+import co.cask.cdap.etl.common.submit.Finisher;
+import co.cask.cdap.etl.common.submit.SubmitterPlugin;
+import co.cask.cdap.etl.proto.v2.spec.StageSpec;
+import org.apache.tephra.TransactionFailureException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * For each stage, call prepareRun() in topological order.
+ * prepareRun will setup the input/output of the pipeline phase and set any arguments that should be visible
+ * to subsequent stages. These configure and prepare operations must be performed in topological order
+ * to ensure that arguments set by one stage are available to subsequent stages.
+ *
+ */
+public abstract class PipelinePhasePreparer {
+  private final PluginContext pluginContext;
+  private final Metrics metrics;
+  protected final MacroEvaluator macroEvaluator;
+  protected final PipelineRuntime pipelineRuntime;
+
+  public PipelinePhasePreparer(PluginContext pluginContext, Metrics metrics, MacroEvaluator macroEvaluator,
+                               PipelineRuntime pipelineRuntime) {
+    this.pluginContext = pluginContext;
+    this.metrics = metrics;
+    this.macroEvaluator = macroEvaluator;
+    this.pipelineRuntime = pipelineRuntime;
+  }
+
+  /**
+   * Prepare all the stages in the given phase and return Finishers that must be run when the pipeline completes.
+   *
+   * @param phaseSpec the pipeline phase to prepare
+   * @return list of finishers that should be run when the pipeline ends
+   */
+  public List<Finisher> prepare(BatchPhaseSpec phaseSpec)
+    throws TransactionFailureException, InstantiationException, IOException {
+    PipelinePluginInstantiator pluginInstantiator =
+      new PipelinePluginInstantiator(pluginContext, metrics, phaseSpec, new MultiConnectorFactory());
+    PipelinePhase phase = phaseSpec.getPhase();
+
+    List<Finisher> finishers = new ArrayList<>();
+    // call prepareRun on each stage in order so that any arguments set by a stage will be visible to subsequent stages
+    for (String stageName : phase.getDag().getTopologicalOrder()) {
+      StageSpec stageSpec = phase.getStage(stageName);
+      String pluginType = stageSpec.getPluginType();
+      boolean isConnectorSource =
+        Constants.Connector.PLUGIN_TYPE.equals(pluginType) && phase.getSources().contains(stageName);
+      boolean isConnectorSink =
+        Constants.Connector.PLUGIN_TYPE.equals(pluginType) && phase.getSinks().contains(stageName);
+
+      SubmitterPlugin submitterPlugin;
+      if (BatchSource.PLUGIN_TYPE.equals(pluginType) || isConnectorSource) {
+        BatchConfigurable<BatchSourceContext> batchSource =
+          pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+        submitterPlugin = createSource(batchSource, stageSpec);
+      } else if (BatchSink.PLUGIN_TYPE.equals(pluginType) || AlertPublisher.PLUGIN_TYPE.equals(pluginType) ||
+        isConnectorSink) {
+        BatchConfigurable<BatchSinkContext> batchSink = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+        submitterPlugin = createSink(batchSink, stageSpec);
+      } else if (Transform.PLUGIN_TYPE.equals(pluginType)) {
+        Transform<?, ?> transform = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+        submitterPlugin = createTransform(transform, stageSpec);
+      } else if (BatchAggregator.PLUGIN_TYPE.equals(pluginType)) {
+        BatchAggregator<?, ?, ?> aggregator = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+        submitterPlugin = createAggregator(aggregator, stageSpec);
+      } else if (BatchJoiner.PLUGIN_TYPE.equals(pluginType)) {
+        BatchJoiner<?, ?, ?> batchJoiner = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+        submitterPlugin = createJoiner(batchJoiner, stageSpec);
+      } else {
+        submitterPlugin = create(pluginInstantiator, stageSpec);
+      }
+
+      if (submitterPlugin != null) {
+        submitterPlugin.prepareRun();
+        finishers.add(submitterPlugin);
+      }
+    }
+
+    return finishers;
+  }
+
+  @Nullable
+  protected abstract SubmitterPlugin create(PipelinePluginInstantiator pluginInstantiator, StageSpec stageSpec)
+    throws InstantiationException;
+
+  protected abstract SubmitterPlugin createSource(BatchConfigurable<BatchSourceContext> batchSource,
+                                                  StageSpec stageSpec);
+
+  protected abstract SubmitterPlugin createSink(BatchConfigurable<BatchSinkContext> batchSink, StageSpec stageSpec);
+
+  protected abstract SubmitterPlugin createTransform(Transform<?, ?> transform, StageSpec stageSpec);
+
+  protected abstract SubmitterPlugin createAggregator(BatchAggregator<?, ?, ?> aggregator, StageSpec stageSpec);
+
+  protected abstract SubmitterPlugin createJoiner(BatchJoiner<?, ?, ?> batchJoiner, StageSpec stageSpec);
+
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2018 Cask Data, Inc.
+ * Copyright © 2015-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.etl.spark.batch;
 
-import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.annotation.TransactionPolicy;
@@ -24,41 +23,17 @@ import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.macro.MacroEvaluator;
-import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.spark.AbstractSpark;
 import co.cask.cdap.api.spark.SparkClientContext;
-import co.cask.cdap.api.workflow.WorkflowToken;
-import co.cask.cdap.etl.api.Transform;
-import co.cask.cdap.etl.api.batch.BatchAggregator;
-import co.cask.cdap.etl.api.batch.BatchConfigurable;
-import co.cask.cdap.etl.api.batch.BatchJoiner;
-import co.cask.cdap.etl.api.batch.BatchSink;
-import co.cask.cdap.etl.api.batch.BatchSinkContext;
-import co.cask.cdap.etl.api.batch.BatchSource;
-import co.cask.cdap.etl.api.batch.BatchSourceContext;
-import co.cask.cdap.etl.api.batch.SparkPluginContext;
-import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.lineage.field.FieldOperation;
 import co.cask.cdap.etl.batch.BatchPhaseSpec;
-import co.cask.cdap.etl.batch.DefaultAggregatorContext;
-import co.cask.cdap.etl.batch.DefaultJoinerContext;
-import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
-import co.cask.cdap.etl.batch.connector.SingleConnectorFactory;
-import co.cask.cdap.etl.common.BasicArguments;
 import co.cask.cdap.etl.common.Constants;
 import co.cask.cdap.etl.common.DefaultMacroEvaluator;
 import co.cask.cdap.etl.common.FieldOperationTypeAdapter;
-import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.common.PipelineRuntime;
 import co.cask.cdap.etl.common.SetMultimapCodec;
-import co.cask.cdap.etl.common.submit.AggregatorContextProvider;
 import co.cask.cdap.etl.common.submit.CompositeFinisher;
-import co.cask.cdap.etl.common.submit.ContextProvider;
 import co.cask.cdap.etl.common.submit.Finisher;
-import co.cask.cdap.etl.common.submit.JoinerContextProvider;
-import co.cask.cdap.etl.common.submit.SubmitterPlugin;
-import co.cask.cdap.etl.proto.v2.spec.StageSpec;
-import co.cask.cdap.etl.spark.plugin.SparkPipelinePluginContext;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import com.google.common.collect.SetMultimap;
 import com.google.gson.Gson;
@@ -67,11 +42,6 @@ import org.apache.spark.SparkConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +62,6 @@ public class ETLSpark extends AbstractSpark {
 
   private final BatchPhaseSpec phaseSpec;
   private Finisher finisher;
-  private List<File> cleanupFiles;
 
   public ETLSpark(BatchPhaseSpec phaseSpec) {
     this.phaseSpec = phaseSpec;
@@ -123,8 +92,6 @@ public class ETLSpark extends AbstractSpark {
   @TransactionPolicy(TransactionControl.EXPLICIT)
   public void initialize() throws Exception {
     SparkClientContext context = getContext();
-    cleanupFiles = new ArrayList<>();
-    List<Finisher> finishers = new ArrayList<>();
 
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.speculation", "false");
@@ -137,109 +104,13 @@ public class ETLSpark extends AbstractSpark {
       sparkConf.set(pipelineProperty.getKey(), pipelineProperty.getValue());
     }
 
-    MacroEvaluator evaluator = new DefaultMacroEvaluator(new BasicArguments(context),
+    PipelineRuntime pipelineRuntime = new PipelineRuntime(context);
+    MacroEvaluator evaluator = new DefaultMacroEvaluator(pipelineRuntime.getArguments(),
                                                          context.getLogicalStartTime(), context,
                                                          context.getNamespace());
-    SparkBatchSourceFactory sourceFactory = new SparkBatchSourceFactory();
-    SparkBatchSinkFactory sinkFactory = new SparkBatchSinkFactory();
-    Map<String, Integer> stagePartitions = new HashMap<>();
-    PluginContext pluginContext = new SparkPipelinePluginContext(context, context.getMetrics(),
-                                                                 phaseSpec.isStageLoggingEnabled(),
-                                                                 phaseSpec.isProcessTimingEnabled());
-    PipelinePluginInstantiator pluginInstantiator =
-      new PipelinePluginInstantiator(pluginContext, context.getMetrics(), phaseSpec, new SingleConnectorFactory());
-    PipelineRuntime pipelineRuntime = new PipelineRuntime(context);
-    Admin admin = context.getAdmin();
-
-    PipelinePhase phase = phaseSpec.getPhase();
-    // Collect field operations emitted by various stages in this MapReduce program
-    Map<String, List<FieldOperation>> stageOperations = new HashMap<>();
-    // go through in topological order so that arguments set by one stage are seen by stages after it
-    for (String stageName : phase.getDag().getTopologicalOrder()) {
-      StageSpec stageSpec = phase.getStage(stageName);
-      String pluginType = stageSpec.getPluginType();
-      boolean isConnectorSource =
-        Constants.Connector.PLUGIN_TYPE.equals(pluginType) && phase.getSources().contains(stageName);
-      boolean isConnectorSink =
-        Constants.Connector.PLUGIN_TYPE.equals(pluginType) && phase.getSinks().contains(stageName);
-
-      SubmitterPlugin submitterPlugin = null;
-      if (BatchSource.PLUGIN_TYPE.equals(pluginType) || isConnectorSource) {
-
-        BatchConfigurable<BatchSourceContext> batchSource = pluginInstantiator.newPluginInstance(stageName, evaluator);
-        ContextProvider<SparkBatchSourceContext> contextProvider =
-          dsContext -> new SparkBatchSourceContext(sourceFactory, context, pipelineRuntime, dsContext, stageSpec);
-        submitterPlugin = new SubmitterPlugin<>(stageName, context, batchSource, contextProvider,
-                                                ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
-
-      } else if (Transform.PLUGIN_TYPE.equals(pluginType)) {
-
-        Transform transform = pluginInstantiator.newPluginInstance(stageName, evaluator);
-        ContextProvider<SparkBatchSourceContext> contextProvider =
-          dsContext -> new SparkBatchSourceContext(sourceFactory, context, pipelineRuntime, dsContext, stageSpec);
-        submitterPlugin = new SubmitterPlugin<>(stageName, context, transform, contextProvider,
-                                                ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
-
-      } else if (BatchSink.PLUGIN_TYPE.equals(pluginType) || isConnectorSink) {
-
-        BatchConfigurable<BatchSinkContext> batchSink = pluginInstantiator.newPluginInstance(stageName, evaluator);
-        ContextProvider<SparkBatchSinkContext> contextProvider =
-          dsContext -> new SparkBatchSinkContext(sinkFactory, context, pipelineRuntime, dsContext, stageSpec);
-        submitterPlugin = new SubmitterPlugin<>(stageName, context, batchSink, contextProvider,
-                                                ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
-
-      } else if (SparkSink.PLUGIN_TYPE.equals(pluginType)) {
-
-        BatchConfigurable<SparkPluginContext> sparkSink = pluginInstantiator.newPluginInstance(stageName, evaluator);
-        ContextProvider<BasicSparkPluginContext> contextProvider =
-          dsContext -> new BasicSparkPluginContext(context, pipelineRuntime, stageSpec, dsContext, admin);
-        submitterPlugin = new SubmitterPlugin<>(stageName, context, sparkSink, contextProvider);
-
-      } else if (BatchAggregator.PLUGIN_TYPE.equals(pluginType)) {
-
-        BatchAggregator aggregator = pluginInstantiator.newPluginInstance(stageName, evaluator);
-        ContextProvider<DefaultAggregatorContext> contextProvider =
-          new AggregatorContextProvider(pipelineRuntime, stageSpec, admin);
-        submitterPlugin = new SubmitterPlugin<>(stageName, context, aggregator, contextProvider,
-                                                ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
-
-      } else if (BatchJoiner.PLUGIN_TYPE.equals(pluginType)) {
-
-        BatchJoiner joiner = pluginInstantiator.newPluginInstance(stageName, evaluator);
-        ContextProvider<DefaultJoinerContext> contextProvider =
-          new JoinerContextProvider(pipelineRuntime, stageSpec, admin);
-        submitterPlugin = new SubmitterPlugin<>(stageName, context, joiner, contextProvider, sparkJoinerContext -> {
-          stagePartitions.put(stageName, sparkJoinerContext.getNumPartitions());
-          stageOperations.put(stageName, sparkJoinerContext.getFieldOperations());
-        });
-
-      }
-      if (submitterPlugin != null) {
-        submitterPlugin.prepareRun();
-        finishers.add(submitterPlugin);
-      }
-    }
-
-    File configFile = File.createTempFile("HydratorSpark", ".config");
-    cleanupFiles.add(configFile);
-    try (Writer writer = Files.newBufferedWriter(configFile.toPath(), StandardCharsets.UTF_8)) {
-      SparkBatchSourceSinkFactoryInfo sourceSinkInfo = new SparkBatchSourceSinkFactoryInfo(sourceFactory,
-                                                                                           sinkFactory,
-                                                                                           stagePartitions);
-      writer.write(GSON.toJson(sourceSinkInfo));
-    }
-
+    SparkPreparer preparer = new SparkPreparer(context, context.getMetrics(), evaluator, pipelineRuntime);
+    List<Finisher> finishers = preparer.prepare(phaseSpec);
     finisher = new CompositeFinisher(finishers);
-    context.localize("HydratorSpark.config", configFile.toURI());
-
-    WorkflowToken token = context.getWorkflowToken();
-    if (token != null) {
-      for (Map.Entry<String, String> entry : pipelineRuntime.getArguments().getAddedArguments().entrySet()) {
-        token.put(entry.getKey(), entry.getValue());
-      }
-      // Put the collected field operations in workflow token
-      token.put(Constants.FIELD_OPERATION_KEY_IN_WORKFLOW_TOKEN, GSON.toJson(stageOperations));
-    }
   }
 
   @Override
@@ -247,11 +118,6 @@ public class ETLSpark extends AbstractSpark {
   public void destroy() {
     if (finisher != null) {
       finisher.onFinish(getContext().getState().getStatus() == ProgramStatus.COMPLETED);
-    }
-    for (File file : cleanupFiles) {
-      if (!file.delete()) {
-        LOG.warn("Failed to clean up resource {} ", file);
-      }
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/SparkPreparer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/co/cask/cdap/etl/spark/batch/SparkPreparer.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.batch;
+
+import co.cask.cdap.api.data.batch.InputFormatProvider;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.spark.SparkClientContext;
+import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchConfigurable;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.api.batch.SparkPluginContext;
+import co.cask.cdap.etl.api.batch.SparkSink;
+import co.cask.cdap.etl.api.lineage.field.FieldOperation;
+import co.cask.cdap.etl.batch.BatchPhaseSpec;
+import co.cask.cdap.etl.batch.DefaultAggregatorContext;
+import co.cask.cdap.etl.batch.DefaultJoinerContext;
+import co.cask.cdap.etl.batch.PipelinePhasePreparer;
+import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.FieldOperationTypeAdapter;
+import co.cask.cdap.etl.common.PipelineRuntime;
+import co.cask.cdap.etl.common.SetMultimapCodec;
+import co.cask.cdap.etl.common.submit.AggregatorContextProvider;
+import co.cask.cdap.etl.common.submit.ContextProvider;
+import co.cask.cdap.etl.common.submit.Finisher;
+import co.cask.cdap.etl.common.submit.JoinerContextProvider;
+import co.cask.cdap.etl.common.submit.SubmitterPlugin;
+import co.cask.cdap.etl.proto.v2.spec.StageSpec;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import com.google.common.collect.SetMultimap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.tephra.TransactionFailureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Prepares Spark jobs.
+ */
+public class SparkPreparer extends PipelinePhasePreparer {
+  private static final Logger LOG = LoggerFactory.getLogger(SparkPreparer.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .registerTypeAdapter(SetMultimap.class, new SetMultimapCodec<>())
+    .registerTypeAdapter(DatasetInfo.class, new DatasetInfoTypeAdapter())
+    .registerTypeAdapter(OutputFormatProvider.class, new OutputFormatProviderTypeAdapter())
+    .registerTypeAdapter(InputFormatProvider.class, new InputFormatProviderTypeAdapter())
+    .registerTypeAdapter(FieldOperation.class, new FieldOperationTypeAdapter())
+    .create();
+  private final SparkClientContext context;
+  private Map<String, List<FieldOperation>> stageOperations;
+  private SparkBatchSourceFactory sourceFactory;
+  private SparkBatchSinkFactory sinkFactory;
+  private Map<String, Integer> stagePartitions;
+
+  public SparkPreparer(SparkClientContext context,
+                       Metrics metrics,
+                       MacroEvaluator macroEvaluator,
+                       PipelineRuntime pipelineRuntime) {
+    super(context, metrics, macroEvaluator, pipelineRuntime);
+    this.context = context;
+  }
+
+  @Override
+  public List<Finisher> prepare(BatchPhaseSpec phaseSpec)
+    throws TransactionFailureException, InstantiationException, IOException {
+    stageOperations = new HashMap<>();
+    stagePartitions = new HashMap<>();
+    sourceFactory = new SparkBatchSourceFactory();
+    sinkFactory = new SparkBatchSinkFactory();
+    File configFile = File.createTempFile("HydratorSpark", ".config");
+
+    List<Finisher> finishers = super.prepare(phaseSpec);
+    finishers.add(new Finisher() {
+      @Override
+      public void onFinish(boolean succeeded) {
+        if (!configFile.delete()) {
+          LOG.warn("Failed to clean up resource {} ", configFile);
+        }
+      }
+    });
+
+    try (Writer writer = Files.newBufferedWriter(configFile.toPath(), StandardCharsets.UTF_8)) {
+      SparkBatchSourceSinkFactoryInfo sourceSinkInfo = new SparkBatchSourceSinkFactoryInfo(sourceFactory,
+                                                                                           sinkFactory,
+                                                                                           stagePartitions);
+      writer.write(GSON.toJson(sourceSinkInfo));
+    }
+
+    context.localize("HydratorSpark.config", configFile.toURI());
+    WorkflowToken token = context.getWorkflowToken();
+    if (token != null) {
+      for (Map.Entry<String, String> entry : pipelineRuntime.getArguments().getAddedArguments().entrySet()) {
+        token.put(entry.getKey(), entry.getValue());
+      }
+      // Put the collected field operations in workflow token
+      token.put(Constants.FIELD_OPERATION_KEY_IN_WORKFLOW_TOKEN, GSON.toJson(stageOperations));
+    }
+    return finishers;
+  }
+
+  @Nullable
+  @Override
+  protected SubmitterPlugin create(PipelinePluginInstantiator pluginInstantiator,
+                                   StageSpec stageSpec) throws InstantiationException {
+    String stageName = stageSpec.getName();
+    if (SparkSink.PLUGIN_TYPE.equals(stageSpec.getPluginType())) {
+      BatchConfigurable<SparkPluginContext> sparkSink = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+      ContextProvider<BasicSparkPluginContext> contextProvider =
+        dsContext -> new BasicSparkPluginContext(context, pipelineRuntime, stageSpec, dsContext, context.getAdmin());
+      return new SubmitterPlugin<>(stageName, context, sparkSink, contextProvider);
+    }
+    return null;
+  }
+
+  @Override
+  protected SubmitterPlugin createSource(BatchConfigurable<BatchSourceContext> batchSource, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<SparkBatchSourceContext> contextProvider =
+      dsContext -> new SparkBatchSourceContext(sourceFactory, context, pipelineRuntime, dsContext, stageSpec);
+    return new SubmitterPlugin<>(stageName, context, batchSource, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createSink(BatchConfigurable<BatchSinkContext> batchSink, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<SparkBatchSinkContext> contextProvider =
+      dsContext -> new SparkBatchSinkContext(sinkFactory, context, pipelineRuntime, dsContext, stageSpec);
+    return new SubmitterPlugin<>(stageName, context, batchSink, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createTransform(Transform<?, ?> transform, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<SparkBatchSourceContext> contextProvider =
+      dsContext -> new SparkBatchSourceContext(sourceFactory, context, pipelineRuntime, dsContext, stageSpec);
+    return new SubmitterPlugin<>(stageName, context, transform, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createAggregator(BatchAggregator<?, ?, ?> aggregator, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultAggregatorContext> contextProvider =
+      new AggregatorContextProvider(pipelineRuntime, stageSpec, context.getAdmin());
+    return new SubmitterPlugin<>(stageName, context, aggregator, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createJoiner(BatchJoiner<?, ?, ?> batchJoiner, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultJoinerContext> contextProvider =
+      new JoinerContextProvider(pipelineRuntime, stageSpec, context.getAdmin());
+    return new SubmitterPlugin<>(stageName, context, batchJoiner, contextProvider, sparkJoinerContext -> {
+      stagePartitions.put(stageName, sparkJoinerContext.getNumPartitions());
+      stageOperations.put(stageName, sparkJoinerContext.getFieldOperations());
+    });
+  }
+}


### PR DESCRIPTION
Consolidate the common code in ETLMapReduce and ETLSpark.
    
This basically amounts to moving code that was common to both
into a new PipelinePhasePreparer and moving MR specific logic into
MapReducePreparer and Spark specific logic into SparkPreparer.