### PR TITLE
Modify api to always add input stage upon input field error

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
@@ -254,7 +254,6 @@ public class DataPipelineServiceTest extends HydratorTestBase {
     Assert.assertEquals(stageName, failure.getCauses().get(0).getAttribute(STAGE));
   }
 
-
   // tests that plugins that cannot be instantiated due to missing required properties are captured
   @Test
   public void testValidateStageMissingRequiredProperty() throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractStageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractStageContext.java
@@ -61,8 +61,9 @@ public abstract class AbstractStageContext implements StageContext {
     this.pipelineRuntime = pipelineRuntime;
     this.stageSpec = stageSpec;
     this.stageMetrics = new DefaultStageMetrics(pipelineRuntime.getMetrics(), stageSpec.getName());
+    Map<String, Schema> inputSchemas = stageSpec.getInputSchemas();
     // all plugins except joiners have just a single input schema
-    this.inputSchema = stageSpec.getInputSchemas().isEmpty() ?
+    this.inputSchema = inputSchemas.isEmpty() ?
       null : stageSpec.getInputSchemas().values().iterator().next();
     Map<String, Schema> portSchemas = new HashMap<>();
     for (StageSpec.Port outputPort : stageSpec.getOutputPorts().values()) {
@@ -72,7 +73,7 @@ public abstract class AbstractStageContext implements StageContext {
     }
     this.outputPortSchemas = Collections.unmodifiableMap(portSchemas);
     this.arguments = pipelineRuntime.getArguments();
-    this.failureCollector = new LoggingFailureCollector(stageSpec.getName());
+    this.failureCollector = new LoggingFailureCollector(stageSpec.getName(), inputSchemas);
     this.macroEvaluator = new DefaultMacroEvaluator(arguments, pipelineRuntime.getLogicalStartTime(),
                                                     pipelineRuntime.getSecureStore(), pipelineRuntime.getNamespace());
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultStageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultStageConfigurer.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
  * where we allow multiple input schemas
  */
 public class DefaultStageConfigurer implements StageConfigurer, MultiInputStageConfigurer, MultiOutputStageConfigurer {
+  private String stageName;
   private Schema outputSchema;
   private Schema outputErrorSchema;
   private boolean errorSchemaSet;
@@ -45,7 +46,7 @@ public class DefaultStageConfigurer implements StageConfigurer, MultiInputStageC
     this.inputSchemas = new HashMap<>();
     this.outputPortSchemas = new HashMap<>();
     this.errorSchemaSet = false;
-    this.collector = new DefaultFailureCollector(stageName);
+    this.stageName = stageName;
   }
 
   @Nullable
@@ -87,6 +88,9 @@ public class DefaultStageConfigurer implements StageConfigurer, MultiInputStageC
 
   @Override
   public FailureCollector getFailureCollector() {
+    if (collector == null) {
+      this.collector = new DefaultFailureCollector(stageName, inputSchemas);
+    }
     return collector;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/DefaultFailureCollector.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/DefaultFailureCollector.java
@@ -16,12 +16,16 @@
 
 package io.cdap.cdap.etl.validation;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -29,22 +33,25 @@ import javax.annotation.Nullable;
  */
 public class DefaultFailureCollector implements FailureCollector {
   private static final String STAGE = "stage";
-  private final List<ValidationFailure> failures;
   private final String stageName;
+  private final Map<String, Schema> inputSchemas;
+  private final List<ValidationFailure> failures;
 
   /**
    * Default failure collector.
    *
    * @param stageName stage name
+   * @param inputSchemas input schemas
    */
-  public DefaultFailureCollector(String stageName) {
+  public DefaultFailureCollector(String stageName, Map<String, Schema> inputSchemas) {
     this.stageName = stageName;
+    this.inputSchemas = Collections.unmodifiableMap(new HashMap<>(inputSchemas));
     this.failures = new ArrayList<>();
   }
 
   @Override
   public ValidationFailure addFailure(String message, @Nullable String correctiveAction) {
-    ValidationFailure failure = new ValidationFailure(message, correctiveAction);
+    ValidationFailure failure = new ValidationFailure(message, correctiveAction, inputSchemas);
     failures.add(failure);
     return failure;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/LoggingFailureCollector.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/LoggingFailureCollector.java
@@ -16,12 +16,14 @@
 
 package io.cdap.cdap.etl.validation;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -35,9 +37,10 @@ public class LoggingFailureCollector extends DefaultFailureCollector {
    * Failure collector that logs the failures.
    *
    * @param stageName stage name
+   * @param inputSchemas input schemas
    */
-  public LoggingFailureCollector(String stageName) {
-    super(stageName);
+  public LoggingFailureCollector(String stageName, Map<String, Schema> inputSchemas) {
+    super(stageName, inputSchemas);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/StringValueFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/StringValueFilterTransform.java
@@ -71,7 +71,7 @@ public class StringValueFilterTransform extends Transform<StructuredRecord, Stru
       if (fieldType != Schema.Type.STRING) {
         collector.addFailure(String.format("'%s' is of type '%s' instead of a string.", config.field, fieldType),
                              "Make sure provided field is of type string.")
-          .withConfigProperty("field").withInputSchemaField(config.field, null);
+          .withConfigProperty("field").withInputSchemaField(config.field);
       }
     }
     stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());


### PR DESCRIPTION
modifying the REST response to always contain input stage name for input field errors. 

![Screen Shot 2019-09-18 at 6 39 13 PM](https://user-images.githubusercontent.com/14131070/65206570-aa84ba80-da43-11e9-90f2-9f20ff13c5c5.png)

build: https://builds.cask.co/browse/CDAP-RUT1694-1