### PR TITLE
[CDAP-16105] [CDAP-16080] [CDAP-15103] validation messaging display changes

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/GetSchemaWidget/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/GetSchemaWidget/index.tsx
@@ -48,7 +48,7 @@ const GetSchemaWidgetView: React.FC<IGetSchemaProps> = ({ extraConfig, classes }
       setLoading(true);
       validateProperties(() => {
         setLoading(false);
-      });
+      }, true);
     }
   }
 

--- a/cdap-ui/app/directives/my-post-run-action-wizard/my-post-run-action-wizard-modal.html
+++ b/cdap-ui/app/directives/my-post-run-action-wizard/my-post-run-action-wizard-modal.html
@@ -24,6 +24,15 @@
       <small>{{action.description}}</small>
     </p>
   </h5>
+  <span class="text-success"
+        ng-if="errorCount === 0">No errors found.</span>
+  <span class="text-danger"
+        ng-if="errorCount > 0">
+    <ng-pluralize count="errorCount"
+                  when="{'1': '1 error found',
+                         'other': '{} errors found.'}">
+    </ng-pluralize>
+  </span>
   <div class="btn-group pull-right">
     <button class="btn btn-primary validate-btn"
             type="button"

--- a/cdap-ui/app/directives/my-post-run-action-wizard/my-post-run-action-wizard.js
+++ b/cdap-ui/app/directives/my-post-run-action-wizard/my-post-run-action-wizard.js
@@ -49,6 +49,7 @@ angular.module(PKG.name + '.commons')
           $scope.mode = rMode;
           $scope.action = rAction;
           $scope.validating = false;
+          $scope.errorCount = null;
           $scope.showValidateButton = function() {
             // Hack-y way of showing Validate button on Configure and Confirm pages only
             if ($scope.action) {
@@ -60,6 +61,7 @@ angular.module(PKG.name + '.commons')
             const action = angular.copy($scope.action);
             const errorCb = ({ errorCount, propertyErrors }) => {
               $scope.validating = false;
+              $scope.errorCount = errorCount;
               if ( errorCount > 0 || !errorCount) {
                 $scope.propertyErrors = propertyErrors;
               } else {

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -450,13 +450,16 @@ class HydratorPlusPlusNodeConfigCtrl {
     return true;
   }
 
-  validatePluginProperties(callback) {
+  validatePluginProperties(callback, validationFromGetSchema) {
     const nodeInfo = this.state.node;
     let vm = this;
-    vm.validating = true;
+    if(!validationFromGetSchema){
+      vm.validating = true;
+    }
     const errorCb = ({ errorCount, propertyErrors, inputSchemaErrors, outputSchemaErrors }) => {
       // errorCount can be 0, a positive integer, or undefined (in case of an error thrown)
       vm.validating = false;
+      vm.errorCount = errorCount;
       if ( errorCount > 0 ){
         vm.propertyErrors = propertyErrors;
         vm.inputSchemaErrors = inputSchemaErrors;
@@ -466,6 +469,10 @@ class HydratorPlusPlusNodeConfigCtrl {
         vm.propertyErrors = {};
         vm.inputSchemaErrors = {};
         vm.outputSchemaErrors = {};
+        // Do not show success validation message for validation via get schema.
+        if (validationFromGetSchema === true) {
+          vm.errorCount = undefined;
+        }
       } else {
         vm.propertyErrors = propertyErrors;
       }

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -51,10 +51,11 @@
       justify-content: space-between;
       .modal-title {
         padding-left: 15px;
-        // 240px for all the buttons
-        max-width: ~"calc(100% - 240px)";
-        max-width: ~"-moz-calc(100% - 240px)";
-        max-width: ~"-webkit-calc(100% - 240px)";
+        // 340px for all the buttons and error validation message
+        width: 100%;
+        max-width: ~"calc(100% - 340px)";
+        max-width: ~"-moz-calc(100% - 340px)";
+        max-width: ~"-webkit-calc(100% - 340px)";
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
@@ -64,9 +65,9 @@
 
         // Adjust max-width of modal title when my-jump-link is present
         &.with-jump {
-          max-width: ~"calc(100% - 340px)";
-          max-width: ~"-moz-calc(100% - 340px)";
-          max-width: ~"-webkit-calc(100% - 340px)";
+          max-width: ~"calc(100% - 440px)";
+          max-width: ~"-moz-calc(100% - 440px)";
+          max-width: ~"-webkit-calc(100% - 440px)";
         }
 
         p {
@@ -119,7 +120,7 @@
           box-shadow: none;
         }
       }
-      div.btn-group { margin-left: auto; }
+
       a.btn {
         background: transparent;
         border: 0;

--- a/cdap-ui/app/hydrator/services/plugin-config-factory.js
+++ b/cdap-ui/app/hydrator/services/plugin-config-factory.js
@@ -335,20 +335,10 @@ class HydratorPlusPlusPluginConfigFactory {
         if (res.failures.length > 0) {
           const { propertyErrors, inputSchemaErrors,outputSchemaErrors } = this.configurationGroupUtilities.constructErrors(res.failures);
           errorCount = this.configurationGroupUtilities.countErrors(propertyErrors, inputSchemaErrors, outputSchemaErrors);
-          this.myAlertOnValium.show({
-            type: 'danger',
-            content: `${errorCount} error${errorCount > 1 ? 's': ''} found.`
-          });
           errorCb({ errorCount, propertyErrors, inputSchemaErrors, outputSchemaErrors });
         } else {
           errorCount = 0;
-
           errorCb({ errorCount });
-          this.myAlertOnValium.show({
-            type: 'success',
-            content: `No validation errors.`
-          });
-
           const outputSchema = this.myHelpers.objectQuery(res, 'spec', 'outputSchema');
           const portSchemas = this.myHelpers.objectQuery(res, 'spec', 'portSchemas');
           let schemas;

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
@@ -26,6 +26,15 @@
       <small>{{HydratorPlusPlusNodeConfigCtrl.state.node.description}}</small>
     </p>
   </h5>
+  <span class="text-success"
+        ng-if="HydratorPlusPlusNodeConfigCtrl.errorCount === 0">No errors found.</span>
+  <span class="text-danger"
+        ng-if="HydratorPlusPlusNodeConfigCtrl.errorCount > 0">
+    <ng-pluralize count="HydratorPlusPlusNodeConfigCtrl.errorCount"
+                  when="{'1': '1 error found',
+                         'other': '{} errors found.'}">
+    </ng-pluralize>
+  </span>
   <div class="btn-group pull-right">
     <button class="btn btn-primary validate-btn" type="button"
             ng-if="!isDisabled"


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-16105
Replaced banner with text in modal header per design. Same for post action plugins.

https://issues.cask.co/browse/CDAP-16080
Success message will not be shown in modal header per new design.

https://issues.cask.co/browse/CDAP-15103
Description will take as much space as it can after leaving space for buttons and validation message.