### PR TITLE
[CDAP-15434] Fixes splitter plugin popover for ports to be dynamic

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-factory.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-factory.js
@@ -85,9 +85,13 @@ angular.module(PKG.name + '.commons')
     };
 
     var splitterEndpointStyle = {
-      anchor: 'Right',
       cssClass: 'splitter-endpoint',
-      isSource: true
+      isSource: true,
+      // [x, y , dx, dy, offsetx, offsety]
+      // x, y - position of the anchor.
+      // dx, dy - orientation of the curve incident on the anchor
+      // offsetx, offsety - offset for the anchor
+      anchor: [0.9, 0.65, 0, 1, 2, 0],
     };
 
     var alertEndpointStyle = {

--- a/cdap-ui/app/directives/splitter-popover/splitter-popover.html
+++ b/cdap-ui/app/directives/splitter-popover/splitter-popover.html
@@ -16,7 +16,7 @@
 
 <div class="arrow"></div>
 <div class="popover-content">
-  <div ng-repeat="port in SplitterPopoverCtrl.ports">
+  <div ng-repeat="port in SplitterPopoverCtrl.ports" class="splitter-popover-row">
     <span class="port-name">{{ port.name | caskCapitalizeFilter }}</span>
     <div class="endpoint-circle"
           ng-class="['endpoint_{{node.name || node.plugin.label}}_port_{{port.name}}', {'disabled': isDisabled}]"

--- a/cdap-ui/app/directives/splitter-popover/splitter-popover.less
+++ b/cdap-ui/app/directives/splitter-popover/splitter-popover.less
@@ -22,8 +22,6 @@
   .node {
     .node-splitter-endpoint {
       .node-splitter-popover {
-        min-width: 80px;
-        max-width: 200px;
         min-height: 40px;
         position: absolute;
         top: -25px;
@@ -63,22 +61,32 @@
         }
 
         .popover-content {
-          padding: 10px;
+          padding: 10px 0 10px 10px;
           color: @text-color;
+          // warning magic number. This is to make sure the endoint arrow
+          // is on the edge of the popvover in splitter
+          margin-right: -8px;
+          white-space: nowrap;
 
-          .port-name {
-            width: 65%;
-            display: inline-block;
+          .splitter-popover-row {
+            display: grid;
+            grid-template-columns: 1fr 14px;
+            grid-template-rows: 13px;
+            padding: 3px 0;
+            grid-gap: 10px;
+            align-items: center;
+            &:first-child {
+              padding-top: 0;
+            }
+            &:last-child {
+              padding-bottom: 0;
+            }
           }
 
           .endpoint-circle {
-            position: relative;
-            display: inline-flex;
-            top: -3px;
-            right: -20px;
-
-            &.disabled {
-              top: 2px;
+            position: static;
+            &:before {
+              transform: translateX(7px);
             }
           }
         }


### PR DESCRIPTION
- Right now the popover for ports in splitter transform occupies a fixed width
- This causes ports with longer names to overflow to the next line.
- Removed the need for width and let the popover to grow based on the longest port name

JIRA: https://issues.cask.co/browse/CDAP-15434
Build: https://builds.cask.co/browse/CDAP-UDUT315