### PR TITLE
CDAP-15299 fix structured record sorting

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/StructuredRecordWritable.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/StructuredRecordWritable.java
@@ -19,12 +19,14 @@ package io.cdap.cdap.etl.batch;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.common.record.StructuredRecordComparator;
 import io.cdap.cdap.format.StructuredRecordStringConverter;
 import org.apache.hadoop.io.WritableComparable;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -36,6 +38,7 @@ import java.util.TreeMap;
 public class StructuredRecordWritable implements WritableComparable<StructuredRecordWritable> {
   // schema cache so that we do not parse schema string for each incoming record
   private static final Map<byte[], Schema> schemaCache = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+  private static final Comparator<StructuredRecord> COMPARATOR = new StructuredRecordComparator();
   private StructuredRecord record;
 
   // required by Hadoop
@@ -91,7 +94,7 @@ public class StructuredRecordWritable implements WritableComparable<StructuredRe
 
   @Override
   public int compareTo(StructuredRecordWritable o) {
-    return Integer.compare(hashCode(), o.hashCode());
+    return COMPARATOR.compare(record, o.record);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/io/cdap/cdap/etl/batch/StructuredRecordWritableTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/io/cdap/cdap/etl/batch/StructuredRecordWritableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,11 +14,10 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.batch;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.etl.batch.StructuredRecordWritable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,5 +50,16 @@ public class StructuredRecordWritableTest {
     writableIn.readFields(input);
 
     Assert.assertEquals(writableIn.get(), record);
+  }
+
+  @Test
+  public void testComparison() {
+    Schema schema = Schema.recordOf("l", Schema.Field.of("l", Schema.of(Schema.Type.LONG)));
+    StructuredRecord record1 = StructuredRecord.builder(schema).set("l", 0L).build();
+    StructuredRecord record2 = StructuredRecord.builder(schema).set("l", -1L).build();
+    StructuredRecordWritable writable1 = new StructuredRecordWritable(record1);
+    StructuredRecordWritable writable2 = new StructuredRecordWritable(record2);
+    Assert.assertNotEquals(0, writable1.compareTo(writable2));
+    Assert.assertNotEquals(writable1, writable2);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/record/SchemaComparator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/record/SchemaComparator.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common.record;
+
+import io.cdap.cdap.api.data.schema.Schema;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * Compares schemas.
+ *
+ * If they are of different physical types, they are compared according to the natural ordering of their types.
+ * If they are of different logical types, they are compared according to the natural ordering of their logical types.
+ *
+ * Union schemas are first compared by the number of schemas they have.
+ * A union with fewer schemas is less than a union with more.
+ * If the number of schemas are the same, the schemas are compared in order.
+ *
+ * Array schemas are compared by their component schemas.
+ *
+ * Record schemas are first compared by the number of fields they have.
+ * A record with fewer fields is less than a record with more.
+ * If the number of fields are the same, their fields are compared in order.
+ *
+ * A schema field is first compared by field name. If the names are the same, they are compared by schema.
+ *
+ * Map schemas are compared first by the key schema, then by the value schema.
+ */
+public class SchemaComparator implements Comparator<Schema> {
+
+  @Override
+  public int compare(Schema s1, Schema s2) {
+    // check physical type
+    int comp = s1.getType().compareTo(s2.getType());
+    if (comp != 0) {
+      return comp;
+    }
+
+    // check logical types
+    if (s1.getLogicalType() == null && s2.getLogicalType() != null) {
+      return -1;
+    } else if (s1.getLogicalType() != null && s2.getLogicalType() == null) {
+      return 1;
+    } else if (s1.getLogicalType() != null) {
+      comp = s1.getLogicalType().compareTo(s2.getLogicalType());
+      if (comp != 0) {
+        return comp;
+      }
+    }
+
+    // must be the same physical and logical type
+    switch (s1.getType()) {
+      case UNION:
+        //noinspection ConstantConditions
+        return compareLists(s1.getUnionSchemas(), s2.getUnionSchemas(), this::compare);
+      case ARRAY:
+        return compare(s1.getComponentSchema(), s2.getComponentSchema());
+      case MAP:
+        //noinspection ConstantConditions
+        return compareMapSchemas(s1.getMapSchema(), s2.getMapSchema());
+      case RECORD:
+        return compareRecordSchemas(s1, s2);
+    }
+    return 0;
+  }
+
+  private int compareMapSchemas(Map.Entry<Schema, Schema> s1, Map.Entry<Schema, Schema> s2) {
+    int comp = compare(s1.getKey(), s2.getKey());
+    if (comp != 0) {
+      return comp;
+    }
+    return compare(s1.getValue(), s2.getValue());
+  }
+
+  private int compareRecordSchemas(Schema s1, Schema s2) {
+    int nameComp = s1.getRecordName().compareTo(s2.getRecordName());
+    if (nameComp != 0) {
+      return nameComp;
+    }
+
+    //noinspection ConstantConditions
+    return compareLists(s1.getFields(), s2.getFields(), (f1, f2) -> {
+      int comp = f1.getName().compareTo(f2.getName());
+      if (comp != 0) {
+        return comp;
+      }
+      return compare(f1.getSchema(), f2.getSchema());
+    });
+  }
+
+  private <T> int compareLists(List<T> l1, List<T> l2, BiFunction<T, T, Integer> comparison) {
+    int comp = Integer.compare(l1.size(), l2.size());
+    if (comp != 0) {
+      return comp;
+    }
+
+    Iterator<T> iter1 = l1.iterator();
+    Iterator<T> iter2 = l2.iterator();
+    while (iter1.hasNext()) {
+      comp = comparison.apply(iter1.next(), iter2.next());
+      if (comp != 0) {
+        return comp;
+      }
+    }
+    return 0;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/record/StructuredRecordComparator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/record/StructuredRecordComparator.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common.record;
+
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+
+import java.lang.reflect.Array;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+/**
+ * Gets a comparator for a value stored in a {@link StructuredRecord}.
+ */
+public class StructuredRecordComparator implements Comparator<StructuredRecord> {
+  private static final Comparator<Schema> SCHEMA_COMPARATOR = new SchemaComparator();
+  private static final Comparator<Object> NULL_COMPARATOR = (x, y) -> 0;
+  private static final Comparator<Object> INT_COMPARATOR = Comparator.comparingInt(x -> (int) x);
+  private static final Comparator<Object> LONG_COMPARATOR = Comparator.comparingLong(x -> (long) x);
+  private static final Comparator<Object> FLOAT_COMPARATOR = Comparator.comparing(x -> (float) x);
+  private static final Comparator<Object> DOUBLE_COMPARATOR = Comparator.comparingDouble(x -> (double) x);
+  private static final Comparator<Object> STRING_COMPARATOR = Comparator.comparing(x -> (String) x);
+  private static final Comparator<Object> BOOL_COMPARATOR = Comparator.comparing(x -> (Boolean) x);
+  private static final Comparator<Object> ENUM_COMPARATOR = Comparator.comparingInt(x -> ((Enum) x).ordinal());
+
+  @Override
+  public int compare(StructuredRecord r1, StructuredRecord r2) {
+    return compareRecords(r1, r2);
+  }
+
+  private Comparator<Object> getComparator(String fieldName, Schema schema) {
+    switch (schema.getType()) {
+      case NULL:
+        return NULL_COMPARATOR;
+      case INT:
+        return INT_COMPARATOR;
+      case LONG:
+        return LONG_COMPARATOR;
+      case FLOAT:
+        return FLOAT_COMPARATOR;
+      case DOUBLE:
+        return DOUBLE_COMPARATOR;
+      case STRING:
+        return STRING_COMPARATOR;
+      case BOOLEAN:
+        return BOOL_COMPARATOR;
+      case ENUM:
+        return ENUM_COMPARATOR;
+      case BYTES:
+        return (x, y) -> Bytes.compareTo(asBytes(fieldName, x), asBytes(fieldName, y));
+      case RECORD:
+        return (x, y) -> compareRecords((StructuredRecord) x, (StructuredRecord) y);
+      case ARRAY:
+        return (x, y) -> compareArrays(fieldName, schema.getComponentSchema(), x, y);
+      case MAP:
+        //noinspection unchecked
+        return (x, y) -> compareMaps(fieldName, schema.getMapSchema(),
+                                     (Map<Object, Object>) x, (Map<Object, Object>) y);
+      case UNION:
+        //noinspection ConstantConditions
+        return (x, y) -> compareUnions(fieldName, schema.getUnionSchemas(), x, y);
+    }
+
+    // should never happen
+    throw new IllegalStateException(String.format("Cannot compare field '%s' of unexpected type '%s'",
+                                                  fieldName, schema.getType()));
+  }
+
+  private int compareRecords(StructuredRecord r1, StructuredRecord r2) {
+    int comp = SCHEMA_COMPARATOR.compare(r1.getSchema(), r2.getSchema());
+    if (comp != 0) {
+      return comp;
+    }
+
+    // both records must have the same fields, otherwise their schemas would be different
+    //noinspection ConstantConditions
+    for (Schema.Field field : r1.getSchema().getFields()) {
+      Comparator<Object> comparator = getComparator(field.getName(), field.getSchema());
+      comp = comparator.compare(r1.get(field.getName()), r2.get(field.getName()));
+      if (comp != 0) {
+        return comp;
+      }
+    }
+
+    return 0;
+  }
+
+  private int compareUnions(String fieldName, List<Schema> schemas, Object val1, Object val2) {
+    Supplier<IllegalArgumentException> schemaNotFoundException = () -> new IllegalArgumentException(
+      String.format("A value for field '%s' is not any of the expected types in its union schema.", fieldName));
+    Schema val1Schema = schemas.stream().filter(s -> matchesSchema(val1, s))
+      .findFirst().orElseThrow(schemaNotFoundException);
+    Schema val2Schema = schemas.stream().filter(s -> matchesSchema(val2, s))
+      .findFirst().orElseThrow(schemaNotFoundException);
+
+    int comp = SCHEMA_COMPARATOR.compare(val1Schema, val2Schema);
+    if (comp != 0) {
+      return comp;
+    }
+
+    return getComparator(fieldName, val1Schema).compare(val1, val2);
+  }
+
+  /**
+   * Returns whether the given val is of the specified schema.
+   * This method assumes the provided schema is one of the union schemas for the provided value.
+   * Unions cannot contain multiple arrays or multiple maps, so there is no need to check the types
+   * within a Map or Collection.
+   */
+  private boolean matchesSchema(Object val, Schema schema) {
+    switch (schema.getType()) {
+      case NULL:
+        return val == null;
+      case INT:
+        return val instanceof Integer;
+      case LONG:
+        return val instanceof Long;
+      case FLOAT:
+        return val instanceof Float;
+      case DOUBLE:
+        return val instanceof Double;
+      case STRING:
+        return val instanceof String;
+      case BOOLEAN:
+        return val instanceof Boolean;
+      case ENUM:
+        return val instanceof Enum;
+      case BYTES:
+        return val instanceof ByteBuffer || val instanceof byte[];
+      case RECORD:
+        if (val instanceof StructuredRecord) {
+          StructuredRecord s = (StructuredRecord) val;
+          return s.getSchema().equals(schema);
+        } else {
+          return false;
+        }
+      case ARRAY:
+        return val instanceof Collection || val.getClass().isArray();
+      case MAP:
+        return val instanceof Map;
+      case UNION:
+        //noinspection ConstantConditions
+        for (Schema s : schema.getUnionSchemas()) {
+          if (matchesSchema(val, s)) {
+            return true;
+          }
+        }
+        return false;
+    }
+    return false;
+  }
+
+  private int compareMaps(String fieldName, Map.Entry<Schema, Schema> mapSchema,
+                          Map<Object, Object> m1, Map<Object, Object> m2) {
+    int comp = Integer.compare(m1.size(), m2.size());
+    if (comp != 0) {
+      return comp;
+    }
+
+    Iterator<Map.Entry<Object, Object>> m1Iter;
+    Iterator<Map.Entry<Object, Object>> m2Iter;
+    Comparator<Object> keyComparator = getComparator(fieldName, mapSchema.getKey());
+    if (m1 instanceof SortedMap && m2 instanceof SortedMap) {
+      m1Iter = m1.entrySet().iterator();
+      m2Iter = m2.entrySet().iterator();
+    } else {
+      TreeMap<Object, Object> m1Copy = new TreeMap<>(keyComparator);
+      m1Copy.putAll(m1);
+      TreeMap<Object, Object> m2Copy = new TreeMap<>(keyComparator);
+      m2Copy.putAll(m2);
+      m1Iter = m1Copy.entrySet().iterator();
+      m2Iter = m2Copy.entrySet().iterator();
+    }
+
+    Comparator<Object> valComparator = getComparator(fieldName, mapSchema.getValue());
+    while (m1Iter.hasNext()) {
+      Map.Entry<Object, Object> m1Entry = m1Iter.next();
+      Map.Entry<Object, Object> m2Entry = m2Iter.next();
+
+      comp = keyComparator.compare(m1Entry.getKey(), m2Entry.getKey());
+      if (comp != 0) {
+        return comp;
+      }
+      comp = valComparator.compare(m1Entry.getValue(), m2Entry.getValue());
+      if (comp != 0) {
+        return comp;
+      }
+    }
+    return 0;
+  }
+
+  private int compareArrays(String fieldName, Schema componentSchema, Object val1, Object val2) {
+    ArrayWrapper val1Array = new ArrayWrapper(fieldName, val1);
+    ArrayWrapper val2Array = new ArrayWrapper(fieldName, val2);
+    int comp = Integer.compare(val1Array.size, val2Array.size);
+    if (comp != 0) {
+      return comp;
+    }
+
+    Iterator<Object> val1Iter = val1Array.iterator();
+    Iterator<Object> val2Iter = val2Array.iterator();
+
+    Comparator<Object> comparator = getComparator(fieldName, componentSchema);
+    while (val1Iter.hasNext()) {
+      comp = comparator.compare(val1Iter.next(), val2Iter.next());
+      if (comp != 0) {
+        return comp;
+      }
+    }
+
+    return 0;
+  }
+
+  private byte[] asBytes(String fieldName, Object val) {
+    if (val instanceof byte[]) {
+      return (byte[]) val;
+    } else if (val instanceof ByteBuffer) {
+      return Bytes.toBytes((ByteBuffer) val);
+    }
+    throw new IllegalArgumentException(String.format("Field '%s' is of type bytes but is of unexpected Java type '%s'",
+                                                     fieldName, val.getClass().getName()));
+  }
+
+  /**
+   * A wrapper around an "array" value that allows iterating through elements in the array and keeps track of its
+   * total size. This is used because an "array" can be a Java array or a Java collection.
+   */
+  private static class ArrayWrapper implements Iterable<Object> {
+    private final Object array;
+    private final boolean isCollection;
+    private final int size;
+
+    private ArrayWrapper(String fieldName, Object array) {
+      if (!(array instanceof Collection) && !array.getClass().isArray()) {
+        throw new IllegalArgumentException(String.format(
+          "Field '%s' is of type array but is a Java '%s' instead of an array or collection.",
+          fieldName, array.getClass().getName()));
+      }
+      this.array = array;
+      this.isCollection = array instanceof Collection;
+      this.size = this.isCollection ? ((Collection) array).size() : Array.getLength(array);
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+      if (isCollection) {
+        return ((Collection<Object>) array).iterator();
+      }
+      return new Iterator<Object>() {
+        private int curr = 0;
+
+        @Override
+        public boolean hasNext() {
+          return curr < size;
+        }
+
+        @Override
+        public Object next() {
+          if (!hasNext()) {
+            throw new NoSuchElementException("There are no more elements in the iterator.");
+          }
+          Object val = Array.get(array, curr);
+          curr++;
+          return val;
+        }
+      };
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/record/SchemaComparatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/record/SchemaComparatorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common.record;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test Schema comparison.
+ */
+public class SchemaComparatorTest {
+  private static final SchemaComparator COMPARATOR = new SchemaComparator();
+  private static final Schema INT = Schema.of(Schema.Type.INT);
+  private static final Schema LONG = Schema.of(Schema.Type.LONG);
+  private static final Schema FLOAT = Schema.of(Schema.Type.FLOAT);
+  private static final Schema DOUBLE = Schema.of(Schema.Type.DOUBLE);
+  private static final Schema STRING = Schema.of(Schema.Type.STRING);
+  private static final Schema BOOL = Schema.of(Schema.Type.BOOLEAN);
+  private static final Schema BYTES = Schema.of(Schema.Type.BYTES);
+  private static final Schema NULL = Schema.of(Schema.Type.NULL);
+  private static final Schema ARRAY_INT = Schema.arrayOf(INT);
+  private static final Schema NULLABLE_INT = Schema.nullableOf(INT);
+  private static final Schema UNION_NUMERIC = Schema.unionOf(INT, LONG, FLOAT, DOUBLE);
+  private static final Schema MAP_STRING_INT = Schema.mapOf(STRING, INT);
+  private static final Schema RECORD_FLAT = Schema.recordOf("x",
+                                                            Schema.Field.of("int", INT),
+                                                            Schema.Field.of("long", LONG),
+                                                            Schema.Field.of("float", FLOAT),
+                                                            Schema.Field.of("double", DOUBLE),
+                                                            Schema.Field.of("string", STRING),
+                                                            Schema.Field.of("bool", BOOL),
+                                                            Schema.Field.of("bytes", BYTES),
+                                                            Schema.Field.of("null", NULL),
+                                                            Schema.Field.of("arr", ARRAY_INT),
+                                                            Schema.Field.of("union", UNION_NUMERIC),
+                                                            Schema.Field.of("map", MAP_STRING_INT));
+
+  @Test
+  public void testTypeComparison() {
+    Set<Schema> schemas = new HashSet<>(Arrays.asList(INT, LONG, FLOAT, DOUBLE, STRING, BOOL, BYTES, NULL,
+                                                      ARRAY_INT, NULLABLE_INT, UNION_NUMERIC,
+                                                      MAP_STRING_INT, RECORD_FLAT));
+
+    for (Schema schema1 : schemas) {
+      Assert.assertEquals(0, COMPARATOR.compare(schema1, schema1));
+      Set<Schema> otherSchemas = new HashSet<>(schemas);
+      otherSchemas.remove(schema1);
+      for (Schema schema2 : otherSchemas) {
+        assertNotEqual(schema1, schema2);
+      }
+    }
+  }
+
+  @Test
+  public void testNullableIs() {
+    assertNotEqual(INT, NULLABLE_INT);
+  }
+
+  @Test
+  public void testUnionSubset() {
+    assertNotEqual(Schema.unionOf(INT, LONG, NULL), Schema.unionOf(INT, LONG));
+  }
+
+  @Test
+  public void testSimpleArrayComponents() {
+    assertNotEqual(Schema.arrayOf(INT), Schema.arrayOf(LONG));
+    assertNotEqual(Schema.arrayOf(INT), Schema.arrayOf(NULLABLE_INT));
+  }
+
+  @Test
+  public void testNestedArrayComponents() {
+    assertNotEqual(Schema.arrayOf(RECORD_FLAT), Schema.arrayOf(Schema.recordOf("x", Schema.Field.of("x", INT))));
+  }
+
+  @Test
+  public void testRecordFieldOrder() {
+    Schema r1 = Schema.recordOf("x", Schema.Field.of("x", INT), Schema.Field.of("y", INT));
+    Schema r2 = Schema.recordOf("x", Schema.Field.of("y", INT), Schema.Field.of("x", INT));
+    assertNotEqual(r1, r2);
+  }
+
+  @Test
+  public void testRecordSubset() {
+    Schema r1 = Schema.recordOf("x", Schema.Field.of("x", INT), Schema.Field.of("y", INT));
+    Schema r2 = Schema.recordOf("x", Schema.Field.of("x", INT));
+    assertNotEqual(r1, r2);
+  }
+
+  @Test
+  public void testRecordName() {
+    assertNotEqual(Schema.recordOf("x", Schema.Field.of("x", INT)),
+                   Schema.recordOf("y", Schema.Field.of("x", INT)));
+  }
+
+  @Test
+  public void testRecordFieldName() {
+    assertNotEqual(Schema.recordOf("x", Schema.Field.of("x", INT)),
+                   Schema.recordOf("x", Schema.Field.of("y", INT)));
+  }
+
+  @Test
+  public void testNestedRecord() {
+    Schema middle = Schema.recordOf("middle",
+                                    Schema.Field.of("int", INT),
+                                    Schema.Field.of("inner", RECORD_FLAT));
+    Schema outer1 = Schema.recordOf("outer",
+                                    Schema.Field.of("middle", middle));
+    Schema outer2 = Schema.recordOf("outer",
+                                    Schema.Field.of("middle", RECORD_FLAT));
+    assertNotEqual(outer1, outer2);
+    Assert.assertEquals(0, COMPARATOR.compare(outer1, outer1));
+    Assert.assertEquals(0, COMPARATOR.compare(outer2, outer2));
+  }
+
+  @Test
+  public void testSimpleMap() {
+    Assert.assertNotEquals(0, COMPARATOR.compare(Schema.mapOf(STRING, STRING),
+                                                 Schema.mapOf(STRING, INT)));
+  }
+
+  @Test
+  public void testNestedMapValues() {
+    Assert.assertNotEquals(0, COMPARATOR.compare(
+      Schema.mapOf(STRING, RECORD_FLAT), Schema.mapOf(STRING, Schema.recordOf("x", Schema.Field.of("x", INT)))));
+  }
+
+  @Test
+  public void testSamePhysicalDifferentLogicalTypes() {
+    Assert.assertNotEquals(0, COMPARATOR.compare(Schema.of(Schema.LogicalType.DATE),
+                                                 Schema.of(Schema.LogicalType.TIME_MILLIS)));
+    Assert.assertNotEquals(0, COMPARATOR.compare(Schema.of(Schema.LogicalType.TIME_MICROS),
+                                                 Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)));
+  }
+
+  private void assertNotEqual(Schema s1, Schema s2) {
+    int comp1 = COMPARATOR.compare(s1, s2);
+    int comp2 = COMPARATOR.compare(s2, s1);
+    Assert.assertNotEquals(0, comp1);
+    Assert.assertNotEquals(0, comp2);
+    if (comp1 > 0) {
+      Assert.assertTrue(comp2 < 0);
+    } else {
+      Assert.assertTrue(comp2 > 0);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/record/StructuredRecordComparatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/record/StructuredRecordComparatorTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common.record;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Tests for comparing StructuredRecords.
+ */
+public class StructuredRecordComparatorTest {
+  private static final Comparator<StructuredRecord> COMPARATOR = new StructuredRecordComparator();
+  private static final Schema INT_SCHEMA = Schema.of(Schema.Type.INT);
+  private static final Schema LONG_SCHEMA = Schema.of(Schema.Type.LONG);
+  private static final Schema FLOAT_SCHEMA = Schema.of(Schema.Type.FLOAT);
+  private static final Schema DOUBLE_SCHEMA = Schema.of(Schema.Type.DOUBLE);
+  private static final Schema STRING_SCHEMA = Schema.of(Schema.Type.STRING);
+  private static final Schema BYTES_SCHEMA = Schema.of(Schema.Type.BYTES);
+  private static final Schema BOOL_SCHEMA = Schema.of(Schema.Type.BOOLEAN);
+
+  @Test
+  public void testSingleSimpleFields() {
+    testSingleFieldNotEqual(INT_SCHEMA, 0, 1);
+    testSingleFieldEqual(INT_SCHEMA, 1);
+
+    testSingleFieldNotEqual(LONG_SCHEMA, 0L, 1L);
+    testSingleFieldEqual(LONG_SCHEMA, 1L);
+
+    testSingleFieldNotEqual(FLOAT_SCHEMA, 0f, 1f);
+    testSingleFieldEqual(FLOAT_SCHEMA, 1f);
+
+    testSingleFieldNotEqual(DOUBLE_SCHEMA, 0d, 1d);
+    testSingleFieldEqual(DOUBLE_SCHEMA, 1d);
+
+    testSingleFieldNotEqual(STRING_SCHEMA, "0", "1");
+    testSingleFieldEqual(STRING_SCHEMA, "1");
+
+    testSingleFieldNotEqual(BYTES_SCHEMA, new byte[] { 0 }, new byte[] { 0, 0 });
+    testSingleFieldEqual(BYTES_SCHEMA, new byte[] { 0, 0 });
+
+    testSingleFieldNotEqual(BOOL_SCHEMA, true, false);
+    testSingleFieldEqual(BOOL_SCHEMA, false);
+  }
+
+  @Test
+  public void testSingleNullableFields() {
+    for (Schema schema : Arrays.asList(INT_SCHEMA, LONG_SCHEMA, FLOAT_SCHEMA, DOUBLE_SCHEMA, STRING_SCHEMA,
+                                       BYTES_SCHEMA, BOOL_SCHEMA)) {
+      testSingleFieldEqual(Schema.nullableOf(schema), null);
+    }
+
+    testSingleFieldNotEqual(Schema.nullableOf(INT_SCHEMA), 0, null);
+    testSingleFieldNotEqual(Schema.nullableOf(LONG_SCHEMA), 0L, null);
+    testSingleFieldNotEqual(Schema.nullableOf(FLOAT_SCHEMA), 0f, null);
+    testSingleFieldNotEqual(Schema.nullableOf(DOUBLE_SCHEMA), 0d, null);
+    testSingleFieldNotEqual(Schema.nullableOf(STRING_SCHEMA), "0", null);
+    testSingleFieldNotEqual(Schema.nullableOf(BYTES_SCHEMA), new byte[] { 0 }, null);
+    testSingleFieldNotEqual(Schema.nullableOf(BOOL_SCHEMA), false, null);
+  }
+
+  @Test
+  public void testMultipleSimpleFields() {
+    Schema schema = Schema.recordOf("x",
+                                    Schema.Field.of("int", INT_SCHEMA),
+                                    Schema.Field.of("long", LONG_SCHEMA),
+                                    Schema.Field.of("float", FLOAT_SCHEMA),
+                                    Schema.Field.of("double", DOUBLE_SCHEMA),
+                                    Schema.Field.of("string", STRING_SCHEMA),
+                                    Schema.Field.of("bool", BOOL_SCHEMA),
+                                    Schema.Field.of("bytes", BYTES_SCHEMA));
+
+    StructuredRecord r1 = StructuredRecord.builder(schema)
+      .set("int", 0)
+      .set("long", 0L)
+      .set("float", 0f)
+      .set("double", 0d)
+      .set("string", "0")
+      .set("bool", false)
+      .set("bytes", new byte[] { 0 })
+      .build();
+    Assert.assertEquals(0, COMPARATOR.compare(r1, r1));
+    StructuredRecord r2 = copy(r1).set("int", 1).build();
+    testRecordsNotEqual(r1, r2);
+
+    r2 = copy(r1).set("long", 1L).build();
+    testRecordsNotEqual(r1, r2);
+
+    r2 = copy(r1).set("float", 1f).build();
+    testRecordsNotEqual(r1, r2);
+
+    r2 = copy(r1).set("double", 1d).build();
+    testRecordsNotEqual(r1, r2);
+
+    r2 = copy(r1).set("string", "1").build();
+    testRecordsNotEqual(r1, r2);
+
+    r2 = copy(r1).set("bool", true).build();
+    testRecordsNotEqual(r1, r2);
+
+    r2 = copy(r1).set("bytes", new byte[] { 0, 0 }).build();
+    testRecordsNotEqual(r1, r2);
+  }
+
+  @Test
+  public void testSimpleArrays() {
+    Schema schema = Schema.recordOf("x", Schema.Field.of("x", Schema.arrayOf(INT_SCHEMA)));
+
+    // test with lists
+    StructuredRecord r1 = StructuredRecord.builder(schema).set("x", Arrays.asList(0, 1, 2, 3, 4, 5)).build();
+    StructuredRecord r2 = StructuredRecord.builder(schema).set("x", Arrays.asList(0, 1, 2, 3, 4)).build();
+    Assert.assertEquals(0, COMPARATOR.compare(r1, r1));
+    testRecordsNotEqual(r1, r2);
+
+    // test comparing list with array
+    r2 = StructuredRecord.builder(schema).set("x", new int[] { 0, 1, 2, 3, 4, 5 }).build();
+    Assert.assertEquals(0, COMPARATOR.compare(r1, r2));
+    r2 = StructuredRecord.builder(schema).set("x", new int[] { 0, 1, 2, 3, 4 }).build();
+    testRecordsNotEqual(r1, r2);
+
+    r2 = StructuredRecord.builder(schema).set("x", Arrays.asList(5, 4, 3, 2, 1, 0)).build();
+    testRecordsNotEqual(r1, r2);
+    r2 = StructuredRecord.builder(schema).set("x", new int[] { 5, 4, 3, 2, 1, 0 }).build();
+    testRecordsNotEqual(r1, r2);
+  }
+
+  @Test
+  public void testArraysOfRecords() {
+    Schema innerSchema = Schema.recordOf("x",
+                                         Schema.Field.of("string", STRING_SCHEMA), Schema.Field.of("int", INT_SCHEMA));
+    Schema arrSchema = Schema.recordOf("arr", Schema.Field.of("r", Schema.arrayOf(innerSchema)));
+
+    StructuredRecord r0 = StructuredRecord.builder(innerSchema).set("string", "0").set("int", 0).build();
+    StructuredRecord r1 = StructuredRecord.builder(innerSchema).set("string", "1").set("int", 1).build();
+    StructuredRecord r2 = StructuredRecord.builder(innerSchema).set("string", "2").set("int", 2).build();
+
+    StructuredRecord arr0 = StructuredRecord.builder(arrSchema).set("r", Arrays.asList(r0, r1, r2)).build();
+    StructuredRecord arr1 = StructuredRecord.builder(arrSchema).set("r", Arrays.asList(r2, r1, r0)).build();
+    Assert.assertEquals(0, COMPARATOR.compare(arr0, arr0));
+    testRecordsNotEqual(arr0, arr1);
+  }
+
+  @Test
+  public void testNestedRecords() {
+    Schema innerSchema = Schema.recordOf("inner", Schema.Field.of("i", INT_SCHEMA));
+    Schema schema = Schema.recordOf("x", Schema.Field.of("x", innerSchema));
+
+    StructuredRecord inner0 = StructuredRecord.builder(innerSchema).set("i", 0).build();
+    StructuredRecord inner1 = StructuredRecord.builder(innerSchema).set("i", 1).build();
+
+    StructuredRecord r0 = StructuredRecord.builder(schema).set("x", inner0).build();
+    StructuredRecord r1 = StructuredRecord.builder(schema).set("x", inner1).build();
+
+    Assert.assertEquals(0, COMPARATOR.compare(r0, r0));
+    testRecordsNotEqual(r0, r1);
+  }
+
+  @Test
+  public void testSimpleMaps() {
+    Schema schema = Schema.recordOf("m", Schema.Field.of("m", Schema.mapOf(STRING_SCHEMA, INT_SCHEMA)));
+
+    StructuredRecord r0 = StructuredRecord.builder(schema).set("m", Collections.singletonMap("x", 0)).build();
+    StructuredRecord r1 = StructuredRecord.builder(schema).set("m", Collections.singletonMap("x", 0)).build();
+    Assert.assertEquals(0, COMPARATOR.compare(r0, r1));
+
+    // test same key, different value
+    r1 = StructuredRecord.builder(schema).set("m", Collections.singletonMap("x", 1)).build();
+    testRecordsNotEqual(r0, r1);
+
+    // test different key, same value
+    r1 = StructuredRecord.builder(schema).set("m", Collections.singletonMap("y", 0)).build();
+    testRecordsNotEqual(r0, r1);
+
+    // test subset
+    Map<String, Integer> map = new HashMap<>();
+    map.put("x", 0);
+    map.put("y", 1);
+    r1 = StructuredRecord.builder(schema).set("m", map).build();
+    testRecordsNotEqual(r0, r1);
+  }
+
+  @Test
+  public void testRecordMaps() {
+    Schema keySchema = Schema.recordOf("key",
+                                       Schema.Field.of("id", LONG_SCHEMA),
+                                       Schema.Field.of("name", STRING_SCHEMA));
+    Schema valSchema = Schema.recordOf("user",
+                                       Schema.Field.of("id", LONG_SCHEMA),
+                                       Schema.Field.of("name", STRING_SCHEMA),
+                                       Schema.Field.of("email", STRING_SCHEMA),
+                                       Schema.Field.of("age", INT_SCHEMA));
+
+    Schema schema = Schema.recordOf("m", Schema.Field.of("m", Schema.mapOf(keySchema, valSchema)));
+
+    StructuredRecord key0 = StructuredRecord.builder(keySchema).set("id", 0L).set("name", "dwayne").build();
+    StructuredRecord key1 = StructuredRecord.builder(keySchema).set("id", 1L).set("name", "chris").build();
+
+    StructuredRecord val0 = StructuredRecord.builder(valSchema)
+      .set("id", 0L)
+      .set("name", "dwayne")
+      .set("email", "therock@example.com")
+      .set("age", 40)
+      .build();
+    StructuredRecord val1 = StructuredRecord.builder(valSchema)
+      .set("id", 1L)
+      .set("name", "chris")
+      .set("email", "walken@example.com")
+      .set("age", 60)
+      .build();
+
+    StructuredRecord r0 = StructuredRecord.builder(schema).set("m", Collections.singletonMap(key0, val0)).build();
+    StructuredRecord r1 = StructuredRecord.builder(schema).set("m", Collections.singletonMap(key0, val0)).build();
+    Assert.assertEquals(0, COMPARATOR.compare(r0, r1));
+
+    // same key, different value
+    r1 = StructuredRecord.builder(schema).set("m", Collections.singletonMap(key0, val1)).build();
+    testRecordsNotEqual(r0, r1);
+
+    // different key, same value
+    r1 = StructuredRecord.builder(schema).set("m", Collections.singletonMap(key1, val0)).build();
+    testRecordsNotEqual(r0, r1);
+
+    // test subset
+    Map<StructuredRecord, StructuredRecord> map = new HashMap<>();
+    map.put(key0, val0);
+    map.put(key1, val1);
+    r1 = StructuredRecord.builder(schema).set("m", map).build();
+    testRecordsNotEqual(r0, r1);
+  }
+
+  @Test
+  public void testSimpleUnions() {
+    Schema schema = Schema.recordOf("u", Schema.Field.of("u", Schema.unionOf(
+      INT_SCHEMA, LONG_SCHEMA, STRING_SCHEMA, BOOL_SCHEMA, FLOAT_SCHEMA, DOUBLE_SCHEMA, Schema.of(Schema.Type.NULL))));
+
+    List<Object> values = Arrays.asList(0, 0L, 0f, 0d, "0", false, null);
+
+    for (Object val1 : values) {
+      StructuredRecord r1 = StructuredRecord.builder(schema).set("u", val1).build();
+      for (Object val2 : values) {
+        StructuredRecord r2 = StructuredRecord.builder(schema).set("u", val2).build();
+        if (Objects.equals(val1, val2)) {
+          Assert.assertEquals(0, COMPARATOR.compare(r1, r2));
+        } else {
+          testRecordsNotEqual(r1, r2);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testRecordUnions() {
+    Schema intFieldSchema = Schema.recordOf("i", Schema.Field.of("x", INT_SCHEMA));
+    Schema longFieldSchema = Schema.recordOf("l", Schema.Field.of("x", LONG_SCHEMA));
+
+    Schema unionSchema = Schema.recordOf("u", Schema.Field.of("u", Schema.unionOf(intFieldSchema, longFieldSchema)));
+
+    StructuredRecord irec = StructuredRecord.builder(intFieldSchema).set("x", 0).build();
+    StructuredRecord lrec = StructuredRecord.builder(longFieldSchema).set("x", 0L).build();
+    StructuredRecord r1 = StructuredRecord.builder(unionSchema).set("u", irec).build();
+    StructuredRecord r2 = StructuredRecord.builder(unionSchema).set("u", lrec).build();
+
+    Assert.assertEquals(0, COMPARATOR.compare(r1, r1));
+    Assert.assertEquals(0, COMPARATOR.compare(r2, r2));
+    testRecordsNotEqual(r1, r2);
+  }
+
+  @Test
+  public void testMultipleMatchingSchemasUnion() {
+    Schema fullSchema = Schema.recordOf("full",
+                                        Schema.Field.of("x", INT_SCHEMA),
+                                        Schema.Field.of("y", Schema.nullableOf(LONG_SCHEMA)));
+
+    Schema subsetSchema = Schema.recordOf("subset", Schema.Field.of("x", INT_SCHEMA));
+
+    Schema unionSchema = Schema.recordOf("u", Schema.Field.of("u", Schema.unionOf(subsetSchema, fullSchema)));
+
+    // These records have the same field values, but different schemas. They should not be equal.
+    StructuredRecord fullRecord = StructuredRecord.builder(fullSchema).set("x", 0).build();
+    StructuredRecord subsetRecord = StructuredRecord.builder(subsetSchema).set("x", 0).build();
+
+    StructuredRecord r1 = StructuredRecord.builder(unionSchema).set("u", fullRecord).build();
+    StructuredRecord r2 = StructuredRecord.builder(unionSchema).set("u", subsetRecord).build();
+    testRecordsNotEqual(r1, r2);
+  }
+
+  @Test
+  public void testArrayOfUnions() {
+    Schema rec1Schema = Schema.recordOf("r1", Schema.Field.of("x", INT_SCHEMA));
+    Schema rec2Schema = Schema.recordOf("r2",
+                                        Schema.Field.of("x", INT_SCHEMA),
+                                        Schema.Field.of("y", Schema.nullableOf(INT_SCHEMA)));
+    Schema unionSchema = Schema.unionOf(INT_SCHEMA, LONG_SCHEMA, FLOAT_SCHEMA, DOUBLE_SCHEMA, STRING_SCHEMA,
+                                        BOOL_SCHEMA, Schema.of(Schema.Type.NULL), rec1Schema, rec2Schema);
+    Schema schema = Schema.recordOf("r", Schema.Field.of("r", Schema.arrayOf(unionSchema)));
+
+    StructuredRecord inner1 = StructuredRecord.builder(rec1Schema).set("x", 0).build();
+    StructuredRecord inner2 = StructuredRecord.builder(rec2Schema).set("x", 0).build();
+
+    // test equality
+    StructuredRecord r1 = StructuredRecord.builder(schema).set("r", Arrays.asList(0, 0L, 0f, 0d, "0", false, null,
+                                                                                  inner1, inner2)).build();
+    StructuredRecord r2 = StructuredRecord.builder(schema).set("r", Arrays.asList(0, 0L, 0f, 0d, "0", false, null,
+                                                                                  inner1, inner2)).build();
+    Assert.assertEquals(0, COMPARATOR.compare(r1, r2));
+
+    // test one array is a subset of the other
+    r2 = StructuredRecord.builder(schema).set("r", Arrays.asList(0, 0L, 0f, 0d, "0", false, null, inner1)).build();
+    testRecordsNotEqual(r1, r2);
+
+    // test different order is different
+    r2 = StructuredRecord.builder(schema)
+      .set("r", Arrays.asList(0, 0L, 0f, 0d, "0", false, null, inner2, inner1)).build();
+    testRecordsNotEqual(r1, r2);
+
+    // test different types are different
+    r1 = StructuredRecord.builder(schema).set("r", Arrays.asList(0)).build();
+    r2 = StructuredRecord.builder(schema).set("r", Arrays.asList(0L)).build();
+    testRecordsNotEqual(r1, r2);
+  }
+
+  @Test
+  public void testMapOfUnions() {
+    Schema intKeySchema = Schema.recordOf("i", Schema.Field.of("i", INT_SCHEMA));
+    Schema stringKeySchema = Schema.recordOf("s", Schema.Field.of("s", STRING_SCHEMA));
+    Schema keySchema = Schema.unionOf(intKeySchema, stringKeySchema);
+
+    Schema mapSchema = Schema.mapOf(keySchema, Schema.unionOf(BOOL_SCHEMA, INT_SCHEMA));
+    Schema schema = Schema.recordOf("m", Schema.Field.of("m", mapSchema));
+
+    StructuredRecord intKey = StructuredRecord.builder(intKeySchema).set("i", 0).build();
+    StructuredRecord stringKey = StructuredRecord.builder(stringKeySchema).set("s", "0").build();
+
+    Map<StructuredRecord, Object> map1 = new HashMap<>();
+    map1.put(intKey, false);
+    map1.put(stringKey, 0);
+
+    // test equality
+    StructuredRecord r1 = StructuredRecord.builder(schema).set("m", map1).build();
+    StructuredRecord r2 = StructuredRecord.builder(schema).set("m", map1).build();
+    Assert.assertEquals(0, COMPARATOR.compare(r1, r2));
+
+    // test same keys, different value type
+    Map<StructuredRecord, Object> map2 = new HashMap<>();
+    map2.put(intKey, 0);
+    map2.put(stringKey, 0);
+    r2 = StructuredRecord.builder(schema).set("m", map2).build();
+    testRecordsNotEqual(r1, r2);
+
+    // test same vals, different key type
+    map2 = new HashMap<>();
+    map2.put(stringKey, false);
+    map2.put(stringKey, 0);
+    r2 = StructuredRecord.builder(schema).set("m", map2).build();
+    testRecordsNotEqual(r1, r2);
+  }
+
+  private StructuredRecord.Builder copy(StructuredRecord r) {
+    StructuredRecord.Builder builder = StructuredRecord.builder(r.getSchema());
+    for (Schema.Field f : r.getSchema().getFields()) {
+      builder.set(f.getName(), r.get(f.getName()));
+    }
+    return builder;
+  }
+
+  private void testSingleFieldEqual(Schema fieldSchema, Object val) {
+    Schema recordSchema = Schema.recordOf("x", Schema.Field.of("x", fieldSchema));
+    StructuredRecord r1 = StructuredRecord.builder(recordSchema).set("x", val).build();
+    StructuredRecord r2 = StructuredRecord.builder(recordSchema).set("x", val).build();
+    Assert.assertEquals(0, COMPARATOR.compare(r1, r2));
+  }
+
+  private void testSingleFieldNotEqual(Schema fieldSchema, Object val1, Object val2) {
+    Schema recordSchema = Schema.recordOf("x", Schema.Field.of("x", fieldSchema));
+    StructuredRecord r1 = StructuredRecord.builder(recordSchema).set("x", val1).build();
+    StructuredRecord r2 = StructuredRecord.builder(recordSchema).set("x", val2).build();
+    testRecordsNotEqual(r1, r2);
+  }
+
+  private void testRecordsNotEqual(StructuredRecord r1, StructuredRecord r2) {
+    int comp1 = COMPARATOR.compare(r1, r2);
+    int comp2 = COMPARATOR.compare(r2, r1);
+    Assert.assertNotEquals(0, comp1);
+    Assert.assertNotEquals(0, comp2);
+    if (comp1 > 0) {
+      Assert.assertTrue(comp2 < 0);
+    } else if (comp1 < 0) {
+      Assert.assertTrue(comp2 > 0);
+    }
+  }
+}


### PR DESCRIPTION
Fix a bug in aggregators run in mapreduce pipelines where group
keys would get dropped when different records hash to the same
value.

Implemented a proper comparison of records instead of comparing
their hash codes.