### PR TITLE
[CDAP-15196] Tolerance to requesting a cursor and passing in an offset to a metadata search

### DIFF
--- a/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
+++ b/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
@@ -838,8 +838,10 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
 
     org.elasticsearch.action.search.SearchRequest searchRequest =
       new org.elasticsearch.action.search.SearchRequest(indexName);
-    searchRequest.source(createSearchSource(request));
-    if (request.isCursorRequested()) {
+    SearchSourceBuilder searchSource = createSearchSource(request);
+    searchRequest.source(searchSource);
+    // only request a scroll if the offset is 0. Elastic will throw otherwise
+    if (request.isCursorRequested() && searchSource.from() == 0) {
       searchRequest.scroll(scrollTimeout);
     }
     LOG.debug("Executing search request {}", searchRequest);

--- a/cdap-ui/app/cdap/components/EntityListView/EntityListInfo/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/EntityListInfo/index.js
@@ -23,11 +23,7 @@ import Typography from '@material-ui/core/Typography';
 import NamespaceStore from 'services/NamespaceStore';
 import SearchStore from 'components/EntityListView/SearchStore';
 import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStoreActions';
-import {
-  search,
-  updateQueryString,
-  nextPage,
-} from 'components/EntityListView/SearchStore/ActionCreator';
+import { search, updateQueryString } from 'components/EntityListView/SearchStore/ActionCreator';
 import Mousetrap from 'mousetrap';
 
 require('./EntityListInfo.scss');
@@ -56,7 +52,7 @@ export default class EntityListInfo extends Component {
         offset: currentPage * limit,
       },
     });
-    nextPage();
+    search();
     updateQueryString();
   }
   goToPreviousPage() {

--- a/cdap-ui/app/cdap/components/EntityListView/SearchStore/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/EntityListView/SearchStore/ActionCreator.js
@@ -28,7 +28,7 @@ import { Theme } from 'services/ThemeHelper';
 
 const search = () => {
   const namespace = getCurrentNamespace();
-  let { offset, limit, activeFilters, activeSort, query } = SearchStore.getState().search;
+  let { offset, limit, activeFilters, activeSort, query, cursor } = SearchStore.getState().search;
 
   let params = {
     namespace: namespace,
@@ -39,6 +39,7 @@ const search = () => {
     query,
     responseFormat: 'v6',
     cursorRequested: true,
+    cursor,
   };
   if (query !== DEFAULT_SEARCH_QUERY) {
     delete params.sort;
@@ -47,19 +48,6 @@ const search = () => {
   }
 
   ExploreTablesStore.dispatch(fetchTables(namespace));
-
-  searchRequest(params);
-};
-
-const nextPage = () => {
-  const { cursor, activeSort } = SearchStore.getState().search;
-
-  const params = {
-    cursor,
-    sort: activeSort.fullSort,
-    cursorRequested: true,
-    responseFormat: 'v6',
-  };
 
   searchRequest(params);
 };
@@ -173,4 +161,4 @@ const updateQueryString = () => {
   // Modify URL to match application state
   history.pushState(obj, obj.title, obj.url);
 };
-export { search, updateQueryString, nextPage };
+export { search, updateQueryString };


### PR DESCRIPTION
Sometimes the UI gets an error back from the Metadata service, when paging through results: 
- case 1: User directly goes to page N. This means, the UI does not have a cursor, but passes in the offset of page N, and requests a cursor.  Elasticsearch refuses to create a cursor (a "scroll") if the offset is not 0.
- case 2: User clicks on next page after a cursor has expired. In that case, the backend performs a new search without cursor, with an offset > 0. Because the UI requests a cursor back, this reduces internally to case 1.

Fix is to not request a scroll from elastic if the offset is not 0. 