### PR TITLE
[CDAP-15054] Adding service to load additional log appender

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -44,6 +44,7 @@ import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.internal.app.runtime.monitor.RuntimeMonitorServer;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.logging.appender.loader.LogAppenderLoaderService;
 import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
 import co.cask.cdap.messaging.server.MessagingHttpService;
@@ -506,6 +507,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
     MetricsCollectionService metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
     services.add(metricsCollectionService);
     services.add(injector.getInstance(ZKClientService.class));
+    services.add(injector.getInstance(LogAppenderLoaderService.class));
 
     switch (ProgramRunners.getClusterMode(programOptions)) {
       case ON_PREMISE:

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -858,14 +858,16 @@ public final class Constants {
     public static final String PIPELINE_LOGGER_CACHE_SIZE = "log.process.pipeline.logger.cache.size";
     public static final String PIPELINE_LOGGER_CACHE_EXPIRATION_MS = "log.process.pipeline.logger.cache.expiration.ms";
 
+    // log appender configs
+    public static final String LOG_APPENDER_PROVIDER = "app.program.log.appender.provider";
+    public static final String LOG_APPENDER_EXT_DIR = "app.program.log.appender.extensions.dir";
+    public static final String LOG_APPENDER_PROPERTY_PREFIX = "app.program.log.appender.system.properties.";
+
     // Property key in the logger context to indicate it is performing pipeline validation
     public static final String PIPELINE_VALIDATION = "log.pipeline.validation";
 
     public static final String SYSTEM_PIPELINE_CHECKPOINT_PREFIX = "cdap";
 
-    // Constants
-    // Table used to store log metadata
-    public static final String META_TABLE = "log.meta";
     // key constants
     public static final String TAG_NAMESPACE_ID = ".namespaceId";
     public static final String TAG_APPLICATION_ID = ".applicationId";

--- a/cdap-common/src/main/java/co/cask/cdap/extension/AbstractExtensionLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/extension/AbstractExtensionLoader.java
@@ -92,8 +92,8 @@ public abstract class AbstractExtensionLoader<EXTENSION_TYPE, EXTENSION> {
     // type should always be an instance of ParameterizedType
     Preconditions.checkState(type instanceof ParameterizedType);
     Type extensionType = ((ParameterizedType) type).getActualTypeArguments()[1];
-    // extensionType should always be an instance of Class
-    Preconditions.checkState(extensionType instanceof Class);
+    extensionType = TypeToken.of(extensionType).getRawType();
+    Preconditions.checkState(extensionType != null);
     this.extensionClass = (Class<EXTENSION>) extensionType;
     this.systemExtensionLoader = ServiceLoader.load(this.extensionClass);
     this.serviceLoaderCache = createServiceLoaderCache();

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1505,6 +1505,22 @@
   </property>
 
   <property>
+    <name>app.program.log.appender.extensions.dir</name>
+    <value>/opt/cdap/master/ext/log/appenders</value>
+    <description>
+      Directory for log appender jars
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.log.appender.provider</name>
+    <value></value>
+    <description>
+      Provider for log appender. The log appender provided by this provider will be loaded in each program container
+    </description>
+  </property>
+
+  <property>
     <name>log.kafka.topic</name>
     <value>logs.user-v2</value>
     <description>
@@ -1548,7 +1564,7 @@
     <name>log.pipeline.cdap.file.cleanup.batch.size</name>
     <value>10000</value>
     <description>
-      Batch size to clean up metadata table.
+      Batch size to clean up log metadata table
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="cd20658fb29ded81b47eef4e0e6779a1"
+DEFAULT_XML_MD5_HASH="6f29951d24e4a780ad293b12eb75084e"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -258,4 +258,12 @@
     </description>
   </property>
 
+  <property>
+    <name>app.program.log.appender.extensions.dir</name>
+    <value>ext/log/appenders</value>
+    <description>
+      Directory for log appender jars
+    </description>
+  </property>
+
 </configuration>

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/loader/LogAppenderExtensionLoader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/loader/LogAppenderExtensionLoader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.appender.loader;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.lang.FilterClassLoader;
+import co.cask.cdap.extension.AbstractExtensionLoader;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Extension loader to load log appenders.
+ */
+public class LogAppenderExtensionLoader extends AbstractExtensionLoader<String, Appender<ILoggingEvent>> {
+  private final CConfiguration cConf;
+
+  LogAppenderExtensionLoader(CConfiguration cConf) {
+    super(cConf.get(Constants.Logging.LOG_APPENDER_EXT_DIR));
+    this.cConf = cConf;
+  }
+
+  @Override
+  protected Set<String> getSupportedTypesForProvider(Appender<ILoggingEvent> appender) {
+    return Collections.singleton(cConf.get(Constants.Logging.LOG_APPENDER_PROVIDER));
+  }
+
+  @Override
+  protected FilterClassLoader.Filter getExtensionParentClassLoaderFilter() {
+    // Only allow spi classes.
+    return new FilterClassLoader.Filter() {
+      @Override
+      public boolean acceptResource(String resource) {
+        return resource.startsWith("ch/qos/logback");
+      }
+
+      @Override
+      public boolean acceptPackage(String packageName) {
+        return packageName.startsWith("ch.qos.logback");
+      }
+    };
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/loader/LogAppenderLoaderService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/loader/LogAppenderLoaderService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.appender.loader;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.status.OnConsoleStatusListener;
+import ch.qos.logback.core.status.StatusManager;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.lang.ClassLoaders;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterators;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Service that programmatically loads additional log appenders. It provides classloader isolation for additional
+ * appender.
+ */
+public class LogAppenderLoaderService extends AbstractIdleService {
+  private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LogAppenderLoaderService.class);
+  private final CConfiguration cConf;
+  private Appender<ILoggingEvent> logAppender;
+
+  @Inject
+  public LogAppenderLoaderService(CConfiguration cConf) {
+    this.cConf = cConf;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    String provider = cConf.get(Constants.Logging.LOG_APPENDER_PROVIDER);
+    // If there is no provider, there is nothing to load. This can happen if no additional appenders are provided.
+    if (Strings.isNullOrEmpty(provider)) {
+      return;
+    }
+
+    logAppender = loadLogAppender(provider, cConf);
+    initialize(logAppender, cConf);
+
+    LOG.info("Log Appender {} is initialized and started.", provider);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (logAppender != null) {
+      logAppender.stop();
+    }
+  }
+
+  /**
+   * Loads log appender using extension loader.
+   */
+  private Appender<ILoggingEvent> loadLogAppender(String appenderProvider, CConfiguration cConf) {
+    Appender<ILoggingEvent> appender = new LogAppenderExtensionLoader(cConf).get(appenderProvider);
+    if (appender == null) {
+      // this will not happen unless log appender provider is misconfigured.
+      throw new RuntimeException("Log appender " + appenderProvider + " is not constructed. " +
+                                   "Please provide correct log appender provider.");
+    }
+    return appender;
+  }
+
+  /**
+   * Initializes log appender by reading properties from cConf.
+   */
+  private void initialize(Appender<ILoggingEvent> appender, CConfiguration cConf) throws Exception {
+    ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+    LoggerContext loggerContext = (LoggerContext) loggerFactory;
+    if (loggerContext != null) {
+      Logger logger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+      // Check if the logger already contains the logAppender
+      if (!Iterators.contains(logger.iteratorForAppenders(), appender)) {
+        appender.setContext(loggerContext);
+        // Display any errors during initialization of log appender to console
+        configureStatusManager(loggerContext);
+
+        ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(appender.getClass().getClassLoader());
+        try {
+          Class<?> appenderClass = appender.getClass();
+          // set all the provided properties for the log appender
+          Map<String, String> properties = getProperties(cConf);
+          for (Map.Entry<String, String> property : properties.entrySet()) {
+            appenderClass.getMethod(property.getKey(), String.class).invoke(appender, property.getValue());
+          }
+
+          appender.start();
+        } finally {
+          Thread.currentThread().setContextClassLoader(oldClassLoader);
+        }
+
+        logger.addAppender(appender);
+      }
+    }
+  }
+
+  /**
+   * Configures status manager.
+   */
+  private void configureStatusManager(LoggerContext loggerContext) {
+    StatusManager statusManager = loggerContext.getStatusManager();
+    OnConsoleStatusListener onConsoleListener = new OnConsoleStatusListener();
+    statusManager.add(onConsoleListener);
+  }
+
+  /**
+   * Gets all the properties of the log appender.
+   */
+  private Map<String, String> getProperties(CConfiguration cConf) {
+    String prefix = String.format("%s%s.", Constants.Logging.LOG_APPENDER_PROPERTY_PREFIX,
+                                  cConf.get(Constants.Logging.LOG_APPENDER_PROVIDER));
+    return Collections.unmodifiableMap(cConf.getPropsWithPrefix(prefix));
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/system/CDAPLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/system/CDAPLogAppender.java
@@ -123,7 +123,7 @@ public class CDAPLogAppender extends AppenderBase<ILoggingEvent> implements Flus
   /**
    * Sets batch size for file cleanup
    */
-  public void setfileCleanupBatchSize(int batchSize) {
+  public void setFileCleanupBatchSize(int batchSize) {
     this.fileCleanupBatchSize = batchSize;
   }
 

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/system/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/system/CDAPLogAppenderTest.java
@@ -137,7 +137,7 @@ public class CDAPLogAppenderTest {
     cdapLogAppender.setFilePermissions("600");
     cdapLogAppender.setFileRetentionDurationDays(1);
     cdapLogAppender.setLogCleanupIntervalMins(10);
-    cdapLogAppender.setfileCleanupBatchSize(100);
+    cdapLogAppender.setFileCleanupBatchSize(100);
     AppenderContext context = new LocalAppenderContext(injector.getInstance(TransactionRunner.class),
                                                        injector.getInstance(LocationFactory.class),
                                                        new NoOpMetricsCollectionService());
@@ -206,7 +206,7 @@ public class CDAPLogAppenderTest {
     cdapLogAppender.setFilePermissions("640");
     cdapLogAppender.setFileRetentionDurationDays(1);
     cdapLogAppender.setLogCleanupIntervalMins(10);
-    cdapLogAppender.setfileCleanupBatchSize(100);
+    cdapLogAppender.setFileCleanupBatchSize(100);
     cdapLogAppender.setContext(context);
     cdapLogAppender.start();
 
@@ -277,7 +277,7 @@ public class CDAPLogAppenderTest {
     cdapLogAppender.setFilePermissions("640");
     cdapLogAppender.setFileRetentionDurationDays(1);
     cdapLogAppender.setLogCleanupIntervalMins(10);
-    cdapLogAppender.setfileCleanupBatchSize(100);
+    cdapLogAppender.setFileCleanupBatchSize(100);
     cdapLogAppender.setContext(context);
     cdapLogAppender.start();
 


### PR DESCRIPTION
Adding service to load additional log appenders. This service loads implementation of `ch.qos.logback.core.Appender` from appender jars using service provider mechanism. It uses Filter classloader to provide classloader isolation for appender classes. The service also initializes and starts loaded log appender with provided set of properties.

Tested on standalone with additional appender jars.

DUT: https://builds.cask.co/browse/CDAP-DUT6917
ITM: https://builds.cask.co/browse/IT-ITM-151