### PR TITLE
CDAP-15943 fix remote runs when master is using internal ssl

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -429,6 +429,9 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
       result.set(Constants.Service.MASTER_SERVICES_BIND_ADDRESS, masterBindAddrConf);
       result.set(Constants.Dataset.Executor.ADDRESS, masterBindAddrConf);
       result.set(Constants.Metadata.SERVICE_BIND_ADDRESS, masterBindAddrConf);
+
+      // Don't try and use the CDAP system certs for SSL
+      result.unset(Constants.Security.SSL.INTERNAL_CERT_PATH);
     }
 
     return result;


### PR DESCRIPTION
For remote runs, set internal ssl to disabled so that it doesn't
try and use ssl for "internal" communication within the same
process and it doesn't try to read a cert/private key file that
doesn't exist.