### PR TITLE
CDAP-15782 fill in field lineage for data pipeline

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/FieldLineageProcessor.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/FieldLineageProcessor.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.lineage.field.Operation;
+import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
+import io.cdap.cdap.etl.common.FieldOperationTypeAdapter;
+import io.cdap.cdap.etl.proto.v2.spec.PipelineSpec;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Field lineage processor to validate the stage operations and convert the pipeline level operations to platform
+ * level operations
+ * TODO: CDAP-15871 move the field operation related classes to etl-core when supporting realtime pipeline
+ */
+public class FieldLineageProcessor {
+  private static final Logger LOG = LoggerFactory.getLogger(FieldLineageProcessor.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(FieldOperation.class, new FieldOperationTypeAdapter()).create();
+
+  private final PipelineSpec pipelineSpec;
+
+  public FieldLineageProcessor(PipelineSpec pipelineSpec) {
+    this.pipelineSpec = pipelineSpec;
+  }
+
+  public Set<Operation> validateAndConvert(Map<String, List<FieldOperation>> allStageOperations) {
+    Map<String, List<FieldOperation>> allOperations = new HashMap<>(allStageOperations);
+    // Set of stages for which no implicit merge operation is required even if
+    // stage has multiple inputs, for example join stages
+    Set<String> noMergeRequiredStages = new HashSet<>();
+    for (StageSpec stageSpec : pipelineSpec.getStages()) {
+      if (BatchJoiner.PLUGIN_TYPE.equals(stageSpec.getPlugin().getType())) {
+        noMergeRequiredStages.add(stageSpec.getName());
+      }
+    }
+
+    // validate the stage operations
+    Map<String, InvalidFieldOperations> stageInvalids = new HashMap<>();
+    for (StageSpec stageSpec : pipelineSpec.getStages()) {
+
+      Map<String, Schema> inputSchemas = stageSpec.getInputSchemas();
+      // If current stage is of type JOIN add fields as inputstageName.fieldName
+      List<String> stageInputs = new ArrayList<>();
+      List<String> stageOutputs = new ArrayList<>();
+      if (BatchJoiner.PLUGIN_TYPE.equals(stageSpec.getPlugin().getType())) {
+        for (Map.Entry<String, Schema> entry : inputSchemas.entrySet()) {
+          if (entry.getValue().getFields() != null) {
+            stageInputs.addAll(entry.getValue().getFields()
+                                 .stream().map(field -> entry.getKey() + "." + field.getName())
+                                 .collect(Collectors.toList()));
+          }
+        }
+      } else {
+        for (Map.Entry<String, Schema> entry : inputSchemas.entrySet()) {
+          if (entry.getValue().getFields() != null) {
+            stageInputs.addAll(entry.getValue().getFields().stream().map(Schema.Field::getName)
+                                 .collect(Collectors.toList()));
+          }
+        }
+      }
+
+      Schema outputSchema = stageSpec.getOutputSchema();
+      if (outputSchema != null && outputSchema.getFields() != null) {
+        stageOutputs.addAll(outputSchema.getFields().stream().map(Schema.Field::getName)
+                              .collect(Collectors.toList()));
+      }
+
+      String stageName = stageSpec.getName();
+      // only auto generate for stages that have input and output schema
+      if (!stageInputs.isEmpty() && !stageOutputs.isEmpty()) {
+        allOperations.compute(stageName, (stage, fieldOperations) -> {
+          // if the field operations are empty for a stage, auto generate it for the stages that have input schema and
+          // output schema
+          if (fieldOperations == null || fieldOperations.isEmpty()) {
+            return  Collections.singletonList(new FieldTransformOperation("Transform", "",
+                                                                          stageInputs, stageOutputs));
+          }
+          return fieldOperations;
+        });
+      }
+
+      List<FieldOperation> fieldOperations = allOperations.computeIfAbsent(stageName, stage -> Collections.emptyList());
+      StageOperationsValidator.Builder builder = new StageOperationsValidator.Builder(fieldOperations);
+      builder.addStageInputs(stageInputs);
+      builder.addStageOutputs(stageOutputs);
+      StageOperationsValidator stageOperationsValidator = builder.build();
+      stageOperationsValidator.validate();
+      LOG.trace("Stage Name: {}", stageName);
+      LOG.trace("Stage Operations {}", GSON.toJson(fieldOperations));
+      LOG.trace("Stage inputs: {}", stageInputs);
+      LOG.trace("Stage outputs: {}", stageOutputs);
+      InvalidFieldOperations invalidFieldOperations = stageOperationsValidator.getStageInvalids();
+      if (invalidFieldOperations != null) {
+        stageInvalids.put(stageName, invalidFieldOperations);
+      }
+    }
+
+    if (!stageInvalids.isEmpty()) {
+      // Do not throw but just log the exception message for validation failure
+      // Once most of the plugins are updated to write lineage exception can be thrown
+      LOG.debug(new InvalidLineageException(stageInvalids).getMessage());
+      return Collections.emptySet();
+    }
+
+    LineageOperationsProcessor processor = new LineageOperationsProcessor(pipelineSpec.getConnections(),
+                                                                          allOperations, noMergeRequiredStages);
+
+    return processor.process();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/FieldLineageProcessorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/FieldLineageProcessorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.lineage.field.EndPoint;
+import io.cdap.cdap.api.lineage.field.InputField;
+import io.cdap.cdap.api.lineage.field.Operation;
+import io.cdap.cdap.api.lineage.field.ReadOperation;
+import io.cdap.cdap.api.lineage.field.TransformOperation;
+import io.cdap.cdap.api.lineage.field.WriteOperation;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
+import io.cdap.cdap.etl.api.lineage.field.FieldReadOperation;
+import io.cdap.cdap.etl.api.lineage.field.FieldWriteOperation;
+import io.cdap.cdap.etl.proto.Connection;
+import io.cdap.cdap.etl.proto.v2.spec.PipelineSpec;
+import io.cdap.cdap.etl.proto.v2.spec.PluginSpec;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FieldLineageProcessorTest {
+  private static final PluginSpec DUMMY_PLUGIN =
+    new PluginSpec("dummy", "src", ImmutableMap.of(),
+                   new ArtifactId("dummy", new ArtifactVersion("1.0.0"), ArtifactScope.USER));
+
+  @Test
+  public void testGeneratedOperations() throws Exception {
+    // src -> transform1 -> transform2 -> sink
+    Schema srcSchema = Schema.recordOf("srcSchema",
+                                       Schema.Field.of("body", Schema.of(Schema.Type.STRING)),
+                                       Schema.Field.of("offset", Schema.of(Schema.Type.INT)));
+    Schema transform1Schema = Schema.recordOf("trans1Schema",
+                                              Schema.Field.of("body", Schema.of(Schema.Type.STRING)));
+    Schema transform2Schema = Schema.recordOf("trans2Schema",
+                                              Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                              Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    Set<StageSpec> stageSpecs = ImmutableSet.of(
+      StageSpec.builder("src", DUMMY_PLUGIN)
+        .addOutput(srcSchema, "transform1")
+        .build(),
+      StageSpec.builder("transform1", DUMMY_PLUGIN)
+        .addInputSchema("src", srcSchema)
+        .addOutput(transform1Schema, "transform2")
+        .build(),
+      StageSpec.builder("transform2", DUMMY_PLUGIN)
+        .addInputSchema("transform1", transform1Schema)
+        .addOutput(transform2Schema, "sink")
+        .build(),
+      StageSpec.builder("sink", DUMMY_PLUGIN)
+        .addInputSchema("transform2", transform2Schema)
+        .build()
+    );
+
+    Set<Connection> connections = ImmutableSet.of(
+      new Connection("src", "transform1"),
+      new Connection("transform1", "transform2"),
+      new Connection("transform2", "sink"));
+
+    PipelineSpec pipelineSpec = PipelineSpec.builder().addStages(stageSpecs).addConnections(connections).build();
+
+    FieldLineageProcessor processor = new FieldLineageProcessor(pipelineSpec);
+
+    Map<String, List<FieldOperation>> fieldOperations =
+      ImmutableMap.of("src", Collections.singletonList(
+        new FieldReadOperation("Read", "1st operation", EndPoint.of("file"), ImmutableList.of("body", "offset"))),
+                      "transform1", Collections.emptyList(),
+                      "transform2", Collections.emptyList(),
+                      "sink", Collections.singletonList(
+          new FieldWriteOperation("Write", "4th operation", EndPoint.of("sink"), ImmutableList.of("id", "name"))));
+    Set<Operation> operations = processor.validateAndConvert(fieldOperations);
+
+    Set<Operation> expected = ImmutableSet.of(
+      new ReadOperation("src.Read", "1st operation", EndPoint.of("file"), ImmutableList.of("body", "offset")),
+      new TransformOperation("transform1.Transform", "",
+                             ImmutableList.of(InputField.of("src.Read", "body"),
+                                              InputField.of("src.Read", "offset")), "body"),
+      new TransformOperation("transform2.Transform", "",
+                             ImmutableList.of(InputField.of("transform1.Transform", "body")),
+                             ImmutableList.of("id", "name")),
+      new WriteOperation("sink.Write", "4th operation", EndPoint.of("sink"),
+                         ImmutableList.of(InputField.of("transform2.Transform", "id"),
+                                          InputField.of("transform2.Transform", "name"))));
+    Assert.assertEquals(expected, operations);
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15782
build: https://builds.cask.co/browse/CDAP-DUT7041-1

This adds FLL for stages that have input and output schemas but are not instrumented, for streaming source we do not have the logic to write FLL yet. Should be added together when we support it. For unit test, currently we don't have e2e test for FLL, opened this JIRA to track https://issues.cask.co/browse/CDAP-15783