### PR TITLE
Fixed path to UI js file when running from IDE

### DIFF
--- a/cdap-standalone/src/main/java/io/cdap/cdap/UserInterfaceService.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/UserInterfaceService.java
@@ -83,11 +83,11 @@ final class UserInterfaceService extends AbstractExecutionThreadService {
     generateConfigFile(cConfJsonFile, cConf);
     generateConfigFile(sConfJsonFile, sConf);
 
-    File uiPath = new File("cdap-ui", "index.js");
+    File uiPath = new File("cdap-ui", "server.js");
     if (!uiPath.exists()) {
       uiPath = new File("ui", "index.js");
     }
-    Preconditions.checkState(uiPath.exists(), "Missing server.js at " + uiPath.getAbsolutePath());
+    Preconditions.checkState(uiPath.exists(), "Missing server/index.js at " + uiPath.getAbsolutePath());
     ProcessBuilder builder = new ProcessBuilder(NODE_JS_EXECUTABLE,
                                                 uiPath.getAbsolutePath(),
                                                 "cConf=\"" + cConfJsonFile.getAbsolutePath() + "\"",


### PR DESCRIPTION
When running from IDE as specified in the README, the UserInterfaceService checks for index.js in cdap-ui and ui. Until it is moved to ui as part of build output, it is called server.js in cdap-ui.

Hopefully this smooths out IDE debugging for some folks!