### PR TITLE
Put v2 FLL UI behind flag

### DIFF
--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
@@ -71,9 +71,11 @@ function FllField({ field, classes }: IFieldProps) {
 
   const timeParams = getTimeQueryParams(selection, start, end);
 
-  const linkPath = `/ns/${field.namespace}/datasets/${field.dataset}/fields${timeParams}&field=${
-    field.name
-  }`;
+  // TO DO: Update linkPath once v1 and v2 FLL UI's are switched
+
+  const linkPath = `/ns/${field.namespace}/datasets/${
+    field.dataset
+  }/fll-experiment${timeParams}&field=${field.name}`;
 
   const toggleHoverState = (nextState) => {
     setHoverState(nextState);

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -86,8 +86,7 @@ const OpsDashboard = Loadable({
   loading: LoadingSVGCentered,
 });
 const FieldLevelLineage = Loadable({
-  loader: () =>
-    import(/* webpackChunkName: "FieldLevelLineage" */ 'components/FieldLevelLineage/v2'),
+  loader: () => import(/* webpackChunkName: "FieldLevelLineage" */ 'components/FieldLevelLineage'),
   loading: LoadingSVGCentered,
 });
 const PipelineList = Loadable({
@@ -118,10 +117,20 @@ export default class Home extends Component {
           <Route
             exact
             path="/ns/:namespace/datasets/:datasetId/fields"
+            component={FieldLevelLineage}
+          />
+          <Route
+            exact
+            path="/ns/:namespace/datasets/:datasetId/fll-experiment"
             render={(props) => {
+              const FllExperiment = Loadable({
+                loader: () =>
+                  import(/* webpackChunkName: "FllExperiment" */ 'components/FieldLevelLineage/v2'),
+                loading: LoadingSVGCentered,
+              });
               return (
                 <ErrorBoundary>
-                  <FieldLevelLineage {...props} />
+                  <FllExperiment {...props} />
                 </ErrorBoundary>
               );
             }}

--- a/cdap-ui/cypress/integration/fieldlevellineage.v2.spec.ts
+++ b/cdap-ui/cypress/integration/fieldlevellineage.v2.spec.ts
@@ -44,38 +44,34 @@ describe('Generating and navigating field level lineage for datasets', () => {
     cy.cleanup_pipelines(headers, fllPipeline);
   });
   it('Should show lineage for the default time frame (last 7 days)', () => {
-    // v1 UI
-    cy.visit('cdap/ns/default/datasets/Airport_sink/fields');
+    cy.visit('cdap/ns/default/datasets/Airport_sink/fll-experiment');
     // should see last 7 days of lineage selected by default
     cy.get('[data-cy="fll-time-picker"]').should(($div) => {
       expect($div).to.contain('Last 7 days');
     });
     // should see the correct fields for the selected dataset
-    cy.get('[data-cy="target-fields"]').within(() => {
-      cy.get('.field-row').should(($fields) => {
-        expect($fields).to.have.length(2);
-        // should see only 'body' field for the impact dataset, assuming no previous lineage exists
-        expect($fields).to.contain('body');
-      });
+    cy.get('[data-cy="target-fields"] .grid-row').within(($fields) => {
+      // should see only 'body' field for the impact dataset, assuming no previous lineage exists
+      expect($fields).to.contain('body');
     });
   });
   it('Should show operations for target field', () => {
     // focus on a field with outgoing operations
-    cy.get('[data-cy="target-fields"] .field-row').within(() => {
-      cy.contains('Incoming operations').click();
+    cy.get('[data-cy="target-fields"]').within(() => {
+      cy.contains('body').click();
+      cy.get('[data-cy="fll-view-dropdown"]').click();
     });
+    cy.get('[data-cy="fll-view-incoming"]').click();
     cy.get('.operations-container').should('exist');
     cy.get('.modal-title .close-section').click();
   });
   it('Should allow user to see field level lineage for a custom date range', () => {
-    cy.get('.time-picker-dropdown')
-      .find('.dropdown-toggle')
-      .click();
-    cy.get('.dropdown-menu')
-      .find('[data-cy="CUSTOM"]')
-      .click();
-    cy.get('.time-range-selector').should('exist');
-    cy.get('.time-range-selector').within(() => {
+    // click on date picker dropdown and choose custom date range
+
+    cy.get('[data-cy="time-picker-dropdown"]').click();
+    cy.get('[data-cy="CUSTOM"]').click();
+    cy.get('[data-cy="time-range-selector"]').should('exist');
+    cy.get('[data-cy="time-range-selector"]').within(() => {
       cy.contains('Start Time').click();
     });
     cy.get('.react-calendar').within(() => {
@@ -92,7 +88,8 @@ describe('Generating and navigating field level lineage for datasets', () => {
         .first()
         .click();
     });
-    cy.get('.time-range-selector').within(() => {
+
+    cy.get('[data-cy="time-range-selector"]').within(() => {
       cy.contains('End Time').click();
     });
     // end of range: two years and zero months for now, first available day
@@ -111,8 +108,12 @@ describe('Generating and navigating field level lineage for datasets', () => {
       .contains('Done')
       .click();
 
-    cy.get('.field-row.disabled').should(($fields) => {
-      expect($fields).to.have.length(1);
-    });
+    // Should see no fields with operations since there is no lineage for the date range
+    cy.get('[data-cy="target-fields"] .grid-row')
+      .first()
+      .click();
+    cy.get('[data-cy="fll-view-dropdown"]').click();
+    cy.get('[data-cy="fll-view-incoming"]').should('have.class', 'Mui-disabled');
+    cy.get('[data-cy="fll-view-outgoing"]').should('have.class', 'Mui-disabled');
   });
 });


### PR DESCRIPTION
Users should see v1 UI when navigating from Lineage tab. New UI can be accessed from url "/ns/:namespace/datasets/:datasetId/fll-experiment"

Also created separate sets of integration tests for v1 and v2 UI's.

Build: https://builds.cask.co/browse/CDAP-UDUT413-1