### PR TITLE
CDAP-16069 fix FLL performance

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/FieldLineageInfo.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/FieldLineageInfo.java
@@ -368,8 +368,12 @@ public class FieldLineageInfo {
     // for transform we traverse backward in graph further through the inputs of the transform
     if (currentOperation.getType() == OperationType.TRANSFORM) {
       TransformOperation transform = (TransformOperation) currentOperation;
-      for (InputField inputField : transform.getInputs()) {
-        computeIncomingSummaryHelper(field, operationsMap.get(inputField.getOrigin()), currentOperation, summary);
+      // optimization to avoid repeating work if there are input fields with the same origin
+      Set<String> transformOrigins = transform.getInputs().stream()
+        .map(InputField::getOrigin)
+        .collect(Collectors.toSet());
+      for (String transformOrigin : transformOrigins) {
+        computeIncomingSummaryHelper(field, operationsMap.get(transformOrigin), currentOperation, summary);
       }
     }
   }


### PR DESCRIPTION
Fixed the logic around calculating incoming field lineage to
avoid re-computation. This avoids an amount of re-computation that
is exponential in the number of field connections. Instead, it
is exponential in the number of datasets, which is many
orders of magnitude smaller than field connections.