### PR TITLE
additional checks for node version when BYO node

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1203,9 +1203,12 @@ cdap_ui() {
       MAIN_CMD="${CDAP_HOME}"/ui/bin/node
     elif [[ $(which node 2>/dev/null) ]]; then
       MAIN_CMD=node
+      cdap_check_node_version ${CDAP_NODE_VERSION_MINIMUM:-v8.7.0} || return ${?}
     else
       die "Unable to locate Node.js binary (node), is it installed and in the PATH?"
     fi
+  else
+    cdap_check_node_version ${CDAP_NODE_VERSION_MINIMUM:-v8.7.0} || return ${?}
   fi
   local readonly MAIN_CMD=${MAIN_CMD}
   export NODE_ENV="production"


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-14137 by checking node version when either of these 2 unlikely cases occurs:
- bundled node version not working (installed on some different architecture)
- bundled node not found (repackaged?)