### PR TITLE
[CDAP-16054] Add cookie-based experiment access to field level lineage v2 UI

### DIFF
--- a/cdap-ui/app/cdap/components/ExperimentWrapper/ExperimentToggle.tsx
+++ b/cdap-ui/app/cdap/components/ExperimentWrapper/ExperimentToggle.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, { useState } from 'react';
+import ToggleSwitchWidget from 'components/AbstractWidget/ToggleSwitchWidget';
+import cookie from 'react-cookie';
+
+const ExperimentToggle = () => {
+  const initSetting = cookie.load('CDAP_enable_experiments') || 'Off';
+  const [showExperiments, toggleExperiments] = useState(initSetting);
+  const onChangeHandler = (exptSetting: string) => {
+    toggleExperiments(exptSetting);
+    cookie.save('CDAP_enable_experiments', exptSetting, { path: '/' });
+  };
+
+  return (
+    <div className="container">
+      <h1>Dev Experiments</h1>
+      <p>To see dev experiments, set to On. Cookies must be enabled.</p>
+      <ToggleSwitchWidget onChange={onChangeHandler} value={showExperiments} />
+    </div>
+  );
+};
+
+export default ExperimentToggle;

--- a/cdap-ui/app/cdap/components/ExperimentWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/ExperimentWrapper/index.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import cookie from 'react-cookie';
+
+interface IExptWrapperProps {
+  defaultComponent: React.ReactElement<any>;
+  experimentComponent: React.ReactElement<any>;
+}
+
+const ExperimentWrapper: React.FC<IExptWrapperProps> = ({
+  defaultComponent,
+  experimentComponent,
+}: IExptWrapperProps) => {
+  const showExperiment = cookie.load('CDAP_enable_experiments');
+  if (showExperiment === 'on') {
+    return experimentComponent;
+  } else {
+    return defaultComponent;
+  }
+};
+
+export default ExperimentWrapper;

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
@@ -67,11 +67,9 @@ function FllField({ field, isActive, classes }: IFieldProps) {
 
   const timeParams = getTimeQueryParams(selection, start, end);
 
-  // TO DO: Update linkPath once v1 and v2 FLL UI's are switched
-
-  const linkPath = `/ns/${field.namespace}/datasets/${
-    field.dataset
-  }/fll-experiment${timeParams}&field=${field.name}`;
+  const linkPath = `/ns/${field.namespace}/datasets/${field.dataset}/fields${timeParams}&field=${
+    field.name
+  }`;
 
   const toggleHoverState = (nextState) => {
     setHoverState(nextState);

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -23,8 +23,8 @@ import NamespaceStore from 'services/NamespaceStore';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import ConfigurationGroupKitchenSync from 'components/ConfigurationGroup/KitchenSync';
-import ErrorBoundary from 'components/ErrorBoundary';
 import HomeActions from 'components/Home/HomeActions';
+import ExperimentWrapper from 'components/ExperimentWrapper';
 
 require('./Home.scss');
 
@@ -85,16 +85,28 @@ const OpsDashboard = Loadable({
   loader: () => import(/* webpackChunkName: "OpsDashboard" */ 'components/OpsDashboard'),
   loading: LoadingSVGCentered,
 });
-const FieldLevelLineage = Loadable({
-  loader: () => import(/* webpackChunkName: "FieldLevelLineage" */ 'components/FieldLevelLineage'),
-  loading: LoadingSVGCentered,
-});
 const PipelineList = Loadable({
   loader: () => import(/* webpackChunkName: "PipelineList" */ 'components/PipelineList'),
   loading: LoadingSVGCentered,
 });
 const SecureKeys = Loadable({
   loader: () => import(/* webpackChunkName: "SecureKeys" */ 'components/SecureKeys'),
+  loading: LoadingSVGCentered,
+});
+
+const FllExperiment = Loadable({
+  loader: () => import(/* webpackChunkName: "FllExperiment" */ 'components/FieldLevelLineage/v2'),
+  loading: LoadingSVGCentered,
+});
+
+const FieldLevelLineage = Loadable({
+  loader: () => import(/* webpackChunkName: "FieldLevelLineage" */ 'components/FieldLevelLineage'),
+  loading: LoadingSVGCentered,
+});
+
+const ExperimentToggle = Loadable({
+  loader: () =>
+    import(/* webpackChunkMame: "ExperimentToggle" */ 'components/ExperimentWrapper/ExperimentToggle'),
   loading: LoadingSVGCentered,
 });
 
@@ -117,21 +129,12 @@ export default class Home extends Component {
           <Route
             exact
             path="/ns/:namespace/datasets/:datasetId/fields"
-            component={FieldLevelLineage}
-          />
-          <Route
-            exact
-            path="/ns/:namespace/datasets/:datasetId/fll-experiment"
             render={(props) => {
-              const FllExperiment = Loadable({
-                loader: () =>
-                  import(/* webpackChunkName: "FllExperiment" */ 'components/FieldLevelLineage/v2'),
-                loading: LoadingSVGCentered,
-              });
               return (
-                <ErrorBoundary>
-                  <FllExperiment {...props} />
-                </ErrorBoundary>
+                <ExperimentWrapper
+                  defaultComponent={<FieldLevelLineage {...props} />}
+                  experimentComponent={<FllExperiment {...props} />}
+                />
               );
             }}
           />
@@ -162,6 +165,7 @@ export default class Home extends Component {
           <Route path="/ns/:namespace/pipelines" component={PipelineList} />
           <Route path="/ns/:namespace/securekeys" component={SecureKeys} />
           <Route path="/ns/:namespace/kitchen" component={ConfigurationGroupKitchenSync} />
+          <Route path="/ns/:namespace/experimentToggle" component={ExperimentToggle} />
           <Route component={Page404} />
         </Switch>
       </div>

--- a/cdap-ui/cypress/fixtures/fll_airport_pipeline2.json
+++ b/cdap-ui/cypress/fixtures/fll_airport_pipeline2.json
@@ -3,7 +3,7 @@
     "description": "without wrangler",
     "artifact": {
         "name": "cdap-data-pipeline",
-        "version": "6.1.0-SNAPSHOT",
+        "version": "[6.1.0-SNAPSHOT, 6.2.0-SNAPSHOT]",
         "scope": "SYSTEM"
     },
     "config": {
@@ -35,7 +35,7 @@
                     "label": "Airport_source",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -72,7 +72,7 @@
                     "label": "Airport_sink",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {

--- a/cdap-ui/cypress/fixtures/fll_wrangler-test-pipeline.json
+++ b/cdap-ui/cypress/fixtures/fll_wrangler-test-pipeline.json
@@ -39,7 +39,7 @@
                     "label": "Airport_source",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -76,7 +76,7 @@
                     "label": "Wrangler",
                     "artifact": {
                         "name": "wrangler-transform",
-                        "version": "4.1.0-SNAPSHOT",
+                        "version": "[4.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -106,7 +106,7 @@
                     "label": "Airport_sink",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {

--- a/cdap-ui/cypress/fixtures/null_splitter_pipeline-cdap-data-pipeline.json
+++ b/cdap-ui/cypress/fixtures/null_splitter_pipeline-cdap-data-pipeline.json
@@ -1,7 +1,7 @@
 {
     "artifact": {
         "name": "cdap-data-pipeline",
-        "version": "6.1.0-SNAPSHOT",
+        "version": "[6.1.0-SNAPSHOT, 6.2.0-SNAPSHOT]",
         "scope": "SYSTEM",
         "label": "Data Pipeline - Batch"
     },
@@ -54,7 +54,7 @@
                     "label": "File",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -77,7 +77,7 @@
                     "label": "CSVParser",
                     "artifact": {
                         "name": "transform-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -102,7 +102,7 @@
                     "label": "JavaScript",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -126,7 +126,7 @@
                     "label": "NullFieldSplitter",
                     "artifact": {
                         "name": "transform-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -159,7 +159,7 @@
                     "label": "Non null sink dataset",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -184,7 +184,7 @@
                     "label": "null sink dataset",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {

--- a/cdap-ui/cypress/fixtures/union_condition_splitter_pipeline_v1-cdap-data-pipeline.json
+++ b/cdap-ui/cypress/fixtures/union_condition_splitter_pipeline_v1-cdap-data-pipeline.json
@@ -1,7 +1,7 @@
 {
     "artifact": {
         "name": "cdap-data-pipeline",
-        "version": "6.1.0-SNAPSHOT",
+        "version": "[6.1.0-SNAPSHOT, 6.2.0-SNAPSHOT]",
         "scope": "SYSTEM",
         "label": "Data Pipeline - Batch"
     },
@@ -72,7 +72,7 @@
                     "label": "File",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -95,7 +95,7 @@
                     "label": "CSVParser",
                     "artifact": {
                         "name": "transform-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -120,7 +120,7 @@
                     "label": "JavaScript3",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -144,7 +144,7 @@
                     "label": "UnionSplitter",
                     "artifact": {
                         "name": "transform-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -177,7 +177,7 @@
                     "label": "String JavaScript Emitter",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -201,7 +201,7 @@
                     "label": "Conditional",
                     "artifact": {
                         "name": "condition-plugins",
-                        "version": "1.4.0-SNAPSHOT",
+                        "version": "[1.4.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -224,7 +224,7 @@
                     "label": "String Prices",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -251,7 +251,7 @@
                     "label": "CDAP Table Dataset",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -276,7 +276,7 @@
                     "label": "JavaScript2",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {
@@ -300,7 +300,7 @@
                     "label": "File3",
                     "artifact": {
                         "name": "core-plugins",
-                        "version": "2.3.0-SNAPSHOT",
+                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
                         "scope": "SYSTEM"
                     },
                     "properties": {

--- a/cdap-ui/cypress/integration/fieldlevellineage.spec.ts
+++ b/cdap-ui/cypress/integration/fieldlevellineage.spec.ts
@@ -39,6 +39,15 @@ describe('Generating and navigating field level lineage for datasets', () => {
       cy.get('[data-cy="Succeeded"]', { timeout: 360000 }).should('contain', 'Succeeded');
     });
   });
+  before(() => {
+    // make sure cookies are set to see v2 UI
+    cy.getCookie('CDAP_enable_experiments').then((cookie) => {
+      if (cookie && cookie.value === 'on') {
+        // toggle experiments off by clearing cookie
+        cy.setCookie('CDAP_enable_experiments', 'off');
+      }
+    });
+  });
   after(() => {
     // Delete the pipeline to clean up
     cy.cleanup_pipelines(headers, fllPipeline);

--- a/cdap-ui/cypress/integration/fieldlevellineage.v2.spec.ts
+++ b/cdap-ui/cypress/integration/fieldlevellineage.v2.spec.ts
@@ -39,12 +39,21 @@ describe('Generating and navigating field level lineage for datasets', () => {
       cy.get('[data-cy="Succeeded"]', { timeout: 360000 }).should('contain', 'Succeeded');
     });
   });
+  before(() => {
+    // toggle experiments on to see v2 lineage
+    cy.getCookie('CDAP_enable_experiments').then((cookie) => {
+      if (!cookie || cookie.value === 'off') {
+        // toggle experiments on
+        cy.setCookie('CDAP_enable_experiments', 'on');
+      }
+    });
+  });
   after(() => {
     // Delete the pipeline to clean up
     cy.cleanup_pipelines(headers, fllPipeline);
   });
   it('Should show lineage for the default time frame (last 7 days)', () => {
-    cy.visit('cdap/ns/default/datasets/Airport_sink/fll-experiment');
+    cy.visit('cdap/ns/default/datasets/Airport_sink/fields');
     // should see last 7 days of lineage selected by default
     cy.get('[data-cy="fll-time-picker"]').should(($div) => {
       expect($div).to.contain('Last 7 days');


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16054
Build: https://builds.cask.co/browse/CDAP-UDUT434

- Added page to set cookie to see experimental components (i.e. v2 FLL UI): When experiments are on, user should see v2 field level lineage UI. Otherwise, they should see the v1 UI. 
- Added ExperimentWrapper component that checks cookie to return appropriate component. 