### PR TITLE
[CDAP-14575] Fixes opening multiple dropdown in dataprep while in pipeline studio

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/ColumnActionsDropdown/index.js
@@ -249,7 +249,7 @@ export default class ColumnActionsDropdown extends Component {
 
     if (newState) {
       let element = document.getElementById('app-container');
-      if (!element && this.singleWorkspaceMode) {
+      if (this.singleWorkspaceMode) {
         element = document.getElementsByClassName('wrangler-modal')[0];
       }
       this.documentClick$ = Observable.fromEvent(element, 'click').subscribe((e) => {


### PR DESCRIPTION
- We were subscribing to click event on the wrong element when wrangler was opened in pipeline studio
- We don't need to check for `element` in the condition to determine what is the right DOM to subscribe to click event.
- `app-container` is added at CDAP level which will be true all the time. This lead us to registering click event on incorrect parent to close the dropdown inside dataprep table.

JIRA: https://issues.cask.co/browse/CDAP-14575
Build: https://builds.cask.co/browse/CDAP-UDUT284