### PR TITLE
Fix for breaking lab tests

### DIFF
--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -188,7 +188,7 @@ export default class Home extends Component {
             exact
             path="/ns/:namespace/lab-experiment-test"
             render={(props) => {
-              if (window.CDAP_CONFIG.cdap.mode !== 'development') {
+              if (!window.Cypress) {
                 return <Page404 {...props} />;
               }
               const LabExperimentTestComp = Loadable({


### PR DESCRIPTION
Lab tests were failing because bamboo cluster was running tests in production mode and we enable a test component required for lab E2E tests only in development.