### PR TITLE
Add a new preferences http handler for internal usage

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -53,6 +53,7 @@ import io.cdap.cdap.gateway.handlers.NamespaceHttpHandler;
 import io.cdap.cdap.gateway.handlers.OperationalStatsHttpHandler;
 import io.cdap.cdap.gateway.handlers.OperationsDashboardHttpHandler;
 import io.cdap.cdap.gateway.handlers.PreferencesHttpHandler;
+import io.cdap.cdap.gateway.handlers.PreferencesHttpHandlerInternal;
 import io.cdap.cdap.gateway.handlers.ProfileHttpHandler;
 import io.cdap.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
 import io.cdap.cdap.gateway.handlers.ProvisionerHttpHandler;
@@ -310,6 +311,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       // TODO: [CDAP-13355] Move OperationsDashboardHttpHandler into report generation app
       handlerBinder.addBinding().to(OperationsDashboardHttpHandler.class);
       handlerBinder.addBinding().to(PreferencesHttpHandler.class);
+      handlerBinder.addBinding().to(PreferencesHttpHandlerInternal.class);
       handlerBinder.addBinding().to(ConsoleSettingsHttpHandler.class);
       handlerBinder.addBinding().to(TransactionHttpHandler.class);
       handlerBinder.addBinding().to(WorkflowHttpHandler.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/config/PreferencesTable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/config/PreferencesTable.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.config;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import io.cdap.cdap.common.ConflictException;
+import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.EntityId;
@@ -37,7 +38,6 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,7 +69,7 @@ public class PreferencesTable {
    * @param entityId the entity id to get the preferences from
    * @return the map which contains the preferences
    */
-  public Map<String, String> getPreferences(EntityId entityId) throws IOException {
+  public PreferencesDetail getPreferences(EntityId entityId) throws IOException {
     switch (entityId.getEntityType()) {
       case INSTANCE:
         return get(EMPTY_NAMESPACE, INSTANCE_PREFERENCE, entityId.getEntityName());
@@ -92,8 +92,7 @@ public class PreferencesTable {
    * Verify that the preferences for the entity id were written with a greater or equal sequence id.
    *
    * @param entityId the entity id to verify
-   * @param afterId the sequence id to check
-   *
+   * @param afterId  the sequence id to check
    * @throws ConflictException if the latest version of the preferences is older than the given sequence id
    */
   public void ensureSequence(EntityId entityId, long afterId)
@@ -121,29 +120,35 @@ public class PreferencesTable {
   }
 
   /**
-   * Get the resolved preferences for the entity id, the preferences are resolved from instance -> namespace -> app
-   * -> program level.
+   * Get the resolved preferences for the entity id, the preferences are resolved from
+   * instance -> namespace -> application -> program level
+   * (e.g. preferences at instance level take precedence over those at child level)
    *
    * @param entityId the entity id to get the preferences from
-   * @return the map which contains the preferences
+   * @return preferences detail
    */
-  public Map<String, String> getResolvedPreferences(EntityId entityId) throws IOException {
+  public PreferencesDetail getResolvedPreferences(EntityId entityId) throws IOException {
     // if it is instance level get the properties and return
     if (entityId.getEntityType().equals(EntityType.INSTANCE)) {
-      return getPreferences(entityId);
+      PreferencesDetail preferences = getPreferences(entityId);
+      return new PreferencesDetail(preferences.getProperties(), preferences.getSeqId(), true);
     }
 
-    Map<String, String> properties = new HashMap<>();
+    PreferencesDetail parentPreferences = null;
     // if the entity id has a parent id, get the preference from its parent
     if (entityId instanceof ParentedId) {
-      properties.putAll(getResolvedPreferences(((ParentedId) entityId).getParent()));
+      parentPreferences = getResolvedPreferences(((ParentedId) entityId).getParent());
     } else if (entityId.getEntityType() == EntityType.NAMESPACE) {
-      // otherwise it is a namespace id, which we want to look at the instance level
-      properties.putAll(getResolvedPreferences(new InstanceId("")));
+      parentPreferences = getResolvedPreferences(new InstanceId(""));
     }
-    // put the current level property
-    properties.putAll(getPreferences(entityId));
-    return properties;
+    PreferencesDetail preferences = getPreferences(entityId);
+
+    PreferencesDetail resolved = new PreferencesDetail(preferences.getProperties(), preferences.getSeqId(),
+                                                       true);
+    if (parentPreferences != null) {
+      resolved = PreferencesDetail.resolve(parentPreferences, resolved);
+    }
+    return resolved;
   }
 
   /**
@@ -151,13 +156,13 @@ public class PreferencesTable {
    * -> program level.
    *
    * @param entityId the entity id to get the preferences from
-   * @param name the name of the preference to resolve
+   * @param name     the name of the preference to resolve
    * @return the resolved value of the preference, or null of the named preference is not there
    */
   @Nullable
   public String getResolvedPreference(EntityId entityId, String name) throws IOException {
     // get the preference for the entity itself
-    String value = getPreferences(entityId).get(name);
+    String value = getPreferences(entityId).getProperties().get(name);
     if (value != null) {
       return value;
     }
@@ -166,7 +171,7 @@ public class PreferencesTable {
       value = getResolvedPreference(((ParentedId) entityId).getParent(), name);
     } else {
       // if there is no parent get from the instance id
-      value = getPreferences(new InstanceId("")).get(name);
+      value = getPreferences(new InstanceId("")).getProperties().get(name);
     }
     return value;
   }
@@ -175,8 +180,7 @@ public class PreferencesTable {
    * Set the preferences for the entity id.
    *
    * @param entityId the entity id to set the preferences from
-   * @param propMap the map which contains the preferences
-   *
+   * @param propMap  the map which contains the preferences
    * @return the sequence id of the operation
    */
   public long setPreferences(EntityId entityId, Map<String, String> propMap) throws IOException {
@@ -206,7 +210,6 @@ public class PreferencesTable {
    * Delete the preferences for the entity id.
    *
    * @param entityId the entity id to delete the preferences
-   *
    * @return the sequence id of the operation, or -1 if no preferences existed for the entity id
    */
   public long deleteProperties(EntityId entityId) throws IOException {
@@ -277,16 +280,19 @@ public class PreferencesTable {
                                               seq, type, name, namespace, String.valueOf(currentSeq)));
   }
 
-  private Map<String, String> get(String namespace, String type, String name) throws IOException {
+  private PreferencesDetail get(String namespace, String type, String name) throws IOException {
     List<Field<?>> primaryKey = getPrimaryKey(namespace, type, name);
     Optional<StructuredRow> row = table.read(primaryKey);
+    Map<String, String> properties = Collections.emptyMap();
+    Long seqId = new Long(0);
     if (row.isPresent()) {
       String string = row.get().getString(StoreDefinition.PreferencesStore.PROPERTIES_FIELD);
+      seqId = row.get().getLong(StoreDefinition.PreferencesStore.SEQUENCE_ID_FIELD);
       if (string != null) {
-        return GSON.fromJson(string, MAP_TYPE);
+        properties = GSON.fromJson(string, MAP_TYPE);
       }
     }
-    return Collections.emptyMap();
+    return new PreferencesDetail(properties, seqId, false);
   }
 
   private List<Field<?>> toFields(String namespace, String type, Config config, long seqId) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/PreferencesHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/PreferencesHttpHandlerInternal.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.ProgramNotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.config.PreferencesService;
+import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
+import io.cdap.cdap.proto.ApplicationDetail;
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.ProgramRecord;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.List;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * Program Preferences HTTP Handler for internal usage
+ */
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3)
+public class PreferencesHttpHandlerInternal extends AbstractAppFabricHttpHandler {
+
+  private static final Gson GSON = new Gson();
+
+  private final PreferencesService preferencesService;
+  private final ApplicationLifecycleService applicationLifecycleService;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+
+  @Inject
+  PreferencesHttpHandlerInternal(PreferencesService preferencesService,
+                                 ApplicationLifecycleService applicationLifecycleService,
+                                 NamespaceQueryAdmin namespaceQueryAdmin) {
+    this.preferencesService = preferencesService;
+    this.applicationLifecycleService = applicationLifecycleService;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
+  }
+
+  @Path("/preferences")
+  @GET
+  public void getInstancePreferences(HttpRequest request, HttpResponder responder) {
+    PreferencesDetail detail = preferencesService.getPreferences();
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(detail, PreferencesDetail.class));
+  }
+
+  @Path("/namespaces/{namespace-id}/preferences")
+  @GET
+  public void getNamespacePreferences(HttpRequest request, HttpResponder responder,
+                                      @PathParam("namespace-id") String namespace,
+                                      @QueryParam("resolved") boolean resolved) throws Exception {
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    if (!namespaceQueryAdmin.exists(namespaceId)) {
+      throw new NamespaceNotFoundException(namespaceId);
+    }
+    PreferencesDetail detail;
+    if (resolved) {
+      detail = preferencesService.getResolvedPreferences(namespaceId);
+    } else {
+      detail = preferencesService.getPreferences(namespaceId);
+    }
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(detail, PreferencesDetail.class));
+  }
+
+  @Path("/namespaces/{namespace-id}/apps/{application-id}/preferences")
+  @GET
+  public void getApplicationPreferences(HttpRequest request, HttpResponder responder,
+                                        @PathParam("namespace-id") String namespace,
+                                        @PathParam("application-id") String appId,
+                                        @QueryParam("resolved") boolean resolved) throws Exception {
+    ApplicationId applicationId = new ApplicationId(namespace, appId);
+    applicationLifecycleService.getAppDetail(applicationId);
+    PreferencesDetail detail;
+    if (resolved) {
+      detail = preferencesService.getResolvedPreferences(applicationId);
+    } else {
+      detail = preferencesService.getPreferences(applicationId);
+    }
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(detail, PreferencesDetail.class));
+  }
+
+  @Path("/namespaces/{namespace-id}/apps/{application-id}/{program-type}/{program-id}/preferences")
+  @GET
+  public void getProgramPreferences(HttpRequest request, HttpResponder responder,
+                                    @PathParam("namespace-id") String namespace,
+                                    @PathParam("application-id") String appId,
+                                    @PathParam("program-type") String programType,
+                                    @PathParam("program-id") String programId,
+                                    @QueryParam("resolved") boolean resolved) throws Exception {
+    ProgramId program = new ProgramId(namespace, appId, getProgramType(programType), programId);
+    ApplicationDetail applicationDetail = applicationLifecycleService.getAppDetail(program.getParent());
+    if (!programExists(applicationDetail, program)) {
+      throw new ProgramNotFoundException(program);
+    }
+    PreferencesDetail detail;
+    if (resolved) {
+      detail = preferencesService.getResolvedPreferences(program);
+    } else {
+      detail = preferencesService.getPreferences(program);
+    }
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(detail, PreferencesDetail.class));
+  }
+
+  /**
+   * Parses the give program type into {@link ProgramType} object.
+   *
+   * @param programType the program type to parse.
+   * @throws BadRequestException if the given program type is not a valid {@link ProgramType}.
+   */
+  private ProgramType getProgramType(String programType) throws BadRequestException {
+    try {
+      return ProgramType.valueOfCategoryName(programType);
+    } catch (Exception e) {
+      throw new BadRequestException(String.format("Invalid program type '%s'", programType), e);
+    }
+  }
+
+  /**
+   * Returns true if the given program id exists in the {@code applicationDetail}
+   */
+  private boolean programExists(ApplicationDetail applicationDetail, ProgramId programId) {
+    List<ProgramRecord> programs = applicationDetail.getPrograms();
+    for (ProgramRecord program : programs) {
+      if (program.getApp().equals(programId.getApplication()) &&
+          program.getName().equals(programId.getProgram()) &&
+          program.getType().equals(programId.getType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -314,7 +314,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
   private Optional<ProfileId> getProfileId(EntityId entityId) throws IOException {
     NamespaceId namespaceId = entityId.getEntityType().equals(EntityType.INSTANCE) ?
       NamespaceId.SYSTEM : ((NamespacedEntityId) entityId).getNamespaceId();
-    String profileName = preferencesTable.getPreferences(entityId).get(SystemArguments.PROFILE_NAME);
+    String profileName = preferencesTable.getPreferences(entityId).getProperties().get(SystemArguments.PROFILE_NAME);
     return profileName == null ? Optional.empty() : Optional.of(ProfileId.fromScopedName(namespaceId, profileName));
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerInternalTest.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services.http.handlers;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.cdap.cdap.AllProgramsApp;
+import io.cdap.cdap.api.app.Application;
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.gateway.handlers.PreferencesHttpHandlerInternal;
+import io.cdap.cdap.internal.app.deploy.Specifications;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Tests for {@link PreferencesHttpHandlerInternal}
+ */
+public class PreferencesHttpHandlerInternalTest extends AppFabricTestBase {
+
+  private static Store store;
+
+  @BeforeClass
+  public static void init() {
+    store = getInjector().getInstance(Store.class);
+  }
+
+  private void addApplication(String namespace, Application app) {
+    ApplicationSpecification appSpec = Specifications.from(app);
+    store.addApplication(new ApplicationId(namespace, appSpec.getName()), appSpec);
+  }
+
+  @Test
+  public void testInstance() throws Exception {
+    String uriInstance = "";
+
+    // Verify preferences are unset.
+    Map<String, String> properties = Maps.newHashMap();
+    Assert.assertEquals(properties, getPreferences(uriInstance, false, 200));
+    Assert.assertEquals(properties, getPreferences(uriInstance, true, 200));
+
+    // Set preferences.
+    properties.put("key1", "val1");
+    properties.put("key2", "val2");
+    setPreferences(uriInstance, properties, 200);
+
+    // Get preferences via internal REST APIs and validate.
+    PreferencesDetail detail1 = null;
+    detail1 = getPreferencesInternal(uriInstance, false, HttpResponseStatus.OK);
+    Assert.assertEquals(properties, detail1.getProperties());
+    Assert.assertFalse(detail1.getResolved());
+    Assert.assertTrue(detail1.getSeqId() > 0);
+
+    // Update preferences.
+    properties.put("key3", "val3");
+    setPreferences(uriInstance, properties, 200);
+
+    // Get preferences via internal REST APIs and validate.
+    PreferencesDetail detail2 = null;
+    detail2 = getPreferencesInternal(uriInstance, false, HttpResponseStatus.OK);
+    Assert.assertEquals(properties, detail2.getProperties());
+    Assert.assertFalse(detail2.getResolved());
+    Assert.assertTrue(detail2.getSeqId() > 0);
+    Assert.assertTrue(detail2.getSeqId() > detail1.getSeqId());
+
+    // "Resolved" should be ignored at instance level, as instance is the top level.
+    detail2 = getPreferencesInternal(uriInstance, true, HttpResponseStatus.OK);
+    Assert.assertEquals(properties, detail2.getProperties());
+    Assert.assertFalse(detail2.getResolved());
+    Assert.assertTrue(detail2.getSeqId() > 0);
+    Assert.assertTrue(detail2.getSeqId() > detail1.getSeqId());
+
+    // Delete preferences
+    properties.clear();
+    deletePreferences(uriInstance, 200);
+    Assert.assertEquals(properties, getPreferences(uriInstance, false, 200));
+    Assert.assertEquals(properties, getPreferences(uriInstance, true, 200));
+
+    // Deleting preferences just set preferences to empty, the record row still exists and seqId should be there.
+    PreferencesDetail detail3 = null;
+    detail3 = getPreferencesInternal(uriInstance, false, HttpResponseStatus.OK);
+    Assert.assertEquals(properties, detail3.getProperties());
+    Assert.assertFalse(detail3.getResolved());
+    Assert.assertTrue(detail3.getSeqId() > 0);
+    Assert.assertTrue(detail3.getSeqId() > detail2.getSeqId());
+  }
+
+  @Test
+  public void testNamespace() throws Exception {
+    String uriInstance = getPreferenceURI();
+    String uriNamespace1 = getPreferenceURI(TEST_NAMESPACE1);
+    String uriNamespace2 = getPreferenceURI(TEST_NAMESPACE2);
+    PreferencesDetail detail1 = null;
+    PreferencesDetail detail2 = null;
+
+    // Verify preferences are empty
+    Map<String, String> properties = Maps.newHashMap();
+    Assert.assertEquals(properties, getPreferences(uriNamespace1, false, 200));
+    Assert.assertEquals(properties, getPreferences(uriNamespace2, false, 200));
+    Assert.assertEquals(properties, getPreferences(uriNamespace1, true, 200));
+    Assert.assertEquals(properties, getPreferences(uriNamespace2, true, 200));
+
+    // Set preferences on namespace1
+    properties.put("key1", "val1");
+    properties.put("key2", "val2");
+    setPreferences(uriNamespace1, properties, 200);
+
+    // Get and verify preferences on namespace1 via internal REST API
+    detail1 = getPreferencesInternal(uriNamespace1, true, HttpResponseStatus.OK);
+    Assert.assertEquals(properties, detail1.getProperties());
+    Assert.assertTrue(detail1.getResolved());
+    Assert.assertTrue(detail1.getSeqId() > 0);
+
+    detail1 = getPreferencesInternal(uriNamespace1, false, HttpResponseStatus.OK);
+    Assert.assertEquals(properties, detail1.getProperties());
+    Assert.assertFalse(detail1.getResolved());
+    Assert.assertTrue(detail1.getSeqId() > 0);
+
+    // Update preferences on namespace1
+    properties.put("key3", "val3");
+    setPreferences(uriNamespace1, properties, 200);
+
+    // Get and verify seqId has increased via internal REST API
+    detail2 = getPreferencesInternal(uriNamespace1, false, HttpResponseStatus.OK);
+    Assert.assertEquals(properties, detail2.getProperties());
+    Assert.assertFalse(detail1.getResolved());
+    Assert.assertTrue(detail2.getSeqId() > detail1.getSeqId());
+
+    // Set preferences on top level instance
+    Map<String, String> instanceProperties = Maps.newHashMap();
+    instanceProperties.put("instance-key1", "instance-val1");
+    setPreferences(uriInstance, instanceProperties, 200);
+    Assert.assertEquals(instanceProperties,
+                        getPreferencesInternal(uriInstance, false, HttpResponseStatus.OK).getProperties());
+
+    // Get preferences on namespace1 via internal REST API and verify it is unchanged.
+    Assert.assertEquals(detail2, getPreferencesInternal(uriNamespace1, false, HttpResponseStatus.OK));
+
+    // Get resolved preferences on namespace1 via internal REST API and verify it includes preferences on instance
+    Map<String, String> resolvedProperties = Maps.newHashMap();
+    resolvedProperties.putAll(properties);
+    resolvedProperties.putAll(instanceProperties);
+    detail2 = getPreferencesInternal(uriNamespace1, true, HttpResponseStatus.OK);
+    Assert.assertEquals(resolvedProperties, detail2.getProperties());
+    Assert.assertTrue(detail2.getResolved());
+
+    // Get preferences on namespace2 via internal rest API.
+    detail1 = getPreferencesInternal(uriNamespace2, false, HttpResponseStatus.OK);
+    Assert.assertEquals(Collections.emptyMap(), detail1.getProperties());
+    Assert.assertFalse(detail1.getResolved());
+
+    // Update the preferences on the instance. Check the resolved for namespace2 via internal REST API,
+    // which should reflect the change.
+    instanceProperties.put("instance-key2", "instance-val2");
+    setPreferences(uriInstance, instanceProperties, 200);
+    detail2 = getPreferencesInternal(uriNamespace2, true, HttpResponseStatus.OK);
+    Assert.assertEquals(instanceProperties, detail2.getProperties());
+    Assert.assertTrue(detail2.getResolved());
+
+    // Delete preferences for both namespace1 and namespace2
+    deletePreferences(uriNamespace1, 200);
+    deletePreferences(uriNamespace2, 200);
+
+    // Set new preferences on the instance
+    instanceProperties.put("instance-key3", "instance-val3");
+    setPreferences(uriInstance, instanceProperties, 200);
+
+    // Check that the change on instance shows up in the resolved for both namespaces.
+    detail1 = getPreferencesInternal(uriNamespace1, true, HttpResponseStatus.OK);
+    detail2 = getPreferencesInternal(uriNamespace2, true, HttpResponseStatus.OK);
+    Assert.assertEquals(instanceProperties, detail1.getProperties());
+    Assert.assertEquals(instanceProperties, detail2.getProperties());
+    Assert.assertEquals(detail1, detail2);
+
+    // Delete preferences for the instance.
+    deletePreferences(uriInstance, 200);
+    detail1 = getPreferencesInternal(uriNamespace1, true, HttpResponseStatus.OK);
+    detail2 = getPreferencesInternal(uriNamespace2, true, HttpResponseStatus.OK);
+    Assert.assertEquals(Collections.emptyMap(), detail1.getProperties());
+    Assert.assertTrue(detail1.getSeqId() > 0);
+    Assert.assertEquals(detail1, detail2);
+
+    // Get preferences on invalid namespace should fail
+    getPreferencesInternal(getPreferenceURI("invalidNamespace"), true, HttpResponseStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void testApplication() throws Exception {
+    String appName = AllProgramsApp.NAME;
+    String namespace1 = TEST_NAMESPACE1;
+    String uriInstance = getPreferenceURI();
+    String uriNamespace1 = getPreferenceURI(namespace1);
+    String uriApp = getPreferenceURI(namespace1, appName);
+    PreferencesDetail detail;
+    Map<String, String> combinedProperties = Maps.newHashMap();
+
+    // Application not created yet, thus get preferences fails with NOT_FOUND
+    getPreferencesInternal(getPreferenceURI(namespace1, "some_non_existing_app"), false,
+                           HttpResponseStatus.NOT_FOUND);
+
+    // Create the app.
+    addApplication(namespace1, new AllProgramsApp());
+    Map<String, String> propMap = Maps.newHashMap();
+    Assert.assertEquals(propMap, getPreferences(uriApp, false, 200));
+    Assert.assertEquals(propMap, getPreferences(uriApp, true, 200));
+    getPreferences(getPreferenceURI(namespace1, "InvalidAppName"), false, 404);
+
+    // Application created but no preferences created yet. API call still succeeds but result is empty.
+    detail = getPreferencesInternal(uriApp, false, HttpResponseStatus.OK);
+    Assert.assertEquals(Collections.emptyMap(), detail.getProperties());
+    // For entity without any references, seqId is set to default 0, otherwise it should be always > 0.
+    Assert.assertEquals(0, detail.getSeqId());
+
+    // Set the preference
+    Map<String, String> instanceProperties = ImmutableMap.of("instance-key1", "instance-val1");
+    Map<String, String> namespace1Properties = ImmutableMap.of("namespace1-key1", "namespace1-val1");
+    Map<String, String> appProperties = ImmutableMap.of("app-key1", "app-val1");
+
+    setPreferences(uriInstance, instanceProperties, 200);
+    setPreferences(uriNamespace1, namespace1Properties, 200);
+    setPreferences(uriApp, appProperties, 200);
+
+    // Get and verify preferences on the application
+    detail = getPreferencesInternal(uriApp, false, HttpResponseStatus.OK);
+    Assert.assertEquals(appProperties, detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertFalse(detail.getResolved());
+
+    // Get and verify resolved preferences on the application
+    detail = getPreferencesInternal(uriApp, true, HttpResponseStatus.OK);
+    combinedProperties.clear();
+    combinedProperties.putAll(instanceProperties);
+    combinedProperties.putAll(namespace1Properties);
+    combinedProperties.putAll(appProperties);
+    Assert.assertEquals(combinedProperties, detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertTrue(detail.getResolved());
+
+    // Delete preferences on the application and verify resolved
+    deletePreferences(uriApp, 200);
+    detail = getPreferencesInternal(uriApp, true, HttpResponseStatus.OK);
+    combinedProperties.clear();
+    combinedProperties.putAll(instanceProperties);
+    combinedProperties.putAll(namespace1Properties);
+    Assert.assertEquals(combinedProperties, detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertTrue(detail.getResolved());
+
+
+    // Delete preferences on the namespace and verify.
+    deletePreferences(uriNamespace1, 200);
+    detail = getPreferencesInternal(uriApp, true, HttpResponseStatus.OK);
+    combinedProperties.clear();
+    combinedProperties.putAll(instanceProperties);
+    Assert.assertEquals(combinedProperties, detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertTrue(detail.getResolved());
+
+    // Delete preferences on the instance and verify.
+    deletePreferences(uriInstance, 200);
+    detail = getPreferencesInternal(uriApp, true, HttpResponseStatus.OK);
+    combinedProperties.clear();
+    Assert.assertEquals(combinedProperties, detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertTrue(detail.getResolved());
+  }
+
+  @Test
+  public void testProgram() throws Exception {
+    String uriInstance = getPreferenceURI();
+    String namespace2 = TEST_NAMESPACE2;
+    String appName = AllProgramsApp.NAME;
+    String uriNamespace2Service = getPreferenceURI(namespace2, appName, "services", AllProgramsApp.NoOpService.NAME);
+    PreferencesDetail detail;
+    Map<String, String> properties = Maps.newHashMap();
+
+    // Create application.
+    addApplication(namespace2, new AllProgramsApp());
+
+    // Get preferences on invalid program type
+    getPreferencesInternal(getPreferenceURI(
+      namespace2, appName, "invalidType", "somename"), false, HttpResponseStatus.BAD_REQUEST);
+
+    // Get preferences on non-existing program id
+    getPreferencesInternal(getPreferenceURI(
+      namespace2, appName, "services", "somename"), false, HttpResponseStatus.NOT_FOUND);
+
+    // Set preferences on the program
+    properties.clear();
+    properties.put("program-key1", "program-val1");
+    setPreferences(uriNamespace2Service, properties, 200);
+
+    // Get and verify preferences
+    detail = getPreferencesInternal(uriNamespace2Service, false, HttpResponseStatus.OK);
+    Assert.assertEquals(properties, detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertFalse(detail.getResolved());
+
+    // Set preferences on the instance and verify.
+    Map<String, String> instanceProperties = ImmutableMap.of("instance-key1", "instance-val1");
+    setPreferences(uriInstance, instanceProperties, 200);
+
+    // Get resolved preferences on the program
+    detail = getPreferencesInternal(uriNamespace2Service, true, HttpResponseStatus.OK);
+    Map<String, String> combinedProperties = Maps.newHashMap();
+    combinedProperties.putAll(properties);
+    combinedProperties.putAll(instanceProperties);
+    Assert.assertEquals(combinedProperties, detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertTrue(detail.getResolved());
+
+    // Delete preferences on the program
+    deletePreferences(uriNamespace2Service, 200);
+    detail = getPreferencesInternal(uriNamespace2Service, true, HttpResponseStatus.OK);
+    Assert.assertEquals(instanceProperties, detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertTrue(detail.getResolved());
+
+    // Delete preferences on the instance
+    deletePreferences(uriInstance, 200);
+    detail = getPreferencesInternal(uriNamespace2Service, true, HttpResponseStatus.OK);
+    Assert.assertEquals(Collections.emptyMap(), detail.getProperties());
+    Assert.assertTrue(detail.getSeqId() > 0);
+    Assert.assertTrue(detail.getResolved());
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -546,6 +546,12 @@ public final class Constants {
     public static final String API_VERSION_3_TOKEN = "v3";
     public static final String API_VERSION_3 = "/" + API_VERSION_3_TOKEN;
     public static final String API_KEY = "X-ApiKey";
+
+    /**
+     * Internal API
+     */
+    public static final String INTERNAL_API_VERSION_3_TOKEN = "v3Internal";
+    public static final String INTERNAL_API_VERSION_3 = "/" + INTERNAL_API_VERSION_3_TOKEN;
   }
 
   /**

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/PreferencesDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/PreferencesDetail.java
@@ -36,15 +36,15 @@ public class PreferencesDetail {
   private boolean resolved;
 
   /**
-   * Return a resolved preference detail where preferences in {@code parent} take precedence over
-   * those in {@code child}. The {@code seqId} would be the max of the two.
+   * Return a resolved preference detail where preferences in {@code child} take precedence over
+   * those in {@code parent}. The {@code seqId} would be the max of the two.
    */
   public static PreferencesDetail resolve(PreferencesDetail parent, PreferencesDetail child) {
     Map<String, String> properties = new HashMap<>();
-    // Copy child's properties first.
-    properties.putAll(child.getProperties());
-    // Add parent's properties and overrides any existing properties in child;
+    // Copy parent's properties first.
     properties.putAll(parent.getProperties());
+    // Add child's properties and overrides any existing properties in parent;
+    properties.putAll(child.getProperties());
 
     long seqId = Long.max(parent.getSeqId(), child.getSeqId());
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/PreferencesDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/PreferencesDetail.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represent preferences
+ */
+public class PreferencesDetail {
+  private final Map<String, String> properties;
+  /**
+   * Sequence id of operations on the preferences
+   * Normally this should be > 0. But can be 0 indicating that no preferences have been set on the entity.
+   */
+  private final long seqId;
+  /**
+   * Whether it is a resolved preferences or not.
+   */
+  private boolean resolved;
+
+  /**
+   * Return a resolved preference detail where preferences in {@code parent} take precedence over
+   * those in {@code child}. The {@code seqId} would be the max of the two.
+   */
+  public static PreferencesDetail resolve(PreferencesDetail parent, PreferencesDetail child) {
+    Map<String, String> properties = new HashMap<>();
+    // Copy child's properties first.
+    properties.putAll(child.getProperties());
+    // Add parent's properties and overrides any existing properties in child;
+    properties.putAll(parent.getProperties());
+
+    long seqId = Long.max(parent.getSeqId(), child.getSeqId());
+
+    return new PreferencesDetail(properties, seqId, true);
+  }
+
+  public PreferencesDetail(Map<String, String> properties, long seqId, boolean resolved) {
+    this.properties = properties;
+    this.seqId = seqId;
+    this.resolved = resolved;
+  }
+
+  public long getSeqId() {
+    return this.seqId;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public boolean getResolved() {
+    return resolved;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PreferencesDetail that = (PreferencesDetail) o;
+    return Objects.equals(properties, that.properties) &&
+      Objects.equals(seqId, that.seqId) &&
+      Objects.equals(resolved, that.resolved);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(properties, seqId, resolved);
+  }
+
+  @Override
+  public String toString() {
+    return "PreferencesDetail{" +
+      "properties='" + properties.toString() +
+      "seqId='" + seqId +
+      "resolved='" + resolved +
+      '}';
+  }
+}
+


### PR DESCRIPTION
Current handler returns Map<String, String>. Creating a new one for internal usage which returns PreferencesDetail that encapsulates the Map along with some other info.

This is server side of change in preparation of switching ProfileMetadataMessageProcessor from direct levelDB access to via REST API calls.