### PR TITLE
Code cleanup of AppMetadataStore

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -298,24 +298,21 @@ public class AppMetadataStore {
     getApplicationSpecificationTable().deleteAll(getNamespaceRange(namespaceId));
   }
 
-  // todo: do we need appId? may be use from appSpec?
-  public void updateAppSpec(String namespaceId, String appId, String versionId,
-                            ApplicationSpecification spec) throws IOException {
-    ApplicationId applicationId = new NamespaceId(namespaceId).app(appId, versionId);
+  public void updateAppSpec(ApplicationId appId, ApplicationSpecification spec) throws IOException {
     if (LOG.isTraceEnabled()) {
-      LOG.trace("App spec to be updated: id: {}: spec: {}", applicationId, GSON.toJson(spec));
+      LOG.trace("App spec to be updated: id: {}: spec: {}", appId, GSON.toJson(spec));
     }
-    ApplicationMeta existing = getApplication(applicationId);
+    ApplicationMeta existing = getApplication(appId);
 
     if (existing == null) {
-      throw new IllegalArgumentException("Application " + applicationId + " does not exist");
+      throw new IllegalArgumentException("Application " + appId + " does not exist");
     }
 
     if (LOG.isTraceEnabled()) {
-      LOG.trace("Application {} exists in mds with specification {}", applicationId, GSON.toJson(existing));
+      LOG.trace("Application {} exists in mds with specification {}", appId, GSON.toJson(existing));
     }
     ApplicationMeta updated = ApplicationMeta.updateSpec(existing, spec);
-    writeApplicationSerialized(namespaceId, appId, versionId, GSON.toJson(updated));
+    writeApplicationSerialized(appId.getNamespace(), appId.getApplication(), appId.getVersion(), GSON.toJson(updated));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -456,7 +456,7 @@ public class DefaultStore implements Store {
                                                                      workerSpec.getResources(),
                                                                      instances, workerSpec.getPlugins());
       ApplicationSpecification newAppSpec = replaceWorkerInAppSpec(appSpec, id, newSpecification);
-      metaStore.updateAppSpec(id.getNamespace(), id.getApplication(), id.getVersion(), newAppSpec);
+      metaStore.updateAppSpec(id.getParent(), newAppSpec);
 
     });
 
@@ -478,7 +478,7 @@ public class DefaultStore implements Store {
                                              serviceSpec.getResources(), instances, serviceSpec.getPlugins());
 
       ApplicationSpecification newAppSpec = replaceServiceSpec(appSpec, id.getProgram(), serviceSpec);
-      metaStore.updateAppSpec(id.getNamespace(), id.getApplication(), id.getVersion(), newAppSpec);
+      metaStore.updateAppSpec(id.getParent(), newAppSpec);
     });
 
     LOG.trace("Setting program instances: namespace: {}, application: {}, service: {}, new instances count: {}",

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -120,7 +120,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public ProgramDescriptor loadProgram(ProgramId id) throws IOException, ApplicationNotFoundException,
+  public ProgramDescriptor loadProgram(ProgramId id) throws ApplicationNotFoundException,
     ProgramNotFoundException {
     ApplicationMeta appMeta = TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getApplication(id.getNamespace(), id.getApplication(), id.getVersion());
@@ -621,7 +621,7 @@ public class DefaultStore implements Store {
   }
 
   @VisibleForTesting
-  void clear() throws Exception {
+  void clear() {
     TransactionRunners.run(transactionRunner, context -> {
       getAppMetadataStore(context).deleteAllAppMetadataTables();
       getWorkflowTable(context).deleteAll();

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgresSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgresSqlStructuredTable.java
@@ -106,6 +106,10 @@ public class PostgresSqlStructuredTable implements StructuredTable {
     throws InvalidFieldException, IOException {
     LOG.trace("Table {}: Read with multiple keys {}", tableSchema.getTableId(), multiKeys);
 
+    if (multiKeys.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     for (Collection<Field<?>> keys : multiKeys) {
       fieldValidator.validatePrimaryKeys(keys, false);
     }


### PR DESCRIPTION
- Use multiRead for getRuns
- Safe guard multiRead from empty request
- Fix bunch of code duplication and warnings as detected by IDE