### PR TITLE
(CDAP-16243) Added upgrade mechanism System Apps managed by SystemAppManagementService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -126,18 +126,21 @@ public class AppFabricServer extends AbstractIdleService {
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.APP_FABRIC_HTTP));
+
     Futures.allAsList(
       ImmutableList.of(
         provisioningService.start(),
         applicationLifecycleService.start(),
         bootstrapService.start(),
-        systemAppManagementService.start(),
         programRuntimeService.start(),
         programNotificationSubscriberService.start(),
         runRecordCorrectorService.start(),
         coreSchedulerService.start()
       )
     ).get();
+
+    // Start system app management service only after bootstrap service is started.
+    systemAppManagementService.start().get();
 
     // Create handler hooks
     List<MetricsReporterHook> handlerHooks = handlerHookNames.stream()

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -126,7 +126,6 @@ public class AppFabricServer extends AbstractIdleService {
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.APP_FABRIC_HTTP));
-
     Futures.allAsList(
       ImmutableList.of(
         provisioningService.start(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.common.logging.LogSamplers;
 import io.cdap.cdap.common.logging.Loggers;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
-import io.cdap.cdap.internal.bootstrap.BootstrapStep.RunCondition;
 import io.cdap.cdap.internal.bootstrap.executor.BootstrapStepExecutor;
 import io.cdap.cdap.proto.bootstrap.BootstrapResult;
 import io.cdap.cdap.proto.bootstrap.BootstrapStepResult;
@@ -78,13 +77,12 @@ public class BootstrapService extends AbstractIdleService {
       try {
         if (isBootstrappedWithRetries()) {
           // if the system is already bootstrapped, skip any bootstrap step that is supposed to only run once
-          bootstrap(step -> step.getRunCondition() == RunCondition.ONCE);
+          bootstrap(step -> step.getRunCondition() == BootstrapStep.RunCondition.ONCE);
         } else {
           bootstrap();
         }
       } catch (InterruptedException e) {
-        LOG.info(
-            "Bootstrapping could not complete due to interruption. It will be re-run the next time CDAP starts.");
+        LOG.info("Bootstrapping could not complete due to interruption. It will be re-run the next time CDAP starts.");
       }
     }).get();
     LOG.info("Started {}", getClass().getSimpleName());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
@@ -27,8 +27,6 @@ import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.internal.bootstrap.executor.BootstrapStepExecutor;
 import io.cdap.cdap.proto.bootstrap.BootstrapResult;
 import io.cdap.cdap.proto.bootstrap.BootstrapStepResult;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -136,11 +136,11 @@ public class SystemAppEnableExecutor {
 
   private void startProgram(ProgramId programId) throws Exception {
     try {
-      // TODO(CDAP-16243): Restart program if the application has changed.
-      // do nothing if the program is already running
       ProgramStatus currentStatus = programLifecycleService.getProgramStatus(programId);
       // If a system app is already running, it needs to be restarted as app artifact/arguments might have changed.
       // Restart should trigger running programs with latest version.
+      // TODO(CDAP-16243): Find smarter way to trigger restart of programs rather than always restarting. May be
+      //                   checking if artifact version has changed would be a good start.
       if (currentStatus == ProgramStatus.RUNNING) {
         programLifecycleService.stop(programId);
       }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -141,8 +141,13 @@ public class SystemAppEnableExecutor {
       // Restart should trigger running programs with latest version.
       // TODO(CDAP-16243): Find smarter way to trigger restart of programs rather than always restarting. May be
       //                   checking if artifact version has changed would be a good start.
-      if (currentStatus == ProgramStatus.RUNNING) {
-        programLifecycleService.stop(programId);
+      try {
+        if (currentStatus == ProgramStatus.RUNNING) {
+          programLifecycleService.stop(programId);
+        }
+      } catch (ConflictException e) {
+        // Will reach here if the program is already stopped, which means it tried to stop after the status check above.
+        // ignore this, as it means the program is stopped as we wanted.
       }
       programLifecycleService.run(programId, Collections.emptyMap(), false);
     } catch (ConflictException e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -139,8 +139,10 @@ public class SystemAppEnableExecutor {
       // TODO(CDAP-16243): Restart program if the application has changed.
       // do nothing if the program is already running
       ProgramStatus currentStatus = programLifecycleService.getProgramStatus(programId);
-      if (currentStatus != ProgramStatus.STOPPED) {
-        return;
+      // If a system app is already running, it needs to be restarted as app artifact/arguments might have changed.
+      // Restart should trigger running programs with latest version.
+      if (currentStatus == ProgramStatus.RUNNING) {
+        programLifecycleService.stop(programId);
       }
       programLifecycleService.run(programId, Collections.emptyMap(), false);
     } catch (ConflictException e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppManagementService.java
@@ -23,6 +23,7 @@ import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.DirUtils;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import org.apache.twill.common.Threads;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
@@ -34,11 +34,9 @@ import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
-import java.nio.file.Files;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -47,6 +45,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -64,10 +63,9 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
   private static File systemConfigDir;
 
   private static final String RUNNING = "RUNNING";
-  private static final String STOPPED = "STOPPPED";
 
   @Rule
-  public TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  public final TemporaryFolder tmpFolder = new TemporaryFolder();
 
 
   @BeforeClass
@@ -110,7 +108,7 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
    */
   @Test
   public void testSystemAppManagementServiceE2E() throws Exception {
-    systemConfigDir = TEMPORARY_FOLDER.newFolder("demo-sys-app-config-dir");
+    systemConfigDir = tmpFolder.newFolder("demo-sys-app-config-dir");
     cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
     systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
                                                                 programLifecycleService);
@@ -135,7 +133,7 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
    */
   @Test
   public void testSystemAppManagementServiceUpgradeApp() throws Exception {
-    systemConfigDir = TEMPORARY_FOLDER.newFolder("demo-sys-app-config-dir");
+    systemConfigDir = tmpFolder.newFolder("demo-sys-app-config-dir");
     cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
     systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
         programLifecycleService);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
@@ -27,21 +27,21 @@ import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.ProgramStatus;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
-import org.iq80.leveldb.util.FileUtils;
-import org.junit.After;
+import java.nio.file.Files;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -55,7 +55,6 @@ import java.util.List;
  */
 public class SystemAppManagementServiceTest extends AppFabricTestBase {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SystemAppManagementServiceTest.class);
   private static final Gson GSON = new Gson();
 
   private static ProgramLifecycleService programLifecycleService;
@@ -65,9 +64,10 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
   private static File systemConfigDir;
 
   private static final String RUNNING = "RUNNING";
+  private static final String STOPPED = "STOPPPED";
 
-  @ClassRule
-  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  @Rule
+  public TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
 
   @BeforeClass
@@ -93,6 +93,7 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
       new SystemAppStep("step for " + artifactId.getName(), SystemAppStep.Type.ENABLE_SYSTEM_APP, step1Argument));
     SystemAppConfig config = new SystemAppConfig(steps);
     File tmpFile = new File(systemConfigDir, filename);
+    Files.deleteIfExists(tmpFile.toPath());
     try (BufferedWriter bw = new BufferedWriter(new FileWriter(tmpFile))) {
       bw.write(GSON.toJson(config));
     }
@@ -123,4 +124,45 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
     waitState(serviceId1, RUNNING);
     Assert.assertEquals(RUNNING, getProgramStatus(serviceId1));
   }
+
+  /**
+   * Tests SystemAppManagementService's upgrade method end to end by running this scenario:
+   * 1. Creates a system app config for an application into corresponding directory with artifact version VERSION1.
+   * 2. Successfully read and load the config.
+   * 3. Runs all steps to enable a system app , tests SystemAppEnableExecutor.
+   * 4. Deploys the VERSION1 app and runs all programs corresponding to the app.
+   * 6. Updates system app config with app version upgraded to VERSION2.
+   * 7. On restart of SystemAppManagementService, app should kill old running programs and start program again.
+   * @throws Exception
+   */
+  @Test
+  public void testSystemAppManagementServiceUpgradeApp() throws Exception {
+    systemConfigDir = TEMPORARY_FOLDER.newFolder("demo-sys-app-config-dir");
+    cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
+    systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
+        programLifecycleService);
+    Id.Artifact artifactId1 = Id.Artifact.from(Id.Namespace.DEFAULT, "App", VERSION1);
+    addAppArtifact(artifactId1, AllProgramsApp.class);
+    createEnableSysAppConfigFile(artifactId1, "demo.json");
+    systemAppManagementService.startUp();
+    ApplicationId appId1 = NamespaceId.DEFAULT.app(AllProgramsApp.NAME);
+    ProgramId serviceId1 = appId1.program(ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME);
+    waitState(serviceId1, RUNNING);
+    Assert.assertEquals(RUNNING, getProgramStatus(serviceId1));
+    // Program shouldn't be killed first time it is started.
+    assertProgramRuns(serviceId1, ProgramRunStatus.KILLED, 0);
+    systemAppManagementService.shutDown();
+
+    // New system app config with newer artifact version.
+    Id.Artifact artifactId2 = Id.Artifact.from(Id.Namespace.DEFAULT, "App", VERSION2);
+    addAppArtifact(artifactId2, AllProgramsApp.class);
+    createEnableSysAppConfigFile(artifactId2, "demo.json");
+    // SystemAppManagement restarts again.
+    systemAppManagementService.startUp();
+    // Program ID still stays the same.
+    waitState(serviceId1, RUNNING);
+    Assert.assertEquals(RUNNING, getProgramStatus(serviceId1));
+    assertProgramRuns(serviceId1, ProgramRunStatus.KILLED, 1);
+  }
+
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
@@ -107,7 +107,6 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
    * 4. Deploys the app.
    * 5. Runs all programs corresponding to the app.
    * 6. Checks status of a continuously running program, i.e a service program.
-   * @throws Exception
    */
   @Test
   public void testSystemAppManagementServiceE2E() throws Exception {
@@ -133,7 +132,6 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
    * 4. Deploys the VERSION1 app and runs all programs corresponding to the app.
    * 6. Updates system app config with app version upgraded to VERSION2.
    * 7. On restart of SystemAppManagementService, app should kill old running programs and start program again.
-   * @throws Exception
    */
   @Test
   public void testSystemAppManagementServiceUpgradeApp() throws Exception {


### PR DESCRIPTION
Changes includes:

1. Start SystemAppManagementService only after BootStrap steps are run due to dependency on metadata and load system artifacts steps.
2. Force restart programs running for a system app when ENABLE_ step is run for it to make sure programs are running with latest system artifacts and arguments. This is safe to do as system apps are stateless and we already restart them while upgrading an instance of CDAP.

TESTS: Tested using unit tests.