### PR TITLE
[CDAP-15876] Add check for empty system properties to see if dataset is valid

### DIFF
--- a/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
@@ -127,6 +127,18 @@ export default class DatasetDetailedView extends Component {
         .subscribe(
           (res) => {
             let appId;
+            // TO DO: Remove this check once backend properly returns a 404 error when dataset does not exist
+            // JIRA to fix backend: CDAP-15909
+            const datasetProps = res[0].properties; // all metadata properties with System scope
+
+            if (datasetProps.length === 0) {
+              this.setState({
+                notFound: true,
+                loading: false,
+              });
+              return;
+            }
+
             let programs = res[1].map((programObj) => {
               programObj.uniqueId = uuidV4();
               appId = programObj.application;


### PR DESCRIPTION
This is to keep UI from breaking when user clicks "see details" from pipeline details page for a dataset that is invalid (i.e. the pipeline failed). 

JIRA: https://issues.cask.co/browse/CDAP-15876
BUILD: https://builds.cask.co/browse/CDAP-UDUT412-1