### PR TITLE
Fixes focus on comment nodes to be draggable when clicked outisde the node (in canvas)

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -486,6 +486,12 @@ angular.module(PKG.name + '.commons')
       };
     }
 
+    vm.handleCanvasClick = () => {
+      vm.toggleNodeMenu();
+      vm.selectedNode = null;
+      vm.clearCommentSelection();
+    };
+
     function addConnection(newConnObj) {
       let connection = {
         from: newConnObj.sourceId,
@@ -983,6 +989,7 @@ angular.module(PKG.name + '.commons')
             $timeout.cancel(nodesTimeout);
           }
           nodesTimeout = $timeout(function () {
+            makeCommentsDraggable();
             makeNodesDraggable();
             initNodes();
           });
@@ -1215,15 +1222,15 @@ angular.module(PKG.name + '.commons')
       DAGPlusPlusNodesActionsFactory.addComment(config);
     };
 
-    function clearCommentSelection() {
+    vm.clearCommentSelection = function clearCommentSelection() {
       angular.forEach(vm.comments, function (comment) {
         comment.isActive = false;
       });
-    }
+    };
 
     vm.commentSelect = function (event, comment) {
       event.stopPropagation();
-      clearCommentSelection();
+      vm.clearCommentSelection();
 
       if (dragged) {
         dragged = false;

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -95,7 +95,7 @@
 
 <div class="my-js-dag"
     ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled, 'normal-cursor': disableNodeClick, 'preview-mode': previewMode }"
-    ng-click="DAGPlusPlusCtrl.toggleNodeMenu(); DAGPlusPlusCtrl.openDagMenu(false);">
+    ng-click="DAGPlusPlusCtrl.handleCanvasClick()">
     <div id="diagram-container">
       <div id="dag-container" ng-style="DAGPlusPlusCtrl.panning.style">
         <!--


### PR DESCRIPTION
Same PR as https://github.com/cdapio/cdap/pull/11209 but for release/5.1