### PR TITLE
CDAP-15570 StructuredRecord#getDecimal fixed to work with ByteBuffer values

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/format/StructuredRecord.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.api.data.schema.Schema.LogicalType;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -185,6 +186,10 @@ public class StructuredRecord implements Serializable {
     }
 
     int scale = logicalTypeSchema.getScale();
+    if (value instanceof ByteBuffer) {
+      return new BigDecimal(new BigInteger(Bytes.toBytes((ByteBuffer) value)), scale);
+    }
+
     return new BigDecimal(new BigInteger((byte[]) value), scale);
   }
 

--- a/cdap-formats/src/test/java/io/cdap/cdap/format/StructuredRecordStringConverterTest.java
+++ b/cdap-formats/src/test/java/io/cdap/cdap/format/StructuredRecordStringConverterTest.java
@@ -25,6 +25,8 @@ import io.cdap.cdap.api.data.schema.Schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -134,6 +136,18 @@ public class StructuredRecordStringConverterTest {
     StructuredRecord recordOfJson = StructuredRecordStringConverter.fromJsonString(jsonOfRecord, dateSchema);
 
     assertRecordsEqual(record, recordOfJson);
+  }
+
+  @Test
+  public void testDecimalLogicalTypeConversion() throws Exception {
+    Schema dateSchema = Schema.recordOf("decimal", Schema.Field.of("d", Schema.nullableOf(Schema.decimalOf(3, 2))));
+    StructuredRecord record = StructuredRecord.builder(dateSchema)
+      .setDecimal("d", new BigDecimal(new BigInteger("111"), 2)).build();
+
+    String jsonOfRecord = StructuredRecordStringConverter.toJsonString(record);
+    StructuredRecord recordOfJson = StructuredRecordStringConverter.fromJsonString(jsonOfRecord, dateSchema);
+
+    Assert.assertEquals(record.getDecimal("d"), recordOfJson.getDecimal("d"));
   }
 
   @Test


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15570

In scope of this PR:
* `StructuredRecord#getDecimal` method fixed to work with `ByteBuffer` values 