### PR TITLE
CDAP-16110 limit reads for batch pipeline previews

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
@@ -480,6 +480,7 @@ public class SmartWorkflow extends AbstractWorkflow {
       stageSpecs.put(stageName, StageSpec.builder(stageName, actionSpec.getPluginSpec())
         .setStageLoggingEnabled(spec.isStageLoggingEnabled())
         .setProcessTimingEnabled(spec.isProcessTimingEnabled())
+        .setMaxPreviewRecords(spec.getNumOfRecordsPreview())
         .build());
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/TransformRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/TransformRunner.java
@@ -103,8 +103,7 @@ public class TransformRunner<KEY, VALUE> {
     MapReduceTransformExecutorFactory<KeyValue<KEY, VALUE>> transformExecutorFactory =
       new MapReduceTransformExecutorFactory<>(context, pluginInstantiator, metrics,
                                               new BasicArguments(context.getWorkflowToken(), runtimeArgs),
-                                              sourceStage, phaseSpec.getNumOfRecordsPreview(),
-                                              phaseSpec.pipelineContainsCondition());
+                                              sourceStage, phaseSpec.pipelineContainsCondition());
     this.transformExecutor = transformExecutorFactory.create(phase, outputWriter);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/preview/LimitingInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/preview/LimitingInputFormat.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.batch.preview;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A wrapper around another input format, that limits the amount of data read.
+ *
+ * @param <K> type of key to read
+ * @param <V> type of value to read
+ */
+public class LimitingInputFormat<K, V> extends InputFormat<K, V> {
+  public static final String DELEGATE_CLASS_NAME = "io.cdap.pipeline.preview.input.classname";
+  public static final String MAX_RECORDS = "io.cdap.pipeline.preview.max.records";
+
+  @Override
+  public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
+    Configuration conf = context.getConfiguration();
+    return createDelegate(conf).getSplits(context);
+  }
+
+  @Override
+  public RecordReader<K, V> createRecordReader(InputSplit split, TaskAttemptContext context)
+    throws IOException, InterruptedException {
+    Configuration conf = context.getConfiguration();
+    int maxRecords = conf.getInt(MAX_RECORDS, 100);
+    InputFormat<K, V> delegateFormat = createDelegate(conf);
+    RecordReader<K, V> delegate = delegateFormat.createRecordReader(split, context);
+    return new LimitingRecordReader<>(delegate, maxRecords);
+  }
+
+  private InputFormat<K, V> createDelegate(Configuration conf) throws IOException {
+    String delegateClassName = conf.get(DELEGATE_CLASS_NAME);
+    try {
+      //noinspection unchecked
+      return (InputFormat<K, V>) conf.getClassLoader().loadClass(delegateClassName).newInstance();
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new IOException("Unable to instantiate delegate input format " + delegateClassName, e);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/preview/LimitingInputFormatProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/preview/LimitingInputFormatProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.batch.preview;
+
+import io.cdap.cdap.api.data.batch.InputFormatProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An InputFormatProvider that limits how much data is read.
+ */
+public class LimitingInputFormatProvider implements InputFormatProvider {
+  private final InputFormatProvider delegate;
+  private final int maxRecords;
+
+  public LimitingInputFormatProvider(InputFormatProvider delegate, int maxRecords) {
+    this.delegate = delegate;
+    this.maxRecords = maxRecords;
+  }
+
+  @Override
+  public String getInputFormatClassName() {
+    return LimitingInputFormat.class.getName();
+  }
+
+  @Override
+  public Map<String, String> getInputFormatConfiguration() {
+    Map<String, String> config = new HashMap<>(delegate.getInputFormatConfiguration());
+    config.put(LimitingInputFormat.DELEGATE_CLASS_NAME, delegate.getInputFormatClassName());
+    config.put(LimitingInputFormat.MAX_RECORDS, String.valueOf(maxRecords));
+    return config;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/preview/LimitingRecordReader.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/preview/LimitingRecordReader.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.batch.preview;
+
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * A record reader that limits the number of records read.
+ *
+ * @param <K> type of key to read
+ * @param <V> type of value to read
+ */
+public class LimitingRecordReader<K, V> extends RecordReader<K, V> {
+  private final RecordReader<K, V> delegate;
+  private final int maxToRead;
+  private int numRead;
+
+  public LimitingRecordReader(RecordReader<K, V> delegate, int maxToRead) {
+    this.delegate = delegate;
+    this.maxToRead = maxToRead;
+  }
+
+  @Override
+  public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+    delegate.initialize(split, context);
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    if (numRead > maxToRead) {
+      return false;
+    }
+    boolean answer = delegate.nextKeyValue();
+    numRead++;
+    return answer;
+  }
+
+  @Override
+  public K getCurrentKey() throws IOException, InterruptedException {
+    return delegate.getCurrentKey();
+  }
+
+  @Override
+  public V getCurrentValue() throws IOException, InterruptedException {
+    return delegate.getCurrentValue();
+  }
+
+  @Override
+  public float getProgress() throws IOException, InterruptedException {
+    return Math.max(delegate.getProgress(), (float) numRead / maxToRead);
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractStageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractStageContext.java
@@ -93,6 +93,10 @@ public abstract class AbstractStageContext implements StageContext {
     return pipelineRuntime.getLogicalStartTime();
   }
 
+  protected int getMaxPreviewRecords() {
+    return stageSpec.getMaxPreviewRecords();
+  }
+
   @Override
   public final PluginProperties getPluginProperties(final String pluginId) {
     return CALLER.callUnchecked(

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -251,6 +251,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
     StageSpec stageSpec = specBuilder
       .setProcessTimingEnabled(validatedPipeline.isProcessTimingEnabled())
       .setStageLoggingEnabled(validatedPipeline.isStageLoggingEnabled())
+      .setMaxPreviewRecords(validatedPipeline.getMaxPreviewRecords())
       .build();
     return new ConfiguredStage(stageSpec, pluginConfigurer.getPipelineProperties());
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/ValidatedPipeline.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/ValidatedPipeline.java
@@ -37,6 +37,7 @@ public class ValidatedPipeline {
   private final Map<String, Map<String, String>> connectionTable;
   private final boolean stageLoggingEnabled;
   private final boolean processTimingEnabled;
+  private final int maxPreviewRecords;
 
   public ValidatedPipeline(List<ETLStage> traversalOrder, ETLConfig config) {
     this.traversalOrder = ImmutableList.copyOf(traversalOrder);
@@ -50,6 +51,7 @@ public class ValidatedPipeline {
     }
     this.stageLoggingEnabled = config.isStageLoggingEnabled();
     this.processTimingEnabled = config.isProcessTimingEnabled();
+    this.maxPreviewRecords = config.getNumOfRecordsPreview();
   }
 
   public List<ETLStage> getTraversalOrder() {
@@ -72,5 +74,9 @@ public class ValidatedPipeline {
 
   public boolean isProcessTimingEnabled() {
     return processTimingEnabled;
+  }
+
+  public int getMaxPreviewRecords() {
+    return maxPreviewRecords;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -226,6 +226,7 @@ public class PipelineSpecGeneratorTest {
       .addConnection("t2", "sink2")
       .addConnection("t2", "t3")
       .addConnection("t3", "sink1")
+      .setNumOfRecordsPreview(100)
       .build();
     // test the spec generated is correct, with the right input and output schemas and artifact information.
     BatchPipelineSpec actual = specGenerator.generateSpec(etlConfig);
@@ -269,6 +270,7 @@ public class PipelineSpecGeneratorTest {
       .setDriverResources(new Resources(1024, 1))
       .setClientResources(new Resources(1024, 1))
       .setStageLoggingEnabled(etlConfig.isStageLoggingEnabled())
+      .setNumOfRecordsPreview(etlConfig.getNumOfRecordsPreview())
       .build();
     Assert.assertEquals(expected, actual);
   }
@@ -296,6 +298,7 @@ public class PipelineSpecGeneratorTest {
       .addConnection("tB", "sinkB")
       .addConnection("sinkA", "action")
       .addConnection("sinkB", "action")
+      .setNumOfRecordsPreview(100)
       .build();
     PipelineSpec actual = specGenerator.generateSpec(config);
 
@@ -339,6 +342,7 @@ public class PipelineSpecGeneratorTest {
       .setDriverResources(config.getDriverResources())
       .setClientResources(config.getClientResources())
       .setStageLoggingEnabled(config.isStageLoggingEnabled())
+      .setNumOfRecordsPreview(config.getNumOfRecordsPreview())
       .build();
 
     Assert.assertEquals(expected, actual);
@@ -389,6 +393,7 @@ public class PipelineSpecGeneratorTest {
       .addConnection("split", "sinkA", "portA")
       .addConnection("split", "sinkB", "portB")
       .addConnection("split", "sinkC", "portC")
+      .setNumOfRecordsPreview(100)
       .build();
 
     PipelineSpec expected = BatchPipelineSpec.builder()
@@ -423,6 +428,7 @@ public class PipelineSpecGeneratorTest {
       .setDriverResources(config.getDriverResources())
       .setClientResources(config.getClientResources())
       .setStageLoggingEnabled(config.isStageLoggingEnabled())
+      .setNumOfRecordsPreview(config.getNumOfRecordsPreview())
       .build();
 
     PipelineSpec actual = specGenerator.generateSpec(config);
@@ -441,6 +447,7 @@ public class PipelineSpecGeneratorTest {
       .addStage(new ETLStage("sink", MOCK_SINK))
       .addConnection("source", "cond")
       .addConnection("cond", "sink", true)
+      .setNumOfRecordsPreview(100)
       .build();
 
     PipelineSpec expected = BatchPipelineSpec.builder()
@@ -464,6 +471,7 @@ public class PipelineSpecGeneratorTest {
       .setDriverResources(config.getDriverResources())
       .setClientResources(config.getClientResources())
       .setStageLoggingEnabled(config.isStageLoggingEnabled())
+      .setNumOfRecordsPreview(config.getNumOfRecordsPreview())
       .build();
 
     PipelineSpec actual = specGenerator.generateSpec(config);
@@ -610,6 +618,7 @@ public class PipelineSpecGeneratorTest {
       .addStage(new ETLStage("a2", new ETLPlugin("action2", Action.PLUGIN_TYPE, empty)))
       .addConnection("a1", "a2")
       .setEngine(Engine.MAPREDUCE)
+      .setNumOfRecordsPreview(100)
       .build();
 
     PipelineSpec actual = new BatchPipelineSpecGenerator(pluginConfigurer, ImmutableSet.of(BatchSource.PLUGIN_TYPE),
@@ -630,6 +639,7 @@ public class PipelineSpecGeneratorTest {
       .setResources(new Resources(1024))
       .setDriverResources(new Resources(1024))
       .setClientResources(new Resources(1024))
+      .setNumOfRecordsPreview(config.getNumOfRecordsPreview())
       .build();
     Assert.assertEquals(expected, actual);
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/spec/StageSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/spec/StageSpec.java
@@ -45,10 +45,11 @@ public class StageSpec implements Serializable {
   private final Schema errorSchema;
   private final boolean stageLoggingEnabled;
   private final boolean processTimingEnabled;
+  private final int maxPreviewRecords;
 
   private StageSpec(String name, PluginSpec plugin, Map<String, Schema> inputSchemas, @Nullable Schema outputSchema,
                     Schema errorSchema, Map<String, Schema> portSchemas, Map<String, Port> outputPorts,
-                    boolean stageLoggingEnabled, boolean processTimingEnabled) {
+                    boolean stageLoggingEnabled, boolean processTimingEnabled, int maxPreviewRecords) {
     this.name = name;
     this.plugin = plugin;
     this.inputSchemas = Collections.unmodifiableMap(inputSchemas);
@@ -58,6 +59,7 @@ public class StageSpec implements Serializable {
     this.outputSchema = outputSchema;
     this.outputPorts = Collections.unmodifiableMap(outputPorts);
     this.portSchemas = Collections.unmodifiableMap(portSchemas);
+    this.maxPreviewRecords = maxPreviewRecords;
   }
 
   public String getName() {
@@ -98,6 +100,10 @@ public class StageSpec implements Serializable {
     return processTimingEnabled;
   }
 
+  public int getMaxPreviewRecords() {
+    return maxPreviewRecords;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -122,7 +128,7 @@ public class StageSpec implements Serializable {
   @Override
   public int hashCode() {
     return Objects.hash(name, plugin, inputSchemas, outputPorts,
-                        outputSchema, errorSchema, stageLoggingEnabled, processTimingEnabled);
+                        outputSchema, errorSchema, stageLoggingEnabled, processTimingEnabled, maxPreviewRecords);
   }
 
   @Override
@@ -132,10 +138,12 @@ public class StageSpec implements Serializable {
       ", plugin=" + plugin +
       ", inputSchemas=" + inputSchemas +
       ", outputPorts=" + outputPorts +
+      ", portSchemas=" + portSchemas +
       ", outputSchema=" + outputSchema +
       ", errorSchema=" + errorSchema +
       ", stageLoggingEnabled=" + stageLoggingEnabled +
       ", processTimingEnabled=" + processTimingEnabled +
+      ", maxPreviewRecords=" + maxPreviewRecords +
       '}';
   }
 
@@ -157,6 +165,7 @@ public class StageSpec implements Serializable {
     private Schema errorSchema;
     private boolean stageLoggingEnabled;
     private boolean processTimingEnabled;
+    private int maxPreviewRecords;
 
     public Builder(String name, PluginSpec plugin) {
       this.name = name;
@@ -167,6 +176,7 @@ public class StageSpec implements Serializable {
       this.stageLoggingEnabled = true;
       this.processTimingEnabled = true;
       this.isSplitter = plugin.getType().equals(SplitterTransform.PLUGIN_TYPE);
+      this.maxPreviewRecords = 100;
     }
 
     public Builder addInputSchema(String stageName, Schema schema) {
@@ -223,9 +233,14 @@ public class StageSpec implements Serializable {
       return this;
     }
 
+    public Builder setMaxPreviewRecords(int maxPreviewRecords) {
+      this.maxPreviewRecords = maxPreviewRecords;
+      return this;
+    }
+
     public StageSpec build() {
       return new StageSpec(name, plugin, inputSchemas, outputSchema, errorSchema, portSchemas, outputs,
-                           stageLoggingEnabled, processTimingEnabled);
+                           stageLoggingEnabled, processTimingEnabled, maxPreviewRecords);
     }
 
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -78,15 +78,13 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
   private transient SparkBatchSinkFactory sinkFactory;
   private transient DatasetContext datasetContext;
   private transient Map<String, Integer> stagePartitions;
-  private transient int numOfRecordsPreview;
 
   @Override
   protected SparkCollection<RecordInfo<Object>> getSource(StageSpec stageSpec, StageStatisticsCollector collector) {
     PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageSpec, sec, collector);
     return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory,
                                sourceFactory.createRDD(sec, jsc, stageSpec.getName(), Object.class, Object.class)
-                                 .flatMap(Compat.convert(new BatchSourceFunction(pluginFunctionContext,
-                                                                                 numOfRecordsPreview))));
+                                 .flatMap(Compat.convert(new BatchSourceFunction(pluginFunctionContext))));
   }
 
   @Override
@@ -132,7 +130,6 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
       stagePartitions = sourceSinkInfo.getStagePartitions();
     }
     datasetContext = context;
-    numOfRecordsPreview = phaseSpec.getNumOfRecordsPreview();
     PipelinePluginContext pluginContext = new PipelinePluginContext(sec.getPluginContext(), sec.getMetrics(),
                                                                     phaseSpec.isStageLoggingEnabled(),
                                                                     phaseSpec.isProcessTimingEnabled());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/BatchSourceFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/BatchSourceFunction.java
@@ -31,13 +31,11 @@ import scala.Tuple2;
  */
 public class BatchSourceFunction implements FlatMapFunc<Tuple2<Object, Object>, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
-  private final int numOfRecordsPreview;
   private transient Transformation<KeyValue<Object, Object>, Object> transform;
   private transient CombinedEmitter<Object> emitter;
 
-  public BatchSourceFunction(PluginFunctionContext pluginFunctionContext, int numOfRecordsPreview) {
+  public BatchSourceFunction(PluginFunctionContext pluginFunctionContext) {
     this.pluginFunctionContext = pluginFunctionContext;
-    this.numOfRecordsPreview = numOfRecordsPreview;
   }
 
   @Override
@@ -45,9 +43,7 @@ public class BatchSourceFunction implements FlatMapFunc<Tuple2<Object, Object>, 
     if (transform == null) {
       BatchSource<Object, Object, Object> batchSource = pluginFunctionContext.createPlugin();
       batchSource.initialize(pluginFunctionContext.createBatchRuntimeContext());
-      transform = new TrackedTransform<>(pluginFunctionContext.getDataTracer().isEnabled() ?
-                                           new LimitingTransform<>(batchSource, numOfRecordsPreview) :
-                                           batchSource,
+      transform = new TrackedTransform<>(batchSource,
                                          pluginFunctionContext.createStageMetrics(),
                                          pluginFunctionContext.getDataTracer(),
                                          pluginFunctionContext.getStageStatisticsCollector());


### PR DESCRIPTION
Fixed a bug in batch pipeline previews where the full input data
was still being read, though not all of it was being output.

Wrapped the input format provided by sources to properly limit
data read by the RecordReaders instead of only limiting the records
output to subsequent stages.