### PR TITLE
[CDAP-15366] Remove parse as xml from UI in wrangler

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/index.js
@@ -36,7 +36,6 @@ require('./ParseDirective.scss');
 
 const DIRECTIVE_MAP = {
   CSV: 'parse-as-csv',
-  XML: 'parse-as-xml',
   JSON: 'parse-as-json',
   XMLTOJSON: 'parse-xml-to-json',
   LOG: 'parse-as-log',
@@ -62,7 +61,6 @@ export default class ParseDirective extends Component {
       'CSV',
       'AVRO',
       'EXCEL',
-      'XML',
       'JSON',
       'XMLTOJSON',
       'LOG',

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -932,8 +932,6 @@ features:
               OPTION12: "EEE, MMM d, 'yy"
               OPTION13: "h:mm AM/PM"
               OPTION14: "H:mm with timezone"
-          XML:
-            label: XML
           XMLTOJSON:
             fieldLabel: Depth
             label: XML to JSON

--- a/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
+++ b/cdap-ui/app/directives/widget-container/widget-wrangler-directives/wrangler-modal.less
@@ -22,7 +22,7 @@
 body.state-hydrator-create.state-hydrator {
   .modal.wrangler-modal {
     .modal-dialog {
-      margin-top: 48px;
+      margin-top: 0;
       margin-bottom: 0;
 
       .dataprephome-wrapper {


### PR DESCRIPTION
- Removes parse as xml menu from column dropdowns in wrangler
- Fixes wrangler modal to not be pushed down when viewing from pipeline.

JIRA: https://issues.cask.co/browse/CDAP-15366
Build: https://builds.cask.co/browse/CDAP-UDUT301