### PR TITLE
Upgrade mechanism for System Apps managed by SystemAppManagementService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -126,6 +126,7 @@ public class AppFabricServer extends AbstractIdleService {
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.APP_FABRIC_HTTP));
+
     Futures.allAsList(
       ImmutableList.of(
         provisioningService.start(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
@@ -24,9 +24,12 @@ import io.cdap.cdap.common.logging.LogSamplers;
 import io.cdap.cdap.common.logging.Loggers;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.bootstrap.BootstrapStep.RunCondition;
 import io.cdap.cdap.internal.bootstrap.executor.BootstrapStepExecutor;
 import io.cdap.cdap.proto.bootstrap.BootstrapResult;
 import io.cdap.cdap.proto.bootstrap.BootstrapStepResult;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,12 +78,13 @@ public class BootstrapService extends AbstractIdleService {
       try {
         if (isBootstrappedWithRetries()) {
           // if the system is already bootstrapped, skip any bootstrap step that is supposed to only run once
-          bootstrap(step -> step.getRunCondition() == BootstrapStep.RunCondition.ONCE);
+          bootstrap(step -> step.getRunCondition() == RunCondition.ONCE);
         } else {
           bootstrap();
         }
       } catch (InterruptedException e) {
-        LOG.info("Bootstrapping could not complete due to interruption. It will be re-run the next time CDAP starts.");
+        LOG.info(
+            "Bootstrapping could not complete due to interruption. It will be re-run the next time CDAP starts.");
       }
     }).get();
     LOG.info("Started {}", getClass().getSimpleName());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -136,18 +136,13 @@ public class SystemAppEnableExecutor {
 
   private void startProgram(ProgramId programId) throws Exception {
     try {
+      // TODO(CDAP-16243): Restart program if the application has changed.
+      // do nothing if the program is already running
       ProgramStatus currentStatus = programLifecycleService.getProgramStatus(programId);
       // If a system app is already running, it needs to be restarted as app artifact/arguments might have changed.
       // Restart should trigger running programs with latest version.
-      // TODO(CDAP-16243): Find smarter way to trigger restart of programs rather than always restarting. May be
-      //                   checking if artifact version has changed would be a good start.
-      try {
-        if (currentStatus == ProgramStatus.RUNNING) {
-          programLifecycleService.stop(programId);
-        }
-      } catch (ConflictException e) {
-        // Will reach here if the program is already stopped, which means it tried to stop after the status check above.
-        // ignore this, as it means the program is stopped as we wanted.
+      if (currentStatus == ProgramStatus.RUNNING) {
+        programLifecycleService.stop(programId);
       }
       programLifecycleService.run(programId, Collections.emptyMap(), false);
     } catch (ConflictException e) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
@@ -98,41 +98,17 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
   }
 
   /**
-   * Tests SystemAppManagementService end to end by running below scenario:
-   * 1. Creates a system app config for an application into corresponding directory.
-   * 2. Successfully read and load the config.
-   * 3. Runs all steps to enable a system app , tests SystemAppEnableExecutor.
-   * 4. Deploys the app.
-   * 5. Runs all programs corresponding to the app.
-   * 6. Checks status of a continuously running program, i.e a service program.
-   */
-  @Test
-  public void testSystemAppManagementServiceE2E() throws Exception {
-    systemConfigDir = tmpFolder.newFolder("demo-sys-app-config-dir");
-    cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
-    systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
-                                                                programLifecycleService);
-    Id.Artifact artifactId1 = Id.Artifact.from(Id.Namespace.DEFAULT, "App", VERSION1);
-    addAppArtifact(artifactId1, AllProgramsApp.class);
-    createEnableSysAppConfigFile(artifactId1, "demo.json");
-    systemAppManagementService.startUp();
-    ApplicationId appId1 = NamespaceId.DEFAULT.app(AllProgramsApp.NAME);
-    ProgramId serviceId1 = appId1.program(ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME);
-    waitState(serviceId1, RUNNING);
-    Assert.assertEquals(RUNNING, getProgramStatus(serviceId1));
-  }
-
-  /**
    * Tests SystemAppManagementService's upgrade method end to end by running this scenario:
    * 1. Creates a system app config for an application into corresponding directory with artifact version VERSION1.
    * 2. Successfully read and load the config.
    * 3. Runs all steps to enable a system app , tests SystemAppEnableExecutor.
    * 4. Deploys the VERSION1 app and runs all programs corresponding to the app.
+   * 5. Checks status of a continuously running program, i.e a service program.
    * 6. Updates system app config with app version upgraded to VERSION2.
    * 7. On restart of SystemAppManagementService, app should kill old running programs and start program again.
    */
   @Test
-  public void testSystemAppManagementServiceUpgradeApp() throws Exception {
+  public void testSystemAppManagementServiceE2E() throws Exception {
     systemConfigDir = tmpFolder.newFolder("demo-sys-app-config-dir");
     cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
     systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
@@ -160,5 +136,4 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
     Assert.assertEquals(RUNNING, getProgramStatus(serviceId1));
     assertProgramRuns(serviceId1, ProgramRunStatus.KILLED, 1);
   }
-
 }


### PR DESCRIPTION
Try 2 of original PR https://github.com/cdapio/cdap/pull/11937 which was reverted.

Changes includes:

Start SystemAppManagementService only after BootStrap steps are run due to dependency on metadata and load system artifacts steps.
Force restart programs running for a system app when ENABLE_ step is run for it to make sure programs are running with latest system artifacts and arguments. This is safe to do as system apps are stateless and we already restart them while upgrading an instance of CDAP.
TESTS: Tested using unit tests.