### PR TITLE
CDAP-15747 fix a race when cancelling a KeyedExecutor task

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/async/KeyedExecutor.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/async/KeyedExecutor.java
@@ -78,7 +78,8 @@ public class KeyedExecutor<K> {
       public boolean cancel(boolean mayInterruptIfRunning) {
         // Cancel the task execution
         if (cancelled.compareAndSet(false, true)) {
-          Optional.ofNullable(futureReference.get()).ifPresent(f -> f.cancel(mayInterruptIfRunning));
+          Future<?> f = futureReference.get();
+          return f == null || f.cancel(mayInterruptIfRunning);
         }
         return super.cancel(mayInterruptIfRunning);
       }


### PR DESCRIPTION
Fixed a race condition in KeyedExecutor where the task could
get cancelled but return that it was not cancelled.
This fixes a race condition in the provisioner where it can
cancel a task, think that the task completed before it was
cancelled, then skip the logic to modify the run state.