### PR TITLE
(CDAP-15375) Exclude LZ4 library from cdap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,6 +531,10 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>net.jpountz.lz4</groupId>
+            <artifactId>lz4</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
- We don’t use LZ4 library at all and it is messing up with Spark 2.3