### PR TITLE
[UI] Bugfixes for pipelines list & Triggers view

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizePopover.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizePopover.scss
@@ -18,9 +18,12 @@
   .popper {
     min-width: 350px;
     min-height: 300px;
+    max-height: 360px;
     z-index: 1;
     padding: 20px;
     text-align: left;
+    overflow-y: auto;
+    overflow-x: hidden;
     &[data-x-out-of-boundaries] {
       visibility: hidden;
     }

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/index.js
@@ -64,6 +64,12 @@ export default class ProfileCustomizePopover extends PureComponent {
         bubbleEvent={false}
         showPopover={this.state.showPopover}
         onTogglePopover={this.onTogglePopover}
+        modifiers={{
+          offset: {
+            enabled: true,
+            offset: '70,0',
+          },
+        }}
       >
         <ProfileCustomizeContent
           profileName={profileName}

--- a/cdap-ui/app/cdap/components/PipelineTriggers/PayloadConfigModal/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/PayloadConfigModal/index.js
@@ -62,6 +62,7 @@ export default class PayloadConfigModal extends Component {
         modalClassName="payload-config-modal"
         size="lg"
         zIndex="1061"
+        backdrop="static"
       >
         <ModalHeader className="clearfix">
           <span className="pull-left">{T.translate(`${PREFIX}.title`)}</span>

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2093,6 +2093,7 @@ features:
       confirm: Delete
       confirmDraftPrompt: 'Are you sure you want to delete the draft '
       confirmPrompt: 'Are you sure you want to delete the pipeline '
+      deleteError: 'There was a problem with the pipeline you were trying to delete'
       pipeline: 'Pipeline '
       proceedPrompt: ' is deleted. Are you sure you want to proceed?'
       title: Delete pipeline


### PR DESCRIPTION
- Fixes configuring triggers payload modal to not close when customizing profiles
- Fixes profile customization popover to not scroll beyond the user window
- Fixes i18n text for pipeline delete confirmation modal to show proper text

Build: https://builds.cask.co/browse/CDAP-UDUT455-1