### PR TITLE
[CDAP-16241] Experiment lab feature

### DIFF
--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -101,11 +101,8 @@ const FieldLevelLineage = Loadable({
   loading: LoadingSVGCentered,
 });
 
-const ExperimentToggle = Loadable({
-  loader: () =>
-    import(
-      /* webpackChunkMame: "ExperimentToggle" */ 'components/ExperimentWrapper/ExperimentToggle'
-    ),
+const Lab = Loadable({
+  loader: () => import(/* webpackChunkMame: "Lab" */ 'components/Lab'),
   loading: LoadingSVGCentered,
 });
 
@@ -164,8 +161,25 @@ export default class Home extends Component {
           <Route path="/ns/:namespace/pipelines" component={PipelineList} />
           <Route path="/ns/:namespace/securekeys" component={SecureKeys} />
           <Route path="/ns/:namespace/kitchen" component={ConfigurationGroupKitchenSync} />
-          <Route path="/ns/:namespace/experimentToggle" component={ExperimentToggle} />
           <Route path="/ns/:namespace/replicator" component={Replicator} />
+          <Route path="/ns/:namespace/lab" component={Lab} />
+          <Route
+            exact
+            path="/ns/:namespace/lab-experiment-test"
+            render={(props) => {
+              if (window.CDAP_CONFIG.cdap.mode !== 'development') {
+                return <Page404 {...props} />;
+              }
+              const LabExperimentTestComp = Loadable({
+                loader: () =>
+                  import(
+                    /* webpackChunkName: "LabExperimentTest" */ 'components/Lab/LabExperimentTest'
+                  ),
+                loading: LoadingSVGCentered,
+              });
+              return <LabExperimentTestComp {...props} />;
+            }}
+          />
           <Route component={Page404} />
         </Switch>
       </div>

--- a/cdap-ui/app/cdap/components/Lab/ExperimentalFeature/index.tsx
+++ b/cdap-ui/app/cdap/components/Lab/ExperimentalFeature/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,19 +13,18 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import * as React from 'react';
 
-interface IIfComponentProps {
-  condition: boolean;
+import * as React from 'react';
+import If from 'components/If';
+
+interface IExperimentWrapperProps {
   children: React.ReactNode;
+  name: string;
 }
 
-const If: React.FC<IIfComponentProps> = ({ condition, children }) => {
-  if (!condition) {
-    return null;
-  }
-
-  return <React.Fragment>{children}</React.Fragment>;
+const ExperimentWrapper: React.FC<IExperimentWrapperProps> = ({ children, name }) => {
+  const featureAvailable = window.localStorage.getItem(name) === 'true';
+  return <If condition={featureAvailable}>{children}</If>;
 };
 
-export default If;
+export default ExperimentWrapper;

--- a/cdap-ui/app/cdap/components/Lab/LabExperimentTest/index.tsx
+++ b/cdap-ui/app/cdap/components/Lab/LabExperimentTest/index.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+
+import ExperimentalFeature from 'components/Lab/ExperimentalFeature';
+import ToggleExperiment from 'components/Lab/ToggleExperiment';
+
+const DEFAULT_EXPERIMENT = 'cdap-common-experiment';
+
+const LabExperimentTest: React.FC = () => {
+  return (
+    <div>
+      <ExperimentalFeature name={DEFAULT_EXPERIMENT}>
+        <p data-cy="experimental-feature-selector">This is an experimental component.</p>
+      </ExperimentalFeature>
+      <ToggleExperiment
+        name={DEFAULT_EXPERIMENT}
+        defaultComponent={
+          <p data-cy="default-feature-toggle-selector">This is default component for the toggle.</p>
+        }
+        experimentalComponent={
+          <p data-cy="experimental-feature-toggle-selector">
+            This is experimental component for the toggle.
+          </p>
+        }
+      ></ToggleExperiment>
+    </div>
+  );
+};
+
+export default LabExperimentTest;

--- a/cdap-ui/app/cdap/components/Lab/ToggleExperiment/index.tsx
+++ b/cdap-ui/app/cdap/components/Lab/ToggleExperiment/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,26 +14,21 @@
  * the License.
  */
 
-import React from 'react';
-import Cookies from 'universal-cookie';
+import * as React from 'react';
 
-const cookie = new Cookies();
-
-interface IExptWrapperProps {
+interface IToggleFeatureProps {
   defaultComponent: React.ReactElement<any>;
-  experimentComponent: React.ReactElement<any>;
+  experimentalComponent: React.ReactElement<any>;
+  name: string;
 }
 
-const ExperimentWrapper: React.FC<IExptWrapperProps> = ({
+const ToggleFeature: React.SFC<IToggleFeatureProps> = ({
   defaultComponent,
-  experimentComponent,
-}: IExptWrapperProps) => {
-  const showExperiment = cookie.get('CDAP_enable_experiments');
-  if (showExperiment === 'on') {
-    return experimentComponent;
-  } else {
-    return defaultComponent;
-  }
+  experimentalComponent,
+  name,
+}) => {
+  const featureAvailable = window.localStorage.getItem(name) === 'true';
+  return featureAvailable ? experimentalComponent : defaultComponent;
 };
 
-export default ExperimentWrapper;
+export default ToggleFeature;

--- a/cdap-ui/app/cdap/components/Lab/experiment-list.tsx
+++ b/cdap-ui/app/cdap/components/Lab/experiment-list.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,19 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import * as React from 'react';
 
-interface IIfComponentProps {
-  condition: boolean;
-  children: React.ReactNode;
-}
-
-const If: React.FC<IIfComponentProps> = ({ condition, children }) => {
-  if (!condition) {
-    return null;
-  }
-
-  return <React.Fragment>{children}</React.Fragment>;
-};
-
-export default If;
+export default [
+  {
+    name: 'CDAP Common',
+    description: `This is a common flag that developers can use to hide or show features. The flag is stored in browser's local storage with experiment ID as the name.`,
+    id: 'cdap-common-experiment',
+    screenshot: null,
+    value: false,
+  },
+];

--- a/cdap-ui/app/cdap/components/Lab/index.tsx
+++ b/cdap-ui/app/cdap/components/Lab/index.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { Typography } from '@material-ui/core';
+import NewReleasesRoundedIcon from '@material-ui/icons/NewReleasesRounded';
+import experimentsList from './experiment-list';
+
+const styles = (): StyleRules => {
+  return {
+    root: {
+      display: 'flex',
+      justifyContent: 'center',
+      paddingTop: '5%',
+    },
+    paperContainer: {
+      display: 'flex',
+    },
+    experimentsTable: {
+      maxWidth: 900,
+    },
+    screenshot: {
+      maxWidth: 256,
+    },
+    defaultExperimentIcon: {
+      display: 'block',
+      fontSize: 64,
+      margin: '0 auto',
+    },
+    switchCell: {
+      width: 145,
+    },
+  };
+};
+
+interface ILabProps extends WithStyles<typeof styles> {}
+interface IExperiment {
+  id: string;
+  value: boolean;
+  screenshot: string | null;
+  name: string;
+  description: string;
+}
+interface ILabState {
+  experiments: IExperiment[];
+}
+
+class Lab extends React.Component<ILabProps, ILabState> {
+  public componentWillMount() {
+    experimentsList.forEach((experiment) => {
+      experiment.value = window.localStorage.getItem(experiment.id) === 'true' ? true : false;
+    });
+    this.state = { experiments: experimentsList };
+  }
+
+  public updatePreference = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const experiments = this.state.experiments.map((experiment: IExperiment) => {
+      if (experiment.id === event.target.name) {
+        experiment.value = !experiment.value;
+        window.localStorage.setItem(event.target.name, experiment.value.toString());
+      }
+      return experiment;
+    });
+    this.setState({ experiments });
+  };
+
+  public render() {
+    const { classes } = this.props;
+
+    return (
+      <div className={classes.root}>
+        <Paper className={classes.paperContainer}>
+          <Table className={classes.experimentsTable}>
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <Typography variant="h5">Image</Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="h5">Experiment</Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="h5">Status</Typography>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {this.state.experiments.map((experiment: IExperiment) => (
+                <TableRow key={experiment.id}>
+                  <TableCell>
+                    {experiment.screenshot ? (
+                      <img className={classes.screenshot} src={experiment.screenshot} />
+                    ) : (
+                      <NewReleasesRoundedIcon className={classes.defaultExperimentIcon} />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="h5">{experiment.name}</Typography>
+                    <br />
+                    <Typography variant="body1">{experiment.description}</Typography>
+                    <br />
+                    <Typography variant="caption">ID: {experiment.id}</Typography>
+                  </TableCell>
+                  <TableCell className={classes.switchCell}>
+                    <FormControlLabel
+                      label={experiment.value ? 'Enabled' : 'Disabled'}
+                      control={
+                        <Switch
+                          data-cy={`${experiment.id}-switch`}
+                          name={experiment.id}
+                          color="primary"
+                          onChange={this.updatePreference}
+                          checked={experiment.value}
+                          value={experiment.value}
+                        />
+                      }
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
+      </div>
+    );
+  }
+}
+
+const StyledLab = withStyles(styles)(Lab);
+export default StyledLab;

--- a/cdap-ui/cypress/integration/lab.spec.ts
+++ b/cdap-ui/cypress/integration/lab.spec.ts
@@ -1,0 +1,64 @@
+import {loginIfRequired} from '../helpers';
+import {dataCy} from '../helpers';
+
+let headers = {};
+
+describe('Lab ', () => {
+  // Uses API call to login instead of logging in manually through UI
+  before(() => {
+    loginIfRequired().then(() => {
+      cy.getCookie('CDAP_Auth_Token').then((cookie) => {
+        if (!cookie) {
+          return;
+        }
+        headers = {
+          Authorization: 'Bearer ' + cookie.value,
+        };
+      });
+    });
+  });
+
+  it('should have cdap-common-experiment disabled by default', () => {
+    cy.visit('/cdap/ns/default/lab');
+    cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'false');
+  });
+
+  describe(' toggle experiment wrapper ', () => {
+    it('should show default component when cdap-common-experiment is disabled', () => {
+      cy.visit('/cdap/ns/default/lab-experiment-test');
+      cy.get(dataCy('default-feature-toggle-selector')).should('have.text', 'This is default component for the toggle.');
+    });
+
+    it('show experimental component when cdap-common-experiment is enabled', () => {
+      cy.visit('/cdap/ns/default/lab');
+      cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'false');
+      cy.get(`${dataCy('cdap-common-experiment-switch')}`).click();
+      cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'true');
+
+      cy.visit('/cdap/ns/default/lab-experiment-test');
+      cy.get(dataCy('experimental-feature-toggle-selector')).should('have.text', 'This is experimental component for the toggle.');
+
+      cy.visit('/cdap/ns/default/lab');
+      cy.get(`${dataCy('cdap-common-experiment-switch')}`).click();
+    });
+  });
+
+  describe(' experiment wrapper ', () => {
+    it('should not show experimental component when cdap-common-experiment is disabled', () => {
+      cy.visit('/cdap/ns/default/lab-experiment-test');
+      cy.get(dataCy('experimental-feature-selector')).should('not.exist');
+    });
+
+    it('should show experimental component when cdap-common-experiment is enabled', () => {
+      cy.visit('/cdap/ns/default/lab');
+      cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'false');
+      cy.get(`${dataCy('cdap-common-experiment-switch')}`).click();
+      cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'true');
+
+      cy.visit('/cdap/ns/default/lab-experiment-test');
+      cy.get(dataCy('experimental-feature-selector')).should('have.text','This is an experimental component.');
+    });
+  });
+
+
+});


### PR DESCRIPTION
Users can create individual experiments to hide a component or show a different version of a component.

A flag is stored in browser's local storage when users modify state of an experiment.

- Added lab page to view list of experiments and their status
- Added wrapper component to hide experiment based on an experiment
- Added wrapper component to toggle between two components based on the experiment
- Added a common experiment that can be used across CDAP