### PR TITLE
CDAP-15498 set some dataproc properties by default

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -302,6 +302,11 @@ public class DataprocProvisioner implements Provisioner {
       }
     }
 
+    // set some dataproc properties that we know will make program execution more stable
+    contextProperties.put("dataproc:dataproc.conscrypt.provider.enable", "false");
+    contextProperties.put("yarn:yarn.nodemanager.pmem-check-enabled", "false");
+    contextProperties.put("yarn:yarn.nodemanager.vmem-check-enabled", "false");
+
     return contextProperties;
   }
 


### PR DESCRIPTION
Disable memory checks so that yarn will never kill containers,
as it is almost always not desired to kill program containers.

Also turn off conscrypt by default, as it causes problems with SSL.