### PR TITLE
CDAP-15905 evaluate macros in pipeline stage validation endpoint

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/macro/MacroParserOptions.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/macro/MacroParserOptions.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.macro;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Options for macro parsing.
+ */
+public class MacroParserOptions {
+  public static final MacroParserOptions DEFAULT = builder().build();
+  private final boolean evaluateLookups;
+  private final boolean evaluateFunctions;
+  private final boolean escapingEnabled;
+  private final boolean skipInvalid;
+  private final int maxRecurseDepth;
+  private final Set<String> functionWhitelist;
+
+  private MacroParserOptions(boolean evaluateLookups, boolean evaluateFunctions,
+                             boolean escapingEnabled, boolean skipInvalid,
+                             int maxRecurseDepth, Set<String> functionWhitelist) {
+    this.evaluateLookups = evaluateLookups;
+    this.evaluateFunctions = evaluateFunctions;
+    this.escapingEnabled = escapingEnabled;
+    this.maxRecurseDepth = maxRecurseDepth;
+    this.skipInvalid = skipInvalid;
+    this.functionWhitelist = functionWhitelist;
+  }
+
+  public boolean shouldEvaluateLookups() {
+    return evaluateLookups;
+  }
+
+  public boolean shouldEvaluateFunctions() {
+    return evaluateFunctions;
+  }
+
+  public boolean shouldSkipInvalid() {
+    return skipInvalid;
+  }
+
+  public boolean isEscapingEnabled() {
+    return escapingEnabled;
+  }
+
+  public int getMaxRecurseDepth() {
+    return maxRecurseDepth;
+  }
+
+  public Set<String> getFunctionWhitelist() {
+    return functionWhitelist;
+  }
+
+  /**
+   * @return Builder to create options
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builds macro parser options.
+   */
+  public static class Builder {
+    private boolean evaluateLookups = true;
+    private boolean evaluateFunctions = true;
+    private boolean escapingEnabled = true;
+    private boolean skipInvalid = false;
+    private int maxRecurseDepth = 10;
+    private Set<String> functionWhitelist = new HashSet<>();
+
+    public Builder disableLookups() {
+      evaluateLookups = false;
+      return this;
+    }
+
+    public Builder disableFunctions() {
+      evaluateFunctions = false;
+      return this;
+    }
+
+    public Builder skipInvalidMacros() {
+      skipInvalid = true;
+      return this;
+    }
+
+    public Builder setEscaping(boolean escapingEnabled) {
+      this.escapingEnabled = escapingEnabled;
+      return this;
+    }
+
+    public Builder setMaxRecurseDepth(int maxRecurseDepth) {
+      this.maxRecurseDepth = maxRecurseDepth;
+      return this;
+    }
+
+    public Builder setFunctionWhitelist(Collection<String> whitelist) {
+      functionWhitelist.clear();
+      functionWhitelist.addAll(whitelist);
+      return this;
+    }
+
+    public Builder setFunctionWhitelist(String... whitelist) {
+      return setFunctionWhitelist(Arrays.asList(whitelist));
+    }
+
+    public MacroParserOptions build() {
+      return new MacroParserOptions(evaluateLookups, evaluateFunctions, escapingEnabled,
+                                    skipInvalid, maxRecurseDepth, functionWhitelist);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/FindPluginHelper.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/FindPluginHelper.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.runtime.plugin;
 
 import com.google.common.base.Throwables;
 import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginProperties;
@@ -52,9 +53,10 @@ public final class FindPluginHelper {
 
     for (PluginPropertyField field : pluginEntry.getValue().getProperties().values()) {
       if (field.isMacroSupported() && properties.getProperties().containsKey(field.getName())) {
-        MacroParser parser = MacroParser.builder(collectMacroEvaluator)
-          .setEscapingEnabled(field.isMacroEscapingEnabled())
-          .build();
+        MacroParser parser = new MacroParser(collectMacroEvaluator,
+                                             MacroParserOptions.builder()
+                                               .setEscaping(field.isMacroEscapingEnabled())
+                                               .build());
         parser.parse(properties.getProperties().get(field.getName()));
       }
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.InvalidPluginConfigException;
 import io.cdap.cdap.api.plugin.InvalidPluginProperty;
 import io.cdap.cdap.api.plugin.Plugin;
@@ -293,16 +294,18 @@ public class PluginInstantiator implements Closeable {
         // TODO: cleanup after endpoint to get plugin details is merged (#6089)
         if (configTime) {
           // parse for syntax check and check if trackingMacroEvaluator finds macro syntax present
-          MacroParser macroParser = MacroParser.builder(trackingMacroEvaluator)
-            .setEscapingEnabled(field.isMacroEscapingEnabled())
-            .build();
+          MacroParser macroParser = new MacroParser(trackingMacroEvaluator,
+                                                    MacroParserOptions.builder()
+                                                      .setEscaping(field.isMacroEscapingEnabled())
+                                                      .build());
           macroParser.parse(propertyValue);
           propertyValue = getOriginalOrDefaultValue(propertyValue, property.getKey(), field.getType(),
                                                     trackingMacroEvaluator);
         } else {
-          MacroParser macroParser = MacroParser.builder(macroEvaluator)
-            .setEscapingEnabled(field.isMacroEscapingEnabled())
-            .build();
+          MacroParser macroParser = new MacroParser(macroEvaluator,
+                                                    MacroParserOptions.builder()
+                                                      .setEscaping(field.isMacroEscapingEnabled())
+                                                      .build());
           propertyValue = macroParser.parse(propertyValue);
         }
       }
@@ -342,9 +345,10 @@ public class PluginInstantiator implements Closeable {
       if (pluginEntry.getValue() != null && pluginField.isMacroSupported()) {
         String macroValue = plugin.getProperties().getProperties().get(pluginEntry.getKey());
         if (macroValue != null) {
-          MacroParser macroParser = MacroParser.builder(trackingMacroEvaluator)
-            .setEscapingEnabled(pluginField.isMacroEscapingEnabled())
-            .build();
+          MacroParser macroParser = new MacroParser(trackingMacroEvaluator,
+                                                    MacroParserOptions.builder()
+                                                      .setEscaping(pluginField.isMacroEscapingEnabled())
+                                                      .build());
           macroParser.parse(macroValue);
           if (trackingMacroEvaluator.hasMacro()) {
             macroFields.add(pluginEntry.getKey());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.artifact.ArtifactManager;
 import io.cdap.cdap.api.artifact.CloseableClassLoader;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.metadata.MetadataReader;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
@@ -237,10 +238,9 @@ public class BasicHttpServiceContext extends AbstractContext implements SystemHt
 
   @Override
   public Map<String, String> evaluateMacros(String namespace, Map<String, String> macros,
-                                            MacroEvaluator evaluator) throws InvalidMacroException {
-    MacroParser macroParser = MacroParser.builder(evaluator)
-      .whitelistFunctions(SECURE_FUNCTION)
-      .build();
+                                            MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    MacroParser macroParser = new MacroParser(evaluator, options);
     Map<String, String> evaluated = new HashMap<>();
 
     for (Map.Entry<String, String> property : macros.entrySet()) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
@@ -25,6 +25,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.Requirements;
 import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.app.runtime.ProgramOptions;
@@ -724,11 +725,12 @@ public class ProvisioningService extends AbstractIdleService {
                                             Map<String, String> properties) {
     // evaluate macros in the provisioner properties
     MacroEvaluator evaluator = new ProvisionerMacroEvaluator(namespace, secureStore);
-    MacroParser macroParser = MacroParser.builder(evaluator)
-      .disableEscaping()
-      .disableLookups()
-      .whitelistFunctions(ProvisionerMacroEvaluator.SECURE_FUNCTION)
-      .build();
+    MacroParser macroParser = new MacroParser(evaluator,
+                                              MacroParserOptions.builder()
+                                                .disableLookups()
+                                                .setFunctionWhitelist(ProvisionerMacroEvaluator.SECURE_FUNCTION)
+                                                .setEscaping(false)
+                                                .build());
     Map<String, String> evaluated = new HashMap<>();
 
     // do secure store lookups as the user that will run the program

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/CollectMacroEvaluatorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/CollectMacroEvaluatorTest.java
@@ -36,7 +36,7 @@ public class CollectMacroEvaluatorTest {
   @Test
   public void testMacrosCollected() {
     CollectMacroEvaluator collectMacroEvaluator = new CollectMacroEvaluator();
-    MacroParser parser = MacroParser.builder(collectMacroEvaluator).build();
+    MacroParser parser = new MacroParser(collectMacroEvaluator);
     List<String> macros = new ArrayList<>();
     macros.add("${hello}${world}");
     macros.add("${secure2(password)}");

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
@@ -56,6 +56,12 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-system-app-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/SecureStoreMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/SecureStoreMacroEvaluator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.api.security.store.SecureStoreData;
+
+/**
+ * Evaluates secure store macros if the key exists. Otherwise, returns the input.
+ */
+public class SecureStoreMacroEvaluator implements MacroEvaluator {
+  private final String namespace;
+  private final SecureStore secureStore;
+
+  public SecureStoreMacroEvaluator(String namespace, SecureStore secureStore) {
+    this.namespace = namespace;
+    this.secureStore = secureStore;
+  }
+
+  @Override
+  public String lookup(String property) throws InvalidMacroException {
+    // this will get ignored by the parser
+    throw new InvalidMacroException("Unable to lookup the value for " + property);
+  }
+
+  @Override
+  public String evaluate(String macroFunction, String... arguments) throws InvalidMacroException {
+    try {
+      SecureStoreData secureStoreData = secureStore.get(namespace, arguments[0]);
+      return Bytes.toString(secureStoreData.get());
+    } catch (Exception e) {
+      throw new InvalidMacroException("Unable to get the secure value for " + arguments[0]);
+    }
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/StudioService.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/StudioService.java
@@ -17,12 +17,12 @@
 
 package io.cdap.cdap.datapipeline.service;
 
-import io.cdap.cdap.api.service.AbstractService;
+import io.cdap.cdap.api.service.AbstractSystemService;
 
 /**
  * Service that handles pipeline studio operations, like validation and schema propagation.
  */
-public class StudioService extends AbstractService {
+public class StudioService extends AbstractSystemService {
   public static final String NAME = "studio";
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
@@ -98,12 +98,12 @@ public class DataPipelineServiceTest extends HydratorTestBase {
 
   @BeforeClass
   public static void setupTest() throws Exception {
-    ArtifactId appArtifactId = NamespaceId.DEFAULT.artifact("app", "1.0.0");
+    ArtifactId appArtifactId = NamespaceId.SYSTEM.artifact("app", "1.0.0");
     setupBatchArtifacts(appArtifactId, DataPipelineApp.class);
 
     ArtifactSummary artifactSummary = new ArtifactSummary(appArtifactId.getArtifact(), appArtifactId.getVersion());
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(artifactSummary, ETLBatchConfig.forSystemService());
-    ApplicationManager appManager = deployApplication(NamespaceId.DEFAULT.app("datapipeline"), appRequest);
+    ApplicationManager appManager = deployApplication(NamespaceId.SYSTEM.app("datapipeline"), appRequest);
     serviceManager = appManager.getServiceManager(StudioService.NAME);
     serviceManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
     serviceURI = serviceManager.getServiceURL(1, TimeUnit.MINUTES).toURI();
@@ -113,6 +113,38 @@ public class DataPipelineServiceTest extends HydratorTestBase {
   public static void teardownTests() throws InterruptedException, ExecutionException, TimeoutException {
     serviceManager.stop();
     serviceManager.waitForStopped(2, TimeUnit.MINUTES);
+  }
+
+  @Test
+  public void testSecureMacroSubstitution() throws Exception {
+    // StringValueFilterTransform checks that the field exists in the input schema
+    String stageName = "tx";
+    Map<String, String> properties = new HashMap<>();
+    properties.put("field", "${secure(field)}");
+    properties.put("value", "y");
+    ETLStage stage = new ETLStage(stageName, new ETLPlugin(StringValueFilterTransform.NAME, Transform.PLUGIN_TYPE,
+                                                           properties));
+    Schema inputSchema = Schema.recordOf("x", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+
+    // this call happens when no value for 'field' is in the secure store, which should not result in
+    // any failures because the macro could not be enabled so the check is skipped
+    StageValidationRequest requestBody =
+      new StageValidationRequest(stage, Collections.singletonList(new StageSchema("input", inputSchema)));
+    StageValidationResponse actual = sendRequest(requestBody);
+    Assert.assertTrue(actual.getFailures().isEmpty());
+
+    // now set the value of 'field' to be 'z', which is not in the input schema
+    // this call should result in a failure
+    getSecureStoreManager().put("default", "field", "z", "desc", Collections.emptyMap());
+    actual = sendRequest(requestBody);
+    Assert.assertNull(actual.getSpec());
+    Assert.assertEquals(1, actual.getFailures().size());
+    ValidationFailure failure = actual.getFailures().iterator().next();
+    // the stage will add 2 causes for invalid input field failure. One is related to input field and the other is
+    // related to config property.
+    Assert.assertEquals(1, failure.getCauses().size());
+    Assert.assertEquals("field", failure.getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+    Assert.assertEquals(stageName, failure.getCauses().get(0).getAttribute(STAGE));
   }
 
   @Test
@@ -177,7 +209,7 @@ public class DataPipelineServiceTest extends HydratorTestBase {
       .getAttribute(CauseAttributes.REQUESTED_ARTIFACT_VERSION));
     Assert.assertEquals(batchMocksArtifactId.getArtifact(), failure.getCauses().get(0)
       .getAttribute(CauseAttributes.SUGGESTED_ARTIFACT_NAME));
-    Assert.assertEquals(ArtifactScope.USER.name(), failure.getCauses().get(0)
+    Assert.assertEquals(ArtifactScope.SYSTEM.name(), failure.getCauses().get(0)
       .getAttribute(CauseAttributes.SUGGESTED_ARTIFACT_SCOPE));
     Assert.assertEquals(batchMocksArtifactId.getVersion(), failure.getCauses().get(0)
       .getAttribute(CauseAttributes.SUGGESTED_ARTIFACT_VERSION));

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
@@ -60,6 +60,12 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-system-app-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-common/src/main/resources/bootstrap/distributed.json
+++ b/cdap-common/src/main/resources/bootstrap/distributed.json
@@ -18,7 +18,7 @@
     {
       "label": "Create pipeline application",
       "type": "CREATE_APPLICATION",
-      "runCondition": "ONCE",
+      "runCondition": "ALWAYS",
       "arguments": {
         "namespace": "system",
         "name": "pipeline",
@@ -29,13 +29,14 @@
         },
         "config": {
           "service": true
-        }
+        },
+        "overwrite": true
       }
     },
     {
       "label": "Start pipeline service",
       "type": "START_PROGRAM",
-      "runCondition": "ONCE",
+      "runCondition": "ALWAYS",
       "arguments": {
         "namespace": "system",
         "application": "pipeline",

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
@@ -19,9 +19,11 @@ package io.cdap.cdap.api.service.http;
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A System HttpServiceContext that exposes capabilities beyond those available to service contexts for user services.
@@ -30,14 +32,33 @@ import java.util.Map;
 public interface SystemHttpServiceContext extends HttpServiceContext, TransactionRunner {
 
   /**
-   * Evaluates macros using provided macro evaluator.
+   * Evaluates lookup macros and the 'secure' macro function using provided macro evaluator.
    *
    * @param namespace namespace in which macros needs to be evaluated
-   * @param macros key-value map of evaluated macros
+   * @param properties key-value map of properties to evaluate
    * @param evaluator macro evaluator to be used to evaluate macros
    * @return map of evaluated macros
    * @throws InvalidMacroException indicates that there is an invalid macro
    */
-  Map<String, String> evaluateMacros(String namespace, Map<String, String> macros,
-                                     MacroEvaluator evaluator) throws InvalidMacroException;
+  default Map<String, String> evaluateMacros(String namespace, Map<String, String> properties,
+                                             MacroEvaluator evaluator) throws InvalidMacroException {
+    return evaluateMacros(namespace, properties, evaluator,
+                          MacroParserOptions.builder()
+                            .setFunctionWhitelist("secure")
+                            .setEscaping(false)
+                            .build());
+  }
+
+  /**
+   * Evaluates macros using provided macro evaluator with the provided parsing options.
+   *
+   * @param namespace namespace in which macros needs to be evaluated
+   * @param properties key-value map of properties to evaluate
+   * @param evaluator macro evaluator to be used to evaluate macros
+   * @param options macro parsing options
+   * @return map of evaluated macros
+   * @throws InvalidMacroException indicates that there is an invalid macro
+   */
+  Map<String, String> evaluateMacros(String namespace, Map<String, String> properties,
+                                     MacroEvaluator evaluator, MacroParserOptions options) throws InvalidMacroException;
 }


### PR DESCRIPTION
Added secure macro evaluation to the pipeline stage validation
endpoint. This required changing the pipeline studio app into
a system service app, which also required changing the bootstrap
config to overwrite the existing studio app if it already exists
on startup, in order for it to automatically get updated when
CDAP is upgraded.

The validation endpoint doesn't want to throw an error if macros
couldn't be evaluated. Instead, it wants to use the original
string if any error is encountered. In order to support this,
refactored the MacroParser to take a MacroParserOptions object
that contains all of the current parser options as well as a new
option to skip evaluation of invalid macros. Enhanced the
system http context to allow the caller to pass in the parser
options when performing evaluation.