### PR TITLE
[CDAP-16100] Reduce the number of backend calls in pipeline studio

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/create-studio-ctrl.js
@@ -40,14 +40,27 @@ class HydratorPlusPlusStudioCtrl {
       return isValidArtifact.length ? isValidArtifact[0]: rArtifacts[0];
     };
     let artifact = getValidArtifact();
+
     if (rConfig) {
-      if (!rConfig.artifact) {
-        rConfig.artifact = artifact;
+      const modifiedConfig = angular.copy(rConfig);
+
+      if (!modifiedConfig.artifact) {
+        modifiedConfig.artifact = artifact;
       }
-      HydratorPlusPlusConfigActions.initializeConfigStore(rConfig);
-      let configJson = rConfig;
-      configJson = HydratorPlusPlusHydratorService.getNodesAndConnectionsFromConfig(rConfig, true);
-      configJson['__ui__'] = Object.assign({}, rConfig.__ui__, {
+
+      // remove backendProperties from rConfig to force re-fetching of properties
+      if (modifiedConfig.config && modifiedConfig.config.stages) {
+        modifiedConfig.config.stages.forEach((stage) => {
+          if (stage._backendProperties) {
+            delete stage._backendProperties;
+          }
+        });
+      }
+
+      HydratorPlusPlusConfigActions.initializeConfigStore(modifiedConfig);
+      let configJson = modifiedConfig;
+      configJson = HydratorPlusPlusHydratorService.getNodesAndConnectionsFromConfig(modifiedConfig, true);
+      configJson['__ui__'] = Object.assign({}, modifiedConfig.__ui__, {
         nodes: configJson.nodes.map( (node) => {
           node.properties = node.plugin.properties;
           node.label = node.plugin.label;


### PR DESCRIPTION
This fix will stop refetching of widget JSON and backend properties from every node drag in pipeline studio. It is also batching the widget JSON request for plugins that do not have backend properties.

This fix also will strip of all backend properties from config that initializes the pipeline (on import, duplicate, or draft open). It will also remove the `_backendProperties` from exporting or duplicating a pipeline from detail view.


JIRA: https://issues.cask.co/browse/CDAP-16100
Build: https://builds.cask.co/browse/CDAP-URUT201