### PR TITLE
Fixes asserting "Dashboard" feature doesn't exist in navbar

### DIFF
--- a/cdap-ui/cypress/integration/navbar.spec.ts
+++ b/cdap-ui/cypress/integration/navbar.spec.ts
@@ -94,7 +94,7 @@ describe('Navbar tests', () => {
     });
   });
   it('Should have right features enabled/disabled in light theme', () => {
-    cy.contains(Theme.featureNames.dashboard).should('not.exist');
+    cy.get(`[data-cy="${Theme.featureNames.dashboard}`).should('not.exist');
     cy.contains(Theme.featureNames.hub);
     cy.get('[data-cy="navbar-hamburger-icon"]').click();
     cy.contains(Theme.featureNames.pipelines);


### PR DESCRIPTION
Long version:
- Previously we used to show the page even before we fetch any namespaces
- This allowed quickly to assert the non-existance of "Dashboard" feature in navbar as it won't be there in the light theme.
- This was ok as we didn't load the HomeAction screen before asserting for Dashboard feature non-existance
    (meaning we check if the page contains "Dashboard" text. This won't be present as we don't wait for everything to be loaded)
- Now we changed that behavior to show a loading icon for the entire page until the namespace is fetched.
- This way when we get the anything in the page, we made sure everything is loaded.
- This caused the failure of test case because the HomeAction link actually has a "Dashboard" link

Fix:
- Fix was to set the right subject (navbar) before checking if "Dashboard" exists.

E2E test: https://builds.cask.co/browse/IT-UPD2121-1