### PR TITLE
[CDAP-15433] FLL graphical representation of datasets

### DIFF
--- a/cdap-ui/app/cdap/components/Experiments/FieldLevelLineage/index.tsx
+++ b/cdap-ui/app/cdap/components/Experiments/FieldLevelLineage/index.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import LineageSummary from 'components/FieldLevelLineage/v2/LineageSummary';
+import { Provider } from 'components/FieldLevelLineage/v2/Context/FllContext';
+
+export default function FllExpt() {
+  return (
+    <Provider>
+      <LineageSummary />
+    </Provider>
+  );
+}

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import data from './sample_response';
+import {
+  parseRelations,
+  makeTargetNodes,
+} from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
+
+interface INode {
+  id: string;
+  name: string;
+  group: number;
+}
+
+const FllContext = React.createContext({});
+
+function getFieldsAndLinks(d) {
+  const incoming = parseRelations(d.entityId.namespace, d.incoming);
+  const outgoing = parseRelations(d.entityId.namespace, d.outgoing, false);
+  const causeTables = incoming.tables;
+  const impactTables = outgoing.tables;
+  const nodes = incoming.relNodes.concat(outgoing.relNodes);
+  const links = incoming.relLinks.concat(outgoing.relLinks);
+  return { causeTables, impactTables, nodes, links };
+}
+
+export function Provider({ children }) {
+  const parsedRes = getFieldsAndLinks(data);
+
+  const defaultState = {
+    target: data.entityId.dataset,
+    targetFields: makeTargetNodes(data.entityId.dataset, data.fields) as INode[],
+    nodes: parsedRes.nodes,
+    links: parsedRes.links,
+    causeSets: parsedRes.causeTables,
+    impactSets: parsedRes.impactTables,
+    activeField: null,
+    numTables: 4,
+    firstCause: 1,
+    firstImpact: 1,
+    firstField: 1,
+  };
+
+  return <FllContext.Provider value={defaultState}>{children}</FllContext.Provider>;
+}
+
+export function Consumer({ children }) {
+  return <FllContext.Consumer>{children}</FllContext.Consumer>;
+}

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContextHelper.ts
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContextHelper.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+// Parses an incoming or outgoing entity object from backend response to get unique nodes (one per incoming or outgoing field), connections, and an object with fieldnames for each incoming or outgoing dataset
+
+export function parseRelations(namespace, ents, isCause = true) {
+  const tables = {};
+  const relNodes = [];
+  const relLinks = [];
+  ents.map((ent) => {
+    const tableName = ent.entityId.dataset;
+    // tables keeps track of fields for each incoming or outgoing dataset
+    tables[tableName] = [];
+    // fieldIds keeps track of fields we've seen already, since a single field can have multiple connections
+    const fieldIds = new Map();
+    ent.relations.map((rel) => {
+      // backend response assumes connection goes from left to right, i.e. an incoming connection's source = incoming field and destination = target field, and outgoing connection's source = target field.
+      const fieldName = isCause ? rel.source : rel.destination;
+      let id = fieldIds.get(fieldName);
+      const field = {
+        id,
+        name: fieldName,
+        group: tableName,
+      };
+      if (!fieldIds.has(fieldName)) {
+        id = `${namespace}_${tableName}_${fieldName}`;
+        field.id = id;
+        fieldIds.set(fieldName, id);
+        tables[tableName].push(field);
+        relNodes.push(field);
+      }
+      relLinks.push({
+        source: isCause ? fieldIds.get(fieldName) : rel.source,
+        destination: isCause ? rel.destination : fieldIds.get(fieldName),
+      });
+    });
+  });
+  return { tables, relNodes, relLinks };
+}
+
+export function makeTargetNodes(entityId, fields) {
+  const targetNodes = fields.map((field) => {
+    const id = `${entityId.namespace}_${entityId.dataset}_${field}`;
+    return {
+      id,
+      name: field,
+      group: entityId.dataset,
+    };
+  });
+  return targetNodes;
+}

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/sample_response.ts
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/sample_response.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+export default {
+  direction: 'both',
+  'start-ts': '1558571821',
+  'end-ts': '1559176621',
+  entityId: {
+    namespace: 'default',
+    dataset: 'Employee_Data',
+  },
+  fields: [
+    'id',
+    'name',
+    'street_number',
+    'street',
+    'apt',
+    'city',
+    'zip',
+    'ssn',
+    'level',
+    'dept_id',
+    'designation',
+    'joining_date',
+    'area_code',
+    'comp_2017',
+    'comp_2018',
+    'comp_2019',
+  ],
+  incoming: [
+    {
+      entityId: {
+        namespace: 'default',
+        dataset: 'Person_Data',
+      },
+      relations: [
+        {
+          source: 'id',
+          destination: 'id',
+        },
+        {
+          source: 'first_name',
+          destination: 'name',
+        },
+        {
+          source: 'last_name',
+          destination: 'street_number',
+        },
+        {
+          source: 'address',
+          destination: 'city',
+        },
+      ],
+    },
+    {
+      entityId: {
+        namespace: 'default',
+        dataset: 'HR_Data',
+      },
+      relations: [
+        {
+          source: 'id',
+          destination: 'id',
+        },
+        {
+          source: 'level',
+          destination: 'level',
+        },
+        {
+          source: 'designation',
+          destination: 'comp_2017',
+        },
+        {
+          source: 'date',
+          destination: 'designation',
+        },
+        {
+          source: 'date',
+          destination: 'comp_2017',
+        },
+      ],
+    },
+    {
+      entityId: {
+        namespace: 'default',
+        dataset: 'Skills_Data',
+      },
+      relations: [
+        {
+          source: 'id',
+          destination: 'id',
+        },
+        {
+          source: 'technical',
+          destination: 'joining_date',
+        },
+        {
+          source: 'ops',
+          destination: 'comp_2017',
+        },
+      ],
+    },
+    {
+      entityId: {
+        namespace: 'default',
+        dataset: 'Comp_Data',
+      },
+      relations: [
+        {
+          source: 'id',
+          destination: 'id',
+        },
+        {
+          source: 'first',
+          destination: 'name',
+        },
+        {
+          source: 'last',
+          destination: 'name',
+        },
+        {
+          source: 'start_date',
+          destination: 'joining_date',
+        },
+      ],
+    },
+    {
+      entityId: {
+        namespace: 'default',
+        dataset: 'Misc_Data',
+      },
+      relations: [
+        {
+          source: 'vacation',
+          destination: 'cities',
+        },
+      ],
+    },
+  ],
+  outgoing: [
+    {
+      entityId: {
+        namespace: 'default',
+        dataset: 'Performance',
+      },
+      relations: [
+        {
+          source: 'id',
+          destination: 'id',
+        },
+      ],
+    },
+    {
+      entityId: {
+        namespace: 'default',
+        dataset: 'Promotion',
+      },
+      relations: [
+        {
+          source: 'id',
+          destination: 'id',
+        },
+        {
+          source: 'dept_id',
+          destination: 'id',
+        },
+        {
+          source: 'level',
+          destination: 'new_level',
+        },
+        {
+          source: 'designation',
+          destination: 'new_designation',
+        },
+        {
+          source: 'comp_2017',
+          destination: '2017_comp',
+        },
+      ],
+    },
+  ],
+};

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllHeader/index.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import T from 'i18n-react';
+import { Consumer } from '../Context/FllContext';
+
+interface IHeaderProps {
+  type: string;
+  first: number;
+  total: number;
+}
+
+function FllHeader({ type, first, total }: IHeaderProps) {
+  return (
+    <Consumer>
+      {({ numTables, target }) => {
+        let last;
+        if (type === ('impact' || 'cause')) {
+          last = first + numTables - 1 <= total ? first + numTables - 1 : total;
+        } else {
+          last = total;
+        }
+
+        const header =
+          type === 'target'
+            ? T.translate('features.FieldLevelLineage.v2.FllHeader.TargetHeader')
+            : T.translate('features.FieldLevelLineage.v2.FllHeader.RelatedHeader', {
+                type,
+                target,
+              });
+        const options = { first, last, total };
+        const subHeader =
+          type === 'target'
+            ? T.translate('features.FieldLevelLineage.v2.FllHeader.TargetSubheader', options)
+            : T.translate('features.FieldLevelLineage.v2.FllHeader.RelatedSubheader', options);
+
+        return (
+          <React.Fragment>
+            <div>{header}</div>
+            <div>{subHeader}</div>
+          </React.Fragment>
+        );
+      }}
+    </Consumer>
+  );
+}
+
+export default FllHeader;

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/index.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import SortableStickyGrid from 'components/SortableStickyGrid/index.js';
+import withStyles from '@material-ui/core/styles/withStyles';
+import createStyles from '@material-ui/core/styles/createStyles';
+import T from 'i18n-react';
+
+const styles = (theme) => {
+  return createStyles({
+    table: {
+      width: '170px',
+      border: `1px solid ${theme.palette.grey[300]}`,
+      margin: '10px',
+      '& .grid-row': {
+        height: '20px',
+      },
+      // TO DO: Fix overflow-y and maxHeight of grid-container to get rid of vertical scroll
+    },
+    tableHeader: {
+      borderBottom: `2px solid ${theme.palette.grey[300]}`,
+      height: '40px',
+      paddingLeft: '10px',
+      fontWeight: 'bold',
+    },
+    tableSubheader: {
+      fontWeight: 'normal',
+      color: theme.palette.grey[200],
+      paddingBottom: 5,
+      paddingTop: 3,
+    },
+  });
+};
+
+function renderGridHeader(nodes, tableName, classes) {
+  const count: number = nodes.length;
+  return (
+    <div className={classes.tableHeader}>
+      {tableName}
+      <div className={classes.tableSubheader}>
+        {T.translate('features.FieldLevelLineage.v2.TableSubheader', { count })}
+      </div>
+    </div>
+  );
+}
+
+function FllTable({ tableName, fields, classes }) {
+  const GRID_HEADERS = [{ property: 'name', label: tableName }];
+  return (
+    <SortableStickyGrid
+      key={`cause ${tableName}`}
+      entities={fields}
+      gridHeaders={GRID_HEADERS}
+      className={classes.table}
+      renderGridHeader={renderGridHeader.bind(null, fields, tableName, classes)}
+    />
+  );
+}
+
+const StyledFllTable = withStyles(styles)(FllTable);
+
+export default StyledFllTable;

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/LineageSummary/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/LineageSummary/index.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import FllHeader from 'components/FieldLevelLineage/v2/FllHeader';
+import FllTable from 'components/FieldLevelLineage/v2/FllTable';
+import withStyles from '@material-ui/core/styles/withStyles';
+import { Consumer } from 'components/FieldLevelLineage/v2/Context/FllContext';
+
+const styles = (theme) => {
+  return {
+    root: {
+      paddingLeft: '100px',
+      paddingRight: '100px',
+      display: 'flex',
+      justifyContent: 'space-between',
+    },
+  };
+};
+
+function LineageSummary({ classes }) {
+  return (
+    <Consumer>
+      {({ causeSets, target, targetFields, impactSets, firstCause, firstImpact, firstField }) => {
+        return (
+          <div className={classes.root}>
+            <div>
+              <FllHeader type="cause" first={firstCause} total={Object.keys(causeSets).length} />
+              {Object.keys(causeSets).map((key) => {
+                return <FllTable key={key} tableName={key} fields={causeSets[key]} />;
+              })}
+            </div>
+            <div>
+              <FllHeader
+                type="target"
+                first={firstField}
+                total={Object.keys(targetFields).length}
+              />
+              <FllTable key={target} tableName={target} fields={targetFields} />
+            </div>
+            <div>
+              <FllHeader type="impact" first={firstImpact} total={Object.keys(impactSets).length} />
+              {Object.keys(impactSets).map((key) => {
+                return <FllTable key={key} tableName={key} fields={impactSets[key]} />;
+              })}
+            </div>
+          </div>
+        );
+      }}
+    </Consumer>
+  );
+}
+
+const StyledLineageSummary = withStyles(styles)(LineageSummary);
+
+export default StyledLineageSummary;

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -207,6 +207,25 @@ class CDAP extends Component {
                     );
                   }}
                 />
+                <Route
+                  exact
+                  path="/fll-experiment"
+                  render={(props) => {
+                    if (window.CDAP_CONFIG.cdap.mode !== 'development') {
+                      return <Page404 {...props} />;
+                    }
+                    const FllExperiment = Loadable({
+                      loader: () =>
+                        import(/* webpackChunkName: "FLLExperiment" */ 'components/Experiments/FieldLevelLineage'),
+                      loading: LoadingSVGCentered,
+                    });
+                    return (
+                      <ErrorBoundary>
+                        <FllExperiment {...props} />
+                      </ErrorBoundary>
+                    );
+                  }}
+                />
                 {/*
                   Eventually handling 404 should move to the error boundary and all container components will have the error object.
                 */}

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1411,7 +1411,7 @@ features:
       Title:
         incoming: "Cause for:"
         outgoing: "Impact for:"
-      viewOperations: View operations
+      viewOperations: View operations 
     TimeRangeOptions:
       CUSTOM: Custom
       last14d: Last 14 days
@@ -1424,6 +1424,13 @@ features:
       subtitle: Explore root cause and impact for each of the fields of the dataset
       timePickerCaption: View field level info in the
       title: Field level lineage
+    v2:
+      FllHeader:
+        RelatedHeader: "Datasets used as {type} by {target}"
+        RelatedSubheader: "Viewing {first} to {last} of {total} datasets"
+        TargetHeader: 'Select a field to view lineage and operations' 
+        TargetSubheader: "Viewing {first} to {last} of {total} fields"
+      TableSubheader: "{count} fields"
 
   FileBrowser:
     directory: Directory


### PR DESCRIPTION
Initial layout using sample JSON from FLL backend design doc

- State properties derived from response JSON
  -  **target**: the target dataset
  -  **targetFields**: fields of target dataset
  -  **nodes**: list of all fields with id and name
  -  **links**: list of connections between nodes
  -  **causeSets**: cause datasets and their fields
  -  **impactSets**: impact datasets and their fields
  -  **activeField**: current selected field
  -  **numTables**: max number of cause or impact datasets shown on a page
  -  **firstCause**: index (starting at 1) of first cause dataset
  -  **firstImpact**:  index (starting at 1) of first impact dataset
  -  **firstField**:  index (starting at 1) of first field of target dataset

- **nodes** and **links** are included with assumption that they will be useful for creating connections between fields

- **numTables** and **firstCause/Impact/Field** are currently being used to get information for the navigational subheadings, i.e. "Viewing 1 to 4 of 5 datasets". I will hopefully figure out a better way to get/show this information in the future.  

Also will look into whether it makes sense to use `SortableStickyGrid` instead of the current Table component. 
