### PR TITLE
CDAP-15677 restore preview status

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
@@ -20,6 +20,7 @@ import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
 import io.cdap.cdap.app.deploy.Manager;
 import io.cdap.cdap.app.deploy.ManagerFactory;
 import io.cdap.cdap.app.store.Store;
@@ -50,6 +51,7 @@ import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
 import io.cdap.cdap.metadata.DefaultMetadataAdmin;
 import io.cdap.cdap.metadata.MetadataAdmin;
 import io.cdap.cdap.pipeline.PipelineFactory;
+import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.scheduler.NoOpScheduler;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.securestore.spi.SecretStore;
@@ -67,6 +69,7 @@ import io.cdap.cdap.store.DefaultOwnerStore;
  * Provides bindings required to create injector for running preview.
  */
 public class PreviewRunnerModule extends PrivateModule {
+  public static final String PREVIEW_PROGRAM_ID = "previewProgramId";
 
   private final ArtifactRepository artifactRepository;
   private final ArtifactStore artifactStore;
@@ -75,11 +78,12 @@ public class PreviewRunnerModule extends PrivateModule {
   private final PrivilegesManager privilegesManager;
   private final PreferencesService preferencesService;
   private final ProgramRuntimeProviderLoader programRuntimeProviderLoader;
+  private final ProgramId programId;
 
   public PreviewRunnerModule(ArtifactRepository artifactRepository, ArtifactStore artifactStore,
                              AuthorizerInstantiator authorizerInstantiator, AuthorizationEnforcer authorizationEnforcer,
                              PrivilegesManager privilegesManager, PreferencesService preferencesService,
-                             ProgramRuntimeProviderLoader programRuntimeProviderLoader) {
+                             ProgramRuntimeProviderLoader programRuntimeProviderLoader, ProgramId programId) {
     this.artifactRepository = artifactRepository;
     this.artifactStore = artifactStore;
     this.authorizerInstantiator = authorizerInstantiator;
@@ -87,6 +91,7 @@ public class PreviewRunnerModule extends PrivateModule {
     this.privilegesManager = privilegesManager;
     this.preferencesService = preferencesService;
     this.programRuntimeProviderLoader = programRuntimeProviderLoader;
+    this.programId = programId;
   }
 
   @Override
@@ -150,5 +155,8 @@ public class PreviewRunnerModule extends PrivateModule {
     expose(OwnerStore.class);
     bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
     expose(OwnerAdmin.class);
+
+    bind(ProgramId.class).annotatedWith(Names.named(PREVIEW_PROGRAM_ID)).toInstance(programId);
+    expose(ProgramId.class).annotatedWith(Names.named(PREVIEW_PROGRAM_ID));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/preview/PreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/preview/PreviewStore.java
@@ -17,10 +17,15 @@ package io.cdap.cdap.app.store.preview;
 
 import com.google.gson.JsonElement;
 import io.cdap.cdap.api.preview.DataTracer;
+import io.cdap.cdap.app.preview.PreviewStatus;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Interface used by {@link DataTracer} to store the preview data.
@@ -52,4 +57,38 @@ public interface PreviewStore {
    * @param applicationId the id of the preview for which the data to be removed
    */
   void remove(ApplicationId applicationId);
+
+  /**
+   * Save the program run id associated with the preview run
+   *
+   * @param programRunId the program run id to save
+   */
+  void setProgramId(ProgramRunId programRunId);
+
+  /**
+   * Get the program run id associated with the preview run
+   *
+   * @param applicationId the preview id
+   * @return the program run id of the preview, null if no run has started with the preview id
+   */
+  @Nullable
+  ProgramRunId getProgramRunId(ApplicationId applicationId);
+
+  /**
+   * Set the preview status assoicated with the preview run
+   *
+   * @param applicationId the preview id
+   * @param previewStatus the preview status
+   */
+  void setPreviewStatus(ApplicationId applicationId, PreviewStatus previewStatus);
+
+  /**
+   * Get the preview status assoicated with the preview run
+   *
+   * @param applicationId the preview id
+   * @return the preview status of the preview run, null if no run has started with the preview id
+   *
+   */
+  @Nullable
+  PreviewStatus getPreviewStatus(ApplicationId applicationId);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -22,11 +22,13 @@ import com.google.common.util.concurrent.Service;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.preview.DataTracerFactory;
 import io.cdap.cdap.app.preview.PreviewRequest;
 import io.cdap.cdap.app.preview.PreviewRunner;
+import io.cdap.cdap.app.preview.PreviewRunnerModule;
 import io.cdap.cdap.app.preview.PreviewStatus;
 import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramRuntimeService;
@@ -70,6 +72,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -79,6 +83,8 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultPreviewRunner.class);
   private static final Gson GSON = new Gson();
+  // default preview running time is 15min
+  private static final long PREVIEW_TIMEOUT = TimeUnit.MINUTES.toMillis(15);
 
   private static final ProgramTerminator NOOP_PROGRAM_TERMINATOR = programId -> {
     // no-op
@@ -101,12 +107,12 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
   private final LevelDBTableService levelDBTableService;
   private final StructuredTableAdmin structuredTableAdmin;
   private final StructuredTableRegistry structuredTableRegistry;
+  private final ProgramId programId;
+  private final CountDownLatch countDownLatch;
 
-  private volatile PreviewStatus status;
   private volatile boolean killedByTimer;
-  private ProgramId programId;
-  private ProgramRunId runId;
   private Timer timer;
+  private long startTimeMillis;
 
   @Inject
   DefaultPreviewRunner(MessagingService messagingService,
@@ -122,7 +128,8 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
                        ProgramNotificationSubscriberService programNotificationSubscriberService,
                        LevelDBTableService levelDBTableService,
                        StructuredTableAdmin structuredTableAdmin,
-                       StructuredTableRegistry structuredTableRegistry) {
+                       StructuredTableRegistry structuredTableRegistry,
+                       @Named(PreviewRunnerModule.PREVIEW_PROGRAM_ID) ProgramId programId) {
     this.messagingService = messagingService;
     this.dsOpExecService = dsOpExecService;
     this.datasetService = datasetService;
@@ -131,7 +138,6 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     this.programRuntimeService = programRuntimeService;
     this.programLifecycleService = programLifecycleService;
     this.previewStore = previewStore;
-    this.status = null;
     this.dataTracerFactory = dataTracerFactory;
     this.namespaceAdmin = namespaceAdmin;
     this.programStore = programStore;
@@ -141,12 +147,16 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     this.levelDBTableService = levelDBTableService;
     this.structuredTableAdmin = structuredTableAdmin;
     this.structuredTableRegistry = structuredTableRegistry;
+    this.programId = programId;
+    // if the preview store already has the status information, this means this preview already finished, and it
+    // is a restoration, set the count to 0 to allow shut down immediately.
+    this.countDownLatch =
+      previewStore.getPreviewStatus(programId.getParent()) == null ? new CountDownLatch(1) : new CountDownLatch(0);
   }
 
   @Override
   public void startPreview(PreviewRequest<?> previewRequest) throws Exception {
     namespaceAdmin.create(new NamespaceMeta.Builder().setName(previewRequest.getProgram().getNamespaceId()).build());
-    programId = previewRequest.getProgram();
     AppRequest<?> request = previewRequest.getAppRequest();
     ArtifactSummary artifactSummary = request.getArtifact();
     ApplicationId preview = programId.getParent();
@@ -159,7 +169,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
                                             artifactSummary, config, NOOP_PROGRAM_TERMINATOR, null,
                                             request.canUpdateSchedules());
     } catch (Exception e) {
-      this.status = new PreviewStatus(PreviewStatus.Status.DEPLOY_FAILED, new BasicThrowable(e), null, null);
+      setStatus(new PreviewStatus(PreviewStatus.Status.DEPLOY_FAILED, new BasicThrowable(e), null, null));
       throw e;
     }
 
@@ -174,8 +184,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
         setStatus(new PreviewStatus(PreviewStatus.Status.RUNNING, null, System.currentTimeMillis(), null));
         // Only have timer if there is a timeout setting.
         if (previewConfig.getTimeout() != null) {
-          timer = new Timer();
-          final int timeOutMinutes =  previewConfig.getTimeout();
+          int timeOutMinutes =  previewConfig.getTimeout();
           timer.schedule(new TimerTask() {
             @Override
             public void run() {
@@ -194,6 +203,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
       @Override
       public void completed() {
+        PreviewStatus status = previewStore.getPreviewStatus(programId.getParent());
         setStatus(new PreviewStatus(PreviewStatus.Status.COMPLETED, null, status.getStartTime(),
                                     System.currentTimeMillis()));
         shutDownUnrequiredServices();
@@ -201,6 +211,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
       @Override
       public void killed() {
+        PreviewStatus status = previewStore.getPreviewStatus(programId.getParent());
         if (!killedByTimer) {
           setStatus(new PreviewStatus(PreviewStatus.Status.KILLED, null, status.getStartTime(),
                                       System.currentTimeMillis()));
@@ -213,21 +224,26 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
       @Override
       public void error(Throwable cause) {
+        PreviewStatus status = previewStore.getPreviewStatus(programId.getParent());
         setStatus(new PreviewStatus(PreviewStatus.Status.RUN_FAILED, new BasicThrowable(cause), status.getStartTime(),
                                     System.currentTimeMillis()));
         shutDownUnrequiredServices();
       }
     }, Threads.SAME_THREAD_EXECUTOR);
-    runId = controller.getProgramRunId();
+    startTimeMillis = System.currentTimeMillis();
+    previewStore.setProgramId(controller.getProgramRunId());
   }
 
   private void setStatus(PreviewStatus status) {
-    this.status = status;
+    previewStore.setPreviewStatus(programId.getParent(), status);
+    if (!status.getStatus().equals(PreviewStatus.Status.RUNNING)) {
+      countDownLatch.countDown();
+    }
   }
 
   @Override
   public PreviewStatus getStatus() {
-    return status;
+    return previewStore.getPreviewStatus(programId.getParent());
   }
 
   @Override
@@ -247,12 +263,12 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
   @Override
   public ProgramRunId getProgramRunId() {
-    return runId;
+    return previewStore.getProgramRunId(programId.getParent());
   }
 
   @Override
   public RunRecordMeta getRunRecord() {
-    return programStore.getRun(runId);
+    return programStore.getRun(previewStore.getProgramRunId(programId.getParent()));
   }
 
   @Override
@@ -262,13 +278,19 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
   @Override
   protected void startUp() throws Exception {
-    // TODO: CDAP-14838 Ensure preivew has it's own copy of the schema mapping.
-    StoreDefinition.createAllTables(structuredTableAdmin, structuredTableRegistry, true);
+    StoreDefinition.createAllTables(structuredTableAdmin, structuredTableRegistry, false);
     if (messagingService instanceof Service) {
       ((Service) messagingService).startAndWait();
     }
     dsOpExecService.startAndWait();
     datasetService.startAndWait();
+    timer = new Timer(programId.getApplication());
+
+    // if there is a preview status in the store, that means this preview already has a run so do not need
+    // to start other services
+    if (previewStore.getPreviewStatus(programId.getParent()) != null) {
+      return;
+    }
 
     // It is recommended to initialize log appender after datasetService is started,
     // since log appender instantiates a dataset.
@@ -287,6 +309,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
   @Override
   protected void shutDown() throws Exception {
+    countDownLatch.await(PREVIEW_TIMEOUT - (System.currentTimeMillis() - startTimeMillis), TimeUnit.MILLISECONDS);
     shutDownUnrequiredServices();
     datasetService.stopAndWait();
     dsOpExecService.stopAndWait();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStoreTest.java
@@ -19,16 +19,20 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Injector;
+import io.cdap.cdap.app.preview.PreviewStatus;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,5 +101,25 @@ public class DefaultPreviewStoreTest {
     store.remove(firstApplicationId);
     firstApplicationData = store.get(firstApplicationId, "mytracer");
     Assert.assertEquals(0, firstApplicationData.size());
+  }
+
+  @Test
+  public void testPreviewInfo() throws IOException {
+    // test non existing preview
+    ApplicationId nonexist = new ApplicationId("ns1", "nonexist");
+    Assert.assertNull(store.getProgramRunId(nonexist));
+    Assert.assertNull(store.getPreviewStatus(nonexist));
+
+    // test put and get
+    ApplicationId applicationId = new ApplicationId("ns1", "app1");
+    ProgramRunId runId = new ProgramRunId("ns1", "app1", ProgramType.WORKFLOW, "test",
+                                          RunIds.generate().getId());
+    PreviewStatus status = new PreviewStatus(PreviewStatus.Status.COMPLETED, null, 0L,
+                                             System.currentTimeMillis());
+    store.setProgramId(runId);
+    store.setPreviewStatus(applicationId, status);
+
+    Assert.assertEquals(runId, store.getProgramRunId(applicationId));
+    Assert.assertEquals(status, store.getPreviewStatus(applicationId));
   }
 }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -126,7 +126,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
           delayMillis = Long.parseLong(confDelay);
           if (delayMillis <= 0) {
             delayMillis = DEFAULT_POD_KILLER_DELAY_MILLIS;
-            LOG.warn("Only positive value is allowed for configuration {}. Defaulting to ",
+            LOG.warn("Only positive value is allowed for configuration {}. Defaulting to {}",
                      POD_KILLER_DELAY_MILLIS, delayMillis);
           }
         } catch (NumberFormatException e) {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15677
Build: https://builds.cask.co/browse/CDAP-DUT7044-1

Restore the preview state to ensure the previous preview runs info are still retrievable after the restart of CDAP. This also prevents the folders getting left behind on restarts of preview. 