### PR TITLE
Introduce wrangler-datamodel-viewer flag and target tab ui

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/TargetTab/DataModelViewer.tsx
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/TargetTab/DataModelViewer.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+import React from 'react';
+import { Theme } from '@material-ui/core/styles';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import T from 'i18n-react';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+
+const PREFIX = 'features.DataPrep.DataPrepSidePanel.TargetTab';
+
+interface IDataModelViewerState {
+  selectedDataModelId: string;
+}
+
+const styles = (theme: Theme) => {
+  return {
+    root: {
+      height: '100%',
+      width: '100%',
+    },
+    select: {
+      width: '100%',
+    },
+  };
+};
+interface IDataModelViewerProps extends WithStyles<typeof styles> {}
+
+class DataModelViewer extends React.Component<IDataModelViewerProps, IDataModelViewerState> {
+  public state = {
+    selectedDataModelId: 'OMOP',
+  };
+
+  public render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.root}>
+        <p>{T.translate(`${PREFIX}.selectDataModel`)}</p>
+        <InputLabel>{T.translate(`${PREFIX}.targetDataModel`)}</InputLabel>
+        <Select value={this.state.selectedDataModelId} className={classes.select} disabled>
+          <MenuItem value="OMOP">{'OMOP'}</MenuItem>
+        </Select>
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(DataModelViewer);

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/TargetTab/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/TargetTab/index.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+import React, { Component } from 'react';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import DataModelViewer from 'components/DataPrep/DataPrepSidePanel/TargetTab/DataModelViewer';
+
+const styles = () => {
+  return {
+    root: {
+      margin: '20px 10px',
+      height: '100%',
+    },
+  };
+};
+
+interface ITargetTabProps extends WithStyles<typeof styles> {
+  className: string;
+  children: React.ReactNode;
+}
+
+class TargetTab extends React.PureComponent<ITargetTabProps> {
+  constructor(props: Readonly<ITargetTabProps>) {
+    super(props);
+  }
+
+  public render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.root}>
+        <DataModelViewer />
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(TargetTab);

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
@@ -15,11 +15,14 @@
  */
 
 import React, { Component } from 'react';
+import { Theme } from 'services/ThemeHelper';
 import DataPrepStore from 'components/DataPrep/store';
 import classnames from 'classnames';
 import ColumnsTab from 'components/DataPrep/DataPrepSidePanel/ColumnsTab';
+import TargetTab from 'components/DataPrep/DataPrepSidePanel/TargetTab';
 import DirectivesTab from 'components/DataPrep/DataPrepSidePanel/DirectivesTab';
 import T from 'i18n-react';
+import If from 'components/If';
 
 require('./DataPrepSidePanel.scss');
 const PREFIX = 'features.DataPrep.DataPrepSidePanel';
@@ -84,12 +87,25 @@ export default class DataPrepSidePanel extends Component {
     );
   }
 
+  renderTarget() {
+    return (
+      <If condition={Theme.showWranglerDatamodelViewer}>
+        <div className="tab-content">
+          <TargetTab />
+        </div>
+      </If>
+    );
+  }
+
   renderTabContent() {
     switch (this.state.activeTab) {
       case 1:
         return this.renderColumns();
       case 2:
         return this.renderDirectives();
+      case 3:
+        return this.renderTarget();
+
       default:
         return null;
     }
@@ -116,6 +132,14 @@ export default class DataPrepSidePanel extends Component {
                 directivesCount: this.state.directives.length,
               })}
             </div>
+            <If condition={Theme.showWranglerDatamodelViewer}>
+              <div
+                className={classnames('tab', { active: this.state.activeTab === 3 })}
+                onClick={this.setActiveTab.bind(this, 3)}
+              >
+                {T.translate(`${PREFIX}.targetTabLabel`)}
+              </div>
+            </If>
           </div>
 
           {this.renderTabContent()}

--- a/cdap-ui/app/cdap/services/ThemeHelper.ts
+++ b/cdap-ui/app/cdap/services/ThemeHelper.ts
@@ -28,6 +28,7 @@ interface IJsonFeatureNames {
   'control-center'?: string;
   dashboard?: string;
   'data-prep'?: string;
+  'wrangler-datamodel-viewer'?: string;
   entities?: string;
   hub?: string;
   metadata?: string;
@@ -75,6 +76,7 @@ interface IOnePoint0SpecJSON extends IThemeJSON {
     dashboard?: boolean;
     reports?: boolean;
     'data-prep'?: boolean;
+    'wrangler-datamodel-viewer'?: boolean;
     pipelines?: boolean;
     pipelineStudio?: boolean;
     analytics?: boolean;
@@ -161,6 +163,7 @@ interface IFeatureNames {
   controlCenter: string;
   dashboard: string;
   dataPrep: string;
+  wranglerDatamodelViewer: string;
   entities: string;
   hub: string;
   metadata: string;
@@ -186,6 +189,7 @@ interface IThemeObj {
   showDashboard?: boolean;
   showReports?: boolean;
   showDataPrep?: boolean;
+  showWranglerDatamodelViewer?: boolean;
   showPipelines?: boolean;
   showPipelineStudio?: boolean;
   showAnalytics?: boolean;
@@ -254,6 +258,7 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
         controlCenter: 'Control Center',
         dashboard: 'Dashboard',
         dataPrep: 'Wrangler',
+        wranglerDatamodelViewer: 'EnhancedWrangler',
         entities: 'Entities',
         hub: 'Hub',
         metadata: 'Metadata',
@@ -332,6 +337,14 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
       if ('data-prep' in contentJson['feature-names']) {
         featureNames.dataPrep = objectQuery(contentJson, 'feature-names', 'data-prep');
       }
+      if ('wrangler-datamodel-viewer' in contentJson['feature-names']) {
+        featureNames.wranglerDatamodelViewer = objectQuery(
+          contentJson,
+          'feature-names',
+          'wrangler-datamodel-viewer'
+        );
+      }
+
       if ('entities' in contentJson['feature-names']) {
         featureNames.entities = objectQuery(contentJson, 'feature-names', 'entities');
       }
@@ -400,6 +413,13 @@ function parse1Point0Spec(themeJSON: IOnePoint0SpecJSON): IThemeObj {
     if ('data-prep' in featuresJson && isBoolean(featuresJson['data-prep'])) {
       features.showDataPrep = featuresJson['data-prep'];
     }
+    if (
+      'wrangler-datamodel-viewer' in featuresJson &&
+      isBoolean(featuresJson['wrangler-datamodel-viewer'])
+    ) {
+      features.showWranglerDatamodelViewer = featuresJson['wrangler-datamodel-viewer'];
+    }
+
     if ('pipelines' in featuresJson && isBoolean(featuresJson.pipelines)) {
       features.showPipelines = featuresJson.pipelines;
     }

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -393,6 +393,10 @@ features:
           clearAll: Clear All
           selectAll: Select All
       directivesTabLabel: Transformation steps ({directivesCount})
+      targetTabLabel: Target
+      TargetTab:
+        selectDataModel: "Select a target data model to start mapping"
+        targetDataModel: "Target data model"
       DirectivesTab:
         label: Transformations
       noColumns: No columns


### PR DESCRIPTION
1. Add a feature flag called enhanced-data-prep
2. The feature flag will be used to turn on/off target tab
3. Target tab is a new tab in DataPrep side panel which displays target data models.