### PR TITLE
fixed issue with hub being cutoff in logviewer

### DIFF
--- a/cdap-ui/app/logviewer/logviewer.html
+++ b/cdap-ui/app/logviewer/logviewer.html
@@ -30,7 +30,7 @@
   <link rel="stylesheet" type="text/css" href="/assets/bundle/app.css" />
 </head>
 
-<body ng-class="bodyClass" ng-controller="BodyCtrl">
+<body ng-class="bodyClass" class="cdap-body-container" ng-controller="BodyCtrl">
   <my-global-navbar></my-global-navbar>
 
   <main class="container" id="app-container">


### PR DESCRIPTION
This PR fixes the issue with hub not being rendered properly when opened in CDAP logs.

JIRA: https://issues.cask.co/browse/CDAP-15582
