### PR TITLE
Improve error handling in ProgramStarter.java

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -326,7 +326,8 @@ public class ProgramLifecycleService {
    * Returns the {@link ProgramSpecification} for the specified {@link ProgramId program}.
    *
    * @param programId the {@link ProgramId program} for which the {@link ProgramSpecification} is requested
-   * @return the {@link ProgramSpecification} for the specified {@link ProgramId program}
+   * @return the {@link ProgramSpecification} for the specified {@link ProgramId program}, or {@code null} if it does
+   *         not exist
    */
   @Nullable
   public ProgramSpecification getProgramSpecification(ProgramId programId) throws Exception {
@@ -339,8 +340,10 @@ public class ProgramLifecycleService {
    * Returns the {@link ProgramSpecification} for the specified {@link ProgramId program}.
    * @param appSpec the {@link ApplicationSpecification} of the existing application
    * @param programId the {@link ProgramId program} for which the {@link ProgramSpecification} is requested
-   * @return the {@link ProgramSpecification} for the specified {@link ProgramId program}
+   * @return the {@link ProgramSpecification} for the specified {@link ProgramId program}, or {@code null} if it does
+   *         not exist
    */
+  @Nullable
   private ProgramSpecification getExistingAppProgramSpecification(ApplicationSpecification appSpec,
                                                                   ProgramId programId) {
     String programName = programId.getProgram();


### PR DESCRIPTION
1. `programLifecycleService.getProgramSpecification` does not throw a NotFoundException, but the code calling it expected it to do so, when the program does not exist.
2. The NotFoundException being thrown by `programLifecycleService.getProgramStatus` could use the "nicer error message" that is being mapped for the call to `programLifecycleService.run`.
3. The last `catch (Exception e)` block is unnecessary.