### PR TITLE
Add client to fetch Application/Schedule/Preferences details 

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -42,6 +42,7 @@ import io.cdap.cdap.common.utils.Networks;
 import io.cdap.cdap.config.guice.ConfigStoreModule;
 import io.cdap.cdap.data.security.DefaultSecretStore;
 import io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandler;
+import io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandlerInternal;
 import io.cdap.cdap.gateway.handlers.ArtifactHttpHandler;
 import io.cdap.cdap.gateway.handlers.AuthorizationHandler;
 import io.cdap.cdap.gateway.handlers.BootstrapHttpHandler;
@@ -307,6 +308,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(UsageHandler.class);
       handlerBinder.addBinding().to(NamespaceHttpHandler.class);
       handlerBinder.addBinding().to(AppLifecycleHttpHandler.class);
+      handlerBinder.addBinding().to(AppLifecycleHttpHandlerInternal.class);
       handlerBinder.addBinding().to(ProgramLifecycleHttpHandler.class);
       // TODO: [CDAP-13355] Move OperationsDashboardHttpHandler into report generation app
       handlerBinder.addBinding().to(OperationsDashboardHttpHandler.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.namespace.NamespacePathLocator;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
+import io.cdap.cdap.proto.ApplicationDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.http.HttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.io.File;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+
+/**
+ * Internal {@link HttpHandler} for Application Lifecycle Management
+ */
+@Singleton
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/namespaces/{namespace-id}")
+public class AppLifecycleHttpHandlerInternal extends AbstractAppFabricHttpHandler {
+  private static final Gson GSON = new Gson();
+
+  /**
+   * Runtime program service for running and managing programs.
+   */
+  private final ProgramRuntimeService runtimeService;
+
+  private final CConfiguration configuration;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final NamespacePathLocator namespacePathLocator;
+  private final ApplicationLifecycleService applicationLifecycleService;
+  private final File tmpDir;
+
+  @Inject
+  AppLifecycleHttpHandlerInternal(CConfiguration configuration,
+                                  ProgramRuntimeService runtimeService,
+                                  NamespaceQueryAdmin namespaceQueryAdmin,
+                                  NamespacePathLocator namespacePathLocator,
+                                  ApplicationLifecycleService applicationLifecycleService) {
+    this.configuration = configuration;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.runtimeService = runtimeService;
+    this.namespacePathLocator = namespacePathLocator;
+    this.applicationLifecycleService = applicationLifecycleService;
+    this.tmpDir = new File(new File(configuration.get(Constants.CFG_LOCAL_DATA_DIR)),
+                           configuration.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+  }
+
+  /**
+   * Get a list of {@link ApplicationDetail} for all applications in the given namespace
+   *
+   * @param request   {@link HttpRequest}
+   * @param responder {@link HttpResponse}
+   * @param namespace the namespace to get all application details
+   * @throws Exception if namespace doesn't exists or failed to get all application details
+   */
+  @GET
+  @Path("/apps")
+  public void getAllAppDetails(HttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") String namespace) throws Exception {
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    if (!namespaceQueryAdmin.exists(namespaceId)) {
+      throw new NamespaceNotFoundException(namespaceId);
+    }
+    responder.sendJson(HttpResponseStatus.OK,
+                       GSON.toJson(applicationLifecycleService.getApps(namespaceId, detail -> true)));
+  }
+
+  /**
+   * Get {@link ApplicationDetail} for a given application
+   *
+   * @param request     {@link HttpRequest}
+   * @param responder   {@link HttpResponse}
+   * @param namespace   the namespace to get all application details   *
+   * @param application the id of the application to get its {@link ApplicationDetail}
+   * @throws Exception if either namespace or application doesn't exist, or failed to get {@link ApplicationDetail}
+   */
+  @GET
+  @Path("/app/{app-id}")
+  public void getAppDetail(HttpRequest request, HttpResponder responder,
+                           @PathParam("namespace-id") String namespace,
+                           @PathParam("app-id") String application) throws Exception {
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    if (!namespaceQueryAdmin.exists(namespaceId)) {
+      throw new NamespaceNotFoundException(namespaceId);
+    }
+    ApplicationId appId = new ApplicationId(namespace, application);
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(applicationLifecycleService.getAppDetail(appId)));
+  }
+
+  /**
+   * Get {@link ApplicationDetail} for a given application
+   *
+   * @param request     {@link HttpRequest}
+   * @param responder   {@link HttpResponse}
+   * @param namespace   the namespace to get all application details
+   * @param application the id of the application to get its {@link ApplicationDetail}
+   * @throws Exception if either namespace or application doesn't exist, or failed to get {@link ApplicationDetail}
+   */
+  @GET
+  @Path("/app/{app-id}/versions/{version-id}")
+  public void getAppDetailForVersion(HttpRequest request, HttpResponder responder,
+                                     @PathParam("namespace-id") final String namespace,
+                                     @PathParam("app-id") final String application,
+                                     @PathParam("version-id") final String version) throws Exception {
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    if (!namespaceQueryAdmin.exists(namespaceId)) {
+      throw new NamespaceNotFoundException(namespaceId);
+    }
+    ApplicationId appId = new ApplicationId(namespace, application, version);
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(applicationLifecycleService.getAppDetail(appId)));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.proto.ApplicationDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Interface for fetching {@code ApplicationDetail}
+ */
+public interface ApplicationDetailFetcher {
+
+  /**
+   * Get the application detail for the given application id
+   * @param appId the id of the application
+   * @return the detail of the given application
+   * @throws IOException if failed to get {@code ApplicationDetail}
+   * @throws NotFoundException if the application or namespace identified by the supplied id doesn't exist
+   */
+  ApplicationDetail get(ApplicationId appId) throws IOException, NotFoundException;
+
+  /**
+   * Get details of all applications in the given namespace
+   * @param namespace the name of the namespace to get the list of applications
+   * @return a list of {@code ApplicationDetail} in the given namspace
+   * @throws IOException if failed to get the list of {@code ApplicationDetail}
+   * @throws NamespaceNotFoundException if the given namespace doesn't exist
+   */
+  List<ApplicationDetail> list(String namespace) throws IOException, NamespaceNotFoundException;
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/PreferencesFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/PreferencesFetcher.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.id.EntityId;
+
+import java.io.IOException;
+
+/**
+ * Interface for fetching {@code PreferencesDetail}
+ */
+public interface PreferencesFetcher {
+  /**
+   * Get preferences for the given identify
+   * @param entityId the id of the entity to fetch preferences for
+   * @param resolved true if resolved properties are desired.
+   * @return the detail of preferences
+   * @throws IOException if failed to get preferences
+   * @throws NotFoundException if the given entity doesn't exist.
+   */
+  PreferencesDetail get(EntityId entityId, boolean resolved) throws IOException, NotFoundException;
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteApplicationDetailFetcher.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
+import io.cdap.cdap.proto.ApplicationDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.common.http.ObjectResponse;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.util.List;
+
+/**
+ * Fetch application detail via internal REST API calls
+ */
+public class RemoteApplicationDetailFetcher implements ApplicationDetailFetcher {
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
+  private static final Type APPLICATION_DETAIL_LIST_TYPE = new TypeToken<List<ApplicationDetail>>() { }.getType();
+
+  private final RemoteClient remoteClient;
+
+  @Inject
+  public RemoteApplicationDetailFetcher(DiscoveryServiceClient discoveryClient) {
+    this.remoteClient = new RemoteClient(discoveryClient,
+                                         Constants.Service.APP_FABRIC_HTTP,
+                                         new DefaultHttpRequestConfig(false),
+                                         Constants.Gateway.INTERNAL_API_VERSION_3);
+  }
+
+  /**
+   * Get the application detail for the given application id
+   */
+  public ApplicationDetail get(ApplicationId appId) throws IOException, NotFoundException {
+    String url = String.format("namespaces/%s/app/%s/versions/%s",
+                               appId.getNamespace(), appId.getApplication(), appId.getVersion());
+    HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
+    HttpResponse httpResponse;
+    httpResponse = execute(requestBuilder.build());
+    return GSON.fromJson(httpResponse.getResponseBodyAsString(), ApplicationDetail.class);
+  }
+
+  /**
+   * Get details of all applications in the given namespace
+   */
+  public List<ApplicationDetail> list(String namespace) throws IOException, NamespaceNotFoundException {
+    String url = String.format("namespaces/%s/apps", namespace);
+    HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
+    HttpResponse httpResponse;
+    try {
+      httpResponse = execute(requestBuilder.build());
+    } catch (NotFoundException e) {
+      throw new NamespaceNotFoundException(new NamespaceId(namespace));
+    }
+    ObjectResponse<List<ApplicationDetail>> objectResponse =
+      ObjectResponse.fromJsonBody(httpResponse, APPLICATION_DETAIL_LIST_TYPE, GSON);
+    return objectResponse.getResponseObject();
+  }
+
+  private HttpResponse execute(HttpRequest request) throws IOException, NotFoundException {
+    HttpResponse httpResponse = remoteClient.execute(request);
+    if (httpResponse.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(httpResponse.getResponseBodyAsString());
+    }
+    if (httpResponse.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new IOException(httpResponse.getResponseBodyAsString());
+    }
+    return httpResponse;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemotePreferencesFetcherInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemotePreferencesFetcherInternal.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpResponse;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import sun.net.www.protocol.http.HttpURLConnection;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+/**
+ * Fetch preferences via REST API calls (using internal endpoint {@code INTERNAL_API_VERSION_3})
+ */
+public class RemotePreferencesFetcherInternal implements PreferencesFetcher {
+  private static final Gson GSON = new Gson();
+  private static final Type PREFERENCES_TYPE = new TypeToken<PreferencesDetail>() { }.getType();
+
+  private final RemoteClient remoteClient;
+
+  @Inject
+  public RemotePreferencesFetcherInternal(DiscoveryServiceClient discoveryClient) {
+    this.remoteClient = new RemoteClient(
+      discoveryClient, Constants.Service.APP_FABRIC_HTTP,
+      new DefaultHttpRequestConfig(false), Constants.Gateway.INTERNAL_API_VERSION_3);
+  }
+
+  /**
+   * Get preferences for the given identify
+   */
+  public PreferencesDetail get(EntityId entityId, boolean resolved) throws IOException, NotFoundException {
+    HttpResponse httpResponse;
+    String url = getPreferencesURI(entityId, resolved);
+    HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
+    httpResponse = execute(requestBuilder.build());
+    return GSON.fromJson(httpResponse.getResponseBodyAsString(), PREFERENCES_TYPE);
+  }
+
+  /**
+   * Construct URI to fetch preferences depending on the type of supplied entity
+   */
+  private String getPreferencesURI(EntityId entityId, boolean resolved) {
+    String uri;
+    switch (entityId.getEntityType()) {
+      case INSTANCE:
+        uri = String.format("preferences");
+        break;
+      case NAMESPACE:
+        NamespaceId namespaceId = (NamespaceId) entityId;
+        uri = String.format("namespaces/%s/preferences", namespaceId.getNamespace());
+        break;
+      case APPLICATION:
+        ApplicationId appId = (ApplicationId) entityId;
+        uri = String.format("namespaces/%s/apps/%s/preferences",
+                            appId.getNamespace(), appId.getApplication());
+        break;
+      case PROGRAM:
+        ProgramId programId = (ProgramId) entityId;
+        uri = String.format("namespaces/%s/apps/%s/%s/%s/preferences",
+                            programId.getNamespace(), programId.getApplication(), programId.getType().getCategoryName(),
+                            programId.getProgram());
+        break;
+      default:
+        throw new UnsupportedOperationException(
+          String.format("Preferences cannot be used on this entity type: %s", entityId.getEntityType()));
+    }
+    if (resolved) {
+      uri += "?resolved=true";
+    }
+    return uri;
+  }
+
+  private HttpResponse execute(HttpRequest request) throws IOException, NotFoundException {
+    HttpResponse httpResponse = remoteClient.execute(request);
+    if (httpResponse.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(httpResponse.getResponseBodyAsString());
+    }
+    if (httpResponse.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new IOException(httpResponse.getResponseBodyAsString());
+    }
+    return httpResponse;
+  }
+
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.schedule.Trigger;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.ProgramNotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleNotFoundException;
+import io.cdap.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
+import io.cdap.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
+import io.cdap.cdap.proto.ScheduleDetail;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ScheduleId;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.common.http.ObjectResponse;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.util.List;
+
+/**
+ * Fetch schedules via REST API calls
+ */
+public class RemoteScheduleFetcher implements ScheduleFetcher {
+  protected static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Trigger.class, new TriggerCodec())
+    .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
+    .create();
+
+  private static final Type SCHEDULE_DETAIL_LIST_TYPE = new TypeToken<List<ScheduleDetail>>() { }.getType();
+
+  private final RemoteClient remoteClient;
+
+  @Inject
+  public RemoteScheduleFetcher(DiscoveryServiceClient discoveryClient) {
+    this.remoteClient = new RemoteClient(
+      discoveryClient, Constants.Service.APP_FABRIC_HTTP,
+      new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
+  }
+
+  /**
+   * Get the schedule identified by the given schedule id
+   */
+  @Override
+  public ScheduleDetail get(ScheduleId scheduleId) throws IOException, ScheduleNotFoundException {
+    String url = String.format(
+      "namespaces/%s/apps/%s/versions/%s/schedules/%s",
+      scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getVersion(), scheduleId.getSchedule());
+    HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
+    HttpResponse httpResponse;
+    try {
+      httpResponse = execute(requestBuilder.build());
+    } catch (NotFoundException e) {
+      throw new ScheduleNotFoundException(scheduleId);
+    }
+    return GSON.fromJson(httpResponse.getResponseBodyAsString(), ScheduleDetail.class);
+  }
+
+  /**
+   * Get the list of schedules for the given program id
+   */
+  @Override
+  public List<ScheduleDetail> list(ProgramId programId) throws IOException, ProgramNotFoundException {
+    String url = String.format("namespaces/%s/apps/%s/versions/%s/schedules",
+                               programId.getNamespace(), programId.getApplication(), programId.getVersion());
+    HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
+    HttpResponse httpResponse = null;
+    try {
+      httpResponse = execute(requestBuilder.build());
+    } catch (NotFoundException e) {
+      throw new ProgramNotFoundException(programId);
+    }
+    ObjectResponse<List<ScheduleDetail>> objectResponse =
+      ObjectResponse.fromJsonBody(httpResponse, SCHEDULE_DETAIL_LIST_TYPE, GSON);
+    return objectResponse.getResponseObject();
+  }
+
+  // TODO: refactor out into a util function that can be shared by RemoteApplicationDetailFetcher
+  //       RemotePreferencesFetcherInternal and RemoteScheduleFetcher
+  private HttpResponse execute(HttpRequest request) throws IOException, NotFoundException {
+    HttpResponse httpResponse = remoteClient.execute(request);
+    if (httpResponse.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(httpResponse.getResponseBodyAsString());
+    }
+    if (httpResponse.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new IOException(httpResponse.getResponseBodyAsString());
+    }
+    return httpResponse;
+  }
+
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ScheduleFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ScheduleFetcher.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import io.cdap.cdap.common.ProgramNotFoundException;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleNotFoundException;
+import io.cdap.cdap.proto.ScheduleDetail;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ScheduleId;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Interface for fetching schedule(s)
+ */
+public interface ScheduleFetcher {
+  /**
+   * Get schedule details for the given {@code scheduleId}
+   * @param scheduleId the id of the schedule to fetch {@code ScheduleDetail} for
+   * @return the schedule detail
+   * @throws IOException if failed to get the detail of the given schedule
+   * @throws ScheduleNotFoundException if the given schedule doesn't exist.
+   */
+  ScheduleDetail get(ScheduleId scheduleId) throws IOException, ScheduleNotFoundException;
+
+  /**
+   *
+   */
+  /**
+   * Get the list of schedules for the given program id
+   * @param programId the id of the program to get the list of schedules for
+   * @return a list of schedules set on the program
+   * @throws IOException if failed to get the list of schedules for the given program
+   * @throws ProgramNotFoundException if the given program id doesn't exist
+   */
+  List<ScheduleDetail> list(ProgramId programId) throws IOException, ProgramNotFoundException;
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/AppWithSchedule.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/AppWithSchedule.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CountDownLatch;
 public class AppWithSchedule extends AbstractApplication<AppWithSchedule.AppConfig> {
 
   public static final String NAME = "AppWithSchedule";
+  public static final String DESC = "Sample application with schedule";
   public static final String WORKFLOW_NAME = "SampleWorkflow";
   public static final String SCHEDULE = "SampleSchedule";
   public static final String SCHEDULE_2 = "SampleSchedule2";
@@ -54,7 +55,7 @@ public class AppWithSchedule extends AbstractApplication<AppWithSchedule.AppConf
   public void configure() {
     try {
       setName(NAME);
-      setDescription("Sample application");
+      setDescription(DESC);
       ObjectStores.createObjectStore(getConfigurer(), "input", String.class);
       ObjectStores.createObjectStore(getConfigurer(), "output", String.class);
       AppConfig config = getConfig();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -520,6 +520,12 @@ public abstract class AppFabricTestBase {
   }
 
   protected HttpResponse deploy(Class<?> application, int expectedCode, @Nullable String apiVersion,
+                                @Nullable String namespace, @Nullable Config appConfig) throws Exception {
+    return deploy(application, expectedCode, apiVersion, namespace, null, appConfig,
+                  null);
+  }
+
+  protected HttpResponse deploy(Class<?> application, int expectedCode, @Nullable String apiVersion,
                                 @Nullable String namespace,
                                 @Nullable String ownerPrincipal) throws Exception {
     return deploy(application, expectedCode, apiVersion, namespace, null, null, ownerPrincipal);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/RemoteApplicationDetailFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/RemoteApplicationDetailFetcherTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.AllProgramsApp;
+import io.cdap.cdap.AppWithSchedule;
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandlerInternal;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.ApplicationDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link RemoteApplicationDetailFetcher} and {@link AppLifecycleHttpHandlerInternal}
+ */
+public class RemoteApplicationDetailFetcherTest extends AppFabricTestBase {
+  private static ApplicationDetailFetcher fetcher = null;
+
+  @BeforeClass
+  public static void init() {
+    fetcher = getInjector().getInstance(RemoteApplicationDetailFetcher.class);
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void testGetApplicationNotFound() throws Exception {
+    String namespace = TEST_NAMESPACE1;
+    String appName = AllProgramsApp.NAME;
+    ApplicationId appId = new ApplicationId(namespace, appName);
+    fetcher.get(appId);
+  }
+
+  /**
+   * Assert the state of {@link ApplicationDetail} matches that of {@link AllProgramsApp}
+   */
+  private void assertAllProgramAppDetail(ApplicationDetail appDetail) {
+    Assert.assertEquals(AllProgramsApp.NAME, appDetail.getName());
+    Assert.assertEquals(AllProgramsApp.DESC, appDetail.getDescription());
+    Assert.assertFalse(appDetail.getAppVersion().isEmpty());
+
+    // Verify dataset names
+    Assert.assertTrue(appDetail.getDatasets().size() > 0);
+    List<String> datasetNames = new ArrayList<>();
+    appDetail.getDatasets().forEach(datasetDetail -> datasetNames.add(datasetDetail.getName()));
+    Assert.assertTrue(datasetNames.containsAll(ImmutableList.of(AllProgramsApp.DATASET_NAME,
+                                                                AllProgramsApp.DATASET_NAME2,
+                                                                AllProgramsApp.DATASET_NAME3)));
+    // Verify program field
+    Assert.assertTrue(appDetail.getPrograms().size() > 0);
+
+    // Verify plugin field
+    Assert.assertNotNull(appDetail.getPlugins());
+
+    // Verify artifact field
+    Assert.assertNotNull(appDetail.getArtifact());
+  }
+
+  @Test
+  public void testGetApplication() throws Exception {
+    String namespace = TEST_NAMESPACE1;
+    String appName = AllProgramsApp.NAME;
+
+    // Deploy the application
+    deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
+
+    // Get and validate the application
+    ApplicationId appId = new ApplicationId(namespace, appName);
+    ApplicationDetail appDetail = fetcher.get(appId);
+    assertAllProgramAppDetail(appDetail);
+
+    // Delete the application
+    Assert.assertEquals(
+      200,
+      doDelete(getVersionedAPIPath("apps/",
+                                   Constants.Gateway.API_VERSION_3_TOKEN, namespace)).getResponseCode());
+  }
+
+  @Test(expected = NamespaceNotFoundException.class)
+  public void testGetAllApplicationNamespaceNotFound() throws Exception {
+    String namespace = "somenamespace";
+    fetcher.list(namespace);
+  }
+
+  @Test
+  public void testGetAllApplications() throws Exception {
+    String namespace = TEST_NAMESPACE1;
+    List<ApplicationDetail> appDetailList = Collections.emptyList();
+    ApplicationDetail appDetail = null;
+
+    // No applications have been deployed
+    appDetailList = fetcher.list(namespace);
+    Assert.assertEquals(Collections.emptyList(), appDetailList);
+
+    // Deploy the application
+    deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
+
+    // Get and validate the application
+    appDetailList = fetcher.list(namespace);
+    Assert.assertEquals(1, appDetailList.size());
+    appDetail = appDetailList.get(0);
+    assertAllProgramAppDetail(appDetail);
+
+    // Deploy another application
+    deploy(AppWithSchedule.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
+
+    // Get and validate the application
+    appDetailList = fetcher.list(namespace);
+    Assert.assertEquals(2, appDetailList.size());
+    Assert.assertEquals(AllProgramsApp.NAME, appDetailList.get(0).getName());
+    Assert.assertEquals(AllProgramsApp.DESC, appDetailList.get(0).getDescription());
+    Assert.assertEquals(AppWithSchedule.NAME, appDetailList.get(1).getName());
+    Assert.assertEquals(AppWithSchedule.DESC, appDetailList.get(1).getDescription());
+
+    // Delete the application
+    Assert.assertEquals(
+      200,
+      doDelete(getVersionedAPIPath("apps/",
+                                   Constants.Gateway.API_VERSION_3_TOKEN, namespace)).getResponseCode());
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/RemotePreferencesFetcherInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/RemotePreferencesFetcherInternalTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.AllProgramsApp;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.InstanceId;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for {@link RemotePreferencesFetcherInternal}
+ */
+public class RemotePreferencesFetcherInternalTest extends AppFabricTestBase {
+  private static PreferencesFetcher fetcher = null;
+
+  @BeforeClass
+  public static void init() {
+    fetcher = getInjector().getInstance(RemotePreferencesFetcherInternal.class);
+  }
+
+  @Test
+  public void testGetPreferences() throws Exception {
+    PreferencesDetail preferences = null;
+    EntityId entityId = null;
+
+    // Get preferences on instance, but none was set.
+    entityId = new InstanceId("");
+    preferences = fetcher.get(entityId, false);
+    Assert.assertEquals(Collections.emptyMap(), preferences.getProperties());
+    Assert.assertFalse(preferences.getResolved());
+    // SeqId should be 0 when preferences never get set on the entity.
+    Assert.assertEquals(0, preferences.getSeqId());
+
+    // Set preferences on instance and fetch again.
+    Map<String, String> instanceProperties = ImmutableMap.of("instance-key1", "instance-val1");
+    setPreferences(getPreferenceURI(), instanceProperties, 200);
+    preferences = fetcher.get(entityId, false);
+    Assert.assertEquals(instanceProperties, preferences.getProperties());
+    Assert.assertFalse(preferences.getResolved());
+    Assert.assertTrue(preferences.getSeqId() > 0);
+
+    // Deploy the application.
+    String namespace = TEST_NAMESPACE1;
+    String appName = AllProgramsApp.NAME;
+    deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
+
+    // Get preferences on the application, but none was set.
+    entityId = new ApplicationId(namespace, appName);
+    preferences = fetcher.get(entityId, false);
+    Assert.assertEquals(Collections.emptyMap(), preferences.getProperties());
+    Assert.assertFalse(preferences.getResolved());
+    Assert.assertEquals(0, preferences.getSeqId());
+
+    // Get resolved preferences on the application, preferences on instance should be returned.
+    entityId = new ApplicationId(namespace, appName);
+    preferences = fetcher.get(entityId, true);
+    Assert.assertEquals(instanceProperties, preferences.getProperties());
+    Assert.assertTrue(preferences.getResolved());
+    Assert.assertTrue(preferences.getSeqId() > 0);
+
+    // Set preferences on application and fetch again, resolved preferences should be returned.
+    Map<String, String> appProperties = ImmutableMap.of("app-key1", "app-val1");
+    setPreferences(getPreferenceURI(namespace, appName), appProperties, 200);
+    preferences = fetcher.get(entityId, true);
+    Map<String, String> resolvedProperites = new HashMap<>();
+    resolvedProperites.putAll(instanceProperties);
+    resolvedProperites.putAll(appProperties);
+    Assert.assertEquals(resolvedProperites, preferences.getProperties());
+    Assert.assertTrue(preferences.getResolved());
+    Assert.assertTrue(preferences.getSeqId() > 0);
+
+    // Delete the app
+    Assert.assertEquals(
+      200,
+      doDelete(getVersionedAPIPath("apps/",
+                                   Constants.Gateway.API_VERSION_3_TOKEN, namespace)).getResponseCode());
+  }
+}
+

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/RemoteScheduleFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/RemoteScheduleFetcherTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import io.cdap.cdap.AllProgramsApp;
+import io.cdap.cdap.AppWithSchedule;
+import io.cdap.cdap.api.Config;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleNotFoundException;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.ScheduleDetail;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ScheduleId;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Tests for {@link RemoteScheduleFetcher}
+ */
+public class RemoteScheduleFetcherTest extends AppFabricTestBase {
+  private static ScheduleFetcher fetcher = null;
+
+  @BeforeClass
+  public static void setUp() {
+    fetcher = getInjector().getInstance(RemoteScheduleFetcher.class);
+  }
+
+  @Test(expected = ScheduleNotFoundException.class)
+  public void testGetScheduleNotFound() throws Exception {
+    String namespace = TEST_NAMESPACE1;
+    String appName = AllProgramsApp.NAME;
+
+    // Deploy the application.
+    deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
+
+    // Get and validate the schedule
+    ScheduleId scheduleId = new ScheduleId(namespace, appName, "InvalidSchedule");
+    try {
+      ScheduleDetail scheduleDetail = fetcher.get(scheduleId);
+    } finally {
+      // Delete the application
+      Assert.assertEquals(
+        200,
+        doDelete(getVersionedAPIPath("apps/",
+                                     Constants.Gateway.API_VERSION_3_TOKEN, namespace)).getResponseCode());
+    }
+  }
+
+  @Test
+  public void testGetSchedule() throws Exception {
+    String namespace = TEST_NAMESPACE1;
+    String appName = AppWithSchedule.NAME;
+    String schedule = AppWithSchedule.SCHEDULE;
+
+    // Deploy the application with just 1 schedule on the workflow.
+    Config appConfig = new AppWithSchedule.AppConfig(true, true, false);
+    deploy(AppWithSchedule.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, namespace, appConfig);
+
+    // Get and validate the schedule
+    ScheduleId scheduleId = new ScheduleId(namespace, appName, schedule);
+    ScheduleDetail scheduleDetail = fetcher.get(scheduleId);
+    Assert.assertEquals(schedule, scheduleDetail.getName());
+
+    // Delete the application
+    Assert.assertEquals(
+      200,
+      doDelete(getVersionedAPIPath("apps/",
+                                   Constants.Gateway.API_VERSION_3_TOKEN, namespace)).getResponseCode());
+  }
+
+  @Test
+  public void testListSchedules() throws Exception {
+    String namespace = TEST_NAMESPACE1;
+    String appName = AppWithSchedule.NAME;
+
+    // Deploy the application with 2 schedules on the workflow
+    Config appConfig = new AppWithSchedule.AppConfig(true, true, true);
+    deploy(AppWithSchedule.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, namespace, appConfig);
+
+    // Get and validate the schedule
+    ProgramId programId = new ProgramId(namespace,
+                                        appName,
+                                        ProgramType.WORKFLOW,
+                                        AppWithSchedule.WORKFLOW_NAME);
+    List<ScheduleDetail> scheduleList = fetcher.list(programId);
+    Assert.assertEquals(2, scheduleList.size());
+    Assert.assertEquals(AppWithSchedule.SCHEDULE, scheduleList.get(0).getName());
+    Assert.assertEquals(AppWithSchedule.SCHEDULE_2, scheduleList.get(1).getName());
+
+    // Delete the application
+    Assert.assertEquals(
+      200,
+      doDelete(getVersionedAPIPath("apps/",
+                                   Constants.Gateway.API_VERSION_3_TOKEN, namespace)).getResponseCode());
+  }
+}


### PR DESCRIPTION
Introduce Abstract*Fetcher interface and Remote*Fetcher implementation that fetch Application, Schedule and Preferences detials. 

Next change will be switching ProfileMetadataMessageProcessor to use these clients instead of currently accessing levelDB directly