### PR TITLE
[CDAP-15065] Fix race condition in schedule profile assignment

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/profile/AdminEventPublisher.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/profile/AdminEventPublisher.java
@@ -38,7 +38,6 @@ import co.cask.cdap.proto.id.TopicId;
 import com.google.common.base.Throwables;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,8 +105,8 @@ public class AdminEventPublisher {
    *
    * @param scheduleId the schedule id that get created
    */
-  public void publishScheduleCreation(ScheduleId scheduleId) {
-    publishMessage(scheduleId, MetadataMessage.Type.ENTITY_CREATION);
+  public void publishScheduleCreation(ScheduleId scheduleId, long updatedTime) {
+    publishMessage(scheduleId, MetadataMessage.Type.ENTITY_CREATION, updatedTime);
   }
 
   /**
@@ -127,15 +126,10 @@ public class AdminEventPublisher {
    * might already get deleted when we process the message. So we must specify it to make sure the profile metadata is
    * removed.
    *
-   * @param scheduleId schedule id who gets deleted
-   * @param programSchedule the detail of this schedule
+   * @param programSchedule the detail of the schedule that was deleted
    */
-  public void publishScheduleDeletion(ScheduleId scheduleId, ProgramSchedule programSchedule) {
-    publishMessage(scheduleId, MetadataMessage.Type.ENTITY_DELETION, programSchedule);
-  }
-
-  private void publishMessage(EntityId entityId, MetadataMessage.Type type) {
-    publishMessage(entityId, type, JsonNull.INSTANCE);
+  public void publishScheduleDeletion(ProgramSchedule programSchedule) {
+    publishMessage(programSchedule.getScheduleId(), MetadataMessage.Type.ENTITY_DELETION, programSchedule);
   }
 
   private void publishMessage(EntityId entityId, MetadataMessage.Type type,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDatasetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDatasetTest.java
@@ -155,13 +155,13 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
       transactionRunner,
       context -> {
         ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
-        store.deleteSchedules(APP1_ID);
+        store.deleteSchedules(APP1_ID, System.currentTimeMillis());
         Assert.assertEquals(ImmutableSet.of(),
                             toScheduleSet(store.listScheduleRecords(APP1_ID)));
-        store.deleteSchedules(PROG2_ID);
+        store.deleteSchedules(PROG2_ID, System.currentTimeMillis());
         Assert.assertEquals(ImmutableSet.of(),
                             toScheduleSet(store.listScheduleRecords(PROG2_ID)));
-        store.deleteSchedules(APP3_ID);
+        store.deleteSchedules(APP3_ID, System.currentTimeMillis());
         Assert.assertEquals(ImmutableSet.of(),
                             toScheduleSet(store.listScheduleRecords(APP3_ID)));
       }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1277,6 +1277,7 @@ public final class Constants {
     public static final String MESSAGING_TOPIC = "metadata.messaging.topic";
     public static final String MESSAGING_FETCH_SIZE = "metadata.messaging.fetch.size";
     public static final String MESSAGING_POLL_DELAY_MILLIS = "metadata.messaging.poll.delay.millis";
+    public static final String MESSAGING_RETRIES_ON_CONFLICT = "metadata.messaging.retries.on.conflict";
 
     public static final String STORAGE_PROVIDER_IMPLEMENTATION = "metadata.storage.implementation";
     public static final String STORAGE_PROVIDER_NOSQL = "nosql";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2262,6 +2262,16 @@
     </description>
   </property>
 
+  <property>
+    <name>metadata.messaging.retries.on.conflict</name>
+    <value>100</value>
+    <description>
+      The maximal number of times a metadata message will be processed if it
+      repeatedly causes a conflict exception. After this, the mesaage will be
+      discarded.
+    </description>
+  </property>
+
   <!-- Metrics Configuration -->
 
   <property>

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/CoreMessagingService.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/CoreMessagingService.java
@@ -87,8 +87,8 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
   private final long txMaxLifeTimeInMillis;
 
   @Inject
-  CoreMessagingService(CConfiguration cConf, TableFactory tableFactory,
-                       MetricsCollectionService metricsCollectionService) {
+  protected CoreMessagingService(CConfiguration cConf, TableFactory tableFactory,
+                                 MetricsCollectionService metricsCollectionService) {
     this(cConf, tableFactory, TimeProvider.SYSTEM_TIME, metricsCollectionService);
   }
 


### PR DESCRIPTION
The issue being fixed is that TMS messages can reach a subscriber before the changes represented by that message are committed to the store. The subscriber then cannot read the data and drops the message, which is not the intention. Fix:

- changes schedule store to keep a "update time" when a schedule is deleted.
- notifications for schedule creation now contain the update time as the payload
- profile message processor, when it receives a schedule creation message, verifies that it sees the change by comparing the "update time" in the store with the one in the message
- if the updated data is not visible yet, it throws a conflict exception, and processing is retried in the next iteration
- to make sure that such conflicts do not block the TMS processsing forever, the subscriber keeps track of how many times it failed to process the same message, and after a (configurable) number of times, it discards the message

Also fixes the issue that schedule deletion was not published to TMS if it was caused by deletion of a program that triggered the schedule.
