### PR TITLE
[UI] Enable hiding experimental features in production version of CDAP

### DIFF
--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -52,14 +52,8 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import { Theme } from 'services/ThemeHelper';
 import AuthRefresher from 'components/AuthRefresher';
 import ThemeWrapper from 'components/ThemeWrapper';
-import { MarkdownImpl } from 'components/Markdown/MarkdownImplExample';
-
 import './globals';
-const SampleTSXComponent = Loadable({
-  loader: () =>
-    import(/* webpackChunkName: "SampleTSXComponent" */ 'components/SampleTSXComponent'),
-  loading: LoadingSVGCentered,
-});
+import If from 'components/If';
 
 const Administration = Loadable({
   loader: () => import(/* webpackChunkName: "Administration" */ 'components/Administration'),
@@ -174,19 +168,45 @@ class CDAP extends Component {
                     </ErrorBoundary>
                   )}
                 />
-                <Route
-                  exact
-                  path="/ts-example"
-                  render={(props) => (
-                    <ErrorBoundary>
-                      <SampleTSXComponent {...props} />
-                    </ErrorBoundary>
-                  )}
-                />
-                <Route exact path="/markdownexperiment" component={MarkdownImpl} />
+                <If condition={window.CDAP_CONFIG.cdap.mode === 'development'}>
+                  <Route
+                    exact
+                    path="/ts-example"
+                    render={(props) => {
+                      const SampleTSXComponent = Loadable({
+                        loader: () =>
+                          import(/* webpackChunkName: "SampleTSXComponent" */ 'components/SampleTSXComponent'),
+                        loading: LoadingSVGCentered,
+                      });
+                      return (
+                        <ErrorBoundary>
+                          <SampleTSXComponent {...props} />
+                        </ErrorBoundary>
+                      );
+                    }}
+                  />
+                </If>
+                <If condition={window.CDAP_CONFIG.cdap.mode === 'development'}>
+                  <Route
+                    exact
+                    path="/markdownexperiment"
+                    render={(props) => {
+                      const MarkdownImpl = Loadable({
+                        loader: () =>
+                          import(/* webpackChunkName: "SampleTSXComponent" */ 'components/Markdown/MarkdownImplExample'),
+                        loading: LoadingSVGCentered,
+                      });
+                      return (
+                        <ErrorBoundary>
+                          <MarkdownImpl {...props} />
+                        </ErrorBoundary>
+                      );
+                    }}
+                  />
+                </If>
                 {/*
-                      Eventually handling 404 should move to the error boundary and all container components will have the error object.
-                      */}
+                  Eventually handling 404 should move to the error boundary and all container components will have the error object.
+                */}
                 <Route
                   render={(props) => (
                     <ErrorBoundary>

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -230,6 +230,7 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
         standaloneWebsiteSDKDownload:
           uiSettings['standalone.website.sdk.download'] === 'true' || false,
         uiDebugEnabled: uiSettings['ui.debug.enabled'] === 'true' || false,
+        mode: process.env.NODE_ENV,
       },
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true',


### PR DESCRIPTION
- Pass on mode (prodution vs development) to clientside. 
- This will help us prevent loading unnecessary experimental routes that we don't want to surface in production.

Build: https://builds.cask.co/browse/CDAP-UDUT309