### PR TITLE
Remove stage profile id

### DIFF
--- a/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
+++ b/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
@@ -874,7 +874,6 @@
             <configuration>
               <nexusUrl>https://oss.sonatype.org</nexusUrl>
               <serverId>sonatype.release</serverId>
-              <stagingProfileId>655dc88dc770c3</stagingProfileId>
             </configuration>
           </plugin>
           <!-- Source JAR -->

--- a/pom.xml
+++ b/pom.xml
@@ -1812,7 +1812,6 @@
           <configuration>
             <nexusUrl>https://oss.sonatype.org</nexusUrl>
             <serverId>sonatype.release</serverId>
-            <stagingProfileId>655dc88dc770c3</stagingProfileId>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
BUT is failing to publish artifacts https://builds.cask.co/browse/CDAP-BUT885-12

As per comment here: https://github.com/cdapio/cdap-clients/pull/86#discussion_r271888622, removing `stagingProfileId `