### PR TITLE
[UI][Pipelines] Lazyload runs & runscount for only viewed pipelines

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/LastStart/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/LastStart/index.tsx
@@ -18,13 +18,24 @@ import * as React from 'react';
 import { humanReadableDate } from 'services/helpers';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
 import { objectQuery } from 'services/helpers';
+import IconSVG from 'components/IconSVG';
 
 interface ILastStartViewProps {
   pipeline: IPipeline;
 }
 
 const LastStart: React.SFC<ILastStartViewProps> = ({ pipeline }) => {
-  const lastStarting = objectQuery(pipeline, 'runs', 0, 'starting');
+  const runs = pipeline.runs;
+  if (runs === null) {
+    return (
+      <div className="last-start">
+        <span className="fa fa-spin fa-lg">
+          <IconSVG name="icon-spinner" />
+        </span>
+      </div>
+    );
+  }
+  const lastStarting = objectQuery(runs, 0, 'starting');
 
   return <div className="last-start">{humanReadableDate(lastStarting)}</div>;
 };

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/Pagination/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/Pagination/index.tsx
@@ -15,27 +15,36 @@
  */
 
 import { connect } from 'react-redux';
-import { Actions } from 'components/PipelineList/DeployedPipelineView/store';
 import PaginationView from 'components/PipelineList/PaginationView';
-
+import { setPage } from 'components/PipelineList/DeployedPipelineView/store/ActionCreator';
 const mapStateToProps = (state) => {
+  let { filteredPipelines = [], pipelines = [] } = state.deployed;
+  const { pageLimit, currentPage } = state.deployed;
+  /**
+   * We need to show pagination if,
+   * 1. The current filtered pipelines length is 1 less than pageLimit, or
+   * 2. The current filtered pipelines is less than total pipelines, or
+   * 3. If the user is in any page other than 1 (which means we need to show always)
+   *
+   * The filteredPipelines will atmost have pageLimit pipelines. We don't need to show
+   * pagination if there are exactly 25 pipelines or less (reason for pipelines & filteredPipelines length check).
+   */
+  filteredPipelines = filteredPipelines || [];
+  pipelines = pipelines || [];
+  const shouldDisplay =
+    (filteredPipelines.length > pageLimit - 1 && pipelines.length > filteredPipelines.length) ||
+    state.deployed.currentPage !== 1;
   return {
-    currentPage: state.deployed.currentPage,
-    pageLimit: state.deployed.pageLimit,
-    shouldDisplay: state.deployed.search.length === 0,
+    currentPage,
+    pageLimit,
+    shouldDisplay,
+    numPipelines: pipelines.length,
   };
 };
 
-const mapDispatch = (dispatch) => {
+const mapDispatch = () => {
   return {
-    setPage: (page) => {
-      dispatch({
-        type: Actions.setPage,
-        payload: {
-          currentPage: page,
-        },
-      });
-    },
+    setPage,
   };
 };
 

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/PipelineCount/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/PipelineCount/index.tsx
@@ -16,6 +16,7 @@
 
 import * as React from 'react';
 import T from 'i18n-react';
+import { connect } from 'react-redux';
 
 import './PipelineCount.scss';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
@@ -27,7 +28,7 @@ interface IProps {
 
 const PREFIX = 'features.PipelineList';
 
-const PipelineCountView: React.SFC<IProps> = ({ pipelines, pipelinesLoading }) => {
+const PipelineCountView: React.SFC<IProps> = ({ pipelines = [], pipelinesLoading }) => {
   if (pipelinesLoading) {
     return null;
   }
@@ -35,13 +36,17 @@ const PipelineCountView: React.SFC<IProps> = ({ pipelines, pipelinesLoading }) =
     <div className="pipeline-count">
       <h5>
         {T.translate(`${PREFIX}.DeployedPipelineView.pipelineCount`, {
-          context: pipelines.length,
+          context: pipelines ? pipelines.length : 0,
         })}
       </h5>
     </div>
   );
 };
 
+const mapStateToProps = (state) => ({
+  pipelines: state.deployed.pipelines,
+});
+
 const PipelineCount = PipelineCountView;
 
-export default PipelineCount;
+export default connect(mapStateToProps)(PipelineCount);

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/RunsCount/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/RunsCount/index.tsx
@@ -16,13 +16,27 @@
 
 import * as React from 'react';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
+import IconSVG from 'components/IconSVG';
 
 interface IProps {
   pipeline: IPipeline;
 }
 
 const RunsCount: React.SFC<IProps> = ({ pipeline }) => {
-  const runsCount = pipeline.totalRuns || 0;
+  const runsCount = pipeline.totalRuns;
+  if (runsCount === null) {
+    return (
+      <div className="runs">
+        <span className="fa fa-spin fa-lg">
+          <IconSVG name="icon-spinner" />
+        </span>
+      </div>
+    );
+  }
+
+  if (runsCount === 0) {
+    return <div className="runs">--</div>;
+  }
 
   return <div className="runs">{runsCount}</div>;
 };

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/SearchBox/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/SearchBox/index.tsx
@@ -17,14 +17,13 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import IconSVG from 'components/IconSVG';
-import { Actions } from 'components/PipelineList/DeployedPipelineView/store';
+import { setSearch } from 'components/PipelineList/DeployedPipelineView/store/ActionCreator';
 import T from 'i18n-react';
 
 interface ISearchBoxProps {
   value: string;
   onChange: () => void;
 }
-
 const PREFIX = 'features.PipelineList';
 
 const SearchBoxView: React.SFC<ISearchBoxProps> = ({ value, onChange }) => {
@@ -54,15 +53,10 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatch = (dispatch) => {
+const mapDispatch = () => {
   return {
     onChange: (e) => {
-      dispatch({
-        type: Actions.setSearch,
-        payload: {
-          search: e.target.value,
-        },
-      });
+      setSearch(e.target.value);
     },
   };
 };

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/Status/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/Status/index.tsx
@@ -20,13 +20,25 @@ import StatusMapper from 'services/StatusMapper';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
 import { PROGRAM_STATUSES } from 'services/global-constants';
 import { objectQuery } from 'services/helpers';
+import isEmpty from 'lodash/isEmpty';
 
 interface IProps {
   pipeline: IPipeline;
 }
 
 const Status: React.SFC<IProps> = ({ pipeline }) => {
-  const pipelineStatus = objectQuery(pipeline, 'runs', 0, 'status') || PROGRAM_STATUSES.DEPLOYED;
+  const pipelineRuns = pipeline.runs;
+  let pipelineStatus = objectQuery(pipelineRuns, 0, 'status');
+  if (pipelineRuns === null) {
+    return (
+      <div className="status">
+        <span className="fa fa-spin fa-lg">
+          <IconSVG name="icon-spinner" />
+        </span>
+      </div>
+    );
+  }
+  pipelineStatus = isEmpty(pipelineStatus) ? PROGRAM_STATUSES.DEPLOYED : pipelineStatus;
   const displayStatus = StatusMapper.statusMap[pipelineStatus];
   const statusClassName = StatusMapper.getStatusIndicatorClass(displayStatus);
 

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
@@ -16,7 +16,10 @@
 
 import * as React from 'react';
 import PipelineTable from 'components/PipelineList/DeployedPipelineView/PipelineTable';
-import { reset } from 'components/PipelineList/DeployedPipelineView/store/ActionCreator';
+import {
+  reset,
+  setFilteredPipelines,
+} from 'components/PipelineList/DeployedPipelineView/store/ActionCreator';
 import PipelineCount from 'components/PipelineList/DeployedPipelineView/PipelineCount';
 import SearchBox from 'components/PipelineList/DeployedPipelineView/SearchBox';
 import Pagination from 'components/PipelineList/DeployedPipelineView/Pagination';
@@ -52,11 +55,14 @@ const DeployedPipeline: React.FC = () => {
     return () => {
       reset();
     };
+  }, []);
+
+  const { loading, error, data, refetch, networkStatus } = useQuery(QUERY, {
+    errorPolicy: 'all',
+    notifyOnNetworkStatusChange: true,
   });
 
-  const { loading, error, data, refetch } = useQuery(QUERY, { errorPolicy: 'all' });
-
-  if (loading) {
+  if (loading || networkStatus === 4) {
     return <LoadingSVGCentered />;
   }
 
@@ -79,18 +85,18 @@ const DeployedPipeline: React.FC = () => {
     return <div className="pipeline-deployed-view error-container">{errors}</div>;
   }
 
-  const pipelines = data.pipelines;
+  setFilteredPipelines(data.pipelines);
 
   return (
     <Provider store={Store}>
       <div className="pipeline-deployed-view pipeline-list-content">
         <div className="deployed-header">
-          <PipelineCount pipelines={pipelines} pipelinesLoading={loading} />
+          <PipelineCount pipelinesLoading={loading} />
           <SearchBox />
-          <Pagination numPipelines={pipelines.length} />
+          <Pagination />
         </div>
 
-        <PipelineTable pipelines={pipelines} refetch={refetch} />
+        <PipelineTable refetch={refetch} />
       </div>
     </Provider>
   );

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/store/ActionCreator.ts
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/store/ActionCreator.ts
@@ -16,8 +16,43 @@
 
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { MyPipelineApi } from 'api/pipeline';
-import Store, { Actions, SORT_ORDER } from 'components/PipelineList/DeployedPipelineView/store';
+import Store, {
+  Actions,
+  SORT_ORDER,
+  IStore,
+} from 'components/PipelineList/DeployedPipelineView/store';
 import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
+import { orderBy } from 'natural-orderby';
+import { objectQuery } from 'services/helpers';
+import { PROGRAM_STATUSES, GLOBALS } from 'services/global-constants';
+import debounce from 'lodash/debounce';
+const debounceFilteredPipelineRunsFetch = debounce(getRunsForFilteredPipelines, 500);
+
+function getOrderColumnFunction(sortColumn, sortOrder) {
+  switch (sortColumn) {
+    case 'name':
+      return (pipeline) => pipeline.name.toLowerCase();
+    case 'type':
+      return (pipeline) => pipeline.artifact.name;
+    case 'status':
+      return (pipeline) => {
+        return objectQuery(pipeline, 'runs', 0, 'status') || PROGRAM_STATUSES.DEPLOYED;
+      };
+    case 'lastStartTime':
+      return (pipeline) => {
+        const lastStarting = objectQuery(pipeline, 'runs', 0, 'starting');
+
+        if (!lastStarting) {
+          return sortOrder === SORT_ORDER.asc ? Infinity : -1;
+        }
+        return lastStarting;
+      };
+    case 'runs':
+      return (pipeline) => {
+        return pipeline.totalRuns || 0;
+      };
+  }
+}
 
 export function deletePipeline(pipeline: IPipeline, refetch: () => void) {
   const namespace = getCurrentNamespace();
@@ -49,6 +84,142 @@ export function reset() {
   });
 }
 
+function getRunsForFilteredPipelines() {
+  const { filteredPipelines, pipelines } = Store.getState().deployed;
+  if (!filteredPipelines || !pipelines) {
+    return;
+  }
+  const pipelinesWithoutRuns = filteredPipelines.filter(
+    (pipeline) => pipeline.runs === null || pipeline.totalRuns === null
+  );
+  if (!pipelinesWithoutRuns.length) {
+    return;
+  }
+  const getProgram = (pipelineType) => {
+    const programId = GLOBALS.programId[pipelineType];
+    const programType = GLOBALS.programTypeName[pipelineType];
+    return {
+      programId,
+      programType,
+    };
+  };
+  const postBody = pipelinesWithoutRuns.map((pipeline) => ({
+    appId: pipeline.name,
+    ...getProgram(pipeline.artifact.name),
+  }));
+  const namespace = getCurrentNamespace();
+  MyPipelineApi.getBatchRuns({ namespace }, postBody)
+    .combineLatest(MyPipelineApi.getRunsCount({ namespace }, postBody))
+    .subscribe(([runs, runsCount]) => {
+      const runsMap = Object.assign({}, ...runs.map((app) => ({ [app.appId]: app.runs })));
+      const runsCountMap = Object.assign(
+        {},
+        ...runsCount.map((app) => ({ [app.appId]: app.runCount }))
+      );
+      const filteredPipelinesWithRuns = filteredPipelines.map((pipeline) => {
+        return {
+          ...pipeline,
+          runs: runsMap[pipeline.name] || pipeline.runs,
+          totalRuns: runsCountMap[pipeline.name] || pipeline.totalRuns,
+        };
+      });
+      const pipelinesWithRuns = pipelines.map((pipeline) => {
+        return {
+          ...pipeline,
+          runs: runsMap[pipeline.name] || pipeline.runs,
+          totalRuns: runsCountMap[pipeline.name] || pipeline.totalRuns,
+        };
+      });
+      Store.dispatch({
+        type: Actions.updateFilteredPipelines,
+        payload: {
+          filteredPipelines: filteredPipelinesWithRuns,
+          pipelines: pipelinesWithRuns,
+        },
+      });
+    });
+}
+
+function getFilteredPipelines({
+  pipelines,
+  search,
+  sortOrder,
+  sortColumn,
+  currentPage,
+  pageLimit,
+}: IStore['deployed']): IPipeline[] {
+  if (!pipelines) {
+    return;
+  }
+  let filteredPipelines = pipelines;
+  if (search.length > 0) {
+    filteredPipelines = pipelines.filter((pipeline) => {
+      const name = pipeline.name.toLowerCase();
+      const searchFilter = search.toLowerCase();
+
+      return name.indexOf(searchFilter) !== -1;
+    });
+  }
+  filteredPipelines = orderBy(
+    filteredPipelines,
+    [getOrderColumnFunction(sortColumn, sortOrder)],
+    [sortOrder]
+  );
+
+  const startIndex = (currentPage - 1) * pageLimit;
+  const endIndex = startIndex + pageLimit;
+  filteredPipelines = filteredPipelines.slice(startIndex, endIndex);
+  return filteredPipelines;
+}
+
+export function setFilteredPipelines(pipelines = Store.getState().deployed.pipelines) {
+  const filteredPipelines = getFilteredPipelines({ ...Store.getState().deployed, pipelines });
+
+  Store.dispatch({
+    type: Actions.setPipelines,
+    payload: {
+      pipelines,
+      filteredPipelines,
+    },
+  });
+  getRunsForFilteredPipelines();
+}
+
+export function setPage(currentPage) {
+  const { currentPage: currentPageFromStore } = Store.getState().deployed;
+  if (!currentPage) {
+    currentPage = currentPageFromStore;
+  }
+  const filteredPipelines = getFilteredPipelines({ ...Store.getState().deployed, currentPage });
+  Store.dispatch({
+    type: Actions.setPage,
+    payload: {
+      currentPage,
+      filteredPipelines,
+    },
+  });
+  getRunsForFilteredPipelines();
+}
+
+export function setSearch(searchText: string) {
+  const newState = {
+    ...Store.getState().deployed,
+    search: searchText,
+  };
+  if (!searchText) {
+    newState.currentPage = 1;
+  }
+  const filteredPipelines = getFilteredPipelines(newState);
+  Store.dispatch({
+    type: Actions.setSearch,
+    payload: {
+      search: searchText,
+      filteredPipelines,
+    },
+  });
+  debounceFilteredPipelineRunsFetch();
+}
+
 export function setSort(columnName: string) {
   const state = Store.getState().deployed;
   const currentColumn = state.sortColumn;
@@ -59,11 +230,20 @@ export function setSort(columnName: string) {
     sortOrder = SORT_ORDER.desc;
   }
 
+  const filteredPipelines = getFilteredPipelines({
+    ...Store.getState().deployed,
+    sortColumn: columnName,
+    sortOrder,
+    currentPage: 1,
+  });
+
   Store.dispatch({
     type: Actions.setSort,
     payload: {
       sortColumn: columnName,
       sortOrder,
+      filteredPipelines,
     },
   });
+  getRunsForFilteredPipelines();
 }

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/store/index.ts
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/store/index.ts
@@ -18,6 +18,7 @@ import { combineReducers, createStore } from 'redux';
 import { composeEnhancers } from 'services/helpers';
 import { Reducer, Store as StoreInterface } from 'redux';
 import { IAction } from 'services/redux-helpers';
+import { IPipeline } from 'components/PipelineList/DeployedPipelineView/types';
 
 enum SORT_ORDER {
   asc = 'asc',
@@ -31,6 +32,8 @@ interface IState {
   search: string;
   currentPage: number;
   pageLimit: number;
+  pipelines: IPipeline[];
+  filteredPipelines: IPipeline[];
 }
 
 interface IStore {
@@ -44,6 +47,8 @@ const Actions = {
   setSort: 'DEPLOYED_PIPELINE_SET_SORT',
   setPage: 'DEPLOYED_PIPELINE_SET_PAGE',
   reset: 'DEPLOYED_PIPELINE_RESET',
+  setPipelines: 'DEPLOYED_PIPELINE_SET_PIPELINES',
+  updateFilteredPipelines: 'DEPLOYED_PIPELINE_UPDATE_FILTERED_PIPELINES',
 };
 
 const defaultInitialState: IState = {
@@ -53,6 +58,8 @@ const defaultInitialState: IState = {
   search: '',
   currentPage: 1,
   pageLimit: 25,
+  pipelines: null,
+  filteredPipelines: null,
 };
 
 const deployed: Reducer<IState> = (state = defaultInitialState, action: IAction) => {
@@ -71,18 +78,34 @@ const deployed: Reducer<IState> = (state = defaultInitialState, action: IAction)
       return {
         ...state,
         search: action.payload.search,
+        filteredPipelines: action.payload.filteredPipelines,
+        currentPage: 1,
       };
     case Actions.setSort:
       return {
         ...state,
         sortColumn: action.payload.sortColumn,
         sortOrder: action.payload.sortOrder,
+        filteredPipelines: action.payload.filteredPipelines,
         currentPage: 1,
       };
     case Actions.setPage:
       return {
         ...state,
         currentPage: action.payload.currentPage,
+        filteredPipelines: action.payload.filteredPipelines,
+      };
+    case Actions.setPipelines:
+      return {
+        ...state,
+        pipelines: action.payload.pipelines,
+        filteredPipelines: action.payload.filteredPipelines,
+      };
+    case Actions.updateFilteredPipelines:
+      return {
+        ...state,
+        pipelines: action.payload.pipelines,
+        filteredPipelines: action.payload.filteredPipelines,
       };
     case Actions.reset:
       return defaultInitialState;
@@ -102,4 +125,4 @@ const Store: StoreInterface<IStore> = createStore(
 );
 
 export default Store;
-export { Actions, SORT_ORDER };
+export { Actions, SORT_ORDER, IStore };

--- a/cdap-ui/app/cdap/services/datasource/index.js
+++ b/cdap-ui/app/cdap/services/datasource/index.js
@@ -255,10 +255,11 @@ export default class Datasource {
     }
   }
 
-  pausePoll() {
+  pausePoll = () => {
     Object.keys(this.bindings)
-      .filter(subscriptionID => this.bindings[subscriptionID].action === 'POLL')
+      .filter(subscriptionID => this.bindings[subscriptionID].type === 'POLL')
       .forEach(subscriptionID => {
+
         Socket.send({
           action: 'poll-stop',
           resource: this.bindings[subscriptionID].resource,
@@ -266,9 +267,9 @@ export default class Datasource {
       });
   }
 
-  resumePoll() {
+  resumePoll = () => {
     Object.keys(this.bindings)
-      .filter(subscriptionID => this.bindings[subscriptionID].action === 'POLL')
+      .filter(subscriptionID => this.bindings[subscriptionID].type === 'POLL')
       .forEach(subscriptionID => {
         Socket.send({
           action: 'poll-start',

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -155,6 +155,11 @@ const GLOBALS = {
     'cdap-data-streams': 'spark',
   },
 
+  programTypeName: {
+    'cdap-data-pipeline': 'Workflow',
+    'cdap-data-streams': 'Spark',
+  },
+
   programId: {
     'cdap-data-pipeline': 'DataPipelineWorkflow',
     'cdap-data-streams': 'DataStreamsSparkStreaming',

--- a/cdap-ui/graphql/Query/pipelinesResolver.js
+++ b/cdap-ui/graphql/Query/pipelinesResolver.js
@@ -16,8 +16,8 @@
 
 const urlHelper = require('../../server/url-helper'),
   cdapConfigurator = require('../../server/cdap-config.js'),
-  resolversCommon = require('../resolvers-common.js');
-
+  resolversCommon = require('../resolvers-common.js'),
+  naturalSort = require('natural-orderby');
 
 let cdapConfig;
 cdapConfigurator.getCDAPConfig().then(function(value) {
@@ -35,7 +35,8 @@ async function queryTypePipelinesResolver(parent, args, context) {
   options.url = urlHelper.constructUrl(cdapConfig, path);
   context.namespace = namespace;
 
-  return await resolversCommon.requestPromiseWrapper(options, context.auth);
+  const apps = await resolversCommon.requestPromiseWrapper(options, context.auth);
+  return naturalSort.orderBy(apps, [(app) => app.name], ['asc']);
 }
 
 module.exports = {

--- a/cdap-ui/graphql/helpers/BatchEndpoints/programRuns.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/programRuns.js
@@ -19,7 +19,7 @@ const urlHelper = require('../../../server/url-helper'),
   resolversCommon = require('../../resolvers-common.js');
 
 let cdapConfig;
-cdapConfigurator.getCDAPConfig().then(function (value) {
+cdapConfigurator.getCDAPConfig().then(function(value) {
   cdapConfig = value;
 });
 
@@ -27,7 +27,7 @@ async function batchProgramRuns(req, auth) {
   const namespace = req[0].namespace;
   const options = resolversCommon.getPOSTRequestOptions();
   options.url = urlHelper.constructUrl(cdapConfig, `/v3/namespaces/${namespace}/runs`);
-  options.body = req.map((reqObj) => reqObj.program);
+  options.body = req.slice(0, 25).map((reqObj) => reqObj.program);
 
   const runInfo = await resolversCommon.requestPromiseWrapper(options, auth);
 
@@ -38,7 +38,7 @@ async function batchProgramRuns(req, auth) {
 
   // DataLoader requires the response to be in the same order as the request. However, the backend
   // do not guarantee this, therefore we are creating a map for lookup to maintain the order.
-  return options.body.map((program) => {
+  return req.map(({ program }) => {
     return runsMap[program.appId];
   });
 }

--- a/cdap-ui/graphql/helpers/BatchEndpoints/totalRuns.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/totalRuns.js
@@ -29,7 +29,7 @@ async function batchTotalRuns(req, auth) {
   const namespace = req[0].namespace;
   const options = resolversCommon.getPOSTRequestOptions();
   options.url = urlHelper.constructUrl(cdapConfig, `/v3/namespaces/${namespace}/runcount`);
-  const body = req.map((reqObj) => reqObj.program);
+  const body = req.slice(0, 25).map((reqObj) => reqObj.program);
   const chunkedBody = chunk(body, 100);
 
   let runInfo = await Promise.all(
@@ -49,7 +49,7 @@ async function batchTotalRuns(req, auth) {
     });
   });
 
-  return body.map((program) => {
+  return req.map(({ program }) => {
     return runsMap[program.appId];
   });
 }

--- a/cdap-ui/graphql/schema/pipelineRecordSchema.graphql
+++ b/cdap-ui/graphql/schema/pipelineRecordSchema.graphql
@@ -24,7 +24,7 @@ type PipelineRecord {
   artifact: ArtifactSummary!
   ownerPrincipal: String
   runs: [PipelineRun]
-  totalRuns: Int!
+  totalRuns: Int
 }
 
 type PipelineRun {

--- a/cdap-ui/graphql/types/PipelineRecord/pipelineRunsResolver.js
+++ b/cdap-ui/graphql/types/PipelineRecord/pipelineRunsResolver.js
@@ -35,8 +35,8 @@ async function pipelineRunsResolver(parent, args, context) {
     program,
   });
 
-  if (runInfo.length === 0) {
-    return [];
+  if (!runInfo || (Array.isArray(runInfo) && runInfo.length === 0)) {
+    return;
   }
 
   return runInfo.runs;

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -190,6 +190,7 @@
     "moment": "2.21.0",
     "moment-timezone": "0.5.17",
     "mousetrap": "1.6.0",
+    "natural-orderby": "2.0.3",
     "ngreact": "0.3.0",
     "numeral": "1.5.3",
     "object-hash": "1.1.0",

--- a/cdap-ui/yarn.lock
+++ b/cdap-ui/yarn.lock
@@ -11289,6 +11289,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+natural-orderby@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
+  integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
+
 ncname@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"


### PR DESCRIPTION
**Problem**
- We right now fetch runs & total runs for all the pipelines while displaying only 25 of them to start with
- This is because we allow users to sort by runs (last start time) and the total runs in the pipeline list view
- If we remove the option to sort by runs & total runs we could save making batch calls with all the pipelines (say 25 instead of 200)

**Solution**
- Remove sorting by anything other than name of the pipeline (since we have to get all the pipelines for now until we actually get pagination from backend)
- Modify graphql to sort([natural-sort](https://www.npmjs.com/package/natural-orderby)) by pipeline name & query runs & total runs for only the first 25 pipelines
- This way the initial call UI makes to get the pipelines list will have the first 25 pipelines with all the information (using the same sort done in grapqhl).
- Then lazy load runs & total runs only for pipelines currently in view based on pagination.
- As part of this change,
  1. Moved pipelines and the filteredPipelines to store
  2. Any modifications done to the current viewed pipelines is always saved to store
  3. This way we can determine currently viewed pipeline for which we need to fetch the runs
  4. Upon fetch we save the runs and runscount to both the filtered pipelines & the full list.
   This way we avoid refetching them multiple times

**UPDATE**
~- Disabling polling entirely in nodejs server. We need to rethink how we pause and resume polling in a consistent way across all inactive tabs across all UI. [CDAP-16284](https://issues.cask.co/browse/CDAP-16284)~ Coming as separate PR