### PR TITLE
[UI] [Market] Fix beta tag to be preview in hub modal

### DIFF
--- a/cdap-ui/app/cdap/components/ExperimentalBanner/ExperimentalBanner.scss
+++ b/cdap-ui/app/cdap/components/ExperimentalBanner/ExperimentalBanner.scss
@@ -17,7 +17,7 @@
 @import '../../styles/variables.scss';
 
 .experimental-banner {
-  width: 47px;
+  width: 72px;
   display: inline-block;
   position: relative;
   color: white;

--- a/cdap-ui/app/cdap/components/ExperimentalBanner/index.js
+++ b/cdap-ui/app/cdap/components/ExperimentalBanner/index.js
@@ -18,5 +18,5 @@ import React from 'react';
 require('./ExperimentalBanner.scss');
 
 export default function ExperimentalBanner() {
-  return <div className="experimental-banner">BETA</div>;
+  return <div className="experimental-banner">PREVIEW</div>;
 }

--- a/cdap-ui/app/cdap/components/Market/UsecaseTab/index.js
+++ b/cdap-ui/app/cdap/components/Market/UsecaseTab/index.js
@@ -53,7 +53,7 @@ export default class UsecaseTab extends Component {
             key={entity.id}
             entity={entity}
             entityId={entity.id}
-            beta={entity.beta}
+            beta={entity.preview || entity.beta}
           />
         ))}
       </div>

--- a/cdap-ui/app/cdap/components/MarketPlaceUsecaseEntity/MarketPlaceUsecaseEntity.scss
+++ b/cdap-ui/app/cdap/components/MarketPlaceUsecaseEntity/MarketPlaceUsecaseEntity.scss
@@ -17,9 +17,6 @@
 @import '../../styles/variables.scss';
 
 .cask-card {
-  .experimental-banner {
-    padding-left: 5px;
-  }
 
   &.market-place-usecase-package-card {
     margin: 5px 0 15px 0;


### PR DESCRIPTION
- Changes the label from beta -> Preview
- Modifies ExperimentBanner to listen to preview flag in addition to beta flag in hub packages to show the beta tag.