### PR TITLE
Bugfix ui/cdap bugfixes 3

### DIFF
--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/NamespacesAccordion/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/NamespacesAccordion/index.js
@@ -56,6 +56,10 @@ const GRID_HEADERS = [
   },
 ];
 
+if (Theme.showApplicationUpload === false) {
+  GRID_HEADERS.splice(1, 1);
+}
+
 const NUM_NS_TO_SHOW = 5;
 
 export default class NamespacesAccordion extends Component {

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/ReloadSystemArtifacts.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/ReloadSystemArtifacts.js
@@ -18,6 +18,7 @@ import React, { Component } from 'react';
 import ConfirmationModal from 'components/ConfirmationModal';
 import { MyArtifactApi } from 'api/artifact';
 import T from 'i18n-react';
+import { Theme } from 'services/ThemeHelper';
 
 const PREFIX = 'features.Administration.Configure.buttons.ReloadSystemArtifacts';
 
@@ -58,6 +59,10 @@ export default class ReloadSystemArtifacts extends Component {
   };
 
   render() {
+    if (Theme.showReloadSystemArtifacts === false) {
+      return null;
+    }
+
     return (
       <span>
         <button className="btn btn-secondary" onClick={this.onClick}>

--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemProfilesAccordion/index.js
@@ -27,6 +27,8 @@ import { connect, Provider } from 'react-redux';
 import { Label, Input } from 'reactstrap';
 import { getProfiles, resetProfiles } from 'components/Cloud/Profiles/Store/ActionCreator';
 import { SYSTEM_NAMESPACE } from 'services/global-constants';
+import { Theme } from 'services/ThemeHelper';
+import If from 'components/If';
 require('./SystemProfilesAccordion.scss');
 
 const PREFIX = 'features.Administration.Accordions.SystemProfiles';
@@ -75,21 +77,27 @@ class SystemProfilesAccordion extends Component {
 
     return (
       <div className="admin-config-container-content system-profiles-container-content">
-        <div className="create-import-profile">
-          <Link className="btn btn-secondary create-profile-button" to="/ns/system/profiles/create">
-            {T.translate(`${PREFIX}.create`)}
-          </Link>
-          <Label className="import-profile-label" for="import-profile">
-            {T.translate(`${PREFIX}.import`)}
-            <Input
-              type="file"
-              accept=".json"
-              id="import-profile"
-              onChange={importProfile.bind(this, SYSTEM_NAMESPACE)}
-              onClick={(e) => (e.target.value = null)}
-            />
-          </Label>
-        </div>
+        <If condition={Theme.showCreateProfile !== false}>
+          <div className="create-import-profile">
+            <Link
+              className="btn btn-secondary create-profile-button"
+              to="/ns/system/profiles/create"
+            >
+              {T.translate(`${PREFIX}.create`)}
+            </Link>
+            <Label className="import-profile-label" for="import-profile">
+              {T.translate(`${PREFIX}.import`)}
+              <Input
+                type="file"
+                accept=".json"
+                id="import-profile"
+                onChange={importProfile.bind(this, SYSTEM_NAMESPACE)}
+                onClick={(e) => (e.target.value = null)}
+              />
+            </Label>
+          </div>
+        </If>
+
         <ProfilesListView namespace={SYSTEM_NAMESPACE} />
       </div>
     );

--- a/cdap-ui/app/cdap/components/AppHeader/BrandImage.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/BrandImage.tsx
@@ -39,7 +39,7 @@ const BrandImage: React.SFC<IBrandImageProps> = ({ classes, context }) => {
 
 const imageStyle = {
   img: {
-    height: '45px',
+    height: '48px',
   },
 };
 const StyledBrandImage = withStyles(imageStyle)(withContext(BrandImage));

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/store/ActionCreator.js
@@ -211,6 +211,9 @@ export function search(e) {
 export function getOperations(direction) {
   Store.dispatch({
     type: Actions.operationsLoading,
+    payload: {
+      direction,
+    },
   });
 
   const state = Store.getState().lineage;

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/store/Store.js
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/store/Store.js
@@ -119,6 +119,7 @@ const operations = (state = operationsInitialState, action = defaultAction) => {
         ...state,
         loading: true,
         showOperations: true,
+        direction: action.payload.direction,
       };
     case Actions.setOperations:
       return {

--- a/cdap-ui/app/cdap/components/NamespaceDetails/ComputeProfiles/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/ComputeProfiles/index.js
@@ -24,6 +24,8 @@ import ProfilesStore from 'components/Cloud/Profiles/Store';
 import { importProfile } from 'components/Cloud/Profiles/Store/ActionCreator';
 import { connect, Provider } from 'react-redux';
 import { Label, Input } from 'reactstrap';
+import { Theme } from 'services/ThemeHelper';
+import If from 'components/If';
 
 require('./ComputeProfiles.scss');
 
@@ -49,25 +51,28 @@ class NamespaceDetailsComputeProfiles extends Component {
     return (
       <div className="namespace-details-section-label">
         {label}
-        <Link
-          to={`/ns/${getCurrentNamespace()}/profiles/create`}
-          className="create-new-profile-label"
-        >
-          {T.translate(`${PREFIX}.create`)}
-        </Link>
-        <span> | </span>
-        <Label className="import-profile-label" for="import-profile">
-          {T.translate(`${PREFIX}.import`)}
-          {/* The onClick here is to clear the file, so if the user uploads the same file
+        <If condition={Theme.showCreateProfile !== false}>
+          <Link
+            to={`/ns/${getCurrentNamespace()}/profiles/create`}
+            className="create-new-profile-label"
+          >
+            {T.translate(`${PREFIX}.create`)}
+          </Link>
+          <span> | </span>
+          <Label className="import-profile-label" for="import-profile">
+            {T.translate(`${PREFIX}.import`)}
+            {/* The onClick here is to clear the file, so if the user uploads the same file
           twice then we can show the error, instead of showing nothing */}
-          <Input
-            type="file"
-            accept=".json"
-            id="import-profile"
-            onChange={importProfile.bind(this, getCurrentNamespace())}
-            onClick={(e) => (e.target.value = null)}
-          />
-        </Label>
+            <Input
+              type="file"
+              accept=".json"
+              id="import-profile"
+              onChange={importProfile.bind(this, getCurrentNamespace())}
+              onClick={(e) => (e.target.value = null)}
+            />
+          </Label>
+        </If>
+
         {this.props.profilesCount ? (
           <p className="create-new-profile-description">{T.translate(`${PREFIX}.description`)}</p>
         ) : null}

--- a/cdap-ui/app/cdap/components/NamespaceDetails/EntityCounts/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDetails/EntityCounts/index.js
@@ -18,6 +18,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import T from 'i18n-react';
+import { Theme } from 'services/ThemeHelper';
+import If from 'components/If';
 require('./EntityCounts.scss');
 
 const PREFIX = 'features.NamespaceDetails.entityCounts';
@@ -35,10 +37,12 @@ const NamespaceDetailsEntityCounts = ({ customAppCount, pipelineCount, datasetCo
     <React.Fragment>
       <hr />
       <div className="namespace-details-entity-count">
-        <div className="entity-count">
-          <span>{T.translate(`${PREFIX}.customApps`)}</span>
-          <div>{customAppCount}</div>
-        </div>
+        <If condition={Theme.showApplicationUpload !== false}>
+          <div className="entity-count">
+            <span>{T.translate(`${PREFIX}.customApps`)}</span>
+            <div>{customAppCount}</div>
+          </div>
+        </If>
         <div className="entity-count">
           <span>{T.translate('commons.pipelines')}</span>
           <div>{pipelineCount}</div>

--- a/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/TypeSelector/index.js
+++ b/cdap-ui/app/cdap/components/OpsDashboard/RunsGraph/TypeSelector/index.js
@@ -20,6 +20,7 @@ import IconSVG from 'components/IconSVG';
 import { connect } from 'react-redux';
 import { DashboardActions } from 'components/OpsDashboard/store/DashboardStore';
 import T from 'i18n-react';
+import { Theme } from 'services/ThemeHelper';
 require('./TypeSelector.scss');
 
 const PREFIX = 'features.OpsDashboard.RunsGraph.TypeSelector';
@@ -32,6 +33,10 @@ function TypeSelectorView({
   pipelineCount,
   customAppCount,
 }) {
+  if (Theme.showApplicationUpload === false) {
+    return null;
+  }
+
   return (
     <div className="type-selector">
       <div className="type-item" onClick={togglePipeline}>

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/PipelineTableRow.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/PipelineTableRow.tsx
@@ -47,7 +47,7 @@ export default class PipelineTableRow extends React.PureComponent<IProps> {
     return (
       <a href={pipelineLink} className=" grid-row">
         <div className="name" title={pipeline.name}>
-          <h5>{pipeline.name}</h5>
+          <h5 className="truncate">{pipeline.name}</h5>
         </div>
         <div className="type">{T.translate(`${PREFIX}.${pipeline.artifact.name}`)}</div>
         <Status pipeline={pipeline} />

--- a/cdap-ui/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/DraftTableRow.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/DraftTableRow.tsx
@@ -43,8 +43,8 @@ export default class DraftTableRow extends React.PureComponent<IProps> {
 
     return (
       <a href={link} className="grid-row">
-        <div className="name">
-          <h5>{draft.name}</h5>
+        <div className="name" title={draft.name}>
+          <h5 className="truncate">{draft.name}</h5>
         </div>
         <div className="type">{T.translate(`${PREFIX}.${draft.artifact.name}`)}</div>
         <div className="last-saved">{lastSaved}</div>

--- a/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModal.scss
+++ b/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModal.scss
@@ -100,6 +100,10 @@ $hightlight-color: #7f8c8d;
         }
       }
 
+      &.search-results-item-link:hover {
+        text-decoration: none;
+      }
+
       .search-results-item {
         padding: 5px 15px;
         margin-right: 0;
@@ -127,6 +131,12 @@ $hightlight-color: #7f8c8d;
           margin-top: 3px;
         }
 
+        .entity-tags-container {
+          .badge {
+            margin-right: 3px;
+          }
+        }
+
         .tag {
           max-width: 200px;
           display: inline-block;
@@ -145,6 +155,7 @@ $hightlight-color: #7f8c8d;
         &:hover {
           background-color: $hightlight-color;
           color: white;
+          text-decoration: none;
         }
       }
     }

--- a/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/index.js
+++ b/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/index.js
@@ -30,6 +30,7 @@ import SpotlightModalHeader from 'components/SpotlightSearch/SpotlightModal/Spot
 import T from 'i18n-react';
 
 import { Col, Modal, ModalBody, Badge } from 'reactstrap';
+import { objectQuery } from 'services/helpers';
 
 require('./SpotlightModal.scss');
 
@@ -146,11 +147,20 @@ export default class SpotlightModal extends Component {
       .map((entity, index) => {
         let entityTypeLabel = convertEntityTypeToApi(entity.type);
         let entityUrl = `/ns/${currentNamespace}/${entityTypeLabel}/${entity.id}`;
+
+        let description = entity.metadata.metadata.properties.find(
+          (property) => property.name === 'description'
+        );
+        description = description ? description.value : null;
+
+        let entityTags = entity.metadata.metadata.tags || [];
+
         return (
           <NavLinkWrapper
             key={entity.id}
             to={this.props.isNativeLink ? `/cdap${entityUrl}` : entityUrl}
             isNativeLink={this.props.isNativeLink}
+            className="search-results-item-link"
           >
             <div
               key={uuidV4()}
@@ -166,19 +176,13 @@ export default class SpotlightModal extends Component {
                   <span className="entity-name">{entity.id}</span>
                 </div>
                 <div className="entity-description">
-                  <span>
-                    {
-                      entity.metadata.metadata.properties.find(
-                        (property) => property.name === 'description'
-                      ).value
-                    }
-                  </span>
+                  <span>{description}</span>
                 </div>
               </Col>
 
               <Col xs="6">
                 <div className="entity-tags-container text-right">
-                  {entity.metadata.metadata.tags.map((tag) => {
+                  {entityTags.map((tag) => {
                     return <Badge key={uuidV4()}>{tag.name}</Badge>;
                   })}
                 </div>
@@ -192,6 +196,8 @@ export default class SpotlightModal extends Component {
   }
 
   render() {
+    const results = objectQuery(this.state.searchResults, 'results') || [];
+
     return (
       <Modal
         isOpen={this.props.isOpen}
@@ -207,7 +213,7 @@ export default class SpotlightModal extends Component {
           query={this.props.query}
           tag={this.props.tag}
           numPages={this.state.numPages}
-          total={this.state.searchResults.total}
+          total={results.length}
         />
         <ModalBody>
           <div className="search-results-container">

--- a/cdap-ui/app/cdap/services/ThemeHelper.ts
+++ b/cdap-ui/app/cdap/services/ThemeHelper.ts
@@ -91,6 +91,8 @@ interface IOnePoint0SpecJSON extends IThemeJSON {
     'system-metrics'?: boolean;
     'namespace-mapping'?: boolean;
     'namespace-security'?: boolean;
+    'create-profile'?: boolean;
+    'reload-system-artifacts'?: boolean;
   };
 }
 
@@ -192,6 +194,8 @@ interface IThemeObj {
   showSystemMetrics?: boolean;
   showNamespaceMapping?: boolean;
   showNamespaceSecurity?: boolean;
+  showCreateProfile?: boolean;
+  showReloadSystemArtifacts?: boolean;
   featureNames?: IFeatureNames;
 }
 
@@ -364,6 +368,8 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
       showSystemMetrics: true,
       showNamespaceMapping: true,
       showNamespaceSecurity: true,
+      showCreateProfile: true,
+      showReloadSystemArtifacts: true,
     };
     if (isNilOrEmpty(featuresJson)) {
       return features;
@@ -436,6 +442,15 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
     }
     if ('namespace-security' in featuresJson && isBoolean(featuresJson['namespace-security'])) {
       features.showNamespaceSecurity = featuresJson['namespace-security'];
+    }
+    if ('create-profile' in featuresJson && isBoolean(featuresJson['create-profile'])) {
+      features.showCreateProfile = featuresJson['create-profile'];
+    }
+    if (
+      'reload-system-artifacts' in featuresJson &&
+      isBoolean(featuresJson['reload-system-artifacts'])
+    ) {
+      features.showReloadSystemArtifacts = featuresJson['reload-system-artifacts'];
     }
     return features;
   }

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -65,9 +65,9 @@
 
         // Adjust max-width of modal title when my-jump-link is present
         &.with-jump {
-          max-width: ~"calc(100% - 215px)";
-          max-width: ~"-moz-calc(100% - 215px)";
-          max-width: ~"-webkit-calc(100% - 215px)";
+          max-width: ~"calc(100% - 240px)";
+          max-width: ~"-moz-calc(100% - 240px)";
+          max-width: ~"-webkit-calc(100% - 240px)";
         }
 
         p {
@@ -80,8 +80,16 @@
         }
       }
 
+      div.btn-group {
+        max-width: none;
+      }
+
       > div {
         @media (max-width: @screen-sm-max) {
+          max-width: none;
+        }
+
+        &.btn-group {
           max-width: none;
         }
       }

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -427,9 +427,6 @@ body.theme-cdap {
           margin: 0;
           padding-left: 15px;
 
-          @media (max-width: @screen-sm-max) {
-            max-width: 200px;
-          }
           h3,
           p {
             @media (max-width: @screen-sm-max) {

--- a/cdap-ui/server/config/themes/default.json
+++ b/cdap-ui/server/config/themes/default.json
@@ -46,6 +46,8 @@
     "system-services-instance": true,
     "system-metrics": true,
     "namespace-mapping": true,
-    "namespace-security": true
+    "namespace-security": true,
+    "create-profile": true,
+    "reload-system-artifacts": true
   }
 }


### PR DESCRIPTION
Changes:
1. Make brand image height 48px (height of entire header)
2. Truncate long pipeline name (published and drafts)
3. Hide custom apps count when upload custom apps is disabled
4. Show/hide create profile
5. Show/hide reload system artifacts
6. Clicking tags in dataset cause UI to crash (cause by description not found in metadata response)
7. Node config modal header overflow on smaller screen
8. Set directions of operations modal in FLL immediately (not wait for API response)

JIRAs:
- https://issues.cask.co/browse/CDAP-15139
- https://issues.cask.co/browse/CDAP-15141
- https://issues.cask.co/browse/CDAP-15138


Build: https://builds.cask.co/browse/CDAP-UDUT261