### PR TITLE
[CDAP-16249] Show dropped field operation in field level lineage UI

### DIFF
--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
@@ -19,7 +19,7 @@ import { objectQuery, parseQueryString } from 'services/helpers';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import {
   IField,
-  ITableFields,
+  ITablesList,
   ITimeParams,
   getTableId,
   getTimeRange,
@@ -60,8 +60,8 @@ export interface IContextState {
   target: string;
   targetFields: IField[];
   links: ILinkSet;
-  causeSets: ITableFields;
-  impactSets: ITableFields;
+  causeSets: ITablesList;
+  impactSets: ITablesList;
   showingOneField: boolean;
   start: ITimeType;
   end: ITimeType;
@@ -76,8 +76,8 @@ export interface IContextState {
   handleViewCauseImpact?: () => void;
   handleReset?: () => void;
   activeField?: IField;
-  activeCauseSets?: ITableFields;
-  activeImpactSets?: ITableFields;
+  activeCauseSets?: ITablesList;
+  activeImpactSets?: ITablesList;
   activeLinks?: ILinkSet;
   numTables?: number;
   firstCause?: number;
@@ -158,14 +158,18 @@ export class Provider extends React.Component<{ children }, IContextState> {
 
         if (nonTargetFd.type === 'cause') {
           if (!(tableId in activeCauseSets)) {
-            activeCauseSets[tableId] = [];
+            activeCauseSets[tableId] = {
+              fields: [],
+            };
           }
-          activeCauseSets[tableId].push(nonTargetFd);
+          activeCauseSets[tableId].fields.push(nonTargetFd);
         } else {
           if (!(tableId in activeImpactSets)) {
-            activeImpactSets[tableId] = [];
+            activeImpactSets[tableId] = {
+              fields: [],
+            };
           }
-          activeImpactSets[tableId].push(nonTargetFd);
+          activeImpactSets[tableId].fields.push(nonTargetFd);
         }
       });
     }

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
@@ -98,7 +98,7 @@ function FllField({ field, isActive, classes }: IFieldProps) {
         </span>
       </If>
       <If condition={activeField.id && field.id === activeField.id && isTarget && !showingOneField}>
-        <FllMenu />
+        <FllMenu hasIncomingOps={field.hasIncomingOps} hasOutgoingOps={field.hasOutgoingOps} />
       </If>
       <If condition={activeField.id && field.id === activeField.id && isTarget && showingOneField}>
         <span className={classes.targetView} onClick={handleReset} data-cy="reset-lineage">

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllMenu/index.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { useState, useContext } from 'react';
-import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
@@ -52,11 +52,14 @@ const styles = (theme): StyleRules => {
   };
 };
 
-function FllMenu({ classes }) {
+interface IFllMenuProps extends WithStyles<typeof styles> {
+  hasIncomingOps?: boolean;
+  hasOutgoingOps?: boolean;
+}
+
+function FllMenu({ hasIncomingOps, hasOutgoingOps, classes }: IFllMenuProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const { handleViewCauseImpact, toggleOperations, activeCauseSets, activeImpactSets } = useContext<
-    IContextState
-  >(FllContext);
+  const { handleViewCauseImpact, toggleOperations } = useContext<IContextState>(FllContext);
 
   function handleViewClick(e: React.MouseEvent<HTMLButtonElement>) {
     setAnchorEl(e.currentTarget);
@@ -71,8 +74,6 @@ function FllMenu({ classes }) {
     handleCloseMenu();
   }
 
-  const hasIncomingOps = Object.keys(activeCauseSets).length !== 0;
-  const hasOutgoingOps = Object.keys(activeImpactSets).length !== 0;
   return (
     <span className={classes.root}>
       <Button onClick={handleViewClick} className={classes.targetView} data-cy="fll-view-dropdown">

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/index.tsx
@@ -138,10 +138,10 @@ function FllTable({ tableId, fields, type, isActive, classes }: ITableProps) {
   // get fields that are a direct cause or impact to selected field
   let activeFields = [];
   if (isActive && !isTarget) {
-    if (type === 'cause') {
-      activeFields = activeCauseSets[tableId];
-    } else {
-      activeFields = activeImpactSets[tableId];
+    if (type === 'cause' && Object.keys(activeCauseSets).length > 0) {
+      activeFields = activeCauseSets[tableId].fields;
+    } else if (type === 'impact' && Object.keys(activeImpactSets).length > 0) {
+      activeFields = activeImpactSets[tableId].fields;
     }
   }
 

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/LineageSummary/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/LineageSummary/index.tsx
@@ -20,7 +20,7 @@ import FllHeader from 'components/FieldLevelLineage/v2/FllHeader';
 import FllTable from 'components/FieldLevelLineage/v2/FllTable';
 import OperationsModal from 'components/FieldLevelLineage/v2/OperationsModal';
 import {
-  ITableFields,
+  ITablesList,
   IField,
   ILinkSet,
 } from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
@@ -67,8 +67,8 @@ const styles = (theme): StyleRules => {
 
 interface ILineageState {
   activeField: IField;
-  activeCauseSets: ITableFields;
-  activeImpactSets: ITableFields;
+  activeCauseSets: ITablesList;
+  activeImpactSets: ITablesList;
   activeLinks: ILinkSet;
 }
 
@@ -269,13 +269,13 @@ class LineageSummary extends React.Component<{ classes }, ILineageState> {
                     <If condition={Object.keys(visibleCauseSets).length === 0}>
                       <FllTable type="cause" />
                     </If>
-                    {Object.entries(visibleCauseSets).map(([tableId, fields]) => {
+                    {Object.entries(visibleCauseSets).map(([tableId, tableInfo]) => {
                       const isActive = tableId in activeCauseSets;
                       return (
                         <FllTable
                           key={tableId}
                           tableId={tableId}
-                          fields={fields}
+                          fields={tableInfo.fields}
                           type="cause"
                           isActive={isActive}
                         />
@@ -291,13 +291,13 @@ class LineageSummary extends React.Component<{ classes }, ILineageState> {
                     <If condition={Object.keys(visibleImpactSets).length === 0}>
                       <FllTable type="impact" />
                     </If>
-                    {Object.entries(visibleImpactSets).map(([tableId, fields]) => {
+                    {Object.entries(visibleImpactSets).map(([tableId, tableInfo]) => {
                       const isActive = tableId in activeImpactSets;
                       return (
                         <FllTable
                           key={tableId}
                           tableId={tableId}
-                          fields={fields}
+                          fields={tableInfo.fields}
                           type="impact"
                           isActive={isActive}
                         />


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16249
Build: https://builds.cask.co/browse/CDAP-UDUT510-1

Currently, FLL breaks if the UI gets a response from the backend with a non-existent cause of impact dataset, i.e. if a field is dropped. Also, target fields where the only operation is being dropped don't have the options to see operations because "View impact" is disabled. 

This PR fixes the UI to show the lineage even when fields are dropped, and also lets users see operations for fields that are dropped (and have no other lineage/operations). 

[Sample pipeline (BQ to Avro) and csv are included](https://drive.google.com/open?id=1UkJB3BRoxjnyLNd4R0vW0D7L9NNnehXF). Pipeline uses Wrangler to drop a single field from airports.csv in BQ. 

