### PR TITLE
Fix HBase Compat module for HBase 1.0 CDH

### DIFF
--- a/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHDeleteBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHDeleteBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Delete;
+
+/**
+ * HBase 1.0 specific implementation for {@link DeleteBuilder}.
+ */
+class HBase10CDHDeleteBuilder extends DefaultDeleteBuilder {
+
+  HBase10CDHDeleteBuilder(byte[] row) {
+    super(row);
+  }
+
+  HBase10CDHDeleteBuilder(Delete delete) {
+    super(delete);
+  }
+
+  @Override
+  public DeleteBuilder setAttribute(String name, byte[] value) {
+    delete.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setId(String id) {
+    delete.setId(id);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setTimestamp(long timestamp) {
+    delete.setTimestamp(timestamp);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHGetBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHGetBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Get;
+
+/**
+ * HBase 1.0 specific implementation for {@link GetBuilder}.
+ */
+class HBase10CDHGetBuilder extends DefaultGetBuilder {
+
+  HBase10CDHGetBuilder(byte[] row) {
+    super(row);
+  }
+
+  HBase10CDHGetBuilder(Get get) {
+    super(get);
+  }
+
+  @Override
+  public GetBuilder setCheckExistenceOnly(boolean checkExistenceOnly) {
+    get.setCheckExistenceOnly(checkExistenceOnly);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setClosestRowBefore(boolean closestRowBefore) {
+    get.setClosestRowBefore(closestRowBefore);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setAttribute(String name, byte[] value) {
+    get.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setCacheBlocks(boolean cacheBlocks) {
+    get.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setId(String id) {
+    get.setId(id);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHHTableDescriptorBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHHTableDescriptorBuilder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ *
+ */
+public class HBase10CDHHTableDescriptorBuilder extends HTableDescriptorBuilder {
+
+  HBase10CDHHTableDescriptorBuilder(TableName tableName) {
+    super(tableName);
+  }
+
+  HBase10CDHHTableDescriptorBuilder(HTableDescriptor toCopy) {
+    super(toCopy);
+  }
+
+  /* Methods whose signature changed in HBase 1.0 due to HBASE-10841 */
+  @Override
+  public HTableDescriptorBuilder setValue(byte[] key, byte[] value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder setValue(String key, String value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addFamily(HColumnDescriptor columnDescriptor) {
+    instance.addFamily(columnDescriptor);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addCoprocessor(String className) throws IOException {
+    instance.addCoprocessor(className);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addCoprocessor(String className, Path jarFilePath, int priority,
+                                                Map<String, String> keyValues) throws IOException {
+    instance.addCoprocessor(className, jarFilePath, priority, keyValues);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHIncrementBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHIncrementBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+/**
+ * HBase 1.0 specific implementation for {@link PutBuilder}.
+ */
+class HBase10CDHIncrementBuilder extends DefaultIncrementBuilder {
+
+  HBase10CDHIncrementBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public IncrementBuilder setAttribute(String name, byte[] value) {
+    increment.setAttribute(name, value);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHPutBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHPutBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Put;
+
+/**
+ * HBase 1.0 specific implementation for {@link PutBuilder}.
+ */
+class HBase10CDHPutBuilder extends DefaultPutBuilder {
+
+  HBase10CDHPutBuilder(Put put) {
+    super(put);
+  }
+
+  HBase10CDHPutBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public PutBuilder setAttribute(String name, byte[] value) {
+    put.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder setId(String id) {
+    put.setId(id);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHScanBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHScanBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.IsolationLevel;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.apache.hadoop.hbase.security.visibility.Authorizations;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * HBase 1.0 specific implementation for {@link ScanBuilder}.
+ */
+public class HBase10CDHScanBuilder extends DefaultScanBuilder {
+
+  public HBase10CDHScanBuilder() {
+    super();
+  }
+
+  HBase10CDHScanBuilder(Scan other) throws IOException {
+    super(other);
+  }
+
+  @Override
+  public ScanBuilder setAttribute(String name, byte[] value) {
+    scan.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setId(String id) {
+    scan.setId(id);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setAuthorizations(Authorizations authorizations) {
+    scan.setAuthorizations(authorizations);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(String user, Permission perms) {
+    scan.setACL(user, perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(Map<String, Permission> perms) {
+    scan.setACL(perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setBatch(int batch) {
+    scan.setBatch(batch);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCacheBlocks(boolean cacheBlocks) {
+    scan.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCaching(int caching) {
+    scan.setCaching(caching);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setIsolationLevel(IsolationLevel level) {
+    scan.setIsolationLevel(level);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setLoadColumnFamiliesOnDemand(boolean value) {
+    scan.setLoadColumnFamiliesOnDemand(value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultSize(long maxResultSize) {
+    scan.setMaxResultSize(maxResultSize);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultsPerColumnFamily(int limit) {
+    scan.setMaxResultsPerColumnFamily(limit);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRaw(boolean raw) {
+    scan.setRaw(raw);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRowOffsetPerColumnFamily(int offset) {
+    scan.setRowOffsetPerColumnFamily(offset);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setSmall(boolean small) {
+    scan.setSmall(small);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHTableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDHTableUtil.java
@@ -34,7 +34,11 @@ import org.apache.hadoop.hbase.NamespaceNotFoundException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.security.access.AccessControlClient;
 import org.slf4j.Logger;
@@ -53,13 +57,13 @@ public class HBase10CDHTableUtil extends HBaseTableUtil {
   @Override
   public HTableDescriptorBuilder buildHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptorBuilder(HTableNameConverter.toTableName(tablePrefix, tableId));
+    return new HBase10CDHHTableDescriptorBuilder(HTableNameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public HTableDescriptorBuilder buildHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
     Preconditions.checkArgument(tableDescriptorToCopy != null, "Table descriptor should not be null");
-    return new HTableDescriptorBuilder(tableDescriptorToCopy);
+    return new HBase10CDHHTableDescriptorBuilder(tableDescriptorToCopy);
   }
 
   @Override
@@ -240,5 +244,50 @@ public class HBase10CDHTableUtil extends HBaseTableUtil {
   @Override
   public Class<? extends Coprocessor> getPayloadTableRegionObserverClassForVersion() {
     return PayloadTableRegionObserver.class;
+  }
+
+  @Override
+  public ScanBuilder buildScan() {
+    return new HBase10CDHScanBuilder();
+  }
+
+  @Override
+  public ScanBuilder buildScan(Scan scan) throws IOException {
+    return new HBase10CDHScanBuilder(scan);
+  }
+
+  @Override
+  public IncrementBuilder buildIncrement(byte[] row) {
+    return new HBase10CDHIncrementBuilder(row);
+  }
+
+  @Override
+  public PutBuilder buildPut(byte[] row) {
+    return new HBase10CDHPutBuilder(row);
+  }
+
+  @Override
+  public PutBuilder buildPut(Put put) {
+    return new HBase10CDHPutBuilder(put);
+  }
+
+  @Override
+  public GetBuilder buildGet(byte[] row) {
+    return new HBase10CDHGetBuilder(row);
+  }
+
+  @Override
+  public GetBuilder buildGet(Get get) {
+    return new HBase10CDHGetBuilder(get);
+  }
+
+  @Override
+  public DeleteBuilder buildDelete(byte[] row) {
+    return new HBase10CDHDeleteBuilder(row);
+  }
+
+  @Override
+  public DeleteBuilder buildDelete(Delete delete) {
+    return new HBase10CDHDeleteBuilder(delete);
   }
 }

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550DeleteBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550DeleteBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Delete;
+
+/**
+ * HBase 1.0 specific implementation for {@link DeleteBuilder}.
+ */
+class HBase10CDH550DeleteBuilder extends DefaultDeleteBuilder {
+
+  HBase10CDH550DeleteBuilder(byte[] row) {
+    super(row);
+  }
+
+  HBase10CDH550DeleteBuilder(Delete delete) {
+    super(delete);
+  }
+
+  @Override
+  public DeleteBuilder setAttribute(String name, byte[] value) {
+    delete.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setId(String id) {
+    delete.setId(id);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setTimestamp(long timestamp) {
+    delete.setTimestamp(timestamp);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550GetBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550GetBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Get;
+
+/**
+ * HBase 1.0 specific implementation for {@link GetBuilder}.
+ */
+class HBase10CDH550GetBuilder extends DefaultGetBuilder {
+
+  HBase10CDH550GetBuilder(byte[] row) {
+    super(row);
+  }
+
+  HBase10CDH550GetBuilder(Get get) {
+    super(get);
+  }
+
+  @Override
+  public GetBuilder setCheckExistenceOnly(boolean checkExistenceOnly) {
+    get.setCheckExistenceOnly(checkExistenceOnly);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setClosestRowBefore(boolean closestRowBefore) {
+    get.setClosestRowBefore(closestRowBefore);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setAttribute(String name, byte[] value) {
+    get.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setCacheBlocks(boolean cacheBlocks) {
+    get.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setId(String id) {
+    get.setId(id);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550HTableDescriptorBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550HTableDescriptorBuilder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ *
+ */
+public class HBase10CDH550HTableDescriptorBuilder extends HTableDescriptorBuilder {
+
+  HBase10CDH550HTableDescriptorBuilder(TableName tableName) {
+    super(tableName);
+  }
+
+  HBase10CDH550HTableDescriptorBuilder(HTableDescriptor toCopy) {
+    super(toCopy);
+  }
+
+  /* Methods whose signature changed in HBase 1.0 due to HBASE-10841 */
+  @Override
+  public HTableDescriptorBuilder setValue(byte[] key, byte[] value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder setValue(String key, String value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addFamily(HColumnDescriptor columnDescriptor) {
+    instance.addFamily(columnDescriptor);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addCoprocessor(String className) throws IOException {
+    instance.addCoprocessor(className);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addCoprocessor(String className, Path jarFilePath, int priority,
+                                                Map<String, String> keyValues) throws IOException {
+    instance.addCoprocessor(className, jarFilePath, priority, keyValues);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550IncrementBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550IncrementBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+/**
+ * HBase 1.0 specific implementation for {@link PutBuilder}.
+ */
+class HBase10CDH550IncrementBuilder extends DefaultIncrementBuilder {
+
+  HBase10CDH550IncrementBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public IncrementBuilder setAttribute(String name, byte[] value) {
+    increment.setAttribute(name, value);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550PutBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550PutBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Put;
+
+/**
+ * HBase 1.0 specific implementation for {@link PutBuilder}.
+ */
+class HBase10CDH550PutBuilder extends DefaultPutBuilder {
+
+  HBase10CDH550PutBuilder(Put put) {
+    super(put);
+  }
+
+  HBase10CDH550PutBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public PutBuilder setAttribute(String name, byte[] value) {
+    put.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder setId(String id) {
+    put.setId(id);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550ScanBuilder.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550ScanBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.IsolationLevel;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.apache.hadoop.hbase.security.visibility.Authorizations;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * HBase 1.0 specific implementation for {@link ScanBuilder}.
+ */
+public class HBase10CDH550ScanBuilder extends DefaultScanBuilder {
+
+  public HBase10CDH550ScanBuilder() {
+    super();
+  }
+
+  HBase10CDH550ScanBuilder(Scan other) throws IOException {
+    super(other);
+  }
+
+  @Override
+  public ScanBuilder setAttribute(String name, byte[] value) {
+    scan.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setId(String id) {
+    scan.setId(id);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setAuthorizations(Authorizations authorizations) {
+    scan.setAuthorizations(authorizations);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(String user, Permission perms) {
+    scan.setACL(user, perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(Map<String, Permission> perms) {
+    scan.setACL(perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setBatch(int batch) {
+    scan.setBatch(batch);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCacheBlocks(boolean cacheBlocks) {
+    scan.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCaching(int caching) {
+    scan.setCaching(caching);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setIsolationLevel(IsolationLevel level) {
+    scan.setIsolationLevel(level);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setLoadColumnFamiliesOnDemand(boolean value) {
+    scan.setLoadColumnFamiliesOnDemand(value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultSize(long maxResultSize) {
+    scan.setMaxResultSize(maxResultSize);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultsPerColumnFamily(int limit) {
+    scan.setMaxResultsPerColumnFamily(limit);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRaw(boolean raw) {
+    scan.setRaw(raw);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRowOffsetPerColumnFamily(int offset) {
+    scan.setRowOffsetPerColumnFamily(offset);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setSmall(boolean small) {
+    scan.setSmall(small);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/io/cdap/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
@@ -34,7 +34,11 @@ import org.apache.hadoop.hbase.NamespaceNotFoundException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.security.access.AccessControlClient;
 import org.slf4j.Logger;
@@ -53,13 +57,13 @@ public class HBase10CDH550TableUtil extends HBaseTableUtil {
   @Override
   public HTableDescriptorBuilder buildHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptorBuilder(HTableNameConverter.toTableName(tablePrefix, tableId));
+    return new HBase10CDH550HTableDescriptorBuilder(HTableNameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public HTableDescriptorBuilder buildHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
     Preconditions.checkArgument(tableDescriptorToCopy != null, "Table descriptor should not be null");
-    return new HTableDescriptorBuilder(tableDescriptorToCopy);
+    return new HBase10CDH550HTableDescriptorBuilder(tableDescriptorToCopy);
   }
 
   @Override
@@ -240,5 +244,51 @@ public class HBase10CDH550TableUtil extends HBaseTableUtil {
   @Override
   public Class<? extends Coprocessor> getPayloadTableRegionObserverClassForVersion() {
     return PayloadTableRegionObserver.class;
+  }
+
+
+  @Override
+  public ScanBuilder buildScan() {
+    return new HBase10CDH550ScanBuilder();
+  }
+
+  @Override
+  public ScanBuilder buildScan(Scan scan) throws IOException {
+    return new HBase10CDH550ScanBuilder(scan);
+  }
+
+  @Override
+  public IncrementBuilder buildIncrement(byte[] row) {
+    return new HBase10CDH550IncrementBuilder(row);
+  }
+
+  @Override
+  public PutBuilder buildPut(byte[] row) {
+    return new HBase10CDH550PutBuilder(row);
+  }
+
+  @Override
+  public PutBuilder buildPut(Put put) {
+    return new HBase10CDH550PutBuilder(put);
+  }
+
+  @Override
+  public GetBuilder buildGet(byte[] row) {
+    return new HBase10CDH550GetBuilder(row);
+  }
+
+  @Override
+  public GetBuilder buildGet(Get get) {
+    return new HBase10CDH550GetBuilder(get);
+  }
+
+  @Override
+  public DeleteBuilder buildDelete(byte[] row) {
+    return new HBase10CDH550DeleteBuilder(row);
+  }
+
+  @Override
+  public DeleteBuilder buildDelete(Delete delete) {
+    return new HBase10CDH550DeleteBuilder(delete);
   }
 }


### PR DESCRIPTION
Tests ran locally and passed. The changes simple involving copying classes from existing HBase 1.0 compat modules, since the CDH one only has differences in the return type.