### PR TITLE
(CDAP-16243) Minor bug fixes to system app initializing phase

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -111,18 +111,15 @@ public class SystemAppEnableExecutor {
     ArtifactSummary artifactSummary = arguments.getArtifact();
 
     KerberosPrincipalId ownerPrincipalId =
-        arguments.getOwnerPrincipal() == null ? null
-            : new KerberosPrincipalId(arguments.getOwnerPrincipal());
+      arguments.getOwnerPrincipal() == null ? null : new KerberosPrincipalId(arguments.getOwnerPrincipal());
 
     // if we don't null check, it gets serialized to "null"
     String configString = arguments.getConfig() == null ? null : GSON.toJson(arguments.getConfig());
 
     try {
-      return appLifecycleService
-          .deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
-              artifactSummary, configString, x -> {
-              },
-              ownerPrincipalId, arguments.canUpdateSchedules());
+      return appLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
+                                           artifactSummary, configString, x -> { },
+                                           ownerPrincipalId, arguments.canUpdateSchedules());
 
     } catch (UnauthorizedException | InvalidArtifactException e) {
       throw e;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -111,17 +111,20 @@ public class SystemAppEnableExecutor {
     ArtifactSummary artifactSummary = arguments.getArtifact();
 
     KerberosPrincipalId ownerPrincipalId =
-      arguments.getOwnerPrincipal() == null ? null : new KerberosPrincipalId(arguments.getOwnerPrincipal());
+        arguments.getOwnerPrincipal() == null ? null
+            : new KerberosPrincipalId(arguments.getOwnerPrincipal());
 
     // if we don't null check, it gets serialized to "null"
     String configString = arguments.getConfig() == null ? null : GSON.toJson(arguments.getConfig());
 
     try {
-      return appLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
-                                           artifactSummary, configString, x -> { },
-                                           ownerPrincipalId, arguments.canUpdateSchedules());
+      return appLifecycleService
+          .deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
+              artifactSummary, configString, x -> {
+              },
+              ownerPrincipalId, arguments.canUpdateSchedules());
 
-    } catch (NotFoundException | UnauthorizedException | InvalidArtifactException e) {
+    } catch (UnauthorizedException | InvalidArtifactException e) {
       throw e;
     } catch (DatasetManagementException e) {
       if (e.getCause() instanceof UnauthorizedException) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppManagementService.java
@@ -74,7 +74,8 @@ public class SystemAppManagementService extends AbstractIdleService {
   }
 
   private void bootStrapSystemAppConfigDir() throws Exception {
-    LOG.debug("Number of config files {} in system app config directory.", systemAppConfigDirPath.listFiles().length);
+    LOG.debug("Number of config files {} in system app config directory.",
+              DirUtils.listFiles(systemAppConfigDirPath).size());
     for (File sysAppConfigFile : DirUtils.listFiles(systemAppConfigDirPath)) {
       LOG.debug("Running steps in config file {}", sysAppConfigFile.getAbsoluteFile());
       executeSysConfig(sysAppConfigFile.getAbsoluteFile());


### PR DESCRIPTION
Fixing bugs discovered during end to end tests.

1. Retry on artifact NotFoundException during system app deployment as bootstrap's LOAD_SYSTEM_ARTIFACT step might not have yet completed as both are running in different threads.

2. Update usage of system file libs with recommended DirUtils.

Build link: https://builds.cask.co/browse/CDAP-DBT44-1