### PR TITLE
(CDAP-15725) Dataproc network selection

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -236,6 +236,13 @@ final class DataprocClient implements AutoCloseable {
       throw new IllegalArgumentException(String.format("Unable to find any networks in project '%s'. "
                                                          + "Please create a network in the project.", project));
     }
+
+    for (Network network: networks) {
+      if (network.getName().equals("default")){
+        return network.getName();
+      }
+    }
+
     return networks.iterator().next().getName();
   }
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -238,7 +238,7 @@ final class DataprocClient implements AutoCloseable {
     }
 
     for (Network network: networks) {
-      if (network.getName().equals("default")) {
+      if ("default".equals(network.getName())) {
         return network.getName();
       }
     }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -238,7 +238,7 @@ final class DataprocClient implements AutoCloseable {
     }
 
     for (Network network: networks) {
-      if (network.getName().equals("default")){
+      if (network.getName().equals("default")) {
         return network.getName();
       }
     }


### PR DESCRIPTION
Fix for [this issue](https://issues.cask.co/browse/CDAP-15725)

DataprocClient will now attempt to select 'default' network first. If no 'default' network is found, then it will select the first network in alphabetical order (same logic as before).