### PR TITLE
[CDAP-15185] Removes hardlimit on the number of characters plugin name can have before showing ellipsis

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -173,7 +173,7 @@
                 </span>
               </div>
             </div>
-            <div class="node-info">
+            <div class="node-info" ng-class="{ 'node-no-errors': node.errorCount === 0 || DAGPlusPlusCtrl.isDisabled}">
               <div
                 ng-if="!DAGPlusPlusCtrl.shouldShowCustomIcon(node)"
                 class="node-icon fa {{node.icon}}"></div>
@@ -188,7 +188,7 @@
 
               <div class="node-metadata">
                 <div class="node-name"
-                      ng-bind="node.plugin.label || node.name | myEllipsis: 15"
+                      ng-bind="node.plugin.label || node.name"
                       ng-attr-title="{{node.plugin.label || node.name}}">
                 </div>
                 <div class="node-version"

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -20,6 +20,8 @@
 @import "./color-constants.less";
 
 @node-box-width: 200px;
+@node-box-width-with-errors: 140px;
+@node-box-width-without-errors: 148px;
 @node-box-height-big: 100px;
 @condition-box-width: 105px;
 @condition-box-height: 105px;
@@ -292,7 +294,13 @@ my-dag-plus {
         }
 
         .node-info {
-          display: flex;
+          display: grid;
+          overflow: hidden;
+          grid-template-columns: 25px minmax(auto, @node-box-width-with-errors);
+
+          &.node-no-errors {
+            grid-template-columns: 25px minmax(auto, @node-box-width-without-errors);
+          }
 
           .node-icon {
             font-size: 25px;
@@ -316,6 +324,7 @@ my-dag-plus {
             .node-version {
               text-overflow: ellipsis;
               overflow: hidden;
+              white-space: nowrap;
             }
 
             .node-name {


### PR DESCRIPTION
- Removes the usage of `myEllipsis` ng-filter which hardlimits at the max 15 characters for plugin name
- The fix allows the name to extend on two scenarios,
  - With node errors (assuming we will only have errors in 2 digits eg., 12)
  - Without node errors.

The new fix will use up the extra if there are no node errors.

JIRA: https://issues.cask.co/browse/CDAP-15185
Build: https://builds.cask.co/browse/CDAP-UDUT278