### PR TITLE
CDAP-15929 add missing required fields to failure collector

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/InvalidPluginConfigException.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/InvalidPluginConfigException.java
@@ -17,18 +17,44 @@
 
 package io.cdap.cdap.api.plugin;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Thrown when a {@link PluginConfig} cannot be created from provided {@link PluginProperties}.
  * This can happen if properties required by the PluginConfig are not in the PluginProperties, or when
  * the property type specified by the PluginConfig is incompatible with the value provided in the PluginProperties.
  */
 public class InvalidPluginConfigException extends RuntimeException {
-
-  public InvalidPluginConfigException(String message) {
-    super(message);
-  }
+  private Set<String> missingProperties;
+  private Set<InvalidPluginProperty> invalidProperties;
 
   public InvalidPluginConfigException(String message, Throwable cause) {
     super(message, cause);
+    this.missingProperties = Collections.emptySet();
+    this.invalidProperties = Collections.emptySet();
+  }
+
+  public InvalidPluginConfigException(String message, Set<String> missingProperties,
+                                      Set<InvalidPluginProperty> invalidProperties) {
+    super(message);
+    this.missingProperties = Collections.unmodifiableSet(new HashSet<>(missingProperties));
+    this.invalidProperties = Collections.unmodifiableSet(new HashSet<>(invalidProperties));
+  }
+
+  /**
+   * @return the set of required properties that were not provided in the PluginProperties.
+   */
+  public Set<String> getMissingProperties() {
+    return missingProperties;
+  }
+
+  /**
+   * @return the set of invalid properties, usually because the value given in the PluginProperties did not match
+   *         the expected type.
+   */
+  public Set<InvalidPluginProperty> getInvalidProperties() {
+    return invalidProperties;
   }
 }

--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/InvalidPluginProperty.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/InvalidPluginProperty.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.plugin;
+
+import java.util.Objects;
+
+/**
+ * An invalid plugin property.
+ */
+public class InvalidPluginProperty {
+  private final String name;
+  private final String errorMessage;
+
+  public InvalidPluginProperty(String name, String errorMessage) {
+    this.name = name;
+    this.errorMessage = errorMessage;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    InvalidPluginProperty that = (InvalidPluginProperty) o;
+
+    return Objects.equals(name, that.name) && Objects.equals(errorMessage, that.errorMessage);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, errorMessage);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultPluginConfigurer.java
@@ -137,7 +137,7 @@ public class DefaultPluginConfigurer implements PluginConfigurer {
                                                                                          pluginType, pluginName,
                                                                                          selector);
         Plugin plugin = FindPluginHelper.getPlugin(Iterables.transform(parents, ArtifactId::toApiArtifactId),
-                                                   pluginEntry, properties, pluginType, pluginName, pluginInstantiator);
+                                                   pluginEntry, properties, pluginInstantiator);
         plugins.put(pluginId, new PluginWithLocation(plugin, pluginEntry.getKey().getLocation()));
         return plugin;
       } catch (PluginNotExistsException e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/FindPluginHelper.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/FindPluginHelper.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.app.runtime.plugin;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.plugin.Plugin;
@@ -44,23 +43,15 @@ public final class FindPluginHelper {
    *                with the first item as the direct parent of the plugin
    * @param pluginEntry artifact and class information for the plugin
    * @param properties plugin properties
-   * @param pluginType plugin type
-   * @param pluginName plugin name
    * @param pluginInstantiator instantiator to add the plugin artifact to
    * @return plugin information
    */
   public static Plugin getPlugin(Iterable<ArtifactId> parents, Map.Entry<ArtifactDescriptor, PluginClass> pluginEntry,
-                                 PluginProperties properties,
-                                 String pluginType, String pluginName, PluginInstantiator pluginInstantiator) {
+                                 PluginProperties properties, PluginInstantiator pluginInstantiator) {
     CollectMacroEvaluator collectMacroEvaluator = new CollectMacroEvaluator();
 
-    // Just verify if all required properties are provided.
-    // No type checking is done for now.
     for (PluginPropertyField field : pluginEntry.getValue().getProperties().values()) {
-      Preconditions.checkArgument(!field.isRequired() || (properties.getProperties().containsKey(field.getName())),
-                                  "Required property '%s' missing for plugin of type %s, name %s.",
-                                  field.getName(), pluginType, pluginName);
-      if (field.isMacroSupported()) {
+      if (field.isMacroSupported() && properties.getProperties().containsKey(field.getName())) {
         MacroParser parser = MacroParser.builder(collectMacroEvaluator)
           .setEscapingEnabled(field.isMacroEscapingEnabled())
           .build();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.plugin.InvalidPluginConfigException;
+import io.cdap.cdap.api.plugin.InvalidPluginProperty;
 import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginConfig;
@@ -260,8 +261,13 @@ public class PluginInstantiator implements Closeable {
       PluginProperties pluginProperties = substituteMacros(plugin, macroEvaluator);
       Set<String> macroFields = (macroEvaluator == null) ? getFieldsWithMacro(plugin) : Collections.emptySet();
 
-      Reflections.visit(config, configFieldType.getType(),
-                        new ConfigFieldSetter(pluginClass, plugin.getArtifactId(), pluginProperties, macroFields));
+      ConfigFieldSetter fieldSetter = new ConfigFieldSetter(pluginClass, pluginProperties, macroFields);
+      Reflections.visit(config, configFieldType.getType(), fieldSetter);
+
+      if (!fieldSetter.invalidProperties.isEmpty() || !fieldSetter.missingProperties.isEmpty()) {
+        throw new InvalidPluginConfigException("Unable to create plugin config.", fieldSetter.missingProperties,
+                                               fieldSetter.invalidProperties);
+      }
 
       // Create the plugin instance
       return newInstance(pluginType, field, configFieldType, config);
@@ -497,15 +503,16 @@ public class PluginInstantiator implements Closeable {
   private static final class ConfigFieldSetter extends FieldVisitor {
     private final PluginClass pluginClass;
     private final PluginProperties properties;
-    private final ArtifactId artifactId;
     private final Set<String> macroFields;
+    private final Set<String> missingProperties;
+    private final Set<InvalidPluginProperty> invalidProperties;
 
-    ConfigFieldSetter(PluginClass pluginClass, ArtifactId artifactId,
-                      PluginProperties properties, Set<String> macroFields) {
+    ConfigFieldSetter(PluginClass pluginClass, PluginProperties properties, Set<String> macroFields) {
       this.pluginClass = pluginClass;
-      this.artifactId = artifactId;
       this.properties = properties;
       this.macroFields = macroFields;
+      this.missingProperties = new HashSet<>();
+      this.invalidProperties = new HashSet<>();
     }
 
     @Override
@@ -530,12 +537,16 @@ public class PluginInstantiator implements Closeable {
       String name = nameAnnotation == null ? field.getName() : nameAnnotation.value();
       PluginPropertyField pluginPropertyField = pluginClass.getProperties().get(name);
       if (pluginPropertyField.isRequired() && !properties.getProperties().containsKey(name)) {
-        throw new IllegalArgumentException("Missing required plugin property " + name
-                                             + " for " + pluginClass.getName() + " in artifact " + artifactId);
+        missingProperties.add(name);
+        return;
       }
       String value = properties.getProperties().get(name);
       if (pluginPropertyField.isRequired() || value != null) {
-        field.set(instance, convertValue(name, declareTypeToken.resolveType(field.getGenericType()), value));
+        try {
+          field.set(instance, convertValue(name, declareTypeToken.resolveType(field.getGenericType()), value));
+        } catch (Exception e) {
+          invalidProperties.add(new InvalidPluginProperty(name, e.getMessage()));
+        }
       }
     }
 
@@ -556,7 +567,7 @@ public class PluginInstantiator implements Closeable {
 
       if (Character.class.equals(rawType)) {
         if (value.length() != 1) {
-          throw new InvalidPluginConfigException(String.format("Property of type char is not length 1: '%s'", value));
+          throw new IllegalArgumentException(String.format("Property of type char is not length 1: '%s'", value));
         } else {
           return value.charAt(0);
         }
@@ -586,7 +597,9 @@ public class PluginInstantiator implements Closeable {
         }
       }
 
-      throw new UnsupportedTypeException("Only primitive and String types are supported");
+      throw new UnsupportedTypeException(String.format("Plugin config property '%s' is of invalid type '%s'. " +
+                                                         "Only primitive and String types are supported",
+                                                       name, rawType.getSimpleName()));
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
@@ -71,7 +71,9 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -263,9 +265,14 @@ public class DataPipelineServiceTest extends HydratorTestBase {
     StageValidationResponse actual = sendRequest(new StageValidationRequest(stage, Collections.emptyList()));
 
     Assert.assertNull(actual.getSpec());
-    Assert.assertEquals(1, actual.getFailures().size());
-    ValidationFailure failure = actual.getFailures().iterator().next();
-    Assert.assertEquals(stageName, failure.getCauses().get(0).getAttribute(STAGE));
+    Assert.assertEquals(2, actual.getFailures().size());
+    Set<String> properties = new HashSet<>();
+    properties.add(actual.getFailures().get(0).getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+    properties.add(actual.getFailures().get(1).getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+    Set<String> expected = new HashSet<>();
+    expected.add("field");
+    expected.add("value");
+    Assert.assertEquals(expected, properties);
   }
 
   @Test


### PR DESCRIPTION
Ensure that the validation endpoint returns explicit failures
for a missing required field instead of some generic error.

This required enhancing the CDAP API to throw an exception that
returns which required properties are missing and which properties
could not be assigned due to an invalid value.