### PR TITLE
Feature/cdap 15699 add schedule restart

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -562,6 +562,21 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
+   * Update schedules which were suspended between startTime and endTime
+   * @param startTime namespace of the triggering program in {@link ProgramStatusTrigger}
+   * @param endTime application name of the triggering program in {@link ProgramStatusTrigger}
+   */
+  @PUT
+  @Path("schedules/re-enable")
+  public void reEnableSuspendedSchedules(HttpRequest request, HttpResponder responder,
+                                         @PathParam("namespace-id") String namespaceId,
+                                         @QueryParam("start-time") long startTime,
+                                         @QueryParam("end-time") long endTime) throws Exception {
+    programScheduleService.reEnableSchedules(new NamespaceId(namespaceId), startTime, endTime);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  /**
    * Get schedules containing {@link ProgramStatusTrigger} filtered by triggering program, and optionally by
    * triggering program statuses or schedule status
    *  @param triggerNamespaceId namespace of the triggering program in {@link ProgramStatusTrigger}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -563,8 +563,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
   /**
    * Update schedules which were suspended between startTime and endTime
-   * @param startTime namespace of the triggering program in {@link ProgramStatusTrigger}
-   * @param endTime application name of the triggering program in {@link ProgramStatusTrigger}
+   * @param startTime lower bound of the update time for schedules (inclusive)
+   * @param endTime upper bound of the update time for schedules (exclusive)
    */
   @PUT
   @Path("schedules/re-enable")

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -563,16 +563,16 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
   /**
    * Update schedules which were suspended between startTime and endTime
-   * @param startTime lower bound of the update time for schedules (inclusive)
-   * @param endTime upper bound of the update time for schedules (exclusive)
+   * @param startTimeMillis lower bound in millis of the update time for schedules (inclusive)
+   * @param endTimeMillis upper bound in millis of the update time for schedules (exclusive)
    */
   @PUT
   @Path("schedules/re-enable")
   public void reEnableSuspendedSchedules(HttpRequest request, HttpResponder responder,
                                          @PathParam("namespace-id") String namespaceId,
-                                         @QueryParam("start-time") long startTime,
-                                         @QueryParam("end-time") long endTime) throws Exception {
-    programScheduleService.reEnableSchedules(new NamespaceId(namespaceId), startTime, endTime);
+                                         @QueryParam("start-time-millis") long startTimeMillis,
+                                         @QueryParam("end-time-millis") long endTimeMillis) throws Exception {
+    programScheduleService.reEnableSchedules(new NamespaceId(namespaceId), startTimeMillis, endTimeMillis);
     responder.sendStatus(HttpResponseStatus.OK);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -562,7 +562,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Update schedules which were suspended between startTime and endTime
+   * Update schedules which were suspended between startTimeMillis and endTimeMillis
    * @param startTimeMillis lower bound in millis of the update time for schedules (inclusive)
    * @param endTimeMillis upper bound in millis of the update time for schedules (exclusive)
    */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
@@ -525,12 +525,12 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
   }
 
   @Override
-  public void reEnableSchedules(NamespaceId namespaceId, long startTime, long endTime)
+  public void reEnableSchedules(NamespaceId namespaceId, long startTimeMillis, long endTimeMillis)
     throws ConflictException {
     checkStarted();
     try {
       execute((StoreTxRunnable<Void, Exception>) store -> {
-        List<ProgramSchedule> schedules = store.listSchedulesSuspended(namespaceId, startTime, endTime);
+        List<ProgramSchedule> schedules = store.listSchedulesSuspended(namespaceId, startTimeMillis, endTimeMillis);
         List<ScheduleId> scheduleIds =
           schedules.stream().map(schedule -> schedule.getScheduleId()).collect(Collectors.toList());
         for (ScheduleId scheduleId : scheduleIds) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
@@ -303,12 +303,7 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
     checkStarted();
     try {
       execute((StoreTxRunnable<Void, Exception>) store -> {
-        ProgramScheduleRecord record = store.getScheduleRecord(scheduleId);
-        if (ProgramScheduleStatus.SUSPENDED != record.getMeta().getStatus()) {
-          throw new ConflictException("Schedule '" + scheduleId + "' is already enabled");
-        }
-        timeSchedulerService.resumeProgramSchedule(record.getSchedule());
-        store.updateScheduleStatus(scheduleId, ProgramScheduleStatus.SCHEDULED);
+        enableScheduleInternal(store, scheduleId);
         return null;
       }, Exception.class);
     } catch (NotFoundException | ConflictException e) {
@@ -529,6 +524,30 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
     return execute(store -> store.findSchedules(triggerKey), RuntimeException.class);
   }
 
+  @Override
+  public void reEnableSchedules(NamespaceId namespaceId, long startTime, long endTime)
+    throws ConflictException {
+    checkStarted();
+    try {
+      execute((StoreTxRunnable<Void, Exception>) store -> {
+        List<ProgramSchedule> schedules = store.listSchedulesSuspended(namespaceId, startTime, endTime);
+        List<ScheduleId> scheduleIds =
+          schedules.stream().map(schedule -> schedule.getScheduleId()).collect(Collectors.toList());
+        for (ScheduleId scheduleId : scheduleIds) {
+          enableScheduleInternal(store, scheduleId);
+        }
+        return null;
+      }, Exception.class);
+    } catch (ConflictException e) {
+      throw e;
+    } catch (SchedulerException | NotFoundException e) {
+      // TODO: [CDAP-11574] temporarily catch the SchedulerException and throw RuntimeException.
+      throw new RuntimeException("Exception occurs when enabling schedules", e);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
   /**
    * Gets a copy of the given {@link ProgramSchedule} and add user and artifact ID in the schedule properties
    * TODO CDAP-13662 - move logic to find artifactId and userId to dashboard service and remove this method
@@ -565,6 +584,16 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
     // construct a copy of the schedule with the additional properties added
     return new ProgramSchedule(schedule.getName(), schedule.getDescription(), schedule.getProgramId(), newProperties,
                                schedule.getTrigger(), schedule.getConstraints(), schedule.getTimeoutMillis());
+  }
+
+  private void enableScheduleInternal(ProgramScheduleStoreDataset store, ScheduleId scheduleId)
+    throws IOException, NotFoundException, ConflictException, SchedulerException {
+    ProgramScheduleRecord record = store.getScheduleRecord(scheduleId);
+    if (ProgramScheduleStatus.SUSPENDED != record.getMeta().getStatus()) {
+      throw new ConflictException("Schedule '" + scheduleId + "' is already enabled");
+    }
+    timeSchedulerService.resumeProgramSchedule(record.getSchedule());
+    store.updateScheduleStatus(scheduleId, ProgramScheduleStatus.SCHEDULED);
   }
 
   private interface StoreTxRunnable<V, T extends Throwable> {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/NoOpScheduler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/NoOpScheduler.java
@@ -126,4 +126,9 @@ public class NoOpScheduler implements Scheduler {
   public Collection<ProgramScheduleRecord> findSchedules(String triggerKey) {
     return Collections.EMPTY_LIST;
   }
+
+  @Override
+  public void reEnableSchedules(NamespaceId namesapceId, long startTime, long endTime) {
+
+  }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ProgramScheduleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ProgramScheduleService.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.api.schedule.Trigger;
 import io.cdap.cdap.common.AlreadyExistsException;
 import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.ProfileConflictException;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
@@ -32,6 +33,7 @@ import io.cdap.cdap.internal.schedule.constraint.Constraint;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.ScheduleDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ScheduleId;
 import io.cdap.cdap.proto.id.WorkflowId;
@@ -243,5 +245,18 @@ public class ProgramScheduleService {
   public void delete(ScheduleId scheduleId) throws Exception {
     authorizationEnforcer.enforce(scheduleId.getParent(), authenticationContext.getPrincipal(), Action.ADMIN);
     scheduler.deleteSchedule(scheduleId);
+  }
+
+  /**
+   * Enables all schedules which were disabled or added between startTime and endTime in a given namespace.
+   *
+   * @param namespaceId the namespace to re-enable schedules in
+   * @param startTime the lower bound for when the schedule was disabled
+   * @param endTime the upper bound for when the schedule was disabled
+   * @throws ConflictException if the schedule was already enabled
+   */
+  public void reEnableSchedules(NamespaceId namespaceId, long startTime, long endTime) throws Exception {
+    authorizationEnforcer.enforce(namespaceId, authenticationContext.getPrincipal(), Action.ADMIN);
+    scheduler.reEnableSchedules(namespaceId, startTime, endTime);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ProgramScheduleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ProgramScheduleService.java
@@ -251,8 +251,8 @@ public class ProgramScheduleService {
    * Enables all schedules which were disabled or added between startTime and endTime in a given namespace.
    *
    * @param namespaceId the namespace to re-enable schedules in
-   * @param startTime the lower bound for when the schedule was disabled
-   * @param endTime the upper bound for when the schedule was disabled
+   * @param startTime the lower bound for when the schedule was disabled (inclusive)
+   * @param endTime the upper bound for when the schedule was disabled (exclusive)
    * @throws ConflictException if the schedule was already enabled
    */
   public void reEnableSchedules(NamespaceId namespaceId, long startTime, long endTime) throws Exception {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ProgramScheduleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ProgramScheduleService.java
@@ -248,15 +248,15 @@ public class ProgramScheduleService {
   }
 
   /**
-   * Enables all schedules which were disabled or added between startTime and endTime in a given namespace.
+   * Enables all schedules which were disabled or added between startTimeMillis and endTimeMillis in a given namespace.
    *
    * @param namespaceId the namespace to re-enable schedules in
-   * @param startTime the lower bound for when the schedule was disabled (inclusive)
-   * @param endTime the upper bound for when the schedule was disabled (exclusive)
+   * @param startTimeMillis the lower bound in millis for when the schedule was disabled (inclusive)
+   * @param endTimeMillis the upper bound in millis for when the schedule was disabled (exclusive)
    * @throws ConflictException if the schedule was already enabled
    */
-  public void reEnableSchedules(NamespaceId namespaceId, long startTime, long endTime) throws Exception {
+  public void reEnableSchedules(NamespaceId namespaceId, long startTimeMillis, long endTimeMillis) throws Exception {
     authorizationEnforcer.enforce(namespaceId, authenticationContext.getPrincipal(), Action.ADMIN);
-    scheduler.reEnableSchedules(namespaceId, startTime, endTime);
+    scheduler.reEnableSchedules(namespaceId, startTimeMillis, endTimeMillis);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/Scheduler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/Scheduler.java
@@ -192,4 +192,14 @@ public interface Scheduler {
    * Find all schedules for a given trigger key
    */
   Collection<ProgramScheduleRecord> findSchedules(String triggerKey);
+
+  /**
+   * Enables all schedules which were disabled or added between startTime and endTime in a given namespace.
+   *
+   * @param namespaceId the namespace to re-enable schedules in
+   * @param startTime the lower bound for when the schedule was disabled
+   * @param endTime the upper bound for when the schedule was disabled
+   * @throws ConflictException if the schedule was already enabled
+   */
+  void reEnableSchedules(NamespaceId namespaceId, long startTime, long endTime) throws ConflictException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/Scheduler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/Scheduler.java
@@ -194,12 +194,12 @@ public interface Scheduler {
   Collection<ProgramScheduleRecord> findSchedules(String triggerKey);
 
   /**
-   * Enables all schedules which were disabled or added between startTime and endTime in a given namespace.
+   * Enables all schedules which were disabled or added between startTimeMillis and endTimeMillis in a given namespace.
    *
    * @param namespaceId the namespace to re-enable schedules in
-   * @param startTime the lower bound for when the schedule was disabled (inclusive)
-   * @param endTime the upper bound for when the schedule was disabled (exclusive)
+   * @param startTimeMillis the lower bound in millis for when the schedule was disabled (inclusive)
+   * @param endTimeMillis the upper bound in millis for when the schedule was disabled (exclusive)
    * @throws ConflictException if the schedule was already enabled
    */
-  void reEnableSchedules(NamespaceId namespaceId, long startTime, long endTime) throws ConflictException;
+  void reEnableSchedules(NamespaceId namespaceId, long startTimeMillis, long endTimeMillis) throws ConflictException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/Scheduler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/Scheduler.java
@@ -197,8 +197,8 @@ public interface Scheduler {
    * Enables all schedules which were disabled or added between startTime and endTime in a given namespace.
    *
    * @param namespaceId the namespace to re-enable schedules in
-   * @param startTime the lower bound for when the schedule was disabled
-   * @param endTime the upper bound for when the schedule was disabled
+   * @param startTime the lower bound for when the schedule was disabled (inclusive)
+   * @param endTime the upper bound for when the schedule was disabled (exclusive)
    * @throws ConflictException if the schedule was already enabled
    */
   void reEnableSchedules(NamespaceId namespaceId, long startTime, long endTime) throws ConflictException;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDatasetTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDatasetTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
+import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.AndTrigger;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.OrTrigger;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.PartitionTrigger;
@@ -147,6 +148,27 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
                             toScheduleSet(store.listScheduleRecords(PROG4_ID)));
         Assert.assertEquals(ImmutableSet.of(sched4),
                             toScheduleSet(store.listScheduleRecords(PROG5_ID)));
+      }
+    );
+
+    // disable a schedule in NS_1
+    long startTime = System.currentTimeMillis();
+    TransactionRunners.run(
+      transactionRunner,
+      context -> {
+        ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
+        store.updateScheduleStatus(sched1.getScheduleId(), ProgramScheduleStatus.SUSPENDED);
+      }
+    );
+    // add one since end is exclusive
+    long endTime = System.currentTimeMillis() + 1;
+
+    // test list schedule disabled
+    TransactionRunners.run(
+      transactionRunner,
+      context -> {
+        ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
+        Assert.assertEquals(ImmutableList.of(sched1), store.listSchedulesSuspended(NS1_ID, startTime, endTime));
       }
     );
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -1004,6 +1004,14 @@ public abstract class AppFabricTestBase {
     return o.get("status");
   }
 
+  protected int reEnableSchedules(String namespace, long startTime, long endTime) throws Exception {
+    String scheduleSuspend = String.format("schedules/re-enable?start-time=%d&end-time=%d", startTime, endTime);
+    String versionedScheduledSuspend = getVersionedAPIPath(scheduleSuspend, Constants.Gateway.API_VERSION_3_TOKEN,
+                                                           namespace);
+    HttpResponse response = doPut(versionedScheduledSuspend, null);
+    return response.getResponseCode();
+  }
+
   protected int suspendSchedule(String namespace, String appName, String schedule) throws Exception {
     String scheduleSuspend = String.format("apps/%s/schedules/%s/suspend", appName, schedule);
     String versionedScheduledSuspend = getVersionedAPIPath(scheduleSuspend, Constants.Gateway.API_VERSION_3_TOKEN,

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -1004,8 +1004,9 @@ public abstract class AppFabricTestBase {
     return o.get("status");
   }
 
-  protected int reEnableSchedules(String namespace, long startTime, long endTime) throws Exception {
-    String scheduleSuspend = String.format("schedules/re-enable?start-time=%d&end-time=%d", startTime, endTime);
+  protected int reEnableSchedules(String namespace, long startTimeMillis, long endTimeMillis) throws Exception {
+    String scheduleSuspend =
+      String.format("schedules/re-enable?start-time-millis=%d&end-time-millis=%d", startTimeMillis, endTimeMillis);
     String versionedScheduledSuspend = getVersionedAPIPath(scheduleSuspend, Constants.Gateway.API_VERSION_3_TOKEN,
                                                            namespace);
     HttpResponse response = doPut(versionedScheduledSuspend, null);


### PR DESCRIPTION
Add functions which allow the user to find all schedules which were suspended within a range of time, and re-enable those schedules.

This is needed for the post-upgrade job.

DUT passing: https://builds.cask.co/browse/CDAP-DUT7011