### PR TITLE
CDAP-15594 batch system metadata

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/DefaultMetadataAdmin.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.spi.metadata.SearchRequest;
 import io.cdap.cdap.spi.metadata.SearchResponse;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -161,6 +162,11 @@ public class DefaultMetadataAdmin extends MetadataValidator implements MetadataA
   @Override
   public void applyMutation(MetadataMutation mutation, MutationOptions options) throws IOException {
     storage.apply(mutation, options);
+  }
+
+  @Override
+  public void applyMutations(List<? extends MetadataMutation> mutations, MutationOptions options) throws IOException {
+    storage.batch(mutations, options);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataAdmin.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.spi.metadata.SearchRequest;
 import io.cdap.cdap.spi.metadata.SearchResponse;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -152,6 +153,11 @@ public interface MetadataAdmin {
    * @param mutation the MetadataMutation to apply
    */
   void applyMutation(MetadataMutation mutation, MutationOptions options) throws IOException;
+
+  /**
+   * Applies a batch of metadata mutations
+   */
+  void applyMutations(List<? extends MetadataMutation> mutations, MutationOptions options) throws IOException;
 
   /**
    * Executes a search for CDAP entities.

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -60,6 +60,10 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
    */
   @Override
   public void write() {
+    metadataServiceClient.create(getMetadataMutation());
+  }
+
+  public MetadataMutation.Create getMetadataMutation() {
     String schema = getSchemaToAdd();
     Set<String> tags = getSystemTagsToAdd();
     Map<String, String> properties = getSystemPropertiesToAdd();
@@ -67,8 +71,7 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
       properties = new HashMap<>(properties);
       properties.put(MetadataConstants.SCHEMA_KEY, schema);
     }
-    metadataServiceClient.create(new MetadataMutation.Create(metadataEntity,
-                                                             new Metadata(MetadataScope.SYSTEM, tags, properties),
-                                                             CREATE_DIRECTIVES));
+    return new MetadataMutation.Create(metadataEntity, new Metadata(MetadataScope.SYSTEM, tags, properties),
+                                       CREATE_DIRECTIVES);
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/writer/MetadataServiceClient.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/writer/MetadataServiceClient.java
@@ -18,6 +18,8 @@ package io.cdap.cdap.data2.metadata.writer;
 
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 
+import java.util.List;
+
 /**
  * This interface exposes functionality for making Metadata HTTP calls to the Metadata Service.
  */
@@ -50,4 +52,11 @@ public interface MetadataServiceClient {
    * @param removeMutation Metadata's remove mutation to apply
    */
   void remove(MetadataMutation.Remove removeMutation);
+
+  /**
+   * Performs a batch of metadata mutation via Metadata Service.
+   *
+   * @param mutations a list of metadata mutations to apply
+   */
+  void batch(List<MetadataMutation> mutations);
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/writer/NoOpMetadataServiceClient.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/writer/NoOpMetadataServiceClient.java
@@ -18,6 +18,8 @@ package io.cdap.cdap.data2.metadata.writer;
 
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 
+import java.util.List;
+
 /**
  * NoOp Metadata service client that allows testing.
  */
@@ -40,6 +42,11 @@ public class NoOpMetadataServiceClient implements MetadataServiceClient {
 
   @Override
   public void remove(MetadataMutation.Remove removeMutation) {
+    // No Op
+  }
+
+  @Override
+  public void batch(List<MetadataMutation> mutations) {
     // No Op
   }
 }

--- a/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataMutationCodec.java
+++ b/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataMutationCodec.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.metadata;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+/**
+ * JSON codec for metadata mutations, this is needed to deserialize the correct subclasses of metadata mutataions.
+ */
+public class MetadataMutationCodec implements JsonSerializer<MetadataMutation>, JsonDeserializer<MetadataMutation> {
+
+  @Override
+  public MetadataMutation deserialize(JsonElement json, Type typeOfT,
+                                      JsonDeserializationContext context) throws JsonParseException {
+    if (!typeOfT.equals(MetadataMutation.class)) {
+      return context.deserialize(json, typeOfT);
+    }
+
+    String type = json.getAsJsonObject().get("type").getAsString();
+    switch (MetadataMutation.Type.valueOf(type)) {
+      case CREATE:
+        return context.deserialize(json, MetadataMutation.Create.class);
+      case REMOVE:
+        return context.deserialize(json, MetadataMutation.Remove.class);
+      case DROP:
+        return context.deserialize(json, MetadataMutation.Drop.class);
+      case UPDATE:
+        return context.deserialize(json, MetadataMutation.Update.class);
+      default:
+        throw new IllegalArgumentException(String.format("Unsupported metadata mutation type %s, only " +
+                                                           "supported types are CREATE, REMOVE, DROP, UPDATE.", type));
+    }
+  }
+
+  @Override
+  public JsonElement serialize(MetadataMutation src, Type typeOfSrc, JsonSerializationContext context) {
+    return context.serialize(src);
+  }
+}

--- a/cdap-metadata-spi/src/test/java/io/cdap/cdap/spi/metadata/MetadataMutationCodecTest.java
+++ b/cdap-metadata-spi/src/test/java/io/cdap/cdap/spi/metadata/MetadataMutationCodecTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.metadata;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.proto.codec.NamespacedEntityIdCodec;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.NamespacedEntityId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+public class MetadataMutationCodecTest {
+
+  @Test
+  public void testMetadataMutationCodec() {
+    List<MetadataMutation> mutations =
+      ImmutableList.of(
+        new MetadataMutation.Create(NamespaceId.DEFAULT.toMetadataEntity(),
+                                    new Metadata(MetadataScope.SYSTEM, ImmutableSet.of("tag1", "val1")),
+                                    Collections.emptyMap()),
+        new MetadataMutation.Drop(NamespaceId.DEFAULT.toMetadataEntity()),
+        new MetadataMutation.Remove(NamespaceId.DEFAULT.toMetadataEntity()),
+        new MetadataMutation.Update(NamespaceId.DEFAULT.toMetadataEntity(), new Metadata(MetadataScope.SYSTEM,
+                                                                                         ImmutableSet.of("newtag"))));
+
+    Gson gson = new GsonBuilder()
+      .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
+      .registerTypeAdapter(Metadata.class, new MetadataCodec())
+      .registerTypeAdapter(MetadataMutation.class, new MetadataMutationCodec())
+      .create();
+
+    String json = gson.toJson(mutations);
+    Assert.assertEquals(mutations, gson.fromJson(json, new TypeToken<List<MetadataMutation>>() { }.getType()));
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15594
build: https://builds.cask.co/browse/CDAP-DUT6995-1

The system metadata writer writes the app and program metadata one by one. The call should be batched to reduce the RPC cost. 