### PR TITLE
CDAP-15011 add metrics to Structured table for better debugging

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/queue/NoSqlJobQueueTableTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/queue/NoSqlJobQueueTableTest.java
@@ -16,10 +16,12 @@
 
 package co.cask.cdap.internal.app.runtime.schedule.queue;
 
+import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocalLocationModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.namespace.InMemoryNamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.runtime.StorageModule;
@@ -76,6 +78,7 @@ public class NoSqlJobQueueTableTest extends JobQueueTableTest {
           bind(DatasetFramework.class).to(InMemoryDatasetFramework.class);
           bind(NamespaceQueryAdmin.class).to(InMemoryNamespaceAdmin.class).in(Scopes.SINGLETON);
           bind(TransactionSystemClient.class).toInstance(new InMemoryTxSystemClient(txManager));
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
         }
       }
     );

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/queue/SqlJobQueueTableTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/queue/SqlJobQueueTableTest.java
@@ -18,10 +18,12 @@ package co.cask.cdap.internal.app.runtime.schedule.queue;
 
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocalLocationModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.namespace.InMemoryNamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.runtime.StorageModule;
@@ -71,6 +73,7 @@ public class SqlJobQueueTableTest extends JobQueueTableTest {
         @Override
         protected void configure() {
           bind(NamespaceQueryAdmin.class).to(InMemoryNamespaceAdmin.class).in(Scopes.SINGLETON);
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
         }
       }
     );

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -629,7 +629,13 @@ public final class Constants {
     public static final Map<String, String> TRANSACTION_MANAGER_CONTEXT =
       ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
                       Constants.Metrics.Tag.COMPONENT, Constants.Service.TRANSACTION);
+    // metrics context for system storage
+    public static final Map<String, String> METRICS_TAGS = ImmutableMap.of(
+      Tag.COMPONENT, "system.storage",
+      Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace());
+
     public static final String PROGRAM_METRICS_ENABLED = "app.program.metrics.enabled";
+    public static final String STRUCTURED_TABLE_TIME_METRICS_ENABLED = "structured.table.time.metrics.enabled";
 
     /**
      * Metric's dataset related constants.
@@ -747,6 +753,19 @@ public final class Constants {
       public static final String PROGRAM_FAILED_RUNS = "program.failed.runs";
       public static final String PROGRAM_KILLED_RUNS = "program.killed.runs";
       public static final String PROGRAM_NODE_MINUTES = "program.node.minutes";
+    }
+
+    /**
+     * Structured table metrics
+     */
+    public static final class StructuredTable {
+
+      public static final String METRICS_PREFIX = "structured.table.";
+      public static final String TRANSACTION_COUNT = "structured.table.transaction.count";
+      public static final String TRANSACTION_CONFLICT = "structured.table.transaction.conflict";
+      public static final String ACTIVE_CONNECTIONS = "structured.table.connection.active";
+      public static final String IDLE_CONNECTIONS = "structured.table.connection.idle";
+      public static final String ERROR_CONNECTIONS = "structured.table.connection.error";
     }
   }
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2552,6 +2552,14 @@
     </description>
   </property>
 
+  <property>
+    <name>structured.table.time.metrics.enabled</name>
+    <value>false</value>
+    <description>
+      Option to turn on the time metrics for the structured table operations.
+    </description>
+  </property>
+
   <!-- Monitor Handler Configuration -->
 
   <property>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/common/MetricStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/common/MetricStructuredTable.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.common;
+
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.spi.data.InvalidFieldException;
+import co.cask.cdap.spi.data.StructuredRow;
+import co.cask.cdap.spi.data.StructuredTable;
+import co.cask.cdap.spi.data.table.StructuredTableId;
+import co.cask.cdap.spi.data.table.field.Field;
+import co.cask.cdap.spi.data.table.field.Range;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Structured table that takes a delegation and emit metrics on each operation.
+ */
+public class MetricStructuredTable implements StructuredTable {
+  private final StructuredTable structuredTable;
+  private final MetricsCollector metricsCollector;
+  private final String metricPrefix;
+  private final boolean emitTimeMetrics;
+
+  public MetricStructuredTable(StructuredTableId tableId,
+                               StructuredTable structuredTable, MetricsCollector metricsCollector,
+                               boolean emitTimeMetrics) {
+    this.structuredTable = structuredTable;
+    this.metricsCollector = metricsCollector;
+    this.metricPrefix = Constants.Metrics.StructuredTable.METRICS_PREFIX + tableId.getName() + ".";
+    this.emitTimeMetrics = emitTimeMetrics;
+  }
+
+  @Override
+  public void upsert(Collection<Field<?>> fields) throws InvalidFieldException, IOException {
+    try {
+      if (!emitTimeMetrics) {
+        structuredTable.upsert(fields);
+      } else {
+        long curTime = System.nanoTime();
+        structuredTable.upsert(fields);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "upsert.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "upsert.count", 1L);
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "upsert.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public Optional<StructuredRow> read(Collection<Field<?>> keys) throws InvalidFieldException, IOException {
+    try {
+      Optional<StructuredRow> result;
+      if (!emitTimeMetrics) {
+        result = structuredTable.read(keys);
+      } else {
+        long curTime = System.nanoTime();
+        result = structuredTable.read(keys);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "read.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "read.count", 1L);
+      return result;
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "read.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public Optional<StructuredRow> read(Collection<Field<?>> keys,
+                                      Collection<String> columns) throws InvalidFieldException, IOException {
+    try {
+      Optional<StructuredRow> result;
+      if (!emitTimeMetrics) {
+        result = structuredTable.read(keys, columns);
+      } else {
+        long curTime = System.nanoTime();
+        result = structuredTable.read(keys, columns);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "read.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "read.count", 1L);
+      return result;
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "read.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit) throws InvalidFieldException, IOException {
+    try {
+      CloseableIterator<StructuredRow> result;
+      if (!emitTimeMetrics) {
+        result = structuredTable.scan(keyRange, limit);
+      } else {
+        long curTime = System.nanoTime();
+        result = structuredTable.scan(keyRange, limit);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "scan.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "scan.count", 1L);
+      return result;
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "scan.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public CloseableIterator<StructuredRow> scan(Field<?> index) throws InvalidFieldException, IOException {
+    try {
+      CloseableIterator<StructuredRow> result;
+      if (!emitTimeMetrics) {
+        result = structuredTable.scan(index);
+      } else {
+        long curTime = System.nanoTime();
+        result = structuredTable.scan(index);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "index.scan.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "index.scan.count", 1L);
+      return result;
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "index.scan.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean compareAndSwap(Collection<Field<?>> keys, Field<?> oldValue, Field<?> newValue)
+    throws InvalidFieldException, IOException, IllegalArgumentException {
+    try {
+      boolean result;
+      if (!emitTimeMetrics) {
+        result = structuredTable.compareAndSwap(keys, oldValue, newValue);
+      } else {
+        long curTime = System.nanoTime();
+        result = structuredTable.compareAndSwap(keys, oldValue, newValue);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "compareAndSwap.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "compareAndSwap.count", 1L);
+      return result;
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "compareAndSwap.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public void increment(Collection<Field<?>> keys, String column,
+                        long amount) throws InvalidFieldException, IOException, IllegalArgumentException {
+    try {
+      if (!emitTimeMetrics) {
+        structuredTable.increment(keys, column, amount);
+      } else {
+        long curTime = System.nanoTime();
+        structuredTable.increment(keys, column, amount);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "increment.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "increment.count", 1L);
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "increment.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public void delete(Collection<Field<?>> keys) throws InvalidFieldException, IOException {
+    try {
+      if (!emitTimeMetrics) {
+        structuredTable.delete(keys);
+      } else {
+        long curTime = System.nanoTime();
+        structuredTable.delete(keys);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "delete.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "delete.count", 1L);
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "delete.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public void deleteAll(Range keyRange) throws InvalidFieldException, IOException {
+    try {
+      if (!emitTimeMetrics) {
+        structuredTable.deleteAll(keyRange);
+      } else {
+        long curTime = System.nanoTime();
+        structuredTable.deleteAll(keyRange);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "deleteAll.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "deleteAll.count", 1L);
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "deleteAll.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    structuredTable.close();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/PostgresSqlStructuredTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/PostgresSqlStructuredTableAdmin.java
@@ -23,6 +23,7 @@ import co.cask.cdap.spi.data.table.StructuredTableRegistry;
 import co.cask.cdap.spi.data.table.StructuredTableSpecification;
 import co.cask.cdap.spi.data.table.field.FieldType;
 import com.google.common.base.Joiner;
+import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,7 @@ public class PostgresSqlStructuredTableAdmin implements StructuredTableAdmin {
   private final StructuredTableRegistry registry;
   private final DataSource dataSource;
 
+  @Inject
   public PostgresSqlStructuredTableAdmin(StructuredTableRegistry registry, DataSource dataSource) {
     this.registry = registry;
     this.dataSource = dataSource;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/SqlStructuredTableContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/SqlStructuredTableContext.java
@@ -16,11 +16,13 @@
 
 package co.cask.cdap.spi.data.sql;
 
+import co.cask.cdap.api.metrics.MetricsCollector;
 import co.cask.cdap.spi.data.StructuredTable;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.StructuredTableContext;
 import co.cask.cdap.spi.data.StructuredTableInstantiationException;
 import co.cask.cdap.spi.data.TableNotFoundException;
+import co.cask.cdap.spi.data.common.MetricStructuredTable;
 import co.cask.cdap.spi.data.table.StructuredTableId;
 import co.cask.cdap.spi.data.table.StructuredTableSchema;
 import co.cask.cdap.spi.data.table.StructuredTableSpecification;
@@ -33,10 +35,15 @@ import java.sql.Connection;
 public class SqlStructuredTableContext implements StructuredTableContext {
   private final StructuredTableAdmin admin;
   private final Connection connection;
+  private final MetricsCollector metricsCollector;
+  private final boolean emitTimeMetrics;
 
-  public SqlStructuredTableContext(StructuredTableAdmin structuredTableAdmin, Connection connection) {
+  public SqlStructuredTableContext(StructuredTableAdmin structuredTableAdmin, Connection connection,
+                                   MetricsCollector metricsCollector, boolean emitTimeMetrics) {
     this.admin = structuredTableAdmin;
     this.connection = connection;
+    this.metricsCollector = metricsCollector;
+    this.emitTimeMetrics = emitTimeMetrics;
   }
 
   @Override
@@ -46,6 +53,8 @@ public class SqlStructuredTableContext implements StructuredTableContext {
     if (specification == null) {
       throw new TableNotFoundException(tableId);
     }
-    return new PostgresSqlStructuredTable(connection, new StructuredTableSchema(specification));
+    return new MetricStructuredTable(
+      tableId, new PostgresSqlStructuredTable(connection, new StructuredTableSchema(specification)),
+      metricsCollector, emitTimeMetrics);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/SqlStructuredTableRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/SqlStructuredTableRegistry.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.spi.data.sql;
 
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.metrics.NoopMetricsContext;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.spi.data.StructuredRow;
 import co.cask.cdap.spi.data.StructuredTable;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
@@ -190,6 +192,8 @@ public class SqlStructuredTableRegistry implements StructuredTableRegistry {
           throw exception;
         }
       };
-    return new SqlTransactionRunner(specAdmin, dataSource);
+    // The metrics collection service might not get started at this moment,
+    // so inject a NoopMetricsCollectionService.
+    return new SqlTransactionRunner(specAdmin, dataSource, new NoOpMetricsCollectionService(), false);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/jdbc/MetricsDataSource.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/spi/data/sql/jdbc/MetricsDataSource.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.data.sql.jdbc;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.common.conf.Constants;
+import org.apache.commons.pool2.ObjectPool;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+/**
+ * A metrics data source that will emit metrics about the number of connections.
+ */
+public class MetricsDataSource implements DataSource {
+  private final DataSource dataSource;
+  private final MetricsCollectionService metricsCollectionService;
+  private final ObjectPool objectPool;
+
+  public MetricsDataSource(DataSource dataSource, MetricsCollectionService metricsCollectionService,
+                           ObjectPool objectPool) {
+    this.dataSource = dataSource;
+    this.metricsCollectionService = metricsCollectionService;
+    this.objectPool = objectPool;
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    MetricsContext metricsCollector = metricsCollectionService.getContext(Constants.Metrics.METRICS_TAGS);
+    try {
+      Connection connection = dataSource.getConnection();
+      metricsCollector.gauge(Constants.Metrics.StructuredTable.ACTIVE_CONNECTIONS, objectPool.getNumActive());
+      metricsCollector.gauge(Constants.Metrics.StructuredTable.IDLE_CONNECTIONS, objectPool.getNumIdle());
+      return connection;
+    } catch (SQLException e) {
+      metricsCollector.increment(Constants.Metrics.StructuredTable.ERROR_CONNECTIONS, 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public Connection getConnection(String username, String password) throws SQLException {
+    MetricsContext metricsCollector = metricsCollectionService.getContext(Constants.Metrics.METRICS_TAGS);
+    try {
+      Connection connection = dataSource.getConnection(username, password);
+      metricsCollector.gauge(Constants.Metrics.StructuredTable.ACTIVE_CONNECTIONS, objectPool.getNumActive());
+      metricsCollector.gauge(Constants.Metrics.StructuredTable.IDLE_CONNECTIONS, objectPool.getNumIdle());
+      return connection;
+    } catch (SQLException e) {
+      metricsCollector.increment(Constants.Metrics.StructuredTable.ERROR_CONNECTIONS, 1L);
+      throw e;
+    }
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    return dataSource.unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return dataSource.isWrapperFor(iface);
+  }
+
+  @Override
+  public PrintWriter getLogWriter() throws SQLException {
+    return dataSource.getLogWriter();
+  }
+
+  @Override
+  public void setLogWriter(PrintWriter out) throws SQLException {
+    dataSource.setLogWriter(out);
+  }
+
+  @Override
+  public void setLoginTimeout(int seconds) throws SQLException {
+    dataSource.setLoginTimeout(seconds);
+  }
+
+  @Override
+  public int getLoginTimeout() throws SQLException {
+    return dataSource.getLoginTimeout();
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    return dataSource.getParentLogger();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/StoreDefinition.java
@@ -31,6 +31,7 @@ import java.io.IOException;
  * TODO: CDAP-14674 Make sure all the store definition goes here.
  */
 public final class StoreDefinition {
+
   private StoreDefinition() {
     // prevent instantiation
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -22,10 +22,12 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.data.runtime.StorageModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
@@ -92,6 +94,8 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
           bind(DatasetDefinitionRegistryFactory.class)
             .to(DefaultDatasetDefinitionRegistryFactory.class).in(Scopes.SINGLETON);
           bind(DatasetFramework.class).to(InMemoryDatasetFramework.class);
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+          expose(MetricsCollectionService.class);
           expose(DatasetFramework.class);
         }
       }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/NoSqlLineageTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/NoSqlLineageTableTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.TableAlreadyExistsException;
 import co.cask.cdap.spi.data.nosql.NoSqlStructuredTableAdmin;
 import co.cask.cdap.spi.data.nosql.NoSqlStructuredTableRegistry;
-import co.cask.cdap.spi.data.nosql.NoSqlTransactionRunner;
+import co.cask.cdap.spi.data.transaction.TransactionRunner;
 import co.cask.cdap.store.StoreDefinition;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -36,7 +36,7 @@ public class NoSqlLineageTableTest extends LineageTableTest {
   public static void beforeClass() throws IOException, TableAlreadyExistsException {
     StructuredTableAdmin structuredTableAdmin =
       dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableAdmin.class);
-    transactionRunner = dsFrameworkUtil.getInjector().getInstance(NoSqlTransactionRunner.class);
+    transactionRunner = dsFrameworkUtil.getInjector().getInstance(TransactionRunner.class);
     NoSqlStructuredTableRegistry registry =
       dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableRegistry.class);
     registry.initialize();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/sql/SqlStructuredTableConcurrencyTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/sql/SqlStructuredTableConcurrencyTest.java
@@ -16,15 +16,19 @@
 
 package co.cask.cdap.spi.data.sql;
 
+import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.data.runtime.StorageModule;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.StructuredTableConcurrencyTest;
 import co.cask.cdap.spi.data.table.StructuredTableRegistry;
 import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -52,7 +56,13 @@ public class SqlStructuredTableConcurrencyTest extends StructuredTableConcurrenc
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new StorageModule()
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
     );
 
     injector.getInstance(StructuredTableRegistry.class).initialize();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/sql/SqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/sql/SqlStructuredTableTest.java
@@ -17,15 +17,19 @@
 
 package co.cask.cdap.spi.data.sql;
 
+import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.data.runtime.StorageModule;
 import co.cask.cdap.spi.data.StructuredTableAdmin;
 import co.cask.cdap.spi.data.StructuredTableTest;
 import co.cask.cdap.spi.data.table.StructuredTableRegistry;
 import co.cask.cdap.spi.data.transaction.TransactionRunner;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -48,7 +52,13 @@ public class SqlStructuredTableTest extends StructuredTableTest {
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new StorageModule()
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
     );
 
     injector.getInstance(StructuredTableRegistry.class).initialize();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/sql/jdbc/DataSourceProviderTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/data/sql/jdbc/DataSourceProviderTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.spi.data.sql.jdbc;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.test.AppJarHelper;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.junit.Assert;
@@ -38,7 +39,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 
-public class DataSourceInstantiatorTest {
+public class DataSourceProviderTest {
   @ClassRule
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
@@ -57,7 +58,7 @@ public class DataSourceInstantiatorTest {
 
     SConfiguration sConf = SConfiguration.create();
 
-    DataSourceInstantiator instantiator = new DataSourceInstantiator(cConf, sConf);
+    DataSourceProvider instantiator = new DataSourceProvider(cConf, sConf, new NoOpMetricsCollectionService());
     DataSource dataSource = instantiator.get();
     Assert.assertNotNull(dataSource);
     Enumeration<Driver> drivers = DriverManager.getDrivers();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
@@ -17,10 +17,12 @@
 package co.cask.cdap.spi.metadata.dataset;
 
 import co.cask.cdap.api.metadata.MetadataEntity;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocalLocationModule;
 import co.cask.cdap.common.guice.NamespaceAdminTestModule;
 import co.cask.cdap.common.metadata.Cursor;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data.runtime.StorageModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -44,9 +46,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closeables;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.runtime.TransactionInMemoryModule;
 import org.junit.AfterClass;
@@ -90,7 +94,13 @@ public class DatasetMetadataStorageTest extends MetadataStorageTest {
         new AuthorizationTestModule(),
         new AuthorizationEnforcementModule().getInMemoryModules(),
         new AuthenticationContextModules().getMasterModule(),
-        new StorageModule())
+        new StorageModule(),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+          }
+        })
       .add(additionalModules)
       .build();
 

--- a/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/StorageMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/StorageMain.java
@@ -16,10 +16,12 @@
 
 package co.cask.cdap.master.environment.k8s;
 
+import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DFSLocationModule;
 import co.cask.cdap.common.guice.InMemoryDiscoveryModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.data.runtime.ConstantTransactionSystemClient;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.StorageModule;
@@ -37,6 +39,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import org.apache.tephra.TransactionSystemClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,6 +76,9 @@ public class StorageMain {
         protected void configure() {
           bind(AuthorizationEnforcer.class).to(NoOpAuthorizer.class);
           bind(TransactionSystemClient.class).to(ConstantTransactionSystemClient.class);
+          // The metrics collection service might not get started at this moment,
+          // so inject a NoopMetricsCollectionService.
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
         }
       }
     );


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15011
Build: https://builds.cask.co/browse/CDAP-DUT6910-1
https://builds.cask.co/browse/IT-ITM-146


This pr adds the metrics by introducing a `MetricStructuredTable` to emit metrics for both SPI implementations. Also a `MetricsDataSource` is introduced to emit metrics for connection. Still need to fix the build due to the guice binding change.