### PR TITLE
CDAP-15723 Add support for shared vpc in Dataproc Provisioner

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -47,6 +47,7 @@ import com.google.cloud.dataproc.v1.GceClusterConfig;
 import com.google.cloud.dataproc.v1.GetClusterRequest;
 import com.google.cloud.dataproc.v1.InstanceGroupConfig;
 import com.google.cloud.dataproc.v1.SoftwareConfig;
+import com.google.common.base.Strings;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
@@ -85,6 +86,7 @@ public class DataprocClient implements AutoCloseable {
   private final ClusterControllerClient client;
   private final Compute compute;
   private final String projectId;
+  private final String networkHostProjectId;
   private final String network;
   private final String zone;
   private final boolean useInternalIP;
@@ -109,6 +111,8 @@ public class DataprocClient implements AutoCloseable {
     }
 
     String projectId = conf.getProjectId();
+    String networkHostProjectID = Strings.isNullOrEmpty(conf.getNetworkHostProjectID()) ? projectId :
+      conf.getNetworkHostProjectID();
     String systemProjectId = null;
     try {
       systemProjectId = DataprocConf.getSystemProjectId();
@@ -121,14 +125,15 @@ public class DataprocClient implements AutoCloseable {
       network = systemNetwork;
     } else if (network == null) {
       // Otherwise, pick a network from the configured project using the Compute API
-      network = findNetwork(projectId, compute);
+
+      network = findNetwork(networkHostProjectID, compute);
     }
     if (network == null) {
       throw new IllegalArgumentException("Unable to automatically detect a network, please explicitly set a network.");
     }
 
     String subnet = conf.getSubnet();
-    Network networkInfo = getNetworkInfo(projectId, network, compute);
+    Network networkInfo = getNetworkInfo(networkHostProjectID, network, compute);
 
     PeeringState state = getPeeringState(systemNetwork, systemProjectId, networkInfo, compute);
 
@@ -140,20 +145,24 @@ public class DataprocClient implements AutoCloseable {
       LOG.info(String.format("VPC Peering from network '%s' in project '%s' to network '%s' " +
                                "in project '%s' is in the ACTIVE state. Prefer External IP can be set to false " +
                                "to launch Dataproc clusters with internal IP only.", systemNetwork,
-                             systemProjectId, network, projectId));
+                             systemProjectId, network, networkHostProjectID));
     }
 
-    // Use internal IP for the Dataproc cluster if instance is private or user has not preferred external IP and
-    // (CDAP is running in the same customer project as Dataproc is going to be launched or
+    // Use internal IP for the Dataproc cluster if instance is private
+    // or
+    // user has not preferred external IP and (CDAP is running in the same customer project as Dataproc is going to
+    // be launched
+    // or
     // Network peering is done between customer network and system network and is in ACTIVE mode).
-    boolean useInternalIP = privateInstance || !conf.isPreferExternalIP()
-      && ((network.equals(systemNetwork) && projectId.equals(systemProjectId)) || state == PeeringState.ACTIVE);
+    boolean useInternalIP = privateInstance ||
+      !conf.isPreferExternalIP() && ((network.equals(systemNetwork) && networkHostProjectID.equals(systemProjectId)) ||
+      state == PeeringState.ACTIVE);
 
     List<String> subnets = networkInfo.getSubnetworks();
     if (subnet != null && !subnetExists(subnets, subnet)) {
       throw new IllegalArgumentException(String.format("Subnet '%s' does not exist in network '%s' in project '%s'. "
                                                          + "Please use a different subnet.",
-                                                       subnet, network, projectId));
+                                                       subnet, network, networkHostProjectID));
     }
 
     // if the network uses custom subnets, a subnet must be provided to the dataproc api
@@ -164,14 +173,11 @@ public class DataprocClient implements AutoCloseable {
       if (subnets == null || subnets.isEmpty()) {
         throw new IllegalArgumentException(String.format("Network '%s' in project '%s' does not contain any subnets. "
                                                            + "Please create a subnet or use a different network.",
-                                                         network, projectId));
-      }
-
-      // if no subnet was configured, choose one
-      if (subnet == null) {
-        subnet = chooseSubnet(network, subnets, conf.getZone());
+                                                         network, networkHostProjectID));
       }
     }
+
+    subnet = chooseSubnet(network, subnets, subnet, conf.getZone());
 
     return new DataprocClient(new DataprocConf(conf, network, subnet), client, compute, useInternalIP);
   }
@@ -217,19 +223,24 @@ public class DataprocClient implements AutoCloseable {
 
   // subnets are identified as
   // "https://www.googleapis.com/compute/v1/projects/<project>/regions/<region>/subnetworks/<name>"
-  // a subnet in the same region as the dataproc cluster must be chosen
-  private static String chooseSubnet(String network, List<String> subnets, String zone) {
+  // a subnet in the same region as the dataproc cluster must be chosen. If a subnet name is provided then the subnet
+  // will be choosen and the region will be picked on basis of the given zone. If a subnet name is not provided then
+  // any subnetwork in the region of the given zone will be picked.
+  private static String chooseSubnet(String network, List<String> subnets, @Nullable String subnet, String zone) {
     // zones are always <region>-<letter>
     String region = zone.substring(0, zone.lastIndexOf('-'));
-    for (String subnet : subnets) {
-      if (subnet.contains(region + "/subnetworks")) {
-        return subnet;
+    for (String currentSubnet : subnets) {
+      // if a subnet name is given then get the region of that subnet based on the zone
+      if (subnet != null && !currentSubnet.endsWith("subnetworks/" + subnet)) {
+        continue;
+      }
+      if (currentSubnet.contains(region + "/subnetworks")) {
+        return currentSubnet;
       }
     }
     throw new IllegalArgumentException(
-      String.format("Could not find any subnets in network '%s' that are for region '%s'. "
-                      + "Please specify a subnet that is in the same region as the selected zone.",
-                    network, region));
+      String.format("Could not find %s in network '%s' that are for region '%s'", subnet == null ? "any subnet" :
+        String.format("a subnet named '%s", subnet), network, region));
   }
 
   private static String findNetwork(String project, Compute compute) throws IOException {
@@ -270,6 +281,8 @@ public class DataprocClient implements AutoCloseable {
   private DataprocClient(DataprocConf conf, ClusterControllerClient client, Compute compute, boolean useInternalIP) {
     this.projectId = conf.getProjectId();
     this.network = conf.getNetwork();
+    this.networkHostProjectId = Strings.isNullOrEmpty(conf.getNetworkHostProjectID()) ? projectId :
+      conf.getNetworkHostProjectID();
     this.zone = conf.getZone();
     this.useInternalIP = useInternalIP;
     this.conf = conf;
@@ -307,11 +320,14 @@ public class DataprocClient implements AutoCloseable {
         .addServiceAccountScopes("https://www.googleapis.com/auth/cloud-platform")
         .setZoneUri(conf.getZone())
         .putAllMetadata(metadata);
+      String networkHostProjectId = Strings.isNullOrEmpty(conf.getNetworkHostProjectID()) ? projectId :
+        conf.getNetworkHostProjectID();
       // subnets are unique within a location, not within a network, which is why these configs are mutually exclusive.
       if (conf.getSubnet() != null) {
         clusterConfig.setSubnetworkUri(conf.getSubnet());
       } else {
-        clusterConfig.setNetworkUri(network);
+        clusterConfig.setNetworkUri(String.format("projects/%s/global/networks/%s", networkHostProjectId,
+                                                  conf.getNetwork()));
       }
 
       for (String targetTag : getFirewallTargetTags()) {
@@ -476,7 +492,7 @@ public class DataprocClient implements AutoCloseable {
    * @throws IOException If failed to discover those firewall rules
    */
   private Collection<String> getFirewallTargetTags() throws IOException {
-    FirewallList firewalls = compute.firewalls().list(projectId).execute();
+    FirewallList firewalls = compute.firewalls().list(networkHostProjectId).execute();
     List<String> tags = new ArrayList<>();
     Set<FirewallPort> requiredPorts = EnumSet.allOf(FirewallPort.class);
 
@@ -516,9 +532,9 @@ public class DataprocClient implements AutoCloseable {
     if (!requiredPorts.isEmpty()) {
       String portList = requiredPorts.stream().map(p -> String.valueOf(p.port)).collect(Collectors.joining(","));
       throw new IllegalArgumentException(String.format(
-        "Could not find an ingress firewall rule for network '%s' for ports '%s'. " +
+        "Could not find an ingress firewall rule for network '%s' in project '%s' for ports '%s'. " +
           "Please create a rule to allow incoming traffic on those ports for your IP range.",
-        network, portList));
+        network, networkHostProjectId, portList));
     }
     return tags;
   }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -43,6 +43,7 @@ public class DataprocConf {
   static final String PROJECT_ID_KEY = "projectId";
   static final String AUTO_DETECT = "auto-detect";
   static final String NETWORK = "network";
+  static final String NETWORK_HOST_PROJECT_ID = "networkHostProjectId";
   static final String PREFER_EXTERNAL_IP = "preferExternalIP";
   static final String STACKDRIVER_LOGGING_ENABLED = "stackdriverLoggingEnabled";
   static final String STACKDRIVER_MONITORING_ENABLED = "stackdriverMonitoringEnabled";
@@ -54,6 +55,7 @@ public class DataprocConf {
   private final String zone;
   private final String projectId;
   private final String network;
+  private final String networkHostProjectID;
   private final String subnet;
 
   private final int masterNumNodes;
@@ -78,7 +80,7 @@ public class DataprocConf {
   private final Map<String, String> dataprocProperties;
 
   DataprocConf(DataprocConf conf, String network, String subnet) {
-    this(conf.accountKey, conf.region, conf.zone, conf.projectId, network, subnet,
+    this(conf.accountKey, conf.region, conf.zone, conf.projectId, conf.networkHostProjectID, network, subnet,
          conf.masterNumNodes, conf.masterCPUs, conf.masterMemoryMB, conf.masterDiskGB,
          conf.workerNumNodes, conf.workerCPUs, conf.workerMemoryMB, conf.workerDiskGB,
          conf.pollCreateDelay, conf.pollCreateJitter, conf.pollDeleteDelay, conf.pollInterval,
@@ -87,7 +89,7 @@ public class DataprocConf {
   }
 
   private DataprocConf(@Nullable String accountKey, String region, String zone, String projectId,
-                       @Nullable String network, @Nullable String subnet,
+                       @Nullable String networkHostProjectId, @Nullable String network, @Nullable String subnet,
                        int masterNumNodes, int masterCPUs, int masterMemoryMB,
                        int masterDiskGB, int workerNumNodes, int workerCPUs, int workerMemoryMB, int workerDiskGB,
                        long pollCreateDelay, long pollCreateJitter, long pollDeleteDelay, long pollInterval,
@@ -98,6 +100,7 @@ public class DataprocConf {
     this.region = region;
     this.zone = zone;
     this.projectId = projectId;
+    this.networkHostProjectID = networkHostProjectId;
     this.network = network;
     this.subnet = subnet;
     this.masterNumNodes = masterNumNodes;
@@ -134,6 +137,11 @@ public class DataprocConf {
   @Nullable
   public String getNetwork() {
     return network;
+  }
+
+  @Nullable
+  public String getNetworkHostProjectID() {
+    return networkHostProjectID;
   }
 
   @Nullable
@@ -275,6 +283,7 @@ public class DataprocConf {
     if (zone == null || AUTO_DETECT.equals(zone)) {
       zone = getSystemZone();
     }
+    String networkHostProjectID = getString(properties, NETWORK_HOST_PROJECT_ID);
     String network = getString(properties, NETWORK);
     if (network == null || AUTO_DETECT.equals(network)) {
       network = null;
@@ -322,7 +331,7 @@ public class DataprocConf {
     );
 
     // always use 'global' region until CDAP-14376 is fixed.
-    return new DataprocConf(accountKey, "global", zone, projectId, network, subnet,
+    return new DataprocConf(accountKey, "global", zone, projectId, networkHostProjectID, network, subnet,
                             masterNumNodes, masterCPUs, masterMemoryGB, masterDiskGB,
                             workerNumNodes, workerCPUs, workerMemoryGB, workerDiskGB,
                             pollCreateDelay, pollCreateJitter, pollDeleteDelay, pollInterval,

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -303,6 +303,7 @@ public class DataprocProvisioner implements Provisioner {
     // Default settings from the system context
     List<String> keys = Arrays.asList(DataprocConf.PREFER_EXTERNAL_IP,
                                       DataprocConf.NETWORK,
+                                      DataprocConf.NETWORK_HOST_PROJECT_ID,
                                       DataprocConf.STACKDRIVER_LOGGING_ENABLED,
                                       DataprocConf.STACKDRIVER_MONITORING_ENABLED);
     for (String key : keys) {

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -33,16 +33,6 @@
       "label": "General Settings",
       "properties": [
         {
-          "widget-type": "textbox",
-          "label": "Network",
-          "name": "network",
-          "description": "Select a VPC network in the specified project to use when creating clusters with this profile. If this is left blank or set to 'auto-detect', a network from the project will be chosen.",
-          "widget-attributes": {
-            "default": "default",
-            "size": "medium"
-          }
-        },
-        {
           "widget-type": "select",
           "label": "Zone",
           "name": "zone",
@@ -97,6 +87,25 @@
               "us-west1-c"
             ],
             "default": "us-east1-c",
+            "size": "medium"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Network",
+          "name": "network",
+          "description": "Select a VPC network in the specified project to use when creating clusters with this profile. If this is left blank or set to 'auto-detect', a network from the project will be chosen.",
+          "widget-attributes": {
+            "default": "default",
+            "size": "medium"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Network Host Project ID",
+          "name": "networkHostProjectId",
+          "description": "Google Cloud Project ID, which uniquely identifies the project where the network resides. This can be left blank if the network resides in the same project as specified in the Project ID. In case of Shared VPC this must be set to the host project ID where the network resides.",
+          "widget-attributes": {
             "size": "medium"
           }
         },


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-15723

Shared VPC: https://cloud.google.com/vpc/docs/shared-vpc

A user can have data sources present on a network (host network) which lives in a project called host project. This host network can then be shared to various other projects (service project) through shared VPC to allow other user to access the data sources present on the host network. In such scenarios dataproc cluster must live on the host network.

Example of a shared vpc in Dataproc 
![image](https://user-images.githubusercontent.com/1472867/62801027-6e843e80-bb02-11e9-8f22-f2063ea318a2.png)


Note: Currently testing this code on an instance.