### PR TITLE
Add failure collector in mock classes

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
@@ -176,7 +176,8 @@ public class SmartWorkflow extends AbstractWorkflow {
     } catch (ValidationException e) {
       throw new IllegalArgumentException(
         String.format("Failed to configure pipeline: %s",
-                      e.getFailures().isEmpty() ? e.getMessage() : e.getFailures().iterator().next().getMessage()), e);
+                      e.getFailures().isEmpty() ? e.getMessage() :
+                        e.getFailures().iterator().next().getFullMessage()), e);
     }
 
     stageSpecs = new HashMap<>();

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsApp.java
@@ -45,7 +45,8 @@ public class DataStreamsApp extends AbstractApplication<DataStreamsConfig> {
     } catch (ValidationException e) {
       throw new IllegalArgumentException(
         String.format("Failed to configure pipeline: %s",
-                      e.getFailures().isEmpty() ? e.getMessage() : e.getFailures().iterator().next().getMessage()), e);
+                      e.getFailures().isEmpty() ? e.getMessage() :
+                        e.getFailures().iterator().next().getFullMessage()), e);
     }
     addSpark(new DataStreamsSparkLauncher(spec));
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/FailureCollector.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/FailureCollector.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -67,5 +68,14 @@ public interface FailureCollector {
    */
   default ValidationException getOrThrowException() throws ValidationException {
     throw new UnsupportedOperationException("Throwing failures is not supported.");
+  }
+
+  /**
+   * Get list of validation failures.
+   *
+   * @return list of validation failures
+   */
+  default List<ValidationFailure> getValidationFailures() {
+    throw new UnsupportedOperationException("Getting failures is not supported.");
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidationFailure.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidationFailure.java
@@ -153,6 +153,16 @@ public class ValidationFailure {
   }
 
   /**
+   * Adds cause attributes that represents invalid input schema field failure cause.
+   *
+   * @param fieldName name of the input schema field
+   * @return validation failure with invalid input schema field cause
+   */
+  public ValidationFailure withInputSchemaField(String fieldName) {
+    return withInputSchemaField(fieldName, null);
+  }
+
+  /**
    * Adds cause attributes that represents invalid output schema field failure cause.
    *
    * @param fieldName name of the output schema field
@@ -164,6 +174,16 @@ public class ValidationFailure {
     cause = outputPort == null ? cause : cause.addAttribute(CauseAttributes.OUTPUT_PORT, outputPort);
     causes.add(cause);
     return this;
+  }
+
+  /**
+   * Adds cause attributes that represents invalid output schema field failure cause.
+   *
+   * @param fieldName name of the output schema field
+   * @return validation failure with invalid output schema field cause
+   */
+  public ValidationFailure withOutputSchemaField(String fieldName) {
+    return withOutputSchemaField(fieldName, null);
   }
 
   /**
@@ -181,6 +201,16 @@ public class ValidationFailure {
    * Returns failure message.
    */
   public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Returns failure message along with corrective action.
+   */
+  public String getFullMessage() {
+    if (correctiveAction != null) {
+      return String.format("%s - %s", message, correctiveAction);
+    }
     return message;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -312,7 +312,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       collector.addFailure("Null error occurred while configuring the stage.", null)
         .withStacktrace(e.getStackTrace());
     } catch (Exception e) {
-      collector.addFailure(String.format("Error encountered while configuring the stage: '%s'.",
+      collector.addFailure(String.format("Error encountered while configuring the stage: '%s'",
                                          e.getMessage()), null);
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/DefaultFailureCollector.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/DefaultFailureCollector.java
@@ -70,9 +70,6 @@ public class DefaultFailureCollector implements FailureCollector {
     throw new ValidationException(failures);
   }
 
-  /**
-   * Returns a list of failures.
-   */
   public List<ValidationFailure> getValidationFailures() {
     return failures;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/LoggingFailureCollector.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/LoggingFailureCollector.java
@@ -56,7 +56,7 @@ public class LoggingFailureCollector extends DefaultFailureCollector {
     List<ValidationFailure> failures = validationException.getFailures();
     LOG.error("Encountered '{}' validation failures: {}{}", failures.size(), System.lineSeparator(),
               IntStream.range(0, failures.size())
-                .mapToObj(index -> String.format("%d. '%s'", index + 1, failures.get(index).getMessage()))
+                .mapToObj(index -> String.format("%d. '%s'", index + 1, failures.get(index).getFullMessage()))
                 .collect(Collectors.joining(System.lineSeparator())));
 
     throw validationException;

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/MockTransformContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/MockTransformContext.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.etl.api.Arguments;
+import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.Lookup;
 import io.cdap.cdap.etl.api.LookupProvider;
 import io.cdap.cdap.etl.api.StageMetrics;
@@ -30,6 +31,7 @@ import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.mock.common.MockArguments;
 import io.cdap.cdap.etl.mock.common.MockLookupProvider;
 import io.cdap.cdap.etl.mock.common.MockStageMetrics;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 
 import java.net.URL;
 import java.util.Collections;
@@ -42,14 +44,16 @@ import javax.annotation.Nullable;
  * Mock context for unit tests
  */
 public class MockTransformContext implements TransformContext {
+  private static final String MOCK_STAGE_NAME = "mockstage";
   private final PluginProperties pluginProperties;
   private final MockStageMetrics metrics;
   private final LookupProvider lookup;
   private final String stageName;
   private final Arguments arguments;
+  private final FailureCollector collector;
 
   public MockTransformContext() {
-    this("someStage");
+    this(MOCK_STAGE_NAME);
   }
 
   public MockTransformContext(String stageName) {
@@ -66,6 +70,7 @@ public class MockTransformContext implements TransformContext {
     this.metrics = new MockStageMetrics(stageName);
     this.stageName = stageName;
     this.arguments = new MockArguments(args);
+    this.collector = new MockFailureCollector(stageName);
   }
 
   @Override
@@ -223,5 +228,10 @@ public class MockTransformContext implements TransformContext {
   @Override
   public void record(List<FieldOperation> fieldOperations) {
     // no-op
+  }
+
+  @Override
+  public FailureCollector getFailureCollector() {
+    return collector;
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/validation/MockFailureCollector.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/validation/MockFailureCollector.java
@@ -73,9 +73,6 @@ public class MockFailureCollector implements FailureCollector {
     throw new ValidationException(failures);
   }
 
-  /**
-   * Returns a list of failures.
-   */
   public List<ValidationFailure> getValidationFailures() {
     return failures;
   }


### PR DESCRIPTION
* Modifying MockTransformContext to use mock failure collector. 
* Exposing validation failures through failure collector. This is to make it easier for tests to get failures from collector.
* Log corrective action along with error messages.

![image](https://user-images.githubusercontent.com/14131070/64402325-60eea580-d029-11e9-85fa-a2580f110a6b.png)

![image](https://user-images.githubusercontent.com/14131070/64402672-8fb94b80-d02a-11e9-847a-8427d6cfacb7.png)



