### PR TITLE
Removes gcp and solutions categories from market. 

### DIFF
--- a/cdap-ui/app/cdap/components/Market/index.js
+++ b/cdap-ui/app/cdap/components/Market/index.js
@@ -65,7 +65,11 @@ export default class Market extends Component {
 
   getCategories = (packages) => {
     const filteredPackages = packages.filter((packet) => {
-      return packet.categories.indexOf('datapack') === -1;
+      return (
+        packet.categories.indexOf('datapack') === -1 &&
+        packet.categories.indexOf('gcp') === -1 &&
+        packet.categories.indexOf('usecase') === -1
+      );
     });
 
     MyMarketApi.getCategories().subscribe(


### PR DESCRIPTION
- This will prevent those categories from appearing in the hub modal for now
- Long term fix should be to hide those categories that doesn't have any entities compatible with current version of CDAP.(https://issues.cask.co/browse/CDAP-15226)