### PR TITLE
CDAP-15590 do not copy if artifact exists

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -131,7 +131,9 @@ public class PluginInstantiator implements Closeable {
    */
   public void addArtifact(Location artifactLocation, ArtifactId destArtifact) throws IOException {
     File destFile = new File(pluginDir, Artifacts.getFileName(destArtifact));
-    Files.copy(Locations.newInputSupplier(artifactLocation), destFile);
+    if (!destFile.exists()) {
+      Files.copy(Locations.newInputSupplier(artifactLocation), destFile);
+    }
   }
 
   /**


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15590
build: https://builds.cask.co/browse/CDAP-DUT6992-1

To reduce the app deploy time, we should not copy artifacts for each plugin. We only need to copy if the artifact is not there. Doing so will reduce the artifact copy times from the number of plugins to the number of actual artifacts used for the app.