### PR TITLE
[CDAP-15950] Fix styling of securekeys in dataprep add connections

### DIFF
--- a/cdap-ui/app/cdap/components/ConfigurationGroup/WidgetWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/WidgetWrapper/index.tsx
@@ -85,7 +85,7 @@ const styles = (theme): StyleRules => {
 
 interface IWidgetWrapperProps extends WithStyles<typeof styles> {
   widgetProperty: IWidgetProperty;
-  pluginProperty: IPluginProperty;
+  pluginProperty?: IPluginProperty;
   value: string;
   onChange: (value: string) => void;
   updateAllProperties: (values) => void;
@@ -94,20 +94,22 @@ interface IWidgetWrapperProps extends WithStyles<typeof styles> {
   hideDescription?: boolean;
   errors?: IErrorObj[];
   size?: 'large' | 'small' | 'medium';
+  hideLabel?: boolean;
 }
 
 const WidgetWrapperView: React.FC<IWidgetWrapperProps> = ({
   widgetProperty,
-  pluginProperty,
+  pluginProperty = {},
   value,
   onChange,
   updateAllProperties,
   extraConfig,
   disabled,
-  hideDescription,
+  hideDescription = false,
   classes,
   errors,
   size = 'large',
+  hideLabel = false,
 }) => {
   const widgetType = objectQuery(widgetProperty, 'widget-type');
   const [isFocused, setIsFocused] = React.useState<boolean>(false);
@@ -133,7 +135,7 @@ const WidgetWrapperView: React.FC<IWidgetWrapperProps> = ({
       onFocus={onFocus}
       onBlur={onBlur}
     >
-      <If condition={!hideWrapper}>
+      <If condition={!hideWrapper || hideLabel}>
         <div className={`widget-wrapper-label ${classes.label}`}>
           {widgetProperty.label}
           <If condition={pluginProperty.required}>

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -213,7 +213,7 @@ $success_alert_bg_color: $brand-success;
 .add-to-pipeline-dataprep-modal.modal-dialog,
 .dataprep-upgrade-modal.modal-dialog {
 
-  .modal-body {
+  .modal-content .modal-body {
     padding: 0;
 
     .message { padding: 15px; }

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DatabaseConnection/DatabaseDetail.js
@@ -29,7 +29,7 @@ import CardActionFeedback from 'components/CardActionFeedback';
 import uuidV4 from 'uuid/v4';
 import LoadingSVG from 'components/LoadingSVG';
 import { ConnectionType } from 'components/DataPrepConnections/ConnectionType';
-import SecureKeyPassword from 'components/AbstractWidget/SecureKey/SecureKeyPassword';
+import { WrappedWidgetWrapper } from 'components/ConfigurationGroup/WidgetWrapper';
 
 const CONN_TYPE = {
   basic: 'BASIC',
@@ -346,7 +346,15 @@ export default class DatabaseDetail extends Component {
       <div className="form-group row">
         <label className={LABEL_COL_CLASS}>{T.translate(`${PREFIX}.password`)}</label>
         <div className={INPUT_COL_CLASS}>
-          <SecureKeyPassword value={this.state.password} onChange={this.handlePasswordChange} />
+          <WrappedWidgetWrapper
+            widgetProperty={{
+              'widget-type': 'securekey-password',
+            }}
+            value={this.state.password}
+            onChange={this.handlePasswordChange}
+            hideLabel={true}
+            hideDescription={true}
+          />
         </div>
       </div>
     );
@@ -357,7 +365,7 @@ export default class DatabaseDetail extends Component {
 
     return (
       <div className="form-group row">
-        <div className="col-8 offset-4 col-offset-4">
+        <div className="col-8 offset-4 col-offset-4 col-xs-offset-4">
           <button className="btn btn-secondary" onClick={this.testConnection} disabled={disabled}>
             {T.translate(`${PREFIX}.testConnection`)}
           </button>
@@ -545,7 +553,7 @@ export default class DatabaseDetail extends Component {
 
     return (
       <div className="row">
-        <div className="col-8 offset-4 col-offset-4">
+        <div className="col-8 offset-4 col-offset-4 col-xs-offset-4">
           <button className="btn btn-primary" onClick={onClickFn} disabled={disabled}>
             {T.translate(`${PREFIX}.Buttons.${this.props.mode}`)}
           </button>

--- a/cdap-ui/app/cdap/components/DataPrepConnections/S3Connection/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/S3Connection/index.js
@@ -27,7 +27,7 @@ import { objectQuery } from 'services/helpers';
 import BtnWithLoading from 'components/BtnWithLoading';
 import ee from 'event-emitter';
 import { ConnectionType } from 'components/DataPrepConnections/ConnectionType';
-import SecureKeyText from 'components/AbstractWidget/SecureKey/SecureKeyText';
+import { WrappedWidgetWrapper } from 'components/ConfigurationGroup/WidgetWrapper';
 
 const PREFIX = 'features.DataPrepConnections.AddConnections.S3';
 const ADDCONN_PREFIX = 'features.DataPrepConnections.AddConnections';
@@ -373,12 +373,17 @@ export default class S3Connection extends Component {
             </label>
             <div className={INPUT_COL_CLASS}>
               <div className="input-text">
-                <SecureKeyText
+                <WrappedWidgetWrapper
+                  widgetProperty={{
+                    'widget-type': 'securekey-text',
+                    'widget-attributes': {
+                      placeholder: T.translate(`${PREFIX}.Placeholders.accessKeyId`).toString(),
+                    },
+                  }}
                   value={this.state.accessKeyId}
                   onChange={this.handleAccessSecretChange('accessKeyId')}
-                  widgetProps={{
-                    placeholder: T.translate(`${PREFIX}.Placeholders.accessKeyId`),
-                  }}
+                  hideLabel={true}
+                  hideDescription={true}
                 />
               </div>
             </div>
@@ -391,12 +396,17 @@ export default class S3Connection extends Component {
             </label>
             <div className={INPUT_COL_CLASS}>
               <div className="input-text">
-                <SecureKeyText
+                <WrappedWidgetWrapper
+                  widgetProperty={{
+                    'widget-type': 'securekey-password',
+                    'widget-attributes': {
+                      placeholder: T.translate(`${PREFIX}.Placeholders.accessSecretKey`).toString(),
+                    },
+                  }}
                   value={this.state.accessSecretKey}
                   onChange={this.handleAccessSecretChange('accessSecretKey')}
-                  widgetProps={{
-                    placeholder: T.translate(`${PREFIX}.Placeholders.accessSecretKey`),
-                  }}
+                  hideLabel={true}
+                  hideDescription={true}
                 />
               </div>
             </div>

--- a/cdap-ui/app/directives/plugin-templates/plugin-templates.html
+++ b/cdap-ui/app/directives/plugin-templates/plugin-templates.html
@@ -29,7 +29,7 @@
     </a>
   </div>
 </div>
-<div class="modal-body">
+<div class="modal-body plugin-template-modal-body">
   <div class="form-content">
     <div ng-if="PluginTemplatesCtrl.pluginType">
       <label class="label-control">
@@ -93,7 +93,7 @@
           <div class="widget-group-container">
             <h5>{{::group.display}}</h5>
             <div ng-repeat="field in group.fields">
-              <div ng-if="field.name !== PluginTemplatesCtrl.groupsConfig.outputSchema.schemaProperty">
+              <div ng-if="field.name !== PluginTemplatesCtrl.groupsConfig.outputSchema.schemaProperty" class="plugin-template-field-row">
 
                 <div class="form-group">
                   <widget-wrapper

--- a/cdap-ui/app/directives/plugin-templates/plugin-templates.less
+++ b/cdap-ui/app/directives/plugin-templates/plugin-templates.less
@@ -20,4 +20,13 @@ plugin-templates {
     overflow-x: hidden;
     overflow-y: auto;
   }
+
+  .plugin-template-field-row {
+    margin-top: 15px;
+    margin-bottom: 25px;
+  }
+
+  .modal-body.plugin-template-modal-body {
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
JIRAs:
- https://issues.cask.co/browse/CDAP-15926
- https://issues.cask.co/browse/CDAP-15950

Build: https://builds.cask.co/browse/CDAP-URUT169

Fixes:
- secure keys have no outline in adding S3 or Database plugins
- alignment of database test connection and add connection buttons in wrangler (from studio)
- plugin templates modal having double scroll