### PR TITLE
[CDAP-7230] Fix lineage for streaming sources

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -42,7 +42,9 @@ public interface StreamingContext extends StageContext, Transactional {
 
   /**
    * Register lineage for this Spark program using the given reference name
+   *
    * @param referenceName reference name used for source
+   *
    * @throws DatasetManagementException thrown if there was an error in creating reference dataset
    * @throws TransactionFailureException thrown if there was an error while fetching the dataset to register usage
    */

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/external/ExternalDataset.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/external/ExternalDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2019 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package io.cdap.cdap.data2.dataset2.lib.external;
 
 import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.api.annotation.ReadOnly;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
 import io.cdap.cdap.api.dataset.Dataset;
@@ -72,5 +73,14 @@ public class ExternalDataset implements Dataset, InputFormatProvider, OutputForm
   @Override
   public void close() throws IOException {
     // Nothing to do
+  }
+
+  /**
+   * Record read access to this dataset. This method does nothing, but the
+   * @ReadOnly annotation causes recording of a read access to this dataset.
+   */
+  @ReadOnly
+  public void recordRead() {
+    // Nothing to do, the platform will record the access based on the @ReadOnly annotation
   }
 }


### PR DESCRIPTION
It is a bit of a hack, because we cannot easily change plugin APIs right now:
- the StreamingContext.registerLineage() already instantiates the external dataset 
- in addition, now also call a @ReadOnly method on that dataset. That will force recording the access as read
- a slight difficulty here is that ExternalDataset is in data-fabric and not visible to the pipeline app. Therefore we must use reflection to invoke that method. 