### PR TITLE
[CDAP-15081] Fixes focus on comment nodes to be draggable when clicked outisde the node (in canvas)

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -528,6 +528,7 @@ angular.module(PKG.name + '.commons')
     vm.handleCanvasClick = () => {
       vm.toggleNodeMenu();
       vm.selectedNode = null;
+      vm.clearCommentSelection();
     };
 
     function addConnection(newConnObj) {
@@ -997,6 +998,7 @@ angular.module(PKG.name + '.commons')
             $timeout.cancel(nodesTimeout);
           }
           nodesTimeout = $timeout(function () {
+            makeCommentsDraggable();
             makeNodesDraggable();
             initNodes();
           });
@@ -1234,15 +1236,15 @@ angular.module(PKG.name + '.commons')
       DAGPlusPlusNodesActionsFactory.addComment(config);
     };
 
-    function clearCommentSelection() {
+    vm.clearCommentSelection = function clearCommentSelection() {
       angular.forEach(vm.comments, function (comment) {
         comment.isActive = false;
       });
-    }
+    };
 
     vm.commentSelect = function (event, comment) {
       event.stopPropagation();
-      clearCommentSelection();
+      vm.clearCommentSelection();
 
       if (dragged) {
         dragged = false;


### PR DESCRIPTION
**Source of the problem:**
- When we click on comment node we have the focus to the text area that sits inside the node. - 
- However when clicked outside the node (in canvas) we don't reset that focus which will make the node draggable.

**Fix:**
- When clicking outside (in the canvas) reset the focus from the comment node which will make it draggable.

**Note:**
There are still couple of use cases that we don't quite fullfil.
- Right now the comment node is not "tied" to any other node for which the comment is supposed to be descriptive of (Don't clean up the graph before deploy, add comment near a node, deploy the pipeline. Post deploy we clean up the graph and the comment no longer stays close to the actual node)
- Clone pipeline (and import) does not import comment nodes. This will come in a separate PR.

JIRA: 
https://issues.cask.co/browse/CDAP-15081
Build:
https://builds.cask.co/browse/CDAP-UDUT240