### PR TITLE
Fix node to parse cdap config in cloud environments

### DIFF
--- a/cdap-ui/app/cdap/components/AppHeader/AppToolBar/AppToolbarMenu.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppToolBar/AppToolbarMenu.tsx
@@ -39,6 +39,7 @@ interface IAppToolbarState {
   anchorEl: EventTarget | null;
   aboutPageOpen: boolean;
   accessTokenModalOpen: boolean;
+  username?: string;
 }
 const styles = (theme) => ({
   root: {
@@ -106,6 +107,7 @@ class AppToolbarMenu extends React.Component<IAppToolbarMenuProps, IAppToolbarSt
     } else {
       this.setState({
         anchorEl: event.currentTarget,
+        username: NamespaceStore.getState().username,
       });
     }
   };
@@ -183,8 +185,7 @@ class AppToolbarMenu extends React.Component<IAppToolbarMenuProps, IAppToolbarSt
                         >
                           <IconSVG name="icon-user" />
                           <a className={`${classes.usernameStyles} ${classes.linkStyles} truncate`}>
-                            {/* {this.state.username} */}
-                            asfjkbsdkljfbsldkjbglkjsdfbgkljsnlkjsnlkjsdnfkjsdngljksf
+                            {this.state.username}
                           </a>
                         </MenuItem>
                         <MenuItem

--- a/cdap-ui/cypress/integration/pipeline.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.spec.ts
@@ -97,6 +97,7 @@ describe('Creating a pipeline', () => {
     cy.url({ timeout: 60000 }).should('include', `/view/${TEST_PIPELINE_NAME}`);
     cy.contains(TEST_PIPELINE_NAME);
     cy.contains('FileDelete');
+    cy.wait(5000);
     cy.get('.pipeline-configure-btn', { timeout: 60000 }).click();
     cy.get('[data-cy="tab-head-Pipeline config"]').click();
     cy.get('.label-with-toggle')

--- a/cdap-ui/server/config/config-reader.js
+++ b/cdap-ui/server/config/config-reader.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+const q = require('q');
+const spawn = require('child_process').spawn;
+const StringDecoder = require('string_decoder').StringDecoder;
+const decoder = new StringDecoder('utf8');
+const log4js = require('log4js');
+const nodepath = require('path');
+var log = log4js.getLogger('default');
+
+class ConfigReader {
+  constructor(param) {
+    this.buffer = '';
+    this.deferred = q.defer();
+    this.tool = spawn(nodepath.join(__dirname, 'bin', 'cdap'), ['config-tool', '--' + param]);
+    this.tool.stderr.on('data', this.configReadFail.bind(this));
+    this.tool.stdout.on('data', this.configRead.bind(this));
+    this.tool.stdout.on('end', this.onConfigReadEnd.bind(this, param));
+  }
+  configReadFail(data) {
+    var textChunk = decoder.write(data);
+    if (textChunk) {
+      log.error(textChunk);
+    }
+  }
+  configRead(data) {
+    try {
+      var textChunk = decoder.write(data);
+      if (textChunk) {
+        this.buffer += textChunk;
+      }
+    } catch (e) {
+      log.error('Error while reading config: ' + e);
+    }
+  }
+  onConfigReadEnd() {
+    let result;
+    try {
+      result = JSON.parse(this.buffer);
+    } catch (e) {
+      log.error('Error parsing configuration: ' + e);
+      this.deferred.reject(e);
+    }
+    this.deferred.resolve(result);
+  }
+  getPromise() {
+    return this.deferred.promise;
+  }
+}
+
+module.exports = ConfigReader;

--- a/cdap-ui/server/config/development/cdap.json
+++ b/cdap-ui/server/config/development/cdap.json
@@ -11,5 +11,6 @@
   "enable.preview": "true",
   "dashboard.router.check.timeout.secs": "0",
   "market.base.url": "https://hub.cdap.io/dev/v2",
-  "ui.theme.file": "config/themes/default.json"
+  "ui.theme.file": "config/themes/default.json",
+  "session.secret.key": "sample-secret-key-for-encryption"
 }

--- a/cdap-ui/server/token.js
+++ b/cdap-ui/server/token.js
@@ -15,7 +15,6 @@
 */
 
 const crypto = require('crypto');
-const fs = require('fs');
 const path = require('path');
 
 const EncryptionConstants = {
@@ -98,25 +97,18 @@ function decrypt(encText, key) {
 }
 
 function getSecretFromCDAPConfig(cdapConfig, logger) {
-  let secretKeyFilePath =
-    cdapConfig['session.secret.key.path'] ||
+  let secretKey =
+    cdapConfig['session.secret.key'] ||
     path.resolve(__dirname, 'config', 'development', 'session_secret.key');
   if (!logger) {
     logger = console;
   }
-  if (!secretKeyFilePath) {
+  if (!secretKey) {
     logger.warn(
       'Secret key missing. This is required to generate a strong time-based token to prevent cswh'
     );
   }
-  let secret;
-  try {
-    secret = fs.readFileSync(secretKeyFilePath, { encoding: 'utf8' });
-  } catch (e) {
-    logger.error('Error in generating key for cswh. ' + e);
-    secret = '';
-  }
-  return secret;
+  return secretKey;
 }
 
 /**

--- a/cdap-ui/server/token_test.js
+++ b/cdap-ui/server/token_test.js
@@ -17,7 +17,7 @@
 var session = require('./token');
 function testLocally() {
   const fakeCDAPConfig = {
-    'session.secret.key.path': '/tmp/secret.file',
+    'session.secret.key': 'secret-key-for-encryption',
   };
   const token = session.generateToken(fakeCDAPConfig, console, 'Bearer 1111');
   const isTokenValid = session.validateToken(token, fakeCDAPConfig, console, 'Bearer 1111');

--- a/cdap-ui/server/uiThemeWrapper.js
+++ b/cdap-ui/server/uiThemeWrapper.js
@@ -18,8 +18,8 @@ const log4js = require('log4js'),
   path = require('path'),
   objectQuery = require('lodash/get'),
   fs = require('fs'),
-  DIST_PATH = path.normalize(__dirname + '/../dist'),
-  CDAP_DIST_PATH = path.normalize(__dirname + '/../cdap_dist');
+  DIST_PATH = path.normalize(__dirname + '/public/dist'),
+  CDAP_DIST_PATH = path.normalize(__dirname + '/public/cdap_dist');
 const log = log4js.getLogger('default');
 const uiThemePropertyName = 'ui.theme.file';
 
@@ -91,7 +91,7 @@ function extractUITheme(cdapConfig, uiThemePath) {
 }
 
 function getFaviconPath(uiThemeConfig) {
-  let faviconPath = DIST_PATH + '/assets/img/favicon.png';
+  let faviconPath = CDAP_DIST_PATH + '/img/favicon.png';
   let themeFaviconPath = objectQuery(uiThemeConfig, ['content', 'favicon-path']);
   if (themeFaviconPath) {
     // If absolute path no need to modify as require'ing absolute path should


### PR DESCRIPTION
- Fixes token generation module to read the secret directly from security config instead of reading a file.
- Fix Node server to isolate parsing config in cloud environments
- Fix AppHeader to show appropriate user menu when security is enabled
- Fix path to favicon to resolve to the right location.
- Minor fix to pipeline spec to account for delay in loading the page.

UI E2E test: https://builds.cask.co/browse/IT-UPD274
UI E2E mini test: https://builds.cask.co/browse/IT-UIE2EMINI8
Build: https://builds.cask.co/browse/CDAP-UDUT400