### PR TITLE
CDAP-13643 add streaming pipeline field lineage

### DIFF
--- a/cdap-api-spark-base/src/main/java/io/cdap/cdap/api/spark/JavaSparkExecutionContextBase.java
+++ b/cdap-api-spark-base/src/main/java/io/cdap/cdap/api/spark/JavaSparkExecutionContextBase.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.data.DatasetInstantiationException;
 import io.cdap.cdap.api.data.batch.Split;
 import io.cdap.cdap.api.dataset.Dataset;
+import io.cdap.cdap.api.lineage.field.LineageRecorder;
 import io.cdap.cdap.api.messaging.MessagingContext;
 import io.cdap.cdap.api.metadata.MetadataReader;
 import io.cdap.cdap.api.metadata.MetadataWriter;
@@ -49,7 +50,7 @@ import javax.annotation.Nullable;
  */
 @Beta
 public abstract class JavaSparkExecutionContextBase implements SchedulableProgramContext, RuntimeContext, Transactional,
-                                                               WorkflowInfoProvider,
+                                                               WorkflowInfoProvider, LineageRecorder,
                                                                SecureStore, MetadataReader, MetadataWriter {
 
   /**

--- a/cdap-api-spark-base/src/main/scala/io/cdap/cdap/api/spark/SparkExecutionContextBase.scala
+++ b/cdap-api-spark-base/src/main/scala/io/cdap/cdap/api/spark/SparkExecutionContextBase.scala
@@ -20,6 +20,7 @@ import java.io.IOException
 
 import io.cdap.cdap.api.annotation.Beta
 import io.cdap.cdap.api.data.batch.Split
+import io.cdap.cdap.api.lineage.field.LineageRecorder
 import io.cdap.cdap.api.messaging.MessagingContext
 import io.cdap.cdap.api.metadata.{MetadataReader, MetadataWriter}
 import io.cdap.cdap.api.metrics.Metrics
@@ -38,7 +39,8 @@ import scala.reflect.ClassTag
   * Spark program execution context. User Spark program can interact with CDAP through this context.
   */
 @Beta
-trait SparkExecutionContextBase extends RuntimeContext with Transactional with MetadataReader with MetadataWriter {
+trait SparkExecutionContextBase extends RuntimeContext
+  with Transactional with MetadataReader with MetadataWriter with LineageRecorder {
 
   /**
     * @return The specification used to configure this Spark job instance.

--- a/cdap-api/src/main/java/io/cdap/cdap/api/lineage/field/LineageRecorder.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/lineage/field/LineageRecorder.java
@@ -32,4 +32,20 @@ public interface LineageRecorder {
    * @param operations the operations to be recorded
    */
   void record(Collection<? extends Operation> operations);
+
+  /**
+   * Flush the existing record, this method will flush all the existing operations to the writer, and clear
+   * the recorded operations. The existing operations should be complete, they should have at least one
+   * operation of type {@link ReadOperation} and one operation of type {@link WriteOperation}. If the operations are
+   * not complete, {@link IllegalArgumentException} will be thrown and existing records will be preserved.
+   *
+   * For batch programs(workflow, batch spark, mapreduce), the method is called automatically at the end of the
+   * successful run.
+   * For realtime programs(worker, service, spark streaming), the method has to be manually called to write the
+   * lineage since realtime program will not stop automatically.
+   *
+   * @throws IllegalArgumentException if the validation of the field operations fails, this can happen when there is
+   * no read or write operations, operations have same names, or there is a cycle in the operations.
+   */
+  void flushLineage() throws IllegalArgumentException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.common.lang.WeakReferenceDelegatorClassLoader;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.lineage.AccessType;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
@@ -101,10 +102,12 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
                         SecureStoreManager secureStoreManager,
                         MessagingService messagingService, MetadataReader metadataReader,
                         MetadataPublisher metadataPublisher,
-                        NamespaceQueryAdmin namespaceQueryAdmin) {
+                        NamespaceQueryAdmin namespaceQueryAdmin,
+                        FieldLineageWriter fieldLineageWriter) {
     super(program, programOptions, cConf, spec.getDataSets(), dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
-          messagingService, pluginInstantiator, metadataReader, metadataPublisher, namespaceQueryAdmin);
+          messagingService, pluginInstantiator, metadataReader, metadataPublisher, namespaceQueryAdmin,
+          fieldLineageWriter);
 
     this.workflowProgramInfo = workflowProgramInfo;
     this.spec = spec;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -53,6 +53,7 @@ import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import io.cdap.cdap.data2.metadata.lineage.AccessType;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
 import io.cdap.cdap.internal.app.runtime.DefaultTaskLocalizationContext;
@@ -140,12 +141,12 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                             AuthenticationContext authenticationContext,
                             MessagingService messagingService, MapReduceClassLoader mapReduceClassLoader,
                             MetadataReader metadataReader, MetadataPublisher metadataPublisher,
-                            NamespaceQueryAdmin namespaceQueryAdmin) {
+                            NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter) {
     super(program, programOptions, cConf, ImmutableSet.of(), dsFramework, txClient, discoveryServiceClient,
           true, metricsCollectionService, createMetricsTags(programOptions,
                                                             taskId, type, workflowProgramInfo), secureStore,
           secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin);
+          namespaceQueryAdmin, fieldLineageWriter);
     this.cConf = cConf;
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -351,7 +351,13 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   @Override
   public void record(Collection<? extends Operation> operations) {
     throw new UnsupportedOperationException("Recording field lineage operations is not supported in " +
-                                              "                                 MapReduce task-level context");
+                                              "MapReduce task-level context");
+  }
+
+  @Override
+  public void flushLineage() {
+    throw new UnsupportedOperationException("Recording field lineage operations is not supported in " +
+                                              "MapReduce task-level context");
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -172,7 +172,8 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
         new BasicMapReduceContext(program, options, cConf, spec, workflowInfo, discoveryServiceClient,
                                   metricsCollectionService, txSystemClient, programDatasetFramework,
                                   getPluginArchive(options), pluginInstantiator, secureStore, secureStoreManager,
-                                  messagingService, metadataReader, metadataPublisher, namespaceQueryAdmin);
+                                  messagingService, metadataReader, metadataPublisher, namespaceQueryAdmin,
+                                  fieldLineageWriter);
       closeables.add(context);
 
       Reflections.visit(mapReduce, mapReduce.getClass(),
@@ -193,7 +194,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
       ClusterMode clusterMode = ProgramRunners.getClusterMode(options);
       Service mapReduceRuntimeService = new MapReduceRuntimeService(injector, cConf, hConf, mapReduce, spec,
                                                                     context, program.getJarLocation(), locationFactory,
-                                                                    fieldLineageWriter, clusterMode);
+                                                                    clusterMode, fieldLineageWriter);
       mapReduceRuntimeService.addListener(createRuntimeServiceListener(closeables), Threads.SAME_THREAD_EXECUTOR);
 
       ProgramController controller = new MapReduceProgramController(mapReduceRuntimeService, context);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
@@ -168,15 +169,16 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
    * Creates a {@link CacheLoader} for the task context cache.
    */
   private CacheLoader<ContextCacheKey, BasicMapReduceTaskContext> createCacheLoader(final Injector injector) {
-    final DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
-    final DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
-    final SecureStore secureStore = injector.getInstance(SecureStore.class);
-    final SecureStoreManager secureStoreManager = injector.getInstance(SecureStoreManager.class);
-    final MessagingService messagingService = injector.getInstance(MessagingService.class);
+    DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
+    DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
+    SecureStore secureStore = injector.getInstance(SecureStore.class);
+    SecureStoreManager secureStoreManager = injector.getInstance(SecureStoreManager.class);
+    MessagingService messagingService = injector.getInstance(MessagingService.class);
     // Multiple instances of BasicMapReduceTaskContext can share the same program.
-    final AtomicReference<Program> programRef = new AtomicReference<>();
-    final MetadataReader metadataReader = injector.getInstance(MetadataReader.class);
-    final MetadataPublisher metadataPublisher = injector.getInstance(MetadataPublisher.class);
+    AtomicReference<Program> programRef = new AtomicReference<>();
+    MetadataReader metadataReader = injector.getInstance(MetadataReader.class);
+    MetadataPublisher metadataPublisher = injector.getInstance(MetadataPublisher.class);
+    FieldLineageWriter fieldLineageWriter = injector.getInstance(FieldLineageWriter.class);
 
     return new CacheLoader<ContextCacheKey, BasicMapReduceTaskContext>() {
       @Override
@@ -249,7 +251,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           transaction, programDatasetFramework, classLoader.getPluginInstantiator(),
           contextConfig.getLocalizedResources(), secureStore, secureStoreManager,
           authorizationEnforcer, authenticationContext, messagingService, mapReduceClassLoader, metadataReader,
-          metadataPublisher, namespaceQueryAdmin
+          metadataPublisher, namespaceQueryAdmin, fieldLineageWriter
         );
       }
     };

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -58,13 +59,14 @@ public class BasicCustomActionContext extends AbstractContext implements CustomA
                                   @Nullable PluginInstantiator pluginInstantiator,
                                   SecureStore secureStore, SecureStoreManager secureStoreManager,
                                   MessagingService messagingService, MetadataReader metadataReader,
-                                  MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin) {
+                                  MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
+                                  FieldLineageWriter fieldLineageWriter) {
 
     super(workflow, programOptions, cConf, customActionSpecification.getDatasets(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, workflowProgramInfo.updateMetricsTags(new HashMap<>()), secureStore,
           secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin);
+          namespaceQueryAdmin, fieldLineageWriter);
 
     this.customActionSpecification = customActionSpecification;
     this.workflowProgramInfo = workflowProgramInfo;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
@@ -78,6 +79,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final PluginFinder pluginFinder;
   private final TransactionRunner transactionRunner;
+  private final FieldLineageWriter fieldLineageWriter;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -88,7 +90,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               ArtifactManagerFactory artifactManagerFactory,
                               MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                               NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder,
-                              TransactionRunner transactionRunner) {
+                              TransactionRunner transactionRunner, FieldLineageWriter fieldLineageWriter) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -104,6 +106,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.pluginFinder = pluginFinder;
     this.transactionRunner = transactionRunner;
+    this.fieldLineageWriter = fieldLineageWriter;
   }
 
   @Override
@@ -146,7 +149,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           pluginInstantiator, secureStore, secureStoreManager,
                                                           messagingService, artifactManager, metadataReader,
                                                           metadataPublisher, namespaceQueryAdmin, pluginFinder,
-                                                          transactionRunner);
+                                                          transactionRunner, fieldLineageWriter);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton(pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -36,6 +36,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.DefaultPluginConfigurer;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
@@ -115,12 +116,13 @@ public class BasicHttpServiceContext extends AbstractContext implements SystemHt
                                  ArtifactManager artifactManager, MetadataReader metadataReader,
                                  MetadataPublisher metadataPublisher,
                                  NamespaceQueryAdmin namespaceQueryAdmin,
-                                 PluginFinder pluginFinder, TransactionRunner transactionRunner) {
+                                 PluginFinder pluginFinder, TransactionRunner transactionRunner,
+                                 FieldLineageWriter fieldLineageWriter) {
     super(program, programOptions, cConf, spec == null ? Collections.emptySet() : spec.getDatasets(),
           dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(spec, instanceId),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin);
+          namespaceQueryAdmin, fieldLineageWriter);
     this.cConf = cConf;
     this.namespaceId = program.getId().getNamespaceId();
     this.artifactId = ProgramRunners.getArtifactId(programOptions);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -58,12 +59,12 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
                      SecureStoreManager secureStoreManager,
                      MessagingService messagingService, MetadataReader metadataReader,
                      MetadataPublisher metadataPublisher,
-                     NamespaceQueryAdmin namespaceQueryAdmin) {
+                     NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter) {
     super(program, programOptions, cConf, spec.getDatasets(),
           datasetFramework, transactionSystemClient, discoveryServiceClient, true,
           metricsCollectionService, ImmutableMap.of(Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin);
+          namespaceQueryAdmin, fieldLineageWriter);
 
     this.specification = spec;
     this.instanceId = instanceId;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
@@ -68,6 +69,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MetadataReader metadataReader;
   private final MetadataPublisher metadataPublisher;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final FieldLineageWriter fieldLineageWriter;
 
   @Inject
   public WorkerProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -75,7 +77,8 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                              TransactionSystemClient txClient,
                              SecureStore secureStore, SecureStoreManager secureStoreManager,
                              MessagingService messagingService, MetadataReader metadataReader,
-                             MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin) {
+                             MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
+                             FieldLineageWriter fieldLineageWriter) {
     super(cConf);
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
@@ -88,6 +91,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.metadataReader = metadataReader;
     this.metadataPublisher = metadataPublisher;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.fieldLineageWriter = fieldLineageWriter;
   }
 
   @Override
@@ -131,7 +135,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           discoveryServiceClient,
                                                           pluginInstantiator, secureStore, secureStoreManager,
                                                           messagingService, metadataReader, metadataPublisher,
-                                                          namespaceQueryAdmin);
+                                                          namespaceQueryAdmin, fieldLineageWriter);
 
       WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
@@ -67,13 +68,13 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
                        SecureStore secureStore, SecureStoreManager secureStoreManager,
                        MessagingService messagingService, @Nullable ConditionSpecification conditionSpecification,
                        MetadataReader metadataReader, MetadataPublisher metadataPublisher,
-                       NamespaceQueryAdmin namespaceQueryAdmin) {
+                       NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter) {
     super(program, programOptions, cConf, new HashSet<>(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, Collections.singletonMap(Constants.Metrics.Tag.WORKFLOW_RUN_ID,
                                                              ProgramRunners.getRunId(programOptions).getId()),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin);
+          namespaceQueryAdmin, fieldLineageWriter);
     this.workflowSpec = workflowSpec;
     this.conditionSpecification = conditionSpecification;
     this.token = token;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.common.lang.PropertyFieldSetter;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.data2.transaction.Transactions;
 import io.cdap.cdap.internal.app.runtime.DataSetFieldSetter;
@@ -86,7 +87,8 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                            MessagingService messagingService,
                            ArtifactManager artifactManager, MetadataReader metadataReader,
                            MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
-                           PluginFinder pluginFinder, TransactionRunner transactionRunner) {
+                           PluginFinder pluginFinder, TransactionRunner transactionRunner,
+                           FieldLineageWriter fieldLineageWriter) {
     super(host, program, programOptions, instanceId, serviceAnnouncer, TransactionControl.IMPLICIT);
 
     this.cConf = cConf;
@@ -96,7 +98,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
-                                               pluginFinder, transactionRunner);
+                                               pluginFinder, transactionRunner, fieldLineageWriter);
     this.context = contextFactory.create(null);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
@@ -145,12 +147,14 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                               MetadataReader metadataReader,
                                                               MetadataPublisher metadataPublisher,
                                                               PluginFinder pluginFinder,
-                                                              TransactionRunner transactionRunner) {
+                                                              TransactionRunner transactionRunner,
+                                                              FieldLineageWriter fieldLineageWriter) {
     return spec -> new BasicHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
-                                               namespaceQueryAdmin, pluginFinder, transactionRunner);
+                                               namespaceQueryAdmin, pluginFinder, transactionRunner,
+                                               fieldLineageWriter);
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
@@ -78,6 +78,7 @@ import io.cdap.cdap.etl.common.PipelinePhase;
 import io.cdap.cdap.etl.common.PipelineRuntime;
 import io.cdap.cdap.etl.common.TrackedIterator;
 import io.cdap.cdap.etl.common.plugin.PipelinePluginContext;
+import io.cdap.cdap.etl.lineage.FieldLineageProcessor;
 import io.cdap.cdap.etl.planner.ConditionBranches;
 import io.cdap.cdap.etl.planner.ControlDag;
 import io.cdap.cdap.etl.planner.Dag;

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkFieldLineageRecorder.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkFieldLineageRecorder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datastreams;
+
+import io.cdap.cdap.api.lineage.field.Operation;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.PhaseSpec;
+import io.cdap.cdap.etl.common.PipelinePhase;
+import io.cdap.cdap.etl.common.PipelineRuntime;
+import io.cdap.cdap.etl.common.plugin.PipelinePluginContext;
+import io.cdap.cdap.etl.lineage.FieldLineageProcessor;
+import io.cdap.cdap.etl.proto.v2.spec.PipelineSpec;
+import io.cdap.cdap.etl.spark.SparkPipelineRuntime;
+import io.cdap.cdap.etl.spark.streaming.SparkStreamingPreparer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Field lineage recorder for streaming pipeline
+ */
+public class SparkFieldLineageRecorder {
+  private final JavaSparkExecutionContext sec;
+  private final PipelinePhase pipelinePhase;
+  private final PipelineSpec pipelineSpec;
+  private Map<String, List<FieldOperation>> operations;
+
+  public SparkFieldLineageRecorder(JavaSparkExecutionContext sec,
+                                   PipelinePhase pipelinePhase, PipelineSpec pipelineSpec) {
+    this.sec = sec;
+    this.pipelinePhase = pipelinePhase;
+    this.pipelineSpec = pipelineSpec;
+    this.operations = new HashMap<>();
+  }
+
+  public void record() throws Exception {
+    if (operations.isEmpty()) {
+      generateOperations();
+    }
+
+    FieldLineageProcessor processor = new FieldLineageProcessor(pipelineSpec);
+    Set<Operation> processedOperations = processor.validateAndConvert(operations);
+    if (!processedOperations.isEmpty()) {
+      sec.record(processedOperations);
+      sec.flushLineage();
+    }
+  }
+
+  private void generateOperations() throws Exception {
+    PipelinePluginContext pluginContext = new PipelinePluginContext(sec.getPluginContext(), sec.getMetrics(),
+                                                                    pipelineSpec.isStageLoggingEnabled(),
+                                                                    pipelineSpec.isProcessTimingEnabled());
+    PipelineRuntime pipelineRuntime = new SparkPipelineRuntime(sec);
+    MacroEvaluator evaluator = new DefaultMacroEvaluator(pipelineRuntime.getArguments(),
+                                                         sec.getLogicalStartTime(), sec,
+                                                         sec.getNamespace());
+    SparkStreamingPreparer preparer = new SparkStreamingPreparer(pluginContext, sec.getMetrics(), evaluator,
+                                                                 pipelineRuntime, sec);
+    preparer.prepare(new PhaseSpec(DataStreamsSparkLauncher.NAME, pipelinePhase, Collections.emptyMap(),
+                                   pipelineSpec.isStageLoggingEnabled(), pipelineSpec.isProcessTimingEnabled()));
+    operations = preparer.getFieldOperations();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingSource.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.etl.api.streaming;
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.etl.api.PipelineConfigurable;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.SubmitterLifecycle;
 import org.apache.spark.streaming.api.java.JavaDStream;
 
 import java.io.Serializable;
@@ -29,7 +30,8 @@ import java.io.Serializable;
  * @param <T> type of object contained in the stream
  */
 @Beta
-public abstract class StreamingSource<T> implements PipelineConfigurable, Serializable {
+public abstract class StreamingSource<T> implements PipelineConfigurable,
+  SubmitterLifecycle<StreamingSourceContext>, Serializable {
 
   public static final String PLUGIN_TYPE = "streamingsource";
 
@@ -42,6 +44,16 @@ public abstract class StreamingSource<T> implements PipelineConfigurable, Serial
    * @return the stream to read from.
    */
   public abstract JavaDStream<T> getStream(StreamingContext context) throws Exception;
+
+  @Override
+  public void prepareRun(StreamingSourceContext context) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, StreamingSourceContext context) {
+    // no-op
+  }
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingSourceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2019 Cask Data, Inc.
+ * Copyright © 2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,40 +16,26 @@
 
 package io.cdap.cdap.etl.api.streaming;
 
-import io.cdap.cdap.api.Transactional;
-import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
-import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
-import io.cdap.cdap.etl.api.StageContext;
-import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import io.cdap.cdap.etl.api.batch.BatchContext;
 import org.apache.tephra.TransactionFailureException;
 
+import javax.annotation.Nullable;
+
 /**
- * Context for streaming plugin stages.
+ * Context passed to streaming source during prepare run phase.
  */
-@Beta
-public interface StreamingContext extends StageContext, Transactional {
-
-  /**
-   * @return Spark JavaStreamingContext for the pipeline.
-   */
-  JavaStreamingContext getSparkStreamingContext();
-
-  /**
-   * @return CDAP JavaSparkExecutionContext for the pipeline.
-   */
-  JavaSparkExecutionContext getSparkExecutionContext();
-
+public interface StreamingSourceContext extends BatchContext {
   /**
    * Register dataset lineage for this Spark program using the given reference name
    *
    * @param referenceName reference name used for source
+   * @param schema schema for this dataset
    *
    * @throws DatasetManagementException thrown if there was an error in creating reference dataset
    * @throws TransactionFailureException thrown if there was an error while fetching the dataset to register usage
-   * @deprecated use {@link StreamingSourceContext#registerLineage(String, Schema)} to record lineage in prepare stage
    */
-  @Deprecated
-  void registerLineage(String referenceName) throws DatasetManagementException, TransactionFailureException;
+  void registerLineage(String referenceName,
+                       @Nullable Schema schema) throws DatasetManagementException, TransactionFailureException;
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/customaction/BasicActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/customaction/BasicActionContext.java
@@ -142,4 +142,9 @@ public class BasicActionContext extends AbstractStageContext implements ActionCo
   public void record(Collection<? extends Operation> operations) {
     context.record(operations);
   }
+
+  @Override
+  public void flushLineage() {
+    context.flushLineage();
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReducePreparer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReducePreparer.java
@@ -29,11 +29,9 @@ import io.cdap.cdap.etl.api.batch.BatchConfigurable;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
-import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.batch.BatchPhaseSpec;
 import io.cdap.cdap.etl.batch.DefaultAggregatorContext;
 import io.cdap.cdap.etl.batch.DefaultJoinerContext;
-import io.cdap.cdap.etl.batch.PipelinePhasePreparer;
 import io.cdap.cdap.etl.batch.PipelinePluginInstantiator;
 import io.cdap.cdap.etl.batch.conversion.WritableConversion;
 import io.cdap.cdap.etl.batch.conversion.WritableConversions;
@@ -44,6 +42,7 @@ import io.cdap.cdap.etl.common.submit.AggregatorContextProvider;
 import io.cdap.cdap.etl.common.submit.ContextProvider;
 import io.cdap.cdap.etl.common.submit.Finisher;
 import io.cdap.cdap.etl.common.submit.JoinerContextProvider;
+import io.cdap.cdap.etl.common.submit.PipelinePhasePreparer;
 import io.cdap.cdap.etl.common.submit.SubmitterPlugin;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import org.apache.hadoop.conf.Configuration;
@@ -57,6 +56,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * For each stage, call prepareRun() in topological order. prepareRun will setup the input/output of the pipeline phase
@@ -72,8 +72,6 @@ public class MapReducePreparer extends PipelinePhasePreparer {
   private Configuration hConf;
   private Map<String, SinkOutput> sinkOutputs;
   private Map<String, String> inputAliasToStage;
-  private Map<String, List<FieldOperation>> stageOperations;
-
 
   public MapReducePreparer(MapReduceContext context, Metrics metrics, MacroEvaluator macroEvaluator,
                            PipelineRuntime pipelineRuntime, Set<String> connectorDatasets) {
@@ -115,6 +113,7 @@ public class MapReducePreparer extends PipelinePhasePreparer {
     return finishers;
   }
 
+  @Nullable
   @Override
   protected SubmitterPlugin create(PipelinePluginInstantiator pluginInstantiator, StageSpec stageSpec) {
     return null;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BatchPhaseSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BatchPhaseSpec.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.etl.batch;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.Resources;
+import io.cdap.cdap.etl.common.PhaseSpec;
 import io.cdap.cdap.etl.common.PipelinePhase;
 
 import java.util.Map;
@@ -26,15 +27,10 @@ import java.util.Map;
 /**
  * Information required by one phase of a batch pipeline.
  */
-public class BatchPhaseSpec {
-  private final String phaseName;
-  private final PipelinePhase phase;
+public class BatchPhaseSpec extends PhaseSpec {
   private final Resources resources;
   private final Resources driverResources;
   private final Resources clientResources;
-  private final boolean isStageLoggingEnabled;
-  private final boolean isProcessTimingEnabled;
-  private final Map<String, String> connectorDatasets;
   private final Map<String, String> pipelineProperties;
   private final String description;
   private final int numOfRecordsPreview;
@@ -45,26 +41,14 @@ public class BatchPhaseSpec {
                         boolean isStageLoggingEnabled, boolean isProcessTimingEnabled,
                         Map<String, String> connectorDatasets, int numOfRecordsPreview,
                         Map<String, String> pipelineProperties, boolean isPipelineContainsCondition) {
-    this.phaseName = phaseName;
-    this.phase = phase;
+    super(phaseName, phase, connectorDatasets, isStageLoggingEnabled, isProcessTimingEnabled);
     this.resources = resources;
     this.driverResources = driverResources;
     this.clientResources = clientResources;
-    this.isStageLoggingEnabled = isStageLoggingEnabled;
-    this.isProcessTimingEnabled = isProcessTimingEnabled;
-    this.connectorDatasets = connectorDatasets;
     this.description = createDescription();
     this.numOfRecordsPreview = numOfRecordsPreview;
     this.pipelineProperties = ImmutableMap.copyOf(pipelineProperties);
     this.isPipelineContainsCondition = isPipelineContainsCondition;
-  }
-
-  public String getPhaseName() {
-    return phaseName;
-  }
-
-  public PipelinePhase getPhase() {
-    return phase;
   }
 
   public Resources getResources() {
@@ -77,18 +61,6 @@ public class BatchPhaseSpec {
 
   public Resources getClientResources() {
     return clientResources;
-  }
-
-  public boolean isStageLoggingEnabled() {
-    return isStageLoggingEnabled;
-  }
-
-  public boolean isProcessTimingEnabled() {
-    return isProcessTimingEnabled;
-  }
-
-  public Map<String, String> getConnectorDatasets() {
-    return connectorDatasets;
   }
 
   public String getDescription() {
@@ -109,10 +81,10 @@ public class BatchPhaseSpec {
 
   private String createDescription() {
     StringBuilder description = new StringBuilder("Sources '");
-    Joiner.on("', '").appendTo(description, phase.getSources());
+    Joiner.on("', '").appendTo(description, getPhase().getSources());
     description.append("' to sinks '");
 
-    Joiner.on("', '").appendTo(description, phase.getSinks());
+    Joiner.on("', '").appendTo(description, getPhase().getSinks());
     description.append("'.");
     return description.toString();
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/PipelinePluginInstantiator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/PipelinePluginInstantiator.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.etl.batch.connector.ConnectorFactory;
 import io.cdap.cdap.etl.batch.connector.ConnectorSink;
 import io.cdap.cdap.etl.batch.connector.ConnectorSource;
 import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.PhaseSpec;
 import io.cdap.cdap.etl.common.plugin.PipelinePluginContext;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 
@@ -41,12 +42,12 @@ import javax.annotation.Nullable;
  */
 public class PipelinePluginInstantiator implements PluginContext {
   private final PluginContext pluginContext;
-  private final BatchPhaseSpec phaseSpec;
+  private final PhaseSpec phaseSpec;
   private final Set<String> connectorSources;
   private final Set<String> connectorSinks;
   private final ConnectorFactory connectorFactory;
 
-  public PipelinePluginInstantiator(PluginContext pluginContext, Metrics metrics, BatchPhaseSpec phaseSpec,
+  public PipelinePluginInstantiator(PluginContext pluginContext, Metrics metrics, PhaseSpec phaseSpec,
                                     ConnectorFactory connectorFactory) {
     this.pluginContext = new PipelinePluginContext(pluginContext, metrics,
                                                    phaseSpec.isStageLoggingEnabled(),

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/PhaseSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/PhaseSpec.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common;
+
+import java.util.Map;
+
+/**
+ * Class that contain common pipeline phase information
+ */
+public class PhaseSpec {
+  private final String name;
+  private final PipelinePhase phase;
+  private final Map<String, String> connectorDatasets;
+  private final boolean isStageLoggingEnabled;
+  private final boolean isProcessTimingEnabled;
+
+  public PhaseSpec(String name, PipelinePhase phase, Map<String, String> connectorDatasets,
+                   boolean isStageLoggingEnabled, boolean isProcessTimingEnabled) {
+    this.name = name;
+    this.phase = phase;
+    this.connectorDatasets = connectorDatasets;
+    this.isStageLoggingEnabled = isStageLoggingEnabled;
+    this.isProcessTimingEnabled = isProcessTimingEnabled;
+  }
+
+  public PipelinePhase getPhase() {
+    return phase;
+  }
+
+  public boolean isStageLoggingEnabled() {
+    return isStageLoggingEnabled;
+  }
+
+  public boolean isProcessTimingEnabled() {
+    return isProcessTimingEnabled;
+  }
+
+  public String getPhaseName() {
+    return name;
+  }
+
+  public Map<String, String> getConnectorDatasets() {
+    return connectorDatasets;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/FieldLineageProcessor.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/FieldLineageProcessor.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.lineage;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
 /**
  * Field lineage processor to validate the stage operations and convert the pipeline level operations to platform
  * level operations
- * TODO: CDAP-15871 move the field operation related classes to etl-core when supporting realtime pipeline
  */
 public class FieldLineageProcessor {
   private static final Logger LOG = LoggerFactory.getLogger(FieldLineageProcessor.class);
@@ -104,8 +103,8 @@ public class FieldLineageProcessor {
           // if the field operations are empty for a stage, auto generate it for the stages that have input schema and
           // output schema
           if (fieldOperations == null || fieldOperations.isEmpty()) {
-            return  Collections.singletonList(new FieldTransformOperation("Transform", "",
-                                                                          stageInputs, stageOutputs));
+            return Collections.singletonList(new FieldTransformOperation("Transform", "",
+                                                                         stageInputs, stageOutputs));
           }
           return fieldOperations;
         });

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/InvalidFieldOperations.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/InvalidFieldOperations.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.lineage;
 
 import java.util.List;
 import java.util.Map;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/InvalidLineageException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/InvalidLineageException.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.lineage;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/LineageOperationsProcessor.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/LineageOperationsProcessor.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.lineage;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/StageOperationsValidator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/StageOperationsValidator.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.lineage;
 
 import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.api.lineage.field.FieldReadOperation;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/lineage/FieldLineageProcessorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/lineage/FieldLineageProcessorTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.lineage;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/lineage/LineageOperationProcessorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/lineage/LineageOperationProcessorTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.lineage;
 
 import io.cdap.cdap.api.lineage.field.EndPoint;
 import io.cdap.cdap.api.lineage.field.InputField;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/lineage/StageOperationsValidatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/lineage/StageOperationsValidatorTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.datapipeline;
+package io.cdap.cdap.etl.lineage;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkPreparer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkPreparer.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark;
+
+import io.cdap.cdap.api.Admin;
+import io.cdap.cdap.api.Transactional;
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.metrics.Metrics;
+import io.cdap.cdap.api.plugin.PluginContext;
+import io.cdap.cdap.etl.api.SplitterTransform;
+import io.cdap.cdap.etl.api.Transform;
+import io.cdap.cdap.etl.api.batch.BatchAggregator;
+import io.cdap.cdap.etl.api.batch.BatchConfigurable;
+import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.batch.SparkPluginContext;
+import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.streaming.StreamingSource;
+import io.cdap.cdap.etl.batch.DefaultAggregatorContext;
+import io.cdap.cdap.etl.batch.DefaultJoinerContext;
+import io.cdap.cdap.etl.batch.PipelinePluginInstantiator;
+import io.cdap.cdap.etl.common.PhaseSpec;
+import io.cdap.cdap.etl.common.PipelineRuntime;
+import io.cdap.cdap.etl.common.submit.AggregatorContextProvider;
+import io.cdap.cdap.etl.common.submit.ContextProvider;
+import io.cdap.cdap.etl.common.submit.Finisher;
+import io.cdap.cdap.etl.common.submit.JoinerContextProvider;
+import io.cdap.cdap.etl.common.submit.PipelinePhasePreparer;
+import io.cdap.cdap.etl.common.submit.SubmitterPlugin;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.batch.BasicSparkPluginContext;
+import io.cdap.cdap.etl.spark.batch.SparkBatchSinkContext;
+import io.cdap.cdap.etl.spark.batch.SparkBatchSinkFactory;
+import io.cdap.cdap.etl.spark.batch.SparkBatchSourceFactory;
+import org.apache.tephra.TransactionFailureException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Abstract preparer for spark related pipelines
+ */
+public abstract class AbstractSparkPreparer extends PipelinePhasePreparer {
+  protected Map<String, Integer> stagePartitions;
+  protected SparkBatchSourceFactory sourceFactory;
+  protected SparkBatchSinkFactory sinkFactory;
+
+  private final Admin admin;
+  private final Transactional transactional;
+
+  public AbstractSparkPreparer(PluginContext pluginContext, Metrics metrics,
+                               MacroEvaluator macroEvaluator, PipelineRuntime pipelineRuntime,
+                               Admin admin, Transactional transactional) {
+    super(pluginContext, metrics, macroEvaluator, pipelineRuntime);
+    this.admin = admin;
+    this.transactional = transactional;
+  }
+
+  @Override
+  public List<Finisher> prepare(PhaseSpec phaseSpec)
+    throws TransactionFailureException, InstantiationException, IOException {
+    stageOperations = new HashMap<>();
+    stagePartitions = new HashMap<>();
+    sourceFactory = new SparkBatchSourceFactory();
+    sinkFactory = new SparkBatchSinkFactory();
+    return super.prepare(phaseSpec);
+  }
+
+  @Nullable
+  @Override
+  protected SubmitterPlugin create(PipelinePluginInstantiator pluginInstantiator,
+                                   StageSpec stageSpec) throws InstantiationException {
+    String stageName = stageSpec.getName();
+    if (SparkSink.PLUGIN_TYPE.equals(stageSpec.getPluginType())) {
+      BatchConfigurable<SparkPluginContext> sparkSink = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+      ContextProvider<SparkPluginContext> contextProvider = dsContext -> getSparkPluginContext(dsContext, stageSpec);
+      return new SubmitterPlugin<>(stageName, transactional, sparkSink, contextProvider);
+    }
+    if (StreamingSource.PLUGIN_TYPE.equals(stageSpec.getPluginType())) {
+      return createStreamingSource(pluginInstantiator, stageSpec);
+    }
+    return null;
+  }
+
+  @Override
+  protected SubmitterPlugin createTransform(Transform<?, ?> transform, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<SparkSubmitterContext> contextProvider =
+      dsContext -> getSparkSubmitterContext(dsContext, stageSpec);
+    return new SubmitterPlugin<>(stageName, transactional, transform, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createSplitterTransform(SplitterTransform<?, ?> splitterTransform, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<SparkSubmitterContext> contextProvider =
+      dsContext -> getSparkSubmitterContext(dsContext, stageSpec);
+    return new SubmitterPlugin<>(stageName, transactional, splitterTransform, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createSink(BatchConfigurable<BatchSinkContext> batchSink, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<SparkBatchSinkContext> contextProvider =
+      dsContext -> getSparkBatchSinkContext(dsContext, stageSpec);
+    return new SubmitterPlugin<>(stageName, transactional, batchSink, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createAggregator(BatchAggregator<?, ?, ?> aggregator, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultAggregatorContext> contextProvider =
+      new AggregatorContextProvider(pipelineRuntime, stageSpec, admin);
+    return new SubmitterPlugin<>(stageName, transactional, aggregator, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createJoiner(BatchJoiner<?, ?, ?> batchJoiner, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultJoinerContext> contextProvider =
+      new JoinerContextProvider(pipelineRuntime, stageSpec, admin);
+    return new SubmitterPlugin<>(stageName, transactional, batchJoiner, contextProvider, sparkJoinerContext -> {
+      stagePartitions.put(stageName, sparkJoinerContext.getNumPartitions());
+      stageOperations.put(stageName, sparkJoinerContext.getFieldOperations());
+    });
+  }
+
+  protected abstract SparkBatchSinkContext getSparkBatchSinkContext(DatasetContext dsContext, StageSpec stageSpec);
+
+  protected abstract BasicSparkPluginContext getSparkPluginContext(DatasetContext dsContext, StageSpec stageSpec);
+
+  protected abstract SparkSubmitterContext getSparkSubmitterContext(DatasetContext dsContext, StageSpec stageSpec);
+
+  // only streaming pipeline can create streaming source
+  @Nullable
+  protected SubmitterPlugin createStreamingSource(PipelinePluginInstantiator pluginInstantiator,
+                                                  StageSpec stageSpec) throws InstantiationException {
+    return null;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkSubmitterContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkSubmitterContext.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark;
+
+import io.cdap.cdap.api.Admin;
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.messaging.MessageFetcher;
+import io.cdap.cdap.api.messaging.MessagePublisher;
+import io.cdap.cdap.api.messaging.MessagingContext;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.api.spark.SparkClientContext;
+import io.cdap.cdap.etl.api.StageSubmitterContext;
+import io.cdap.cdap.etl.batch.AbstractBatchContext;
+import io.cdap.cdap.etl.common.PipelineRuntime;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * The submitter context can be used for both batch and realtime spark pipelines
+ */
+public class SparkSubmitterContext extends AbstractBatchContext implements StageSubmitterContext {
+  private final MessagingContext messagingContext;
+
+  public SparkSubmitterContext(SparkClientContext sparkContext,
+                               PipelineRuntime pipelineRuntime,
+                               DatasetContext datasetContext, StageSpec stageSpec) {
+    super(pipelineRuntime, stageSpec, datasetContext, sparkContext.getAdmin());
+    this.messagingContext = sparkContext;
+  }
+
+  public SparkSubmitterContext(JavaSparkExecutionContext sparkContext,
+                               PipelineRuntime pipelineRuntime,
+                               DatasetContext datasetContext, StageSpec stageSpec) {
+    super(pipelineRuntime, stageSpec, datasetContext, sparkContext.getAdmin());
+    this.messagingContext = sparkContext.getMessagingContext();
+  }
+
+  @Override
+  public void createTopic(String topic) throws TopicAlreadyExistsException, IOException {
+    admin.createTopic(topic);
+  }
+
+  @Override
+  public void createTopic(String topic,
+                          Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
+    admin.createTopic(topic, properties);
+  }
+
+  @Override
+  public Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException {
+    return admin.getTopicProperties(topic);
+  }
+
+  @Override
+  public void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException {
+    admin.updateTopic(topic, properties);
+  }
+
+  @Override
+  public void deleteTopic(String topic) throws TopicNotFoundException, IOException {
+    admin.deleteTopic(topic);
+  }
+
+  @Override
+  public MessagePublisher getMessagePublisher() {
+    return messagingContext.getMessagePublisher();
+  }
+
+  @Override
+  public MessagePublisher getDirectMessagePublisher() {
+    return messagingContext.getDirectMessagePublisher();
+  }
+
+  @Override
+  public MessageFetcher getMessageFetcher() {
+    return messagingContext.getMessageFetcher();
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceContext.java
@@ -19,36 +19,26 @@ package io.cdap.cdap.etl.spark.batch;
 import io.cdap.cdap.api.data.DatasetContext;
 import io.cdap.cdap.api.data.batch.Input;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
-import io.cdap.cdap.api.messaging.MessageFetcher;
-import io.cdap.cdap.api.messaging.MessagePublisher;
-import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
-import io.cdap.cdap.api.messaging.TopicNotFoundException;
 import io.cdap.cdap.api.spark.SparkClientContext;
-import io.cdap.cdap.etl.api.StageSubmitterContext;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
-import io.cdap.cdap.etl.batch.AbstractBatchContext;
 import io.cdap.cdap.etl.batch.preview.LimitingInputFormatProvider;
 import io.cdap.cdap.etl.common.ExternalDatasets;
 import io.cdap.cdap.etl.common.PipelineRuntime;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.SparkSubmitterContext;
 
-import java.io.IOException;
-import java.util.Map;
 import java.util.UUID;
 
 /**
  * Default implementation of {@link BatchSourceContext} for spark contexts.
  */
-public class SparkBatchSourceContext extends AbstractBatchContext
-  implements BatchSourceContext, StageSubmitterContext {
+public class SparkBatchSourceContext extends SparkSubmitterContext implements BatchSourceContext {
   private final SparkBatchSourceFactory sourceFactory;
   private final boolean isPreviewEnabled;
-  private final SparkClientContext sparkContext;
 
   public SparkBatchSourceContext(SparkBatchSourceFactory sourceFactory, SparkClientContext sparkContext,
                                  PipelineRuntime pipelineRuntime, DatasetContext datasetContext, StageSpec stageSpec) {
-    super(pipelineRuntime, stageSpec, datasetContext, sparkContext.getAdmin());
-    this.sparkContext = sparkContext;
+    super(sparkContext, pipelineRuntime, datasetContext, stageSpec);
     this.sourceFactory = sourceFactory;
     this.isPreviewEnabled = sparkContext.getDataTracer(stageSpec.getName()).isEnabled();
   }
@@ -75,46 +65,5 @@ public class SparkBatchSourceContext extends AbstractBatchContext
   private Input suffixInput(Input input) {
     String suffixedAlias = String.format("%s-%s", input.getAlias(), UUID.randomUUID());
     return input.alias(suffixedAlias);
-  }
-
-  @Override
-  public MessagePublisher getMessagePublisher() {
-    return sparkContext.getMessagePublisher();
-  }
-
-  @Override
-  public MessagePublisher getDirectMessagePublisher() {
-    return sparkContext.getDirectMessagePublisher();
-  }
-
-  @Override
-  public MessageFetcher getMessageFetcher() {
-    return sparkContext.getMessageFetcher();
-  }
-
-  @Override
-  public void createTopic(String topic) throws TopicAlreadyExistsException, IOException {
-    sparkContext.getAdmin().createTopic(topic);
-  }
-
-  @Override
-  public void createTopic(String topic,
-                          Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
-    sparkContext.getAdmin().createTopic(topic, properties);
-  }
-
-  @Override
-  public Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException {
-    return sparkContext.getAdmin().getTopicProperties(topic);
-  }
-
-  @Override
-  public void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException {
-    sparkContext.getAdmin().updateTopic(topic, properties);
-  }
-
-  @Override
-  public void deleteTopic(String topic) throws TopicNotFoundException, IOException {
-    sparkContext.getAdmin().deleteTopic(topic);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceFactory.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceFactory.java
@@ -41,13 +41,13 @@ import static java.lang.Thread.currentThread;
  * A POJO class for storing source information being set from {@link SparkBatchSourceContext} and used in
  * {@link BatchSparkPipelineDriver}.
  */
-final class SparkBatchSourceFactory {
+public final class SparkBatchSourceFactory {
 
   private final Map<String, InputFormatProvider> inputFormatProviders;
   private final Map<String, DatasetInfo> datasetInfos;
   private final Map<String, Set<String>> sourceInputs;
 
-  SparkBatchSourceFactory() {
+  public SparkBatchSourceFactory() {
     this.inputFormatProviders = new HashMap<>();
     this.datasetInfos = new HashMap<>();
     this.sourceInputs = new HashMap<>();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/plugin/WrappedStreamingSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/plugin/WrappedStreamingSource.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.etl.spark.plugin;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
+import io.cdap.cdap.etl.api.streaming.StreamingSourceContext;
 import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.common.plugin.Caller;
 import org.apache.spark.streaming.api.java.JavaDStream;
@@ -48,6 +49,22 @@ public class WrappedStreamingSource<T> extends StreamingSource<T> {
         source.configurePipeline(pipelineConfigurer);
         return null;
       }
+    });
+  }
+
+  @Override
+  public void prepareRun(StreamingSourceContext context) throws Exception {
+    caller.call((Callable<Void>) () -> {
+      source.prepareRun(context);
+      return null;
+    });
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, StreamingSourceContext context) {
+    caller.callUnchecked((Callable<Void>) () -> {
+      source.onRunFinish(succeeded, context);
+      return null;
     });
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -70,8 +70,9 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
   }
 
   @Override
-  public void registerLineage(final String referenceName)
+  public void registerLineage(String referenceName)
     throws DatasetManagementException, TransactionFailureException {
+
     try {
       if (!admin.datasetExists(referenceName)) {
         admin.createDataset(referenceName, EXTERNAL_DATASET_TYPE, DatasetProperties.EMPTY);
@@ -113,6 +114,7 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
 
   @Override
   public void record(List<FieldOperation> operations) {
-    throw new UnsupportedOperationException("Lineage recording is not supported.");
+    throw new UnsupportedOperationException("Field lineage recording is not supported. Please record lineage " +
+                                              "in prepareRun() stage");
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingSourceContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingSourceContext.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.streaming;
+
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.dataset.Dataset;
+import io.cdap.cdap.api.dataset.DatasetManagementException;
+import io.cdap.cdap.api.dataset.DatasetProperties;
+import io.cdap.cdap.api.dataset.InstanceConflictException;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.etl.api.streaming.StreamingSourceContext;
+import io.cdap.cdap.etl.batch.AbstractBatchContext;
+import io.cdap.cdap.etl.common.PipelineRuntime;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import org.apache.tephra.TransactionFailureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import javax.annotation.Nullable;
+
+/**
+ * Default implementation of streaming source context, this method will not start its own transaction when registering
+ * lineage since the prepareRun() method is run in its own transaction
+ */
+public class DefaultStreamingSourceContext extends AbstractBatchContext implements StreamingSourceContext {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultStreamingContext.class);
+  private static final String EXTERNAL_DATASET_TYPE = "externalDataset";
+  private final JavaSparkExecutionContext sec;
+
+  public DefaultStreamingSourceContext(PipelineRuntime pipelineRuntime, StageSpec stageSpec,
+                                       DatasetContext datasetContext, JavaSparkExecutionContext sec) {
+    super(pipelineRuntime, stageSpec, datasetContext, sec.getAdmin());
+    this.sec = sec;
+  }
+
+  @Override
+  public void registerLineage(String referenceName,
+                              @Nullable Schema schema) throws DatasetManagementException, TransactionFailureException {
+    DatasetProperties datasetProperties;
+    if (schema == null) {
+      datasetProperties = DatasetProperties.EMPTY;
+    } else {
+      datasetProperties = DatasetProperties.of(Collections.singletonMap(DatasetProperties.SCHEMA, schema.toString()));
+    }
+
+    try {
+      if (!admin.datasetExists(referenceName)) {
+        admin.createDataset(referenceName, EXTERNAL_DATASET_TYPE, datasetProperties);
+      }
+    } catch (InstanceConflictException ex) {
+      // Might happen if there is executed in multiple drivers in parallel. A race condition exists between check
+      // for dataset existence and creation.
+      LOG.debug("Dataset with name {} already created. Hence not creating the external dataset.", referenceName);
+    }
+
+    // we cannot start transaction here, since all prepare run is running in its own transaction
+    Dataset ds = getDataset(referenceName);
+    try {
+      Class<? extends Dataset> dsClass = ds.getClass();
+      Method method = dsClass.getMethod("recordRead");
+      method.invoke(ds);
+    } catch (NoSuchMethodException e) {
+      LOG.warn("ExternalDataset '{}' does not have method 'recordRead()'. " +
+                 "Can't register read-only lineage for this dataset", referenceName);
+    } catch (Exception e) {
+      LOG.warn("Unable to register read access for dataset {}", referenceName);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/SparkStreamingPreparer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/SparkStreamingPreparer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.streaming;
+
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.metrics.Metrics;
+import io.cdap.cdap.api.plugin.PluginContext;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.etl.api.batch.BatchConfigurable;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
+import io.cdap.cdap.etl.api.streaming.StreamingSource;
+import io.cdap.cdap.etl.batch.PipelinePluginInstantiator;
+import io.cdap.cdap.etl.common.PipelineRuntime;
+import io.cdap.cdap.etl.common.submit.ContextProvider;
+import io.cdap.cdap.etl.common.submit.SubmitterPlugin;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.AbstractSparkPreparer;
+import io.cdap.cdap.etl.spark.SparkSubmitterContext;
+import io.cdap.cdap.etl.spark.batch.BasicSparkPluginContext;
+import io.cdap.cdap.etl.spark.batch.SparkBatchSinkContext;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Preparer for spark streaming pipeline
+ */
+public class SparkStreamingPreparer extends AbstractSparkPreparer {
+  private final JavaSparkExecutionContext context;
+
+  public SparkStreamingPreparer(PluginContext pluginContext, Metrics metrics, MacroEvaluator macroEvaluator,
+                                PipelineRuntime pipelineRuntime, JavaSparkExecutionContext context) {
+    super(pluginContext, metrics, macroEvaluator, pipelineRuntime, context.getAdmin(), context);
+    this.context = context;
+  }
+
+  @Nullable
+  @Override
+  protected SubmitterPlugin createSource(BatchConfigurable<BatchSourceContext> batchSource, StageSpec stageSpec) {
+    return null;
+  }
+
+  @Override
+  protected SubmitterPlugin createStreamingSource(PipelinePluginInstantiator pluginInstantiator,
+                                                  StageSpec stageSpec) throws InstantiationException {
+    String stageName = stageSpec.getName();
+    StreamingSource<?> streamingSource = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+    ContextProvider<DefaultStreamingSourceContext> contextProvider =
+      dsContext -> new DefaultStreamingSourceContext(pipelineRuntime, stageSpec, dsContext, context);
+    return new SubmitterPlugin<>(stageName, context, streamingSource, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SparkBatchSinkContext getSparkBatchSinkContext(DatasetContext dsContext, StageSpec stageSpec) {
+    return new SparkBatchSinkContext(sinkFactory, context, dsContext, pipelineRuntime, stageSpec);
+  }
+
+  @Override
+  protected BasicSparkPluginContext getSparkPluginContext(DatasetContext dsContext, StageSpec stageSpec) {
+    return new BasicSparkPluginContext(null, pipelineRuntime, stageSpec, dsContext, context.getAdmin());
+  }
+
+  @Override
+  protected SparkSubmitterContext getSparkSubmitterContext(DatasetContext dsContext, StageSpec stageSpec) {
+    return new SparkSubmitterContext(context, pipelineRuntime, dsContext, stageSpec);
+  }
+
+  public Map<String, List<FieldOperation>> getFieldOperations() {
+    return stageOperations;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/action/MockActionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/action/MockActionContext.java
@@ -245,6 +245,11 @@ public class MockActionContext implements ActionContext {
   }
 
   @Override
+  public void flushLineage() {
+    // no-op
+  }
+
+  @Override
   public FailureCollector getFailureCollector() {
     return collector;
   }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.condition.Condition;
 import io.cdap.cdap.etl.api.lineage.AccessType;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.cdap.etl.mock.action.FieldLineageAction;
@@ -142,7 +143,9 @@ public class HydratorTestBase extends TestBase {
                    Transform.class.getPackage().getName(),
                    SparkCompute.class.getPackage().getName(),
                    InvalidStageException.class.getPackage().getName(),
-                   PipelineConfigurable.class.getPackage().getName());
+                   PipelineConfigurable.class.getPackage().getName(),
+                   // have to export this package, otherwise getting ClassCastException in unit test
+                   FieldOperation.class.getPackage().getName());
 
 
     streamingMocksArtifactId = new ArtifactId(artifactId.getNamespace(), artifactId.getArtifact() + "-mocks", "1.0.0");

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/IdentityTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/IdentityTransform.java
@@ -28,10 +28,13 @@ import io.cdap.cdap.etl.api.StageConfigurer;
 import io.cdap.cdap.etl.api.StageSubmitterContext;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.TransformContext;
+import io.cdap.cdap.etl.api.lineage.field.FieldTransformOperation;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Identity transform for testing.
@@ -50,6 +53,13 @@ public class IdentityTransform extends Transform<StructuredRecord, StructuredRec
   @Override
   public void prepareRun(StageSubmitterContext context) throws Exception {
     super.prepareRun(context);
+    Schema schema = context.getInputSchema();
+    if (schema != null && schema.getFields() != null) {
+      schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList())
+        .forEach(field -> context.record(Collections.singletonList(
+          new FieldTransformOperation("Identity transform " + field, "Identity transform",
+                                      Collections.singletonList(field), field))));
+    }
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/BasicSparkClientContext.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/BasicSparkClientContext.java
@@ -426,6 +426,11 @@ final class BasicSparkClientContext implements SparkClientContext {
   }
 
   @Override
+  public void flushLineage() {
+    sparkRuntimeContext.flushLineage();
+  }
+
+  @Override
   public void addProperties(MetadataEntity metadataEntity, Map<String, String> properties) {
     sparkRuntimeContext.addProperties(metadataEntity, properties);
   }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -86,7 +86,7 @@ import javax.annotation.Nullable;
  */
 @VisibleForTesting
 public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
-                                      implements ProgramClassLoaderProvider, Closeable {
+  implements ProgramClassLoaderProvider, Closeable {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkProgramRunner.class);
 
@@ -191,7 +191,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                                                                    authorizationEnforcer, authenticationContext,
                                                                    messagingService, serviceAnnouncer, pluginFinder,
                                                                    locationFactory, metadataReader, metadataPublisher,
-                                                                   namespaceQueryAdmin);
+                                                                   namespaceQueryAdmin, fieldLineageWriter);
       closeables.addFirst(runtimeContext);
 
       Spark spark;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -32,6 +32,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.lang.WeakReferenceDelegatorClassLoader;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
@@ -86,11 +87,11 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
                       MessagingService messagingService, ServiceAnnouncer serviceAnnouncer,
                       PluginFinder pluginFinder, LocationFactory locationFactory,
                       MetadataReader metadataReader, MetadataPublisher metadataPublisher,
-                      NamespaceQueryAdmin namespaceQueryAdmin) {
+                      NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter) {
     super(program, programOptions, cConf, getSparkSpecification(program).getDatasets(), datasetFramework, txClient,
           discoveryServiceClient, true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin);
+          namespaceQueryAdmin, fieldLineageWriter);
     this.cConf = cConf;
     this.hConf = hConf;
     this.hostname = hostname;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -51,6 +51,7 @@ import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.service.ServiceDiscoverable;
 import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
 import io.cdap.cdap.internal.app.runtime.ProgramClassLoader;
@@ -271,7 +272,8 @@ public final class SparkRuntimeContextProvider {
         injector.getInstance(LocationFactory.class),
         injector.getInstance(MetadataReader.class),
         injector.getInstance(MetadataPublisher.class),
-        injector.getInstance(NamespaceQueryAdmin.class)
+        injector.getInstance(NamespaceQueryAdmin.class),
+        injector.getInstance(FieldLineageWriter.class)
       );
       LoggingContextAccessor.setLoggingContext(sparkRuntimeContext.getLoggingContext());
       return sparkRuntimeContext;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -447,6 +447,8 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     runtimeContext.destroyProgram(programLifecycle, txControl, false);
     if (emitFieldLineage()) {
       try {
+        // here we cannot call context.flushRecord() since the WorkflowNodeState will need to record and store
+        // the lineage information
         FieldLineageInfo info = new FieldLineageInfo(runtimeContext.getFieldLineageOperations());
         fieldLineageWriter.write(runtimeContext.getProgramRunId(), info);
       } catch (Throwable t) {
@@ -707,7 +709,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
 
     // See if the scriptURI is on the same cluster.
     if (Objects.equals(homeURI.getScheme(), scriptURI.getScheme())
-        && Objects.equals(homeURI.getAuthority(), scriptURI.getAuthority())) {
+      && Objects.equals(homeURI.getAuthority(), scriptURI.getAuthority())) {
       // If the extension is ".py", just return it.
       if (scriptURI.getPath().endsWith(".py")) {
         return scriptURI;
@@ -947,7 +949,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
           invalidateAll.setAccessible(true);
           invalidateAll.invoke(cache);
           LOG.debug("BeanIntrospector.ctorParamNamesCache has been invalidated.");
-        break;
+          break;
 
         default:
           // Unexpected, maybe due to version change in the BeanIntrospector, hence log a WARN.

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
@@ -35,6 +35,7 @@ import io.cdap.cdap.api.data.batch.DatasetOutputCommitter
 import io.cdap.cdap.api.data.batch.OutputFormatProvider
 import io.cdap.cdap.api.data.batch.Split
 import io.cdap.cdap.api.dataset.Dataset
+import io.cdap.cdap.api.lineage.field.Operation
 import io.cdap.cdap.api.messaging.MessagingContext
 import io.cdap.cdap.api.metadata.Metadata
 import io.cdap.cdap.api.metadata.MetadataEntity
@@ -361,6 +362,14 @@ abstract class AbstractSparkExecutionContext(sparkClassLoader: SparkClassLoader,
 
   override def removeTags(metadataEntity: MetadataEntity, tags: String*): Unit = {
     runtimeContext.removeTags(metadataEntity, tags:_*)
+  }
+
+  override def record(operations: util.Collection[_ <: Operation]): Unit = {
+    runtimeContext.record(operations)
+  }
+
+  override def flushLineage(): Unit = {
+    runtimeContext.flushLineage()
   }
 
   override def getDataTracer(tracerName: String): DataTracer = new SparkDataTracer(runtimeContext, tracerName)

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.ServiceDiscoverer
 import io.cdap.cdap.api.TxRunnable
 import io.cdap.cdap.api.app.ApplicationSpecification
 import io.cdap.cdap.api.data.batch.Split
+import io.cdap.cdap.api.lineage.field.Operation
 import io.cdap.cdap.api.messaging.MessagingContext
 import io.cdap.cdap.api.metadata.Metadata
 import io.cdap.cdap.api.metadata.MetadataEntity
@@ -182,5 +183,13 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
 
   override def removeTags(metadataEntity: MetadataEntity, tags: String*): Unit = {
     sec.removeTags(metadataEntity, tags:_*)
+  }
+
+  override def record(operations: util.Collection[_ <: Operation]): Unit = {
+    sec.record(operations)
+  }
+
+  override def flushLineage(): Unit = {
+    sec.flushLineage()
   }
 }

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -21,6 +21,7 @@ import java.{lang, util}
 
 import io.cdap.cdap.api.TxRunnable
 import io.cdap.cdap.api.data.batch.Split
+import io.cdap.cdap.api.lineage.field.Operation
 import io.cdap.cdap.api.metadata.{Metadata, MetadataEntity, MetadataScope}
 import io.cdap.cdap.api.preview.DataTracer
 import io.cdap.cdap.api.schedule.TriggeringScheduleInfo
@@ -154,4 +155,12 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
   override def getTriggeringScheduleInfo: Option[TriggeringScheduleInfo] = delegate.getTriggeringScheduleInfo
 
   override def toJavaSparkExecutionContext() = delegate.toJavaSparkExecutionContext()
+
+  override def record(operations: util.Collection[_ <: Operation]): Unit = {
+    delegate.record(operations)
+  }
+
+  override def flushLineage(): Unit = {
+    delegate.flushLineage()
+  }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-13643
build: https://builds.cask.co/browse/CDAP-DUT7108

Added the ability for streaming pipeline to emit field lineage. Currently we record lineage before anything runs and we force people to emit lineage in `prepareRun` instead of `getStream` because due to checkpointing, some part of code might not get run. For example, I have seen `getStream()` not getting called during the second run in the unit test. And thus no lineage is getting emitted by the source. 

This means before any data is written, the dataset lineage for streaming source is recorded as well as all the field lineage. And there are two drawbacks:
1. Dataset lineage for the sink is recorded automatically using external dataset, which means it will only be recorded if there is actually data written to it. So the dataset lineage will have an incomplete graph(showing just the streaming source) if the pipeline is just starting or it fails to process any data.
2. Field lineage will be complete. But since dataset lineage is not, clicking into field lineage page will result in a confusing complete graph. 

Looking to see if I can move the code of recording lineage in the sink runnables. This we can make sure the lineage is only written if the data is written to the sink. But since there are already so many files changed, looking to merge this one first