### PR TITLE
CDAP-16356 improve the field lineage compute algorithms

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/FieldLineageInfo.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/FieldLineageInfo.java
@@ -329,18 +329,30 @@ public class FieldLineageInfo {
       computeAndValidateFieldLineageInfo(this.operations);
     }
 
+    Map<String, Set<EndPointField>> operationEndPointMap = new HashMap<>();
     Map<EndPointField, Set<EndPointField>> summary = new HashMap<>();
     for (WriteOperation write : writeOperations) {
       List<InputField> inputs = write.getInputs();
       for (InputField input : inputs) {
-        computeIncomingSummaryHelper(new EndPointField(write.getDestination(), input.getName()),
-                                     operationsMap.get(input.getOrigin()), write, summary);
+        EndPointField dest = new EndPointField(write.getDestination(), input.getName());
+        if (operationEndPointMap.containsKey(input.getOrigin())) {
+          summary.put(dest, operationEndPointMap.get(input.getOrigin()));
+        } else {
+          summary.put(dest, computeIncomingSummaryHelper(operationsMap.get(input.getOrigin()), write,
+                                                         operationEndPointMap));
+        }
       }
     }
     for (TransformOperation transform : dropTransforms) {
       for (InputField input : transform.getInputs()) {
         Operation previous = operationsMap.get(input.getOrigin());
-        computeIncomingSummaryHelper(NULL_EPF, previous, transform, summary);
+        // drop transforms uses a common NULL endpoint as key
+        Set<EndPointField> endPointFields = summary.computeIfAbsent(NULL_EPF, k -> new HashSet<>());
+        if (operationEndPointMap.containsKey(input.getOrigin())) {
+          endPointFields.addAll(new HashSet<>(operationEndPointMap.get(input.getOrigin())));
+          continue;
+        }
+        endPointFields.addAll(computeIncomingSummaryHelper(previous, transform, operationEndPointMap));
       }
     }
     return summary;
@@ -349,18 +361,17 @@ public class FieldLineageInfo {
   /**
    * Helper method to compute the incoming summary
    *
-   * @param field the {@link EndPointField} whose summary needs to be calculated
    * @param currentOperation the operation being processed. Since we are processing incoming this operation is on the
    * left side if graph is imagined in horizontal orientation or this operation is the input to the to
    * previousOperation
    * @param previousOperation the previous operation which is processed and reside on right to the current operation if
    * the graph is imagined to be in horizontal orientation.
-   * @param summary a {@link Map} of {@link EndPointField} to {@link Set} of {@link EndPointField} which represents all
-   * the fields which have incoming connection the key field
+   * @param operationEndPointMap a map that contains the operation name to the final endpoint field it will generate,
+   * this is used to track the path we already computed to ensure we do not do the same computation again
    */
-  private void computeIncomingSummaryHelper(EndPointField field, Operation currentOperation,
-                                            Operation previousOperation,
-                                            Map<EndPointField, Set<EndPointField>> summary) {
+  private Set<EndPointField> computeIncomingSummaryHelper(Operation currentOperation,
+                                                          Operation previousOperation,
+                                                          Map<String, Set<EndPointField>> operationEndPointMap) {
     if (currentOperation.getType() == OperationType.READ) {
       // if current operation is of type READ, previous operation must be of type TRANSFORM or WRITE
       // get only the input fields from the previous operations for which the origin is current READ operation
@@ -372,7 +383,8 @@ public class FieldLineageInfo {
         TransformOperation previousTransform = (TransformOperation) previousOperation;
         inputFields = new HashSet<>(previousTransform.getInputs());
       }
-      Set<EndPointField> sourceEndPointFields = summary.computeIfAbsent(field, k -> new HashSet<>());
+
+      Set<EndPointField> sourceEndPointFields = new HashSet<>();
 
       // for all the input fields of the previous operation if the origin was current operation (remember we are
       // traversing backward)
@@ -384,9 +396,10 @@ public class FieldLineageInfo {
         }
       }
       // reached the end of graph unwind the recursive calls
-      return;
+      return sourceEndPointFields;
     }
 
+    Set<EndPointField> relatedSources = new HashSet<>();
     // for transform we traverse backward in graph further through the inputs of the transform
     if (currentOperation.getType() == OperationType.TRANSFORM) {
       TransformOperation transform = (TransformOperation) currentOperation;
@@ -395,9 +408,16 @@ public class FieldLineageInfo {
         .map(InputField::getOrigin)
         .collect(Collectors.toSet());
       for (String transformOrigin : transformOrigins) {
-        computeIncomingSummaryHelper(field, operationsMap.get(transformOrigin), currentOperation, summary);
+        if (operationEndPointMap.containsKey(transformOrigin)) {
+          relatedSources.addAll(operationEndPointMap.get(transformOrigin));
+        } else {
+          relatedSources.addAll(
+            computeIncomingSummaryHelper(operationsMap.get(transformOrigin), currentOperation, operationEndPointMap));
+        }
       }
+      operationEndPointMap.put(currentOperation.getName(), relatedSources);
     }
+    return relatedSources;
   }
 
   private Map<EndPointField, Set<EndPointField>> computeOutgoingSummary() {

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/field/FieldLineageInfoTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/field/FieldLineageInfoTest.java
@@ -49,6 +49,43 @@ public class FieldLineageInfoTest {
     .registerTypeAdapter(Operation.class, new OperationTypeAdapter())
     .create();
 
+  @Test(timeout = 10000)
+  public void testLargeLineageOperation() {
+    List<String> inputs = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      inputs.add("num" + i);
+    }
+
+    List<Operation> operations = new ArrayList<>();
+    operations.add(new ReadOperation("read", "Read from something", EndPoint.of("start"), inputs));
+
+    // generate 500+ operations with 5 identity + all-to-all combos
+    generateLineage(inputs, operations, "first identity", "read", "alltoall1");
+    generateLineage(inputs, operations, "second identity", "alltoall1", "alltoall2");
+    generateLineage(inputs, operations, "third identity", "alltoall2", "alltoall3");
+    generateLineage(inputs, operations, "forth identity", "alltoall3", "alltoall4");
+    generateLineage(inputs, operations, "fifth identity", "alltoall4", "alltoall5");
+
+    List<InputField> newList = new ArrayList<>();
+    inputs.forEach(s -> newList.add(InputField.of("alltoall5", s)));
+    WriteOperation operation = new WriteOperation("Write", "", EndPoint.of("dest"), newList);
+    operations.add(operation);
+
+    FieldLineageInfo info = new FieldLineageInfo(operations);
+
+    Assert.assertNotNull(info);
+    Set<EndPointField> relatedSources = new HashSet<>();
+    Map<EndPointField, Set<EndPointField>> expectedIncoming = new HashMap<>();
+    for (int i = 0; i < inputs.size(); i++) {
+      relatedSources.add(new EndPointField(EndPoint.of("start"), "num" + i));
+    }
+    for (int i = 0; i < inputs.size(); i++) {
+      EndPointField key = new EndPointField(EndPoint.of("dest"), "num" + i);
+      expectedIncoming.put(key, relatedSources);
+    }
+    Assert.assertEquals(expectedIncoming, info.getIncomingSummary());
+  }
+
   @Test
   public void testInvalidOperations() {
     ReadOperation read = new ReadOperation("read", "some read", EndPoint.of("endpoint1"), "offset", "body");
@@ -878,5 +915,25 @@ public class FieldLineageInfoTest {
     int aIndex = list.indexOf(a);
     int bIndex = list.indexOf(b);
     Assert.assertTrue(aIndex < bIndex);
+  }
+
+  private void generateLineage(List<String> inputs, List<Operation> operations, String identityNamePrefix,
+                               String identityOrigin, String transform) {
+    // emit identity transform for all fields
+    for (int i = 0; i < inputs.size(); i++) {
+      operations.add(new TransformOperation(identityNamePrefix + i, "identity transform",
+                                            Collections.singletonList(InputField.of(identityOrigin, inputs.get(i))),
+                                            inputs.get(i)));
+    }
+
+    // generate an all-to-all, so that when track back, this operation has to track back to all the previous
+    // identity transform
+    List<InputField> inputFields = new ArrayList<>();
+    for (int i = 0; i < inputs.size(); i++) {
+      inputFields.add(InputField.of(identityNamePrefix + i, inputs.get(i)));
+    }
+    TransformOperation parse = new TransformOperation(transform, "all to all transform",
+                                                      inputFields, inputs);
+    operations.add(parse);
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16356
build: https://builds.cask.co/browse/CDAP-DUT7125-1

The old algorithm does a lot of repeated computation for the same operation name, introduce a map to remember for each operation name, what is the endpoint field related to it. If next time, the same operation is queried again, the result is already known. This reduces the exponential time complexity to number of the operations. 