### PR TITLE
[CDAP-15939] Modify property error handling to handle multiple errors

### DIFF
--- a/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
@@ -185,7 +185,7 @@ export function constructErrors(failures) {
   const propsWithPropErrors = new Set(); // keep track of properties w/property-level errors
 
   // helper for adding an error to error object
-  const addError = (errorObj, newError, key) => {
+  const addError = (errorObj: IPropErrors, newError: IErrorObj, key: string) => {
     if (errorObj.hasOwnProperty(key)) {
       errorObj[key].push(newError);
     } else {

--- a/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
@@ -221,11 +221,7 @@ export function constructErrors(failures) {
               }
             }
             // For property-level errors, keep only first property-level error
-            else if (
-              (propertyErrors.hasOwnProperty(stageConfig) &&
-                !propsWithPropErrors.has(stageConfig)) ||
-              !propertyErrors.hasOwnProperty(stageConfig)
-            ) {
+            else if (!propsWithPropErrors.has(stageConfig)) {
               addError(propertyErrors, err, stageConfig);
               propsWithPropErrors.add(stageConfig);
             }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15939
Build: https://builds.cask.co/browse/CDAP-UDUT419

The current desired behavior in the UI is to only surface a single property level error at a time (if multiple exists), and also to only surface a single element level error at a time. The Configuration group and its child components currently assume the errors it gets follow those constraints, so it breaks (i.e. shows no errors) if it gets multiple property level errors. 

Changes made: 
- Modified property and element-level error handling logic to only keep first property level and element level error, which gets passed down and surfaced by ConfigurationGroup or appropriate child component. 
- Factored out logic for adding an error to an error object