### PR TITLE
[CDAP-16133] Fix UI to stop polling on tabs/windows not active

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/NextRun/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/NextRun/index.tsx
@@ -23,7 +23,7 @@ import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { MyPipelineApi } from 'api/pipeline';
 import ee from 'event-emitter';
-import { WINDON_ON_FOCUS, WINDOW_ON_BLUR } from 'services/WindowManager';
+import { WINDOW_ON_FOCUS, WINDOW_ON_BLUR } from 'services/WindowManager';
 
 interface IProps {
   pipeline: IPipeline;
@@ -51,13 +51,13 @@ export default class NextRun extends React.PureComponent<IProps, IState> {
     // Interval only runs after the delay, so have to
     // initially call the function first
     this.startNextRunInterval();
-    this.eventemitter.on(WINDON_ON_FOCUS, this.startNextRunInterval);
+    this.eventemitter.on(WINDOW_ON_FOCUS, this.startNextRunInterval);
     this.eventemitter.on(WINDOW_ON_BLUR, this.stopNextRunInterval);
   }
 
   public componentWillUnmount() {
     this.stopNextRunInterval();
-    this.eventemitter.off(WINDON_ON_FOCUS, this.startNextRunInterval);
+    this.eventemitter.off(WINDOW_ON_FOCUS, this.startNextRunInterval);
     this.eventemitter.off(WINDOW_ON_BLUR, this.stopNextRunInterval);
   }
 

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -60,7 +60,7 @@ import { IntrospectionFragmentMatcher, InMemoryCache } from 'apollo-cache-inmemo
 // See ./graphql/fragements/README.md
 import introspectionQueryResultData from '../../graphql/fragments/fragmentTypes.json';
 import SessionTokenStore, { fetchSessionToken } from 'services/SessionTokenStore';
-import { WINDON_ON_FOCUS, WINDOW_ON_BLUR } from 'services/WindowManager';
+import { WINDOW_ON_FOCUS, WINDOW_ON_BLUR } from 'services/WindowManager';
 
 const Administration = Loadable({
   loader: () => import(/* webpackChunkName: "Administration" */ 'components/Administration'),
@@ -98,7 +98,7 @@ class CDAP extends Component {
       loading: true,
     };
     this.eventEmitter = ee(ee);
-    this.eventEmitter.on(WINDON_ON_FOCUS, this.onWindowFocus);
+    this.eventEmitter.on(WINDOW_ON_FOCUS, this.onWindowFocus);
     this.eventEmitter.on(WINDOW_ON_BLUR, this.onWindowBlur);
   }
 
@@ -107,7 +107,7 @@ class CDAP extends Component {
   }
 
   componentWillUnmount() {
-    this.eventEmitter.off(WINDON_ON_FOCUS, this.onWindowFocus);
+    this.eventEmitter.off(WINDOW_ON_FOCUS, this.onWindowFocus);
     this.eventEmitter.off(WINDOW_ON_BLUR, this.onWindowBlur);
   }
 

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -60,6 +60,7 @@ import { IntrospectionFragmentMatcher, InMemoryCache } from 'apollo-cache-inmemo
 // See ./graphql/fragements/README.md
 import introspectionQueryResultData from '../../graphql/fragments/fragmentTypes.json';
 import SessionTokenStore, { fetchSessionToken } from 'services/SessionTokenStore';
+import { WINDON_ON_FOCUS, WINDOW_ON_BLUR } from 'services/WindowManager';
 
 const Administration = Loadable({
   loader: () => import(/* webpackChunkName: "Administration" */ 'components/Administration'),
@@ -97,11 +98,26 @@ class CDAP extends Component {
       loading: true,
     };
     this.eventEmitter = ee(ee);
+    this.eventEmitter.on(WINDON_ON_FOCUS, this.onWindowFocus);
+    this.eventEmitter.on(WINDOW_ON_BLUR, this.onWindowBlur);
   }
 
   componentWillMount() {
     this.fetchSessionTokenAndUpdateState().then(this.setUIState);
   }
+
+  componentWillUnmount() {
+    this.eventEmitter.off(WINDON_ON_FOCUS, this.onWindowFocus);
+    this.eventEmitter.off(WINDOW_ON_BLUR, this.onWindowBlur);
+  }
+
+  onWindowBlur = () => {
+    StatusFactory.stopPollingForBackendStatus();
+  };
+
+  onWindowFocus = () => {
+    this.fetchSessionTokenAndUpdateState().then(this.setUIState);
+  };
 
   setUIState = () => {
     StatusFactory.startPollingForBackendStatus();

--- a/cdap-ui/app/cdap/services/StatusFactory.js
+++ b/cdap-ui/app/cdap/services/StatusFactory.js
@@ -21,7 +21,7 @@ import StatusAlertMessageStore from 'components/StatusAlertMessage/StatusAlertMe
 import cookie from 'react-cookie';
 import isNil from 'lodash/isNil';
 import { Observable } from 'rxjs/Observable';
-import SystemServicesStore, { pollSystemServices } from 'services/SystemServicesStore';
+import SystemServicesStore, { pollSystemServices, stopSystemServicesPolling } from 'services/SystemServicesStore';
 import SessionTokenStore from 'services/SessionTokenStore';
 
 let pollingObservable;
@@ -153,6 +153,7 @@ const stopServicePolling = () => {
     systemServiceSubscription();
     systemServiceSubscription = null;
   }
+  stopSystemServicesPolling();
 };
 
 const stopPolling = () => {

--- a/cdap-ui/app/cdap/services/SystemServicesStore.js
+++ b/cdap-ui/app/cdap/services/SystemServicesStore.js
@@ -75,7 +75,7 @@ const pollSystemServices = () => {
 };
 
 const stopSystemServicesPolling = () => {
-  systemServicesPollSubscription();
+  systemServicesPollSubscription.unsubscribe();
 };
 
 export default ServicesStore;

--- a/cdap-ui/app/cdap/services/WindowManager/index.ts
+++ b/cdap-ui/app/cdap/services/WindowManager/index.ts
@@ -16,7 +16,7 @@
 
 import ee from 'event-emitter';
 const WINDOW_ON_BLUR = 'WINDOW_BLUR_EVENT';
-const WINDON_ON_FOCUS = 'WINDOW_FOCUS_EVENT';
+const WINDOW_ON_FOCUS = 'WINDOW_FOCUS_EVENT';
 
 class WindowManager {
   public eventemitter = ee(ee);
@@ -35,9 +35,9 @@ class WindowManager {
   };
 
   public onFocusHandler = () => {
-    this.eventemitter.emit(WINDON_ON_FOCUS);
+    this.eventemitter.emit(WINDOW_ON_FOCUS);
   };
 }
 
 export default new WindowManager();
-export { WINDOW_ON_BLUR, WINDON_ON_FOCUS };
+export { WINDOW_ON_BLUR, WINDOW_ON_FOCUS };

--- a/cdap-ui/app/cdap/services/WindowManager/index.ts
+++ b/cdap-ui/app/cdap/services/WindowManager/index.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import ee from 'event-emitter';
+const WINDOW_ON_BLUR = 'WINDOW_BLUR_EVENT';
+const WINDON_ON_FOCUS = 'WINDOW_FOCUS_EVENT';
+
+class WindowManager {
+  public eventemitter = ee(ee);
+  constructor() {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        this.onFocusHandler();
+      } else {
+        this.onBlurEventHandler();
+      }
+    });
+  }
+
+  public onBlurEventHandler = () => {
+    this.eventemitter.emit(WINDOW_ON_BLUR);
+  };
+
+  public onFocusHandler = () => {
+    this.eventemitter.emit(WINDON_ON_FOCUS);
+  };
+}
+
+export default new WindowManager();
+export { WINDOW_ON_BLUR, WINDON_ON_FOCUS };

--- a/cdap-ui/app/cdap/services/datasource/index.js
+++ b/cdap-ui/app/cdap/services/datasource/index.js
@@ -32,7 +32,7 @@ import 'rxjs/add/operator/combineLatest';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/debounceTime';
-import WindowManager, {WINDOW_ON_BLUR, WINDON_ON_FOCUS} from 'services/WindowManager';
+import WindowManager, {WINDOW_ON_BLUR, WINDOW_ON_FOCUS} from 'services/WindowManager';
 
 var CDAP_API_VERSION = 'v3';
 // FIXME (CDAP-14836): Right now this is scattered across node and client. Need to consolidate this.
@@ -107,7 +107,7 @@ export default class Datasource {
         }
       });
     });
-    this.eventEmitter.on(WINDON_ON_FOCUS, this.resumePoll.bind(this));
+    this.eventEmitter.on(WINDOW_ON_FOCUS, this.resumePoll.bind(this));
     this.eventEmitter.on(WINDOW_ON_BLUR, this.pausePoll.bind(this));
   }
 

--- a/cdap-ui/app/hydrator/controllers/detail-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.hydrator')
-  .controller('HydratorPlusPlusDetailCtrl', function(rPipelineDetail, $scope, $stateParams, PipelineAvailablePluginsActions, GLOBALS) {
+  .controller('HydratorPlusPlusDetailCtrl', function(rPipelineDetail, $scope, $stateParams, PipelineAvailablePluginsActions, GLOBALS, caskWindowManager) {
     // FIXME: This should essentially be moved to a scaffolding service that will do stuff for a state/view
     const pipelineDetailsActionCreator = window.CaskCommon.PipelineDetailActionCreator;
     const pipelineMetricsActionCreator = window.CaskCommon.PipelineMetricsActionCreator;
@@ -27,7 +27,7 @@ angular.module(PKG.name + '.feature.hydrator')
     let programName = this.pipelineType === GLOBALS.etlDataPipeline ? 'DataPipelineWorkflow' : 'DataStreamsSparkStreaming';
     let scheduleId = GLOBALS.defaultScheduleId;
 
-    let currentRun, metricsObservable, runsPoll;
+    let currentRun, metricsObservable, runsPoll, runsCountPoll;
     let pluginsFetched = false;
 
     pipelineDetailsActionCreator.init(rPipelineDetail);
@@ -75,19 +75,28 @@ angular.module(PKG.name + '.feature.hydrator')
       } else if (runid) {
         pipelineDetailsActionCreator.setCurrentRunId(runid);
       }
+      pollRuns();
+    });
+
+    pollRunsCount();
+
+    function pollRuns() {
       runsPoll = pipelineDetailsActionCreator.pollRuns({
         namespace: $stateParams.namespace,
         appId: rPipelineDetail.name,
         programType,
         programName
       });
-    });
-    let pollRunsCount = pipelineDetailsActionCreator.pollRunsCount({
-      namespace: $stateParams.namespace,
-      appId: rPipelineDetail.name,
-      programType: programTypeForRunsCount,
-      programName
-    });
+    }
+
+    function pollRunsCount() {
+      runsCountPoll = pipelineDetailsActionCreator.pollRunsCount({
+        namespace: $stateParams.namespace,
+        appId: rPipelineDetail.name,
+        programType: programTypeForRunsCount,
+        programName
+      });
+    }
 
     pipelineDetailsActionCreator.fetchScheduleStatus({
       namespace: $stateParams.namespace,
@@ -141,13 +150,30 @@ angular.module(PKG.name + '.feature.hydrator')
       }
     });
 
+    $scope.$on(caskWindowManager.event.focus, () => {
+      pollRuns();
+      pollRunsCount();
+    });
+
+    $scope.$on(caskWindowManager.event.blur, () => {
+      if (metricsObservable) {
+        metricsObservable.unsubscribe();
+      }
+      if (runsPoll) {
+        runsPoll.unsubscribe();
+      }
+      if (runsCountPoll) {
+        runsCountPoll.unsubscribe();
+      }
+    });
+
     $scope.$on('$destroy', function() {
       // FIXME: This should essentially be moved to a scaffolding service that will do stuff for a state/view
       if (runsPoll) {
         runsPoll.unsubscribe();
       }
-      if (pollRunsCount) {
-        pollRunsCount.unsubscribe();
+      if (runsCountPoll) {
+        runsCountPoll.unsubscribe();
       }
       if (metricsObservable) {
         metricsObservable.unsubscribe();


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16133
Build: https://builds.cask.co/browse/CDAP-UDUT461

- Adds a `WindowManager` to listen to document visibility change event and publish it through UI
- Adds the logic to `datasource` to stop all the bindings of type `POLL` if the current browser tab/window is inactive
- Modifies following feature areas for individual changes,
  - Pipelines list view for nextrun time
  - Pipeline Detail view for runs and runscount
  - System service poll globally

**Context:**
- We used to have the ability to stop any polling request we make happening in tabs that are not currently active. 
- This is to avoid making too many unnecessary requests to app-fabric. 
- We decided not to do it because there were discrepancies in data when the user went back to the tab they were in which was causing confusion
- This effort is to restore that functionality to be able to reduce the load we put on app-fabric without causing any confusion to user.
- The right fix should be from app-fabric where it should be able to handle any number of requests from UI however we can be proactive in making the UI avoid making calls that are not useful.
- This is not a solution but a step towards reducing the requests from UI to app-fabric for sessions that are not active. This will help us significantly when we scale up.

**Note:**
- Have avoided changing this in other places for now. This is to avoid making this change any more bigger. Other lesser frequented places include 
  - Application detailed view (which we don't show for pipelines anymore), 
  - Reports
  - Administration
  - logviewer