### PR TITLE
CDAP-15971 reorder CMEK property to be on bottom

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -103,24 +103,6 @@
           }
         },
         {
-          "widget-type": "textbox",
-          "label": "Encryption Key Name",
-          "name": "encryptionKeyName",
-          "description": "The GCP customer managed encryption key(CMEK) name used by Cloud Dataproc",
-          "widget-attributes": {
-            "placeholder": "projects/<gcp-project-id>/locations/<key-location>/keyRings/<key-ring-name>/cryptoKeys/<key-name>"
-          }
-        },
-        {
-          "widget-type": "textbox",
-          "label": "GCS Bucket",
-          "name": "gcsBucket",
-          "description": "The Cloud Storage bucket used by Cloud Dataproc to read/write cluster and job data",
-          "widget-attributes": {
-            "placeholder": "Specify your GCS Bucket"
-          }
-        },
-        {
           "widget-type": "select",
           "label": "Prefer External IP",
           "name": "preferExternalIP",
@@ -160,6 +142,24 @@
             ],
             "default": "true",
             "size": "medium"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "GCS Bucket",
+          "name": "gcsBucket",
+          "description": "The Cloud Storage bucket used by Cloud Dataproc to read/write cluster and job data",
+          "widget-attributes": {
+            "size": "medium"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Encryption Key Name",
+          "name": "encryptionKeyName",
+          "description": "The GCP customer managed encryption key(CMEK) name used by Cloud Dataproc",
+          "widget-attributes": {
+            "placeholder": "projects/<gcp-project-id>/locations/<key-location>/keyRings/<key-ring-name>/cryptoKeys/<key-name>"
           }
         }
       ]


### PR DESCRIPTION
Move the CMEK dataproc property to the bottom of the section and
change the bucket property to be of medium size. This fixes the
weird styling where everything is medium except for CMEK, which is
in the middle of the section.