### PR TITLE
Fixes e2e tests to use a version range for plugins in pipelines

### DIFF
--- a/cdap-ui/cypress/fixtures/fll_airport_pipeline2.json
+++ b/cdap-ui/cypress/fixtures/fll_airport_pipeline2.json
@@ -35,7 +35,7 @@
                     "label": "Airport_source",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -72,7 +72,7 @@
                     "label": "Airport_sink",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {

--- a/cdap-ui/cypress/fixtures/fll_wrangler-test-pipeline.json
+++ b/cdap-ui/cypress/fixtures/fll_wrangler-test-pipeline.json
@@ -39,7 +39,7 @@
                     "label": "Airport_source",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -76,7 +76,7 @@
                     "label": "Wrangler",
                     "artifact": {
                         "name": "wrangler-transform",
-                        "version": "4.1.0-SNAPSHOT",
+                        "version": "[4.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -106,7 +106,7 @@
                     "label": "Airport_sink",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {

--- a/cdap-ui/cypress/fixtures/null_splitter_pipeline-cdap-data-pipeline.json
+++ b/cdap-ui/cypress/fixtures/null_splitter_pipeline-cdap-data-pipeline.json
@@ -54,7 +54,7 @@
                     "label": "File",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -77,7 +77,7 @@
                     "label": "CSVParser",
                     "artifact": {
                         "name": "transform-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -102,7 +102,7 @@
                     "label": "JavaScript",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -126,7 +126,7 @@
                     "label": "NullFieldSplitter",
                     "artifact": {
                         "name": "transform-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -159,7 +159,7 @@
                     "label": "Non null sink dataset",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -184,7 +184,7 @@
                     "label": "null sink dataset",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {

--- a/cdap-ui/cypress/fixtures/union_condition_splitter_pipeline_v1-cdap-data-pipeline.json
+++ b/cdap-ui/cypress/fixtures/union_condition_splitter_pipeline_v1-cdap-data-pipeline.json
@@ -72,7 +72,7 @@
                     "label": "File",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -95,7 +95,7 @@
                     "label": "CSVParser",
                     "artifact": {
                         "name": "transform-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -120,7 +120,7 @@
                     "label": "JavaScript3",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -144,7 +144,7 @@
                     "label": "UnionSplitter",
                     "artifact": {
                         "name": "transform-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -177,7 +177,7 @@
                     "label": "String JavaScript Emitter",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -201,7 +201,7 @@
                     "label": "Conditional",
                     "artifact": {
                         "name": "condition-plugins",
-                        "version": "1.4.0-SNAPSHOT",
+                        "version": "[1.4.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -224,7 +224,7 @@
                     "label": "String Prices",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -251,7 +251,7 @@
                     "label": "CDAP Table Dataset",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -276,7 +276,7 @@
                     "label": "JavaScript2",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -300,7 +300,7 @@
                     "label": "File3",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {


### PR DESCRIPTION
- This to make sure e2e for UI passes fine in latest develop
- We can merge this post release/6.1. There is no urgency in merging the pull request

E2E Build: https://builds.cask.co/browse/IT-UPD279-1