### PR TITLE
[UI][BUGFIX] Fix stop & starting system services properly 

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/InputFieldDropdown/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/InputFieldDropdown/index.tsx
@@ -61,7 +61,7 @@ function getFields(schemas: IStageSchema[], allowedTypes: string[]) {
 // This is meant to handle nullable fields since a nullable string type is
 // presented as ['string','null'].
 function containsType(types: string[], allowedTypes: string[]) {
-  if (allowedTypes.length == 0) {
+  if (allowedTypes.length === 0) {
     return true;
   }
 
@@ -99,7 +99,7 @@ const InputFieldDropdown: React.FC<IInputFieldProps> = ({
   const newValue = value
     .toString()
     .split(delimiter)
-    .filter((value) => fieldValues.includes(value))
+    .filter((v) => fieldValues.includes(v))
     .join(delimiter);
 
   if (newValue !== value) {

--- a/cdap-ui/app/cdap/services/StatusFactory.js
+++ b/cdap-ui/app/cdap/services/StatusFactory.js
@@ -135,8 +135,8 @@ const startServicePolling = () => {
 };
 
 const startPolling = () => {
-  pollSystemServices();
   stopPolling();
+  pollSystemServices();
   startServicePolling();
   pollingObservable = Observable.interval(BACKEND_STATUS_POLL_INTERVAL)
     .mergeMap(() =>

--- a/cdap-ui/app/cdap/services/SystemServicesStore.js
+++ b/cdap-ui/app/cdap/services/SystemServicesStore.js
@@ -75,7 +75,9 @@ const pollSystemServices = () => {
 };
 
 const stopSystemServicesPolling = () => {
-  systemServicesPollSubscription.unsubscribe();
+  if (systemServicesPollSubscription) {
+    systemServicesPollSubscription.unsubscribe();
+  }
 };
 
 export default ServicesStore;


### PR DESCRIPTION
**Issue:**
 - System services table in Admin page keeps spinning

**Cause**
  - We stop polling system services and their status before starting to poll
  - However we didn't it in order (start -> stop -> start). We restarted polling system service status BUT not system services per se. 
  - This causes UI to never request for list of system services which causes services table to show loading icon forever. 

**Solution**
  - Fix the order of polling to make sure we make the request.