### PR TITLE
Use older dataproc image for provisioning

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/co/cask/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -179,7 +179,7 @@ public class DataprocProvisioner implements Provisioner {
           break;
         case SPARK2_2_11:
         default:
-          imageVersion = "1.2";
+          imageVersion = "1.2.65-deb9";
           break;
       }
 


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-15070
Attempting to use older image