### PR TITLE
Fix resiliency of websocket

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorPlusPlusTopPanelCtrl {
-  constructor($stateParams, HydratorPlusPlusConfigStore, HydratorPlusPlusConfigActions, $uibModal, HydratorPlusPlusConsoleActions, DAGPlusPlusNodesActionsFactory, GLOBALS, myHelpers, HydratorPlusPlusConsoleStore, myPipelineExportModalService, $timeout, $scope, HydratorPlusPlusPreviewStore, HydratorPlusPlusPreviewActions, $interval, myPipelineApi, $state, MyCDAPDataSource, myAlertOnValium, MY_CONFIG, PREVIEWSTORE_ACTIONS, $q, NonStorePipelineErrorFactory, rArtifacts,  $window, LogViewerStore, LOGVIEWERSTORE_ACTIONS, myPreviewLogsApi, DAGPlusPlusNodesStore, myPreferenceApi, HydratorPlusPlusHydratorService, $rootScope, uuid, HydratorUpgradeService) {
+  constructor($stateParams, HydratorPlusPlusConfigStore, HydratorPlusPlusConfigActions, $uibModal, HydratorPlusPlusConsoleActions, DAGPlusPlusNodesActionsFactory, GLOBALS, myHelpers, HydratorPlusPlusConsoleStore, myPipelineExportModalService, $timeout, $scope, HydratorPlusPlusPreviewStore, HydratorPlusPlusPreviewActions, $interval, myPipelineApi, $state, MyCDAPDataSource, myAlertOnValium, MY_CONFIG, PREVIEWSTORE_ACTIONS, $q, NonStorePipelineErrorFactory, rArtifacts, $window, LogViewerStore, LOGVIEWERSTORE_ACTIONS, myPreviewLogsApi, DAGPlusPlusNodesStore, myPreferenceApi, HydratorPlusPlusHydratorService, $rootScope, uuid, HydratorUpgradeService) {
     this.consoleStore = HydratorPlusPlusConsoleStore;
     this.myPipelineExportModalService = myPipelineExportModalService;
     this.HydratorPlusPlusConfigStore = HydratorPlusPlusConfigStore;

--- a/cdap-ui/app/services/cask-angular-socket-datasource/datasource.js
+++ b/cdap-ui/app/services/cask-angular-socket-datasource/datasource.js
@@ -73,7 +73,7 @@ var socketDataSource = angular.module(PKG.name+'.services');
         var re = {};
         if (!resource.url) {
           re = resource;
-        }else {
+        } else {
           re = {
             id: resource.id,
             url: resource.url,
@@ -151,9 +151,9 @@ var socketDataSource = angular.module(PKG.name+'.services');
           var isPoll;
           hash = data.resource.id;
 
-          if(data.statusCode>299 || data.warning) {
+          if (data.statusCode>299 || data.warning) {
             if (self.bindings[hash]) {
-              if(self.bindings[hash].errorCallback) {
+              if (self.bindings[hash].errorCallback) {
                 $rootScope.$apply(self.bindings[hash].errorCallback.bind(null, data.error || data.response));
               } else if (self.bindings[hash].reject) {
                 $rootScope.$apply(self.bindings[hash].reject.bind(null, {data: data.error || data.response, statusCode: data.statusCode }));

--- a/cdap-ui/app/services/cask-angular-socket-datasource/socket.js
+++ b/cdap-ui/app/services/cask-angular-socket-datasource/socket.js
@@ -56,8 +56,12 @@ angular.module(PKG.name+'.services')
 
       socket.onopen = function () {
         if (!firstTime) {
-          EventPipe.emit(MYSOCKET_EVENT.reconnected);
-          attempt = 1;
+          window.CaskCommon.SessionTokenStore.fetchSessionToken().then(() => {
+            EventPipe.emit(MYSOCKET_EVENT.reconnected);
+            attempt = 1;
+          }, () => {
+            console.log('Failed to fetch session token');
+          });
         }
         firstTime = false;
 

--- a/cdap-ui/server/aggregator.js
+++ b/cdap-ui/server/aggregator.js
@@ -85,7 +85,14 @@ Aggregator.prototype.validateSession = function(message) {
      * Closes the connection if the session is not valid.
      */
     messageJSON = JSON.parse(message);
-    let authToken = messageJSON.resource.headers.Authorization || '';
+    let authToken = '';
+    if (
+      messageJSON.resource &&
+      messageJSON.resource.headers &&
+      messageJSON.resource.headers.Authorization
+    ) {
+      authToken = messageJSON.resource.headers.Authorization;
+    }
     if (!sessionToken.validateToken(messageJSON.sessionToken, this.cdapConfig, log, authToken)) {
       log.error('Found invalid session token. Closing websocket connection');
       this.connection.end();


### PR DESCRIPTION
Build: https://builds.cask.co/browse/CDAP-URUT195

## Description
When the WebSocket connection gets terminated, the UI will retry to create a new connection. However, when the connection is re-established, the Session Token already expire, therefore any existing poll that gets revived won't get the data back. Therefore, when the WebSocket connection gets reconnected, fetch the session token first before broadcasting that the socket is reconnected.