### PR TITLE
[CDAP-16130] Adds generic ContextMenu for right click menus in pipeline studio

### DIFF
--- a/cdap-ui/app/cdap/components/ContextMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/ContextMenu/index.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import * as React from 'react';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import withStyles from '@material-ui/core/styles/withStyles';
+import PropTypes from 'prop-types';
+export interface IContextMenuOption {
+  name: string;
+  label: (() => string) | string;
+  onClick: (event: React.SyntheticEvent) => void;
+  disabled?: boolean;
+}
+
+interface IContextMenuProps {
+  element?: HTMLElement;
+  selector?: string;
+  options?: IContextMenuOption[];
+  onOpen?: () => void; // to update disabled flags
+}
+
+const initialMousePosition = {
+  mouseX: null,
+  mouseY: null,
+};
+
+const StyledMenuItem = withStyles(() => ({
+  root: {
+    minHeight: 'auto',
+  },
+}))(MenuItem);
+
+const StyledDisabledMenuItem = withStyles((theme) => ({
+  root: {
+    minHeight: 'auto',
+    color: theme.palette.grey[500],
+    cursor: 'not-allowed',
+  },
+}))(MenuItem);
+
+export const ContextMenu = ({ selector, element, options, onOpen }: IContextMenuProps) => {
+  const [mousePosition, setMousePosition] = React.useState(initialMousePosition);
+
+  const toggleMenu = (e: PointerEvent) => {
+    setMousePosition({
+      mouseX: e.clientX - 2,
+      mouseY: e.clientY - 4,
+    });
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    if (onOpen) {
+      onOpen();
+    }
+  };
+  const defaultEventHandler = (e) => e.preventDefault();
+
+  // state to capture children of context menu to disable right click on them.
+  const [children, setChildren] = React.useState(null);
+  // we don't use 'useRef' but a 'useCallback' is because 'ref.current' state is not
+  // tracked. So a useEffect(() => {...}, [ref.current]) won't get called back if
+  // the dom node changes.
+  const measuredRef = React.useCallback((node) => {
+    if (node !== null) {
+      setChildren([...Array.prototype.slice.call(node.children), node]);
+    }
+  }, []);
+
+  React.useEffect(
+    () => {
+      if (children) {
+        children.forEach((child) => {
+          child.removeEventListener('contextmenu', defaultEventHandler);
+          child.addEventListener('contextmenu', defaultEventHandler);
+        });
+      }
+      return () => {
+        if (children) {
+          children.forEach((child) =>
+            child.removeEventListener('contextmenu', defaultEventHandler)
+          );
+        }
+      };
+    },
+    [children]
+  );
+
+  // on mount determine the position of the mouse pointer and place the menu right there.
+  React.useEffect(() => {
+    let el: HTMLElement;
+    if (selector) {
+      el = document.querySelector(selector);
+    }
+    if (element) {
+      el = element;
+    }
+    if (!el) {
+      throw new Error("Context Menu either needs a 'selector' or 'element' props to be passed");
+    }
+
+    el.addEventListener('contextmenu', toggleMenu);
+    return () => el.removeEventListener('contextmenu', toggleMenu);
+  }, []);
+
+  const handleClose = (option: IContextMenuOption, e: React.SyntheticEvent) => {
+    setMousePosition(initialMousePosition);
+    option.onClick(e);
+  };
+
+  return (
+    <Menu
+      keepMounted={true}
+      open={mousePosition.mouseY !== null}
+      onClose={() => setMousePosition(initialMousePosition)}
+      anchorReference="anchorPosition"
+      anchorPosition={
+        mousePosition.mouseY !== null && mousePosition.mouseX !== null
+          ? { top: mousePosition.mouseY, left: mousePosition.mouseX }
+          : undefined
+      }
+      ref={measuredRef}
+    >
+      {options.map((option) => {
+        const { name, label, disabled } = option;
+        const MenuItemComp = disabled ? StyledDisabledMenuItem : StyledMenuItem;
+        return (
+          <MenuItemComp
+            key={name}
+            onClick={disabled === true ? undefined : handleClose.bind(null, option)}
+          >
+            {typeof label === 'function' ? label() : label}
+          </MenuItemComp>
+        );
+      })}
+    </Menu>
+  );
+};
+
+(ContextMenu as any).propTypes = {
+  selector: PropTypes.string,
+  element: PropTypes.node,
+  options: PropTypes.object,
+  onOpen: PropTypes.func,
+};
+
+export default function ContextMenuWrapper() {
+  const options: IContextMenuOption[] = [
+    {
+      name: 'option1',
+      label: 'Option One',
+      onClick: () => ({}),
+    },
+    {
+      name: 'option2',
+      label: 'Option Two',
+      onClick: () => ({}),
+    },
+    {
+      name: 'option3',
+      label: 'Option Three',
+      onClick: () => ({}),
+    },
+  ];
+  return (
+    <React.Fragment>
+      <h1 id="right-click-item">Right click here</h1>
+      <ContextMenu selector="#right-click-item" options={options} />
+    </React.Fragment>
+  );
+}

--- a/cdap-ui/app/cdap/components/PipelineContextMenu/PipelineTypes.ts
+++ b/cdap-ui/app/cdap/components/PipelineContextMenu/PipelineTypes.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+export enum PluginTypes {
+  BATCHSOURCE = 'batchsource',
+  TRANSFORM = 'transform',
+  BATCHAGGREGATOR = 'batchaggregator',
+  SPLITTERTRANSFORM = 'splittertransform',
+  BATCHSINK = 'batchsink',
+
+  ALERTPUBLISHER = 'alertpublisher',
+  ERRORTRANSFORM = 'errortransform',
+  BATCHJOINER = 'batchjoiner',
+  WINDOWER = 'windower',
+
+  STREAMINGSOURCE = 'streamingsource',
+  SPARKSINK = 'sparksink',
+}
+
+export interface IArtifactObj {
+  name: string;
+  version: string;
+  scope: string;
+}
+
+export interface IProperties {
+  [key: string]: any;
+}
+
+export interface IPluginObj {
+  name: string;
+  artifact: IArtifactObj;
+  properties: IProperties;
+  label: string;
+}
+
+export interface INode {
+  name: string;
+  type: PluginTypes;
+  icon: string;
+  plugin: IPluginObj;
+  label: string;
+}
+
+export interface IConnection {
+  from: string;
+  to: string;
+}

--- a/cdap-ui/app/cdap/components/PipelineContextMenu/WranglerConnection/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineContextMenu/WranglerConnection/index.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import { Modal, ModalBody } from 'reactstrap';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import ThemeWrapper from 'components/ThemeWrapper';
+import IconSVG from 'components/IconSVG';
+import PropTypes from 'prop-types';
+import DataPrepHome from 'components/DataPrepHome';
+import getPipelineConfig from 'components/DataPrep/TopPanel/PipelineConfigHelper';
+import If from 'components/If';
+import {
+  IArtifactObj,
+  PluginTypes,
+  IProperties,
+} from 'components/PipelineContextMenu/PipelineTypes';
+import { GLOBALS } from 'services/global-constants';
+
+const styles = (theme) => ({
+  modalBtnClose: {
+    height: '50px',
+    width: '50px',
+    boxShadow: 'none',
+    border: 0,
+    background: 'transparent',
+    borderLeft: `1px solid ${theme.palette.grey['300']}`,
+    fontWeight: 'bold' as 'bold',
+    fontSize: '1.5rem',
+    '&:hover': {
+      background: theme.palette.blue['40'],
+      color: theme.palette.white['50'],
+    },
+  },
+});
+
+interface IPluginObj {
+  name: string;
+  artifact: IArtifactObj;
+  label: string;
+  type: PluginTypes;
+  properties: IProperties;
+}
+
+interface INode {
+  name: string;
+  plugin: IPluginObj;
+}
+
+interface IConnection {
+  from: string;
+  to: string;
+}
+
+export type INewWranglerConnection = (obj: { nodes: INode[]; connections: IConnection[] }) => void;
+interface IContextMenuOptionProp extends WithStyles<typeof styles> {
+  onModalClose: () => void;
+  onWranglerSourceAdd: INewWranglerConnection;
+  pipelineArtifactType: 'cdap-data-pipeline' | 'cdap-data-streams';
+}
+
+function WranglerConnection({
+  classes,
+  onModalClose,
+  onWranglerSourceAdd,
+  pipelineArtifactType,
+}: IContextMenuOptionProp) {
+  const [showModal, setShowModal] = React.useState(true);
+  const toggleModal = () => {
+    setShowModal(!showModal);
+    onModalClose();
+  };
+  const onWranglerConnectionSubmit = ({ onUnmount }) => {
+    if (onUnmount) {
+      return;
+    }
+    getPipelineConfig().subscribe(({ batchConfig, realtimeConfig }) => {
+      let finalConfig;
+      if (pipelineArtifactType === GLOBALS.etlDataPipeline) {
+        finalConfig = batchConfig;
+      }
+      if (pipelineArtifactType === GLOBALS.etlDataStreams) {
+        finalConfig = realtimeConfig;
+      }
+      if (!finalConfig) {
+        return;
+      }
+      onWranglerSourceAdd({
+        nodes: finalConfig.config.stages,
+        connections: finalConfig.config.connections,
+      });
+      setShowModal(!showModal);
+    });
+  };
+  return (
+    <Modal
+      isOpen={showModal}
+      toggle={toggleModal}
+      size="lg"
+      modalClassName="wrangler-modal"
+      backdrop="static"
+      zIndex="1061"
+    >
+      <div className="modal-header">
+        <h5 className="modal-title">Wrangle</h5>
+        <button className={classes.modalBtnClose} onClick={toggleModal}>
+          <IconSVG name="icon-close" />
+        </button>
+      </div>
+      <div className="modal-body">
+        <If condition={showModal}>
+          <DataPrepHome singleWorkspaceMode={true} onSubmit={onWranglerConnectionSubmit} />
+        </If>
+      </div>
+    </Modal>
+  );
+}
+
+const StyledWranglerConnection = withStyles(styles)(WranglerConnection);
+
+export default function WranglerConnectionWrapper(props) {
+  return (
+    <ThemeWrapper>
+      <StyledWranglerConnection {...props} />
+    </ThemeWrapper>
+  );
+}
+
+(WranglerConnectionWrapper as any).propTypes = {
+  onModalClose: PropTypes.func,
+  onWranglerSourceAdd: PropTypes.func,
+  pipelineArtifactType: PropTypes.oneOf([GLOBALS.etlDataPipeline, GLOBALS.etlDataStreams]),
+};

--- a/cdap-ui/app/cdap/components/PipelineContextMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineContextMenu/index.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import { ContextMenu, IContextMenuOption } from 'components/ContextMenu';
+import WranglerConnection from 'components/PipelineContextMenu/WranglerConnection';
+import If from 'components/If';
+import PropTypes from 'prop-types';
+import { getValueFromClipboard } from 'services/Clipboard';
+import { objectQuery } from 'services/helpers';
+import { INode, IConnection } from 'components/PipelineContextMenu/PipelineTypes';
+import { INewWranglerConnection } from 'components/PipelineContextMenu/WranglerConnection';
+import { GLOBALS } from 'services/global-constants';
+
+export interface IStage {
+  nodes: INode[];
+  connections: IConnection[];
+}
+interface IPipelineContextMenuProps {
+  onNodesPaste: (stages: IStage) => void;
+  onWranglerSourceAdd: INewWranglerConnection;
+  pipelineArtifactType: 'cdap-data-pipeline' | 'cdap-data-streams';
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  fitToScreen: () => void;
+  prettyPrintGraph: () => void;
+}
+
+async function getNodesFromClipBoard(): Promise<IStage | undefined> {
+  let clipText;
+  try {
+    clipText = await getValueFromClipboard();
+  } catch (e) {
+    return Promise.reject();
+  }
+  return Promise.resolve(parseClipboardData(clipText));
+}
+
+function parseClipboardData(text): IStage | undefined {
+  let config;
+  if (typeof text !== 'object') {
+    try {
+      config = JSON.parse(text);
+      config.nodes = config.stages;
+      delete config.stages;
+    } catch (e) {
+      return;
+    }
+  }
+  return config;
+}
+
+async function isPasteOptionDisabled(): Promise<boolean> {
+  let clipText;
+  try {
+    clipText = await getValueFromClipboard();
+  } catch (e) {
+    return Promise.reject(true);
+  }
+  return Promise.resolve(isClipboardPastable(clipText));
+}
+
+function isClipboardPastable(text) {
+  let jsonNodes;
+  if (typeof text !== 'object') {
+    try {
+      jsonNodes = JSON.parse(text);
+    } catch (e) {
+      return true;
+    }
+  }
+  return objectQuery(jsonNodes, 'stages', 'length') > 0 ? false : true;
+}
+
+export default function PipelineContextMenu({
+  onWranglerSourceAdd,
+  onNodesPaste,
+  pipelineArtifactType,
+  onZoomIn,
+  onZoomOut,
+  fitToScreen,
+  prettyPrintGraph,
+}: IPipelineContextMenuProps) {
+  const [showWranglerModal, setShowWranglerModal] = React.useState(false);
+  const [pasteOptionDisabled, setPasteOptionDisabled] = React.useState(true);
+
+  isPasteOptionDisabled().then(setPasteOptionDisabled);
+
+  const updateOptionDisabledFlags = () => {
+    isPasteOptionDisabled().then(setPasteOptionDisabled);
+  };
+  const menuOptions: IContextMenuOption[] = [
+    {
+      name: 'add-wrangler-source',
+      label: 'Add a wrangler source',
+      onClick: () => setShowWranglerModal(!showWranglerModal),
+    },
+    {
+      name: 'zoom-in',
+      label: 'Zoom in',
+      onClick: onZoomIn,
+    },
+    {
+      name: 'zoom-out',
+      label: 'Zoom Out',
+      onClick: onZoomOut,
+    },
+    {
+      name: 'fit-to-screen',
+      label: 'Fit to Screen',
+      onClick: fitToScreen,
+    },
+    {
+      name: 'align-nodes',
+      label: 'Pretty print',
+      onClick: prettyPrintGraph,
+    },
+    {
+      name: 'pipeline-node-paste',
+      label: 'Paste',
+      onClick: () => {
+        getNodesFromClipBoard().then(onNodesPaste);
+      },
+      disabled: pasteOptionDisabled,
+    },
+  ];
+  const onWranglerSourceAddWrapper = (...props) => {
+    setShowWranglerModal(!showWranglerModal);
+    onWranglerSourceAdd.apply(null, props);
+  };
+  return (
+    <React.Fragment>
+      <ContextMenu
+        selector="#diagram-container"
+        options={menuOptions}
+        onOpen={updateOptionDisabledFlags}
+      />
+      <If condition={showWranglerModal}>
+        <WranglerConnection
+          onModalClose={() => setShowWranglerModal(!showWranglerModal)}
+          onWranglerSourceAdd={onWranglerSourceAddWrapper}
+          pipelineArtifactType={pipelineArtifactType}
+        />
+      </If>
+    </React.Fragment>
+  );
+}
+
+(PipelineContextMenu as any).propTypes = {
+  onWranglerSourceAdd: PropTypes.func,
+  onNodesPaste: PropTypes.func,
+  pipelineArtifactType: PropTypes.oneOf([GLOBALS.etlDataPipeline, GLOBALS.etlDataStreams]),
+  onZoomIn: PropTypes.func,
+  onZoomOut: PropTypes.func,
+  fitToScreen: PropTypes.func,
+  prettyPrintGraph: PropTypes.func,
+};

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -46,6 +46,17 @@ const sanitizeConfig = (pipeline) => {
       delete stage[k];
     });
   });
+  pipelineClone.config.stages = pipelineClone.config.stages.map((stage) => {
+    return Object.assign({}, stage, {
+      name: stage.name.replace(/[ \/]/g, '-'),
+    });
+  });
+  pipelineClone.config.connections = pipelineClone.config.connections.map((conn) => {
+    return Object.assign({}, conn, {
+      from: conn.from.replace(/[ \/]/g, '-'),
+      to: conn.to.replace(/[ \/]/g, '-'),
+    });
+  });
 
   return pipelineClone;
 };

--- a/cdap-ui/app/cdap/components/PluginContextMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginContextMenu/index.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import { ContextMenu, IContextMenuOption } from 'components/ContextMenu';
+import PropTypes from 'prop-types';
+import { copyToClipBoard } from 'services/Clipboard';
+
+export default function PluginContextMenu({
+  nodeId,
+  getPluginConfiguration,
+  getSelectedConnections,
+  getSelectedNodes,
+  onDelete,
+  onOpen,
+}) {
+  const PluginContextMenuOptions: IContextMenuOption[] = [
+    {
+      name: 'plugin copy',
+      label: () => (getSelectedNodes().length > 1 ? 'Copy Plugins' : 'Copy Plugin'),
+      onClick: () => {
+        const stages = getPluginConfiguration().stages;
+        const connections = getSelectedConnections();
+        const text = JSON.stringify({
+          stages,
+          connections,
+        });
+        copyToClipBoard(text).then(
+          () => {
+            /* tslint:disable:no-console */
+            console.log('Success now show a tooltip or something to the user');
+          },
+          () => {
+            /* tslint:disable:no-console */
+            console.error('Fail!. Show to the user copy failed');
+          }
+        );
+      },
+    },
+    {
+      name: 'plugin delete',
+      label: () => (getSelectedNodes().length > 1 ? 'Delete Plugins' : 'Delete Plugin'),
+      onClick: () => {
+        onDelete();
+      },
+    },
+  ];
+  const onPluginContextMenuOpen = () => {
+    onOpen(nodeId);
+  };
+  return (
+    <React.Fragment>
+      <ContextMenu
+        selector={`#${nodeId}`}
+        options={PluginContextMenuOptions}
+        onOpen={onPluginContextMenuOpen}
+      />
+    </React.Fragment>
+  );
+}
+
+(PluginContextMenu as any).propTypes = {
+  nodeId: PropTypes.string,
+  getPluginConfiguration: PropTypes.func,
+  getSelectedConnections: PropTypes.func,
+  getSelectedNodes: PropTypes.func,
+  onDelete: PropTypes.func,
+  onOpen: PropTypes.func,
+};

--- a/cdap-ui/app/cdap/components/SelectionBox/index.tsx
+++ b/cdap-ui/app/cdap/components/SelectionBox/index.tsx
@@ -88,12 +88,12 @@ export default function SelectionBox(props: ISelectionBoxProps) {
           onSelectionStart();
         }
       });
-      selection.on('move', ({ selected }) => {
+      selection.on('move', ({ selected, changed: { added, removed } }) => {
         const selectedNodes = [];
         for (const el of selected) {
           selectedNodes.push(el.id);
         }
-        if (onSelectionMove && selectedNodes.length > 0) {
+        if (onSelectionMove && (added.length > 0 || removed.length > 0)) {
           onSelectionMove({ selected: selectedNodes });
         }
       });

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -278,7 +278,7 @@ class CDAP extends Component {
                       );
                     }}
                   />
-                  {/* <Route
+                  <Route
                     exact
                     path="/contextmenu"
                     render={(props) => {
@@ -287,7 +287,7 @@ class CDAP extends Component {
                       }
                       const ContextMenu = Loadable({
                         loader: () =>
-                          import(/* webpackChunkName: "ContextMenu" *\/ 'components/ContextMenu'),
+                          import(/* webpackChunkName: "ContextMenu" */ 'components/ContextMenu'),
                         loading: LoadingSVGCentered,
                       });
                       return (
@@ -296,7 +296,7 @@ class CDAP extends Component {
                         </ErrorBoundary>
                       );
                     }}
-                  />*/}
+                  />
                   {/*
                     Eventually handling 404 should move to the error boundary and all container components will have the error object.
                   */}

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -104,8 +104,8 @@ var WidgetWrapper = require('../cdap/components/ConfigurationGroup/WidgetWrapper
 var ConfigurationGroupUtilities = require('../cdap/components/ConfigurationGroup/utilities');
 var DynamicFiltersUtilities = require('../cdap/components/ConfigurationGroup/utilities/DynamicPluginFilters');
 var LoadingSVG = require('../cdap/components/LoadingSVG').default;
-// var PipelineContextMenu = require('../cdap/components/PipelineContextMenu').default;
-// var PluginContextMenu = require('../cdap/components/PluginContextMenu').default;
+var PipelineContextMenu = require('../cdap/components/PipelineContextMenu').default;
+var PluginContextMenu = require('../cdap/components/PluginContextMenu').default;
 var SelectionBox = require('../cdap/components/SelectionBox').default;
 export {
   Store,
@@ -184,7 +184,7 @@ export {
   ConfigurationGroupUtilities,
   DynamicFiltersUtilities,
   LoadingSVG,
-  // PipelineContextMenu,
-  // PluginContextMenu,
+  PipelineContextMenu,
+  PluginContextMenu,
   SelectionBox,
 };

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -75,7 +75,11 @@ angular.module(PKG.name + '.commons')
       if (vm.isDisabled) { return; }
       event.stopPropagation();
       clearConnectionsSelection();
-      vm.selectedNode.push(node);
+      if (vm.selectionBox.toggle) {
+        vm.selectedNode.push(node);
+        return;
+      }
+      vm.selectedNode = [node];
     };
     vm.getSelectedNodes = () => vm.selectedNode;
     /**
@@ -158,6 +162,7 @@ angular.module(PKG.name + '.commons')
         vm.selectedNode = selectedNodes;
         const selectedNodesMap = {};
         vm.selectedNode.forEach(node => selectedNodesMap[node.name] = true);
+        console.log('selected nodes: ', selectedNodesMap);
         const adjacencyMap = DAGPlusPlusNodesStore.getAdjacencyMap();
         clearConnectionsSelection();
         vm.selectedNode.forEach(({name}) => {
@@ -166,13 +171,21 @@ angular.module(PKG.name + '.commons')
             return;
           }
           const connectionsFromSource = vm.instance.getConnections({sourceId: name});
+          console.log('Connections from source: ', name, connectionsFromSource);
           connectedNodes.forEach(nodeId => {
             if (!selectedNodesMap[nodeId]) {
+              console.log(nodeId + ' doesn\'t exist in the selected nodes');
               return;
             }
-            const connObj = connectionsFromSource.find(conn => conn.targetId === nodeId);
-            if (connObj) {
-              toggleConnection(connObj);
+            const connObj = connectionsFromSource.filter(conn => conn.source.getAttribute('data-nodeid') === name && conn.targetId === nodeId);
+            if (connObj.length) {
+              connObj.forEach(conn => {
+                console.log(`
+                Highlighting connection:
+                  ${conn.sourceId} - ${conn.targetId}
+                `);
+                toggleConnection(conn, false);
+              });
             }
           });
         });
@@ -745,7 +758,7 @@ angular.module(PKG.name + '.commons')
       DAGPlusPlusNodesActionsFactory.setConnections($scope.connections);
     };
 
-    function toggleConnections(selectedObj) {
+    function toggleConnections(selectedObj, event) {
       if (vm.isDisabled) { return; }
 
       vm.selectedNode = [];
@@ -786,9 +799,14 @@ angular.module(PKG.name + '.commons')
           connection.removeType('selected');
         });
       }
+      if (event) {
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        event.preventDefault();
+      }
     }
 
-    function toggleConnection(connObj) {
+    function toggleConnection(connObj, toggle = true) {
       if (!connObj) {
         return;
       }
@@ -797,6 +815,11 @@ angular.module(PKG.name + '.commons')
         selectedConnections.push(connObj);
       } else {
         selectedConnections.splice(selectedConnections.indexOf(connObj), 1);
+      }
+      if (!toggle) {
+        console.log('setting selected type');
+        connObj.addType('selected');
+        return;
       }
       connObj.toggleType('selected');
     }
@@ -1056,6 +1079,9 @@ angular.module(PKG.name + '.commons')
           }
         }
       }
+      event.stopPropagation();
+      event.preventDefault();
+      event.stopImmediatePropagation();
     };
 
     jsPlumb.ready(function() {

--- a/cdap-ui/app/hydrator/controllers/create/partials/pipelineupgrade-modal-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/pipelineupgrade-modal-ctrl.js
@@ -96,6 +96,17 @@ angular.module(PKG.name + '.feature.hydrator')
             !this.fixAllDisabled
           ) {
             HydratorPlusPlusConfigStore.setState(HydratorPlusPlusConfigStore.getDefaults());
+            rPipelineConfig.config.stages = rPipelineConfig.config.stages.map(stage => {
+              return Object.assign({}, stage, {
+                name: stage.name.replace(/[ \/]/g, '-')
+              });
+            });
+            rPipelineConfig.config.connections = rPipelineConfig.config.connections.map(conn => {
+              return Object.assign({}, conn, {
+                from: conn.from.replace(/[ \/]/g, '-'),
+                to: conn.to.replace(/[ \/]/g, '-')
+              });
+            });
             $state.go('hydrator.create', { data: rPipelineConfig });
           } else {
             this.loading = false;

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -203,6 +203,7 @@ class HydratorPlusPlusConfigStore {
         inputSchema: node.inputSchema
       };
 
+      configObj.name = configObj.name.replace(/[ \/]/g, '-');
       if (node.errorDatasetName) {
         configObj.errorDatasetName = node.errorDatasetName;
       }
@@ -239,8 +240,8 @@ class HydratorPlusPlusConfigStore {
         toPluginName = toConnectionName.plugin.label || toConnectionName.name;
         toConnectionName = toPluginName;
       }
-      connection.from = fromConnectionName;
-      connection.to = toConnectionName;
+      connection.from = fromConnectionName.replace(/[ \/]/g, '-');
+      connection.to = toConnectionName.replace(/[ \/]/g, '-');
     });
     config.connections = connections;
 
@@ -333,7 +334,7 @@ class HydratorPlusPlusConfigStore {
     state.config = angular.copy(config);
 
     var nodes = angular.copy(this.getNodes()).map( node => {
-      node.name = node.plugin.label;
+      node.name = node.plugin.label.replace(/[ \/]/g, '-');
       return node;
     });
     state.__ui__.nodes = nodes;


### PR DESCRIPTION
Final PR that stitches everything.
- User should be able to multi-select nodes/connections
- Adds context menu to pipeline canvas and plugins
- Fixes the way we assign node names (both in stages & connections). The current change replaces all `spaces` with `-`. This should be a safe change. This is required to assign valid strings for node `id`s in HTML. (HTML id won't accept spaces).
