### PR TITLE
CDAP-15131 fix metrics deletion on k8s

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/MetricsServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/environment/k8s/MetricsServiceMain.java
@@ -32,6 +32,7 @@ import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.metrics.guice.MetricsProcessorStatusServiceModule;
 import co.cask.cdap.metrics.guice.MetricsStoreModule;
 import co.cask.cdap.metrics.process.MessagingMetricsProcessorServiceFactory;
+import co.cask.cdap.metrics.process.MetricsAdminSubscriberService;
 import co.cask.cdap.metrics.process.MetricsProcessorStatusService;
 import co.cask.cdap.metrics.query.MetricsQueryService;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -94,6 +95,7 @@ public class MetricsServiceMain extends AbstractServiceMain<EnvironmentOptions> 
                    .create(topicNumbers, metricsContext, 0));
     services.add(injector.getInstance(MetricsProcessorStatusService.class));
     services.add(injector.getInstance(MetricsQueryService.class));
+    services.add(injector.getInstance(MetricsAdminSubscriberService.class));
   }
 
   @Nullable


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15131
Build: https://builds.cask.co/browse/CDAP-DUT6942-1

The MetricsAdminSubcriberService needs to be added otherwise the metrics deletion is never happening. 