### PR TITLE
CDAP-15501 set block interval automatically

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -98,6 +98,7 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
 
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
+    sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
     for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {
       sparkConf.set(property.getKey(), property.getValue());
     }


### PR DESCRIPTION
For most streaming pipelines, the default block interval of
200ms generates too many partitions. This is especially true of
file based sinks, which will write out a file for each part.

If the block interval is not explicitly set by the user, set it
to 20% of the batch interval to generate a smaller number of
partitions.