### PR TITLE
[CDAP-15250] Fix the way extract plugin ids from endpoints (condition, alert/error, splitter) 

### DIFF
--- a/cdap-ui/app/cdap/components/EntityListView/Welcome/index.tsx
+++ b/cdap-ui/app/cdap/components/EntityListView/Welcome/index.tsx
@@ -59,7 +59,7 @@ export default class Welcome extends React.PureComponent<void, IWelcomeState> {
     MyUserStoreApi.get().subscribe((res) => {
       const storeValue = objectQuery(res, 'property', USER_STORE_KEY);
 
-      if (!storeValue || storeValue !== USER_STORE_VALUE) {
+      if ((!storeValue || storeValue !== USER_STORE_VALUE) && !window.Cypress) {
         this.setState({
           showModal: true,
         });

--- a/cdap-ui/app/cdap/globals.ts
+++ b/cdap-ui/app/cdap/globals.ts
@@ -19,6 +19,7 @@ declare global {
   interface Window {
     getHydratorUrl: ({}) => string;
     angular;
+    Cypress;
   }
 }
 

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -119,6 +119,8 @@
                   ng-if="node.type !== 'splittertransform'"
                   ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled, 'endpoint-circle-right': node.type === 'condition'}"
                   ng-attr-id="{{node.type === 'condition' ? 'endpoint_' + node.name + '_condition_true' : 'endpoint_' + node.name}}"
+                  data-nodeid="{{node.name}}"
+                  data-nodetype="{{node.type === 'condition' ? 'condition-true' : 'regular'}}"
                   ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)">
               <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
             </div>
@@ -144,7 +146,9 @@
                   ng-if="node.type === 'condition'"
                   ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
                   ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
-                  ng-attr-id="{{'endpoint_' + node.name + '_condition_false'}}">
+                  ng-attr-id="{{'endpoint_' + node.name + '_condition_false'}}"
+                  data-nodeid="{{node.name}}"
+                  data-nodetype="condition-false">
               <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
             </div>
             <div ng-if="node.error">
@@ -220,7 +224,9 @@
                 <div class="endpoint-circle endpoint-circle-bottom"
                       ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
                       ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
-                      ng-attr-id="{{'endpoint_' + node.name + '_alert'}}">
+                      ng-attr-id="{{'endpoint_' + node.name + '_alert'}}"
+                      data-nodeid="{{node.name}}"
+                      data-nodetype="alert">
                   <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
                 </div>
               </div>
@@ -229,7 +235,9 @@
                 <div class="endpoint-circle endpoint-circle-bottom"
                       ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
                       ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
-                      ng-attr-id="{{'endpoint_' + node.name + '_error'}}">
+                      ng-attr-id="{{'endpoint_' + node.name + '_error'}}"
+                      data-nodeid="{{node.name}}"
+                      data-nodetype="error">
                   <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
                 </div>
                 <span>Error</span>

--- a/cdap-ui/app/directives/splitter-popover/splitter-popover.html
+++ b/cdap-ui/app/directives/splitter-popover/splitter-popover.html
@@ -19,7 +19,10 @@
   <div ng-repeat="port in SplitterPopoverCtrl.ports">
     <span class="port-name">{{ port.name | caskCapitalizeFilter }}</span>
     <div class="endpoint-circle"
-          ng-class="['endpoint_{{node.name || node.plugin.label}}_port_{{port.name}}', {'disabled': isDisabled}]">
+          ng-class="['endpoint_{{node.name || node.plugin.label}}_port_{{port.name}}', {'disabled': isDisabled}]"
+          data-nodeid="{{node.name || node.plugin.label}}"
+          data-nodetype="splitter"
+          data-portname="{{port.name}}">
       <div class="endpoint-caret" ng-if="!isDisabled"></div>
     </div>
     <div class="port-metrics" ng-if="isDisabled">

--- a/cdap-ui/cypress/fixtures/null_splitter_pipeline-cdap-data-pipeline.json
+++ b/cdap-ui/cypress/fixtures/null_splitter_pipeline-cdap-data-pipeline.json
@@ -1,0 +1,210 @@
+{
+    "artifact": {
+        "name": "cdap-data-pipeline",
+        "version": "6.0.0-SNAPSHOT",
+        "scope": "SYSTEM",
+        "label": "Data Pipeline - Batch"
+    },
+    "description": "",
+    "name": "null_splitter_pipeline",
+    "config": {
+        "resources": {
+            "memoryMB": 2048,
+            "virtualCores": 1
+        },
+        "driverResources": {
+            "memoryMB": 2048,
+            "virtualCores": 1
+        },
+        "connections": [
+            {
+                "from": "File",
+                "to": "CSVParser"
+            },
+            {
+                "from": "CSVParser",
+                "to": "JavaScript"
+            },
+            {
+                "from": "JavaScript",
+                "to": "NullFieldSplitter"
+            },
+            {
+                "from": "NullFieldSplitter",
+                "to": "Non null sink dataset",
+                "port": "nonnull"
+            },
+            {
+                "from": "NullFieldSplitter",
+                "to": "null sink dataset",
+                "port": "null"
+            }
+        ],
+        "comments": [],
+        "postActions": [],
+        "properties": {},
+        "processTimingEnabled": true,
+        "stageLoggingEnabled": true,
+        "stages": [
+            {
+                "name": "File",
+                "plugin": {
+                    "name": "File",
+                    "type": "batchsource",
+                    "label": "File",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}",
+                        "format": "text",
+                        "filenameOnly": "false",
+                        "recursive": "false",
+                        "ignoreNonExistingFolders": "false",
+                        "referenceName": "File1",
+                        "path": "/tmp/cdap-ui-integration-fixtures/purchase_bad.csv"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}"
+            },
+            {
+                "name": "CSVParser",
+                "plugin": {
+                    "name": "CSVParser",
+                    "type": "transform",
+                    "label": "CSVParser",
+                    "artifact": {
+                        "name": "transform-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "format": "DEFAULT",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                        "field": "body"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "File",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "JavaScript",
+                "plugin": {
+                    "name": "JavaScript",
+                    "type": "transform",
+                    "label": "JavaScript",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "script": "/**\n * @summary Transforms the provided input record into zero or more output records or errors.\n\n * Input records are available in JavaScript code as JSON objects. \n\n * @param input an object that contains the input record as a JSON.   e.g. to access a field called 'total' from the input record, use input.total.\n * @param emitter an object that can be used to emit zero or more records (using the emitter.emit() method) or errors (using the emitter.emitError() method) \n * @param context an object that provides access to:\n *            1. CDAP Metrics - context.getMetrics().count('output', 1);\n *            2. CDAP Logs - context.getLogger().debug('Received a record');\n *            3. Lookups - context.getLookup('blacklist').lookup(input.id); or\n *            4. Runtime Arguments - context.getArguments().get('priceThreshold') \n */ \nfunction transform(input, emitter, context) {\n   if (input.name === 'Phyllis' || input.name === 'Nicole') {\n    emitter.emit({\n      name: input.name,\n      product: input.product,\n      price: null\n    })\n  }\n  emitter.emit(input);\n}",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"null\"]}]}"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"null\"]}]}",
+                "inputSchema": [
+                    {
+                        "name": "CSVParser",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "NullFieldSplitter",
+                "plugin": {
+                    "name": "NullFieldSplitter",
+                    "type": "splittertransform",
+                    "label": "NullFieldSplitter",
+                    "artifact": {
+                        "name": "transform-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "modifySchema": "true",
+                        "field": "price"
+                    }
+                },
+                "outputSchema": [
+                    {
+                        "name": "null",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"null\"]}]}"
+                    },
+                    {
+                        "name": "nonnull",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                ],
+                "inputSchema": [
+                    {
+                        "name": "JavaScript",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"null\"]}]}"
+                    }
+                ]
+            },
+            {
+                "name": "Non null sink dataset",
+                "plugin": {
+                    "name": "Table",
+                    "type": "batchsink",
+                    "label": "Non null sink dataset",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                        "name": "nonnullpurchasedataset",
+                        "schema.row.field": "name"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "NullFieldSplitter",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "null sink dataset",
+                "plugin": {
+                    "name": "Table",
+                    "type": "batchsink",
+                    "label": "null sink dataset",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"null\"]}]}",
+                        "name": "nullpurchasesink",
+                        "schema.row.field": "name"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"null\"]}]}",
+                "inputSchema": [
+                    {
+                        "name": "NullFieldSplitter",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"null\"]}]}"
+                    }
+                ]
+            }
+        ],
+        "schedule": "0 * * * *",
+        "engine": "mapreduce",
+        "numOfRecordsPreview": 100,
+        "maxConcurrentRuns": 1
+    }
+}

--- a/cdap-ui/cypress/fixtures/pipeline_old.json
+++ b/cdap-ui/cypress/fixtures/pipeline_old.json
@@ -35,7 +35,7 @@
           "type": "batchsource",
           "label": "Amazon S3",
           "artifact": {
-            "name": "amazon-s3-plugins",
+            "name": "amazon-s3-plugins1",
             "version": "1.9.2",
             "scope": "USER"
           },
@@ -64,7 +64,7 @@
           "type": "batchsink",
           "label": "Amazon S32",
           "artifact": {
-            "name": "amazon-s3-plugins",
+            "name": "amazon-s3-plugins1",
             "version": "1.9.2",
             "scope": "USER"
           },

--- a/cdap-ui/cypress/fixtures/purchase_bad.csv
+++ b/cdap-ui/cypress/fixtures/purchase_bad.csv
@@ -1,0 +1,9 @@
+Charles,apples,10
+Phyllis,beer,"10"
+Nicole,chocoloates,"100"
+Adam,oranges,44
+Charles,oranges,44
+Stephen,oranges,44
+Dennis,oranges,44
+Joyce,oranges,44
+Frances,oranges,44

--- a/cdap-ui/cypress/fixtures/union_condition_splitter_pipeline_v1-cdap-data-pipeline.json
+++ b/cdap-ui/cypress/fixtures/union_condition_splitter_pipeline_v1-cdap-data-pipeline.json
@@ -1,0 +1,328 @@
+{
+    "artifact": {
+        "name": "cdap-data-pipeline",
+        "version": "6.0.0-SNAPSHOT",
+        "scope": "SYSTEM",
+        "label": "Data Pipeline - Batch"
+    },
+    "description": "",
+    "name": "condition_pipeline_v1",
+    "config": {
+        "resources": {
+            "memoryMB": 2048,
+            "virtualCores": 1
+        },
+        "driverResources": {
+            "memoryMB": 2048,
+            "virtualCores": 1
+        },
+        "connections": [
+            {
+                "from": "File",
+                "to": "CSVParser"
+            },
+            {
+                "from": "CSVParser",
+                "to": "JavaScript3"
+            },
+            {
+                "from": "JavaScript3",
+                "to": "UnionSplitter"
+            },
+            {
+                "from": "UnionSplitter",
+                "to": "String JavaScript Emitter",
+                "port": "string"
+            },
+            {
+                "from": "String JavaScript Emitter",
+                "to": "Conditional"
+            },
+            {
+                "from": "Conditional",
+                "to": "String Prices",
+                "condition": "true"
+            },
+            {
+                "from": "Conditional",
+                "to": "CDAP Table Dataset",
+                "condition": "false"
+            },
+            {
+                "from": "UnionSplitter",
+                "to": "JavaScript2",
+                "port": "int"
+            },
+            {
+                "from": "JavaScript2",
+                "to": "File3"
+            }
+        ],
+        "comments": [],
+        "postActions": [],
+        "properties": {},
+        "processTimingEnabled": true,
+        "stageLoggingEnabled": true,
+        "stages": [
+            {
+                "name": "File",
+                "plugin": {
+                    "name": "File",
+                    "type": "batchsource",
+                    "label": "File",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":[\"string\",\"null\"]}]}",
+                        "format": "text",
+                        "filenameOnly": "false",
+                        "recursive": "false",
+                        "ignoreNonExistingFolders": "false",
+                        "referenceName": "file",
+                        "path": "/tmp/cdap-ui-integration-fixtures/purchase_bad.csv"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":[\"string\",\"null\"]}]}"
+            },
+            {
+                "name": "CSVParser",
+                "plugin": {
+                    "name": "CSVParser",
+                    "type": "transform",
+                    "label": "CSVParser",
+                    "artifact": {
+                        "name": "transform-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "format": "DEFAULT",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                        "field": "body"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "File",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":[\"string\",\"null\"]}]}"
+                    }
+                ]
+            },
+            {
+                "name": "JavaScript3",
+                "plugin": {
+                    "name": "JavaScript",
+                    "type": "transform",
+                    "label": "JavaScript3",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "script": "/**\n * @summary Transforms the provided input record into zero or more output records or errors.\n\n * Input records are available in JavaScript code as JSON objects. \n\n * @param input an object that contains the input record as a JSON.   e.g. to access a field called 'total' from the input record, use input.total.\n * @param emitter an object that can be used to emit zero or more records (using the emitter.emit() method) or errors (using the emitter.emitError() method) \n * @param context an object that provides access to:\n *            1. CDAP Metrics - context.getMetrics().count('output', 1);\n *            2. CDAP Logs - context.getLogger().debug('Received a record');\n *            3. Lookups - context.getLookup('blacklist').lookup(input.id); or\n *            4. Runtime Arguments - context.getArguments().get('priceThreshold') \n */ \nfunction transform(input, emitter, context) {\n   if (input.name === 'Phyllis' || input.name === 'Nicole') {\n    emitter.emit({\n      name: input.name,\n      product: input.product,\n      price: parseInt(input.price, 10)\n    })\n  }\n  emitter.emit(input);\n}",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"int\"]}]}"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"int\"]}]}",
+                "inputSchema": [
+                    {
+                        "name": "CSVParser",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "UnionSplitter",
+                "plugin": {
+                    "name": "UnionSplitter",
+                    "type": "splittertransform",
+                    "label": "UnionSplitter",
+                    "artifact": {
+                        "name": "transform-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "modifySchema": "true",
+                        "unionField": "price"
+                    }
+                },
+                "outputSchema": [
+                    {
+                        "name": "string",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    },
+                    {
+                        "name": "int",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"int\"}]}"
+                    }
+                ],
+                "inputSchema": [
+                    {
+                        "name": "JavaScript3",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":[\"string\",\"int\"]}]}"
+                    }
+                ]
+            },
+            {
+                "name": "String JavaScript Emitter",
+                "plugin": {
+                    "name": "JavaScript",
+                    "type": "transform",
+                    "label": "String JavaScript Emitter",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "script": "/**\n * @summary Transforms the provided input record into zero or more output records or errors.\n\n * Input records are available in JavaScript code as JSON objects. \n\n * @param input an object that contains the input record as a JSON.   e.g. to access a field called 'total' from the input record, use input.total.\n * @param emitter an object that can be used to emit zero or more records (using the emitter.emit() method) or errors (using the emitter.emitError() method) \n * @param context an object that provides access to:\n *            1. CDAP Metrics - context.getMetrics().count('output', 1);\n *            2. CDAP Logs - context.getLogger().debug('Received a record');\n *            3. Lookups - context.getLookup('blacklist').lookup(input.id); or\n *            4. Runtime Arguments - context.getArguments().get('priceThreshold') \n */ \nfunction transform(input, emitter, context) {\n  emitter.emit(input);\n  emitter.emitError({\n    'errorCode': 31,\n    'errorMsg': 'Something went wrong',\n    'invalidRecord': input\n  });\n}",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "UnionSplitter",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "Conditional",
+                "plugin": {
+                    "name": "Conditional",
+                    "type": "condition",
+                    "label": "Conditional",
+                    "artifact": {
+                        "name": "condition-plugins",
+                        "version": "1.3.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "expression": "token['String JavaScript Emitter']['error'] > 1 "
+                    }
+                },
+                "outputSchema": [
+                    {
+                        "name": "etlSchemaBody",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                ],
+                "inputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+            },
+            {
+                "name": "String Prices",
+                "plugin": {
+                    "name": "File",
+                    "type": "batchsink",
+                    "label": "String Prices",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "suffix": "yyyy-MM-dd-HH-mm",
+                        "format": "csv",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                        "referenceName": "stringprice",
+                        "path": "/tmp/cdap-ui-integration-fixtures/prices_in_string.txt"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "Conditional",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "CDAP Table Dataset",
+                "plugin": {
+                    "name": "Table",
+                    "type": "batchsink",
+                    "label": "CDAP Table Dataset",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                        "name": "nonstringdataset",
+                        "schema.row.field": "name"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "Conditional",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "JavaScript2",
+                "plugin": {
+                    "name": "JavaScript",
+                    "type": "transform",
+                    "label": "JavaScript2",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "script": "/**\n * @summary Transforms the provided input record into zero or more output records or errors.\n\n * Input records are available in JavaScript code as JSON objects. \n\n * @param input an object that contains the input record as a JSON.   e.g. to access a field called 'total' from the input record, use input.total.\n * @param emitter an object that can be used to emit zero or more records (using the emitter.emit() method) or errors (using the emitter.emitError() method) \n * @param context an object that provides access to:\n *            1. CDAP Metrics - context.getMetrics().count('output', 1);\n *            2. CDAP Logs - context.getLogger().debug('Received a record');\n *            3. Lookups - context.getLookup('blacklist').lookup(input.id); or\n *            4. Runtime Arguments - context.getArguments().get('priceThreshold') \n */ \nfunction transform(input, emitter, context) {\n  emitter.emit(input);\n}",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"int\"}]}"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"int\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "UnionSplitter",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"int\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "File3",
+                "plugin": {
+                    "name": "File",
+                    "type": "batchsink",
+                    "label": "File3",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.2.0",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "suffix": "yyyy-MM-dd-HH-mm",
+                        "format": "json",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"int\"}]}",
+                        "referenceName": "file2",
+                        "path": "/tmp/cdap-ui-integration-fixtures/prices_in_int.txt"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"int\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "JavaScript2",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"product\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"int\"}]}"
+                    }
+                ]
+            }
+        ],
+        "schedule": "0 * * * *",
+        "engine": "mapreduce",
+        "numOfRecordsPreview": 100,
+        "maxConcurrentRuns": 1
+    }
+}

--- a/cdap-ui/cypress/integration/navbar.spec.ts
+++ b/cdap-ui/cypress/integration/navbar.spec.ts
@@ -27,7 +27,7 @@ describe('Navbar tests', () => {
       url: '/updateTheme',
       method: 'POST',
       body: {
-        uiThemePath: 'cdap-ui/server/config/themes/default.json',
+        uiThemePath: 'config/themes/default.json',
       },
     });
   });
@@ -63,7 +63,7 @@ describe('Navbar tests', () => {
       url: '/updateTheme',
       method: 'POST',
       body: {
-        uiThemePath: 'cdap-ui/server/config/themes/light.json',
+        uiThemePath: 'config/themes/light.json',
       },
     }).then(() => {
       cy.visit('/cdap');

--- a/cdap-ui/cypress/integration/pipeline.plugin.multipleendpoints.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.plugin.multipleendpoints.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import * as Helpers from '../helpers';
+const nullSplitterPipeline = `null_splitter_pipeline_${Date.now()}`;
+const unionConditionPipeline = `union_condition_splitter_${Date.now()}`;
+const pipelines = [nullSplitterPipeline, unionConditionPipeline];
+
+describe('Pipelines with plugins having more than one endpoints', () => {
+  afterEach(() => {
+    // Delete the pipeline to clean up
+    const headers = Helpers.getAuthHeaders();
+    pipelines.forEach((pipeline) => cy.cleanup_pipelines(headers, pipeline));
+  });
+
+  function deployAndTestPipeline(filename, pipelineName) {
+    cy.visit('/');
+    cy.get('#resource-center-btn').click();
+    cy.get('#create-pipeline-link').click();
+    cy.url().should('include', '/studio');
+    cy.upload_pipeline(filename, '#pipeline-import-config-link > input[type="file"]').then(() => {
+      // This is arbitrary. Right now we don't have a way to determine
+      // if the upgrade check is done. Since this a standalone the assumption
+      // is this won't take more than 10 seconds.
+      cy.wait(6000);
+      // Name pipeline then deploy pipeline
+      cy.get('.pipeline-name').click();
+      cy.get('#pipeline-name-input')
+        .clear()
+        .type(pipelineName)
+        .type('{enter}');
+      cy.get('[data-testid=deploy-pipeline]').click();
+      cy.wait(6000);
+      cy.url().should('include', `/view/${pipelineName}`);
+    });
+  }
+  it('Should work with union splitter and condition plugins', () => {
+    deployAndTestPipeline(
+      'union_condition_splitter_pipeline_v1-cdap-data-pipeline.json',
+      unionConditionPipeline
+    );
+  });
+  it('Should work with null splitter plugin', () => {
+    deployAndTestPipeline('null_splitter_pipeline-cdap-data-pipeline.json', nullSplitterPipeline);
+  });
+});

--- a/cdap-ui/cypress/pre-startup.js
+++ b/cdap-ui/cypress/pre-startup.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+/**
+ * This snippet makes sure we setup the input data for pipelines to run before we kick off integration tests.
+ *
+ * This copies csv files from fixtures folder to /tmp/cdap-ui-integration-fixtures/ folder and all the pipelines
+ * can refer the input from that specific path.
+ */
+var fs = require('fs');
+var path = require('path');
+let files;
+const fixturepath = path.join(__dirname, '/fixtures');
+const tmpPath = '/tmp/cdap-ui-integration-fixtures';
+try {
+  files = fs.readdirSync(fixturepath);
+} catch (e) {
+  console.log('Error: Unable to read cypress fixtures directory. ', e);
+}
+files.filter((file) => file.indexOf('.csv') !== -1).forEach((file) => {
+  if (!fs.existsSync(tmpPath)) {
+    fs.mkdirSync(tmpPath);
+  }
+  fs.copyFile(`${fixturepath}/${file}`, `${tmpPath}/${file}`, (err) => {
+    if (err) {
+      console.log(`Copying ${file} failed. `, err);
+      return;
+    }
+  });
+});

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -25,6 +25,8 @@
     "karma-test-single-run": "node ./node_modules/karma/bin/karma start test/karma-conf.js --no-auto-watch --single-run",
     "storybook": "NODE_ENV=development start-storybook -p 6006",
     "build-storybook": "NODE_ENV=development build-storybook",
+    "precypress-open": "node cypress/pre-startup.js",
+    "precypress": "node cypress/pre-startup.js",
     "cypress": "cypress run",
     "cypress-open": "cypress open",
     "test": "run-p jest cypress",

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -170,6 +170,7 @@
                   <exclude>**/npm-debug.log</exclude>
                   <exclude>**/node/**</exclude>
                   <exclude>**/*.json</exclude>
+                  <exclude>**/*.csv</exclude>
                   <exclude>**/*.lock</exclude>
                   <exclude>**/*.yaml</exclude>
                   <exclude>**/dll/**</exclude>


### PR DESCRIPTION
**Issue**
- Plugins with "space" in their name were causing issue while building in studio.
- Primary reason for this is, while developing DAG we encode the plugin id and plugin type in css class names.
- While extracting it back we use dom's `classList` API which breaks when plugin names have spaces.

**Solution**
- Encode plugin id and names as `data-` attributes in endpoints.
- This will avoid having any custom decode logic to get node id and type

_Note_
- Have added startup script for cypress to copy all the files required for pipelines (source)
- Have also fixed other e2e tests so that we can now enable integration tests in bamboo.

JIRA: https://issues.cask.co/browse/CDAP-15250
Build: https://builds.cask.co/browse/CDAP-URUT159
