### PR TITLE
CDAP-15394 remove parallel sink writes by default

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -343,6 +343,15 @@ public abstract class SparkPipelineRunner {
       emittedRecords.put(stageName, emittedBuilder.build());
     }
 
+    boolean shouldWriteInParallel = Boolean.parseBoolean(
+      sec.getRuntimeArguments().get("pipeline.spark.parallel.sinks.enabled"));
+    if (!shouldWriteInParallel) {
+      for (Runnable runnable : sinkRunnables) {
+        runnable.run();
+      }
+      return;
+    }
+
     Collection<Future> sinkFutures = new ArrayList<>(sinkRunnables.size());
     ExecutorService executorService = Executors.newFixedThreadPool(sinkRunnables.size(), new ThreadFactoryBuilder()
       .setNameFormat("pipeline-sink-task")


### PR DESCRIPTION
Added a runtime argument to enable parallel sink writes in Spark
pipelines, which defaults to false. This is because the parallel
writes causes Spark to re-process much of the pipeline, resulting
in very confusing metrics for most people.

In some situations, this will cause the pipeline to run slower
than it otherwise would have, but the default experience for
people should be better.