### PR TITLE
[CDAP-15931] Fix bug for clicking Next in pipeline alert

### DIFF
--- a/cdap-ui/app/cdap/components/ConfigurationGroup/index.tsx
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/index.tsx
@@ -113,7 +113,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
         values: newValues,
       };
     },
-    [values]
+    [values, pluginProperties]
   );
 
   // This onUnMount is to make sure we clear out all properties that are hidden.
@@ -121,13 +121,15 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
     return () => {
       const newValues = { ...referenceValueForUnMount.current.values };
       const configGroups = referenceValueForUnMount.current.configurationGroups;
-      configGroups.forEach((group) => {
-        group.properties.forEach((property) => {
-          if (property.show === false) {
-            delete newValues[property.name];
-          }
+      if (configGroups) {
+        configGroups.forEach((group) => {
+          group.properties.forEach((property) => {
+            if (property.show === false) {
+              delete newValues[property.name];
+            }
+          });
         });
-      });
+      }
       changeParentHandler(newValues);
     };
   }, []);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15931
Build: https://builds.cask.co/browse/CDAP-UDUT415

The bugs: 

- When user clicked on "Next" button to configure a pipeline alert, nothing happened. 
- When the modal was closed, a console error came up. 
- No widgets were being rendered in the configure modal

The first issue was caused by not checking if configGroups were defined before using it. The last two issues were being caused by the ConfigurationGroup component not getting rerendered when the pluginProperties changed (only rerendered when the values prop changed). 