### PR TITLE
Modifies favicon path path validation to be fs.existsSync instead of require.resolve

### DIFF
--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -79,8 +79,10 @@ function getFaviconPath(uiThemeConfig) {
       themeFaviconPath = `${CDAP_DIST_PATH}/${themeFaviconPath}`;
     }
     try {
-      if (require.resolve(themeFaviconPath)) {
+      if (fs.existsSync(themeFaviconPath)) {
         faviconPath = themeFaviconPath;
+      } else {
+        log.warn(`Unable to find favicon at path ${themeFaviconPath}`);
       }
     } catch (e) {
       log.warn(`Unable to find favicon at path ${themeFaviconPath}`);


### PR DESCRIPTION
Build: https://builds.cask.co/browse/CDAP-UDUT242