### PR TITLE
[CDAP-14999] Adds validation checks for input stages in joiner plugin to not have specific special characters

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.html
+++ b/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.html
@@ -16,9 +16,7 @@
 
 <div class="sql-conditions-container">
   <div class="text-danger"
-       ng-if="SqlConditions.error && SqlConditions.stageList.length > 0">
-    {{ SqlConditions.error }}
-  </div>
+       ng-if="SqlConditions.error && SqlConditions.stageList.length > 0">{{ SqlConditions.error }}</div>
 
   <div class="text-warning"
        ng-if="SqlConditions.warning && !SqlConditions.error">

--- a/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.js
+++ b/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.js
@@ -23,8 +23,32 @@ function SqlConditionsController() {
 
   vm.mapInputSchema = {};
   vm.stageList = [];
+  vm.error = null;
 
+  /**
+   * FIXME: CDAP-14999
+   * This exists as a stopgap solution when user clicks on generate schema on joiner plugin
+   * where the input stages have either & or . or = in their name.
+   * The right fix is to fix it in backend.
+   */
+  vm.checkRulesForValidStageNames = () => {
+    const invalidRule = /[&\.=]/g;
+    let invalidStageNames = [];
+    angular.forEach(vm.rules, (rule) => {
+      var invalidStageName = rule.filter(field => invalidRule.test(field.stageName));
+      if (invalidStageName.length) {
+        invalidStageNames = invalidStageNames.concat(invalidStageName.map(stage => stage.stageName));
+      }
+    });
+    if (invalidStageNames.length) {
+      vm.error = 'Invalid name for input ' + (invalidStageNames.length > 1 ? 'nodes' : 'node') + ': ' +
+        invalidStageNames.map(sn => JSON.stringify(sn)).join(', ') +
+        '. \n Node names cannot contain "&" "=" "."';
+    }
+    return vm.error && vm.error.length;
+  };
   vm.formatOutput = () => {
+    vm.checkRulesForValidStageNames();
     if (vm.stageList.length < 2) {
       vm.model = '';
       return;

--- a/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.less
+++ b/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.less
@@ -23,6 +23,9 @@ my-sql-conditions {
     .rule { margin-bottom: 10px; }
     .empty-message { margin-bottom: 0; }
 
+    .text-danger {
+      white-space: pre-line;
+    }
     .select-fields-group {
       position: relative;
       left: 0;


### PR DESCRIPTION
**Problem:**
- When we generate schema for joiner plugin we need plugin properties and input schemas.
- One of the properties of joiner plugin is the joinkeys which has the condition to join.
- The join condition is of the format `stagename.fieldname = stagename2.fieldname & stagename3.fieldname = stagename4.fieldname`.
- The problem arises when one of the stage names has `&` or `=` or `.` in it. The backend cannot deterministically parse the joinKeys property as its just a string containing the join condition.

**Solution**
- As a stopgap solution we show a message in the UI before user clicks on generate schema.
- We do this because the error message from the backend does not entirely convey what the issue is.
- This is a temporary bandaid until we fix it in the backend to either,
  - Accept join condition in a different format
  - Or, parse the joinKeys in a more deterministic way.

JIRA: https://issues.cask.co/browse/CDAP-14999
Build: https://builds.cask.co/browse/CDAP-UDUT286