### PR TITLE
[CDAP-16208] Add generic widgets to storybook

### DIFF
--- a/cdap-ui/.storybook/config.js
+++ b/cdap-ui/.storybook/config.js
@@ -13,7 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 */
-import { configure, setAddon } from '@storybook/react';
+import { configure } from '@storybook/react';
+import T from 'i18n-react';
 
 require('font-awesome-sass-loader!../app/cdap/styles/font-awesome.config.js');
 require('../app/cdap/styles/lib-styles.scss');
@@ -22,11 +23,5 @@ require('../app/cdap/styles/main.scss');
 require('./stories.global.scss');
 require('../app/cdap/styles/bootstrap_4_patch.scss');
 
-// automatically import all files ending in *.stories.js
-const req = require.context('../app/cdap/components/', true, /.stories.tsx$/);
-function loadStories() {
-  require('./Welcome');
-  req.keys().forEach(filename => req(filename));
-}
-
-configure(loadStories, module);
+configure(require.context('../app/cdap/components/', true, /\.stories\.tsx$/), module);
+T.setTexts(require('../app/cdap/text/text-en.yaml'));

--- a/cdap-ui/.storybook/preview-head.html
+++ b/cdap-ui/.storybook/preview-head.html
@@ -1,0 +1,20 @@
+<!--
+  Copyright © 2020 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<script>
+  const mockCdapConfig = { 'marketUrl': 'fake url'};
+  window.CDAP_CONFIG = mockCdapConfig;
+</script>

--- a/cdap-ui/.storybook/stories.global.scss
+++ b/cdap-ui/.storybook/stories.global.scss
@@ -17,7 +17,7 @@
 @import "~styles/bootstrap_4_patch.scss";
 
 body {
-  padding: 10px;
+  padding: 30px 10px;
   height: 100vh;
   #root {
     height: 100%;

--- a/cdap-ui/app/cdap/components/AbstractWidget/CodeEditorWidgets.stories.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/CodeEditorWidgets.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import AbstractWidget from './index';
+import { withInfo } from '@storybook/addon-info';
+
+export default {
+  title: 'Widgets/CodeEditors',
+  component: AbstractWidget,
+  decorators: [withInfo],
+};
+
+export const javascriptEditor = () => <AbstractWidget type="javascript-editor" />;
+
+export const jsonEditor = () => <AbstractWidget type="json-editor" />;
+
+export const pythonEditor = () => <AbstractWidget type="python-editor" />;
+
+export const scalaEditor = () => <AbstractWidget type="scala-editor" />;
+
+export const sqlEditor = () => <AbstractWidget type="sql-editor" />;
+
+export const textEditor = () => <AbstractWidget type="textarea" />;

--- a/cdap-ui/app/cdap/components/AbstractWidget/DateRangeWidget/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/DateRangeWidget/index.tsx
@@ -45,7 +45,7 @@ const DateRangeWidget: React.FC<IDateRangeWidgetProps> = ({
   };
 
   return (
-    <div className={classes.root}>
+    <div className={classes ? classes.root : undefined}>
       <ExpandableTimeRange
         showRange={true}
         start={startTime}

--- a/cdap-ui/app/cdap/components/AbstractWidget/JoinWidgets.stories.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/JoinWidgets.stories.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import AbstractWidget from './index';
+import { withInfo } from '@storybook/addon-info';
+
+export default {
+  title: 'Widgets/Joins',
+  component: AbstractWidget,
+  decorators: [withInfo],
+};
+
+const inputSchema = [
+  {
+    name: 'Projection',
+    schema:
+      '{"type":"record","name":"etlSchemaBody","fields":[{"name":"haha","type":"string"},{"name":"hehe","type":"string"},{"name":"hohoho","type":"string"}]}',
+  },
+  {
+    name: 'JavaScript',
+    schema:
+      '{"type":"record","name":"etlSchemaBody","fields":[{"name":"field1","type":"string"},{"name":"field2","type":"string"},{"name":"field3","type":"string"}]}',
+  },
+];
+const extraConfig = { inputSchema };
+
+export const joinType = () => <AbstractWidget type="join-types" extraConfig={extraConfig} />;
+
+export const sqlConditions = () => (
+  <AbstractWidget type="sql-conditions" extraConfig={extraConfig} />
+);
+
+// TO DO: Fix i18n
+export const sqlSelectFields = () => (
+  <AbstractWidget type="sql-select-fields" extraConfig={extraConfig} />
+);

--- a/cdap-ui/app/cdap/components/AbstractWidget/Widgets.stories.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/Widgets.stories.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { action } from '@storybook/addon-actions';
+import { withInfo } from '@storybook/addon-info';
+import AbstractWidget from './index';
+
+export default {
+  component: AbstractWidget,
+  title: 'Widgets',
+  decorators: [withInfo],
+};
+
+const memoryOptions = [1024, 2048];
+
+const selectOptions = [
+  { value: 'choice A', label: 'choice A' },
+  { value: 'choice B', label: 'choice B' },
+];
+
+const aliasOptions = [
+  { value: 'Avg', label: 'Avg' },
+  { value: 'Count', label: 'Count' },
+  { value: 'CollectList', label: 'CollectList' },
+];
+
+const radioOptions = [
+  { label: 'choice A', id: 'choice A' },
+  { label: 'choice B', id: 'choice B' },
+  { label: 'choice C', id: 'choice C' },
+];
+
+const widgetProps = {
+  functionDropdown: {
+    dropdownOptions: aliasOptions,
+  },
+  keyValueDropdown: {
+    dropdownOptions: ['simple option 1', 'simple option 2', 'simple option 3'],
+  },
+  memorySelect: {
+    values: memoryOptions,
+  },
+  radio: { options: radioOptions },
+  select: { options: selectOptions },
+  textbox: { placeholder: 'placeholder text' },
+  toggle: {
+    on: { value: 'on', label: 'on' },
+    off: { value: 'off', label: 'off' },
+  },
+};
+
+export const csv = () => <AbstractWidget type="csv" />;
+
+export const daterange = () => <AbstractWidget type="daterange" />;
+
+export const datetime = () => <AbstractWidget type="datetime" />;
+
+export const multipleValues = () => <AbstractWidget type="ds-multiplevalues" />;
+
+export const dsv = () => <AbstractWidget type="dsv" />;
+
+export const functionDropdownWithAlias = () => (
+  <AbstractWidget type="function-dropdown-with-alias" widgetProps={widgetProps.functionDropdown} />
+);
+
+export const keyValueDropdown = () => (
+  <AbstractWidget type="keyvalue-dropdown" widgetProps={widgetProps.keyValueDropdown} />
+);
+
+export const keyValueEncoded = () => <AbstractWidget type="keyvalue-encoded" />;
+
+export const keyValue = () => <AbstractWidget type="keyvalue" />;
+
+export const memoryDropdown = () => (
+  <AbstractWidget type="memory-dropdown" widgetProps={widgetProps.memorySelect} />
+);
+
+export const memoryTextbox = () => <AbstractWidget type="memory-textbox" />;
+
+export const multiSelect = () => (
+  <AbstractWidget type="multi-select" widgetProps={widgetProps.radio} />
+);
+
+export const numberTextbox = () => <AbstractWidget type="number" />;
+
+export const password = () => <AbstractWidget type="password" />;
+
+export const radioGroup = () => (
+  <AbstractWidget type="radio-group" widgetProps={widgetProps.radio} value="choice A" />
+);
+
+export const secureKeyPassword = () => <AbstractWidget type="securekey-password" />;
+
+export const secureKeyText = () => <AbstractWidget type="securekey-text" />;
+
+export const secureKeyTextArea = () => <AbstractWidget type="securekey-textarea" />;
+
+export const selectDropdown = () => (
+  <AbstractWidget
+    value={'choice A'}
+    type="select"
+    widgetProps={widgetProps.select}
+    onChange={action('onChange')}
+  />
+);
+
+export const textbox = () => <AbstractWidget type="textbox" widgetProps={widgetProps.textbox} />;
+
+export const toggle = () => <AbstractWidget type="toggle" widgetProps={widgetProps.toggle} />;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16208
Build: https://builds.cask.co/browse/CDAP-UDUT495

Adding abstract widgets to storybook. Also updated config file to allow use of Component Story Format and get i18n info. 

e2e tests: ~https://builds.cask.co/browse/IT-UPD2109~ https://builds.cask.co/browse/IT-UPD2124-1