### PR TITLE
(CDAP-16116) Update input field dropdown, select, multiselect and GetSchema

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
@@ -14,14 +14,14 @@
  * the License.
 */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import { IWidgetProps } from 'components/AbstractWidget';
 import { objectQuery } from 'services/helpers';
 import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
 
-interface IOption {
+export interface IOption {
   id: string;
   label: string;
 }
@@ -47,6 +47,14 @@ export default function MultiSelect({ value, widgetProps, disabled, onChange }: 
     setSelections(values);
     onChange(selectionsString);
   };
+
+  useEffect(
+    () => {
+      const selection = value.toString().split(delimiter);
+      setSelections(selection);
+    },
+    [value]
+  );
 
   return (
     <Select multiple value={selections} onChange={onChangeHandler} disabled={disabled}>

--- a/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/Select/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/Select/index.tsx
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 */
-
 import React from 'react';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';

--- a/cdap-ui/app/cdap/components/AbstractWidget/GetSchemaWidget/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/GetSchemaWidget/index.tsx
@@ -30,14 +30,28 @@ const styles = (): StyleRules => {
     spinner: {
       fontSize: '16px',
     },
+    buttonWrapper: {
+      textAlign: 'right',
+    },
   };
 };
 
-interface IGetSchemaProps extends IWidgetProps<null>, WithStyles<typeof styles> {}
+export enum Position {
+  TopLeft = 'top-left',
+  TopRight = 'top-right',
+  BottomLeft = 'bottom-left',
+  BottomRight = 'bottom-right',
+}
+interface IGetSchemaWidgetProps {
+  position?: Position;
+}
 
-const GetSchemaWidgetView: React.FC<IGetSchemaProps> = ({ extraConfig, classes }) => {
+interface IGetSchemaProps extends IWidgetProps<IGetSchemaWidgetProps>, WithStyles<typeof styles> {}
+
+const GetSchemaWidgetView: React.FC<IGetSchemaProps> = ({ extraConfig, classes, widgetProps }) => {
   const validateProperties = objectQuery(extraConfig, 'validateProperties');
   const [loading, setLoading] = React.useState<boolean>(false);
+  const position = widgetProps.position || '';
 
   function onClickHander() {
     if (loading) {
@@ -58,11 +72,15 @@ const GetSchemaWidgetView: React.FC<IGetSchemaProps> = ({ extraConfig, classes }
     </span>
   );
 
+  const className =
+    position === Position.TopRight || position === Position.BottomRight
+      ? classes.buttonWrapper
+      : '';
   return (
-    <div>
+    <div className={className}>
       <Button
-        variant="contained"
-        color="primary"
+        variant="outlined"
+        color="default"
         disabled={typeof validateProperties !== 'function'}
         onClick={onClickHander}
         className={classes.button}

--- a/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
@@ -22,6 +22,7 @@ import {
 } from 'components/ConfigurationGroup/types';
 import xor from 'lodash/xor';
 import flatten from 'lodash/flatten';
+import { Position } from 'components/AbstractWidget/GetSchemaWidget';
 
 interface IDefaultValues {
   [key: string]: string;
@@ -157,6 +158,7 @@ function addPluginFunctions(configurationGroups) {
       }
 
       // add plugin function as a separate widget
+      const pluginFunctionPosition: string = pluginFunction.position || Position.BottomLeft;
       const pluginFunctionWidget = {
         'widget-type': 'get-schema',
         'widget-category': 'plugin',
@@ -166,6 +168,7 @@ function addPluginFunctions(configurationGroups) {
           'add-properties': pluginFunction['add-properties'],
           'required-fields': pluginFunction['required-fields'],
           'missing-required-fields-message': pluginFunction['missing-required-fields-message'],
+          position: pluginFunctionPosition, // top, bottom, left, right or a combination ex. top-left
         },
       };
 
@@ -174,8 +177,16 @@ function addPluginFunctions(configurationGroups) {
       };
       delete propertyWidget['plugin-function'];
 
-      newGroup.properties.push(pluginFunctionWidget);
-      newGroup.properties.push(propertyWidget);
+      if (
+        pluginFunctionPosition === Position.BottomLeft ||
+        pluginFunctionPosition === Position.BottomRight
+      ) {
+        newGroup.properties.push(propertyWidget);
+        newGroup.properties.push(pluginFunctionWidget);
+      } else {
+        newGroup.properties.push(pluginFunctionWidget);
+        newGroup.properties.push(propertyWidget);
+      }
     });
 
     updatedConfigurationGroups.push(newGroup);


### PR DESCRIPTION
Add support for two new optional attributes in InputFieldDropdown:

- 'multiselect': Will allow the user to select multiple input fields (separated by comma)
- 'allowedTypes': List of types allowed for this dropdown (ex. 'string' will only show fields of type string in the dropdown)

Added support for new attribute in GetSchema/Plugin Function widget:
- 'position': will determine where the get schema button will get added relative to the widget that has the plugin function. Valid values are top, bottom, left, right or combination of two (ex. top-right)
- Changed appearance of button to be 'default' (grey outlined instead of blue filled)

Minor bug fixes for Select and MultiSelect where the selections were not being saved into the state properly