### PR TITLE
CDAP-15240 support fll for actions

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/customaction/CustomActionContext.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/customaction/CustomActionContext.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.SchedulableProgramContext;
 import io.cdap.cdap.api.ServiceDiscoverer;
 import io.cdap.cdap.api.Transactional;
 import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.lineage.field.LineageRecorder;
 import io.cdap.cdap.api.messaging.MessagingContext;
 import io.cdap.cdap.api.metadata.MetadataReader;
 import io.cdap.cdap.api.metadata.MetadataWriter;
@@ -34,7 +35,7 @@ import io.cdap.cdap.api.workflow.WorkflowInfoProvider;
  */
 public interface CustomActionContext extends SchedulableProgramContext, RuntimeContext, DatasetContext, Transactional,
   WorkflowInfoProvider, PluginContext, SecureStore, ServiceDiscoverer, MessagingContext, MetadataReader,
-  MetadataWriter {
+  MetadataWriter, LineageRecorder {
 
   /**
    * Return the specification of the custom action.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/DatasetFieldLineageSummary.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/DatasetFieldLineageSummary.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.metadata;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.annotations.SerializedName;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.id.DatasetId;
@@ -92,7 +93,8 @@ public class DatasetFieldLineageSummary {
     private final DatasetId datasetId;
     private final Set<FieldRelation> relations;
 
-    FieldLineageRelations(DatasetId datasetId, Set<FieldRelation> relations) {
+    @VisibleForTesting
+    public FieldLineageRelations(DatasetId datasetId, Set<FieldRelation> relations) {
       this.datasetId = datasetId;
       this.relations = relations;
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/FieldLineageAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/FieldLineageAdmin.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.metadata;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.lineage.field.EndPoint;
@@ -151,8 +150,9 @@ public class FieldLineageAdmin {
    * @return the summary which contains all the field level lineage information about all the fields in a dataset
    * @throws IOException if fails to get teh schema of the dataset
    */
-  DatasetFieldLineageSummary getDatasetFieldLineage(Constants.FieldLineage.Direction direction, EndPoint endPoint,
-                                                    long start, long end) throws IOException {
+  public DatasetFieldLineageSummary getDatasetFieldLineage(Constants.FieldLineage.Direction direction,
+                                                           EndPoint endPoint,
+                                                           long start, long end) throws IOException {
     Set<String> lineageFields = fieldLineageReader.getFields(endPoint, start, end);
     Map<DatasetId, Set<FieldRelation>> incomingRelations = new HashMap<>();
     Map<DatasetId, Set<FieldRelation>> outgoingRelations = new HashMap<>();

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/action/ActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/action/ActionContext.java
@@ -17,14 +17,22 @@
 package io.cdap.cdap.etl.api.action;
 
 import io.cdap.cdap.api.Transactional;
+import io.cdap.cdap.api.dataset.DatasetManagementException;
+import io.cdap.cdap.api.lineage.field.LineageRecorder;
 import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.api.security.store.SecureStoreManager;
 import io.cdap.cdap.etl.api.StageContext;
+import io.cdap.cdap.etl.api.lineage.AccessType;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
+import org.apache.tephra.TransactionFailureException;
+
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Represents the context available to the action plugin during runtime.
  */
-public interface ActionContext extends StageContext, Transactional, SecureStore, SecureStoreManager {
+public interface ActionContext extends StageContext, Transactional, SecureStore, SecureStoreManager, LineageRecorder {
 
   /**
    * Returns settable pipeline arguments. These arguments are shared by all pipeline stages, so plugins should be
@@ -35,4 +43,32 @@ public interface ActionContext extends StageContext, Transactional, SecureStore,
   @Override
   SettableArguments getArguments();
 
+  /**
+   * This method is based on the assumption that the plugin has an input schema or output schema and the DAG of the
+   * operations are known. Actions do not have input and output schema, and the DAG is unknown to us. Therefore,
+   * this method cannot be used to emit field lineage information.
+   *
+   * @param fieldOperations the operations to be recorded
+   * @deprecated use {@link #record(Collection)} to emit field operations for actions, that method requires the input
+   *             field to contain the previous originated operation name. Using that DAG can be computed so the field
+   *             linage can be computed.
+   */
+  @Override
+  @Deprecated
+  default void record(List<FieldOperation> fieldOperations) {
+    throw new UnsupportedOperationException("Lineage recording is not supported.");
+  }
+
+  /**
+   * Register lineage for this Spark program using the given reference name
+   *
+   * @param referenceName reference name used for source
+   * @param accessType the access type of the lineage
+   * @throws DatasetManagementException thrown if there was an error in creating reference dataset
+   * @throws TransactionFailureException thrown if there was an error while fetching the dataset to register usage
+   */
+ default void registerLineage(String referenceName,
+                              AccessType accessType) throws DatasetManagementException, TransactionFailureException {
+   // no-op
+ }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/lineage/AccessType.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/lineage/AccessType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.lineage;
+
+/**
+ * Lineage access type, only support READ and WRITE
+ */
+public enum AccessType {
+  READ,
+  WRITE
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/customaction/BasicActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/customaction/BasicActionContext.java
@@ -15,17 +15,30 @@
  */
 package io.cdap.cdap.etl.batch.customaction;
 
+import io.cdap.cdap.api.Admin;
+import io.cdap.cdap.api.Transactionals;
 import io.cdap.cdap.api.TxRunnable;
 import io.cdap.cdap.api.customaction.CustomActionContext;
+import io.cdap.cdap.api.dataset.Dataset;
+import io.cdap.cdap.api.dataset.DatasetManagementException;
+import io.cdap.cdap.api.dataset.DatasetProperties;
+import io.cdap.cdap.api.dataset.InstanceConflictException;
+import io.cdap.cdap.api.lineage.field.Operation;
 import io.cdap.cdap.api.security.store.SecureStoreData;
 import io.cdap.cdap.api.security.store.SecureStoreMetadata;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.cdap.etl.api.lineage.AccessType;
 import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.common.AbstractStageContext;
 import io.cdap.cdap.etl.common.PipelineRuntime;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import org.apache.tephra.TransactionFailureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -34,12 +47,16 @@ import javax.annotation.Nullable;
  * Default implementation for the {@link ActionContext}.
  */
 public class BasicActionContext extends AbstractStageContext implements ActionContext  {
+  private static final Logger LOG = LoggerFactory.getLogger(BasicActionContext.class);
+  private static final String EXTERNAL_DATASET_TYPE = "externalDataset";
 
   private final CustomActionContext context;
+  private final Admin admin;
 
   public BasicActionContext(CustomActionContext context, PipelineRuntime pipelineRuntime, StageSpec stageSpec) {
     super(pipelineRuntime, stageSpec);
     this.context = context;
+    this.admin = context.getAdmin();
   }
 
   @Override
@@ -76,5 +93,53 @@ public class BasicActionContext extends AbstractStageContext implements ActionCo
   @Override
   public void record(List<FieldOperation> fieldOperations) {
     throw new UnsupportedOperationException("Lineage recording is not supported.");
+  }
+
+  @Override
+  public void registerLineage(String referenceName, AccessType accessType) throws DatasetManagementException {
+    try {
+      if (!admin.datasetExists(referenceName)) {
+        admin.createDataset(referenceName, EXTERNAL_DATASET_TYPE, DatasetProperties.EMPTY);
+      }
+    } catch (InstanceConflictException ex) {
+      // Might happen if there is executed in multiple drivers in parallel. A race condition exists between check
+      // for dataset existence and creation.
+      LOG.debug("Dataset with name {} already created. Hence not creating the external dataset.", referenceName);
+    }
+
+    Transactionals.execute(context, context -> {
+      // we cannot instantiate ExternalDataset here - it is in CDAP data-fabric,
+      // and this code (the pipeline app) cannot depend on that. Thus, use reflection
+      // to invoke a method on the dataset.
+      Dataset ds = context.getDataset(referenceName);
+      Class<? extends Dataset> dsClass = ds.getClass();
+
+      switch (accessType) {
+        case READ:
+          invokeMethod(referenceName, ds, dsClass, "recordRead", accessType);
+          break;
+        case WRITE:
+          invokeMethod(referenceName, ds, dsClass, "recordWrite", accessType);
+          break;
+        default:
+          LOG.warn("Failed to register lineage because of unknown access type {}", accessType);
+      }
+    }, DatasetManagementException.class);
+  }
+
+  private void invokeMethod(String referenceName, Dataset ds, Class<? extends Dataset> dsClass, String methodName,
+                            AccessType accessType) throws IllegalAccessException, InvocationTargetException {
+    try {
+      Method method = dsClass.getMethod(methodName);
+      method.invoke(ds);
+    } catch (NoSuchMethodException e) {
+      LOG.warn("ExternalDataset '{}' does not have method '{}'. " +
+                 "Can't register {} lineage for this dataset", referenceName, methodName, accessType);
+    }
+  }
+
+  @Override
+  public void record(Collection<? extends Operation> operations) {
+    context.record(operations);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/action/FieldLineageAction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/action/FieldLineageAction.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.mock.action;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.lineage.field.Operation;
+import io.cdap.cdap.api.lineage.field.OperationType;
+import io.cdap.cdap.api.lineage.field.ReadOperation;
+import io.cdap.cdap.api.lineage.field.TransformOperation;
+import io.cdap.cdap.api.lineage.field.WriteOperation;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.etl.api.action.Action;
+import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.cdap.etl.api.lineage.AccessType;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mock action to write dummy field lineage information for two datasets
+ */
+@Plugin(type = Action.PLUGIN_TYPE)
+@Name("FieldLineageAction")
+public class FieldLineageAction extends Action {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Operation.class, new OperationTypeAdapter()).create();
+  private static final Type LIST_OPERTAION = new TypeToken<List<Operation>>() { }.getType();
+  private final Config config;
+
+  /**
+   * Config for the FieldLineageAction
+   */
+  public static class Config extends PluginConfig {
+    private String readDataset;
+    private String writeDataset;
+    // json string for the field operations
+    private String fieldOperations;
+  }
+
+  public FieldLineageAction(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void run(ActionContext context) throws Exception {
+    context.registerLineage(config.readDataset, AccessType.READ);
+    context.registerLineage(config.writeDataset, AccessType.WRITE);
+
+    List<Operation> operations = GSON.fromJson(config.fieldOperations, LIST_OPERTAION);
+    context.record(operations);
+  }
+
+  public static ETLPlugin getPlugin(String readDataset, String writeDataset, Collection<Operation> fieldOperations) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    builder.put("readDataset", readDataset);
+    builder.put("writeDataset", writeDataset);
+    builder.put("fieldOperations", GSON.toJson(fieldOperations));
+    return new ETLPlugin("FieldLineageAction", Action.PLUGIN_TYPE, builder.build(), null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("readDataset", new PluginPropertyField("readDataset", "", "string", true, false));
+    properties.put("writeDataset", new PluginPropertyField("writeDataset", "", "string", true, false));
+    properties.put("fieldOperations", new PluginPropertyField("fieldOperations", "", "string", true, false));
+
+    return new PluginClass(Action.PLUGIN_TYPE, "FieldLineageAction", "", FieldLineageAction.class.getName(),
+                           "config", properties);
+  }
+
+  /**
+   * Type adapter for {@link Operation}.
+   */
+  private static class OperationTypeAdapter implements JsonSerializer<Operation>, JsonDeserializer<Operation> {
+    @Override
+    public JsonElement serialize(Operation src, Type typeOfSrc, JsonSerializationContext context) {
+      return context.serialize(src);
+    }
+
+    @Override
+    public Operation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+      JsonObject jsonObj = json.getAsJsonObject();
+
+      OperationType type = context.deserialize(jsonObj.get("type"), OperationType.class);
+
+      switch (type) {
+        case READ:
+          return context.deserialize(json, ReadOperation.class);
+        case TRANSFORM:
+          return context.deserialize(json, TransformOperation.class);
+        case WRITE:
+          return context.deserialize(json, WriteOperation.class);
+      }
+      return null;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/action/MockActionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/action/MockActionContext.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.etl.mock.action;
 
 import io.cdap.cdap.api.TxRunnable;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.lineage.field.Operation;
 import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
@@ -27,11 +28,13 @@ import io.cdap.cdap.api.security.store.SecureStoreMetadata;
 import io.cdap.cdap.etl.api.StageMetrics;
 import io.cdap.cdap.etl.api.action.ActionContext;
 import io.cdap.cdap.etl.api.action.SettableArguments;
+import io.cdap.cdap.etl.api.lineage.AccessType;
 import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.mock.common.MockArguments;
 import io.cdap.cdap.proto.id.NamespaceId;
 
 import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -226,5 +229,14 @@ public class MockActionContext implements ActionContext {
   public void record(List<FieldOperation> fieldOperations) {
     // no-op
   }
-}
 
+  @Override
+  public void registerLineage(String referenceName, AccessType accessType) {
+    // no-op
+  }
+
+  @Override
+  public void record(Collection<? extends Operation> operations) {
+    // no-op
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -24,8 +24,10 @@ import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.condition.Condition;
+import io.cdap.cdap.etl.api.lineage.AccessType;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
+import io.cdap.cdap.etl.mock.action.FieldLineageAction;
 import io.cdap.cdap.etl.mock.action.FileMoveAction;
 import io.cdap.cdap.etl.mock.action.MockAction;
 import io.cdap.cdap.etl.mock.alert.NullAlertTransform;
@@ -82,8 +84,8 @@ public class HydratorTestBase extends TestBase {
     DoubleTransform.PLUGIN_CLASS, AllErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
     FieldsPrefixTransform.PLUGIN_CLASS, IntValueFilterTransform.PLUGIN_CLASS,
     StringValueFilterTransform.PLUGIN_CLASS, DropNullTransform.PLUGIN_CLASS,
-    MockAction.PLUGIN_CLASS, FileMoveAction.PLUGIN_CLASS, StringValueFilterCompute.PLUGIN_CLASS,
-    FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,
+    MockAction.PLUGIN_CLASS, FileMoveAction.PLUGIN_CLASS, FieldLineageAction.PLUGIN_CLASS,
+    StringValueFilterCompute.PLUGIN_CLASS, FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,
     NullFieldSplitterTransform.PLUGIN_CLASS, TMSAlertPublisher.PLUGIN_CLASS, NullAlertTransform.PLUGIN_CLASS,
     MockCondition.PLUGIN_CLASS, MockSource.PLUGIN_CLASS, MockSink.PLUGIN_CLASS
   );
@@ -113,6 +115,7 @@ public class HydratorTestBase extends TestBase {
                    Action.class.getPackage().getName(),
                    Condition.class.getPackage().getName(),
                    PipelineConfigurable.class.getPackage().getName(),
+                   AccessType.class.getPackage().getName(),
                    InvalidStageException.class.getPackage().getName(),
                    "org.apache.avro.mapred", "org.apache.avro", "org.apache.avro.generic", "org.apache.avro.io");
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/external/ExternalDataset.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/external/ExternalDataset.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.data2.dataset2.lib.external;
 
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.annotation.ReadOnly;
+import io.cdap.cdap.api.annotation.WriteOnly;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.data.batch.OutputFormatProvider;
 import io.cdap.cdap.api.dataset.Dataset;
@@ -82,5 +83,14 @@ public class ExternalDataset implements Dataset, InputFormatProvider, OutputForm
   @ReadOnly
   public void recordRead() {
     // Nothing to do, the platform will record the access based on the @ReadOnly annotation
+  }
+
+  /**
+   * Record write access to this dataset. This method does nothing, but the
+   * @WriteOnly annotation causes recording of a write access to this dataset.
+   */
+  @WriteOnly
+  public void recordWrite() {
+    // Nothing to do, the platform will record the access based on the @WriteOnly annotation
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/LineageTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/LineageTable.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/Relation.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/Relation.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.metadata.lineage;
 
-import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespacedEntityId;
 import io.cdap.cdap.proto.id.ProgramId;

--- a/cdap-master/src/main/java/io/cdap/cdap/master/upgrade/UpgradeJobMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/upgrade/UpgradeJobMain.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.proto.ApplicationRecord;
 import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.ProgramStatus;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -85,6 +85,8 @@ import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.context.BasicMessagingAdmin;
 import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
+import io.cdap.cdap.metadata.FieldLineageAdmin;
+import io.cdap.cdap.metadata.LineageAdmin;
 import io.cdap.cdap.metadata.MetadataAdmin;
 import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.MetadataService;
@@ -194,6 +196,8 @@ public class TestBase {
   private static MetadataSubscriberService metadataSubscriberService;
   private static MetadataStorage metadataStorage;
   private static MetadataAdmin metadataAdmin;
+  private static FieldLineageAdmin fieldLineageAdmin;
+  private static LineageAdmin lineageAdmin;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -351,6 +355,8 @@ public class TestBase {
     messagingContext = new MultiThreadMessagingContext(messagingService);
     firstInit = false;
     previewManager = injector.getInstance(PreviewManager.class);
+    fieldLineageAdmin = injector.getInstance(FieldLineageAdmin.class);
+    lineageAdmin = injector.getInstance(LineageAdmin.class);
     provisioningService = injector.getInstance(ProvisioningService.class);
     provisioningService.startAndWait();
     metadataSubscriberService.startAndWait();
@@ -952,6 +958,20 @@ public class TestBase {
    */
   protected static PreviewManager getPreviewManager() {
     return previewManager;
+  }
+
+  /**
+   * Returns a {@link FieldLineageAdmin to interact with field lineage.
+   */
+  protected static FieldLineageAdmin getFieldLineageAdmin() {
+    return fieldLineageAdmin;
+  }
+
+  /**
+   * Returns a {@link LineageAdmin to interact with field lineage.
+   */
+  protected static LineageAdmin getLineageAdmin() {
+    return lineageAdmin;
   }
 
   /**


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15240
Build: https://builds.cask.co/browse/CDAP-DUT7058-2

This pr adds the ability for actions to emit dataset lineage and field lineage. The action has to use the api level lineage api since it does not know the DAG and not have an input and output schema