### PR TITLE
[CDAP-15053] Store CDAP version in Elasticsearch index metadata

### DIFF
--- a/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/Config.java
+++ b/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/Config.java
@@ -39,4 +39,14 @@ public final class Config {
   static final int DEFAULT_ELASTIC_CONFLICT_NUM_RETRIES = 50;
   static final int DEFAULT_ELASTIC_CONFLICT_RETRY_SLEEP_MS = 100;
   static final int DEFAULT_MAX_RESULT_WINDOW = 10000; // this is hardcoded in Elasticsearch
+
+  // index.mappings.json will have a mapping: "cdap_version": "CDAP_VERSION".
+  // the latter (placeholder) is replaced with the current CDAP version at index creation
+  // and similar for the metadata version and the checksum of the mappings file
+  static final String MAPPING_CDAP_VERSION = "cdap_version";
+  static final String MAPPING_CDAP_VERSION_PLACEHOLDER = "CDAP_VERSION";
+  static final String MAPPING_METADATA_VERSION = "metadata_version";
+  static final String MAPPING_METADATA_VERSION_PLACEHOLDER = "METADATA_VERSION";
+  static final String MAPPING_MAPPING_CHECKSUM = "mapping_checksum";
+  static final String MAPPING_MAPPING_CHECKSUM_PLACEHOLDER = "MAPPING_CHECKSUM";
 }

--- a/cdap-elastic/src/main/resources/index.mapping.json
+++ b/cdap-elastic/src/main/resources/index.mapping.json
@@ -17,6 +17,11 @@
 // Note: Strictly speaking, JSON does not allow comments, but GSON and Elasticsearch appear to be tolerant.
 // This file directly corresponds to the structure of co.cask.cdap.metadata.elastic.MetadataDocument.
 {
+  "_meta": {
+    "cdap_version": "CDAP_VERSION",
+    "metadata_version": "METADATA_VERSION",
+    "mapping_checksum": "MAPPING_CHECKSUM"
+  },
   "properties": {
     "entity": {
       "enabled": "false"


### PR DESCRIPTION
Stores the CDAP version in the Elasticsearch index metadata. Elastic's way of doing this is (interestingly enough) to create a mapping for the special field _meta. This mapping is ignored by Elastic, but can be retrieved as part of a GetMappings request. 
