### PR TITLE
supporting filename ending with verison and no dash in between

### DIFF
--- a/cdap-ui/app/cdap/services/__tests__/helpers.test.js
+++ b/cdap-ui/app/cdap/services/__tests__/helpers.test.js
@@ -63,4 +63,11 @@ describe('Unit Tests for Helpers: "getArtifactNameAndVersion"', () => {
     expect(version).toBe('1.2.3');
   });
 
+  it('Usecase 8: Should return filename for name and version when filename ends with a version i.e ojdbc8.jar', () => {
+    const FILE_NAME = 'ojdbc8';
+    let {name, version} = getArtifactNameAndVersion(FILE_NAME);
+    expect(name).toBe(FILE_NAME);
+    expect(version).toBe('8');
+  });
+
 });

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -218,11 +218,11 @@ function getArtifactNameAndVersion(nameWithVersion) {
   if (version && Array.isArray(version)) {
     version = version[0].slice(1);
   } else {
-    // when version is the filename i.e 1.2.3.jar
+    // when version is the filename i.e 1.2.3.jar or ojdbc8.jar
     let nameIsVersionRegEx = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
     let validVersion = nameIsVersionRegEx.exec(nameWithVersion);
     if (validVersion && Array.isArray(validVersion)) {
-      return { name: nameWithVersion, version: nameWithVersion };
+      return { name: nameWithVersion, version: validVersion[0] };
     }
   }
   let name = version


### PR DESCRIPTION
Supporting filenames that end with versions and have no '-' separator i.e ojdbc8.jar, ojdbc1.2.3.jar etc

JIRA: https://issues.cask.co/browse/CDAP-16051