### PR TITLE
CDAP-15369 Disable oslogin for provisioned Dataproc cluster VMs.

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -146,6 +146,8 @@ public class DataprocClient implements AutoCloseable {
         // Don't fail if there is no public key. It is for tooling case that the key might be generated differently.
         metadata.put("ssh-keys", publicKey.getUser() + ":" + publicKey.getKey());
       }
+      // override any os-login that may be set on the project-level metadata
+      metadata.put("enable-oslogin", "false");
 
       GceClusterConfig.Builder clusterConfig = GceClusterConfig.newBuilder()
         .setNetworkUri(conf.getNetwork())


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-15369

Without this change, a project can have oslogin enabled via the project level metadata, which would result in VMs ignoring the public ssh keys that DataprocClient uploads to the VMs' metadata.

For more info, see [Enabling or disabling OS Login](https://cloud.google.com/compute/docs/instances/managing-instance-access#enable_oslogin)
![image](https://user-images.githubusercontent.com/2440977/57504888-2b1ff700-72ab-11e9-911b-b124721f308b.png)