### PR TITLE
[CDAP-16117] Refactored UI to Allow Triggering on Non-Batch Pipelines

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/index.js
@@ -31,7 +31,9 @@ require('./PipelineDetailsTopPanel.scss');
 
 const mapStateToButtonsProps = (state) => {
   return {
-    isBatch: state.artifact.name === GLOBALS.etlDataPipeline,
+    isBatch:
+      state.artifact.name === GLOBALS.etlDataPipeline ||
+      state.artifact.name === GLOBALS.eltSqlPipeline,
     pipelineName: state.name,
     schedule: state.config.schedule,
     maxConcurrentRuns: state.config.maxConcurrentRuns,
@@ -57,7 +59,9 @@ export default class PipelineDetailsTopPanel extends Component {
       type: PipelineConfigurationsActions.SET_PIPELINE_VISUAL_CONFIGURATION,
       payload: {
         pipelineVisualConfiguration: {
-          isBatch: pipelineDetailStore.artifact.name === GLOBALS.etlDataPipeline,
+          isBatch:
+            pipelineDetailStore.artifact.name === GLOBALS.etlDataPipeline ||
+            pipelineDetailStore.artifact.name === GLOBALS.eltSqlPipeline,
         },
       },
     });

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/NextRun/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/NextRun/index.tsx
@@ -41,7 +41,7 @@ export default class NextRun extends React.PureComponent<IProps, IState> {
   };
 
   public componentDidMount() {
-    if (this.props.pipeline.artifact.name !== GLOBALS.etlDataPipeline) {
+    if (this.props.pipeline.artifact.name === GLOBALS.etlDataStreams) {
       return;
     }
 
@@ -62,7 +62,7 @@ export default class NextRun extends React.PureComponent<IProps, IState> {
     const pipeline = this.props.pipeline;
 
     const params = {
-      ...GLOBALS.programInfo[GLOBALS.etlDataPipeline],
+      ...GLOBALS.programInfo[this.props.pipeline.artifact.name],
       namespace,
       appId: pipeline.name,
     };

--- a/cdap-ui/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledTriggerRow.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/EnabledTriggersTab/EnabledTriggerRow.js
@@ -36,11 +36,12 @@ export default class EnabledTriggerRow extends Component {
     super(props);
 
     this.pipelineName = PipelineTriggersStore.getState().triggers.pipelineName;
+    this.workflowName = PipelineTriggersStore.getState().triggers.workflowName;
     this.disableTriggerClick = this.disableTriggerClick.bind(this);
   }
 
   disableTriggerClick() {
-    disableSchedule(this.props.schedule, this.pipelineName);
+    disableSchedule(this.props.schedule, this.pipelineName, this.workflowName);
   }
 
   renderLoading() {

--- a/cdap-ui/app/cdap/components/PipelineTriggers/PipelineListTab/PipelineTriggersRow.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/PipelineListTab/PipelineTriggersRow.js
@@ -45,6 +45,7 @@ export default class PipelineTriggersRow extends Component {
   constructor(props) {
     super(props);
     this.pipelineName = PipelineTriggersStore.getState().triggers.pipelineName;
+    this.workflowName = PipelineTriggersStore.getState().triggers.workflowName;
   }
 
   toggleKey(key) {
@@ -73,6 +74,7 @@ export default class PipelineTriggersRow extends Component {
     let config = this.getConfig();
     enableSchedule(
       this.props.triggeringPipelineInfo,
+      this.workflowName,
       this.pipelineName,
       this.props.selectedNamespace,
       config
@@ -115,6 +117,7 @@ export default class PipelineTriggersRow extends Component {
     };
     enableSchedule(
       this.props.triggeringPipelineInfo,
+      this.workflowName,
       this.pipelineName,
       this.props.selectedNamespace,
       config

--- a/cdap-ui/app/cdap/components/PipelineTriggers/PipelineListTab/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/PipelineListTab/index.js
@@ -23,6 +23,7 @@ import { connect } from 'react-redux';
 import PipelineTriggersActions from 'components/PipelineTriggers/store/PipelineTriggersActions';
 import PipelineTriggersRow from 'components/PipelineTriggers/PipelineListTab/PipelineTriggersRow';
 import T from 'i18n-react';
+import { GLOBALS } from 'services/global-constants';
 
 const TRIGGER_PREFIX = 'features.PipelineTriggers';
 const PREFIX = `${TRIGGER_PREFIX}.SetTriggers`;
@@ -35,6 +36,7 @@ const mapStateToProps = (state) => {
     selectedNamespace: state.triggers.selectedNamespace,
     pipelineName: state.triggers.pipelineName,
     expandedPipeline: state.triggers.expandedPipeline,
+    workflowName: state.triggers.workflowName,
   };
 };
 
@@ -55,6 +57,7 @@ function PipelineListTabView({
   selectedNamespace,
   expandedPipeline,
   toggleExpandPipeline,
+  workflowName,
 }) {
   let namespaceList = NamespaceStore.getState().namespaces;
   let { selectedNamespace: namespace } = NamespaceStore.getState();
@@ -107,6 +110,7 @@ function PipelineListTabView({
               id: pipeline.name,
               namespace: selectedNamespace,
               description: pipeline.description,
+              workflowName: GLOBALS.programId[pipeline.artifact.name],
             };
             return (
               <PipelineTriggersRow
@@ -117,6 +121,7 @@ function PipelineListTabView({
                 triggeringPipelineInfo={triggeringPipelineInfo}
                 triggeredPipelineInfo={triggeredPipelineInfo}
                 selectedNamespace={selectedNamespace}
+                workflowName={workflowName}
               />
             );
           })}
@@ -132,6 +137,7 @@ PipelineListTabView.propTypes = {
   pipelineName: PropTypes.string,
   expandedPipeline: PropTypes.string,
   toggleExpandPipeline: PropTypes.bool,
+  workflowName: PropTypes.string,
 };
 
 const PipelineListTab = connect(

--- a/cdap-ui/app/cdap/components/PipelineTriggers/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/index.js
@@ -27,6 +27,7 @@ import PipelineTriggersStore from 'components/PipelineTriggers/store/PipelineTri
 import NamespaceStore from 'services/NamespaceStore';
 import { Provider } from 'react-redux';
 import T from 'i18n-react';
+import { GLOBALS } from 'services/global-constants';
 
 const PREFIX = 'features.PipelineTriggers';
 
@@ -76,14 +77,19 @@ export default class PipelineTriggers extends Component {
 
   componentWillMount() {
     PipelineTriggersStore.dispatch({
-      type: PipelineTriggersActions.setPipelineName,
+      type: PipelineTriggersActions.setPipeline,
       payload: {
         pipelineName: this.props.pipelineName,
+        workflowName: GLOBALS.programId[this.props.pipelineType],
       },
     });
 
     let namespace = NamespaceStore.getState().selectedNamespace;
-    fetchTriggersAndApps(this.props.pipelineName, namespace);
+    fetchTriggersAndApps(
+      this.props.pipelineName,
+      GLOBALS.programId[this.props.pipelineType],
+      namespace
+    );
   }
 
   componentWillUnmount() {
@@ -151,4 +157,5 @@ export default class PipelineTriggers extends Component {
 PipelineTriggers.propTypes = {
   pipelineName: PropTypes.string.isRequired,
   namespace: PropTypes.string.isRequired,
+  pipelineType: PropTypes.string.isRequired,
 };

--- a/cdap-ui/app/cdap/components/PipelineTriggers/store/PipelineTriggersActions.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/store/PipelineTriggersActions.js
@@ -16,7 +16,7 @@
 
 const PipelineTriggersActions = {
   changeNamespace: 'TRIGGERS_CHANGE_NAMESPACE',
-  setPipelineName: 'TRIGGERS_SET_PIPELINE_NAME',
+  setPipeline: 'TRIGGERS_SET_PIPELINE',
   setExpandedPipeline: 'TRIGGERS_SET_EXPANDED_PIPELINE',
   setExpandedTrigger: 'TRIGGERS_SET_EXPANDED_TRIGGER',
   setTriggersAndPipelineList: 'TRIGGERS_SET_TRIGGERS_PIPELINE',

--- a/cdap-ui/app/cdap/components/PipelineTriggers/store/PipelineTriggersStore.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggers/store/PipelineTriggersStore.js
@@ -27,6 +27,7 @@ const defaultInitialState = {
   selectedNamespace: '',
   enabledTriggers: [],
   pipelineName: '',
+  pipelineType: '',
   expandedPipeline: null,
   expandedTrigger: null,
 };
@@ -40,9 +41,10 @@ const triggers = (state = defaultInitialState, action = defaultAction) => {
   let stateCopy;
 
   switch (action.type) {
-    case PipelineTriggersActions.setPipelineName:
+    case PipelineTriggersActions.setPipeline:
       stateCopy = Object.assign({}, state, {
         pipelineName: action.payload.pipelineName,
+        workflowName: action.payload.workflowName,
       });
       break;
     case PipelineTriggersActions.changeNamespace:

--- a/cdap-ui/app/cdap/components/PipelineTriggersSidebars/index.js
+++ b/cdap-ui/app/cdap/components/PipelineTriggersSidebars/index.js
@@ -21,14 +21,18 @@ import PipelineTriggers from 'components/PipelineTriggers';
 import TriggeredPipelines from 'components/TriggeredPipelines';
 import { Theme } from 'services/ThemeHelper';
 
-export default function PipelineTriggersSidebars({ pipelineName, namespace }) {
+export default function PipelineTriggersSidebars({ pipelineName, namespace, pipelineType }) {
   if (Theme.showTriggers === false) {
     return null;
   }
 
   return (
     <div className="pipeline-triggers-sidebar-container">
-      <PipelineTriggers pipelineName={pipelineName} namespace={namespace} />
+      <PipelineTriggers
+        pipelineName={pipelineName}
+        namespace={namespace}
+        pipelineType={pipelineType}
+      />
       <TriggeredPipelines pipelineName={pipelineName} />
     </div>
   );
@@ -37,4 +41,5 @@ export default function PipelineTriggersSidebars({ pipelineName, namespace }) {
 PipelineTriggersSidebars.propTypes = {
   pipelineName: PropTypes.string,
   namespace: PropTypes.string,
+  pipelineType: PropTypes.string,
 };

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -55,6 +55,7 @@ const GLOBALS = {
       source: 'sqlsource',
       sink: 'sqlsink',
       transform: 'sqltransform',
+      sqljoiner: 'sqljoiner'
     },
     'cdap-etl-batch': {
       source: 'batchsource',
@@ -121,7 +122,8 @@ const GLOBALS = {
     splittertransform: pluginLabels['transform'],
     sqlsource: pluginLabels['source'],
     sqlsink: pluginLabels['sink'],
-    sqltransform: pluginLabels['transform']
+    sqltransform: pluginLabels['transform'],
+    sqljoiner: pluginLabels['analytics']
   },
   pluginLabels: pluginLabels,
   // understand what plugin type is what.
@@ -146,7 +148,8 @@ const GLOBALS = {
     splittertransform: 'transform',
     sqlsource: 'source',
     sqlsink: 'sink',
-    sqltransform: 'transform'
+    sqltransform: 'transform',
+    sqljoiner: 'transform'
   },
 
   artifactConvert: {

--- a/cdap-ui/app/hydrator/templates/detail.html
+++ b/cdap-ui/app/hydrator/templates/detail.html
@@ -21,8 +21,9 @@
 <div class="detail-canvas-container" ui-view="canvas"></div>
 
 <!-- TRIGGERS -->
-<div ng-if="$state.params.pipelineId && DetailCtrl.pipelineType === 'cdap-data-pipeline'">
+<div ng-if="$state.params.pipelineId && (DetailCtrl.pipelineType === 'cdap-data-pipeline'|| DetailCtrl.pipelineType === 'cdap-sql-pipeline')">
   <pipeline-triggers-sidebars
     pipeline-name="$state.params.pipelineId"
-    namespace="$state.params.namespace"></pipeline-triggers-sidebars>
+    namespace="$state.params.namespace"
+    pipeline-type="DetailCtrl.pipelineType"></pipeline-triggers-sidebars>
 </div>


### PR DESCRIPTION
Added a workflowName variable to the PipelineTriggersStore redux state which contains the workflow application name (e.g. DataPipelineWorkflow or SQLWorkflow). Ideally, we should be checking the pipeline app type (e.g. spark or workflows) in order to determine whether or not a pipeline is triggerable. This still needs to be changed in cdap-ui/app/hydrator/templates/detail.html. However, everything else should work out of the box assuming that the global-constants.js file has the proper constants set for new applications.