### PR TITLE
[CDAP-16189] Fixes Create Profile form to not reset to default when s…

### DIFF
--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileActionCreator.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/CreateProfileActionCreator.js
@@ -33,6 +33,11 @@ function updateProfileDescription(description) {
 }
 
 function initializeProperties(provisionerJson = {}) {
+  const { properties: provisionerProperties } = CreateProfileStore.getState();
+  // This indicates the properties are already initialized.
+  if (Object.keys(provisionerProperties).length) {
+    return;
+  }
   let configs = provisionerJson['configuration-groups'] || [];
   let properties = {};
   configs.forEach((config) => {

--- a/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
+++ b/cdap-ui/app/cdap/components/Cloud/Profiles/CreateView/index.js
@@ -47,6 +47,7 @@ import T from 'i18n-react';
 import { SCOPES, SYSTEM_NAMESPACE } from 'services/global-constants';
 import { Theme } from 'services/ThemeHelper';
 import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import If from 'components/If';
 
 const PREFIX = 'features.Cloud.Profiles.CreateView';
 
@@ -286,9 +287,9 @@ class ProfileCreateView extends Component {
               </Form>
             </fieldset>
           </div>
-          {this.state.error ? (
+          <If condition={this.state.error}>
             <div className="error-section text-danger">{this.state.error}</div>
-          ) : null}
+          </If>
           <div className="btns-section">
             <CreateProfileBtn
               className="btn-primary"

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -156,9 +156,11 @@ class CDAP extends Component {
     } catch (e) {
       console.log('Fetching session token failed.');
     }
-    this.setState({
-      loading: false,
-    });
+    if (this.state.loading) {
+      this.setState({
+        loading: false,
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
…witching between tabs

**Source of the issue**
  - When switching tabs we pause any polling we do in inactive tab and resume the polling when user switches back to the same tab
  - During this switch back we start the polling
  - Here we unnecessarily update state which causes a whole re-render
  - This re-render makes create form to fetch provisioner spec json and resets all values to default from the spec

**Fix**
Do not update state unnecessarily 

JIRA: https://issues.cask.co/browse/CDAP-16189
Build: https://builds.cask.co/browse/CDAP-URUT209