### PR TITLE
(CDAP-16128) Speed up SQL query

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -516,5 +516,5 @@ public interface Store {
    * @return          runs for each program
    */
   List<ProgramHistory> getRuns(Collection<ProgramId> programs, ProgramRunStatus status, long startTime, long endTime,
-                               int limit, Predicate<RunRecordMeta> filter);
+                               int limit, @Nullable Predicate<RunRecordMeta> filter);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -95,19 +95,6 @@ public interface Store {
   void setStart(ProgramRunId id, @Nullable String twillRunId, Map<String, String> systemArgs, byte[] sourceId);
 
   /**
-   * Logs rejection of a program run and persists program status to {@link ProgramRunStatus#REJECTED}.
-   *
-   * @param id run id of the program
-   * @param runtimeArgs the runtime arguments for this program run
-   * @param systemArgs the system arguments for this program run
-   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
-   *                 when the current program run status is reached
-   * @param artifactId artifact id used to create the application the program belongs to
-   */
-  void setRejected(ProgramRunId id, Map<String, String> runtimeArgs, Map<String, String> systemArgs,
-                   byte[] sourceId, ArtifactId artifactId);
-
-  /**
    * Logs start of program run and persists program status to {@link ProgramRunStatus#RUNNING}.
    *
    * @param id run id of the program
@@ -275,19 +262,6 @@ public interface Store {
    * @return map of logged runs
    */
   Map<ProgramRunId, RunRecordMeta> getActiveRuns(ProgramId programId);
-
-  /**
-   * Fetches the historical (i.e COMPLETED or FAILED or KILLED) run records from a given set of namespaces
-   * which matches both the earliestStopTime and latestStartTime conditions.
-   *
-   * @param namespaces fetch run history that is belonged to one of these namespaces
-   * @param earliestStopTime fetch run history that has stopped at or after the earliestStopTime in seconds
-   * @param latestStartTime fetch run history that has started before the latestStartTime in seconds
-   * @param limit max number of entries to fetch for this history call
-   * @return map of logged runs
-   */
-  Map<ProgramRunId, RunRecordMeta> getHistoricalRuns(Set<NamespaceId> namespaces,
-                                                     long earliestStopTime, long latestStartTime, int limit);
 
   /**
    * Fetches the run record for particular run of a program.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -271,7 +271,7 @@ public class ProgramLifecycleService {
                                  ProgramRunStatus programRunStatus, long start, long end, int limit) throws Exception {
     Set<? extends EntityId> visibleEntities = authorizationEnforcer.isVisible(new HashSet<>(programs),
                                                                               authenticationContext.getPrincipal());
-    for (ProgramHistory programHistory : store.getRuns(programs, programRunStatus, start, end, limit, x -> true)) {
+    for (ProgramHistory programHistory : store.getRuns(programs, programRunStatus, start, end, limit, null)) {
       ProgramId programId = programHistory.getProgramId();
       if (visibleEntities.contains(programId)) {
         histories.add(programHistory);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -787,7 +787,7 @@ public class DefaultStore implements Store {
 
   @Override
   public List<ProgramHistory> getRuns(Collection<ProgramId> programs, ProgramRunStatus status, long startTime,
-                                      long endTime, int limit, Predicate<RunRecordMeta> filter) {
+                                      long endTime, int limit, @Nullable Predicate<RunRecordMeta> filter) {
     return TransactionRunners.run(transactionRunner, context -> {
       List<ProgramHistory> result = new ArrayList<>(programs.size());
       AppMetadataStore appMetadataStore = getAppMetadataStore(context);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -160,14 +160,6 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void setRejected(ProgramRunId id, Map<String, String> runtimeArgs,
-                          Map<String, String> systemArgs, byte[] sourceId, ArtifactId artifactId) {
-    TransactionRunners.run(transactionRunner, context -> {
-      getAppMetadataStore(context).recordProgramRejected(id, runtimeArgs, systemArgs, sourceId, artifactId);
-    });
-  }
-
-  @Override
   public void setRunning(ProgramRunId id, long runTime, String twillRunId, byte[] sourceId) {
     TransactionRunners.run(transactionRunner, context -> {
       getAppMetadataStore(context).recordProgramRunning(id, runTime, twillRunId, sourceId);
@@ -373,14 +365,6 @@ public class DefaultStore implements Store {
   public Map<ProgramRunId, RunRecordMeta> getActiveRuns(ProgramId programId) {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getActiveRuns(programId);
-    });
-  }
-
-  @Override
-  public Map<ProgramRunId, RunRecordMeta> getHistoricalRuns(Set<NamespaceId> namespaces,
-                                                            long earliestStopTime, long latestStartTime, int limit) {
-    return TransactionRunners.run(transactionRunner, context -> {
-      return getAppMetadataStore(context).getHistoricalRuns(namespaces, earliestStopTime, latestStartTime, limit);
     });
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -105,7 +105,6 @@ import javax.annotation.Nullable;
  * Tests for {@link ProgramLifecycleHttpHandler}
  */
 public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(ProgramLifecycleHttpHandlerTest.class);
 
   private static final Gson GSON = new GsonBuilder()
     .create();

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgresSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgresSqlStructuredTable.java
@@ -60,6 +60,7 @@ import javax.annotation.Nullable;
  */
 public class PostgresSqlStructuredTable implements StructuredTable {
   private static final Logger LOG = LoggerFactory.getLogger(PostgresSqlStructuredTable.class);
+  private static final int SCAN_FETCH_SIZE = 100;
 
   private final Connection connection;
   private final StructuredTableSchema tableSchema;
@@ -199,6 +200,7 @@ public class PostgresSqlStructuredTable implements StructuredTable {
     // We don't close the statement here because once it is closed, the result set is also closed.
     try {
       PreparedStatement statement = connection.prepareStatement(scanQuery);
+      statement.setFetchSize(SCAN_FETCH_SIZE);
       int index = 1;
       if (keyRange.getBegin() != null) {
         for (Field<?> key : keyRange.getBegin()) {
@@ -233,6 +235,7 @@ public class PostgresSqlStructuredTable implements StructuredTable {
     // We don't close the statement here because once it is closed, the result set is also closed.
     try {
       PreparedStatement statement = connection.prepareStatement(sql);
+      statement.setFetchSize(SCAN_FETCH_SIZE);
       setField(statement, index, 1);
       LOG.trace("SQL statement: {}", statement);
       ResultSet resultSet = statement.executeQuery();


### PR DESCRIPTION
- Remove useless predicate
- Push run record start/end time into sql predicate
- Use cursor fetch instead of fetching the whole result set