### PR TITLE
(CDAP-16243) Support for config based bootstrapping for system application on CDAP

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -90,6 +90,7 @@ import io.cdap.cdap.internal.bootstrap.guice.BootstrapModules;
 import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
 import io.cdap.cdap.internal.profile.ProfileService;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
+import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
@@ -285,6 +286,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       bind(ArtifactStore.class).in(Scopes.SINGLETON);
       bind(ProfileService.class).in(Scopes.SINGLETON);
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
+      bind(SystemAppManagementService.class).in(Scopes.SINGLETON);
       bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
       bind(CoreSchedulerService.class).in(Scopes.SINGLETON);
       bind(Scheduler.class).to(CoreSchedulerService.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.common.metrics.MetricsReporterHook;
 import io.cdap.cdap.common.security.HttpsEnabler;
 import io.cdap.cdap.internal.bootstrap.BootstrapService;
 import io.cdap.cdap.internal.provision.ProvisioningService;
+import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.http.HttpHandler;
@@ -70,6 +71,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final CoreSchedulerService coreSchedulerService;
   private final ProvisioningService provisioningService;
   private final BootstrapService bootstrapService;
+  private final SystemAppManagementService systemAppManagementService;
   private final CConfiguration cConf;
   private final SConfiguration sConf;
   private final boolean sslEnabled;
@@ -95,7 +97,8 @@ public class AppFabricServer extends AbstractIdleService {
                          @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
                          CoreSchedulerService coreSchedulerService,
                          ProvisioningService provisioningService,
-                         BootstrapService bootstrapService) {
+                         BootstrapService bootstrapService,
+                         SystemAppManagementService systemAppManagementService) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.handlers = handlers;
@@ -112,6 +115,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.coreSchedulerService = coreSchedulerService;
     this.provisioningService = provisioningService;
     this.bootstrapService = bootstrapService;
+    this.systemAppManagementService = systemAppManagementService;
   }
 
   /**
@@ -127,6 +131,7 @@ public class AppFabricServer extends AbstractIdleService {
         provisioningService.start(),
         applicationLifecycleService.start(),
         bootstrapService.start(),
+        systemAppManagementService.start(),
         programRuntimeService.start(),
         programNotificationSubscriberService.start(),
         runRecordCorrectorService.start(),
@@ -165,6 +170,7 @@ public class AppFabricServer extends AbstractIdleService {
   protected void shutDown() throws Exception {
     coreSchedulerService.stopAndWait();
     bootstrapService.stopAndWait();
+    systemAppManagementService.stopAndWait();
     cancelHttpService.cancel();
     programRuntimeService.stopAndWait();
     applicationLifecycleService.stopAndWait();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppConfig.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.sysapp;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Specified operations to perform for system app in a CDAP instance.
+ */
+public class SystemAppConfig {
+  public static final SystemAppConfig EMPTY = new SystemAppConfig(Collections.emptyList());
+  private final List<SystemAppStep> steps;
+
+  public SystemAppConfig(List<SystemAppStep> steps) {
+    this.steps = steps;
+  }
+
+  public List<SystemAppStep> getSteps() {
+    // can be null when deserialized through gson
+    return steps == null ? Collections.emptyList() : Collections.unmodifiableList(steps);
+  }
+
+  /**
+   * Check that this is a valid config, throwing an exception if not.
+   *
+   * @throws IllegalArgumentException if the config is invalid
+   */
+  public void validate() {
+    steps.forEach(SystemAppStep::validate);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.sysapp;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.dataset.DatasetManagementException;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.app.program.ProgramDescriptor;
+import io.cdap.cdap.common.ApplicationNotFoundException;
+import io.cdap.cdap.common.ConflictException;
+import io.cdap.cdap.common.InvalidArtifactException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.logging.LogSamplers;
+import io.cdap.cdap.common.logging.Loggers;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
+import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
+import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
+import io.cdap.cdap.internal.sysapp.SystemAppStep.Arguments;
+import io.cdap.cdap.proto.ProgramStatus;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.KerberosPrincipalId;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Deploys an application with given arguments. Also runs all programs corresponding to the
+ * application.
+ */
+public class SystemAppEnableExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SystemAppEnableExecutor.class);
+  private static final Logger LIMITED_LOGGER = Loggers
+    .sampling(LOG, LogSamplers.limitRate(TimeUnit.SECONDS.toMillis(100)));
+
+  private static final Gson GSON = new Gson();
+  private final ApplicationLifecycleService appLifecycleService;
+  private final ProgramLifecycleService programLifecycleService;
+
+  @Inject
+  SystemAppEnableExecutor(ApplicationLifecycleService appLifecycleService,
+                          ProgramLifecycleService programLifecycleService) {
+    this.appLifecycleService = appLifecycleService;
+    this.programLifecycleService = programLifecycleService;
+  }
+
+  /**
+   * Deploys an application with given arguments and starts all its programs.
+   */
+  public void deployAppAndStartPrograms(Arguments arguments) {
+    // TODO(CDAP-16243): Make deploy app and start programs idempotent to not have transactional issues.
+    ApplicationWithPrograms appDetail = retryableDeploySystemApp(arguments);
+    if (appDetail == null) {
+      return;
+    }
+
+    // TODO(CDAP-16243): Fix logic to restart programs for app with difference version/config.
+    for (ProgramDescriptor program : appDetail.getPrograms()) {
+      try {
+        startProgram(program.getProgramId());
+      } catch (Exception ex) {
+        LOG.error("Failed to start program {} for app {}.", program.getProgramId(), arguments.getId(), ex);
+      }
+    }
+  }
+
+  @Nullable
+  private ApplicationWithPrograms retryableDeploySystemApp(Arguments arguments) {
+    try {
+      return Retries.callWithRetries(() -> {
+        try {
+          return deploySystemApp(arguments);
+        } catch (RetryableException ex) {
+          LIMITED_LOGGER.debug("Failed to deploy app {}. Will retry", arguments.getId(), ex);
+          throw ex;
+        }
+      },
+      RetryStrategies.fixDelay(6, TimeUnit.SECONDS));
+    } catch (Exception ex) {
+      LOG.error("Failed to deploy app {} with exception", arguments.getId(), ex);
+      return null;
+    }
+  }
+
+  private ApplicationWithPrograms deploySystemApp(Arguments arguments) throws Exception {
+    ApplicationId appId = arguments.getId();
+    ArtifactSummary artifactSummary = arguments.getArtifact();
+
+    KerberosPrincipalId ownerPrincipalId =
+      arguments.getOwnerPrincipal() == null ? null : new KerberosPrincipalId(arguments.getOwnerPrincipal());
+
+    // if we don't null check, it gets serialized to "null"
+    String configString = arguments.getConfig() == null ? null : GSON.toJson(arguments.getConfig());
+
+    try {
+      return appLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
+                                           artifactSummary, configString, x -> { },
+                                           ownerPrincipalId, arguments.canUpdateSchedules());
+
+    } catch (NotFoundException | UnauthorizedException | InvalidArtifactException e) {
+      throw e;
+    } catch (DatasetManagementException e) {
+      if (e.getCause() instanceof UnauthorizedException) {
+        throw (UnauthorizedException) e.getCause();
+      } else {
+        throw new RetryableException(e);
+      }
+    } catch (Exception e) {
+      throw new RetryableException(e);
+    }
+  }
+
+  private void startProgram(ProgramId programId) throws Exception {
+    try {
+      // TODO(CDAP-16243): Restart program if the application has changed.
+      // do nothing if the program is already running
+      ProgramStatus currentStatus = programLifecycleService.getProgramStatus(programId);
+      if (currentStatus != ProgramStatus.STOPPED) {
+        return;
+      }
+      programLifecycleService.run(programId, Collections.emptyMap(), false);
+    } catch (ConflictException e) {
+      // thrown if the program is already running, which means it was started after the status check above.
+      // ignore this, as it means the program is running as expected
+    } catch (NotFoundException e) {
+      // use a nicer error message
+      throw new IllegalArgumentException(String.format("Cannot start %s because it does not exist.", programId), e);
+    }
+  }
+}
+

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppManagementService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.sysapp;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.utils.DirUtils;
+import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
+import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Enables system apps using system app config files located in SYSTEM_APP_CONFIG_DIR. Each config
+ * describes steps to perform to start one (or more) system app. Currently
+ * SystemAppManagementService runs during bootstrap phase.
+ */
+public class SystemAppManagementService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SystemAppManagementService.class);
+  private static final Gson GSON = new Gson();
+
+  private final File systemAppConfigDirPath;
+  private final SystemAppEnableExecutor systemAppEnableExecutor;
+  private ExecutorService executorService;
+
+  @Inject
+  SystemAppManagementService(CConfiguration cConf, ApplicationLifecycleService appLifecycleService,
+                             ProgramLifecycleService programLifecycleService) {
+    this.systemAppConfigDirPath = new File(cConf.get(Constants.SYSTEM_APP_CONFIG_DIR));
+    this.systemAppEnableExecutor = new SystemAppEnableExecutor(appLifecycleService, programLifecycleService);
+  }
+
+  @Override
+  protected void startUp() {
+    LOG.debug("Starting {}", getClass().getSimpleName());
+    executorService =
+      Executors.newSingleThreadExecutor(Threads.createDaemonThreadFactory("sys-app-management-service"));
+    executorService.execute(() -> {
+      try {
+        // Execute all steps for each config file in system config directory.
+        bootStrapSystemAppConfigDir();
+      } catch (Exception ex) {
+        LOG.error("Got exception in watch service for system app config dir", ex);
+      }
+    });
+  }
+
+  private void bootStrapSystemAppConfigDir() throws Exception {
+    LOG.debug("Number of config files {} in system app config directory.", systemAppConfigDirPath.listFiles().length);
+    for (File sysAppConfigFile : DirUtils.listFiles(systemAppConfigDirPath)) {
+      LOG.debug("Running steps in config file {}", sysAppConfigFile.getAbsoluteFile());
+      executeSysConfig(sysAppConfigFile.getAbsoluteFile());
+    }
+  }
+
+  private void executeSysConfig(File fileName) throws Exception {
+    SystemAppConfig config = parseConfig(fileName);
+    for (SystemAppStep step : config.getSteps()) {
+      try {
+        step.validate();
+      } catch (IllegalArgumentException e) {
+        LOG.warn("Config step {} failed because it is malformed: {}", step.getLabel(), e);
+        return;
+      }
+      if (step.getType() == SystemAppStep.Type.ENABLE_SYSTEM_APP) {
+        systemAppEnableExecutor.deployAppAndStartPrograms(step.getArguments());
+        LOG.debug("Deployed and enabled system app with id {} and label {}. Config file: {}.",
+                  step.getArguments().getId(), step.getLabel(), fileName);
+      } else {
+        LOG.warn("Unknown system app step type {} for step label {}. Config file: {}. Ignoring it.",
+                 step.getLabel(), step.getType(), fileName);
+      }
+    }
+  }
+
+  private SystemAppConfig parseConfig(File fileName) {
+    try (Reader reader = new FileReader(fileName)) {
+      return GSON.fromJson(reader, SystemAppConfig.class);
+    } catch (FileNotFoundException e) {
+      LOG.info("System app config file {} does not exist.", fileName);
+      return SystemAppConfig.EMPTY;
+    } catch (JsonParseException e) {
+      LOG.warn("Could not parse system app config file {}.", fileName, e);
+      return SystemAppConfig.EMPTY;
+    } catch (IOException e) {
+      LOG.warn("Could not read system app config file {}.", fileName, e);
+      return SystemAppConfig.EMPTY;
+    }
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    // Shutdown the executor, which will issue an interrupt to the running thread.
+    // There is only a single daemon thread, so no need to wait for termination
+    executorService.shutdownNow();
+    LOG.debug("Stopped {}", getClass().getSimpleName());
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppStep.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppStep.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.sysapp;
+
+import com.google.gson.JsonObject;
+import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
+
+/**
+ * Definition for a single step in a system app config. Defines what operation to perform for a
+ * system app and any arguments required to perform the operation.
+ */
+public class SystemAppStep {
+
+  private final String label;
+  private final Type type;
+  private final Arguments arguments;
+
+  public SystemAppStep(String label, Type type, Arguments arguments) {
+    this.label = label;
+    this.type = type;
+    this.arguments = arguments;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public Arguments getArguments() {
+    return arguments;
+  }
+
+  /**
+   * Validate that all required fields exist.
+   *
+   * @throws IllegalArgumentException if the step is invalid
+   */
+  public void validate() {
+    if (label == null || label.isEmpty()) {
+      throw new IllegalArgumentException("An accelerator step must contain a label.");
+    }
+
+    if (type == null) {
+      throw new IllegalArgumentException("An accelerator step must contain a type.");
+    }
+
+    arguments.validate();
+  }
+
+  /**
+   * System app step type
+   */
+  public enum Type {
+    ENABLE_SYSTEM_APP
+  }
+
+  /**
+   * Arguments required to create an application
+   */
+  static class Arguments extends AppRequest<JsonObject> {
+
+    private String namespace;
+    private String name;
+    private boolean overwrite;
+
+    Arguments(AppRequest<JsonObject> appRequest, String namespace, String name, boolean overwrite) {
+      super(appRequest.getArtifact(), appRequest.getConfig(), appRequest.getPreview(),
+            appRequest.getOwnerPrincipal(),
+            appRequest.canUpdateSchedules());
+      this.namespace = namespace;
+      this.name = name;
+      this.overwrite = overwrite;
+    }
+
+    public ApplicationId getId() {
+      return new NamespaceId(namespace).app(name);
+    }
+
+    public void validate() {
+      super.validate();
+      if (namespace == null || namespace.isEmpty()) {
+        throw new IllegalArgumentException("Namespace must be specified");
+      }
+      if (name == null || name.isEmpty()) {
+        throw new IllegalArgumentException("Application name must be specified");
+      }
+      getId();
+    }
+
+    public boolean isOverwrite() {
+      return overwrite;
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -947,6 +947,9 @@ public abstract class AppFabricTestBase {
                                   programId.getApplicationId(),
                                   programId.getType().getCategoryName(), programId.getId());
       HttpResponse response = doGet(getVersionedAPIPath(path, programId.getNamespaceId()));
+      if (response.getResponseCode() == 404) {
+        return null;
+      }
       JsonObject status = GSON.fromJson(response.getResponseBodyAsString(), JsonObject.class);
       if (status == null || !status.has("status")) {
         return null;
@@ -965,6 +968,9 @@ public abstract class AppFabricTestBase {
                                   programId.getVersion(),
                                   programId.getType().getCategoryName(), programId.getProgram());
       HttpResponse response = doGet(getVersionedAPIPath(path, programId.getNamespace()));
+      if (response.getResponseCode() == 404) {
+        return null;
+      }
       JsonObject status = GSON.fromJson(response.getResponseBodyAsString(), JsonObject.class);
       if (status == null || !status.has("status")) {
         return null;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.sysapp;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.inject.Injector;
+import io.cdap.cdap.AllProgramsApp;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
+import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramId;
+import org.iq80.leveldb.util.FileUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for the {@link SystemAppManagementService}.
+ */
+public class SystemAppManagementServiceTest extends AppFabricTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SystemAppManagementServiceTest.class);
+  private static final Gson GSON = new Gson();
+
+  private static ProgramLifecycleService programLifecycleService;
+  private static ApplicationLifecycleService applicationLifecycleService;
+  private static CConfiguration cConf;
+  private static SystemAppManagementService systemAppManagementService;
+  private static File systemConfigDir;
+
+  private static final String RUNNING = "RUNNING";
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    Injector injector = getInjector();
+    programLifecycleService = injector.getInstance(ProgramLifecycleService.class);
+    applicationLifecycleService = injector.getInstance(ApplicationLifecycleService.class);
+    cConf = injector.getInstance(CConfiguration.class);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    systemAppManagementService.shutDown();
+  }
+
+  private void createEnableSysAppConfigFile(Id.Artifact artifactId, String filename) throws IOException {
+    AppRequest<JsonObject> appRequest = new AppRequest<>(new ArtifactSummary(artifactId.getName(),
+                                                         artifactId.getVersion().getVersion()));
+    SystemAppStep.Arguments step1Argument =
+      new SystemAppStep.Arguments(appRequest, artifactId.getNamespace().getId(), artifactId.getName(), false);
+    List<SystemAppStep> steps = new ArrayList<>();
+    steps.add(
+      new SystemAppStep("step for " + artifactId.getName(), SystemAppStep.Type.ENABLE_SYSTEM_APP, step1Argument));
+    SystemAppConfig config = new SystemAppConfig(steps);
+    File tmpFile = new File(systemConfigDir, filename);
+    try (BufferedWriter bw = new BufferedWriter(new FileWriter(tmpFile))) {
+      bw.write(GSON.toJson(config));
+    }
+  }
+
+  /**
+   * Tests SystemAppManagementService end to end by running below scenario:
+   * 1. Creates a system app config for an application into corresponding directory.
+   * 2. Successfully read and load the config.
+   * 3. Runs all steps to enable a system app , tests SystemAppEnableExecutor.
+   * 4. Deploys the app.
+   * 5. Runs all programs corresponding to the app.
+   * 6. Checks status of a continuously running program, i.e a service program.
+   * @throws Exception
+   */
+  @Test
+  public void testSystemAppManagementServiceE2E() throws Exception {
+    systemConfigDir = TEMPORARY_FOLDER.newFolder("demo-sys-app-config-dir");
+    cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
+    systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
+                                                                programLifecycleService);
+    Id.Artifact artifactId1 = Id.Artifact.from(Id.Namespace.DEFAULT, "App", VERSION1);
+    addAppArtifact(artifactId1, AllProgramsApp.class);
+    createEnableSysAppConfigFile(artifactId1, "demo.json");
+    systemAppManagementService.startUp();
+    ApplicationId appId1 = NamespaceId.DEFAULT.app(AllProgramsApp.NAME);
+    ProgramId serviceId1 = appId1.program(ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME);
+    waitState(serviceId1, RUNNING);
+    Assert.assertEquals(RUNNING, getProgramStatus(serviceId1));
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -62,6 +62,8 @@ public final class Constants {
   public static final String SPARK_COMPAT_ENV = "SPARK_COMPAT";
   // File specifying bootstrap steps
   public static final String BOOTSTRAP_FILE = "bootstrap.file";
+  // Directory path location for all system app configs
+  public static final String SYSTEM_APP_CONFIG_DIR = "system.app.config.dir";
 
   public static final String CLUSTER_NAME = "cluster.name";
   /* Used by the user to specify what part of a path should be replaced by the current user's name. */

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -322,6 +322,15 @@
   </property>
 
   <property>
+    <name>system.app.config.dir</name>
+    <value>/opt/cdap/master/system-app-config</value>
+    <description>
+      Directory that contains definitions for what system apps should be running. This directory is continuously
+      monitored for new/modified config files and updating application state to match what is defined in those files.
+    </description>
+  </property>
+
+  <property>
     <name>dataset.unchecked.upgrade</name>
     <value>false</value>
     <description>

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -38,6 +38,15 @@
     </description>
   </property>
 
+  <property>
+    <name>system.app.config.dir</name>
+    <value>system-app-config</value>
+    <description>
+      Directory that contains definitions for what system apps should be running. This directory is continuously
+      monitored for new/modified config files and updating application state to match what is defined in those files.
+    </description>
+  </property>
+
   <!-- Applications Configuration -->
 
   <property>


### PR DESCRIPTION
Adding support for bootstrapping system apps using separate config files

Adding support for bootstrapping system apps using separate config files. Looks for config files during app fabric start in a given directory. Ideally one separate file for one application. Runs steps (currently only ENABLE_SYSTEM_APP step) for the application. Deploys and starts program for each application. 

This will be basis for dynamic start/stop of system apps.

TESTS: tested using unit tests and sandbox testing.

BUILD link: https://builds.cask.co/browse/CDAP-DUT7102