### PR TITLE
[CDAP-16357] Fix upgrade to jexl library for Dynamic Plugin Filters in UI

### DIFF
--- a/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/index.ts
@@ -162,6 +162,7 @@ function addPluginFunctions(configurationGroups) {
       const pluginFunctionWidget = {
         'widget-type': 'get-schema',
         'widget-category': 'plugin',
+        name: property.name,
         'widget-attributes': {
           'output-property': pluginFunction['output-property'],
           'omit-properties': pluginFunction['omit-properties'],


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16357

- Fixes `jexl` upgrade regression issue
- Fixes the functionality to hide entire group if the `show` predicate has group to hide

TODO
- We still need to automate running unit tests in bamboo (or CI) for every PR to be able to catch regressions like this.