### PR TITLE
CDAP-15206 remove local datasets in lineage

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LineageAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LineageAdmin.java
@@ -17,13 +17,16 @@
 package io.cdap.cdap.metadata;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.workflow.WorkflowActionNode;
+import io.cdap.cdap.api.workflow.WorkflowNode;
+import io.cdap.cdap.api.workflow.WorkflowSpecification;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.data2.metadata.lineage.AccessType;
@@ -31,12 +34,14 @@ import io.cdap.cdap.data2.metadata.lineage.DefaultLineageStoreReader;
 import io.cdap.cdap.data2.metadata.lineage.Lineage;
 import io.cdap.cdap.data2.metadata.lineage.LineageStoreReader;
 import io.cdap.cdap.data2.metadata.lineage.Relation;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.store.RunRecordMeta;
-import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
-import io.cdap.cdap.proto.id.NamespacedEntityId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.WorkflowId;
 import org.apache.twill.api.RunId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +53,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -57,10 +64,6 @@ import javax.annotation.Nullable;
 public class LineageAdmin {
 
   private static final Logger LOG = LoggerFactory.getLogger(LineageAdmin.class);
-
-  private static final Function<Relation, ProgramId> RELATION_TO_PROGRAM_FUNCTION = Relation::getProgram;
-
-  private static final Function<Relation, NamespacedEntityId> RELATION_TO_DATA_FUNCTION = Relation::getData;
 
   private static final Function<Collection<Relation>, Collection<Relation>> COLLAPSE_UNKNOWN_TYPE_FUNCTION =
     relations -> {
@@ -90,7 +93,7 @@ public class LineageAdmin {
    * @param rollup indicates whether to aggregate programs, currently supports rolling up programs into workflows
    * @return lineage for sourceDataset
    */
-  public Lineage computeLineage(final DatasetId sourceDataset, long startMillis, long endMillis,
+  public Lineage computeLineage(DatasetId sourceDataset, long startMillis, long endMillis,
                                 int levels, String rollup) {
     return doComputeLineage(sourceDataset, startMillis, endMillis, levels, rollup);
   }
@@ -104,145 +107,58 @@ public class LineageAdmin {
    * @param levels number of levels to compute lineage for
    * @return lineage for sourceDataset
    */
-  public Lineage computeLineage(final DatasetId sourceDataset, long startMillis, long endMillis, int levels) {
+  public Lineage computeLineage(DatasetId sourceDataset, long startMillis, long endMillis, int levels) {
     return doComputeLineage(sourceDataset, startMillis, endMillis, levels, null);
   }
 
-  @Nullable
-  private ProgramRunId getWorkflowProgramRunid (Relation relation, Map<ProgramRunId,
-    RunRecordMeta> runRecordMap, Map<String, ProgramRunId> workflowIdMap) {
-    ProgramRunId workflowProgramRunId = null;
-
-    RunRecordMeta runRecord = runRecordMap.get(
-      new ProgramRunId(relation.getProgram().getNamespace(), relation.getProgram().getApplication(),
-                       relation.getProgram().getType(), relation.getProgram().getProgram(),
-                       relation.getRun().getId()));
-    if (runRecord != null
-      && runRecord.getProperties().containsKey("workflowrunid")) {
-      String workflowRunId = runRecord.getProperties().get("workflowrunid");
-      workflowProgramRunId = workflowIdMap.get(workflowRunId);
-    }
-    return workflowProgramRunId;
-  }
-
-  private Multimap<RelationKey, Relation> getRollupRelations(Multimap<RelationKey, Relation> relations,
-                                                             Map<ProgramRunId, RunRecordMeta> runRecordMap,
-                                                             Map<String, ProgramRunId> workflowIdMap) {
-
-    Multimap<RelationKey, Relation> relationsNew = HashMultimap.create();
-    for (Map.Entry<RelationKey, Collection<Relation>> entry : relations.asMap().entrySet()) {
-      for (Relation relation : entry.getValue()) {
-        ProgramRunId workflowProgramRunId = getWorkflowProgramRunid(relation, runRecordMap, workflowIdMap);
-        if (workflowProgramRunId == null) {
-          relationsNew.put(entry.getKey(), relation);
-        } else {
-          ProgramId workflowProgramId = new ProgramId(workflowProgramRunId.getNamespace(),
-                                                        workflowProgramRunId.getApplication(),
-                                                        workflowProgramRunId.getType(),
-                                                        workflowProgramRunId.getProgram());
-
-          NamespacedEntityId data = relation.getData();
-          if (!(data instanceof DatasetId)) {
-            // This shouldn't happen
-            throw new IllegalStateException("Unknown data type " + data);
-          }
-          Relation workflowRelation = new Relation((DatasetId) data, workflowProgramId,
-                                                   relation.getAccess(),
-                                                   RunIds.fromString(workflowProgramRunId.getRun()));
-          relationsNew.put(entry.getKey(), workflowRelation);
-        }
-      }
-    }
-    return relationsNew;
-  }
-
-  private Set<String> getWorkflowIds(Multimap<RelationKey, Relation> relations,
-                                     Map<ProgramRunId, RunRecordMeta> runRecordMap) {
-
-    final Set<String> workflowIDs = new HashSet<>();
-    for (Relation relation : Iterables.concat(relations.values())) {
-      RunRecordMeta runRecord = runRecordMap.get(
-        new ProgramRunId(relation.getProgram().getNamespace(), relation.getProgram().getApplication(),
-                         relation.getProgram().getType(), relation.getProgram().getProgram(),
-                         relation.getRun().getId()));
-      if (runRecord != null && runRecord.getProperties().containsKey("workflowrunid")) {
-        String workflowRunId = runRecord.getProperties().get("workflowrunid");
-        workflowIDs.add(workflowRunId);
-      }
-    }
-
-    return workflowIDs;
-  }
-
-  private Multimap<RelationKey, Relation> doComputeRollupLineage(Multimap<RelationKey, Relation> relations) {
-
-    // Make a set of all ProgramIDs in the relations
-    Set<ProgramRunId> programRunIdSet = new HashSet<>();
-    for (Relation relation : Iterables.concat(relations.values())) {
-      programRunIdSet.add(new ProgramRunId(relation.getProgram().getNamespace(), relation.getProgram().getApplication(),
-                                        relation.getProgram().getType(), relation.getProgram().getProgram(),
-                                        relation.getRun().getId()));
-    }
-
-    // Get RunRecordMeta for all these ProgramRunIDs
-    final Map<ProgramRunId, RunRecordMeta> runRecordMap = store.getRuns(programRunIdSet);
-
-    // Get workflow Run IDs for all the programs in the relations
-    final Set<String> workflowIDs = getWorkflowIds(relations, runRecordMap);
-
-    // Get Program IDs for workflow Run IDs
-    // TODO: These scans could be expensive. CDAP-7571.
-    Map<ProgramRunId, RunRecordMeta> workflowRunRecordMap =
-      store.getRuns(ProgramRunStatus.ALL,
-                    input ->  workflowIDs.contains(input.getPid()));
-
-    // Create a map from RunId to ProgramId for all workflows
-    Map<String, ProgramRunId> workflowIdMap = new HashMap<>();
-    for (Map.Entry<ProgramRunId, RunRecordMeta> entry : workflowRunRecordMap.entrySet()) {
-      workflowIdMap.put(entry.getValue().getPid(), entry.getKey());
-    }
-
-    // For all relations, replace ProgramIds with workflow ProgramIds
-    return getRollupRelations(relations, runRecordMap, workflowIdMap);
-  }
-
-  private Lineage doComputeLineage(final NamespacedEntityId sourceData,
+  private Lineage doComputeLineage(DatasetId sourceData,
                                    long startMillis, long endMillis,
                                    int levels, @Nullable String rollup) {
     LOG.trace("Computing lineage for data {}, startMillis {}, endMillis {}, levels {}",
               sourceData, startMillis, endMillis, levels);
+    boolean rollUpWorkflow = rollup != null && rollup.contains("workflow");
 
     // Convert start time and end time period into scan keys in terms of program start times.
     Set<RunId> runningInRange = store.getRunningInRange(TimeUnit.MILLISECONDS.toSeconds(startMillis),
                                                         TimeUnit.MILLISECONDS.toSeconds(endMillis));
-    if (LOG.isTraceEnabled()) {
-      LOG.trace("Got {} rundIds in time range ({}, {})", runningInRange.size(), startMillis, endMillis);
-    }
+    LOG.trace("Got {} rundIds in time range ({}, {})", runningInRange.size(), startMillis, endMillis);
 
     ScanRangeWithFilter scanRange = getScanRange(runningInRange);
     LOG.trace("Using scan start = {}, scan end = {}", scanRange.getStart(), scanRange.getEnd());
 
     Multimap<RelationKey, Relation> relations = HashMultimap.create();
-    Set<NamespacedEntityId> visitedDatasets = new HashSet<>();
-    Set<NamespacedEntityId> toVisitDatasets = new HashSet<>();
+    Set<DatasetId> visitedDatasets = new HashSet<>();
+    Set<DatasetId> toVisitDatasets = new HashSet<>();
     Set<ProgramId> visitedPrograms = new HashSet<>();
     Set<ProgramId> toVisitPrograms = new HashSet<>();
+    // this map is to map the inner program run id to the workflow run id, this is needed to collapse the inner
+    // program and local datasets
+    Map<ProgramRunId, ProgramRunId> programWorkflowMap = new HashMap<>();
 
     toVisitDatasets.add(sourceData);
     for (int i = 0; i < levels; ++i) {
       LOG.trace("Level {}", i);
       toVisitPrograms.clear();
-      for (NamespacedEntityId d : toVisitDatasets) {
+      for (DatasetId d : toVisitDatasets) {
         if (visitedDatasets.add(d)) {
           LOG.trace("Visiting dataset {}", d);
-          // Fetch related programs
-          Iterable<Relation> programRelations = getProgramRelations(d, scanRange.getStart(), scanRange.getEnd(),
-                                                                    scanRange.getFilter());
+          // Fetch related programs, the programs will be the inner programs which access the datasets. For example,
+          // mapreduce or spark program in a workflow
+          Set<Relation> programRelations = lineageStoreReader.getRelations(d, scanRange.getStart(), scanRange.getEnd(),
+                                                                           scanRange.getFilter());
           LOG.trace("Got program relations {}", programRelations);
-          for (Relation relation : programRelations) {
-            relations.put(new RelationKey(relation), relation);
+
+          // if we want to roll up lineage for workflow, we need to figure out what workflow these programs are related
+          // to and find out all the inner programs of that workflow, the workflow run id can also be used to
+          // determine if a dataset is local dataset. The local dataset always ends with the workflow run id
+          if (rollUpWorkflow) {
+            computeWorkflowInnerPrograms(toVisitPrograms, programWorkflowMap, programRelations);
           }
-          Iterables.addAll(toVisitPrograms, Iterables.transform(programRelations, RELATION_TO_PROGRAM_FUNCTION));
+
+          // add to the relations, replace the inner program with the workflow using the map, ignore the
+          // local datasets relations, the local dataset always ends with the run id of the workflow
+          filterAndAddRelations(rollUpWorkflow, relations, programWorkflowMap, programRelations);
+          toVisitPrograms.addAll(programRelations.stream().map(Relation::getProgram).collect(Collectors.toSet()));
         }
       }
 
@@ -251,35 +167,133 @@ public class LineageAdmin {
         if (visitedPrograms.add(p)) {
           LOG.trace("Visiting program {}", p);
           // Fetch related datasets
-          Iterable<Relation> datasetRelations = lineageStoreReader.getRelations(p, scanRange.getStart(),
-                                                                                scanRange.getEnd(),
-                                                                                scanRange.getFilter());
+          Set<Relation> datasetRelations = lineageStoreReader.getRelations(p, scanRange.getStart(),
+                                                                           scanRange.getEnd(), scanRange.getFilter());
           LOG.trace("Got data relations {}", datasetRelations);
-          for (Relation relation : datasetRelations) {
-            relations.put(new RelationKey(relation), relation);
-          }
-          Iterables.addAll(toVisitDatasets,
-                           Iterables.transform(datasetRelations, RELATION_TO_DATA_FUNCTION));
+          Set<DatasetId> localDatasets = filterAndAddRelations(rollUpWorkflow, relations,
+                                                               programWorkflowMap, datasetRelations);
+          toVisitDatasets.addAll(
+            datasetRelations.stream().map(relation -> (DatasetId) relation.getData())
+              .filter(datasetId -> !localDatasets.contains(datasetId)).collect(Collectors.toSet()));
         }
       }
     }
 
-    if (rollup != null && rollup.contains("workflow")) {
-      relations = doComputeRollupLineage(relations);
-    }
-
-    Lineage lineage = new Lineage(Iterables.concat(Maps.transformValues(relations.asMap(),
-                                                                        COLLAPSE_UNKNOWN_TYPE_FUNCTION).values()));
+    Lineage lineage = new Lineage(
+      Iterables.concat(Maps.transformValues(relations.asMap(), COLLAPSE_UNKNOWN_TYPE_FUNCTION::apply).values()));
     LOG.trace("Got lineage {}", lineage);
     return lineage;
   }
 
-  private Iterable<Relation> getProgramRelations(NamespacedEntityId data, long start, long end,
-                                                 Predicate<Relation> filter) {
-    if (!(data instanceof DatasetId)) {
-      throw new IllegalStateException("Unknown data type " + data);
+  /**
+   * Filter the relations based on the rollUp flag, if set to true, the method will replace the inner program with
+   * the workflow using the map and ignore the local datasets relations. The local dataset always ends with the run
+   * id of the workflow. The set of filtered local datasets is returned
+   */
+  private Set<DatasetId> filterAndAddRelations(boolean rollUpWorkflow, Multimap<RelationKey, Relation> relations,
+                                               Map<ProgramRunId, ProgramRunId> programWorkflowMap,
+                                               Set<Relation> relationss) {
+    Set<DatasetId> localDatasets = new HashSet<>();
+    for (Relation relation : relationss) {
+      if (rollUpWorkflow && programWorkflowMap.containsKey(relation.getProgramRunId())) {
+        ProgramRunId workflowId = programWorkflowMap.get(relation.getProgramRunId());
+        // skip the relation for local datasets, local datasets always end with the workflow run id
+        DatasetId data = (DatasetId) relation.getData();
+        if (data.getDataset().endsWith(workflowId.getRun())) {
+          localDatasets.add(data);
+          continue;
+        }
+        relation = new Relation(data, workflowId.getParent(), relation.getAccess(),
+                                RunIds.fromString(workflowId.getRun()));
+      }
+      relations.put(new RelationKey(relation), relation);
     }
-    return lineageStoreReader.getRelations((DatasetId) data, start, end, filter);
+    return localDatasets;
+  }
+
+  /**
+   * Compute the inner programs and program runs based on the program relations and add them to the collections.
+   *
+   * @param toVisitPrograms the collection of next to visit programs
+   * @param programWorkflowMap the program workflow run id map
+   * @param programRelations the program relations of the dataset
+   */
+  private void computeWorkflowInnerPrograms(Set<ProgramId> toVisitPrograms,
+                                            Map<ProgramRunId, ProgramRunId> programWorkflowMap,
+                                            Set<Relation> programRelations) {
+    // Step 1 walk through the program relations, filter out the possible mapreduce and spark programs that
+    // could be in the workflow, and get the appSpec for the program, to determine what other programs
+    // are in the workflow
+    Map<ApplicationId, ApplicationSpecification> appSpecs = new HashMap<>();
+    Set<ProgramRunId> possibleInnerPrograms = new HashSet<>();
+    programRelations.forEach(relation -> {
+      ProgramType type = relation.getProgram().getType();
+      if (type.equals(ProgramType.MAPREDUCE) || type.equals(ProgramType.SPARK)) {
+        possibleInnerPrograms.add(relation.getProgramRunId());
+        appSpecs.computeIfAbsent(relation.getProgram().getParent(), store::getApplication);
+      }
+    });
+
+    // Step 2, get the run record for all the possible inner programs, the run record contains the
+    // workflow information, fetch the workflow id and add them to the map
+    Map<ProgramRunId, RunRecordMeta> runRecords = store.getRuns(possibleInnerPrograms);
+    Set<ProgramRunId> workflowRunIds = new HashSet<>();
+    runRecords.entrySet().stream()
+      .filter(e -> e.getValue() != null)
+      .forEach(entry -> {
+        ProgramRunId programRunId = entry.getKey();
+        RunRecordMeta runRecord = entry.getValue();
+
+        if (runRecord.getSystemArgs().containsKey(ProgramOptionConstants.WORKFLOW_RUN_ID)) {
+          ProgramRunId wfRunId = extractWorkflowRunId(programRunId, runRecord);
+          programWorkflowMap.put(programRunId, wfRunId);
+          workflowRunIds.add(wfRunId);
+        }
+      }
+    );
+
+    // Step 3, fetch run records of the workflow, the properties of the workflow run record has all
+    // the inner program run ids, compare them with the app spec to get the type of the program
+    runRecords = store.getRuns(workflowRunIds);
+    runRecords.entrySet().stream()
+      .filter(e -> e.getValue() != null)
+      .forEach(entry -> {
+        ProgramRunId programRunId = entry.getKey();
+        RunRecordMeta runRecord = entry.getValue();
+        extractAndAddInnerPrograms(toVisitPrograms, programWorkflowMap, appSpecs, programRunId, runRecord);
+      });
+  }
+
+  private ProgramRunId extractWorkflowRunId(ProgramRunId programRunId, RunRecordMeta runRecord) {
+    Map<String, String> systemArgs = runRecord.getSystemArgs();
+    String workflowRunId = systemArgs.get(ProgramOptionConstants.WORKFLOW_RUN_ID);
+    String workflowName = systemArgs.get(ProgramOptionConstants.WORKFLOW_NAME);
+    WorkflowId workflowId = programRunId.getParent().getParent().workflow(workflowName);
+    return workflowId.run(workflowRunId);
+  }
+
+  /**
+   * Extract inner programs and runs from the workflow run record, the run record's properties have all the
+   * inner program run ids. The workflow spec can then be used to determine what the inner programs are and
+   * create the program run ids for them
+   */
+  private void extractAndAddInnerPrograms(Set<ProgramId> toVisitPrograms,
+                                          Map<ProgramRunId, ProgramRunId> programWorkflowMap,
+                                          Map<ApplicationId, ApplicationSpecification> appSpecs,
+                                          ProgramRunId programRunId, RunRecordMeta wfRunRecord) {
+    ApplicationId appId = programRunId.getParent().getParent();
+    WorkflowSpecification workflowSpec =
+      appSpecs.get(appId).getWorkflows().get(programRunId.getProgram());
+    Map<String, WorkflowNode> nodeIdMap = workflowSpec.getNodeIdMap();
+    wfRunRecord.getProperties().forEach((key, value) -> {
+      if (nodeIdMap.containsKey(key)) {
+        WorkflowActionNode node = (WorkflowActionNode) nodeIdMap.get(key);
+        ProgramType type = ProgramType.valueOf(node.getProgram().getProgramType().name());
+        ProgramId program = appId.program(type, key);
+        programWorkflowMap.put(program.run(value), programRunId);
+        toVisitPrograms.add(program);
+      }
+    });
   }
 
   /**
@@ -370,6 +384,10 @@ public class LineageAdmin {
     @Override
     public int hashCode() {
       return hashCode;
+    }
+
+    public Relation getRelation() {
+      return relation;
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/LineageTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/LineageTable.java
@@ -337,6 +337,6 @@ public class LineageTable {
     ProgramId program = getProgramFromRow(row);
     LOG.trace("Got program {}", program);
 
-    return new Relation(datasetInstance, program, accessType, runId, Collections.emptySet());
+    return new Relation(datasetInstance, program, accessType, runId);
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/Relation.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/Relation.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespacedEntityId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.RunId;
 
 import java.util.Collections;
@@ -35,18 +36,16 @@ public class Relation {
   private final AccessType access;
   private final RunId run;
   private final Set<NamespacedEntityId> components;
+  // Don't serialize this id
+  private final transient ProgramRunId runId;
 
   public Relation(DatasetId data, ProgramId program, AccessType access, RunId run) {
-    this(data, program, access, run, Collections.<NamespacedEntityId>emptySet());
-  }
-
-  public Relation(DatasetId data, ProgramId program, AccessType access, RunId run,
-                  Set<? extends NamespacedEntityId> components) {
     this.data = data;
     this.program = program;
     this.access = access;
     this.run = run;
-    this.components = ImmutableSet.copyOf(components);
+    this.components = Collections.emptySet();
+    this.runId = program.run(run);
   }
 
   public NamespacedEntityId getData() {
@@ -67,6 +66,10 @@ public class Relation {
 
   public Set<NamespacedEntityId> getComponents() {
     return components;
+  }
+
+  public ProgramRunId getProgramRunId() {
+    return runId;
   }
 
   @Override


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15206
Build: https://builds.cask.co/browse/CDAP-DUT7034-2

This pr removes local datasets and correctly rolls up the lineage for workflow. It also refactors the code to avoid a full scan on all the run records, and removes some complicated logic around determine the workflow run id. The detailed design can be seen in the JIRA