### PR TITLE
[CDAP-15499] Throw error when plugin artifact does not contain provided class

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactRepository.java
@@ -269,6 +269,7 @@ public class DefaultArtifactRepository implements ArtifactRepository {
       parentClassLoader = createParentClassLoader(artifactId, parentArtifacts, entityImpersonator);
     }
     try {
+      additionalPlugins = additionalPlugins == null ? Collections.emptySet() : additionalPlugins;
       ArtifactClasses artifactClasses = inspectArtifact(artifactId, artifactFile, additionalPlugins, parentClassLoader);
       ArtifactMeta meta = new ArtifactMeta(artifactClasses, parentArtifacts, properties);
       ArtifactDetail artifactDetail = artifactStore.write(artifactId, meta, artifactFile, entityImpersonator);
@@ -500,11 +501,11 @@ public class DefaultArtifactRepository implements ArtifactRepository {
     }
   }
 
-  private ArtifactClasses inspectArtifact(Id.Artifact artifactId, File artifactFile,
-                                          @Nullable Set<PluginClass> additionalPlugins,
-                                          @Nullable ClassLoader parentClassLoader) throws IOException,
-    InvalidArtifactException {
-    ArtifactClasses artifactClasses = artifactInspector.inspectArtifact(artifactId, artifactFile, parentClassLoader);
+  private ArtifactClasses inspectArtifact(Id.Artifact artifactId, File artifactFile, Set<PluginClass> additionalPlugins,
+                                          @Nullable ClassLoader parentClassLoader)
+    throws IOException, InvalidArtifactException {
+    ArtifactClasses artifactClasses = artifactInspector.inspectArtifact(artifactId, artifactFile,
+                                                                        parentClassLoader, additionalPlugins);
     validatePluginSet(artifactClasses.getPlugins());
     if (additionalPlugins == null || additionalPlugins.isEmpty()) {
       return artifactClasses;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -214,8 +214,8 @@ public class ArtifactRepositoryTest {
     // write plugins config file
     Map<String, PluginPropertyField> emptyMap = Collections.emptyMap();
     Set<PluginClass> manuallyAddedPlugins1 = ImmutableSet.of(
-      new PluginClass("typeA", "manual1", "desc", "io.cdap.classname", null, emptyMap),
-      new PluginClass("typeB", "manual2", "desc", "io.cdap.otherclassname", null, emptyMap)
+      new PluginClass("typeA", "manual1", "desc", TestPlugin.class.getName(), null, emptyMap),
+      new PluginClass("typeB", "manual2", "desc", TestPlugin.class.getName(), null, emptyMap)
     );
     File pluginConfigFile = new File(systemArtifactsDir1, "APlugin-1.0.0.json");
     ArtifactConfig pluginConfig1 = new ArtifactConfig(
@@ -237,8 +237,8 @@ public class ArtifactRepositoryTest {
 
     // write plugins config file
     Set<PluginClass> manuallyAddedPlugins2 = ImmutableSet.of(
-      new PluginClass("typeA", "manual1", "desc", "co.notcask.classname", null, emptyMap),
-      new PluginClass("typeB", "manual2", "desc", "co.notcask.otherclassname", null, emptyMap)
+      new PluginClass("typeA", "manual1", "desc", TestPlugin.class.getName(), null, emptyMap),
+      new PluginClass("typeB", "manual2", "desc", TestPlugin.class.getName(), null, emptyMap)
     );
     pluginConfigFile = new File(systemArtifactsDir2, "BPlugin-1.0.0.json");
     ArtifactConfig pluginConfig2 = new ArtifactConfig(

--- a/cdap-client-tests/src/test/java/io/cdap/cdap/client/ArtifactClientTestRun.java
+++ b/cdap-client-tests/src/test/java/io/cdap/cdap/client/ArtifactClientTestRun.java
@@ -204,7 +204,7 @@ public class ArtifactClientTestRun extends ClientTestBase {
       myapp2Id.getParent().getNamespace(), myapp2Id.getArtifact(),
       new ArtifactVersion(myapp2Id.getVersion()), new ArtifactVersion("3.0.0")));
     Set<PluginClass> additionalPlugins = Sets.newHashSet(new PluginClass(
-      "jdbc", "mysql", "", "com.mysql.jdbc.Driver", null, Collections.<String, PluginPropertyField>emptyMap()));
+      "jdbc", "mysql", "", Plugin1.class.getName(), null, Collections.<String, PluginPropertyField>emptyMap()));
     artifactClient.add(pluginId.getParent(), pluginId.getArtifact(), contentProvider,
                        pluginId.getVersion(), parents, additionalPlugins);
 


### PR DESCRIPTION
Modified ArtifactInspector to throw InvalidArtifactException if the additional plugin class is not found in the artifact. 

Build: https://builds.cask.co/browse/CDAP-DUT7031-11
ITM: https://builds.cask.co/browse/IT-ITM-235