### PR TITLE
[CDAP-15091] reload log appender property

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -388,6 +388,8 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
    */
   private CConfiguration createContainerCConf(CConfiguration cConf) {
     CConfiguration result = CConfiguration.copy(cConf);
+    // reload config
+    result.reloadConfiguration();
     // don't have tephra retry in order to give CDAP more control over when to retry and how.
     result.set(TxConstants.Service.CFG_DATA_TX_CLIENT_RETRY_STRATEGY, "n-times");
     result.setInt(TxConstants.Service.CFG_DATA_TX_CLIENT_ATTEMPTS, 0);


### PR DESCRIPTION
Reload cConf for cdap-site updates before launching pipeline. 

Tested locally by modifying cdap-site without cdap restart

DUT: https://builds.cask.co/browse/CDAP-DUT6929
ITM: https://builds.cask.co/browse/IT-ITM-159