### PR TITLE
[CDAP-14798] Fixes pipeline nodes to have _ in name

### DIFF
--- a/cdap-ui/app/hydrator/adapters.less
+++ b/cdap-ui/app/hydrator/adapters.less
@@ -237,7 +237,7 @@ body.theme-cdap {
   &.state-hydrator-create {
     .alerts {
       top: 50px;
-      z-index: 999;
+      z-index: 1062;
     }
   }
   &.state-hydrator-detail {


### PR DESCRIPTION
**Context**
- Add couple of nodes to pipeline
- Rename a source with a label that has underscore in it.
- Now try connecting the source to any other node.

**Source of the problem**
- When we implemented "ports" and "condition" feature in UI we seem to have added markers to endpoints to differentiate between ports (\_port\_) and conditions (\_condition\_) and regular endpoints (endpoint_). 
- The logic we used to extract the actual node name (devoid of regular endpoint marker) is to split the node name by "_" and get the name in the first index. 
- This is incorrect as nodes with underscore in it gets incorrectly split 

**Example**: `mysql_get_increment_marketing_program_member`

In this case the node name with marker would look like `endpoint_mysql_get_increment_marketing_program_member`,
 and when we split by '_' and take the name at index 1 we get `mysql` instead of the entire name.

**Fix**
- Have fixed only for regular endpoints. Nodes with ports and condition should still function the same. Tested building a pipeline with splitter and group by plugins and it seems to work fine. 
- Have fixed only the regular endpoints to minimize the impact of change at this time. We need to rethink and a bigger refactor needs to happen.