### PR TITLE
Migrate csv, keyvalue, and keyvalue-encoded widgets to React component

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/AbstractMultiRowWidget/AbstractRow.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/AbstractMultiRowWidget/AbstractRow.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import IconButton from '@material-ui/core/IconButton';
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
+import { WithStyles } from '@material-ui/core/styles/withStyles';
+import If from 'components/If';
+
+enum KEY_CODE {
+  Enter = 13,
+  Up = 38,
+  Down = 40,
+}
+
+const styles = (theme) => {
+  return {
+    root: {
+      height: '44px',
+    },
+  };
+};
+
+export interface IAbstractRowProps<S extends typeof styles> extends WithStyles<S> {
+  value: string;
+  id: string;
+  index: number;
+  autofocus: boolean;
+  disabled: boolean;
+  onChange: (id: string, value: string) => void;
+  addRow: () => void;
+  removeRow: () => void;
+  changeFocus: (index: number) => void;
+  forwardedRef: () => void;
+}
+
+export default class AbstractRow<
+  P extends IAbstractRowProps<typeof styles>,
+  State
+> extends React.PureComponent<P, State> {
+  public static defaultProps = {
+    valuePlaceholder: 'Value',
+  };
+
+  public onChange = (value) => {
+    this.props.onChange(this.props.id, value);
+  };
+
+  public handleKeyPress = (e) => {
+    if (e.nativeEvent.keyCode !== KEY_CODE.Enter) {
+      return;
+    }
+
+    this.props.addRow();
+  };
+
+  public handleKeyDown = (e) => {
+    switch (e.nativeEvent.keyCode) {
+      case KEY_CODE.Up:
+        e.preventDefault();
+        this.props.changeFocus(this.props.index - 1);
+        return;
+      case KEY_CODE.Down:
+        this.props.changeFocus(this.props.index + 1);
+        return;
+    }
+  };
+
+  public renderInput = () => {
+    return null;
+  };
+
+  public render() {
+    return (
+      <div className={this.props.classes.root}>
+        {this.renderInput()}
+
+        <If condition={!this.props.disabled}>
+          <React.Fragment>
+            <IconButton onClick={this.props.addRow}>
+              <AddIcon fontSize="small" />
+            </IconButton>
+
+            <IconButton color="secondary" onClick={this.props.removeRow}>
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </React.Fragment>
+        </If>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/AbstractWidget/AbstractMultiRowWidget/Container.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/AbstractMultiRowWidget/Container.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+
+const styles = (theme) => {
+  return {
+    multiRowContainer: {
+      padding: '10px',
+      border: `2px solid ${theme.palette.grey['400']}`,
+      borderRadius: `4px`,
+    },
+  };
+};
+
+interface IMultiRowContainerProps extends WithStyles<typeof styles> {
+  children: any[] | any;
+}
+
+function MultiRowContainer(props: IMultiRowContainerProps) {
+  return <div className={props.classes.multiRowContainer}>{props.children}</div>;
+}
+
+const StyledContainer = withStyles(styles)(MultiRowContainer);
+export default StyledContainer;

--- a/cdap-ui/app/cdap/components/AbstractWidget/AbstractMultiRowWidget/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/AbstractMultiRowWidget/index.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import uuidV4 from 'uuid/v4';
+import MultiRowContainer from 'components/AbstractWidget/AbstractMultiRowWidget/Container';
+
+export interface IMultiRowProps {
+  onChange: (values: string) => void;
+  value: string;
+  disabled: boolean;
+  delimiter?: string;
+}
+
+interface IMultiRowState {
+  rows: string[];
+  autofocus?: string;
+}
+
+export default class AbstractMultiRowWidget<P extends IMultiRowProps> extends React.PureComponent<
+  P,
+  IMultiRowState
+> {
+  public static defaultProps = {
+    delimiter: ',',
+  };
+
+  public state = {
+    rows: [],
+    autofocus: null,
+  };
+
+  public values = {};
+
+  public componentDidMount() {
+    if (!this.props.value || this.props.value.length === 0) {
+      this.addRow();
+      return;
+    }
+
+    const delimiter = this.props.delimiter;
+
+    const splitValues = this.props.value.split(delimiter);
+    const rows = [];
+
+    splitValues.forEach((value) => {
+      const id = uuidV4();
+      this.values[id] = {
+        ref: React.createRef(),
+        value,
+      };
+
+      rows.push(id);
+    });
+
+    this.setState({ rows });
+  }
+
+  public addRow = (index = -1) => {
+    const rows = this.state.rows.slice();
+    const id = uuidV4();
+    rows.splice(index + 1, 0, id);
+
+    this.values[id] = {
+      ref: React.createRef(),
+      value: '',
+    };
+
+    this.setState({
+      rows,
+      autofocus: id,
+    });
+
+    this.onChange();
+  };
+
+  public removeRow = (index) => {
+    const rows = this.state.rows.slice();
+    const id = rows[index];
+
+    rows.splice(index, 1);
+
+    this.setState(
+      {
+        rows,
+      },
+      () => {
+        delete this.values[id];
+        if (rows.length === 0) {
+          this.addRow();
+        }
+        this.onChange();
+      }
+    );
+  };
+
+  public editRow = (id, value) => {
+    this.values[id].value = value;
+
+    this.onChange();
+  };
+
+  public onChange = () => {
+    const values = this.state.rows
+      .filter((id) => this.values[id].value)
+      .map((id) => this.values[id].value)
+      .join(this.props.delimiter);
+
+    if (this.props.onChange) {
+      this.props.onChange(values);
+    }
+  };
+
+  public changeFocus = (index) => {
+    if (index < 0 || index > this.state.rows.length - 1) {
+      return;
+    }
+
+    const focusId = this.state.rows[index];
+    if (this.values[focusId].ref.current) {
+      this.values[focusId].ref.current.focus();
+    }
+  };
+
+  public renderRow = (id, index) => {
+    return null;
+  };
+
+  public render() {
+    return (
+      <MultiRowContainer>
+        {this.state.rows.map((id, index) => {
+          return this.renderRow(id, index);
+        })}
+      </MultiRowContainer>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/AbstractWidget/CSVWidget/CSVRow.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/CSVWidget/CSVRow.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import Input from '@material-ui/core/Input';
+import withStyles from '@material-ui/core/styles/withStyles';
+
+import AbstractRow, {
+  IAbstractRowProps,
+} from 'components/AbstractWidget/AbstractMultiRowWidget/AbstractRow';
+
+const styles = (theme) => {
+  return {
+    root: {
+      height: '44px',
+    },
+    input: {
+      width: 'calc(100% - 100px)',
+      marginRight: '10px',
+    },
+    disabled: {
+      color: `${theme.palette.grey['50']}`,
+    },
+  };
+};
+
+interface ICSVRowProps extends IAbstractRowProps<typeof styles> {
+  valuePlaceholder?: string;
+}
+
+interface ICSVRowState {
+  value: string;
+}
+
+class CSVRow extends AbstractRow<ICSVRowProps, ICSVRowState> {
+  public static defaultProps = {
+    valuePlaceholder: 'Value',
+  };
+
+  public state = {
+    value: this.props.value,
+  };
+
+  private handleChange = (e) => {
+    const value = e.target.value;
+
+    this.setState({
+      value,
+    });
+
+    this.onChange(value);
+  };
+
+  public renderInput = () => {
+    return (
+      <Input
+        className={this.props.classes.input}
+        classes={{ disabled: this.props.classes.disabled }}
+        placeholder={this.props.valuePlaceholder}
+        onChange={this.handleChange}
+        value={this.state.value}
+        autoFocus={this.props.autofocus}
+        onKeyPress={this.handleKeyPress}
+        onKeyDown={this.handleKeyDown}
+        disabled={this.props.disabled}
+        inputRef={this.props.forwardedRef}
+      />
+    );
+  };
+}
+
+const StyledCSVRow = withStyles(styles)(CSVRow);
+export default StyledCSVRow;

--- a/cdap-ui/app/cdap/components/AbstractWidget/CSVWidget/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/CSVWidget/index.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import CSVRow from 'components/AbstractWidget/CSVWidget/CSVRow';
+import ThemeWrapper from 'components/ThemeWrapper';
+import AbstractMultiRowWidget, {
+  IMultiRowProps,
+} from 'components/AbstractWidget/AbstractMultiRowWidget';
+
+interface ICSVWidgetProps extends IMultiRowProps {
+  valuePlaceholder?: string;
+}
+
+class CSVWidget extends AbstractMultiRowWidget<ICSVWidgetProps> {
+  public renderRow = (id, index) => {
+    return (
+      <CSVRow
+        key={id}
+        value={this.values[id].value}
+        id={id}
+        index={index}
+        onChange={this.editRow}
+        addRow={this.addRow.bind(this, index)}
+        removeRow={this.removeRow.bind(this, index)}
+        autofocus={this.state.autofocus === id}
+        changeFocus={this.changeFocus}
+        disabled={this.props.disabled}
+        valuePlaceholder={this.props.valuePlaceholder}
+        forwardedRef={this.values[id].ref}
+      />
+    );
+  };
+}
+
+export default function StyledCSVWidgetWrapper(props) {
+  return (
+    <ThemeWrapper>
+      <CSVWidget {...props} />
+    </ThemeWrapper>
+  );
+}
+
+(StyledCSVWidgetWrapper as any).propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  delimiter: PropTypes.string,
+  valuePlaceholder: PropTypes.string,
+};

--- a/cdap-ui/app/cdap/components/AbstractWidget/KeyValueWidget/KeyValueRow.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/KeyValueWidget/KeyValueRow.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import Input from '@material-ui/core/Input';
+import withStyles from '@material-ui/core/styles/withStyles';
+
+import AbstractRow, {
+  IAbstractRowProps,
+} from 'components/AbstractWidget/AbstractMultiRowWidget/AbstractRow';
+
+const styles = (theme) => {
+  return {
+    root: {
+      height: '44px',
+    },
+    inputContainer: {
+      width: 'calc(100% - 100px)',
+      display: 'inline-flex',
+      marginRight: '10px',
+    },
+    input: {
+      width: 'calc(50% - 5px)',
+      '&:first-child': {
+        marginRight: '10px',
+      },
+    },
+    disabled: {
+      color: `${theme.palette.grey['50']}`,
+    },
+  };
+};
+
+interface IKeyValueRowProps extends IAbstractRowProps<typeof styles> {
+  valuePlaceholder?: string;
+  keyPlaceholder?: string;
+  kvDelimiter?: string;
+  isEncoded: boolean;
+}
+
+interface IKeyValueState {
+  value: string;
+  key: string;
+}
+
+type StateKeys = keyof IKeyValueState;
+
+class KeyValueRow extends AbstractRow<IKeyValueRowProps, IKeyValueState> {
+  public static defaultProps = {
+    keyPlaceholder: 'Key',
+    valuePlaceholder: 'Value',
+    kvDelimiter: ':',
+    isEncoded: false,
+  };
+
+  public state = {
+    key: '',
+    value: '',
+  };
+
+  public componentDidMount() {
+    let [key = '', value = ''] = this.props.value.split(this.props.kvDelimiter);
+
+    if (this.props.isEncoded) {
+      key = decodeURIComponent(key);
+      value = decodeURIComponent(value);
+    }
+
+    this.setState({
+      key,
+      value,
+    });
+  }
+
+  private handleChange = (type: StateKeys, e) => {
+    this.setState(
+      {
+        [type]: e.target.value,
+      } as Pick<IKeyValueState, StateKeys>,
+      () => {
+        let key = this.state.key;
+        let value = this.state.value;
+
+        if (this.props.isEncoded) {
+          key = encodeURIComponent(key);
+          value = encodeURIComponent(value);
+        }
+
+        const updatedValue = key.length > 0 ? [key, value].join(this.props.kvDelimiter) : '';
+        this.onChange(updatedValue);
+      }
+    );
+  };
+
+  public renderInput = () => {
+    return (
+      <div className={this.props.classes.inputContainer}>
+        <Input
+          className={this.props.classes.input}
+          classes={{ disabled: this.props.classes.disabled }}
+          placeholder={this.props.keyPlaceholder}
+          onChange={this.handleChange.bind(this, 'key')}
+          value={this.state.key}
+          autoFocus={this.props.autofocus}
+          onKeyPress={this.handleKeyPress}
+          onKeyDown={this.handleKeyDown}
+          disabled={this.props.disabled}
+          inputRef={this.props.forwardedRef}
+        />
+
+        <Input
+          className={this.props.classes.input}
+          classes={{ disabled: this.props.classes.disabled }}
+          placeholder={this.props.valuePlaceholder}
+          onChange={this.handleChange.bind(this, 'value')}
+          value={this.state.value}
+          onKeyPress={this.handleKeyPress}
+          onKeyDown={this.handleKeyDown}
+          disabled={this.props.disabled}
+        />
+      </div>
+    );
+  };
+}
+
+const StyledKeyValueRow = withStyles(styles)(KeyValueRow);
+export default StyledKeyValueRow;

--- a/cdap-ui/app/cdap/components/AbstractWidget/KeyValueWidget/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/KeyValueWidget/index.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import KeyValueRow from 'components/AbstractWidget/KeyValueWidget/KeyValueRow';
+import ThemeWrapper from 'components/ThemeWrapper';
+import AbstractMultiRowWidget, {
+  IMultiRowProps,
+} from 'components/AbstractWidget/AbstractMultiRowWidget';
+
+interface IKeyValueWidgetProps extends IMultiRowProps {
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  kvDelimiter?: string;
+  isEncoded: boolean;
+}
+
+class KeyValueWidget extends AbstractMultiRowWidget<IKeyValueWidgetProps> {
+  public renderRow = (id, index) => {
+    return (
+      <KeyValueRow
+        key={id}
+        value={this.values[id].value}
+        id={id}
+        index={index}
+        onChange={this.editRow}
+        addRow={this.addRow.bind(this, index)}
+        removeRow={this.removeRow.bind(this, index)}
+        autofocus={this.state.autofocus === id}
+        changeFocus={this.changeFocus}
+        disabled={this.props.disabled}
+        keyPlaceholder={this.props.keyPlaceholder}
+        valuePlaceholder={this.props.valuePlaceholder}
+        kvDelimiter={this.props.kvDelimiter}
+        isEncoded={this.props.isEncoded}
+        forwardedRef={this.values[id].ref}
+      />
+    );
+  };
+}
+
+export default function StyledKeyValueWidgetWrapper(props) {
+  return (
+    <ThemeWrapper>
+      <KeyValueWidget {...props} />
+    </ThemeWrapper>
+  );
+}
+
+(StyledKeyValueWidgetWrapper as any).propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  delimiter: PropTypes.string,
+  valuePlaceholder: PropTypes.string,
+  keyPlaceholder: PropTypes.string,
+  kvDelimiter: PropTypes.string,
+  isEncoded: PropTypes.bool,
+};

--- a/cdap-ui/app/cdap/components/Experimental/index.js
+++ b/cdap-ui/app/cdap/components/Experimental/index.js
@@ -27,13 +27,13 @@ export default class Experimental extends Component {
       const state = SchemaStore.getState();
       const schema = state.schema;
 
-      this.setState({parsed: schema});
+      this.setState({ parsed: schema });
     });
   }
 
   state = {
-    parsed: ''
-  }
+    parsed: '',
+  };
 
   componentWillMount() {
     const schema = {
@@ -45,47 +45,46 @@ export default class Experimental extends Component {
           type: [
             {
               type: 'long',
-              logicalType: 'timestamp-micros'
+              logicalType: 'timestamp-micros',
             },
-            'null'
-          ]
+            'null',
+          ],
         },
         {
           name: 'time',
           type: {
             type: 'long',
-            logicalType: 'time-micros'
-          }
+            logicalType: 'time-micros',
+          },
         },
         {
           name: 'date',
           type: {
             type: 'int',
-            logicalType: 'date'
-          }
+            logicalType: 'date',
+          },
         },
         {
           name: 'haha',
           type: [
             {
               type: 'int',
-              logicalType: 'date'
+              logicalType: 'date',
             },
             {
               type: 'long',
-              logicalType: 'time-micros'
-            }
-          ]
-        }
-      ]
+              logicalType: 'time-micros',
+            },
+          ],
+        },
+      ],
     };
-
 
     SchemaStore.dispatch({
       type: 'FIELD_UPDATE',
       payload: {
-        schema
-      }
+        schema,
+      },
     });
   }
 

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -74,6 +74,8 @@ var CodeEditor = require('../cdap/components/CodeEditor').default;
 var JSONEditor = require('../cdap/components/CodeEditor/JSONEditor').default;
 var TextBox = require('../cdap/components/AbstractWidget/FormInputs/TextBox').default;
 var Number = require('../cdap/components/AbstractWidget/FormInputs/Number').default;
+var CSVWidget = require('../cdap/components/AbstractWidget/CSVWidget').default;
+var KeyValueWidget = require('../cdap/components/AbstractWidget/KeyValueWidget').default;
 
 export {
   Store,
@@ -129,4 +131,6 @@ export {
   JSONEditor,
   TextBox,
   Number,
+  CSVWidget,
+  KeyValueWidget,
 };

--- a/cdap-ui/app/directives/react-components/index.js
+++ b/cdap-ui/app/directives/react-components/index.js
@@ -80,4 +80,10 @@ angular.module(PKG.name + '.commons')
   })
   .directive('number', function(reactDirective) {
     return reactDirective(window.CaskCommon.Number);
+  })
+  .directive('csvWidget', function(reactDirective) {
+    return reactDirective(window.CaskCommon.CSVWidget);
+  })
+  .directive('keyValueWidget', function (reactDirective) {
+    return reactDirective(window.CaskCommon.KeyValueWidget);
   });

--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -59,22 +59,24 @@ angular.module(PKG.name + '.commons')
         }
       },
       'csv': {
-        element: '<my-dsv></my-dsv>',
+        element: '<csv-widget></csv-widget>',
         attributes: {
-          'ng-model': 'model',
-          'delimiter': '{{::myconfig["widget-attributes"].delimiter}}',
-          'type': 'csv',
-          'config': 'myconfig'
-        }
+          'value': 'model',
+          'delimiter': 'myconfig["widget-attributes"].delimiter',
+          'value-placeholder': 'myconfig["widget-attributes"]["value-placeholder"]',
+          'on-change': 'onChange',
+          'disabled': 'disabled',
+        },
       },
       'dsv': {
-        element: '<my-dsv></my-dsv>',
+        element: '<csv-widget></csv-widget>',
         attributes: {
-          'ng-model': 'model',
-          'delimiter': '{{::myconfig["widget-attributes"].delimiter}}',
-          'type': 'dsv',
-          'config': 'myconfig'
-        }
+          'value': 'model',
+          'delimiter': 'myconfig["widget-attributes"].delimiter',
+          'value-placeholder': 'myconfig["widget-attributes"]["value-placeholder"]',
+          'on-change': 'onChange',
+          'disabled': 'disabled',
+        },
       },
       'ds-multiplevalues': {
         element: '<my-ds-multiple-values></my-ds-multiple-values>',
@@ -140,17 +142,28 @@ angular.module(PKG.name + '.commons')
         }
       },
       'keyvalue': {
-        element: '<my-key-value></my-key-value>',
+        element: '<key-value-widget></key-value-widget>',
         attributes: {
-          'ng-model': 'model',
-          'data-config': 'myconfig'
+          'value': 'model',
+          'delimiter': 'myconfig["widget-attributes"].delimiter',
+          'kv-delimiter': 'myconfig["widget-attributes"]["kv-delimiter"]',
+          'key-placeholder': 'myconfig["widget-attributes"]["key-placeholder"]',
+          'value-placeholder': 'myconfig["widget-attributes"]["value-placeholder"]',
+          'on-change': 'onChange',
+          'disabled': 'disabled',
         }
       },
       'keyvalue-encoded': {
-        element: '<my-key-value-encoded></my-key-value-encoded>',
+        element: '<key-value-widget></key-value-widget>',
         attributes: {
-          'ng-model': 'model',
-          'data-config': 'myconfig'
+          'value': 'model',
+          'delimiter': 'myconfig["widget-attributes"].delimiter',
+          'kv-delimiter': 'myconfig["widget-attributes"]["kv-delimiter"]',
+          'key-placeholder': 'myconfig["widget-attributes"]["key-placeholder"]',
+          'value-placeholder': 'myconfig["widget-attributes"]["value-placeholder"]',
+          'on-change': 'onChange',
+          'disabled': 'disabled',
+          'is-encoded': true,
         }
       },
       'keyvalue-dropdown': {


### PR DESCRIPTION
[CDAP-15451] Migrate csv and dsv widgets to react component
[CDAP-15463] Migrate keyvalue widget to react component
[CDAP-15463] Migrate keyvalue-encoded widget to react component


JIRAs:
- https://issues.cask.co/browse/CDAP-15451
- https://issues.cask.co/browse/CDAP-15463
- https://issues.cask.co/browse/CDAP-15464

Build: https://builds.cask.co/browse/CDAP-UDUT320