### PR TITLE
[CDAP-15433] Part 3: Update graph on selecting field, View, and Reset 

### DIFF
--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContextHelper.ts
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContextHelper.ts
@@ -14,61 +14,122 @@
  * the License.
 */
 
-// Parses an incoming or outgoing entity object from backend response to get unique nodes (one per incoming or outgoing field), connections, and an object with fieldnames for each incoming or outgoing dataset
+// types for backend response
+interface IFllEntity {
+  entityId?: IEntityId;
+  relations?: IRelation[];
+}
 
-export function parseRelations(namespace, target, ents, isCause = true) {
-  const tables = {};
-  const relNodes = [];
+interface IEntityId {
+  namespace?: string;
+  dataset?: string;
+  entity?: string;
+}
+
+export interface IRelation {
+  source?: string;
+  destination?: string;
+}
+
+// These types are used by the frontend
+export interface IField {
+  id: string;
+  type: string;
+  name: string;
+  dataset: string;
+  namespace: string;
+}
+
+export interface ILink {
+  source: IField;
+  destination: IField;
+}
+
+export interface ITableFields {
+  [tablename: string]: IField[];
+}
+
+/** Parses an incoming or outgoing entity object from backend response
+ * to get array of edges and an object with fields keyed by dataset.
+ * namespace and target are the target namespace and dataset name
+ */
+
+export function parseRelations(
+  namespace: string,
+  target: string,
+  ents: IFllEntity[],
+  isCause: boolean = true
+) {
+  const tables: ITableFields = {};
   const relLinks = [];
   ents.map((ent) => {
-    // Assumes that all tableNames are unique (since all datasets in a namespace should have unique names)
-    // tableName is later used to display the table name in the header
+    // Assumes that all tableNames are unique within a namespace
 
     const tableId = `${isCause ? 'cause' : 'impact'}_ns-${ent.entityId.namespace}_ds-${
       ent.entityId.dataset
     }`;
     // tables keeps track of fields for each incoming or outgoing dataset.
     tables[tableId] = [];
-    // fieldIds keeps track of fields we've seen already, since a single field can have multiple connections
+    // fieldIds keeps track of fields, since a single field can have multiple connections
     const fieldIds = new Map();
     ent.relations.map((rel) => {
-      // backend response assumes connection goes from left to right, i.e. an incoming connection's source = incoming field and destination = target field, and outgoing connection's source = target field.
+      /** backend response assumes connection goes from left to right
+       * i.e. an incoming connection's destination = target field,
+       * and outgoing connection's source = target field.
+       */
+
       const fieldName = isCause ? rel.source : rel.destination;
       let id = fieldIds.get(fieldName);
-      const field = {
+      const field: IField = {
         id,
+        type: isCause ? 'cause' : 'impact',
         name: fieldName,
-        group: ent.entityId.dataset,
+        dataset: ent.entityId.dataset,
+        namespace: ent.entityId.namespace,
       };
       if (!fieldIds.has(fieldName)) {
         id = `${tableId}_fd-${fieldName}`;
         field.id = id;
         fieldIds.set(fieldName, id);
         tables[tableId].push(field);
-        relNodes.push(field);
       }
-      relLinks.push({
-        // if connection goes from cause to target
-        source: isCause
-          ? fieldIds.get(fieldName)
-          : `target_ns-${namespace}_ds-${target}_fd-${rel.source}`,
-        destination: isCause
-          ? `target_ns-${namespace}_ds-${target}_fd-${rel.destination}`
-          : fieldIds.get(fieldName),
-      });
+      const targetField: IField = {
+        id: `target_ns-${namespace}_ds-${target}_fd-${isCause ? rel.destination : rel.source}`,
+        type: 'target',
+        dataset: target,
+        namespace,
+        name: isCause ? rel.destination : rel.source,
+      };
+      const link: ILink = {
+        source: isCause ? field : targetField,
+        destination: isCause ? targetField : field,
+      };
+      relLinks.push(link);
     });
   });
-  return { tables, relNodes, relLinks };
+  return { tables, relLinks };
 }
 
-export function makeTargetNodes(entityId, fields) {
-  const targetNodes = fields.map((field) => {
-    const id = `target_ns-${entityId.namespace}_ds-${entityId.dataset}_fd-${field}`;
-    return {
+export function getFieldsAndLinks(d) {
+  const incoming = parseRelations(d.entityId.namespace, d.entityId.dataset, d.incoming);
+  const outgoing = parseRelations(d.entityId.namespace, d.entityId.dataset, d.outgoing, false);
+  const causeTables = incoming.tables;
+  const impactTables = outgoing.tables;
+  const links = incoming.relLinks.concat(outgoing.relLinks);
+  return { causeTables, impactTables, links };
+}
+
+export function makeTargetFields({ namespace, dataset }: IEntityId, fields: string[]) {
+  const targetFields = fields.map((fieldname) => {
+    const id = `target_ns-${namespace}_ds-${dataset}_fd-${fieldname}`;
+    const field: IField = {
       id,
-      name: field,
-      group: entityId.dataset,
+      type: 'target',
+      name: fieldname,
+      dataset,
+      namespace,
     };
+    return field;
   });
-  return targetNodes;
+  return targetFields;
 }

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllHeader/index.tsx
@@ -14,14 +14,13 @@
  * the License.
 */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import T from 'i18n-react';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
-import { Consumer } from '../Context/FllContext';
+import { FllContext, IContextState } from 'components/FieldLevelLineage/v2/Context/FllContext';
 
 interface IHeaderProps extends WithStyles<typeof styles> {
   type: string;
-  first: number;
   total: number;
 }
 
@@ -40,38 +39,43 @@ const styles = (theme) => {
   };
 };
 
-function FllHeader({ type, first, total, classes }: IHeaderProps) {
+function FllHeader({ type, total, classes }: IHeaderProps) {
+  const { firstCause, firstImpact, firstField, target, numTables } = useContext<IContextState>(
+    FllContext
+  );
+  let last;
+  let first;
+
+  if (type === 'impact') {
+    first = firstImpact;
+  } else {
+    first = firstCause;
+  }
+
+  last = first + numTables - 1 <= total ? first + numTables - 1 : total;
+
+  if (type === 'target') {
+    last = total;
+  }
+
+  const header =
+    type === 'target'
+      ? T.translate('features.FieldLevelLineage.v2.FllHeader.TargetHeader')
+      : T.translate('features.FieldLevelLineage.v2.FllHeader.RelatedHeader', {
+          type,
+          target,
+        });
+  const options = { first, last, total };
+  const subHeader =
+    type === 'target'
+      ? T.translate('features.FieldLevelLineage.v2.FllHeader.TargetSubheader', options)
+      : T.translate('features.FieldLevelLineage.v2.FllHeader.RelatedSubheader', options);
+
   return (
-    <Consumer>
-      {({ numTables, target }) => {
-        let last;
-        if (type === ('impact' || 'cause')) {
-          last = first + numTables - 1 <= total ? first + numTables - 1 : total;
-        } else {
-          last = total;
-        }
-
-        const header =
-          type === 'target'
-            ? T.translate('features.FieldLevelLineage.v2.FllHeader.TargetHeader')
-            : T.translate('features.FieldLevelLineage.v2.FllHeader.RelatedHeader', {
-                type,
-                target,
-              });
-        const options = { first, last, total };
-        const subHeader =
-          type === 'target'
-            ? T.translate('features.FieldLevelLineage.v2.FllHeader.TargetSubheader', options)
-            : T.translate('features.FieldLevelLineage.v2.FllHeader.RelatedSubheader', options);
-
-        return (
-          <div className={classes.root}>
-            <div className={type}>{header}</div>
-            <div className={classes.subHeader}>{subHeader}</div>
-          </div>
-        );
-      }}
-    </Consumer>
+    <div className={classes.root}>
+      <div>{header}</div>
+      <div className={classes.subHeader}>{subHeader}</div>
+    </div>
   );
 }
 const StyledFllHeader = withStyles(styles)(FllHeader);

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, { useState, useContext } from 'react';
+import { IField } from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import classnames from 'classnames';
+import T from 'i18n-react';
+import If from 'components/If';
+import IconButton from '@material-ui/core/IconButton';
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import { FllContext, IContextState } from 'components/FieldLevelLineage/v2/Context/FllContext';
+
+const styles = (theme): StyleRules => {
+  return {
+    root: {
+      paddingLeft: '10px',
+      paddingRight: '10px',
+      borderTop: `1px solid ${theme.palette.grey[500]}`,
+      ' & .grid-row:hover': {
+        backgroundColor: theme.palette.grey[700],
+      },
+      ' & .grid-row:selected': {
+        backgroundColor: theme.palette.yellow[200],
+        color: theme.palette.orange[50],
+        fontWeight: 'bold',
+      },
+    },
+    hoverText: {
+      color: theme.palette.blue[200],
+    },
+    targetView: {
+      color: theme.palette.blue[200],
+      textAlign: 'right',
+    },
+    viewDropdown: {
+      padding: 0,
+      color: theme.palette.blue[200],
+    },
+  };
+};
+
+interface IFieldProps extends WithStyles<typeof styles> {
+  field: IField;
+}
+
+function FllField({ field, classes }: IFieldProps) {
+  const [isHovering, setHoverState] = useState<boolean>(false);
+  const {
+    activeField,
+    showingOneField,
+    handleFieldClick,
+    handleViewCauseImpact,
+    handleReset,
+  } = useContext<IContextState>(FllContext);
+
+  const toggleHoverState = () => {
+    setHoverState(!isHovering);
+  };
+  const isTarget = field.type === 'target';
+  return (
+    <div
+      onClick={isTarget && !showingOneField ? handleFieldClick : undefined}
+      onMouseEnter={toggleHoverState}
+      onMouseLeave={toggleHoverState}
+      className={classnames('grid-row', 'grid-link', classes.root)}
+      id={field.id}
+    >
+      {field.name}
+      <If condition={isHovering && !isTarget}>
+        <span className={classes.hoverText}>
+          {T.translate('features.FieldLevelLineage.v2.FllTable.FllField.viewLineage')}
+        </span>
+      </If>
+      <If condition={field.id === activeField && isTarget && !showingOneField}>
+        <span className={classes.targetView} onClick={handleViewCauseImpact}>
+          {T.translate('features.FieldLevelLineage.v2.FllTable.FllField.viewDropdown')}
+          <IconButton className={classes.viewDropdown}>
+            <KeyboardArrowDownIcon />
+          </IconButton>
+        </span>
+      </If>
+      <If condition={field.id === activeField && isTarget && showingOneField}>
+        <span className={classes.targetView} onClick={handleReset}>
+          {T.translate('features.FieldLevelLineage.v2.FllTable.FllField.resetLineage')}
+        </span>
+      </If>
+    </div>
+  );
+}
+
+const StyledFllField = withStyles(styles)(FllField);
+
+export default StyledFllField;

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/index.tsx
@@ -14,19 +14,23 @@
  * the License.
 */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import SortableStickyGrid from 'components/SortableStickyGrid/index.js';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import createStyles from '@material-ui/core/styles/createStyles';
 import T from 'i18n-react';
 import classnames from 'classnames';
-import { INode } from 'components/FieldLevelLineage/v2/Context/FllContext';
+import { IField } from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
+import FllField from 'components/FieldLevelLineage/v2/FllTable/FllField';
+import { FllContext, IContextState } from 'components/FieldLevelLineage/v2/Context/FllContext';
 
+// TO DO: Consolidate different fontsizes in ThemeWrapper
 const styles = (theme) => {
   return createStyles({
     table: {
       width: '170px',
       border: `1px solid ${theme.palette.grey[300]}`,
+      fontSize: '0.92rem',
       marginBottom: '10px',
       '& .grid.grid-container': {
         maxHeight: 'none',
@@ -40,7 +44,15 @@ const styles = (theme) => {
       '& .grid-row': {
         paddingLeft: '10px',
         paddingRight: '10px',
-        borderBottom: `1px solid ${theme.palette.grey[500]}`,
+        borderTop: `1px solid ${theme.palette.grey[500]}`,
+      },
+      ' & .grid-row:hover': {
+        backgroundColor: theme.palette.grey[700],
+      },
+      ' & .grid-row.selected': {
+        backgroundColor: theme.palette.yellow[200],
+        color: theme.palette.orange[50],
+        fontWeight: 'bold',
       },
     },
     tableHeader: {
@@ -48,58 +60,63 @@ const styles = (theme) => {
       height: '40px',
       paddingLeft: '10px',
       fontWeight: 'bold',
+      fontSize: '1rem',
     },
     tableSubheader: {
       fontWeight: 'normal',
       color: theme.palette.grey[200],
-      paddingBottom: 5,
-      paddingTop: 3,
+      fontSize: '0.92rem',
+    },
+    viewLineage: {
+      visibility: 'hidden',
+      color: theme.palette.blue[300],
     },
   });
 };
 
 interface ITableProps extends WithStyles<typeof styles> {
   tableId: string;
-  fields: INode[];
-  isTarget?: boolean;
+  fields: IField[];
 }
 
-function renderGridHeader(fields, tableId, classes) {
+function renderGridHeader(fields: IField[], showingOneField: boolean, classes) {
   const count: number = fields.length;
-  const tableName = fields[0].group;
+  const tableName = fields[0].dataset;
   return (
     <div className={classes.tableHeader}>
-      {tableName}
+      <div>{tableName}</div>
       <div className={classes.tableSubheader}>
-        {T.translate('features.FieldLevelLineage.v2.TableSubheader', { count })}
+        {showingOneField
+          ? T.translate('features.FieldLevelLineage.v2.FllTable.relatedFieldsCount', {
+              context: count,
+            })
+          : T.translate('features.FieldLevelLineage.v2.FllTable.fieldsCount', { context: count })}
       </div>
     </div>
   );
 }
 
-function renderGridBody(fields, tableName, classes) {
+function renderGridBody(fields: IField[], tableName: string, classes) {
   return (
     <div className={classes.gridBody} id={tableName}>
       {fields.map((field) => {
-        return (
-          <div className={classnames('grid-row', 'grid-link')} key={field.id} id={field.id}>
-            {field.name}
-          </div>
-        );
+        return <FllField key={field.id} field={field} />;
       })}
     </div>
   );
 }
 
-function FllTable({ tableId, fields, classes, isTarget = false }: ITableProps) {
+function FllTable({ tableId, fields, classes }: ITableProps) {
   const GRID_HEADERS = [{ property: 'name', label: tableId }];
+  const { showingOneField } = useContext<IContextState>(FllContext);
+  const isTarget = fields[0].type === 'target';
   return (
     <SortableStickyGrid
       key={`cause ${tableId}`}
       entities={fields}
       gridHeaders={GRID_HEADERS}
       className={classnames(classes.table, { [classes.targetTable]: isTarget })}
-      renderGridHeader={renderGridHeader.bind(null, fields, tableId, classes)}
+      renderGridHeader={renderGridHeader.bind(null, fields, showingOneField, classes)}
       renderGridBody={renderGridBody.bind(this, fields, tableId, classes)}
     />
   );

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1472,7 +1472,18 @@ features:
         RelatedSubheader: "Viewing {first} to {last} of {total} datasets"
         TargetHeader: 'Select a field to view lineage and operations'
         TargetSubheader: "Viewing {first} to {last} of {total} fields"
-      TableSubheader: "{count} fields"
+      FllTable:
+        fieldsCount: 
+          1: "{context} field"
+          _: "{context} fields"
+        FllField:
+          viewLineage: "View lineage"
+          viewDropdown: "View"
+          resetLineage: "Reset"
+        relatedFieldsCount:
+          1: "{context} related field"
+          _: "{context} related fields"
+          
   ADLSBrowser:
     directory: Directory
     EmptyMessage:
@@ -1493,6 +1504,7 @@ features:
       directoryMetrics: "{count} files and directories"
       searchPlaceholder: Search this directory
       selectData: "Select file/directory to preview"
+
   FileBrowser:
     directory: Directory
     EmptyMessage:

--- a/cdap-ui/tsconfig.json
+++ b/cdap-ui/tsconfig.json
@@ -13,7 +13,8 @@
     "allowSyntheticDefaultImports": true,
     "lib": [
       "es2015",
-      "dom"
+      "dom",
+      "es2017"
     ],
     "typeRoots": [
       "./typings",


### PR DESCRIPTION
First PR for interacting with target dataset fields. Main behaviors added:

- Clicking on a field in the target dataset highlights the related edges and anchors, "View" text appears (This will become a dropdown  menu in the next PR)
- Clicking on "View" causes only the related fields and datasets to be shown, and "Reset" text appears
- Clicking "Reset" goes back to the previous view where nonrelated fields and edges are shown in grey

Notes:

- Updated edges/link objects to have source and destination properties that are field objects instead of field id's to avoid parsing id strings 

JIRA(s): https://issues.cask.co/browse/CDAP-15449 , https://issues.cask.co/browse/CDAP-15433
BUILD: https://builds.cask.co/browse/CDAP-UDUT348-1