### PR TITLE
[CDAP-15539] removing capitalization filter for splitter popover

### DIFF
--- a/cdap-ui/app/directives/splitter-popover/splitter-popover.html
+++ b/cdap-ui/app/directives/splitter-popover/splitter-popover.html
@@ -17,7 +17,7 @@
 <div class="arrow"></div>
 <div class="popover-content">
   <div ng-repeat="port in SplitterPopoverCtrl.ports" class="splitter-popover-row">
-    <span class="port-name">{{ port.name | caskCapitalizeFilter }}</span>
+    <span class="port-name">{{ port.name }}</span>
     <div class="endpoint-circle"
           ng-class="['endpoint_{{node.name || node.plugin.label}}_port_{{port.name}}', {'disabled': isDisabled}]"
           data-nodeid="{{node.name || node.plugin.label}}"


### PR DESCRIPTION
Removing capitalization filter for port names in splitter popover.

JIRA: https://issues.cask.co/browse/CDAP-15539