### PR TITLE
Fixes gulp build to not lint nodejs server files

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -365,7 +365,6 @@ gulp.task('lint', function() {
       '!./app/lib/**/*.js',
       '!./app/common/**/*.js',
       '!./app/wrangler/**/*.js',
-      './server/*.js',
     ])
     .pipe(plug.plumber())
     .pipe(plug.jshint())


### PR DESCRIPTION
https://builds.cask.co/browse/CDAP-UDUT366