### PR TITLE
[CDAP-16045] Change View details from pipeline to go to metadata summary

### DIFF
--- a/cdap-ui/app/cdap/components/FieldLevelLineage/OperationsModal/ModalContent.js
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/OperationsModal/ModalContent.js
@@ -26,6 +26,7 @@ import T from 'i18n-react';
 const PREFIX = 'features.FieldLevelLineage.OperationsModal';
 
 function formatDatasets(datasets) {
+  // return in form 'dataset1; dataset2; dataset3'
   return datasets.map((dataset) => `'${dataset}'`).join('; ');
 }
 

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
@@ -185,15 +185,21 @@ export class Provider extends React.Component<{ children }, IContextState> {
   private fetchFieldLineage(qParams, timeParams, dataset = this.state.target) {
     const namespace = getCurrentNamespace();
     const updateState = (newState: IContextState) => {
-      // if there is an active field, get active links and active sets
-      if (newState.activeField.id) {
-        const activeLinks = this.getActiveLinks(newState.activeField.id, newState.links);
-        const activeSets = this.getActiveSets(activeLinks);
-
-        newState.activeLinks = activeLinks;
-        newState.activeCauseSets = activeSets.activeCauseSets;
-        newState.activeImpactSets = activeSets.activeImpactSets;
+      // If no field selected, grab the first field with lineage
+      if (!newState.activeField.id && newState.targetFields.length > 0) {
+        newState.activeField = {
+          id: newState.targetFields[0].id,
+          name: newState.targetFields[0].name,
+        };
       }
+
+      const activeLinks = this.getActiveLinks(newState.activeField.id, newState.links);
+      const activeSets = this.getActiveSets(activeLinks);
+
+      newState.activeLinks = activeLinks;
+      newState.activeCauseSets = activeSets.activeCauseSets;
+      newState.activeImpactSets = activeSets.activeImpactSets;
+
       this.setState(newState);
     };
     getFieldLineage(namespace, dataset, qParams, timeParams, updateState);

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/OperationsModal/ModalContent.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/OperationsModal/ModalContent.tsx
@@ -25,7 +25,21 @@ import T from 'i18n-react';
 const PREFIX = 'features.FieldLevelLineage.OperationsModal';
 
 function formatDatasets(datasets) {
-  return datasets.map((dataset) => `'${dataset}'`).join('; ');
+  // return in form 'dataset1, dataset2, and dataset3'
+  switch (datasets.length) {
+    case 0:
+      return '';
+    case 1:
+      return `'${datasets[0]}'`;
+    case 2:
+      return `'${datasets[0]}' and ${datasets[1]}`;
+
+    default: {
+      const last = datasets[-1];
+      const rest = datasets.slice(0, -1);
+      return `${rest.map((dataset) => `'${dataset}'`).join(', ')}, and '${last}'`;
+    }
+  }
 }
 
 function getDatasets(operations) {

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1488,17 +1488,17 @@ features:
     noSearchFields: No fields matching the search query
     OperationsModal:
       lastExecution: "Last executed by '{app}' on {time}"
-      summaryText: "Operations between {sources} and {targets}"
+      summaryText: "Transformations between {sources} and {targets}"
       Table:
         description: Description
         input: Input
         inputFields: Input fields
-        operation: Operation
+        operation: Transformation
         outputFields: Output fields
         output: Output
       Title:
-        incoming: "Cause operations for field '{fieldName}'"
-        outgoing: "Impact operations for field '{fieldName}'"
+        incoming: "Cause for field '{fieldName}'"
+        outgoing: "Impact for field '{fieldName}'"
     outgoingOperations: Outgoing operations
     searchPlaceholder: Search by field name
     SectionTitle:
@@ -1534,7 +1534,7 @@ features:
         NoRelatedSubheader: "0 datasets"
         RelatedHeader: "Datasets used as {type} by {target}"
         RelatedSubheader: "Viewing {first} to {last} of {total} datasets"
-        TargetHeader: 'Select a field to view lineage and operations'
+        TargetHeader: 'Select a field to view lineage and transformations'
         TargetSubheader: "Viewing {first} to {last} of {total} fields"
       FllTable:
         fieldsCount:
@@ -1545,9 +1545,9 @@ features:
           viewDropdown: "View"
           resetLineage: "Reset"
         FllMenu:
-          causeImpact: "Cause and impact"
-          viewIncoming: "Incoming operations"
-          viewOutgoing: "Outgoing operations"
+          causeImpact: "Pin field"
+          viewIncoming: "View cause"
+          viewOutgoing: "View impact"
         noRelatedTables: "There is no {type} for {target}"
         relatedFieldsCount:
           1: "{context} related field"

--- a/cdap-ui/app/directives/my-link-button/my-link-button.html
+++ b/cdap-ui/app/directives/my-link-button/my-link-button.html
@@ -24,7 +24,7 @@
       class="btn btn-my-link"
       href="{{dataset.url}}"
     >
-      <span>View details</span>
+      <span>View metadata</span>
     </a>
   </fieldset>
 </span>

--- a/cdap-ui/app/directives/my-link-button/my-link-button.js
+++ b/cdap-ui/app/directives/my-link-button/my-link-button.js
@@ -38,10 +38,16 @@ class MyLinkButtonCtrl {
         let macroName = datasetId.substring(datasetId.lastIndexOf('${') + 2, datasetId.lastIndexOf('}'));
         datasetId = runtimeargs[macroName];
       }
-      entity.url = window.getAbsUIUrl({
-        namespaceId: $stateParams.namespace,
+
+      const stateParams = {
+        namespace: $stateParams.namespace,
         entityType: entity.entityType,
-        entityId: datasetId
+        entityId: datasetId,
+      };
+
+      entity.url = window.getTrackerUrl({
+        stateParams, 
+        stateName: 'tracker.detail.entity.summary',
       });
     });
   }

--- a/cdap-ui/app/ui-utils/url-generator.js
+++ b/cdap-ui/app/ui-utils/url-generator.js
@@ -165,6 +165,7 @@ window.getTrackerUrl = function(navigationObj = {}) {
     'tracker.detail.entity': '/entity/:entityType/:entityId',
     'tracker.detail.entity.metadata': '/entity/:entityType/:entityId/metadata',
     'tracker.detail.entity.lineage': '/entity/:entityType/:entityId/lineage',
+    'tracker.detail.entity.summary': '/entity/:entityType/:entityId/summary',
   };
   let url = baseUrl + stateToUrlMap[stateName || 'tracker'];
   url = buildCustomUrl(url, stateParams);


### PR DESCRIPTION
JIRAs:
Change "View details" to "View metadata": https://issues.cask.co/browse/CDAP-16045
Update terms in FLL menu: https://issues.cask.co/browse/CDAP-16049
Build: https://builds.cask.co/browse/CDAP-UDUT433

From pipeline details page:

- After clicking on sink or source Properties button: "View details" button text changed to "View metadata" 
- Clicking on "View metadata" goes to dataset metadata summary page instead of dataset detail page. 

For Field level Lineage v2
- First field is selected by default if user hasn't selected a target field yet

Menu (from clicking on a target field), changed:
- "Cause and impact" to "Pin field"
- "Incoming operations" and "Outgoing operations" to "View cause" and "View impact"

Operations modal, changed:
- Removed "operations" from title
- Change semicolons to "and"/commas when concatenating dataset names