### PR TITLE
[CDAP-14731] Changes to error/warning count on nodes

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -151,24 +151,9 @@
                   data-nodetype="condition-false">
               <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
             </div>
-            <div ng-if="node.error">
-              <div class="error-node-notification"
-                   ng-if="node.errorCount > 0"
-                   uib-tooltip="{{node.errorMessage || 'Please check the node properties'}}"
-                   tooltip-append-to-body="true"
-                   tooltip-class="tooltip-error">
-                <span class="badge badge-danger">
-                  <span>{{node.errorCount}}</span>
-                </span>
-              </div>
-            </div>
-            <div ng-if="!node.error">
-              <div class="error-node-notification"
-                   ng-if="node.errorCount > 0"
-                   uib-tooltip="Please check the node properties"
-                   tooltip-append-to-body="true"
-                   tooltip-class="tooltip-warning">
-                <span class="badge badge-warning">
+            <div ng-click="!disableNodeClick && DAGPlusPlusCtrl.onNodeClick($event, node)">
+              <div class="error-node-notification" ng-if="node.errorCount > 0">
+                <span class="badge" ng-class="{'badge-warning': !node.error, 'badge-danger': node.error}">
                   <span>{{node.errorCount}}</span>
                 </span>
               </div>

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -410,6 +410,11 @@ my-dag-plus {
           position: absolute;
           top: 1px;
           right: 3px;
+          .badge {
+            &:hover {
+              background-color: @blue-03;
+            }
+          }
           .badge-warning {
             background-color: @badge-warning-color;
           }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-14731
BUILD: https://builds.cask.co/browse/CDAP-UDUT350

- The number of missing fields on the node is clickable.
- Clicking on the number, opens the Properties modal 
- Remove the tooltip that displays on hover
- On hover the background color of the number changes to $blue-03: #0099ff