### PR TITLE
Adds whitelisted domain name from cdap-site 

### DIFF
--- a/cdap-ui/server.js
+++ b/cdap-ui/server.js
@@ -64,6 +64,7 @@ function getFullURL(host) {
 }
 async function setAllowedOrigin() {
   const nodejsserver = cdapConfig['dashboard.bind.address'];
+  const whitelistedDomain = cdapConfig['dashboard.domain.name'];
   allowedOrigin = [getFullURL(nodejsserver)];
   try {
     hostname = await getHostName();
@@ -76,6 +77,9 @@ async function setAllowedOrigin() {
   }
   if (hostIP) {
     allowedOrigin.push(getFullURL(hostIP));
+  }
+  if (whitelistedDomain) {
+    allowedOrigin.push(getFullURL(whitelistedDomain));
   }
   if (['localhost', '127.0.0.1', '0.0.0.0'].indexOf(nodejsserver) !== -1) {
     allowedOrigin.push(getFullURL('127.0.0.1'), getFullURL('0.0.0.0'), getFullURL('localhost'));

--- a/cdap-ui/server/token.js
+++ b/cdap-ui/server/token.js
@@ -99,7 +99,7 @@ function decrypt(encText, key) {
 function getSecretFromCDAPConfig(cdapConfig, logger) {
   let secretKey =
     cdapConfig['session.secret.key'] ||
-    path.resolve(__dirname, 'config', 'development', 'session_secret.key');
+    path.resolve(__dirname, 'config', 'development', 'session.secret.key');
   if (!logger) {
     logger = console;
   }


### PR DESCRIPTION
Add whitelisted domain to the list of origins allowed to connect to web socket server.

Build: https://builds.cask.co/browse/CDAP-UDUT403-1