### PR TITLE
CDAP-15352 fix oracle-thin jdbc driver image

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseConnection.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseConnection.scss
@@ -193,6 +193,10 @@ $db-sprite-url: url('/cdap_assets/img/db-sprite.png');
   @include db-image(1);
 }
 
+.db-oracle-thin {
+  @include db-image(1);
+}
+
 .db-mssql {
   @include db-image(2);
 }


### PR DESCRIPTION
The oracle-thin jdbc driver was renamed in wrangler to make sure
it does not conflict with the regular oracle jdbc driver. This
change makes sure the icon still shows up for the thin driver.