### PR TITLE
[CDAP-16182] Fixes correctly setting active connection when switching…

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserStore/index.js
@@ -214,7 +214,7 @@ const database = (state = defaultDatabaseValue, action = defaultAction) => {
     case Actions.SET_DATABASE_PROPERTIES:
       return Object.assign({}, state, {
         info: objectQuery(action, 'payload', 'info') || state.info,
-        connectionId: objectQuery(action, 'payload', 'connectionId'),
+        connectionId: objectQuery(action, 'payload', 'connectionId') || state.connectionId,
         tables: objectQuery(action, 'payload', 'tables'),
         error: null,
         loading: false,
@@ -253,7 +253,7 @@ const kafka = (state = defaultKafkaValue, action = defaultAction) => {
     case Actions.SET_KAFKA_PROPERTIES:
       return Object.assign({}, state, {
         info: objectQuery(action, 'payload', 'info') || state.info,
-        connectionId: objectQuery(action, 'payload', 'connectionId'),
+        connectionId: objectQuery(action, 'payload', 'connectionId') || state.connectionId,
         topics: objectQuery(action, 'payload', 'topics'),
         error: null,
         loading: false,
@@ -293,6 +293,7 @@ const s3 = (state = defaultS3Value, action = defaultAction) => {
       return {
         ...state,
         info: action.payload.info,
+        connectionId: objectQuery(action, 'payload', 'connectionId') || state.connectionId,
         error: null,
       };
     case Actions.SET_S3_LOADING:
@@ -347,6 +348,7 @@ const gcs = (state = defaultGCSValue, action = defaultAction) => {
       return {
         ...state,
         info: action.payload.info,
+        connectionId: objectQuery(action, 'payload', 'connectionId') || state.connectionId,
         error: null,
       };
     case Actions.SET_GCS_LOADING:
@@ -401,6 +403,7 @@ const bigquery = (state = defaultBigQueryValue, action = defaultAction) => {
       return {
         ...state,
         info: action.payload.info,
+        connectionId: objectQuery(action, 'payload', 'connectionId') || state.connectionId,
         error: null,
       };
     case Actions.SET_BIGQUERY_LOADING:
@@ -452,6 +455,7 @@ const spanner = (state = defaultSpannerValue, action = defaultAction) => {
       return {
         ...state,
         info: action.payload.info,
+        connectionId: objectQuery(action, 'payload', 'connectionId') || state.connectionId,
         error: null,
       };
     case Actions.SET_SPANNER_LOADING:
@@ -513,6 +517,7 @@ const adls = (state = defaultADLSValue, action = defaultAction) => {
       return {
         ...state,
         info: action.payload.info,
+        connectionId: objectQuery(action, 'payload', 'connectionId') || state.connectionId,
         error: null,
       };
     case Actions.SET_ADLS_LOADING:
@@ -523,7 +528,7 @@ const adls = (state = defaultADLSValue, action = defaultAction) => {
     case Actions.SET_ADLS_PROPERTIES:
       return Object.assign({}, state, {
         info: objectQuery(action, 'payload', 'info') || state.info,
-        connectionId: objectQuery(action, 'payload', 'connectionId'),
+        connectionId: objectQuery(action, 'payload', 'connectionId') || state.connectionId,
         error: null,
         loading: false,
       });

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -343,7 +343,11 @@ export default class DataPrepConnections extends Component {
         spannerList = [],
         adlsList = [];
 
-      if (!state.activeConnectionId && !state.activeConnectionType && state.defaultConnection) {
+      if (
+        !this.state.activeConnectionId &&
+        !this.state.activeConnectionType &&
+        state.defaultConnection
+      ) {
         let defaultConnectionObj = find(res.values, { id: state.defaultConnection });
         if (defaultConnectionObj) {
           state.activeConnectionid = objectQuery(defaultConnectionObj, 'id');


### PR DESCRIPTION
… between wrangler tabs and connection browser

**Root Cause:**
- We incorrectly overwrite the active connection id when navigating (toggling) between wrangler workspace and connection browser.
- The active connection should be from the workspace (tab) when toggling (clicking on the arrow in the wrangler workspace mode).
- This gets overwritten when we can get a default connection and we are using that information inconsistently (incorrect path) which was throwing an error from backend
- The error from backend seems to be of the format ```{ values: [] }```. And we take this error and directly add it to the error banner which causes React to error out (cannot render object in react).

**Side Effect of this change:**
- Now that we have fixed the root cause, this now leads us to do less backend API calls
- As a side effect of it, when we switch between connections we get the response from backend only once and set it in the store.
- AFTER setting it in the store we unmount the previous connection which resets the store (resetting the connection id)
- So now in order to prevent any further failures we set the connection id that we get as part of the connection detail. 
- This is a safe change as if we didn't get the connection id it fallsback to the existing value.

Note:
We still have many inconsistencies with dataprep connections view. Have filed a  [CDAP-16183](https://issues.cask.co/browse/CDAP-16183)