### PR TITLE
[CDAP-16278] Modifies selection to be default in pipeline studio

### DIFF
--- a/cdap-ui/app/cdap/components/ContextMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/ContextMenu/index.tsx
@@ -20,13 +20,15 @@ import MenuItem from '@material-ui/core/MenuItem';
 import withStyles from '@material-ui/core/styles/withStyles';
 import PropTypes from 'prop-types';
 import MenuItemContentWrapper from 'components/ContextMenu/MenuItemContentWrapper';
+import Divider from '@material-ui/core/Divider';
 
 export interface IContextMenuOption {
-  name: string;
-  label: (() => string) | string;
-  onClick: (event: React.SyntheticEvent) => void;
+  name?: string;
+  label?: (() => string) | string;
+  onClick?: (event: React.SyntheticEvent) => void;
   disabled?: boolean;
   icon?: React.ReactElement;
+  type?: 'divider';
 }
 
 interface IContextMenuProps {
@@ -46,7 +48,7 @@ const StyledMenuItem = withStyles(() => ({
     minHeight: 'auto',
   },
   gutters: {
-    padding: '2px 12px',
+    padding: '5px 15px',
   },
 }))(MenuItem);
 
@@ -139,7 +141,10 @@ export const ContextMenu = ({ selector, element, options, onOpen }: IContextMenu
       ref={measuredRef}
     >
       {options.map((option) => {
-        const { name, label, disabled, icon } = option;
+        const { name, disabled, type } = option;
+        if (type === 'divider') {
+          return <Divider />;
+        }
         const MenuItemComp = disabled ? StyledDisabledMenuItem : StyledMenuItem;
         return (
           <MenuItemComp

--- a/cdap-ui/app/cdap/components/PipelineContextMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineContextMenu/index.tsx
@@ -111,6 +111,18 @@ export default function PipelineContextMenu({
       onClick: () => setShowWranglerModal(!showWranglerModal),
     },
     {
+      type: 'divider',
+    },
+    {
+      name: 'pipeline-node-paste',
+      label: 'Paste',
+      icon: <IconSVG name="icon-filecopyaction" />,
+      onClick: () => {
+        getNodesFromClipBoard().then(onNodesPaste);
+      },
+      disabled: pasteOptionDisabled,
+    },
+    {
       name: 'zoom-in',
       label: 'Zoom In',
       icon: <IconSVG name="icon-zoomIn" />,
@@ -133,15 +145,6 @@ export default function PipelineContextMenu({
       label: 'Align',
       icon: <IconSVG name="icon-clean" />,
       onClick: prettyPrintGraph,
-    },
-    {
-      name: 'pipeline-node-paste',
-      label: 'Paste',
-      icon: <IconSVG name="icon-filecopyaction" />,
-      onClick: () => {
-        getNodesFromClipBoard().then(onNodesPaste);
-      },
-      disabled: pasteOptionDisabled,
     },
   ];
   const onWranglerSourceAddWrapper = (...props) => {

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -97,12 +97,25 @@
           data-cy="pipeline-redo-action-btn">
     <i class="fa fa-repeat"></i>
   </button>
+
+  <button class="btn btn-default"
+          uib-tooltip="Move"
+          tooltip-append-to-body="true"
+          tooltip-placement="left"
+          tooltip-popup-delay="500"
+          ng-if="!DAGPlusPlusCtrl.isDisabled"
+          ng-click="DAGPlusPlusCtrl.selectionBox.toggleSelectionMode()"
+          ng-class="{'move-mode-selected': !DAGPlusPlusCtrl.selectionBox.toggle}"
+          data-cy="pipeline-move-mdoe-action-btn"
+  >
+    <i class="fa fa-arrows"></i>
+  </button>
 </div>
 
 <div class="my-js-dag"
     ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled, 'normal-cursor': disableNodeClick, 'preview-mode': previewMode }"
-    ng-click="DAGPlusPlusCtrl.handleCanvasClick()">
-    <div id="diagram-container">
+    ng-click="DAGPlusPlusCtrl.handleCanvasClick($event, true)">
+    <div id="diagram-container" ng-class="{'move-mode': !DAGPlusPlusCtrl.selectionBox.toggle, 'disabled': DAGPlusPlusCtrl.isDisabled}">
       <div id="dag-container" ng-style="DAGPlusPlusCtrl.panning.style">
         <!--
           The condition on ng-click is to prevent user from being able to click

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -139,6 +139,12 @@ my-dag-plus {
       width: inherit;
       height: inherit;
       overflow: hidden;
+      cursor: crosshair;
+
+      &.move-mode,
+      &.disabled {
+        cursor: move;
+      }
     }
 
     &.disabled {

--- a/cdap-ui/app/hydrator/adapters.less
+++ b/cdap-ui/app/hydrator/adapters.less
@@ -49,7 +49,7 @@ body.theme-cdap {
     }
 
     .my-js-dag {
-      overflow: auto;
+      overflow: hidden;
     }
 
     i.fa-exclamation-circle {
@@ -147,6 +147,12 @@ body.theme-cdap {
     .btn-group-vertical {
       > .btn:not(:last-child) {
         border-bottom: 0;
+      }
+      button.move-mode-selected {
+        background-color: #6a7387;
+        i.fa.fa-arrows {
+          color: white;
+        }
       }
     }
   }

--- a/cdap-ui/cypress/integration/pipeline.multiselect.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.multiselect.spec.ts
@@ -46,19 +46,34 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
   it('Should not select if not in selection mode', () => {
     cy.visit('/pipelines/ns/default/studio');
     cy.create_simple_pipeline().then(({ sourceNodeId: from, transformNodeId: to }) => {
-      let fromNodeElement, toNodeElement;
-      cy.get_node(from).then(sElement => {
+      let fromNodeElement;
+      let toNodeElement;
+      cy.get_node(from).then((sElement) => {
         fromNodeElement = sElement;
-        cy.get_node(to).then(tElement => {
+        cy.get_node(to).then((tElement) => {
           toNodeElement = tElement;
           const { x: fromX, y: fromY } = fromNodeElement[0].getBoundingClientRect();
-          const { x: toX, y: toY, width: toWidth, height: toHeight } = toNodeElement[0].getBoundingClientRect();
+          const {
+            x: toX,
+            y: toY,
+            width: toWidth,
+            height: toHeight,
+          } = toNodeElement[0].getBoundingClientRect();
+          cy.get('[data-cy="pipeline-move-mdoe-action-btn"]').click();
+          cy.get('#dag-container').trigger('mousedown', {
+            which: 1,
+            clientX: fromX - 10,
+            clientY: fromY - 10,
+          });
           cy.get('#dag-container')
-            .trigger('mousedown', { which: 1, clientX: (fromX - 10), clientY: (fromY - 10) });
-          cy.get('#dag-container')
-            .trigger('mousemove', { which: 1, clientX: (toX + toWidth + 10), clientY: (toY + toHeight + 10) })
+            .trigger('mousemove', {
+              which: 1,
+              clientX: toX + toWidth + 10,
+              clientY: toY + toHeight + 10,
+            })
             .trigger('mouseup', { force: true });
           cy.get('.box.selected').should('have.length', 0);
+          cy.get('[data-cy="pipeline-move-mdoe-action-btn"]').click();
         });
       });
     });
@@ -66,15 +81,17 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
 
   it('Should select everything including edges', () => {
     cy.visit('/pipelines/ns/default/studio');
-    cy.create_complex_pipeline().then(({ sourceNodeId1, transformNodeId2, joinerNodeId, sinkNodeId2 }) => {
-      cy.get('[data-cy="feature-heading"]').click();
-      cy.select_from_to(sourceNodeId1, transformNodeId2);
-      cy.get('.box.selected').should('have.length', 4);
-      cy.get('svg.selected-connector').should('have.length', 2);
-      cy.get('#dag-container').click();
-      cy.select_from_to(joinerNodeId, sinkNodeId2);
-      cy.get('svg.selected-connector').should('have.length', 3);
-    });
+    cy.create_complex_pipeline().then(
+      ({ sourceNodeId1, transformNodeId2, joinerNodeId, sinkNodeId2 }) => {
+        cy.get('[data-cy="feature-heading"]').click();
+        cy.select_from_to(sourceNodeId1, transformNodeId2);
+        cy.get('.box.selected').should('have.length', 4);
+        cy.get('svg.selected-connector').should('have.length', 2);
+        cy.get('#dag-container').click();
+        cy.select_from_to(joinerNodeId, sinkNodeId2);
+        cy.get('svg.selected-connector').should('have.length', 3);
+      }
+    );
   });
 
   it('Should correctly copy/paste/delete only nodes/connections in the selection', () => {
@@ -88,7 +105,7 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
       cy.get('[data-cy="menu-item-plugin copy"]:visible').click();
       cy.get('#dag-container').rightclick({ force: true });
       cy.get('[data-cy="menu-item-pipeline-node-paste"]').click();
-      cy.get_pipeline_json().then(pipelineConfig => {
+      cy.get_pipeline_json().then((pipelineConfig) => {
         const connections = pipelineConfig.config.connections;
         const stages = pipelineConfig.config.stages;
         expect(connections.length).eq(3);
@@ -96,7 +113,7 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
       });
       const undoSelector = '[data-cy="pipeline-undo-action-btn"]';
       cy.get(undoSelector).click();
-      cy.get_pipeline_json().then(pipelineConfig => {
+      cy.get_pipeline_json().then((pipelineConfig) => {
         const connections = pipelineConfig.config.connections;
         const stages = pipelineConfig.config.stages;
         expect(connections.length).eq(2);

--- a/cdap-ui/cypress/support/commands.ts
+++ b/cdap-ui/cypress/support/commands.ts
@@ -17,7 +17,11 @@
 import { ConnectionType } from '../../app/cdap/components/DataPrepConnections/ConnectionType';
 import { DEFAULT_GCP_PROJECTID, DEFAULT_GCP_SERVICEACCOUNT_PATH } from '../support/constants';
 import { INodeIdentifier, INodeInfo, IgetNodeIDOptions } from '../typings';
-import { getGenericEndpoint, getConditionNodeEndpoint, getNodeSelectorFromNodeIndentifier } from '../helpers';
+import {
+  getGenericEndpoint,
+  getConditionNodeEndpoint,
+  getNodeSelectorFromNodeIndentifier,
+} from '../helpers';
 /**
  * Uploads a pipeline json from fixtures to input file element.
  *
@@ -325,47 +329,62 @@ Cypress.Commands.add('move_node', (node: INodeIdentifier | string, toX: number, 
 });
 
 Cypress.Commands.add('select_from_to', (from: INodeIdentifier, to: INodeIdentifier) => {
-  let fromNodeElement, toNodeElement;
-  cy.get_node(from).then(sElement => {
+  let fromNodeElement;
+  let toNodeElement;
+  cy.get_node(from).then((sElement) => {
     fromNodeElement = sElement;
-    cy.get_node(to).then(tElement => {
+    cy.get_node(to).then((tElement) => {
       toNodeElement = tElement;
       const { x: fromX, y: fromY } = fromNodeElement[0].getBoundingClientRect();
-      const { x: toX, y: toY, width: toWidth, height: toHeight } = toNodeElement[0].getBoundingClientRect();
-      cy.get('body').type('{shift}', { release: false });
+      const {
+        x: toX,
+        y: toY,
+        width: toWidth,
+        height: toHeight,
+      } = toNodeElement[0].getBoundingClientRect();
+      cy.get('#diagram-container').trigger('mousedown', {
+        which: 1,
+        force: true,
+        clientX: fromX - 10,
+        clientY: fromY - 10,
+      });
       cy.get('#diagram-container')
-        .trigger('mousedown', { which: 1, force: true, clientX: (fromX - 10), clientY: (fromY - 10) });
-      cy.get('#diagram-container')
-        .trigger('mousemove', { which: 1, clientX: (toX + toWidth + 10), clientY: (toY + toHeight + 10) })
+        .trigger('mousemove', {
+          which: 1,
+          clientX: toX + toWidth + 10,
+          clientY: toY + toHeight + 10,
+        })
         .trigger('mouseup', { force: true });
-      cy.get('body').type('{shift}', { release: true });
     });
   });
 });
 
-Cypress.Commands.add('connect_two_nodes', (
-  sourceNode: INodeIdentifier,
-  targetNode: INodeIdentifier,
-  sourceEndpoint: (options: IgetNodeIDOptions, s: string) => string,
-  options: IgetNodeIDOptions = {},
-) => {
-  cy.get_node(sourceNode).then(sourceEl => {
-    cy.get_node(targetNode).then(targetEl => {
-      let sourceCoOrdinates = sourceEl[0].getBoundingClientRect();
-      let targetCoOrdinates = targetEl[0].getBoundingClientRect();
-      // connect from source endpoint to midway between the target node
-      cy.move_node(
-        sourceEndpoint(options, sourceEl[0].id),
-        (targetCoOrdinates.left - sourceCoOrdinates.right + (targetCoOrdinates.width / 2)),
-        (targetCoOrdinates.top - sourceCoOrdinates.bottom + (targetCoOrdinates.height / 2))
-      );
+Cypress.Commands.add(
+  'connect_two_nodes',
+  (
+    sourceNode: INodeIdentifier,
+    targetNode: INodeIdentifier,
+    sourceEndpoint: (options: IgetNodeIDOptions, s: string) => string,
+    options: IgetNodeIDOptions = {}
+  ) => {
+    cy.get_node(sourceNode).then((sourceEl) => {
+      cy.get_node(targetNode).then((targetEl) => {
+        let sourceCoOrdinates = sourceEl[0].getBoundingClientRect();
+        let targetCoOrdinates = targetEl[0].getBoundingClientRect();
+        // connect from source endpoint to midway between the target node
+        cy.move_node(
+          sourceEndpoint(options, sourceEl[0].id),
+          targetCoOrdinates.left - sourceCoOrdinates.right + targetCoOrdinates.width / 2,
+          targetCoOrdinates.top - sourceCoOrdinates.bottom + targetCoOrdinates.height / 2
+        );
+      });
     });
-  });
-});
+  }
+);
 
 Cypress.Commands.add('get_node', (element: INodeIdentifier) => {
   let elementId = getNodeSelectorFromNodeIndentifier(element);
-  return cy.get(elementId).then(e => cy.wrap(e));
+  return cy.get(elementId).then((e) => cy.wrap(e));
 });
 
 Cypress.Commands.add('create_simple_pipeline', () => {
@@ -460,7 +479,7 @@ Cypress.Commands.add('create_complex_pipeline', () => {
     joinerNodeId,
     conditionNodeId,
     sinkNodeId1,
-    sinkNodeId2
+    sinkNodeId2,
   });
 });
 


### PR DESCRIPTION
- Modifies the behavior to default to selecting nodes while developing pipelines
- Provides a way to toggle between selection mode and move mode to move canvas around
- Fixes comments to not dissapear when copy/pasting

JIRA: https://issues.cask.co/browse/CDAP-16278
Build: https://builds.cask.co/browse/CDAP-UDUT531-1

On-hold: 
- Fixing e2e tests + adding new ones to validate the change. 
- Pipeline context menu changes
