### PR TITLE
CDAP-15785 remove redundant check for fll

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/FieldLineageProcessor.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/FieldLineageProcessor.java
@@ -139,7 +139,6 @@ public class FieldLineageProcessor {
       // Do not throw but just log the exception message for validation failure
       // Once most of the plugins are updated to write lineage exception can be thrown
       LOG.debug(new InvalidLineageException(stageInvalids).getMessage());
-      return Collections.emptySet();
     }
 
     LineageOperationsProcessor processor = new LineageOperationsProcessor(pipelineSpec.getConnections(),

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/FieldLineageProcessor.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/FieldLineageProcessor.java
@@ -67,6 +67,7 @@ public class FieldLineageProcessor {
 
     // validate the stage operations
     Map<String, InvalidFieldOperations> stageInvalids = new HashMap<>();
+    Map<String, Map<String, List<String>>> stageRedundants = new HashMap<>();
     for (StageSpec stageSpec : pipelineSpec.getStages()) {
 
       Map<String, Schema> inputSchemas = stageSpec.getInputSchemas();
@@ -124,6 +125,14 @@ public class FieldLineageProcessor {
       if (invalidFieldOperations != null) {
         stageInvalids.put(stageName, invalidFieldOperations);
       }
+
+      if (!stageOperationsValidator.getRedundantOutputs().isEmpty()) {
+        stageRedundants.put(stageName, stageOperationsValidator.getRedundantOutputs());
+      }
+    }
+
+    if (!stageRedundants.isEmpty()) {
+      LOG.debug("The pipeline has redundant operations {} and they will be ignored", stageRedundants);
     }
 
     if (!stageInvalids.isEmpty()) {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/StageOperationsValidator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/StageOperationsValidator.java
@@ -133,6 +133,11 @@ public class StageOperationsValidator {
           break;
         case TRANSFORM:
           FieldTransformOperation transform = (FieldTransformOperation) pipelineOperation;
+          // if this transform writes to no input or output fields, ignore the validation since the operation will
+          // take no effect
+          if (transform.getInputFields().isEmpty() || transform.getOutputFields().isEmpty()) {
+            continue;
+          }
           validateInputs(pipelineOperation.getName(), transform.getInputFields(), validInputsSoFar);
           updateInvalidOutputs(transform.getInputFields(), unusedOutputs, redundantOutputs);
           validInputsSoFar.addAll(transform.getOutputFields());

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/StageOperationsValidator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/StageOperationsValidator.java
@@ -71,9 +71,11 @@ import javax.annotation.Nullable;
  * OP5: [c] -> [x]
  * OP6: [a, c] -> [z]
  *
- * In this case the output field [z] created by OP4 is redundant (and so is invalid), since the
+ * In this case the output field [z] created by OP4 is redundant, since the
  * field [z] of the output schema will always come from OP6 and [z] is not used as input by any
- * operation subsequent of OP6. However note that even OP1 and OP5 both outputs [x], OP1 output is
+ * operation subsequent of OP6.
+ * The redundant operations will be considered valid but will be ignored.
+ * However note that even OP1 and OP5 both outputs [x], OP1 output is
  * not considered as invalid, since its used as input by OP2 which happens before OP5.
  */
 public class StageOperationsValidator {
@@ -84,7 +86,7 @@ public class StageOperationsValidator {
   private final Set<String> stageOutputs;
   private final Map<String, List<String>> invalidOutputs;
   private final Map<String, List<String>> invalidInputs;
-
+  private final Map<String, List<String>> redundantOutputs;
 
   private StageOperationsValidator(List<FieldOperation> operations, Set<String> stageInputs,
                                    Set<String> stageOutputs) {
@@ -93,6 +95,7 @@ public class StageOperationsValidator {
     this.stageOutputs = stageOutputs;
     this.invalidInputs = new HashMap<>();
     this.invalidOutputs = new HashMap<>();
+    this.redundantOutputs = new HashMap<>();
   }
 
   /**
@@ -163,34 +166,23 @@ public class StageOperationsValidator {
       String field = next.getKey();
       List<FieldOperation> origins = next.getValue();
 
-      if (stageOutputs.contains(field)) {
-        if (origins.size() > 1) {
-          // size will be greater than 1 only if its redundant
-          origins.remove(origins.size() - 1);
-        } else {
-          iterator.remove();
-        }
-      } else {
-        // If this field is not in the output schema of the stage, it is valid.
-        // For example, a Joiner joins two datasets D1,D2 based on the joiner key D1.K1, D2.K2, and
-        // decides to drop the joiner key in the output schema. The operation
-        // [D1.K1, D2.K2] ->[K1, K2] is a valid even though K1,K2 are not in the output schema.
-
-        // this means the field has redundant, TODO: CDAP-15785 revist redundant validation
-        if (origins.size() > 1) {
-          continue;
-        }
-
-        // Origin is empty means this is an generated field, it can be considered valid.
-        // If the size is 1, this field has no redundant operations, it is valid.
-        iterator.remove();
+      if (origins.size() > 1) {
+        List<FieldOperation> operations = redundantOutputs.computeIfAbsent(field, k -> new ArrayList<>());
+        // except the last origin, all others are redundant
+        operations.addAll(origins.subList(0, origins.size() - 1));
       }
+
+      // No matter this field is or is not in the output schema of the stage, it is valid.
+      // For example, a Joiner joins two datasets D1,D2 based on the joiner key D1.K1, D2.K2, and
+      // decides to drop the joiner key in the output schema. The operation
+      // [D1.K1, D2.K2] ->[K1, K2] is a valid even though K1,K2 are not in the output schema.
+      iterator.remove();
     }
 
     this.invalidOutputs.putAll(unusedOutputs.entrySet().stream().collect(
       Collectors.toMap(Map.Entry::getKey,
                        e -> e.getValue().stream().map(FieldOperation::getName).collect(Collectors.toList()))));
-    this.invalidOutputs.putAll(redundantOutputs.entrySet().stream().collect(
+    this.redundantOutputs.putAll(redundantOutputs.entrySet().stream().collect(
       Collectors.toMap(Map.Entry::getKey,
                        e -> e.getValue().stream().map(FieldOperation::getName).collect(Collectors.toList()))));
   }
@@ -260,6 +252,10 @@ public class StageOperationsValidator {
     }
 
     return new InvalidFieldOperations(invalidInputs, invalidOutputs);
+  }
+
+  public Map<String, List<String>> getRedundantOutputs() {
+    return redundantOutputs;
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/StageOperationsValidatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/StageOperationsValidatorTest.java
@@ -176,11 +176,9 @@ public class StageOperationsValidatorTest {
     StageOperationsValidator stageOperationsValidator = builder.build();
     stageOperationsValidator.validate();
 
-    InvalidFieldOperations expected =
-      new InvalidFieldOperations(Collections.emptyMap(),
-                                 ImmutableMap.of("name", Collections.singletonList("redundant_parse")));
+    Map<String, List<String>> expected = ImmutableMap.of("name", Collections.singletonList("redundant_parse"));
 
-    Assert.assertEquals(expected, stageOperationsValidator.getStageInvalids());
+    Assert.assertEquals(expected, stageOperationsValidator.getRedundantOutputs());
   }
 
   @Test
@@ -201,10 +199,9 @@ public class StageOperationsValidatorTest {
     StageOperationsValidator stageOperationsValidator = builder.build();
     stageOperationsValidator.validate();
 
-    InvalidFieldOperations expected =
-      new InvalidFieldOperations(Collections.emptyMap(),
-                                 ImmutableMap.of("name", Arrays.asList("redundant_parse1", "redundant_parse2")));
+    Map<String, List<String>> expected =
+      ImmutableMap.of("name", Arrays.asList("redundant_parse1", "redundant_parse2"));
 
-    Assert.assertEquals(expected, stageOperationsValidator.getStageInvalids());
+    Assert.assertEquals(expected, stageOperationsValidator.getRedundantOutputs());
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15785
build: https://builds.cask.co/browse/CDAP-RUT1725-1

The check for the redundant operations is too strict and it is very easy for user to make a mistake and get the entire lineage graph invisible. Instead of failing the lineage check, change this to a log message. 