### PR TITLE
Fixes the case of showing all incoming data in preview in joiner plugin

### DIFF
--- a/cdap-ui/app/hydrator/services/hydrator-node-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-node-service.js
@@ -49,7 +49,7 @@ class HydratorPlusPlusNodeService {
       }
 
       if (sourceNode.outputSchema[0].name !== this.GLOBALS.defaultSchemaName) {
-        let sourcePort = sourceConnections[0].port;
+        let sourcePort = (sourceConnections.find(sconn => sconn.port) || {}).port;
         let sourceSchema = sourceNode.outputSchema.filter(outputSchema => outputSchema.name === sourcePort);
         schema = sourceSchema[0].schema;
       } else {


### PR DESCRIPTION
Fix:
  - We incorrectly assumed that there will be only one incoming while requesting for preview data
  - Preview API requires all in coming stages to be able show the entire preview data for a particular stage. 
  - The fix involves passing in all the incoming stages.
  - However we have some complication interms of incoming connections from ports and condition plugin. I have fixed tested them but since we don't have tests backing this change I am not confident if this won't introduce any further regressions.

JIRA: https://issues.cask.co/browse/CDAP-16106
Build: ~https://builds.cask.co/browse/CDAP-UDUT469-1~ https://builds.cask.co/browse/CDAP-UDUT480-1