### PR TITLE
CDAP-15373 add subnet as a dataproc provisioner property

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -53,6 +53,7 @@ public class DataprocConf {
   private final String zone;
   private final String projectId;
   private final String network;
+  private final String subnet;
 
   private final int masterNumNodes;
   private final int masterCPUs;
@@ -75,16 +76,18 @@ public class DataprocConf {
   private final SSHPublicKey publicKey;
   private final Map<String, String> dataprocProperties;
 
-  DataprocConf(DataprocConf conf, String network) {
-    this(conf.accountKey, conf.region, conf.zone, conf.projectId, network, conf.masterNumNodes, conf.masterCPUs,
-         conf.masterMemoryMB, conf.masterDiskGB, conf.workerNumNodes, conf.workerCPUs, conf.workerMemoryMB,
-         conf.workerDiskGB, conf.pollCreateDelay, conf.pollCreateJitter, conf.pollDeleteDelay, conf.pollInterval,
+  DataprocConf(DataprocConf conf, String network, String subnet) {
+    this(conf.accountKey, conf.region, conf.zone, conf.projectId, network, subnet,
+         conf.masterNumNodes, conf.masterCPUs, conf.masterMemoryMB, conf.masterDiskGB,
+         conf.workerNumNodes, conf.workerCPUs, conf.workerMemoryMB, conf.workerDiskGB,
+         conf.pollCreateDelay, conf.pollCreateJitter, conf.pollDeleteDelay, conf.pollInterval,
          conf.preferExternalIP, conf.stackdriverLoggingEnabled, conf.stackdriverMonitoringEnabled, conf.publicKey,
          conf.dataprocProperties);
   }
 
   private DataprocConf(@Nullable String accountKey, String region, String zone, String projectId,
-                       @Nullable String network, int masterNumNodes, int masterCPUs, int masterMemoryMB,
+                       @Nullable String network, @Nullable String subnet,
+                       int masterNumNodes, int masterCPUs, int masterMemoryMB,
                        int masterDiskGB, int workerNumNodes, int workerCPUs, int workerMemoryMB, int workerDiskGB,
                        long pollCreateDelay, long pollCreateJitter, long pollDeleteDelay, long pollInterval,
                        boolean preferExternalIP, boolean stackdriverLoggingEnabled,
@@ -95,6 +98,7 @@ public class DataprocConf {
     this.zone = zone;
     this.projectId = projectId;
     this.network = network;
+    this.subnet = subnet;
     this.masterNumNodes = masterNumNodes;
     this.masterCPUs = masterCPUs;
     this.masterMemoryMB = masterMemoryMB;
@@ -129,6 +133,11 @@ public class DataprocConf {
   @Nullable
   public String getNetwork() {
     return network;
+  }
+
+  @Nullable
+  public String getSubnet() {
+    return subnet;
   }
 
   public int getMasterNumNodes() {
@@ -269,6 +278,7 @@ public class DataprocConf {
     if (network == null || AUTO_DETECT.equals(network)) {
       network = null;
     }
+    String subnet = getString(properties, "subnet");
 
     int masterNumNodes = getInt(properties, "masterNumNodes", 1);
     if (masterNumNodes != 1 && masterNumNodes != 3) {
@@ -311,7 +321,7 @@ public class DataprocConf {
     );
 
     // always use 'global' region until CDAP-14376 is fixed.
-    return new DataprocConf(accountKey, "global", zone, projectId, network,
+    return new DataprocConf(accountKey, "global", zone, projectId, network, subnet,
                             masterNumNodes, masterCPUs, masterMemoryGB, masterDiskGB,
                             workerNumNodes, workerCPUs, workerMemoryGB, workerDiskGB,
                             pollCreateDelay, pollCreateJitter, pollDeleteDelay, pollInterval,

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -36,7 +36,7 @@
           "widget-type": "textbox",
           "label": "Network",
           "name": "network",
-          "description": "Select a VPC network in the specified project to use for creating clusters with this profile. If this is left blank or set to 'auto-detect', a network from the project will be chosen.",
+          "description": "Select a VPC network in the specified project to use when creating clusters with this profile. If this is left blank or set to 'auto-detect', a network from the project will be chosen.",
           "widget-attributes": {
             "default": "default",
             "size": "medium"
@@ -97,6 +97,15 @@
               "us-west1-c"
             ],
             "default": "us-east1-c",
+            "size": "medium"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Subnet",
+          "name": "subnet",
+          "description": "Subnet to use when creating clusters. The subnet must be within the given network, and it must be for the same region that the zone is in. If this is left blank, a subnet will automatically be chosen based on the network and zone.",
+          "widget-attributes": {
             "size": "medium"
           }
         },


### PR DESCRIPTION
Added a subnet property to the dataproc provisioner that lets
users specify a subnet when creating a profile. The subnet
must be in the network chosen, and it must be for the region
that the chosen zone is in.

If no subnet is given and the chosen network uses custom subnet
creation, the provisioner will now try to pick a subnet from
the network.

This fixes failures that would occur if a network was used that does
not use automatic subnet creation.