### PR TITLE
(CDAP-15867) Bugfix for flaky WorkerProgramRunnerTest

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
@@ -249,18 +249,6 @@ public class WorkerProgramRunnerTest {
       }
     }, Threads.SAME_THREAD_EXECUTOR);
 
-    Tasks.waitFor(ProgramController.State.ALIVE, new Callable<ProgramController.State>() {
-      @Override
-      public ProgramController.State call() throws Exception {
-        Throwable t = errorCause.get();
-        if (t != null) {
-          Throwables.propagateIfInstanceOf(t, Exception.class);
-          throw Throwables.propagate(t);
-        }
-        return controller.getState();
-      }
-    }, 30, TimeUnit.SECONDS);
-
     return controller;
   }
 


### PR DESCRIPTION
Bugfix for [this issue](https://issues.cask.co/browse/CDAP-15867)

Checking for 'ALIVE' state in startProgram was not needed since the tests later check for successful completion of Worker. Removing this check prevents tests failing due to the race condition without compromising the test goal. 