### PR TITLE
[CDAP-15359] Fixes vertical alignment of plugin icon and plugin name to prevent cutting off plugin name on the top

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -297,6 +297,7 @@ my-dag-plus {
           display: grid;
           overflow: hidden;
           grid-template-columns: 25px minmax(auto, @node-box-width-with-errors);
+          align-items: flex-start;
 
           &.node-no-errors {
             grid-template-columns: 25px minmax(auto, @node-box-width-without-errors);
@@ -317,8 +318,8 @@ my-dag-plus {
 
           .node-metadata {
             display: inline-block;
-            transform: translateY(-5px);
             margin-left: 8px;
+            line-height: 1.2;
 
             .node-name,
             .node-version {
@@ -330,6 +331,7 @@ my-dag-plus {
             .node-name {
               font-size: 14px;
               font-weight: bold;
+              margin-bottom: 5px;
             }
 
             .node-version {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15359
Build: https://builds.cask.co/browse/CDAP-UDUT299