### PR TITLE
Code cleanup: rename xxxLogHandler to xxxLogHttpHandler to be consistent with other handler class

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandler.java
@@ -32,7 +32,7 @@ import io.cdap.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.internal.app.store.RunRecordMeta;
 import io.cdap.cdap.logging.context.LoggingContextHelper;
-import io.cdap.cdap.logging.gateway.handlers.AbstractLogHandler;
+import io.cdap.cdap.logging.gateway.handlers.AbstractLogHttpHandler;
 import io.cdap.cdap.logging.read.LogReader;
 import io.cdap.cdap.metrics.query.MetricsQueryHelper;
 import io.cdap.cdap.proto.BasicThrowable;
@@ -71,7 +71,7 @@ import javax.ws.rs.QueryParam;
  */
 @Singleton
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
-public class PreviewHttpHandler extends AbstractLogHandler {
+public class PreviewHttpHandler extends AbstractLogHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(PreviewHttpHandler.class);
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec())

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/log/LogHandlerTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/log/LogHandlerTest.java
@@ -53,7 +53,7 @@ import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.logging.gateway.handlers.FormattedTextLogEvent;
 import io.cdap.cdap.logging.gateway.handlers.LogData;
-import io.cdap.cdap.logging.gateway.handlers.LogHandler;
+import io.cdap.cdap.logging.gateway.handlers.LogHttpHandler;
 import io.cdap.cdap.logging.guice.LogQueryServerModule;
 import io.cdap.cdap.logging.read.LogOffset;
 import io.cdap.cdap.logging.read.LogReader;
@@ -692,7 +692,7 @@ public class LogHandlerTest {
    *
    * @param response {@link HttpResponse}
    * @param entityId Entity for which the logs were fetched
-   * @param format {@link LogHandler.LogFormatType}
+   * @param format {@link LogHttpHandler.LogFormatType}
    * @param runIdOrFilter true if the log is fetched for a runId or a filter was used
    * @param fullLogs true if /logs endpoint was used (this is because the response format is different
    *                 for /logs vs /next or /prev)
@@ -713,7 +713,7 @@ public class LogHandlerTest {
    *
    * @param response {@link HttpResponse}
    * @param entityId Entity for which the logs were fetched
-   * @param format {@link LogHandler.LogFormatType}
+   * @param format {@link LogHttpHandler.LogFormatType}
    * @param runIdOrFilter true if the log is fetched for a runId or a filter was used
    * @param fullLogs true if /logs endpoint was used (this is because the response format is different
    *                 for /logs vs /next or /prev)
@@ -736,7 +736,7 @@ public class LogHandlerTest {
    *
    * @param response {@link HttpResponse}
    * @param entityId Entity for which the logs were fetched
-   * @param format {@link LogHandler.LogFormatType}
+   * @param format {@link LogHttpHandler.LogFormatType}
    * @param stepSize the number used to increment expected integer value in the log message every time
    * @param fullLogs true if /logs endpoint was used (this is because the response format is different
    *                 for /logs vs /next or /prev)

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/AbstractLogHttpHandler.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/AbstractLogHttpHandler.java
@@ -41,13 +41,13 @@ import javax.annotation.Nullable;
 /**
  * Abstract Class that contains commonly used methods for log Http Requests.
  */
-public abstract class AbstractLogHandler extends AbstractHttpHandler {
+public abstract class AbstractLogHttpHandler extends AbstractHttpHandler {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractLogHandler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractLogHttpHandler.class);
 
   private final String logPattern;
 
-  protected AbstractLogHandler(CConfiguration cConfig) {
+  protected AbstractLogHttpHandler(CConfiguration cConfig) {
     this.logPattern = cConfig.get(LoggingConfiguration.LOG_PATTERN, LoggingConfiguration.DEFAULT_LOG_PATTERN);
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LogHttpHandler.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LogHttpHandler.java
@@ -45,13 +45,13 @@ import javax.ws.rs.QueryParam;
  */
 @Singleton
 @Path(Constants.Gateway.API_VERSION_3)
-public class LogHandler extends AbstractLogHandler {
+public class LogHttpHandler extends AbstractLogHttpHandler {
 
   private final ProgramStore programStore;
   private final LogReader logReader;
 
   @Inject
-  public LogHandler(LogReader logReader, CConfiguration cConf, ProgramStore programStore) {
+  public LogHttpHandler(LogReader logReader, CConfiguration cConf, ProgramStore programStore) {
     super(cConf);
     this.logReader = logReader;
     this.programStore = programStore;

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/guice/LogQueryServerModule.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/guice/LogQueryServerModule.java
@@ -22,7 +22,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.gateway.handlers.CommonHandlers;
-import io.cdap.cdap.logging.gateway.handlers.LogHandler;
+import io.cdap.cdap.logging.gateway.handlers.LogHttpHandler;
 import io.cdap.cdap.logging.service.LogQueryService;
 import io.cdap.http.HttpHandler;
 
@@ -35,7 +35,7 @@ public class LogQueryServerModule extends PrivateModule {
   protected void configure() {
     Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(binder(), HttpHandler.class,
                                                                       Names.named(Constants.Service.LOG_QUERY));
-    handlerBinder.addBinding().to(LogHandler.class);
+    handlerBinder.addBinding().to(LogHttpHandler.class);
     CommonHandlers.add(handlerBinder);
 
     bind(LogQueryService.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
Code cleanup:  rename two classes to be consistent with rest of the code base:

AbstractLogHandler -> AbstractLogHttpHandler
LogHandler-> LogHttpHandler