### PR TITLE
CDAP-15591 use same extension loader for preview

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.internal.app.namespace.NoopNamespaceResourceDeleter;
 import io.cdap.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
 import io.cdap.cdap.internal.app.preview.DefaultDataTracerFactory;
 import io.cdap.cdap.internal.app.preview.DefaultPreviewRunner;
+import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactStore;
 import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowStateWriter;
@@ -73,16 +74,19 @@ public class PreviewRunnerModule extends PrivateModule {
   private final AuthorizationEnforcer authorizationEnforcer;
   private final PrivilegesManager privilegesManager;
   private final PreferencesService preferencesService;
+  private final ProgramRuntimeProviderLoader programRuntimeProviderLoader;
 
   public PreviewRunnerModule(ArtifactRepository artifactRepository, ArtifactStore artifactStore,
                              AuthorizerInstantiator authorizerInstantiator, AuthorizationEnforcer authorizationEnforcer,
-                             PrivilegesManager privilegesManager, PreferencesService preferencesService) {
+                             PrivilegesManager privilegesManager, PreferencesService preferencesService,
+                             ProgramRuntimeProviderLoader programRuntimeProviderLoader) {
     this.artifactRepository = artifactRepository;
     this.artifactStore = artifactStore;
     this.authorizerInstantiator = authorizerInstantiator;
     this.authorizationEnforcer = authorizationEnforcer;
     this.privilegesManager = privilegesManager;
     this.preferencesService = preferencesService;
+    this.programRuntimeProviderLoader = programRuntimeProviderLoader;
   }
 
   @Override
@@ -101,6 +105,8 @@ public class PreviewRunnerModule extends PrivateModule {
     // bind explore client to mock.
     bind(ExploreClient.class).to(MockExploreClient.class);
     expose(ExploreClient.class);
+    bind(ProgramRuntimeProviderLoader.class).toInstance(programRuntimeProviderLoader);
+    expose(ProgramRuntimeProviderLoader.class);
     bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
 
     bind(PipelineFactory.class).to(SynchronousPipelineFactory.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -56,6 +56,7 @@ import io.cdap.cdap.data.runtime.preview.PreviewDataModules;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.data2.metadata.writer.NoOpMetadataServiceClient;
+import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactStore;
 import io.cdap.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
@@ -116,6 +117,7 @@ public class DefaultPreviewManager implements PreviewManager {
   private final AuthorizationEnforcer authorizationEnforcer;
   private final Cache<ApplicationId, Injector> appInjectors;
   private final Path previewDataDir;
+  private final ProgramRuntimeProviderLoader programRuntimeProviderLoader;
 
   @Inject
   DefaultPreviewManager(final CConfiguration cConf, Configuration hConf, DiscoveryService discoveryService,
@@ -123,7 +125,8 @@ public class DefaultPreviewManager implements PreviewManager {
                         PreferencesService preferencesService, SecureStore secureStore,
                         TransactionSystemClient transactionSystemClient, ArtifactRepository artifactRepository,
                         ArtifactStore artifactStore, AuthorizerInstantiator authorizerInstantiator,
-                        PrivilegesManager privilegesManager, AuthorizationEnforcer authorizationEnforcer) {
+                        PrivilegesManager privilegesManager, AuthorizationEnforcer authorizationEnforcer,
+                        ProgramRuntimeProviderLoader programRuntimeProviderLoader) {
     this.cConf = cConf;
     this.hConf = hConf;
     this.datasetFramework = datasetFramework;
@@ -137,6 +140,7 @@ public class DefaultPreviewManager implements PreviewManager {
     this.privilegesManager = privilegesManager;
     this.authorizationEnforcer = authorizationEnforcer;
     this.previewDataDir = Paths.get(cConf.get(Constants.CFG_LOCAL_DATA_DIR), "preview").toAbsolutePath();
+    this.programRuntimeProviderLoader = programRuntimeProviderLoader;
 
     this.appInjectors = CacheBuilder.newBuilder()
       .maximumSize(cConf.getInt(Constants.Preview.PREVIEW_CACHE_SIZE, 10))
@@ -239,7 +243,7 @@ public class DefaultPreviewManager implements PreviewManager {
       new LocalLocationModule(),
       new ConfigStoreModule(),
       new PreviewRunnerModule(artifactRepository, artifactStore, authorizerInstantiator, authorizationEnforcer,
-                              privilegesManager, preferencesService),
+                              privilegesManager, preferencesService, programRuntimeProviderLoader),
       new ProgramRunnerRuntimeModule().getStandaloneModules(),
       new PreviewDataModules().getDataFabricModule(transactionSystemClient),
       new PreviewDataModules().getDataSetsModule(datasetFramework),


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15591
build: https://builds.cask.co/browse/CDAP-DUT6993-1

Each preview run will deploy the app and run the program. And each run will have its own injector. So each time when a preview is deployed, a new extension loader will be used and the same extension will get used. We should share the extension across the preview run.