### PR TITLE
[CDAP-15256] Support decimal type in schema

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/SchemaHash.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/SchemaHash.java
@@ -188,6 +188,11 @@ public final class SchemaHash implements Serializable {
         case TIMESTAMP_MICROS:
           md5.update((byte) 17);
           break;
+        case DECIMAL:
+          md5.update((byte) 18);
+          md5.update((byte) schema.getPrecision());
+          md5.update((byte) schema.getScale());
+          break;
       }
     }
 

--- a/cdap-api-common/src/main/java/io/cdap/cdap/internal/io/SchemaTypeAdapter.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/internal/io/SchemaTypeAdapter.java
@@ -56,6 +56,8 @@ public final class SchemaTypeAdapter extends TypeAdapter<Schema> {
   private static final String KEYS = "keys";
   private static final String VALUES = "values";
   private static final String FIELDS = "fields";
+  private static final String PRECISION = "precision";
+  private static final String SCALE = "scale";
 
   @Override
   public void write(JsonWriter writer, Schema schema) throws IOException {
@@ -145,6 +147,8 @@ public final class SchemaTypeAdapter extends TypeAdapter<Schema> {
     List<Schema.Field> fields = null;
     // List of items for ARRAY type
     Schema items = null;
+    int precision = 0;
+    int scale = 0;
     // Loop through current object and populate the fields as required
     // For ENUM type List of enumValues will be populated
     // For ARRAY type items will be populated
@@ -155,6 +159,12 @@ public final class SchemaTypeAdapter extends TypeAdapter<Schema> {
       switch (name) {
         case LOGICAL_TYPE:
           logicalType = Schema.LogicalType.fromToken(reader.nextString());
+          break;
+        case PRECISION:
+          precision = Integer.parseInt(reader.nextString());
+          break;
+        case SCALE:
+          scale = Integer.parseInt(reader.nextString());
           break;
         case TYPE:
           schemaType = Schema.Type.valueOf(reader.nextString().toUpperCase());
@@ -215,6 +225,10 @@ public final class SchemaTypeAdapter extends TypeAdapter<Schema> {
     }
 
     if (logicalType != null) {
+      if (logicalType == Schema.LogicalType.DECIMAL) {
+        return Schema.decimalOf(precision, scale);
+      }
+
       return Schema.of(logicalType);
     }
 
@@ -324,6 +338,10 @@ public final class SchemaTypeAdapter extends TypeAdapter<Schema> {
     if (schema.getLogicalType() != null) {
       writer.beginObject().name(TYPE).value(schema.getType().name().toLowerCase());
       writer.name(LOGICAL_TYPE).value(schema.getLogicalType().getToken());
+      if (schema.getLogicalType() == Schema.LogicalType.DECIMAL) {
+        writer.name("precision").value(schema.getPrecision());
+        writer.name("scale").value(schema.getScale());
+      }
       writer.endObject();
       return writer;
     }

--- a/cdap-common/src/test/java/io/cdap/cdap/io/SchemaHashTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/io/SchemaHashTest.java
@@ -65,4 +65,14 @@ public class SchemaHashTest {
     Assert.assertEquals(schema.getSchemaHash(), schema.getSchemaHash());
     Assert.assertEquals(schemaWithLogicalType.getSchemaHash(), schemaWithLogicalType.getSchemaHash());
   }
+
+  @Test
+  public void testDecimalSchemaHash() {
+    Schema schema1 = Schema.decimalOf(3, 5);
+    Schema schema2 = Schema.decimalOf(3);
+
+    Assert.assertNotEquals(schema1.getSchemaHash(), schema2.getSchemaHash());
+    Assert.assertNotEquals(schema1, schema2);
+    Assert.assertEquals(schema1.getSchemaHash(), schema1.getSchemaHash());
+  }
 }

--- a/cdap-common/src/test/java/io/cdap/cdap/io/SchemaTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/io/SchemaTest.java
@@ -587,6 +587,11 @@ public class SchemaTest {
     Assert.assertEquals(timestampMicros, timestampMicros);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidDecimalSchema() {
+    Schema.of(Schema.LogicalType.DECIMAL);
+  }
+
   private org.apache.avro.Schema convertSchema(Schema cdapSchema) {
     return new org.apache.avro.Schema.Parser().parse(cdapSchema.toString());
   }


### PR DESCRIPTION
Adding support for decimal logical type.

Design: https://wiki.cask.co/display/CE/Decimal+Type+support+in+CDAP+Schema
Build: https://builds.cask.co/browse/CDAP-RUT1669-1