### PR TITLE
[CDAP-16136] hiding plugin functions in deploy view

### DIFF
--- a/cdap-ui/app/cdap/components/ConfigurationGroup/index.tsx
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/index.tsx
@@ -202,6 +202,14 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
               if (property.show === false) {
                 return null;
               }
+              // Hiding all plugin functions if pipeline is deployed
+              if (
+                disabled &&
+                property.hasOwnProperty('widget-category') &&
+                property['widget-category'] === 'plugin'
+              ) {
+                return null;
+              }
               // Check if a field is present to display the error contextually
               const errorObjs =
                 errors && errors.hasOwnProperty(property.name) ? errors[property.name] : null;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16136

Hiding all plugin functions when disabled is true like in deploy view