### PR TITLE
Adjust width and position of auto-complete-container to not cover up CLI

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/AutoComplete/AutoComplete.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/AutoComplete/AutoComplete.scss
@@ -16,8 +16,7 @@
 
 .dataprep-auto-complete-container {
   position: absolute;
-  bottom: 80px;
-  width: 75%;
+  bottom: 29px;
   left: 0;
   right: 0;
   background-color: black;

--- a/cdap-ui/app/cdap/components/DataPrep/AutoComplete/AutoComplete.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/AutoComplete/AutoComplete.scss
@@ -16,7 +16,8 @@
 
 .dataprep-auto-complete-container {
   position: absolute;
-  bottom: 29px;
+  bottom: 80px;
+  width: 75%;
   left: 0;
   right: 0;
   background-color: black;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/DataPrepCLI.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/DataPrepCLI.scss
@@ -21,7 +21,6 @@ $cli-font: "Courier New", Courier, monospace;
 
 .dataprep-container {
   .dataprep-cli {
-    bottom: 54px;
     height: 30px;
     width: 100%;
     position: relative;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/DataPrepCLI.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/DataPrepCLI.scss
@@ -24,6 +24,7 @@ $cli-font: "Courier New", Courier, monospace;
     bottom: 54px;
     height: 30px;
     width: 100%;
+    position: relative;
     border-top: 1px solid #cccccc;
 
     .error-bar {


### PR DESCRIPTION
Fixing position of autocomplete when you use CLI in Wrangler UI from Wrangler pipeline plugin 

JIRA: https://issues.cask.co/browse/CDAP-15261