### PR TITLE
[CDAP-15410]Port ace editor widget in plugin config from angular to react

### DIFF
--- a/cdap-ui/app/cdap/components/AceEditor/index.tsx
+++ b/cdap-ui/app/cdap/components/AceEditor/index.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import 'ace-builds/src-min-noconflict/ace';
+import ThemeWrapper from 'components/ThemeWrapper';
+import PropTypes from 'prop-types';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+
+const styles = (theme) => {
+  return {
+    root: {
+      border: `1px solid ${theme.palette.grey['300']}`,
+      borderRadius: 4,
+      margin: '10px 0 10px 10px',
+    },
+  };
+};
+interface IAceEditorProps extends WithStyles<typeof styles> {
+  mode?: string;
+  value: string;
+  onChange: (value: string) => void;
+  rows?: number;
+  className?: string;
+}
+class AceEditor extends React.Component<IAceEditorProps> {
+  public static LINE_HEIGHT = 20;
+  public static defaultProps = {
+    mode: 'plain_text',
+    value: '',
+    rows: 5,
+  };
+  public aceRef: HTMLElement;
+  public componentDidMount() {
+    window.ace.config.set('basePath', '/assets/bundle/ace-editor-worker-scripts/');
+    const editor = window.ace.edit(this.aceRef);
+    editor.getSession().setMode(`ace/mode/${this.props.mode}`);
+    editor.getSession().setUseWrapMode(true);
+    editor.getSession().on('change', () => {
+      if (typeof this.props.onChange === 'function') {
+        this.props.onChange(editor.getSession().getValue());
+      }
+    });
+    editor.setShowPrintMargin(false);
+  }
+  public shouldComponentUpdate() {
+    return false;
+  }
+  public render() {
+    const { value, className, classes } = this.props;
+    return (
+      <div
+        className={`${className} ${classes.root}`}
+        style={{ height: `${this.props.rows * AceEditor.LINE_HEIGHT}px` }}
+        ref={(ref) => (this.aceRef = ref)}
+      >
+        {value}
+      </div>
+    );
+  }
+}
+const AceEditorWrapper = withStyles(styles)(AceEditor);
+export default function StyledAceEditor(props) {
+  return (
+    <ThemeWrapper>
+      <AceEditorWrapper {...props} />
+    </ThemeWrapper>
+  );
+}
+
+(StyledAceEditor as any).propTypes = {
+  mode: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  rows: PropTypes.number,
+};

--- a/cdap-ui/app/cdap/components/SampleTSXComponent/index.tsx
+++ b/cdap-ui/app/cdap/components/SampleTSXComponent/index.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import * as Loadable from 'react-loadable';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import AceEditor from 'components/AceEditor';
 const SubTSXComponent = Loadable({
   loader: () =>
     import(/* webpackChunkName: "ChildTSXComponent" */ 'components/SampleTSXComponent/ChildTSXComponent'),
@@ -58,9 +59,5 @@ class StatefullComponent extends React.PureComponent<IStatefulComponentProps, {}
   }
 }
 export default function SampleTSXComponent() {
-  return [
-    <h1 key="super-title"> Hello from TSX! </h1>,
-    <FunctionalComponent prop1={true} prop2="Nice!" />,
-    <StatefullComponent prop3="hurray!! stateful prop" />,
-  ];
+  return [<h1 key="super-title"> Hello from TSX! </h1>, <AceEditor rows={20} />];
 }

--- a/cdap-ui/app/cdap/globals.ts
+++ b/cdap-ui/app/cdap/globals.ts
@@ -20,6 +20,7 @@ declare global {
     getHydratorUrl: ({}) => string;
     angular;
     Cypress;
+    ace;
   }
 }
 

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -70,7 +70,7 @@ var ToggleSwitch = require('../cdap/components/ToggleSwitch').default;
 var PipelineList = require('../cdap/components/PipelineList').default;
 var AppHeader = require('../cdap/components/AppHeader').default;
 var Markdown = require('../cdap/components/Markdown').MarkdownWithStyles;
-
+var AceEditor = require('../cdap/components/AceEditor').default;
 export {
   Store,
   DataPrepHome,
@@ -121,4 +121,5 @@ export {
   PipelineList,
   AppHeader,
   Markdown,
+  AceEditor,
 };

--- a/cdap-ui/app/directives/react-components/index.js
+++ b/cdap-ui/app/directives/react-components/index.js
@@ -68,4 +68,7 @@ angular.module(PKG.name + '.commons')
   })
   .directive('markdown', function(reactDirective) {
     return reactDirective(window.CaskCommon.Markdown);
+  })
+  .directive('aceEditor', function(reactDirective) {
+    return reactDirective(window.CaskCommon.AceEditor);
   });

--- a/cdap-ui/app/directives/widget-container/widget-container.js
+++ b/cdap-ui/app/directives/widget-container/widget-container.js
@@ -46,6 +46,9 @@ angular.module(PKG.name + '.commons')
         fieldset.attr('ng-disabled', scope.widgetDisabled);
 
         angularElement = angular.element(widget.element);
+        scope.onChange = (value) => {
+          scope.model = value;
+        };
         angular.forEach(widget.attributes, function(value, key) {
           if (key.indexOf('data-') !== -1) {
             angularElement.attr(key, '::'+value);

--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -36,13 +36,13 @@ angular.module(PKG.name + '.commons')
         }
       },
       'textarea': {
-        element: '<div my-ace-editor></div>',
+        element: '<ace-editor></ace-editor>',
         attributes: {
-          'ng-model': 'model',
-          'data-config': 'myconfig',
-          'mode': 'plain_text',
+          'value': 'model',
+          'mode': '"plain_text"',
+          'on-change': 'onChange',
           'disabled': 'disabled',
-          'rows': '{{myconfig["widget-attributes"].rows}}',
+          'rows': 15,
         }
       },
       'password': {
@@ -93,44 +93,43 @@ angular.module(PKG.name + '.commons')
         }
       },
       'javascript-editor': {
-        element: '<div my-ace-editor></div>',
+        element: '<ace-editor></ace-editor>',
         attributes: {
-          'ng-model': 'model',
-          'config': 'myconfig',
-          'mode': 'javascript',
+          'value': 'model',
+          'mode': '"javascript"',
+          'on-change': 'onChange',
           'disabled': 'disabled',
-          placeholder: '{{::myconfig["widget-attributes"].default}}'
+          'rows': 25,
         }
       },
       'python-editor': {
-        element: '<div my-ace-editor></div>',
+        element: '<ace-editor></ace-editor>',
         attributes: {
-          'ng-model': 'model',
-          'data-config': 'myconfig',
-          'mode': 'python',
+          'value': 'model',
+          'mode': '"python"',
+          'on-change': 'onChange',
           'disabled': 'disabled',
-          placeholder: '{{::myconfig["widget-attributes"].default}}'
+          'rows': 25,
         }
       },
       'scala-editor': {
-        element: '<div my-ace-editor></div>',
+        element: '<ace-editor></ace-editor>',
         attributes: {
-          'ng-model': 'model',
-          'data-config': 'myconfig',
-          'mode': 'scala',
+          'value': 'model',
+          'mode': '"scala"',
+          'on-change': 'onChange',
           'disabled': 'disabled',
-          placeholder: '{{::myconfig["widget-attributes"].default}}'
+          'rows': 25,
         }
       },
       'sql-editor': {
-        element: '<div my-ace-editor></div>',
+        element: '<ace-editor></ace-editor>',
         attributes: {
-          'ng-model': 'model',
-          'data-config': 'myconfig',
-          'mode': 'sql',
+          'value': 'model',
+          'mode': '"sql"',
+          'on-change': 'onChange',
           'disabled': 'disabled',
-          'row': '20',
-          placeholder: '{{::myconfig["widget-attributes"].default}}'
+          'rows': 15,
         }
       },
       'schema': {

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -138,6 +138,7 @@
     "@babel/polyfill": "7.0.0-beta.53",
     "@material-ui/core": "3.6.1",
     "@material-ui/icons": "3.0.1",
+    "ace-builds": "1.4.4",
     "body-parser": "1.14.2",
     "bootstrap": "4.1.3",
     "cask-datavoyager": "2.0.0-alpha.12.9",

--- a/cdap-ui/yarn.lock
+++ b/cdap-ui/yarn.lock
@@ -2392,6 +2392,10 @@ accord@^0.20.1:
     uglify-js "2.x"
     when "3.x"
 
+ace-builds@1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.4.tgz#b1ad500f99b451710ce51d20f43313027e9fb73a"
+
 acorn-dynamic-import@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"


### PR DESCRIPTION
- Adds `ace-builds` to package.json for use in react
- Adds base implementation of ace editor as a wrapper in react
- Modifies `widget-container` to handle react components
- Replaces angular ace-editor in `widget-factory` with react's ace-editor.

JIRA: https://issues.cask.co/browse/CDAP-15410
Build: https://builds.cask.co/browse/CDAP-UDUT310