### PR TITLE
[CDAP-16249] Show/hide unrelated fields in cause/impact datasets

### DIFF
--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
@@ -18,16 +18,18 @@ import React from 'react';
 import { objectQuery, parseQueryString } from 'services/helpers';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import {
-  IField,
-  ITablesList,
-  ITimeParams,
+  fetchUnrelatedFields,
+  getDefaultLinks,
+  getFieldLineage,
   getTableId,
   getTimeRange,
   getTimeRangeFromUrl,
   replaceHistory,
-  getFieldLineage,
+  IField,
   ILinkSet,
-  getDefaultLinks,
+  ITableInfo,
+  ITablesList,
+  ITimeParams,
 } from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
 import * as d3 from 'd3';
 import { TIME_OPTIONS } from 'components/FieldLevelLineage/store/Store';
@@ -38,7 +40,7 @@ import {
 
 const defaultContext: IContextState = {
   target: '',
-  targetFields: [],
+  targetFields: {},
   links: getDefaultLinks(),
   causeSets: {},
   impactSets: {},
@@ -54,11 +56,11 @@ const defaultContext: IContextState = {
 
 export const FllContext = React.createContext<IContextState>(defaultContext);
 
-type ITimeType = number | string | null;
+export type ITimeType = number | string | null;
 
 export interface IContextState {
   target: string;
-  targetFields: IField[];
+  targetFields: ITableInfo;
   links: ILinkSet;
   causeSets: ITablesList;
   impactSets: ITablesList;
@@ -75,6 +77,7 @@ export interface IContextState {
   handleFieldClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
   handleViewCauseImpact?: () => void;
   handleReset?: () => void;
+  handleExpandFields?: (namespace: string, entityId: string, type: string) => void;
   activeField?: IField;
   activeCauseSets?: ITablesList;
   activeImpactSets?: ITablesList;
@@ -192,10 +195,10 @@ export class Provider extends React.Component<{ children }, IContextState> {
     const namespace = getCurrentNamespace();
     const updateState = (newState: IContextState) => {
       // If no field selected, grab the first field with lineage
-      if (!newState.activeField.id && newState.targetFields.length > 0) {
+      if (!newState.activeField.id && newState.targetFields.fields.length > 0) {
         newState.activeField = {
-          id: newState.targetFields[0].id,
-          name: newState.targetFields[0].name,
+          id: newState.targetFields.fields[0].id,
+          name: newState.targetFields.fields[0].name,
         };
       }
 
@@ -292,9 +295,48 @@ export class Provider extends React.Component<{ children }, IContextState> {
     });
   };
 
+  private handleExpandFields = (namespace: string, tablename: string, type: string) => {
+    const entityId = getTableId(tablename, namespace, type);
+    const relatedFields =
+      type === 'cause'
+        ? this.state.causeSets[entityId].fields
+        : this.state.impactSets[entityId].fields;
+
+    const allSets = type === 'cause' ? this.state.causeSets : this.state.impactSets;
+    const updatedSets = { ...allSets };
+
+    // If we already the unrelated fields for this table, no need to fetch again - just update expansion state for that table
+    if (allSets[entityId].hasOwnProperty('unrelatedFields')) {
+      updatedSets[entityId].isExpanded = !updatedSets[entityId].isExpanded;
+      this.setState(updatedSets);
+      return;
+    }
+
+    fetchUnrelatedFields(
+      namespace,
+      tablename,
+      type,
+      relatedFields,
+      this.state.start,
+      this.state.end
+    ).subscribe(
+      (unrelatedFields) => {
+        // Look up the sets to update (cause or impact)
+        // Add unrelated fields to the appropriate entity in the cause or impact sets
+        updatedSets[entityId].unrelatedFields = unrelatedFields;
+        updatedSets[entityId].isExpanded = true;
+        this.setState(updatedSets);
+      },
+      (err) => {
+        // tslint:disable-next-line: no-console
+        console.error('Error getting unrelated fields', err);
+      }
+    );
+  };
+
   public state = {
     target: '',
-    targetFields: [],
+    targetFields: {},
     links: getDefaultLinks(),
     causeSets: {},
     impactSets: {},
@@ -319,6 +361,7 @@ export class Provider extends React.Component<{ children }, IContextState> {
     handleFieldClick: this.handleFieldClick,
     handleViewCauseImpact: this.handleViewCauseImpact,
     handleReset: this.handleReset,
+    handleExpandFields: this.handleExpandFields,
     setTimeRange: this.setTimeRange,
     setCustomTimeRange: this.setCustomTimeRange,
     toggleOperations: this.toggleOperations,

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllHeader/index.tsx
@@ -72,7 +72,7 @@ function FllHeader({ type, total, classes }: IHeaderProps) {
     last = total;
   }
 
-  const options = { first, last, total };
+  const options = { first, last, total, context: total };
   let subHeader;
 
   if (total === 0) {

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllExpandableField.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllExpandableField.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import classnames from 'classnames';
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
+import T from 'i18n-react';
+
+export const styles = (theme) => {
+  return {
+    root: {
+      color: theme.palette.blue[200],
+      fontSize: '0.92em',
+      cursor: 'pointer',
+    },
+  };
+};
+
+interface IExpandableFieldProps extends WithStyles<typeof styles> {
+  isExpanded: boolean;
+  handleClick: () => void;
+  tablename: string;
+}
+
+const I18N_PREFIX = 'features.FieldLevelLineage.v2.FllTable.FllExpandableField';
+
+function ExpandableField({ isExpanded, handleClick, tablename, classes }: IExpandableFieldProps) {
+  const message = isExpanded
+    ? T.translate(`${I18N_PREFIX}.hideFields`)
+    : T.translate(`${I18N_PREFIX}.showFields`);
+  const arrowIcon = isExpanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />;
+  return (
+    <div
+      className={classnames('grid-row', 'grid-link', classes.root)}
+      data-cy={`${isExpanded ? 'hide' : 'show'}-fields-panel-${tablename}`}
+      onClick={handleClick}
+    >
+      {message}
+      {arrowIcon}
+    </div>
+  );
+}
+
+const StyledExpandableField = withStyles(styles)(ExpandableField);
+export default StyledExpandableField;

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
@@ -27,7 +27,7 @@ import { Link } from 'react-router-dom';
 import { FllContext, IContextState } from 'components/FieldLevelLineage/v2/Context/FllContext';
 import FllMenu from 'components/FieldLevelLineage/v2/FllTable/FllMenu';
 
-const styles = (theme): StyleRules => {
+export const styles = (theme): StyleRules => {
   return {
     root: {
       '&.grid-row.activeField': {

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/index.tsx
@@ -20,9 +20,11 @@ import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import createStyles from '@material-ui/core/styles/createStyles';
 import T from 'i18n-react';
 import classnames from 'classnames';
-import { IField } from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
+import { IField, ITableInfo } from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
 import FllField from 'components/FieldLevelLineage/v2/FllTable/FllField';
 import { FllContext, IContextState } from 'components/FieldLevelLineage/v2/Context/FllContext';
+import ExpandableField from 'components/FieldLevelLineage/v2/FllTable/FllExpandableField';
+import If from 'components/If';
 
 // TO DO: Consolidate different fontsizes in ThemeWrapper
 const styles = (theme) => {
@@ -90,66 +92,70 @@ const styles = (theme) => {
 
 interface ITableProps extends WithStyles<typeof styles> {
   tableId?: string;
-  fields?: IField[];
+  tableInfo?: ITableInfo;
   type?: string;
   isActive?: boolean;
 }
 
-function renderGridHeader(fields: IField[], isTarget: boolean, classes) {
+function renderGridHeader(
+  fields: IField[],
+  isTarget: boolean,
+  isExpanded: boolean = false,
+  classes
+) {
   const count: number = fields.length;
   const tableName = fields[0].dataset;
+  const options = { context: count };
   return (
     <div className={classes.tableHeader}>
       <div className="table-name">{tableName}</div>
       <div className={classes.tableSubheader}>
-        {isTarget
-          ? T.translate('features.FieldLevelLineage.v2.FllTable.fieldsCount', {
-              context: count,
-            })
-          : T.translate('features.FieldLevelLineage.v2.FllTable.relatedFieldsCount', {
-              context: count,
-            })}
+        {isTarget || isExpanded
+          ? T.translate('features.FieldLevelLineage.v2.FllTable.fieldsCount', options)
+          : T.translate('features.FieldLevelLineage.v2.FllTable.relatedFieldsCount', options)}
       </div>
     </div>
   );
 }
 
-function renderGridBody(fields: IField[], tableName: string, activeFields = new Set(), classes) {
+function renderGridBody(
+  fields: IField[],
+  tableId: string,
+  activeFields = new Set(),
+  hasUnrelatedFields: boolean = false,
+  isExpanded: boolean = false,
+  handleClick: () => void,
+  classes
+) {
+  const namespace = fields[0].namespace;
   return (
     <div
       className={classes.gridBody}
-      id={tableName}
-      data-tablename={fields[0].dataset}
-      data-namespace={fields[0].namespace}
+      id={tableId}
+      data-tablename={tableId}
+      data-namespace={namespace}
     >
       {fields.map((field) => {
         const isActiveField = activeFields.has(field.id);
         return <FllField key={field.id} field={field} isActive={isActiveField} />;
       })}
+      <If condition={hasUnrelatedFields}>
+        <ExpandableField
+          isExpanded={isExpanded}
+          handleClick={handleClick}
+          tablename={fields[0].dataset}
+        />
+      </If>
     </div>
   );
 }
 
-function FllTable({ tableId, fields, type, isActive, classes }: ITableProps) {
+function FllTable({ tableId, tableInfo, type, isActive, classes }: ITableProps) {
   const GRID_HEADERS = [{ property: 'name', label: tableId }];
-  const { target, activeCauseSets, activeImpactSets } = useContext<IContextState>(FllContext);
-  const isTarget = type === 'target';
-
-  // get fields that are a direct cause or impact to selected field
-  let activeFields = [];
-  if (isActive && !isTarget) {
-    if (type === 'cause' && Object.keys(activeCauseSets).length > 0) {
-      activeFields = activeCauseSets[tableId].fields;
-    } else if (type === 'impact' && Object.keys(activeImpactSets).length > 0) {
-      activeFields = activeImpactSets[tableId].fields;
-    }
-  }
-
-  const activeFieldIds = new Set(
-    activeFields.map((field) => {
-      return field.id;
-    })
-  );
+  const { target, activeCauseSets, activeImpactSets, handleExpandFields } = useContext<
+    IContextState
+  >(FllContext);
+  let fields = tableInfo ? tableInfo.fields : [];
 
   if (!fields || fields.length === 0) {
     return (
@@ -158,6 +164,44 @@ function FllTable({ tableId, fields, type, isActive, classes }: ITableProps) {
       </div>
     );
   }
+
+  const unrelatedFields = tableInfo.unrelatedFields;
+  const fieldCount = tableInfo.fieldCount;
+  const isExpanded = tableInfo.isExpanded || false;
+  const isTarget = type === 'target';
+  const hasUnrelatedFields = fields.length < fieldCount;
+
+  // If there are unrelated fields AND the user has expanded to see all fields
+  // render the unrelated fields
+  if (unrelatedFields && isExpanded) {
+    fields = fields.concat(unrelatedFields);
+  }
+
+  // get fields that are a direct cause or impact to selected field
+  const getActiveFields = () => {
+    let activeFields = [];
+    if (isActive && !isTarget) {
+      if (type === 'cause' && Object.keys(activeCauseSets).length > 0) {
+        activeFields = activeCauseSets[tableId].fields;
+      } else if (type === 'impact' && Object.keys(activeImpactSets).length > 0) {
+        activeFields = activeImpactSets[tableId].fields;
+      }
+    }
+    return activeFields;
+  };
+
+  const activeFieldIds = new Set(
+    getActiveFields().map((field) => {
+      return field.id;
+    })
+  );
+
+  const handleClick = () => {
+    const namespace = fields[0].namespace;
+    const tablename = fields[0].dataset;
+
+    handleExpandFields(namespace, tablename, type);
+  };
 
   return (
     <SortableStickyGrid
@@ -169,8 +213,17 @@ function FllTable({ tableId, fields, type, isActive, classes }: ITableProps) {
         { [classes.targetTable]: isTarget },
         { [classes.activeTable]: isActive }
       )}
-      renderGridHeader={renderGridHeader.bind(null, fields, isTarget, classes)}
-      renderGridBody={renderGridBody.bind(this, fields, tableId, activeFieldIds, classes)}
+      renderGridHeader={renderGridHeader.bind(null, fields, isTarget, isExpanded, classes)}
+      renderGridBody={renderGridBody.bind(
+        this,
+        fields,
+        tableId,
+        activeFieldIds,
+        hasUnrelatedFields,
+        isExpanded,
+        handleClick,
+        classes
+      )}
     />
   );
 }

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/LineageSummary/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/LineageSummary/index.tsx
@@ -275,7 +275,7 @@ class LineageSummary extends React.Component<{ classes }, ILineageState> {
                         <FllTable
                           key={tableId}
                           tableId={tableId}
-                          fields={tableInfo.fields}
+                          tableInfo={tableInfo}
                           type="cause"
                           isActive={isActive}
                         />
@@ -283,8 +283,8 @@ class LineageSummary extends React.Component<{ classes }, ILineageState> {
                     })}
                   </div>
                   <div data-cy="target-fields" className={this.props.classes.summaryCol}>
-                    <FllHeader type="target" total={Object.keys(targetFields).length} />
-                    <FllTable tableId={target} fields={targetFields} type="target" />
+                    <FllHeader type="target" total={targetFields.fields.length} />
+                    <FllTable tableId={target} tableInfo={targetFields} type="target" />
                   </div>
                   <div data-cy="impact-fields" className={this.props.classes.summaryCol}>
                     <FllHeader type="impact" total={Object.keys(visibleImpactSets).length} />
@@ -297,7 +297,7 @@ class LineageSummary extends React.Component<{ classes }, ILineageState> {
                         <FllTable
                           key={tableId}
                           tableId={tableId}
-                          fields={tableInfo.fields}
+                          tableInfo={tableInfo}
                           type="impact"
                           isActive={isActive}
                         />

--- a/cdap-ui/app/cdap/components/KeyValuePairs/KeyValuePair.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/KeyValuePair.js
@@ -142,7 +142,7 @@ class KeyValuePair extends Component {
 
   render() {
     return (
-      <div className="key-value-pair-preference">
+      <div className="key-value-pair-preference" data-cy={`key-value-pair-${this.props.index}`}>
         {this.renderKeyField()}
         {this.renderValueField()}
         {this.renderActionButtons()}

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsModeless/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsModeless/index.js
@@ -97,6 +97,7 @@ class RuntimeArgsModeless extends PureComponent {
         <BtnWithLoading
           loading={this.state.saving}
           className="btn btn-primary"
+          data-cy="save-runtime-args-btn"
           onClick={this.saveRuntimeArgs}
           disabled={this.state.saving || !isEmpty(this.state.savedSuccessMessage)}
           label="Save"

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1541,13 +1541,20 @@ features:
         InputHeader: "Input datasets to {target}"
         NoRelatedSubheader: "0 datasets"
         OutputHeader: "Output datasets from {target}"
-        RelatedSubheader: "Viewing {first} to {last} of {total} datasets"
+        RelatedSubheader: 
+          1: "Viewing {first} of {total} dataset"
+          _: "Viewing {first} to {last} of {total} datasets"
         TargetHeader: 'Select a field to view lineage and transformations'
-        TargetSubheader: "Viewing {first} to {last} of {total} fields"
+        TargetSubheader:
+          1:  "Viewing {first} of {total} field"
+          _:  "Viewing {first} to {last} of {total} fields"
       FllTable:
         fieldsCount:
           1: "{context} field"
           _: "{context} fields"
+        FllExpandableField:
+          hideFields: "Hide unrelated fields"
+          showFields: "Show unrelated fields"
         FllField:
           viewLineage: "View"
           viewDropdown: "View"

--- a/cdap-ui/cypress/fixtures/fll_wrangler-test-pipeline.json
+++ b/cdap-ui/cypress/fixtures/fll_wrangler-test-pipeline.json
@@ -1,28 +1,28 @@
 {
-    "name": "Airport_test",
-    "description": "Data Pipeline Application",
     "artifact": {
         "name": "cdap-data-pipeline",
-        "version": "[6.1.0-SNAPSHOT, 6.2.0-SNAPSHOT]",
+        "version": "[6.2.0-SNAPSHOT, 7.0.0-SNAPSHOT]",
         "scope": "SYSTEM"
     },
+    "description": "With wrangler. Drops fields to get unrelated fields.",
+    "name": "FLL_airport_pipeline2",
     "config": {
         "resources": {
-            "memoryMB": 1024,
+            "memoryMB": 2048,
             "virtualCores": 1
         },
         "driverResources": {
-            "memoryMB": 1024,
+            "memoryMB": 2048,
             "virtualCores": 1
         },
         "connections": [
             {
-                "from": "Airport_source",
+                "from": "BigQueryTable",
                 "to": "Wrangler"
             },
             {
                 "from": "Wrangler",
-                "to": "Airport_sink"
+                "to": "Avro-Time-Partitioned-Dataset"
             }
         ],
         "comments": [],
@@ -32,41 +32,31 @@
         "stageLoggingEnabled": true,
         "stages": [
             {
-                "name": "Airport_source",
+                "name": "BigQueryTable",
                 "plugin": {
-                    "name": "File",
+                    "name": "BigQueryTable",
                     "type": "batchsource",
-                    "label": "Airport_source",
+                    "label": "BigQueryTable",
                     "artifact": {
-                        "name": "core-plugins",
-                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
+                        "name": "google-cloud",
+                        "version": "[0.15.0-SNAPSHOT, 1.0.0-SNAPSHOT]",
                         "scope": "SYSTEM"
                     },
                     "properties": {
-                        "copyHeader": "true",
-                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":\"string\"}]}",
-                        "path": "file:/tmp/cdap-ui-integration-fixtures/airports.csv",
-                        "format": "text",
-                        "ignoreNonExistingFolders": "false",
-                        "recursive": "false",
-                        "referenceName": "airports.csv",
-                        "filenameOnly": "false"
+                        "project": "${projectId}",
+                        "serviceFilePath": "${serviceFilePath}",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"iata\",\"type\":[\"string\",\"null\"]},{\"name\":\"name\",\"type\":[\"string\",\"null\"]},{\"name\":\"city\",\"type\":[\"string\",\"null\"]},{\"name\":\"state\",\"type\":[\"string\",\"null\"]},{\"name\":\"country\",\"type\":[\"string\",\"null\"]},{\"name\":\"latitude\",\"type\":[\"double\",\"null\"]},{\"name\":\"longitude\",\"type\":[\"double\",\"null\"]}]}",
+                        "dataset": "fll_test",
+                        "referenceName": "airport_source",
+                        "table": "airports"
                     }
                 },
                 "outputSchema": [
                     {
                         "name": "etlSchemaBody",
-                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":\"string\"}]}"
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"iata\",\"type\":[\"string\",\"null\"]},{\"name\":\"name\",\"type\":[\"string\",\"null\"]},{\"name\":\"city\",\"type\":[\"string\",\"null\"]},{\"name\":\"state\",\"type\":[\"string\",\"null\"]},{\"name\":\"country\",\"type\":[\"string\",\"null\"]},{\"name\":\"latitude\",\"type\":[\"double\",\"null\"]},{\"name\":\"longitude\",\"type\":[\"double\",\"null\"]}]}"
                     }
-                ],
-                "type": "batchsource",
-                "label": "Airport_source",
-                "icon": "icon-file",
-                "$$hashKey": "object:2727",
-                "_uiPosition": {
-                    "left": "320px",
-                    "top": "239.5px"
-                }
+                ]
             },
             {
                 "name": "Wrangler",
@@ -76,66 +66,61 @@
                     "label": "Wrangler",
                     "artifact": {
                         "name": "wrangler-transform",
-                        "version": "[4.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
+                        "version": "[4.2.0-SNAPSHOT, 5.0.0-SNAPSHOT]",
                         "scope": "SYSTEM"
                     },
                     "properties": {
-                        "workspaceId": "d39a2514-b8f8-4314-a03f-1e7291d30428",
-                        "directives": "parse-as-csv :body ',' true\ndrop body",
-                        "schema": "{\"name\":\"avroSchema\",\"type\":\"record\",\"fields\":[{\"name\":\"iata\",\"type\":[\"string\",\"null\"]},{\"name\":\"name\",\"type\":[\"string\",\"null\"]},{\"name\":\"city\",\"type\":[\"string\",\"null\"]},{\"name\":\"state\",\"type\":[\"string\",\"null\"]},{\"name\":\"country\",\"type\":[\"string\",\"null\"]},{\"name\":\"latitude\",\"type\":[\"string\",\"null\"]},{\"name\":\"longitude\",\"type\":[\"string\",\"null\"]}]}",
-                        "field": "body",
+                        "field": "*",
                         "precondition": "false",
-                        "threshold": "1"
-                    }
-                },
-                "outputSchema": "{\"name\":\"avroSchema\",\"type\":\"record\",\"fields\":[{\"name\":\"iata\",\"type\":[\"string\",\"null\"]},{\"name\":\"name\",\"type\":[\"string\",\"null\"]},{\"name\":\"city\",\"type\":[\"string\",\"null\"]},{\"name\":\"state\",\"type\":[\"string\",\"null\"]},{\"name\":\"country\",\"type\":[\"string\",\"null\"]},{\"name\":\"latitude\",\"type\":[\"string\",\"null\"]},{\"name\":\"longitude\",\"type\":[\"string\",\"null\"]}]}",
-                "type": "transform",
-                "label": "Wrangler",
-                "icon": "icon-DataPreparation",
-                "$$hashKey": "object:2728",
-                "_uiPosition": {
-                    "left": "620px",
-                    "top": "239.5px"
-                }
-            },
-            {
-                "name": "Airport_sink",
-                "plugin": {
-                    "name": "File",
-                    "type": "batchsink",
-                    "label": "Airport_sink",
-                    "artifact": {
-                        "name": "core-plugins",
-                        "version": "[2.3.0-SNAPSHOT, 3.0.0-SNAPSHOT)",
-                        "scope": "SYSTEM"
-                    },
-                    "properties": {
-                        "suffix": "yyyy-MM-dd-HH-mm",
-                        "format": "csv",
-                        "referenceName": "Airport_sink",
-                        "path": "/tmp/cdap-ui-integration-fixtures"
+                        "threshold": "1",
+                        "workspaceId": "120cac00-0e66-4607-9672-e774a298d6b3",
+                        "directives": "drop name\ndrop state",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"iata\",\"type\":\"string\"},{\"name\":\"city\",\"type\":\"string\"},{\"name\":\"country\",\"type\":\"string\"},{\"name\":\"latitude\",\"type\":\"double\"},{\"name\":\"longitude\",\"type\":\"double\"}]}"
                     }
                 },
                 "outputSchema": [
                     {
                         "name": "etlSchemaBody",
-                        "schema": ""
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"iata\",\"type\":\"string\"},{\"name\":\"city\",\"type\":\"string\"},{\"name\":\"country\",\"type\":\"string\"},{\"name\":\"latitude\",\"type\":\"double\"},{\"name\":\"longitude\",\"type\":\"double\"}]}"
                     }
                 ],
-                "inputSchema": [],
-                "type": "batchsink",
-                "label": "Airport_sink",
-                "icon": "icon-file",
-                "$$hashKey": "object:2729",
-                "_uiPosition": {
-                    "left": "920px",
-                    "top": "239.5px"
-                }
+                "inputSchema": [
+                    {
+                        "name": "BigQueryTable",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"iata\",\"type\":[\"string\",\"null\"]},{\"name\":\"name\",\"type\":[\"string\",\"null\"]},{\"name\":\"city\",\"type\":[\"string\",\"null\"]},{\"name\":\"state\",\"type\":[\"string\",\"null\"]},{\"name\":\"country\",\"type\":[\"string\",\"null\"]},{\"name\":\"latitude\",\"type\":[\"double\",\"null\"]},{\"name\":\"longitude\",\"type\":[\"double\",\"null\"]}]}"
+                    }
+                ]
+            },
+            {
+                "name": "Avro-Time-Partitioned-Dataset",
+                "plugin": {
+                    "name": "TPFSAvro",
+                    "type": "batchsink",
+                    "label": "Avro Time Partitioned Dataset",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "[2.4.0-SNAPSHOT, 3.0.0-SNAPSHOT]",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "compressionCodec": "None",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"iata\",\"type\":\"string\"},{\"name\":\"city\",\"type\":\"string\"},{\"name\":\"country\",\"type\":\"string\"},{\"name\":\"latitude\",\"type\":\"double\"},{\"name\":\"longitude\",\"type\":\"double\"}]}",
+                        "name": "avro_sink"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"iata\",\"type\":\"string\"},{\"name\":\"city\",\"type\":\"string\"},{\"name\":\"country\",\"type\":\"string\"},{\"name\":\"latitude\",\"type\":\"double\"},{\"name\":\"longitude\",\"type\":\"double\"}]}",
+                "inputSchema": [
+                    {
+                        "name": "Wrangler",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"iata\",\"type\":\"string\"},{\"name\":\"city\",\"type\":\"string\"},{\"name\":\"country\",\"type\":\"string\"},{\"name\":\"latitude\",\"type\":\"double\"},{\"name\":\"longitude\",\"type\":\"double\"}]}"
+                    }
+                ]
             }
         ],
         "schedule": "0 * * * *",
         "engine": "mapreduce",
         "numOfRecordsPreview": 100,
+        "description": "With wrangler. Drops fields to get unrelated fields.",
         "maxConcurrentRuns": 1
     }
-}
+  }

--- a/cdap-ui/cypress/helpers.ts
+++ b/cdap-ui/cypress/helpers.ts
@@ -113,7 +113,7 @@ function deployAndTestPipeline(filename, pipelineName, done) {
     .type(pipelineName)
     .type('{enter}');
   cy.get('[data-testid=deploy-pipeline]').click();
-  cy.get('[data-cy="Deployed"]', { timeout: 10000 }).should('contain', 'Deployed');
+  cy.get('[data-cy="Deployed"]', { timeout: 20000 }).should('contain', 'Deployed');
   cy.url()
     .should('include', `/view/${pipelineName}`)
     .then(() => done());


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16248
Build: https://builds.cask.co/browse/CDAP-UDUT513

For cause or impact datasets with unrelated fields (i.e. fields that are not cause or impact fields for the target fields), add ability to show or hide unrelated fields. 

Also modified e2e test to check show/hide unrelated field functionality, which involved changing the pipeline to use macros.