### PR TITLE
Updates MD5 checksum for cdap-default.xml for docs build

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -332,12 +332,12 @@ function copy_license_pdfs() {
 function set_environment() {
   source ${PROJECT_PATH}/cdap-common/bin/functions.sh
   if [[ ${OSTYPE} == "darwin"* ]]; then
-    # NOTE: hard-coded Java version 1.7
-    export JAVA_HOME=$(/usr/libexec/java_home -v 1.7)
+    # NOTE: hard-coded Java version 1.8
+    export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
   else
     if [[ -z ${JAVA_HOME} ]]; then
       if [[ -z ${JAVA_JDK_VERSION} ]]; then
-        JAVA_JDK_VERSION="jdk1.7.0_75"
+        JAVA_JDK_VERSION="jdk1.8.0_231"
       fi
       export JAVA_HOME=/usr/lib/jvm/${JAVA_JDK_VERSION}
     fi

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="18f656b5beb6a02e1b37e9c466af83ed"
+DEFAULT_XML_MD5_HASH="1f3344e3e560107d888f2986d24b8adc"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
- Updates release notes
- Updates dependency license.
- Update cdap-default.xml MD5 checksum.

Docs build: https://builds.cask.co/browse/CDAP-DBT41-5