### PR TITLE
CDAP-15611 do workaround only for scala2_10

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
@@ -303,6 +303,10 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
     SparkRunnerClassLoader runnerClassLoader = new SparkRunnerClassLoader(classLoaderUrls,
                                                                           runnerParentClassLoader, rewriteYarnClient);
 
+    if (providerSparkCompat != SparkCompat.SPARK1_2_10) {
+      return runnerClassLoader;
+    }
+
     // CDAP-8087: Due to Scala 2.10 bug in not able to support runtime reflection from multiple threads,
     // we create the runtime mirror from this synchronized method
     // (there is only one instance of SparkProgramRuntimeProvider), and the mirror will be cached by Scala in a


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15611
build: https://builds.cask.co/browse/CDAP-DUT7000-1

The workaround is only needed in scala2_10, in 2_11 it is fixed and we don't need to do this workaround.