### PR TITLE
CDAP-15427: Made cache storage level configurable and allowed setting it for spark pipelines.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -31,6 +31,8 @@ public final class Constants {
   public static final String MDC_STAGE_KEY = "pipeline.stage";
   public static final String FIELD_OPERATION_KEY_IN_WORKFLOW_TOKEN = "field.operations";
   public static final String SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG = "spark.cdap.pipeline.autocache.enable";
+  public static final String SPARK_PIPELINE_CACHING_STORAGE_LEVEL = "spark.cdap.pipeline.caching.storage.level";
+  public static final String DEFAULT_CACHING_STORAGE_LEVEL = "MEMORY_AND_DISK"; 
 
   private Constants() {
     throw new AssertionError("Suppress default constructor for noninstantiability");

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -54,6 +54,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.storage.StorageLevel;
 import scala.Tuple2;
 
 import javax.annotation.Nullable;
@@ -91,7 +92,10 @@ public class RDDCollection<T> implements SparkCollection<T> {
   public SparkCollection<T> cache() {
     SparkConf sparkConf = jsc.getConf();
     if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
-      return wrap(rdd.cache());
+      String cacheStorageLevelString = sparkConf.get(Constants.SPARK_PIPELINE_CACHING_STORAGE_LEVEL, 
+                                                     Constants.DEFAULT_CACHING_STORAGE_LEVEL);
+      StorageLevel cacheStorageLevel = StorageLevel.fromString(cacheStorageLevelString);
+      return wrap(rdd.persist(cacheStorageLevel));
     } else {
       return wrap(rdd);
     }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -49,6 +49,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.streaming.Durations;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaPairDStream;
@@ -78,9 +79,12 @@ public class DStreamCollection<T> implements SparkCollection<T> {
 
   @Override
   public SparkCollection<T> cache() {
-    SparkConf sparkconf = stream.context().sparkContext().getConf();
-    if (sparkconf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
-      return wrap(stream.cache());
+    SparkConf sparkConf = stream.context().sparkContext().getConf();
+    if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
+      String cacheStorageLevelString = sparkConf.get(Constants.SPARK_PIPELINE_CACHING_STORAGE_LEVEL, 
+                                                     Constants.DEFAULT_CACHING_STORAGE_LEVEL);
+      StorageLevel cacheStorageLevel = StorageLevel.fromString(cacheStorageLevelString);
+      return wrap(stream.persist(cacheStorageLevel));
     } else {
       return wrap(stream);
     }


### PR DESCRIPTION
Problem: Spark supports different storage levels for caching RDDs as mentioned below
1. MEMORY_AND_DISK_2
2. MEMORY_AND_DISK_SER
3. MEMORY_AND_DISK
4. MEMORY_ONLY
5. MEMORY_ONLY_SER_2
6. MEMORY_ONLY_SER
7. MEMORY_ONLY 

But currently, CDAP doesn't support providing these different storage levels while caching RDDs for Spark Pipelines. This Pull Request is raised to solve this limitation in CDAP. A new Spark Configuration has been added 

"**spark.cdap.pipeline.caching.storage.level**"

which will be passed through spark configuration and allow user to change the storage level from **Memory_Only** to any one as mentioned before.

By default the value of this new spark configuration will be "**MEMORY_AND_DISK**" which will cache the RDDs first in available Memory and then on Disk.