### PR TITLE
CDAP-15335 fix a bug in program state for provision failures

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
@@ -539,12 +539,16 @@ public class ProvisioningService extends AbstractIdleService {
     } catch (IOException e) {
       runWithProgramLogging(taskInfo.getProgramRunId(), systemArgs,
                             () -> LOG.error("Failed to load ssh key. The run will be marked as failed.", e));
+      programStateWriter.error(programRunId,
+                               new IllegalStateException("Failed to load ssh key.", e));
       provisionerNotifier.deprovisioning(taskInfo.getProgramRunId());
       return () -> { };
     } catch (InvalidMacroException e) {
       runWithProgramLogging(taskInfo.getProgramRunId(), systemArgs,
                             () -> LOG.error("Could not evaluate macros while provisoning. "
                                               + "The run will be marked as failed.", e));
+      programStateWriter.error(programRunId,
+                               new IllegalStateException("Could not evaluate macros while provisioning", e));
       provisionerNotifier.deprovisioning(taskInfo.getProgramRunId());
       return () -> { };
     }


### PR DESCRIPTION
Fixed a bug where the program state was not getting marked as
failed when there is a provisioning failure due to macro
evaluation failure.