### PR TITLE
[CDAP-15058] Ability to limit concurrent runs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramStateWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramStateWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -82,4 +82,16 @@ public interface ProgramStateWriter {
    * @param programRunId the id of the program run
    */
   void resume(ProgramRunId programRunId);
+
+  /**
+   * Updates the program run's status to be rejected
+   *
+   * @param programRunId the id of the program run
+   * @param programOptions the program options
+   * @param programDescriptor the program descriptor
+   * @param userId the user that attempted to run the program
+   * @param cause the cause of the failure
+   */
+  void reject(ProgramRunId programRunId, ProgramOptions programOptions, ProgramDescriptor programDescriptor,
+              String userId, Throwable cause);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -95,6 +95,19 @@ public interface Store {
   void setStart(ProgramRunId id, @Nullable String twillRunId, Map<String, String> systemArgs, byte[] sourceId);
 
   /**
+   * Logs rejection of a program run and persists program status to {@link ProgramRunStatus#REJECTED}.
+   *
+   * @param id run id of the program
+   * @param runtimeArgs the runtime arguments for this program run
+   * @param systemArgs the system arguments for this program run
+   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
+   *                 when the current program run status is reached
+   * @param artifactId artifact id used to create the application the program belongs to
+   */
+  void setRejected(ProgramRunId id, Map<String, String> runtimeArgs, Map<String, String> systemArgs,
+                   byte[] sourceId, ArtifactId artifactId);
+
+  /**
    * Logs start of program run and persists program status to {@link ProgramRunStatus#RUNNING}.
    *
    * @param id run id of the program
@@ -214,6 +227,14 @@ public interface Store {
    * @return        map of logged runs
    */
   Map<ProgramRunId, RunRecordMeta> getRuns(Set<ProgramRunId> programRunIds);
+
+  /**
+   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records across all namespaces.
+   *
+   * @param limit count at most that many runs, stop if there are more.
+   * @return map of logged runs
+   */
+  int countActiveRuns(@Nullable Integer limit);
 
   /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records against a given NamespaceId.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/MessagingProgramStateWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/MessagingProgramStateWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -126,6 +126,20 @@ public final class MessagingProgramStateWriter implements ProgramStateWriter {
       .put(ProgramOptionConstants.RESUME_TIME, String.valueOf(System.currentTimeMillis()))
       .put(ProgramOptionConstants.PROGRAM_STATUS, ProgramRunStatus.RESUMING.name()).build();
     programStatePublisher.publish(Notification.Type.PROGRAM_STATUS, properties);
+  }
+
+  @Override
+  public void reject(ProgramRunId programRunId, ProgramOptions programOptions,
+                     ProgramDescriptor programDescriptor, String userId, Throwable cause) {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
+      .put(ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId))
+      .put(ProgramOptionConstants.USER_OVERRIDES, GSON.toJson(programOptions.getUserArguments().asMap()))
+      .put(ProgramOptionConstants.SYSTEM_OVERRIDES, GSON.toJson(programOptions.getArguments().asMap()))
+      .put(ProgramOptionConstants.PROGRAM_STATUS, ProgramRunStatus.REJECTED.name())
+      .put(ProgramOptionConstants.USER_ID, userId)
+      .put(ProgramOptionConstants.PROGRAM_DESCRIPTOR, GSON.toJson(programDescriptor))
+      .put(ProgramOptionConstants.PROGRAM_ERROR, GSON.toJson(new BasicThrowable(cause)));
+    programStatePublisher.publish(Notification.Type.PROGRAM_STATUS, properties.build());
   }
 
   private void stop(ProgramRunId programRunId, ProgramRunStatus runStatus, @Nullable Throwable cause) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/RuntimeMonitor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/monitor/RuntimeMonitor.java
@@ -417,9 +417,7 @@ public class RuntimeMonitor extends AbstractRetryableScheduledService {
         continue;
       }
 
-      if (programStatus.equals(ProgramRunStatus.COMPLETED.name()) ||
-        programStatus.equals(ProgramRunStatus.FAILED.name()) ||
-        programStatus.equals(ProgramRunStatus.KILLED.name())) {
+      if (ProgramRunStatus.isEndState(programStatus)) {
         try {
           return Long.parseLong(properties.get(ProgramOptionConstants.END_TIME));
         } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -160,6 +160,14 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public void setRejected(ProgramRunId id, Map<String, String> runtimeArgs,
+                          Map<String, String> systemArgs, byte[] sourceId, ArtifactId artifactId) {
+    TransactionRunners.run(transactionRunner, context -> {
+      getAppMetadataStore(context).recordProgramRejected(id, runtimeArgs, systemArgs, sourceId, artifactId);
+    });
+  }
+
+  @Override
   public void setRunning(ProgramRunId id, long runTime, String twillRunId, byte[] sourceId) {
     TransactionRunners.run(transactionRunner, context -> {
       getAppMetadataStore(context).recordProgramRunning(id, runTime, twillRunId, sourceId);
@@ -324,6 +332,12 @@ public class DefaultStore implements Store {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getRuns(programRunIds);
     });
+  }
+
+  @Override
+  public int countActiveRuns(@Nullable Integer limit) {
+    return TransactionRunners.run(transactionRunner,
+                                  context -> (int) getAppMetadataStore(context).countActiveRuns(limit));
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ConstraintCheckerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/scheduler/ConstraintCheckerService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.scheduler;
 
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.ConflictException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
@@ -270,6 +271,8 @@ class ConstraintCheckerService extends AbstractIdleService {
 
       try {
         taskRunner.launch(job);
+      } catch (ConflictException e) {
+        LOG.error("Skip job {} because it was rejected while launching: {}", job.getJobKey(), e.getMessage());
       } catch (Exception e) {
         LOG.error("Skip launching job {} because the program {} encountered an exception while launching.",
                   job.getJobKey(), job.getSchedule().getProgramId(), e);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithServicesAndWorker.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithServicesAndWorker.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.service.BasicService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import co.cask.cdap.api.worker.AbstractWorker;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Test Application with services for the new application API.
+ */
+public class AppWithServicesAndWorker extends AbstractApplication {
+
+  public static final String NAME = AppWithServicesAndWorker.class.getSimpleName();
+  public static final String NO_OP_SERVICE = "NoOpService";
+  public static final String PING_SERVICE = "PingService";
+  public static final String NO_OP_WORKER = DummyWorker.class.getSimpleName();
+
+  /**
+   * Override this method to configure the application.
+   */
+  @Override
+  public void configure() {
+    setName(NAME);
+    setDescription("Application with Services");
+    addService(new BasicService(PING_SERVICE, new PingHandler()));
+    addService(new BasicService(NO_OP_SERVICE, new NoOpHandler()));
+    addWorker(new DummyWorker());
+  }
+
+  public static class DummyWorker extends AbstractWorker {
+    @Override
+    public void run() {
+      // no-op
+    }
+  }
+
+  public class NoOpHandler extends AbstractHttpServiceHandler {
+
+    @Path("/noop")
+    @GET
+    public void handler(HttpServiceRequest request, HttpServiceResponder responder) {
+      responder.sendStatus(200);
+    }
+  }
+
+  public static final class PingHandler extends AbstractHttpServiceHandler {
+
+    @Path("ping")
+    @GET
+    public void handler(HttpServiceRequest request, HttpServiceResponder responder) {
+      responder.sendStatus(200);
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/NoOpProgramStateWriter.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/NoOpProgramStateWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -58,6 +58,12 @@ public class NoOpProgramStateWriter implements ProgramStateWriter {
 
   @Override
   public void resume(ProgramRunId programRunId) {
+    // no-op
+  }
+
+  @Override
+  public void reject(ProgramRunId programRunId, ProgramOptions programOptions, ProgramDescriptor programDescriptor,
+                     String userId, Throwable cause) {
     // no-op
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramRunLimitTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramRunLimitTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services.http.handlers;
+
+import co.cask.cdap.AppWithServicesAndWorker;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.test.SlowTests;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for {@link ProgramLifecycleHttpHandler}
+ */
+public class ProgramRunLimitTest extends AppFabricTestBase {
+  private static final String STOPPED = "STOPPED";
+  private static final String RUNNING = "RUNNING";
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    CConfiguration cConf = createBasicCConf();
+    // we enable Kerberos for these unit tests, so we can test namespace group permissions (see testDataDirCreation).
+    cConf.setInt(Constants.AppFabric.MAX_CONCURRENT_RUNS, 2);
+    initializeAndStartServices(cConf, null);
+  }
+
+  @Category(SlowTests.class)
+  @Test
+  public void testConcurrentProgramRunLimit() throws Exception {
+    // deploy, check the status
+    deploy(AppWithServicesAndWorker.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
+
+    ApplicationId appId = new ApplicationId(TEST_NAMESPACE1, AppWithServicesAndWorker.NAME);
+    ProgramId noOpService = appId.service(AppWithServicesAndWorker.NO_OP_SERVICE);
+    ProgramId pingService = appId.service(AppWithServicesAndWorker.PING_SERVICE);
+    ProgramId noOpWorker = appId.worker(AppWithServicesAndWorker.NO_OP_WORKER);
+
+    // all programs are stopped initially
+    Assert.assertEquals(STOPPED, getProgramStatus(noOpService));
+    Assert.assertEquals(STOPPED, getProgramStatus(pingService));
+    Assert.assertEquals(STOPPED, getProgramStatus(noOpWorker));
+
+    // start both services and check the status
+    startProgram(noOpService);
+    waitState(noOpService, RUNNING);
+
+    startProgram(pingService);
+    waitState(pingService, RUNNING);
+
+    // start the worker and check that it is rejected
+    startProgram(noOpWorker, 409);
+    Tasks.waitFor(1, () -> getProgramRuns(noOpWorker, ProgramRunStatus.ALL).size(), 10, TimeUnit.SECONDS);
+    Assert.assertEquals(ProgramRunStatus.REJECTED, getProgramRuns(noOpWorker, ProgramRunStatus.ALL).get(0).getStatus());
+
+    // stop one service
+    stopProgram(noOpService);
+    waitState(noOpService, STOPPED);
+
+    // starting the worker should now succeed
+    startProgram(noOpWorker, 200);
+    Tasks.waitFor(1, () -> getProgramRuns(noOpWorker, ProgramRunStatus.COMPLETED).size(), 10, TimeUnit.SECONDS);
+
+    // stop other service
+    stopProgram(pingService);
+    waitState(pingService, STOPPED);
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -513,6 +513,11 @@ public abstract class AppMetadataStoreTest {
         allActual.get(programId).add(activeRun.getValue().getStatus());
       }
       Assert.assertEquals(allExpected, allActual);
+
+      // test the count-all method
+      Assert.assertEquals(store.getActiveRuns(x -> true).size(), store.countActiveRuns(null));
+      Assert.assertEquals(store.getActiveRuns(x -> true).size(), store.countActiveRuns(100));
+      Assert.assertEquals(2, store.countActiveRuns(2));
     });
 
     // check active runs per app

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -205,6 +205,7 @@ public final class Constants {
       "app.program.yarn.attempt.failures.validity.interval";
 
     public static final String PROGRAM_TRANSACTION_CONTROL = "app.program.transaction.control";
+    public static final String MAX_CONCURRENT_RUNS = "app.max.concurrent.runs";
 
     /**
      * Guice named bindings.
@@ -752,6 +753,7 @@ public final class Constants {
       public static final String PROGRAM_COMPLETED_RUNS = "program.completed.runs";
       public static final String PROGRAM_FAILED_RUNS = "program.failed.runs";
       public static final String PROGRAM_KILLED_RUNS = "program.killed.runs";
+      public static final String PROGRAM_REJECTED_RUNS = "program.rejected.runs";
       public static final String PROGRAM_NODE_MINUTES = "program.node.minutes";
     }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/Checksums.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/Checksums.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.utils;
+
+/**
+ * Utilities for computing checksums.
+ */
+public final class Checksums {
+
+  private Checksums() { }
+
+  private static final long EMPTY64 = 0xc15d213aa4d7a795L;
+
+  /**
+   * The implementation of fingerprint algorithm is copied from {@code org.apache.avro.SchemaNormalization} class.
+   *
+   * @param data byte string for which fingerprint is to be computed
+   * @return the 64-bit Rabin Fingerprint (as recommended in the Avro spec) of a byte string
+   */
+   public static long fingerprint64(byte[] data) {
+    long result = EMPTY64;
+    for (byte b: data) {
+      int index = (int) (result ^ b) & 0xff;
+      result = (result >>> 8) ^ FP64.FP_TABLE[index];
+    }
+    return result;
+  }
+
+  /* An inner class ensures that FP_TABLE initialized only when needed. */
+  private static class FP64 {
+    private static final long[] FP_TABLE = new long[256];
+    static {
+      for (int i = 0; i < 256; i++) {
+        long fp = i;
+        for (int j = 0; j < 8; j++) {
+          long mask = -(fp & 1L);
+          fp = (fp >>> 1) ^ (EMPTY64 & mask);
+        }
+        FP_TABLE[i] = fp;
+      }
+    }
+  }
+}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -379,6 +379,14 @@
   </property>
 
   <property>
+    <name>app.max.concurrent.runs</name>
+    <value>-1</value>
+    <description>
+      Maximum number of concurrent program runs allowed; set to -1 for unlimited
+    </description>
+  </property>
+
+  <property>
     <name>app.program.max.start.seconds</name>
     <value>300</value>
     <description>

--- a/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/VersionInfo.java
+++ b/cdap-elastic/src/main/java/co/cask/cdap/metadata/elastic/VersionInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata.elastic;
+
+import co.cask.cdap.common.utils.ProjectInfo;
+
+/**
+ * Information about the version of this metadata storage provider. It includes the version of CDAP,
+ * the version of the metadata implementation, and a checksum of the index mappings file.
+ *
+ * This information is stored as metadata in the index mappings, to be abe to decide whether the
+ * index needs to be migrated after an upgrade. Strictly speaking, the {@link #METADATA_VERSION}
+ * should be sufficient to make this determination, but we record a checksum of the index mappings
+ * as an additional safeguard, as it will allow detecting a change that neglected to bump the
+ * {@link #METADATA_VERSION}.
+ */
+public class VersionInfo {
+
+  /**
+   * The current version of the Elasticsearch metadata provider. This must be changed any time
+   * the indexing schema, index settings, or index mappings are changed in a way that requires
+   * an index migration (reindexing of all metadata). This is information is stored in the
+   * index metadata, and at upgrade time, it is used to determine whether migration is needed.
+   */
+  public static final int METADATA_VERSION = 1;
+
+  private final ProjectInfo.Version cdapVersion;
+  private final int metadataVersion;
+  private final long mappingsChecksum;
+
+  public VersionInfo(ProjectInfo.Version cdapVersion, int metadataVersion, long mappingsChecksum) {
+    this.cdapVersion = cdapVersion;
+    this.metadataVersion = metadataVersion;
+    this.mappingsChecksum = mappingsChecksum;
+  }
+
+  public ProjectInfo.Version getCdapVersion() {
+    return cdapVersion;
+  }
+
+  public int getMetadataVersion() {
+    return metadataVersion;
+  }
+
+  public long getMappingsChecksum() {
+    return mappingsChecksum;
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2018 Cask Data, Inc.
+ * Copyright © 2014-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,10 @@ package co.cask.cdap.proto;
 import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.workflow.NodeStatus;
 
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Program Status Types used to query program runs
  */
@@ -31,7 +35,13 @@ public enum ProgramRunStatus {
   RESUMING,
   COMPLETED,
   FAILED,
-  KILLED;
+  KILLED,
+  REJECTED;
+
+  private static final Set<ProgramRunStatus> UNSUCCESSFUL_STATES = EnumSet.of(FAILED, KILLED, REJECTED);
+  private static final Set<ProgramRunStatus> END_STATES = EnumSet.of(COMPLETED, FAILED, KILLED, REJECTED);
+  private static final Set<String> END_STATE_NAMES =
+    END_STATES.stream().map(ProgramRunStatus::name).collect(Collectors.toSet());
 
   /**
    * Return whether this state can transition to the specified state.
@@ -81,7 +91,21 @@ public enum ProgramRunStatus {
    * @return whether the status is an end status for a program run.
    */
   public boolean isEndState() {
-    return this == COMPLETED || this == FAILED || this == KILLED;
+    return END_STATES.contains(this);
+  }
+
+  /**
+   * @return whether a name (string) represents an end status for a program run.
+   */
+  public static boolean isEndState(String name) {
+    return END_STATE_NAMES.contains(name);
+  }
+
+  /**
+   * @return whether the status is an end status for a program run.
+   */
+  public boolean isUnsuccessful() {
+    return UNSUCCESSFUL_STATES.contains(this);
   }
 
   /**

--- a/cdap-ui/app/cdap/components/OpsDashboard/OpsDashboard.scss
+++ b/cdap-ui/app/cdap/components/OpsDashboard/OpsDashboard.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -53,7 +53,8 @@ $header-height: 70px;
       @include setColor($succeeded);
     }
 
-    .failed {
+    .failed,
+    .rejected {
       @include setColor($failed);
     }
   }

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/DataParser.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/DataParser.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -63,7 +63,7 @@ export function parseDashboardData(rawData, startTime, duration, pipeline, custo
     if (buckets[endTime]) {
       if (runInfo.status === 'COMPLETED') {
         buckets[endTime].successful++;
-      } else if (runInfo.status === 'FAILED') {
+      } else if (['FAILED', 'REJECTED'].indexOf(runInfo.status) !== -1) {
         buckets[endTime].failed++;
       }
       buckets[endTime].runsList.push(runInfo);

--- a/cdap-ui/app/cdap/services/StatusMapper.js
+++ b/cdap-ui/app/cdap/services/StatusMapper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2018 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,6 +22,7 @@ const statusMap = {
   [PROGRAM_STATUSES.RUNNING]: 'Running',
   [PROGRAM_STATUSES.SUCCEEDED]: 'Succeeded',
   [PROGRAM_STATUSES.FAILED]: 'Failed',
+  [PROGRAM_STATUSES.REJECTED]: 'Rejected',
   [PROGRAM_STATUSES.DRAFT]: 'Draft',
   [PROGRAM_STATUSES.STOPPED]: 'Stopped',
   [PROGRAM_STATUSES.COMPLETED]: 'Succeeded',
@@ -59,7 +60,10 @@ function getStatusIndicatorClass(displayStatus) {
     displayStatus === statusMap[PROGRAM_STATUSES.STOPPING]
   ) {
     return 'status-light-green';
-  } else if (displayStatus === statusMap[PROGRAM_STATUSES.FAILED]) {
+  } else if (
+    displayStatus === statusMap[PROGRAM_STATUSES.FAILED] ||
+    displayStatus === statusMap[PROGRAM_STATUSES.REJECTED]
+  ) {
     return 'status-light-red';
   } else {
     return 'status-light-grey';

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2018 Cask Data, Inc.
+ * Copyright © 2017-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -267,6 +267,7 @@ const PROGRAM_STATUSES = {
   RUNNING: 'RUNNING',
   SUCCEEDED: 'SUCCEEDED',
   FAILED: 'FAILED',
+  REJECTED: 'REJECTED',
   DRAFT: 'DRAFT',
   STOPPED: 'STOPPED',
   COMPLETED: 'COMPLETED',


### PR DESCRIPTION
- adds a new cdap-site property to control the number of allowed concurrent program runs (excluding system apps)
- program lifecycle service checks how many runs are active and if it exceeds the limit, rejects the new run
- for a rejected run, create a run record with status "REJECTED". This is the only way a UI user would know about exceeding the limit
- in the UI, an error message is displayed when attempting to start too many runs. 
- if a scheduled run is rejected, that schedule is skipped with an error message in the logs (and the run record will be visible in the UI)
- Rejected status is displayed in red in the UI