### PR TITLE
CDAP-15525: Adding changes for runtime impersonation

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -222,6 +222,14 @@
       <artifactId>otj-pg-embedded</artifactId>
       <scope>test</scope>
     </dependency>
+   <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minikdc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.directory.jdbm</groupId>
+      <artifactId>apacheds-jdbm1</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/SystemArguments.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/SystemArguments.java
@@ -87,6 +87,12 @@ public final class SystemArguments {
   public static final String PROFILE_PROPERTIES_PREFIX = "system.profile.properties.";
 
   /**
+   * Runtime arguments for program impersonation
+   */
+  public static final String RUNTIME_KEYTAB_PATH = "system.runtime.keytab.path";
+  public static final String RUNTIME_PRINCIPAL_NAME = "system.runtime.principal.name";
+
+  /**
    * Extracts log level settings from the given arguments. It extracts arguments prefixed with key
    * {@link #LOG_LEVEL} + {@code .}, with the remaining part of the key as the logger name, with the argument value
    * as the log level. Also, the key {@link #LOG_LEVEL} will be used to setup the log level of the root logger.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -360,7 +360,8 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
         }
       };
 
-      return impersonator.doAs(program.getId(), callable);
+      ProgramRunId programRunId = program.getId().run(ProgramRunners.getRunId(options));
+      return impersonator.doAs(programRunId, callable);
 
     } catch (Exception e) {
       deleteDirectory(tempDir);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -71,6 +71,7 @@ import io.cdap.cdap.proto.RunCountResult;
 import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
@@ -107,6 +108,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import javax.security.auth.kerberos.KerberosPrincipal;
 
 /**
  * Service that manages lifecycle of Programs.
@@ -385,6 +387,9 @@ public class ProgramLifecycleService {
     if (overrides != null) {
       userArgs.putAll(overrides);
     }
+
+    authorizePipelineRuntimeImpersonation(userArgs);
+
     return runInternal(programId, userArgs, sysArgs, debug);
   }
 
@@ -492,6 +497,8 @@ public class ProgramLifecycleService {
     if (overrides != null) {
       userArgs.putAll(overrides);
     }
+
+    authorizePipelineRuntimeImpersonation(userArgs);
 
     BasicArguments systemArguments = new BasicArguments(sysArgs);
     BasicArguments userArguments = new BasicArguments(userArgs);
@@ -1073,5 +1080,16 @@ public class ProgramLifecycleService {
                                                     plugin.getPluginClass().getType(),
                                                     plugin.getPluginClass().getRequirements()))
       .collect(Collectors.toSet());
+  }
+
+  private void authorizePipelineRuntimeImpersonation(Map<String, String> userArgs) throws Exception {
+    if ((userArgs.containsKey(SystemArguments.RUNTIME_PRINCIPAL_NAME)) &&
+            (userArgs.containsKey(SystemArguments.RUNTIME_KEYTAB_PATH))) {
+      String principal = userArgs.get(SystemArguments.RUNTIME_PRINCIPAL_NAME);
+      LOG.debug("Checking authorisation for user: %s, using runtime config principal: %s",
+                authenticationContext.getPrincipal(), principal);
+      KerberosPrincipalId kid = new KerberosPrincipalId(principal);
+      authorizationEnforcer.enforce(kid, authenticationContext.getPrincipal(), Action.ADMIN);
+    }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/security/impersonation/DefaultUGIProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/security/impersonation/DefaultUGIProvider.java
@@ -16,15 +16,28 @@
 
 package io.cdap.cdap.security.impersonation;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
 import com.google.inject.Inject;
+
+import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.FeatureDisabledException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.common.utils.FileUtils;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.app.runtime.SystemArguments;
+import io.cdap.cdap.internal.app.store.RunRecordMeta;
 import io.cdap.cdap.proto.NamespaceConfig;
 import io.cdap.cdap.proto.element.EntityType;
+import io.cdap.cdap.proto.id.NamespacedEntityId;
+import io.cdap.cdap.proto.id.ProgramRunId;
+
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.twill.filesystem.Location;
@@ -35,10 +48,14 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Provides a UGI by logging in with a keytab file for that user.
@@ -50,15 +67,18 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
   private final LocationFactory locationFactory;
   private final File tempDir;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final Store store;
+  private static final Gson gson = new Gson();
 
   @Inject
   DefaultUGIProvider(CConfiguration cConf, LocationFactory locationFactory, OwnerAdmin ownerAdmin,
-                     NamespaceQueryAdmin namespaceQueryAdmin) {
+                     NamespaceQueryAdmin namespaceQueryAdmin, Store store) {
     super(cConf, ownerAdmin);
     this.locationFactory = locationFactory;
     this.tempDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                             cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.store = store;
   }
 
   /**
@@ -103,6 +123,18 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
    */
   @Override
   protected UGIWithPrincipal createUGI(ImpersonationRequest impersonationRequest) throws IOException {
+
+    // Get impersonation keytab and principal from runtime arguments if present
+    Map<String, String> properties = getRuntimeProperties(impersonationRequest.getEntityId());
+    if ((properties != null) && (properties.containsKey(SystemArguments.RUNTIME_KEYTAB_PATH))
+          && (properties.containsKey(SystemArguments.RUNTIME_PRINCIPAL_NAME))) {
+      String keytab = properties.get(SystemArguments.RUNTIME_KEYTAB_PATH);
+      String principal = properties.get(SystemArguments.RUNTIME_PRINCIPAL_NAME);
+      LOG.debug("Using runtime config principal: %s, keytab: %s", principal, keytab);
+      UserGroupInformation ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+              principal, keytab);
+      return new UGIWithPrincipal(principal, ugi);
+    }
 
     // no need to get a UGI if the current UGI is the one we're requesting; simply return it
     String configuredPrincipalShortName = new KerberosName(impersonationRequest.getPrincipal()).getShortName();
@@ -171,5 +203,50 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
     }
 
     return localKeytabFile.toFile();
+  }
+
+  /**
+   * Returns the runtime user supplied arguments to a program if entity is of type ProgramRun
+   *
+   * @param programId the entity id
+   * @return properties map
+   */
+  private Map<String, String> getRuntimeProperties(NamespacedEntityId entityId) {
+    if (!(entityId instanceof ProgramRunId)) {
+      LOG.debug("Entity Id not of type ProgramRunId, skipping checking of runtime args");
+      return Collections.emptyMap();
+    }
+
+    ProgramRunId runId = ((ProgramRunId) entityId);
+    RunRecordMeta runRecord = null;
+
+    long sleepDelayMs = TimeUnit.MILLISECONDS.toMillis(100);
+    long timeoutMs = TimeUnit.SECONDS.toMillis(10);
+
+    try {
+      runRecord = Retries.callWithRetries(() -> {
+        RunRecordMeta rec = store.getRun(runId);
+        if (rec != null) {
+          return rec;
+        }
+        throw new Exception("Retrying again to fetch run record");
+      }, RetryStrategies.timeLimit(timeoutMs, TimeUnit.MILLISECONDS,
+                  RetryStrategies.fixDelay(sleepDelayMs, TimeUnit.MILLISECONDS)),
+                  Exception.class::isInstance);
+    } catch (Exception e) {
+      LOG.warn("Failed to fetch run record for {} due to {}", runId, e.getMessage(), e);
+      return Collections.emptyMap();
+    }
+
+    Type stringStringMap = new TypeToken<Map<String, String>>() { }.getType();
+
+    Map<String, String> properties = runRecord.getProperties();
+    String runtimeArgsJson = properties.get("runtimeArgs");
+    if (runtimeArgsJson == null) {
+      LOG.debug("Could not find any runtime args");
+      return Collections.emptyMap();
+    }
+
+    return gson.fromJson(runtimeArgsJson, stringStringMap);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/security/impersonation/DefaultUGIProviderTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/security/impersonation/DefaultUGIProviderTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright © 2016-2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.impersonation;
+
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.DefaultStore;
+import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.codec.EntityIdTypeAdapter;
+import io.cdap.cdap.proto.id.DatasetId;
+import io.cdap.cdap.proto.id.KerberosPrincipalId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.NamespacedEntityId;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.apache.twill.filesystem.FileContextLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Unit tests for {@link UGIProvider}.
+ */
+public class DefaultUGIProviderTest extends AppFabricTestBase {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static CConfiguration cConf;
+  private static MiniDFSCluster miniDFSCluster;
+  private static LocationFactory locationFactory;
+  private static MiniKdc miniKdc;
+  private static InMemoryNamespaceAdmin namespaceClient;
+  private static KerberosPrincipalId aliceKerberosPrincipalId;
+  private static KerberosPrincipalId bobKerberosPrincipalId;
+  private static KerberosPrincipalId eveKerberosPrincipalId;
+  private static NamespaceId namespaceId = new NamespaceId("DefaultUGIProviderTest");
+  private static DatasetId aliceEntity = namespaceId.dataset("aliceDataset");
+  private static DatasetId bobEntity = namespaceId.dataset("dummyDataset");
+
+  private static File localKeytabDirPath;
+  private static File aliceKeytabFile;
+  private static File bobKeytabFile;
+  private static File eveKeytabFile;
+  private static Store store;
+
+  private static File createPrincipal(File keytabDirPath, String username) throws Exception {
+    File keytabFile = new File(keytabDirPath, username + ".keytab");
+    Assert.assertTrue(keytabFile.createNewFile());
+    miniKdc.createPrincipal(keytabFile, username);
+    return keytabFile;
+  }
+
+  @BeforeClass
+  public static void init() throws Exception {
+    cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+
+    namespaceClient = new InMemoryNamespaceAdmin();
+
+    // Start KDC
+    miniKdc = new MiniKdc(MiniKdc.createConf(), TEMP_FOLDER.newFolder());
+    miniKdc.start();
+    System.setProperty("java.security.krb5.conf", miniKdc.getKrb5conf().getAbsolutePath());
+
+    localKeytabDirPath = TEMP_FOLDER.newFolder();
+
+    // Generate keytab
+    aliceKeytabFile = createPrincipal(localKeytabDirPath, "alice");
+    bobKeytabFile = createPrincipal(localKeytabDirPath, "bob");
+    eveKeytabFile = createPrincipal(localKeytabDirPath, "eve");
+
+    // construct Kerberos PrincipalIds
+    aliceKerberosPrincipalId = new KerberosPrincipalId(getPrincipal("alice"));
+    bobKerberosPrincipalId = new KerberosPrincipalId(getPrincipal("bob"));
+    eveKerberosPrincipalId = new KerberosPrincipalId(getPrincipal("eve"));
+
+    // Start mini DFS cluster
+    Configuration hConf = new Configuration();
+    hConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    hConf.setBoolean("ipc.client.fallback-to-simple-auth-allowed", true);
+
+    miniDFSCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
+    miniDFSCluster.waitClusterUp();
+    locationFactory = new FileContextLocationFactory(miniDFSCluster.getFileSystem().getConf());
+
+    hConf = new Configuration();
+    hConf.set("hadoop.security.authentication", "kerberos");
+    hConf.set("hadoop.security.auth_to_local", "RULE:[1:$1@$0](.*@EXAMPLE.COM)s/@.*//");
+    UserGroupInformation.setConfiguration(hConf);
+
+    store = getInjector().getInstance(DefaultStore.class);
+  }
+
+  @AfterClass
+  public static void finish() {
+    if (miniDFSCluster != null) {
+      miniDFSCluster.shutdown();
+    }
+    if (miniKdc != null) {
+      miniKdc.stop();
+    }
+  }
+
+  @Test
+  public void testDefaultUGIProviderWithLocalFiles() throws Exception {
+    System.setProperty("sun.security.krb5.debug", "true");
+
+    // sets the path of local keytabs in cConf to be used by SecurityUtil to fetch owner keytab
+    setKeytabDir(localKeytabDirPath.getAbsolutePath());
+
+    // get the owner admin which has been created from the cConf which got modified above
+    OwnerAdmin ownerAdmin = getOwnerAdmin();
+
+    DefaultUGIProvider provider = new DefaultUGIProvider(cConf, locationFactory, ownerAdmin, namespaceClient, store);
+
+    // create a namespace with a principal and keytab so that later we can verify that if a required entity owner does
+    // not exists then the provider gives the UGI for namespace owner
+    namespaceClient.create(new NamespaceMeta.Builder().setName(namespaceId).setPrincipal(
+      eveKerberosPrincipalId.getPrincipal()).setKeytabURI(eveKeytabFile.getAbsolutePath()).build());
+
+    // add an owner for some entity
+    ownerAdmin.add(aliceEntity, aliceKerberosPrincipalId);
+    ownerAdmin.add(bobEntity, bobKerberosPrincipalId);
+
+    // Try with local keytab file
+    ImpersonationRequest aliceImpRequest = new ImpersonationRequest(aliceEntity, ImpersonatedOpType.OTHER);
+    ImpersonationRequest bobImpRequest = new ImpersonationRequest(bobEntity, ImpersonatedOpType.OTHER);
+    UGIWithPrincipal aliceUGIWithPrincipal = verifyAndGetUGI(provider, aliceKerberosPrincipalId, aliceImpRequest);
+    UGIWithPrincipal bobUGIWithPrincipal = verifyAndGetUGI(provider, bobKerberosPrincipalId, bobImpRequest);
+
+    // delete the local keytab file for bob
+    Assert.assertTrue(bobKeytabFile.delete());
+
+    // verify caching by fetch the bob UGI again, it should still return the valid one but after invalidating the
+    // cache it shouldn't
+    verifyCaching(provider, aliceImpRequest, bobImpRequest, aliceUGIWithPrincipal, bobUGIWithPrincipal);
+
+    // delete the owner info for bob's entity
+    ownerAdmin.delete(bobEntity);
+
+    // now we should get the namespace owner principal if we get try to impersonate bobEntity
+    UGIWithPrincipal eveUGIWithPrincipal = provider.getConfiguredUGI(bobImpRequest);
+    Assert.assertEquals(UserGroupInformation.AuthenticationMethod.KERBEROS,
+                        eveUGIWithPrincipal.getUGI().getAuthenticationMethod());
+    Assert.assertTrue(eveUGIWithPrincipal.getUGI().hasKerberosCredentials());
+    Assert.assertEquals(eveKerberosPrincipalId.getPrincipal(), eveUGIWithPrincipal.getPrincipal());
+
+    // cleanup
+    ownerAdmin.delete(aliceEntity);
+    ownerAdmin.delete(bobEntity);
+    namespaceClient.delete(namespaceId);
+  }
+
+  @Test
+  public void testDefaultUGIProviderWithHDFSFiles() throws Exception {
+    // create a location on hdfs for keytabs
+    Location hdfsKeytabDir = locationFactory.create("keytabs");
+    // set in the cConf so that later it can be used to fetch the keytabs for the given principal
+    setKeytabDir(hdfsKeytabDir.toURI().toString());
+
+    Location aliceRemoteKeytabFile = copyFileToHDFS(hdfsKeytabDir, aliceKeytabFile);
+    Location bobRemoteKeytabFile = copyFileToHDFS(hdfsKeytabDir, bobKeytabFile);
+
+    OwnerAdmin ownerAdmin = getOwnerAdmin();
+    DefaultUGIProvider provider = new DefaultUGIProvider(cConf, locationFactory, ownerAdmin, namespaceClient, store);
+
+    // add some entity owners
+    ownerAdmin.add(aliceEntity, aliceKerberosPrincipalId);
+    ownerAdmin.add(bobEntity, bobKerberosPrincipalId);
+
+    // Try with keytab file on hdfs
+    ImpersonationRequest aliceImpRequest = new ImpersonationRequest(aliceEntity, ImpersonatedOpType.OTHER);
+    ImpersonationRequest bobImpRequest = new ImpersonationRequest(bobEntity, ImpersonatedOpType.OTHER);
+    UGIWithPrincipal aliceUGIWithPrincipal = verifyAndGetUGI(provider, aliceKerberosPrincipalId, aliceImpRequest);
+    UGIWithPrincipal bobUGIWithPrincipal = verifyAndGetUGI(provider, bobKerberosPrincipalId, bobImpRequest);
+
+    // delete bob's keytab file on hdfs
+    Assert.assertTrue(bobRemoteKeytabFile.delete());
+
+    // verify caching by ensuring that we are able to fetch bob's ugi even after delete but not after invalidating the
+    // cache
+    verifyCaching(provider, aliceImpRequest, bobImpRequest, aliceUGIWithPrincipal, bobUGIWithPrincipal);
+
+    // cleanup
+    ownerAdmin.delete(aliceEntity);
+    ownerAdmin.delete(bobEntity);
+  }
+
+  private void verifyCaching(DefaultUGIProvider provider, ImpersonationRequest aliceImpRequest,
+                             ImpersonationRequest bobImpRequest, UGIWithPrincipal aliceUGIWithPrincipal,
+                             UGIWithPrincipal bobUGIWithPrincipal) throws IOException {
+    // Fetch the bob UGI again, it should still return the valid one
+    Assert.assertSame(bobUGIWithPrincipal, provider.getConfiguredUGI(bobImpRequest));
+
+    // Invalid the cache, getting of Alice UGI should pass, while getting of Bob should fails
+    provider.invalidCache();
+    Assert.assertNotSame(aliceUGIWithPrincipal, provider.getConfiguredUGI(aliceImpRequest));
+    try {
+      provider.getConfiguredUGI(bobImpRequest);
+      Assert.fail("Expected IOException when getting UGI for " + bobImpRequest);
+    } catch (IOException e) {
+      // Expected
+    }
+  }
+
+  private Location copyFileToHDFS(Location hdfsKeytabDir, File localFile) throws IOException {
+    Location remoteFile = hdfsKeytabDir.append(localFile.getName());
+    Assert.assertTrue(remoteFile.createNew());
+    Files.copy(localFile, Locations.newOutputSupplier(remoteFile));
+    return remoteFile;
+  }
+
+  private UGIWithPrincipal verifyAndGetUGI(UGIProvider provider, KerberosPrincipalId principalId,
+                                           ImpersonationRequest impersonationRequest) throws IOException {
+    UGIWithPrincipal ugiWithPrincipal = provider.getConfiguredUGI(impersonationRequest);
+    Assert.assertEquals(UserGroupInformation.AuthenticationMethod.KERBEROS,
+                        ugiWithPrincipal.getUGI().getAuthenticationMethod());
+    Assert.assertEquals(principalId.getPrincipal(), ugiWithPrincipal.getPrincipal());
+    Assert.assertTrue(ugiWithPrincipal.getUGI().hasKerberosCredentials());
+
+    // Fetch it again, it is should return the same UGI since there is caching
+    Assert.assertSame(ugiWithPrincipal.getUGI(), provider.getConfiguredUGI(impersonationRequest).getUGI());
+    return ugiWithPrincipal;
+  }
+
+  private OwnerAdmin getOwnerAdmin() {
+    return new DefaultOwnerAdmin(cConf, new InMemoryOwnerStore(), namespaceClient);
+  }
+
+  private void setKeytabDir(String keytabDirPath) {
+    cConf.set(Constants.Security.KEYTAB_PATH, keytabDirPath + "/" +
+      Constants.USER_NAME_SPECIFIER + ".keytab");
+  }
+
+  private static String getPrincipal(String name) {
+    return String.format("%s@%s", name, miniKdc.getRealm());
+  }
+}

--- a/cdap-app-fabric/src/test/resources/realm.properties
+++ b/cdap-app-fabric/src/test/resources/realm.properties
@@ -1,0 +1,19 @@
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+java-client:password,user
+client:password,user
+
+

--- a/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/AbstractCachedUGIProvider.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/AbstractCachedUGIProvider.java
@@ -23,6 +23,8 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +72,12 @@ public abstract class AbstractCachedUGIProvider implements UGIProvider {
         return ugi;
       }
       boolean isCache = checkExploreAndDetermineCache(impersonationRequest);
-      ImpersonationInfo info = getPrincipalForEntity(impersonationRequest);
+      ImpersonationRequest tmpRequest = impersonationRequest;
+      if (impersonationRequest.getEntityId() instanceof ProgramRunId) {
+        ProgramId progId = ((ProgramRunId) impersonationRequest.getEntityId()).getParent();
+        tmpRequest = new ImpersonationRequest(progId, impersonationRequest.getImpersonatedOpType());
+      }
+      ImpersonationInfo info = getPrincipalForEntity(tmpRequest);
       ImpersonationRequest newRequest = new ImpersonationRequest(impersonationRequest.getEntityId(),
                                                                  impersonationRequest.getImpersonatedOpType(),
                                                                  info.getPrincipal(), info.getKeytabURI());


### PR DESCRIPTION
Adding changes for runtime impersonation of user in CDAP pipelines.

**How to Use**
To use this feature, provide the following runtime arguments before running a pipeline:
- pipeline.principal.name: Kerberos Principal to be used for impersonation
- pipeline.keytab.path: Path of keytab file on local filesystem where CDAP master is running

For implementation details, please check: https://wiki.cask.co/display/CE/Run-time+Impersonation+support+for+Pipelines

[Contributor certificate Nov 2018.pdf](https://github.com/cdapio/cdap/files/3319469/Contributor.certificate.Nov.2018.pdf)


Guavus Contributor License Agreement is attached.