### PR TITLE
fix metrics clean up on k8s

### DIFF
--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.metrics.process.MessagingMetricsProcessorServiceFactory;
 import io.cdap.cdap.metrics.process.MetricsAdminSubscriberService;
 import io.cdap.cdap.metrics.process.MetricsProcessorStatusService;
 import io.cdap.cdap.metrics.query.MetricsQueryService;
+import io.cdap.cdap.metrics.store.MetricsCleanUpService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
@@ -96,6 +97,7 @@ public class MetricsServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     services.add(injector.getInstance(MetricsProcessorStatusService.class));
     services.add(injector.getInstance(MetricsQueryService.class));
     services.add(injector.getInstance(MetricsAdminSubscriberService.class));
+    services.add(injector.getInstance(MetricsCleanUpService.class));
   }
 
   @Nullable

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMainTest.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.metrics.process.RemoteMetricsSystemClient;
+import io.cdap.cdap.metrics.store.MetricsCleanUpService;
 import io.cdap.cdap.proto.MetricQueryResult;
 import io.cdap.cdap.proto.id.NamespaceId;
 import org.apache.twill.discovery.Discoverable;
@@ -49,6 +50,10 @@ public class MetricsServiceMainTest extends MasterServiceMainTestBase {
   @Test
   public void testMetricsService() throws Exception {
     Injector injector = getServiceMainInstance(MetricsServiceMain.class).getInjector();
+
+    // make sure the metrics clean up service is running
+    MetricsCleanUpService service = injector.getInstance(MetricsCleanUpService.class);
+    Assert.assertTrue(service.isRunning());
 
     // Publish some metrics via the MetricsCollectionService
     MetricsCollectionService metricsCollectionService = injector.getInstance(MetricsCollectionService.class);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/guice/MetricsClientRuntimeModule.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/guice/MetricsClientRuntimeModule.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.metrics.collect.LocalMetricsCollectionService;
 import io.cdap.cdap.metrics.process.DirectMetricsSystemClient;
 import io.cdap.cdap.metrics.process.MessagingMetricsProcessorService;
 import io.cdap.cdap.metrics.process.MessagingMetricsProcessorServiceFactory;
+import io.cdap.cdap.metrics.store.MetricsCleanUpService;
 
 /**
  * A {@link RuntimeModule} that defines Guice modules for metrics collection in different runtime mode.
@@ -80,6 +81,7 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
     // Both LocalMetricsCollectionService and the AppFabricService needs it
     binder.install(new MetricsStoreModule());
     binder.expose(MetricStore.class);
+    binder.expose(MetricsCleanUpService.class);
 
     binder.bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
     binder.expose(MetricsCollectionService.class);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/guice/MetricsStoreModule.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/guice/MetricsStoreModule.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.metrics.MetricStore;
 import io.cdap.cdap.metrics.store.DefaultMetricDatasetFactory;
 import io.cdap.cdap.metrics.store.DefaultMetricStore;
 import io.cdap.cdap.metrics.store.MetricDatasetFactory;
+import io.cdap.cdap.metrics.store.MetricsCleanUpService;
 
 /**
  * Guice module for providing bindings for {@link MetricStore} and {@link MetricDatasetFactory}.
@@ -32,5 +33,6 @@ public final class MetricsStoreModule extends AbstractModule {
   protected void configure() {
     bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
     bind(MetricStore.class).to(DefaultMetricStore.class);
+    bind(MetricsCleanUpService.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/MetricsCleanUpService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/MetricsCleanUpService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.store;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.metrics.MetricStore;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import org.apache.twill.common.Threads;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The metrics clean up service that will clean up resolution metrics table periodically based on their retention time.
+ */
+public class MetricsCleanUpService extends AbstractScheduledService {
+  private final MetricStore metricStore;
+  private final long cleanUpInterval;
+  private ScheduledExecutorService executor;
+
+  @Inject
+  MetricsCleanUpService(MetricStore metricStore, CConfiguration cConf) {
+    this.metricStore = metricStore;
+    this.cleanUpInterval = cConf.getLong(Constants.Metrics.MINIMUM_RESOLUTION_RETENTION_SECONDS);
+  }
+
+  @Override
+  protected final ScheduledExecutorService executor() {
+    executor = Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("metrics-cleanup"));
+    return executor;
+  }
+
+  @Override
+  protected void runOneIteration() {
+    // delete metrics from resolution table
+    metricStore.deleteTTLExpired();
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    // Try right away if there's anything to cleanup, we will then schedule based on the minimum retention interval
+    return Scheduler.newFixedRateSchedule(1, cleanUpInterval, TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
Build: https://builds.cask.co/browse/CDAP-DUT6987-1

The metrics are not cleaned up on k8s since we do not use the LocalMetricsCollectionService on k8s. 