### PR TITLE
Modifies the 'save' button to be 'ok' while updating pipeline name

### DIFF
--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -63,7 +63,7 @@
                 placeholder="Enter a description for your pipeline."
                 ng-if="HydratorPlusPlusTopPanelCtrl.metadataExpanded"></textarea>
       <div class="btn-group pull-left" ng-if="HydratorPlusPlusTopPanelCtrl.metadataExpanded">
-        <button type="button" class="btn btn-primary save-button" ng-click="HydratorPlusPlusTopPanelCtrl.saveMetadata($event)">Save</button>
+        <button type="button" class="btn btn-primary save-button" ng-click="HydratorPlusPlusTopPanelCtrl.saveMetadata($event)">Ok</button>
         <button type="button" class="btn btn-secondary cancel-button" ng-click="HydratorPlusPlusTopPanelCtrl.resetMetadata($event)">Cancel</button>
       </div>
     </div>


### PR DESCRIPTION
Modifies the 'save' button to be 'ok' to avoid confusion about saving pipeline in backend vs saving pipeline name in UI

Build: https://builds.cask.co/browse/CDAP-UDUT311