### PR TITLE
[CDAP-15930] concatenate error msg and corrective action with space

### DIFF
--- a/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
@@ -271,7 +271,7 @@ function constructErrorMessage(error: string, correctiveAction: string) {
     message += error;
   }
   if (correctiveAction) {
-    message += ` - ${correctiveAction}`;
+    message += ` ${correctiveAction}`;
   }
   return message;
 }


### PR DESCRIPTION
Error message and corrective action separator would be a space.