### PR TITLE
[CDAP-16298] Fix timing issue in loading namespace before navigating to any page

### DIFF
--- a/cdap-ui/app/cdap/components/AppHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/index.tsx
@@ -33,6 +33,7 @@ import { SYSTEM_NAMESPACE } from 'services/global-constants';
 import { objectQuery } from 'services/helpers';
 import { NamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
 import ThemeWrapper from 'components/ThemeWrapper';
+import LoadingSVGCentered from 'components/LoadingSVGCentered';
 
 require('styles/bootstrap_4_patch.scss');
 
@@ -113,6 +114,14 @@ class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderSta
       namespace: this.state.currentNamespace,
       isNativeLink: this.props.nativeLink,
     };
+    // (TODO): This still doesn't capture correctly how we handle
+    // when authorization is enabled and user has access to no namespaces.
+    if (
+      !this.state.currentNamespace ||
+      (typeof this.state.currentNamespace === 'string' && !this.state.currentNamespace.length)
+    ) {
+      return <LoadingSVGCentered showFullPage />;
+    }
     return (
       <AppBar
         position="fixed"

--- a/cdap-ui/app/cdap/components/LoadingSVGCentered/LoadingSVGCentered.scss
+++ b/cdap-ui/app/cdap/components/LoadingSVGCentered/LoadingSVGCentered.scss
@@ -27,6 +27,12 @@
   font-size: 72px;
   z-index: 1000;
 
+  &.full-page {
+    top: 0;
+    background-color: rgba(255, 255, 255, 1);
+    z-index: 1001;
+  }
+
   > .loading-bar {
     position: absolute;
     top: 45%;

--- a/cdap-ui/app/cdap/components/LoadingSVGCentered/index.js
+++ b/cdap-ui/app/cdap/components/LoadingSVGCentered/index.js
@@ -14,15 +14,25 @@
  * the License.
 */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import LoadingSVG from 'components/LoadingSVG';
+import classname from 'classnames';
 
 require('./LoadingSVGCentered.scss');
 
-export default function LoadingSVGCentered() {
+export default function LoadingSVGCentered({ showFullPage = false }) {
   return (
-    <div className="loading-svg-centered text-center">
+    <div
+      className={classname('loading-svg-centered text-center', {
+        'full-page': showFullPage,
+      })}
+    >
       <LoadingSVG />
     </div>
   );
 }
+
+LoadingSVGCentered.propTypes = {
+  showFullPage: PropTypes.bool,
+};


### PR DESCRIPTION
- UI needs namespace for any navigation.
- If the network latency is high, we load the page and then the namespaces list comes in.
- This causes issue because now all the links in the home page and in the navbar are incorrect which leads user navigating to 404 page for all the links.

**Solution**
- Load the page until all the namespaces are available.