### PR TITLE
[CDAP-16119] Fix for avro schema parsing error for union splitter

### DIFF
--- a/cdap-ui/app/directives/complex-schema/complex-schema.js
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.js
@@ -123,7 +123,7 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
       vm.emptySchema = true;
       return;
     }
-    // TODO: for splitters, the backend returns port names similar to [schemaName].string or [schemaName].int.
+    // TODO(CDAP-13010): for splitters, the backend returns port names similar to [schemaName].string or [schemaName].int.
     // However, some weird parsing code in the avsc library doesn't allow primitive type names to be after periods(.),
     // so we have to manually make this change here. Ideally the backend should provide a different syntax for port
     // names so that we don't have to do this hack in the UI.

--- a/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
@@ -197,6 +197,14 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
           return;
         }
 
+        // TODO(CDAP-13010): for splitters, the backend returns port names similar to [schemaName].string or [schemaName].int.
+        // However, some weird parsing code in the avsc library doesn't allow primitive type names to be after periods(.),
+        // so we have to manually make this change here. Ideally the backend should provide a different syntax for port
+        // names so that we don't have to do this hack in the UI.
+        if (jsonSchema.name) {
+          jsonSchema.name = jsonSchema.name.replace('.', '.type');
+        }
+
         schema.schema = avsc.parse(jsonSchema, { wrapUnions: true });
         return schema;
 


### PR DESCRIPTION
We replace '.' in schema name to '.type' to prevent the error avro parsing library throws in complex schema editor on init. This was missing on schema import.