### PR TITLE
[CDAP-15097] artifact version defaults to 1.0.0-SNAPSHOT, if not present

### DIFF
--- a/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/ConfigureStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/ConfigureStep/index.js
@@ -44,6 +44,13 @@ const mapStateToArtifactClassnameProps = (state) => {
     placeholder: T.translate('features.Wizard.ArtifactUpload.Step2.classnamePlaceholder'),
   };
 };
+const mapStateToArtifactVersionProps = (state) => {
+  return {
+    value: state.configure.version,
+    type: 'text',
+    placeholder: T.translate('features.Wizard.ArtifactUpload.Step2.versionPlaceholder'),
+  };
+};
 const mapDispatchToArtifactNameProps = (dispatch) => {
   return {
     onChange: (e) => {
@@ -72,6 +79,15 @@ const mapDispatchToArtifactClassnameProps = (dispatch) => {
       }),
   };
 };
+const mapDispatchToArtifactVersionProps = (dispatch) => {
+  return {
+    onChange: (e) =>
+      dispatch({
+        type: ArtifactUploadActions.setVersion,
+        payload: { version: e.target.value },
+      }),
+  };
+};
 
 const InputArtifactName = connect(
   mapStateToArtifactNameProps,
@@ -84,6 +100,10 @@ const InputArtifactDescription = connect(
 const InputArtifactClassname = connect(
   mapStateToArtifactClassnameProps,
   mapDispatchToArtifactClassnameProps
+)(InputWithValidations);
+const InputArtifactVersion = connect(
+  mapStateToArtifactVersionProps,
+  mapDispatchToArtifactVersionProps
 )(InputWithValidations);
 
 export default function ConfigureStep() {
@@ -116,6 +136,18 @@ export default function ConfigureStep() {
           </Col>
           <Col xs="7">
             <InputArtifactClassname />
+          </Col>
+          <i className="fa fa-asterisk text-danger float-left" />
+        </FormGroup>
+
+        <FormGroup row>
+          <Col xs="3">
+            <Label className="control-label">
+              {T.translate('features.Wizard.ArtifactUpload.Step2.versionLabel')}
+            </Label>
+          </Col>
+          <Col xs="7">
+            <InputArtifactVersion />
           </Col>
           <i className="fa fa-asterisk text-danger float-left" />
         </FormGroup>

--- a/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/UploadStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/UploadStep/index.js
@@ -18,6 +18,7 @@ import React from 'react';
 import { connect, Provider } from 'react-redux';
 import ArtifactUploadStore from 'services/WizardStores/ArtifactUpload/ArtifactUploadStore';
 import ArtifactUploadActions from 'services/WizardStores/ArtifactUpload/ArtifactUploadActions';
+import { getArtifactNameAndVersion } from 'services/helpers';
 import FileDnD from 'components/FileDnD';
 require('./UploadStep.scss');
 
@@ -29,6 +30,11 @@ const mapStateWithDNDFileProps = (state) => {
 const mapDispatchWithDNDFileProps = (dispatch) => {
   return {
     onDropHandler: (e) => {
+      let { version } = getArtifactNameAndVersion(e[0].name.split('.jar')[0]);
+      dispatch({
+        type: ArtifactUploadActions.setVersion,
+        payload: { version },
+      });
       dispatch({
         type: ArtifactUploadActions.setFilePath,
         payload: {

--- a/cdap-ui/app/cdap/components/CaskWizards/LibraryUpload/ConfigureStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/LibraryUpload/ConfigureStep/index.js
@@ -51,6 +51,13 @@ const mapStateToArtifactTypeInputProps = (state) => {
     placeholder: T.translate('features.Wizard.LibraryUpload.Step2.typePlaceholder'),
   };
 };
+const mapStateToArtifactVersionProps = (state) => {
+  return {
+    value: state.configure.version,
+    type: 'text',
+    placeholder: T.translate('features.Wizard.LibraryUpload.Step2.versionPlaceholder'),
+  };
+};
 
 const mapDispatchToArtifactNameProps = (dispatch) => {
   return {
@@ -94,6 +101,15 @@ const mapDispatchToArtifactTypeProps = (dispatch) => {
   };
 };
 
+const mapDispatchToArtifactVersionProps = (dispatch) => {
+  return {
+    onChange: (e) =>
+      dispatch({
+        type: ArtifactUploadActions.setVersion,
+        payload: { version: e.target.value },
+      }),
+  };
+};
 const InputArtifactName = connect(
   mapStateToArtifactNameProps,
   mapDispatchToArtifactNameProps
@@ -110,6 +126,10 @@ const TypeInput = connect(
   mapStateToArtifactTypeInputProps,
   mapDispatchToArtifactTypeProps
 )(Input);
+const InputArtifactVersion = connect(
+  mapStateToArtifactVersionProps,
+  mapDispatchToArtifactVersionProps
+)(InputWithValidations);
 
 export default function ConfigureStep() {
   return (
@@ -153,6 +173,18 @@ export default function ConfigureStep() {
           </Col>
           <Col xs="7">
             <InputArtifactClassname />
+          </Col>
+          <i className="fa fa-asterisk text-danger float-left" />
+        </FormGroup>
+
+        <FormGroup row>
+          <Col xs="3">
+            <Label className="control-label">
+              {T.translate('features.Wizard.LibraryUpload.Step2.versionLabel')}
+            </Label>
+          </Col>
+          <Col xs="7">
+            <InputArtifactVersion />
           </Col>
           <i className="fa fa-asterisk text-danger float-left" />
         </FormGroup>

--- a/cdap-ui/app/cdap/components/CaskWizards/LibraryUpload/UploadStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/LibraryUpload/UploadStep/index.js
@@ -18,6 +18,7 @@ import React from 'react';
 import { connect, Provider } from 'react-redux';
 import ArtifactUploadStore from 'services/WizardStores/ArtifactUpload/ArtifactUploadStore';
 import ArtifactUploadActions from 'services/WizardStores/ArtifactUpload/ArtifactUploadActions';
+import { getArtifactNameAndVersion } from 'services/helpers';
 import FileDnD from 'components/FileDnD';
 require('components/CaskWizards/ArtifactUpload/UploadStep/UploadStep.scss');
 
@@ -29,6 +30,11 @@ const mapStateWithDNDFileProps = (state) => {
 const mapDispatchWithDNDFileProps = (dispatch) => {
   return {
     onDropHandler: (e) => {
+      let { version } = getArtifactNameAndVersion(e[0].name.split('.jar')[0]);
+      dispatch({
+        type: ArtifactUploadActions.setVersion,
+        payload: { version },
+      });
       dispatch({
         type: ArtifactUploadActions.setFilePath,
         payload: {

--- a/cdap-ui/app/cdap/services/WizardConfigs/ArtifactUploadWizardConfig.js
+++ b/cdap-ui/app/cdap/services/WizardConfigs/ArtifactUploadWizardConfig.js
@@ -34,7 +34,7 @@ let commonSteps = [
     title: T.translate('features.Wizard.ArtifactUpload.Step2.title'),
     description: T.translate('features.Wizard.ArtifactUpload.Step2.description'),
     content: <ConfigureStep />,
-    requiredFields: ['name', 'type', 'parentArtifact', 'classname'],
+    requiredFields: ['name', 'type', 'parentArtifact', 'classname', 'version'],
   },
 ];
 

--- a/cdap-ui/app/cdap/services/WizardConfigs/LibraryUploadWizardConfig.js
+++ b/cdap-ui/app/cdap/services/WizardConfigs/LibraryUploadWizardConfig.js
@@ -34,7 +34,7 @@ let commonSteps = [
     title: T.translate('features.Wizard.LibraryUpload.Step2.title'),
     description: T.translate('features.Wizard.LibraryUpload.Step2.description'),
     content: <ConfigureStep />,
-    requiredFields: ['name', 'type', 'parentArtifact', 'classname'],
+    requiredFields: ['name', 'type', 'parentArtifact', 'classname', 'version'],
   },
 ];
 

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
@@ -19,7 +19,6 @@ import cookie from 'react-cookie';
 import NamespaceStore from 'services/NamespaceStore';
 import ArtifactUploadStore from 'services/WizardStores/ArtifactUpload/ArtifactUploadStore';
 import isNil from 'lodash/isNil';
-import { Observable } from 'rxjs/Observable';
 
 // FIXME: Extract it out???
 const uploadArtifact = (includeParents = true) => {
@@ -40,7 +39,17 @@ const uploadArtifact = (includeParents = true) => {
     if (version && Array.isArray(version)) {
       version = version[0];
     }
-    let name = version ? nameWithVersion.substr(0, nameWithVersion.indexOf(version) - 1) : null;
+    let name = version
+      ? nameWithVersion.substr(0, nameWithVersion.indexOf(version) - 1)
+      : nameWithVersion;
+    // If version is not present, use default.
+    if (!version) {
+      version = '1.0.0-SNAPSHOT';
+    }
+    // If name is not present i.e 1.2.3.jar, use 1.2.3 as name and version.
+    if (!name) {
+      name = version;
+    }
     return { version, name };
   };
 
@@ -49,9 +58,6 @@ const uploadArtifact = (includeParents = true) => {
     filename = state.upload.file.name.split('.jar')[0];
   }
   let { name, version } = getArtifactNameAndVersion(filename);
-  if (!name || !version) {
-    return Observable.throw('Invalid driver JAR file name. The driver JAR file name must conform to the format <name>-<version>.jar (eg: mysql-connector-java-5.1.39-bin.jar)');
-  }
   let namespace = NamespaceStore.getState().selectedNamespace;
 
   let url = `/namespaces/${namespace}/artifacts/${name}`;

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
@@ -29,7 +29,7 @@ const uploadArtifact = (includeParents = true) => {
   if (state.upload.file.name && state.upload.file.name.length !== 0) {
     filename = state.upload.file.name.split('.jar')[0];
   }
-  let { name, version } = getArtifactNameAndVersion(filename);
+  let { name } = getArtifactNameAndVersion(filename);
   let namespace = NamespaceStore.getState().selectedNamespace;
 
   let url = `/namespaces/${namespace}/artifacts/${name}`;
@@ -37,7 +37,7 @@ const uploadArtifact = (includeParents = true) => {
   let headers = {
     'Content-Type': 'application/octet-stream',
     'X-Archive-Name': name,
-    'Artifact-Version': version,
+    'Artifact-Version': state.configure.version,
     'Artifact-Plugins': JSON.stringify([
       {
         name: state.configure.name,

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
@@ -19,39 +19,11 @@ import cookie from 'react-cookie';
 import NamespaceStore from 'services/NamespaceStore';
 import ArtifactUploadStore from 'services/WizardStores/ArtifactUpload/ArtifactUploadStore';
 import isNil from 'lodash/isNil';
+import { getArtifactNameAndVersion } from 'services/helpers';
 
 // FIXME: Extract it out???
 const uploadArtifact = (includeParents = true) => {
   const state = ArtifactUploadStore.getState();
-
-  let getArtifactNameAndVersion = (nameWithVersion) => {
-    if (!nameWithVersion) {
-      return {
-        version: null,
-        name: null,
-      };
-    }
-
-    // core-plugins-3.4.0-SNAPSHOT.jar
-    // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning up to version beginning)
-    let regExpRule = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
-    let version = regExpRule.exec(nameWithVersion);
-    if (version && Array.isArray(version)) {
-      version = version[0];
-    }
-    let name = version
-      ? nameWithVersion.substr(0, nameWithVersion.indexOf(version) - 1)
-      : nameWithVersion;
-    // If version is not present, use default.
-    if (!version) {
-      version = '1.0.0-SNAPSHOT';
-    }
-    // If name is not present i.e 1.2.3.jar, use 1.2.3 as name and version.
-    if (!name) {
-      name = version;
-    }
-    return { version, name };
-  };
 
   let filename;
   if (state.upload.file.name && state.upload.file.name.length !== 0) {

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ArtifactUploadActions.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ArtifactUploadActions.js
@@ -21,6 +21,7 @@ const ArtifactUploadActions = {
   setType: 'SET-ARTIFACT-TYPE',
   setFilePath: 'SET-ARTIFACT-PATH',
   setNameAndClass: 'SET-ARTIFACT-NAME-AND-CLASSNAME',
+  setVersion: 'SET-ARTIFACT-VERSION',
   onReset: 'RESET-STORE',
 };
 

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ArtifactUploadStore.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ArtifactUploadStore.js
@@ -34,7 +34,7 @@ const defaultConfigureState = Object.assign(
     type: '',
     description: '',
     classname: '',
-    version: '1.0.0',
+    version: '',
     parentArtifact: [
       'system:cdap-data-pipeline[3.0.0,10.0.0]',
       'system:cdap-data-streams[3.0.0,10.0.0]',

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ArtifactUploadStore.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ArtifactUploadStore.js
@@ -34,6 +34,7 @@ const defaultConfigureState = Object.assign(
     type: '',
     description: '',
     classname: '',
+    version: '1.0.0',
     parentArtifact: [
       'system:cdap-data-pipeline[3.0.0,10.0.0]',
       'system:cdap-data-streams[3.0.0,10.0.0]',
@@ -104,6 +105,11 @@ const configure = (state = defaultConfigureState, action = defaultAction) => {
     case ArtifactUploadActions.setType:
       stateCopy = Object.assign({}, state, {
         type: action.payload.type,
+      });
+      break;
+    case ArtifactUploadActions.setVersion:
+      stateCopy = Object.assign({}, state, {
+        version: action.payload.version,
       });
       break;
     case ArtifactUploadActions.setNameAndClass:

--- a/cdap-ui/app/cdap/services/__tests__/helpers.test.js
+++ b/cdap-ui/app/cdap/services/__tests__/helpers.test.js
@@ -25,11 +25,11 @@ describe('Unit Tests for Helpers: "getArtifactNameAndVersion"', () => {
     expect(version).toBe('1.3.0-SNAPSHOT');
   });
 
-  it('Usecase 2 - Invalid: Should return undefined for version if it could not find', () => {
+  it('Usecase 2 - Invalid: Should return 1.0.0-SNAPSHOT for version if it could not find', () => {
     var jarfileName = 'invalid-file-name-without-a-version';
     let {name, version} = getArtifactNameAndVersion(jarfileName);
     expect(name).toBe(jarfileName);
-    expect(version).toBe(undefined);
+    expect(version).toBe('1.0.0-SNAPSHOT');
   });
 
   it('Usecase 3: Should ignore unnecessary patterns & return correct name, version', () => {
@@ -55,6 +55,12 @@ describe('Unit Tests for Helpers: "getArtifactNameAndVersion"', () => {
     let {name, version} = getArtifactNameAndVersion(null);
     expect(name).toBe(null);
     expect(version).toBe(undefined);
+  });
+
+  it('Usecase 7: Should return filename for name and version when filename is the version i.e 1.2.3.jar', () => {
+    let {name, version} = getArtifactNameAndVersion('1.2.3');
+    expect(name).toBe('1.2.3');
+    expect(version).toBe('1.2.3');
   });
 
 });

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -215,11 +215,23 @@ function getArtifactNameAndVersion(nameWithVersion) {
   }
   let regExpRule = new RegExp('\\-(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
   let version = regExpRule.exec(nameWithVersion);
-  if (!version) {
-    return { name: nameWithVersion, version: undefined };
+  if (version && Array.isArray(version)) {
+    version = version[0].slice(1);
+  } else {
+    // when version is the filename i.e 1.2.3.jar
+    let nameIsVersionRegEx = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
+    let validVersion = nameIsVersionRegEx.exec(nameWithVersion);
+    if (validVersion && Array.isArray(validVersion)) {
+      return { name: nameWithVersion, version: nameWithVersion };
+    }
   }
-  version = version[0].slice(1);
-  let name = nameWithVersion.substr(0, nameWithVersion.indexOf(version) - 1);
+  let name = version
+    ? nameWithVersion.substr(0, nameWithVersion.indexOf(version) - 1)
+    : nameWithVersion;
+  // if version is not present, default it to 1.0.0-SNAPSHOT
+  if (!version) {
+    version = '1.0.0-SNAPSHOT';
+  }
   return { version, name };
 }
 

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -228,9 +228,9 @@ function getArtifactNameAndVersion(nameWithVersion) {
   let name = version
     ? nameWithVersion.substr(0, nameWithVersion.indexOf(version) - 1)
     : nameWithVersion;
-  // if version is not present, default it to 1.0.0-SNAPSHOT
+  // if version is not present, default it to 1.0.0
   if (!version) {
-    version = '1.0.0-SNAPSHOT';
+    version = '1.0.0';
   }
   return { version, name };
 }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1411,7 +1411,7 @@ features:
       Title:
         incoming: "Cause for:"
         outgoing: "Impact for:"
-      viewOperations: View operations 
+      viewOperations: View operations
     TimeRangeOptions:
       CUSTOM: Custom
       last14d: Last 14 days
@@ -1428,7 +1428,7 @@ features:
       FllHeader:
         RelatedHeader: "Datasets used as {type} by {target}"
         RelatedSubheader: "Viewing {first} to {last} of {total} datasets"
-        TargetHeader: 'Select a field to view lineage and operations' 
+        TargetHeader: 'Select a field to view lineage and operations'
         TargetSubheader: "Viewing {first} to {last} of {total} fields"
       TableSubheader: "{count} fields"
 
@@ -2571,6 +2571,8 @@ features:
         parentArtifactLabel: Parent artifact
         shorttitle: Driver configuration
         title: Configure driver
+        versionLabel: Version
+        versionPlaceholder: Driver version
       success: You have successfully uploaded the driver "{artifactName}".
       subtitle: You can now create a pipeline to extract data from database using the driver.
     DirectiveUpload:
@@ -2621,6 +2623,8 @@ features:
         title: Configure library
         typeLabel: Type
         typePlaceholder: Library type. E.g. sparkprogram
+        versionLabel: Version
+        versionPlaceholder: Library version
       success: You have successfully uploaded the library "{artifactName}".
       subtitle: You can now create a pipeline using the library.
     licenseStep:


### PR DESCRIPTION
When uploading an artifact in wrangler,

- If name is present and version is present i.e abc-1.2.3.jar -> no change; name: abc, version: 1.2.3
- If name is present and version is not i.e abc.jar -> name: abc, version: 1.0.0-SNAPSHOT
- If name is not present and version is present i.e 1.2.3.jar -> name: 1.2.3, version: 1.2.3

Also made changes to use helper method to get artifact's name and version.

JIRA: https://issues.cask.co/browse/CDAP-15097
