### PR TITLE
CDAP-15037 fix user scoped plugin loading in service

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
@@ -56,7 +56,8 @@ public interface HttpServiceContext extends RuntimeContext, DatasetContext, Serv
    * at configure time. Plugins registered by the dynamic configurer live in their own scope and will not
    * conflict with any plugins that were registered by the service when it was configured. Plugins registered by
    * the returned configurer will also not be available through {@link #newPluginInstance(String)} or
-   * {@link #newPluginInstance(String, MacroEvaluator)}.
+   * {@link #newPluginInstance(String, MacroEvaluator)}. Plugins with system scope and plugins in the same namespace
+   * as the running service will be visible.
    *
    * The dynamic configurer is meant to be used to create plugins for the lifetime of a single service call and
    * then to be forgotten.
@@ -64,4 +65,20 @@ public interface HttpServiceContext extends RuntimeContext, DatasetContext, Serv
    * @return an dynamic plugin configurer that must be closed
    */
   PluginConfigurer createPluginConfigurer();
+
+  /**
+   * Create a {@link PluginConfigurer} that can be used to instantiate plugins at runtime that were not registered
+   * at configure time. Plugins registered by the dynamic configurer live in their own scope and will not
+   * conflict with any plugins that were registered by the service when it was configured. Plugins registered by
+   * the returned configurer will also not be available through {@link #newPluginInstance(String)} or
+   * {@link #newPluginInstance(String, MacroEvaluator)}. Plugins with system scope and plugins in the specified
+   * namespace will be visible.
+   *
+   * The dynamic configurer is meant to be used to create plugins for the lifetime of a single service call and
+   * then to be forgotten.
+   *
+   * @param namespace the namespace for user scoped plugins
+   * @return an dynamic plugin configurer that must be closed
+   */
+  PluginConfigurer createPluginConfigurer(String namespace);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -159,6 +159,11 @@ public class BasicHttpServiceContext extends AbstractContext implements SystemHt
 
   @Override
   public PluginConfigurer createPluginConfigurer() {
+    return createPluginConfigurer(getNamespace());
+  }
+
+  @Override
+  public PluginConfigurer createPluginConfigurer(String namespace) {
     File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     try {
@@ -171,7 +176,7 @@ public class BasicHttpServiceContext extends AbstractContext implements SystemHt
           DirUtils.deleteDirectoryContents(pluginsDir, true);
         }
       });
-      return new DefaultPluginConfigurer(artifactId, namespaceId, instantiator, pluginFinder);
+      return new DefaultPluginConfigurer(artifactId, new NamespaceId(namespace), instantiator, pluginFinder);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -674,6 +674,11 @@ public class HttpHandlerGeneratorTest {
     }
 
     @Override
+    public PluginConfigurer createPluginConfigurer(String namespace) {
+      return null;
+    }
+
+    @Override
     public ApplicationSpecification getApplicationSpecification() {
       return null;
     }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/service/ValidationHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/service/ValidationHandler.java
@@ -103,7 +103,8 @@ public class ValidationHandler extends AbstractHttpServiceHandler {
     }
 
     ETLStage stageConfig = validationRequest.getStage();
-    ValidatingConfigurer validatingConfigurer = new ValidatingConfigurer(getContext().createPluginConfigurer());
+    ValidatingConfigurer validatingConfigurer =
+      new ValidatingConfigurer(getContext().createPluginConfigurer(namespace));
     // Batch or Streaming doesn't matter for a single stage.
     PipelineSpecGenerator<ETLBatchConfig, BatchPipelineSpec> pipelineSpecGenerator =
       new BatchPipelineSpecGenerator(validatingConfigurer, Collections.emptySet(), Collections.emptySet(),

--- a/cdap-unit-test/src/test/java/co/cask/cdap/service/DynamicPluginServiceTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/service/DynamicPluginServiceTestRun.java
@@ -86,6 +86,19 @@ public class DynamicPluginServiceTestRun extends TestFrameworkTestBase {
   }
 
   @Test
+  public void testNamespaceIsolation() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("value", "x");
+    URL url = baseURI.resolve(String.format("plugins/%s/apply", ConstantFunction.NAME)).toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.POST, url)
+      .withBody(GSON.toJson(properties))
+      .addHeader(DynamicPluginServiceApp.NAMESPACE_HEADER, "ghost")
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(404, response.getResponseCode());
+  }
+
+  @Test
   public void testDynamicPluginSimple() throws Exception {
     // test a single plugin
     Map<String, String> properties = new HashMap<>();


### PR DESCRIPTION
Added a way to get a dynamic plugin configurer for a different
namespace than the one a service is running in. Used this
capability to fix a bug in the pipeline studio service where
only system scoped plugins were able to be loaded.