### PR TITLE
[CDAP-12820] Splitter popover is centered and hairline removed

### DIFF
--- a/cdap-ui/app/directives/splitter-popover/splitter-popover.less
+++ b/cdap-ui/app/directives/splitter-popover/splitter-popover.less
@@ -24,7 +24,6 @@
       .node-splitter-popover {
         min-height: 40px;
         position: absolute;
-        top: -25px;
         left: 24px;
         padding: 1px;
         font-size: 13px;
@@ -44,17 +43,17 @@
         }
 
         > .arrow {
-          top: 31px;
+          top: 50%;
           border-width: 11px 11px 11px 0;
           margin-top: -11px;
           left: -11px;
           border-right-color: @splitter-border-color;
 
           &:after {
-            border-width: 10px;
+            border-width: 11px;
             content: '';
             left: 1px;
-            bottom: -10px;
+            bottom: -11px;
             border-left-width: 0;
             border-right-color: white;
           }


### PR DESCRIPTION
Splitter popover is vertically centered wrto splitter node. 
Blue hairline on splitter popover is removed.
JIRA: https://issues.cask.co/browse/CDAP-12820