### PR TITLE
[CDAP-15049] fix runtime args bad state in pipeline detail

### DIFF
--- a/cdap-ui/app/cdap/components/Popover/index.js
+++ b/cdap-ui/app/cdap/components/Popover/index.js
@@ -120,7 +120,9 @@ export default class Popover extends PureComponent {
     );
 
     if (newState) {
-      this.eventEmitter.emit('POPOVER_OPEN', this.id);
+      if (this.props.showOn !== 'Hover') {
+        this.eventEmitter.emit('POPOVER_OPEN', this.id);
+      }
       this.documentClick$ = Observable.fromEvent(document, 'click').subscribe((e) => {
         let parent = document.getElementById(this.id);
         let child = e.target;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15049
Build: https://builds.cask.co/browse/CDAP-UDUT231

Root cause:
The popover for no logs or no runtime args is emitting event to close all other popovers. 