### PR TITLE
[CDAP-16368] Check for duplicate dataset names in operations modal

### DIFF
--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/OperationsModal/ModalContent.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/OperationsModal/ModalContent.tsx
@@ -43,25 +43,25 @@ function formatDatasets(datasets) {
 }
 
 function getDatasets(operations) {
-  const inputs = [];
-  const outputs = [];
+  const inputs = new Set(); // to prevent duplicate datasets in header
+  const outputs = new Set();
 
   operations.forEach((operation) => {
     const input = objectQuery(operation, 'inputs', 'endPoint', 'name');
     const output = objectQuery(operation, 'outputs', 'endPoint', 'name');
 
     if (input) {
-      inputs.push(input);
+      inputs.add(input);
     }
 
     if (output) {
-      outputs.push(output);
+      outputs.add(output);
     }
   });
 
   return {
-    sources: formatDatasets(inputs),
-    targets: formatDatasets(outputs),
+    sources: formatDatasets(Array.from(inputs)),
+    targets: formatDatasets(Array.from(outputs)),
   };
 }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16368
Build: https://builds.cask.co/browse/CDAP-UDUT524

Small change to check for duplicate dataset names in header of the Operations Modal. This will handle the edge cases where a pipeline has multiple sources with the same name now and in the future (i.e. we or a plugin developer makes this sort of change to how a plugin emits lineage: https://github.com/cdapio/hydrator-plugins/pull/1032).