### PR TITLE
CDAP-15757 fix k8s and standalone packaging to exclude commons-logging

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -814,10 +814,10 @@
                 <goals>
                   <goal>copy-dependencies</goal>
                 </goals>
-                <configuration combine.self="append">
-                  <excludeGroupIds>org.apache.hadoop,org.apache.hbase,org.apache.hive,com.google.protobuf,\
-                    org.datanucleus,asm,org.apache.spark,slf4j-log4j12,org.scala-lang,org.apache.kafka,\
-                    commons-logging</excludeGroupIds>
+                <configuration>
+                  <excludeGroupIds>
+                    ${dependency.groupId.exclusions},org.scala-lang,org.apache.kafka
+                  </excludeGroupIds>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -476,7 +476,7 @@
                   <overWriteReleases>false</overWriteReleases>
                   <overWriteSnapshots>false</overWriteSnapshots>
                   <overWriteIfNewer>true</overWriteIfNewer>
-                  <excludeGroupIds>org.apache.hbase,asm,org.apache.kafka,org.scala-lang</excludeGroupIds>
+                  <excludeGroupIds>org.apache.hbase,asm,org.apache.kafka,org.scala-lang,commons-logging</excludeGroupIds>
                   <excludeArtifactIds>zkclient,servlet-api,cdap-cli,cdap-explore-jdbc</excludeArtifactIds>
                   <prependGroupId>true</prependGroupId>
                   <silent>true</silent>

--- a/pom.xml
+++ b/pom.xml
@@ -2001,6 +2001,8 @@
         <package.rpm.arch>all</package.rpm.arch>
         <package.dirs>opt etc</package.dirs>
         <package.config.dirs>--config-files etc/cdap --config-files etc/logrotate.d --config-files etc/security</package.config.dirs>
+        <dependency.groupId.exclusions>org.apache.hadoop,org.apache.hbase,org.apache.hive,com.google.protobuf,\
+          org.datanucleus,asm,org.apache.spark,slf4j-log4j12,commons-logging</dependency.groupId.exclusions>
       </properties>
       <build>
         <pluginManagement>
@@ -2040,8 +2042,7 @@
                     <overWriteReleases>false</overWriteReleases>
                     <overWriteSnapshots>false</overWriteSnapshots>
                     <overWriteIfNewer>true</overWriteIfNewer>
-                    <excludeGroupIds>org.apache.hadoop,org.apache.hbase,org.apache.hive,com.google.protobuf,\
-                      org.datanucleus,asm,org.apache.spark,slf4j-log4j12,commons-logging</excludeGroupIds>
+                    <excludeGroupIds>${dependency.groupId.exclusions}</excludeGroupIds>
                     <excludeArtifactIds>hive-exec,jackson-core-asl,jackson-mapper-asl</excludeArtifactIds>
                     <prependGroupId>true</prependGroupId>
                     <silent>true</silent>


### PR DESCRIPTION
This fixes a logging issue for remote workflow runs where only logs from
the workflow driver were available. Removing commons-logging allows
the slf4j jcl bridge to get packaged in the application jar, which
correctly sets up the logging for the YARN apps.