### PR TITLE
Adds a generic backend proxy in express router to route calls to back…

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -152,6 +152,7 @@
     "ejs": "2.6.1",
     "event-emitter": "0.3.4",
     "express": "4.16.2",
+    "express-http-proxy": "1.5.1",
     "finalhandler": "0.4.1",
     "font-awesome": "4.6.3",
     "fuse.js": "2.5.0",

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -19,6 +19,7 @@
 var urlhelper = require('./url-helper');
 const url = require('url');
 const csp = require('helmet-csp');
+var proxy = require('express-http-proxy');
 
 module.exports = {
   getApp: function() {
@@ -179,6 +180,13 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
   }
 
   app.use(compression());
+  app.use(
+    '/api',
+    proxy(urlhelper.constructUrl.bind(null, cdapConfig), {
+      parseReqBody: false,
+      limit: '500gb',
+    })
+  );
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(cookieParser());
@@ -383,36 +391,14 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     For now it handles file upload POST /namespaces/:namespace/apps API
   */
   app.post('/namespaces/:namespace/:path(*)', function(req, res) {
-    var protocol, port;
-    if (cdapConfig['ssl.external.enabled'] === 'true') {
-      protocol = 'https://';
-    } else {
-      protocol = 'http://';
-    }
-    if (cdapConfig['ssl.external.enabled'] === 'true') {
-      port = cdapConfig['router.ssl.server.port'];
-    } else {
-      port = cdapConfig['router.server.port'];
-    }
     var headers = {};
     if (req.headers) {
       headers = req.headers;
     }
-
-    var url = [
-      protocol,
-      cdapConfig['router.server.address'],
-      ':',
-      port,
-      '/v3/namespaces/',
-      req.param('namespace'),
-      '/',
-      req.param('path'),
-    ].join('');
-
+    const constructedPath = `/v3/namespaces/${req.param('namespace')}/${req.param('path')}`;
     var opts = {
       method: 'POST',
-      url: url,
+      url: urlhelper.constructUrl(cdapConfig, constructedPath),
       headers: {
         'Content-Type': headers['content-type'],
       },

--- a/cdap-ui/server/url-helper.js
+++ b/cdap-ui/server/url-helper.js
@@ -23,14 +23,15 @@ function constructUrl(cdapConfig, path, origin = REQUEST_ORIGIN_ROUTER) {
   if (!cdapConfig) {
     return null;
   }
-  path = path[0] === '/' ? path.slice(1) : path;
+  path = path && path[0] === '/' ? path.slice(1) : path;
   if (origin === REQUEST_ORIGIN_MARKET) {
     return `${cdapConfig['market.base.url']}/${path}`;
   }
   let routerhost = cdapConfig['router.server.address'],
     routerport = cdapConfig['router.server.port'],
     routerprotocol = cdapConfig['ssl.external.enabled'] === 'true' ? 'https' : 'http';
-  return `${routerprotocol}://${routerhost}:${routerport}/${path}`;
+  const baseUrl = `${routerprotocol}://${routerhost}:${routerport}`;
+  return path ? `${baseUrl}/${path}` : baseUrl;
 }
 
 function deconstructUrl(cdapConfig, url, requestOrigin) {

--- a/cdap-ui/yarn.lock
+++ b/cdap-ui/yarn.lock
@@ -3642,6 +3642,10 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+
 cacache@^10.0.4:
   version "10.0.4"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
@@ -5176,7 +5180,7 @@ debug@3.1.0, debug@^3.0.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.1.0:
+debug@3.2.6, debug@^3.0.1, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
@@ -5780,6 +5784,10 @@ es6-promise@^3.0.2:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
 
+es6-promise@^4.1.1:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+
 es6-shim@^0.35.3:
   version "0.35.3"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.3.tgz#9bfb7363feffff87a6cdb6cd93e405ec3c4b6f26"
@@ -6156,6 +6164,14 @@ expect@^23.6.0:
     jest-matcher-utils "^23.6.0"
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
+
+express-http-proxy@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/express-http-proxy/-/express-http-proxy-1.5.1.tgz#cbf45695c759693c9c5f946117462d25b57e77a8"
+  dependencies:
+    debug "^3.0.1"
+    es6-promise "^4.1.1"
+    raw-body "^2.3.0"
 
 express@4.16.2:
   version "4.16.2"
@@ -7833,6 +7849,16 @@ http-errors@1.6.2, http-errors@~1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
+http-errors@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 http-errors@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.3.1.tgz#197e22cdebd4198585e8694ef6786197b91ed942"
@@ -8024,6 +8050,10 @@ inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, i
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+
+inherits@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
@@ -12046,6 +12076,15 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
+raw-body@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.3"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
 raw-body@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-1.1.7.tgz#1d027c2bfa116acc6623bca8f00016572a87d425"
@@ -13429,6 +13468,10 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
+
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.9"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.9.tgz#98f64880474b74f4a38b8da9d3c0f2d104633e7d"
@@ -13806,6 +13849,10 @@ static-module@^1.1.0:
 statuses@1, "statuses@>= 1.3.1 < 2", statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+"statuses@>= 1.5.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
 
 statuses@~1.3.1:
   version "1.3.1"
@@ -14529,6 +14576,10 @@ to-regex@^3.0.2:
 toggle-selection@^1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+
+toidentifier@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
 
 topojson@1:
   version "1.6.27"


### PR DESCRIPTION
…end via nodejs

Sample request:
```
http://<node-server-host>:<node-server-port>/api/v3/namespaces/default/apps

http://<node-server-host>:<node-server-port>/api/v3/namespaces/default/apps/appId1 -X DELETE

http://<node-server-host>:<node-server-port>/api/v3/namespaces/default/apps/appId1 -X DELETE -H "Authorization: 'Bearer <auth_token>'"

```
All the above requests will just forward it from nodejs to backend and sends response back to the client (say curl).