### PR TITLE
(CDAP-16211) Updated AppRequest to add configuration field

### DIFF
--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/AppRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/AppRequest.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 public class AppRequest<T> {
   private final ArtifactSummary artifact;
   private final T config;
+  private final T configuration;
   private final PreviewConfig preview;
   @SerializedName("principal")
   private final String ownerPrincipal;
@@ -60,6 +61,9 @@ public class AppRequest<T> {
     this.preview = preview;
     this.ownerPrincipal = ownerPrincipal;
     this.updateSchedules = updateSchedules;
+
+    // This should never be set programmatically, this is added as a workaround for JIRA issue CDAP-16211
+    this.configuration = null;
   }
 
   public ArtifactSummary getArtifact() {
@@ -68,7 +72,7 @@ public class AppRequest<T> {
 
   @Nullable
   public T getConfig() {
-    return config;
+    return config != null ? config : configuration;
   }
 
   @Nullable


### PR DESCRIPTION
[This ticket](https://issues.cask.co/browse/CDAP-16211) outlines the issue. 

Best fix to maintain backwards compatibility is to add a `configuration` field to the schema of AppRequest. This will allow the user to use the response from `GET .../apps/[app-id]` to deploy a pipeline using `PUT .../apps/[app-id]`.