### PR TITLE
CDAP-15973 log cluster creation failures in dataproc provisioner

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -481,7 +481,17 @@ final class DataprocClient implements AutoCloseable {
         OperationsClient.ListOperationsPagedResponse operationsResponse =
           client.getOperationsClient().listOperations(resourceName, filter);
         OperationsClient.ListOperationsPage page = operationsResponse.getPage();
-        if (page != null && page.getPageElementCount() > 0) {
+        if (page == null) {
+          LOG.warn("Unable to get the cause of the cluster creation failure.");
+          return status;
+        }
+
+        if (page.getPageElementCount() > 1) {
+          // shouldn't be possible
+          LOG.warn("Multiple create operations found for cluster {}, may not be able to find the failure message.",
+                   name);
+        }
+        if (page.getPageElementCount() > 0) {
           Operation operation = page.getValues().iterator().next();
           Status operationError = operation.getError();
           if (operationError != null) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -23,6 +23,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.Throwables;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.rpc.AlreadyExistsException;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.NotFoundException;
@@ -48,6 +49,9 @@ import com.google.cloud.dataproc.v1.GceClusterConfig;
 import com.google.cloud.dataproc.v1.GetClusterRequest;
 import com.google.cloud.dataproc.v1.InstanceGroupConfig;
 import com.google.cloud.dataproc.v1.SoftwareConfig;
+import com.google.longrunning.Operation;
+import com.google.longrunning.OperationsClient;
+import com.google.rpc.Status;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
@@ -397,7 +401,9 @@ final class DataprocClient implements AutoCloseable {
         .setConfig(builder.build())
         .build();
 
-      return client.createClusterAsync(projectId, conf.getRegion(), cluster).getMetadata().get();
+      OperationFuture<Cluster, ClusterOperationMetadata> operationFuture =
+        client.createClusterAsync(projectId, conf.getRegion(), cluster);
+      return operationFuture.getMetadata().get();
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof ApiException) {
@@ -463,8 +469,32 @@ final class DataprocClient implements AutoCloseable {
    */
   io.cdap.cdap.runtime.spi.provisioner.ClusterStatus getClusterStatus(String name)
     throws RetryableProvisionException {
-    return getDataprocCluster(name).map(cluster -> convertStatus(cluster.getStatus()))
+    io.cdap.cdap.runtime.spi.provisioner.ClusterStatus status = getDataprocCluster(name)
+      .map(cluster -> convertStatus(cluster.getStatus()))
       .orElse(io.cdap.cdap.runtime.spi.provisioner.ClusterStatus.NOT_EXISTS);
+
+    // if it failed, try to get the create operation and log the error message
+    try {
+      if (status == io.cdap.cdap.runtime.spi.provisioner.ClusterStatus.FAILED) {
+        String resourceName = String.format("projects/%s/regions/%s/operations", projectId, conf.getRegion());
+        String filter = String.format("clusterName=%s AND operationType=CREATE", name);
+        OperationsClient.ListOperationsPagedResponse operationsResponse =
+          client.getOperationsClient().listOperations(resourceName, filter);
+        OperationsClient.ListOperationsPage page = operationsResponse.getPage();
+        if (page != null && page.getPageElementCount() > 0) {
+          Operation operation = page.getValues().iterator().next();
+          Status operationError = operation.getError();
+          if (operationError != null) {
+            LOG.warn("Failed to create cluster {}: {}", name, operationError.getMessage());
+          }
+        }
+      }
+    } catch (Exception e) {
+      // if we failed to get the operations list, log an error and proceed with normal execution
+      LOG.warn("Unable to get the cause of the cluster creation failure.", e);
+    }
+
+    return status;
   }
 
   /**

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocTool.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocTool.java
@@ -46,7 +46,8 @@ public class DataprocTool {
   private static final String PROVISION = "provision";
   private static final String DETAILS = "details";
   private static final String DEPROVISION = "deprovision";
-  private static final Set<String> COMMANDS = ImmutableSet.of(PROVISION, DETAILS, DEPROVISION);
+  private static final String STATUS = "status";
+  private static final Set<String> COMMANDS = ImmutableSet.of(PROVISION, DETAILS, DEPROVISION, STATUS);
 
   public static void main(String[] args) throws Exception {
 
@@ -121,6 +122,8 @@ public class DataprocTool {
         if (deleteOp.isPresent()) {
           System.out.println(GSON.toJson(deleteOp));
         }
+      } else if (STATUS.equalsIgnoreCase(command)) {
+        System.out.println(client.getClusterStatus(name));
       }
     }
   }
@@ -128,7 +131,7 @@ public class DataprocTool {
   private static void printUsage(Options options) {
     HelpFormatter helpFormatter = new HelpFormatter();
     helpFormatter.printHelp(
-      DataprocTool.class.getSimpleName() + " provision|details|deprovision",
+      DataprocTool.class.getSimpleName() + " provision|details|status|deprovision",
       "Provisions, deprovisions, or gets the status of a cluster. Basic provisioner settings can be passed in as " +
         "options. Advanced provisioner settings can be specified in a file, in which case every setting must be " +
         "given.",


### PR DESCRIPTION
Enhanced the provisioner to log the creation failure error message
if it sees a failed cluster. Without this, the user will not know
why the cluster failed to create.