### PR TITLE
(CDAP-16243) Upgrade mechanism for System Apps managed by SystemAppManagementService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -139,6 +139,9 @@ public class AppFabricServer extends AbstractIdleService {
       )
     ).get();
 
+    // Start system app management service only after bootstrap service is started.
+    systemAppManagementService.start().get();
+
     // Create handler hooks
     List<MetricsReporterHook> handlerHooks = handlerHookNames.stream()
       .map(name -> new MetricsReporterHook(metricsCollectionService, name))

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -131,16 +131,12 @@ public class AppFabricServer extends AbstractIdleService {
         provisioningService.start(),
         applicationLifecycleService.start(),
         bootstrapService.start(),
-        systemAppManagementService.start(),
         programRuntimeService.start(),
         programNotificationSubscriberService.start(),
         runRecordCorrectorService.start(),
         coreSchedulerService.start()
       )
     ).get();
-
-    // Start system app management service only after bootstrap service is started.
-    systemAppManagementService.start().get();
 
     // Create handler hooks
     List<MetricsReporterHook> handlerHooks = handlerHookNames.stream()

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.internal.bootstrap.executor.BootstrapStepExecutor;
 import io.cdap.cdap.proto.bootstrap.BootstrapResult;
 import io.cdap.cdap.proto.bootstrap.BootstrapStepResult;
+import java.util.concurrent.ExecutionException;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,11 +68,11 @@ public class BootstrapService extends AbstractIdleService {
   }
 
   @Override
-  protected void startUp() {
+  protected void startUp() throws Exception {
     LOG.info("Starting {}", getClass().getSimpleName());
     config = bootstrapConfigProvider.getConfig();
     executorService = Executors.newSingleThreadExecutor(Threads.createDaemonThreadFactory("bootstrap-service"));
-    executorService.execute(() -> {
+    executorService.submit(() -> {
       try {
         if (isBootstrappedWithRetries()) {
           // if the system is already bootstrapped, skip any bootstrap step that is supposed to only run once
@@ -82,7 +83,7 @@ public class BootstrapService extends AbstractIdleService {
       } catch (InterruptedException e) {
         LOG.info("Bootstrapping could not complete due to interruption. It will be re-run the next time CDAP starts.");
       }
-    });
+    }).get();
     LOG.info("Started {}", getClass().getSimpleName());
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
@@ -52,7 +52,7 @@ public class BootstrapService extends AbstractIdleService {
   private static final Logger SAMPLING_LOG = Loggers.sampling(LOG, LogSamplers.onceEvery(50));
   private final BootstrapConfigProvider bootstrapConfigProvider;
   private final BootstrapStore bootstrapStore;
-  private SystemAppManagementService systemAppManagementService;
+  private final SystemAppManagementService systemAppManagementService;
   private final Map<BootstrapStep.Type, BootstrapStepExecutor> bootstrapStepExecutors;
   private final AtomicBoolean bootstrapping;
   private BootstrapConfig config;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
@@ -89,7 +89,7 @@ public class BootstrapService extends AbstractIdleService {
 
       // Only start SystemAppManagement service after bootstrap steps are run due to depedency on
       // LOAD_SYSTEM_ARTIFACT step.
-      // TODO(CDAP-16243): Find better way to add depedency between BootStrapService and SystemAppManagementService.
+      // TODO(CDAP-16243): Find better way to add dependency between BootStrapService and SystemAppManagementService.
       try {
         this.systemAppManagementService.start();
       } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
@@ -71,7 +71,7 @@ public class BootstrapService extends AbstractIdleService {
   }
 
   @Override
-  protected void startUp() throws Exception {
+  protected void startUp() {
     LOG.info("Starting {}", getClass().getSimpleName());
     config = bootstrapConfigProvider.getConfig();
     executorService = Executors.newSingleThreadExecutor(Threads.createDaemonThreadFactory("bootstrap-service"));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -136,11 +136,18 @@ public class SystemAppEnableExecutor {
 
   private void startProgram(ProgramId programId) throws Exception {
     try {
-      // TODO(CDAP-16243): Restart program if the application has changed.
-      // do nothing if the program is already running
       ProgramStatus currentStatus = programLifecycleService.getProgramStatus(programId);
-      if (currentStatus != ProgramStatus.STOPPED) {
-        return;
+      // If a system app is already running, it needs to be restarted as app artifact/arguments might have changed.
+      // Restart should trigger running programs with latest version.
+      // TODO(CDAP-16243): Find smarter way to trigger restart of programs rather than always restarting. May be
+      //                   checking if artifact version has changed would be a good start.
+      try {
+        if (currentStatus == ProgramStatus.RUNNING) {
+          programLifecycleService.stop(programId);
+        }
+      } catch (ConflictException e) {
+        // Will reach here if the program is already stopped, which means it tried to stop after the status check above.
+        // ignore this, as it means the program is stopped as we wanted.
       }
       programLifecycleService.run(programId, Collections.emptyMap(), false);
     } catch (ConflictException e) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/bootstrap/BootstrapServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/bootstrap/BootstrapServiceTest.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.internal.bootstrap.executor.BaseStepExecutor;
 import io.cdap.cdap.internal.bootstrap.executor.BootstrapStepExecutor;
 import io.cdap.cdap.internal.bootstrap.executor.EmptyArguments;
+import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
 import io.cdap.cdap.proto.bootstrap.BootstrapResult;
 import io.cdap.cdap.proto.bootstrap.BootstrapStepResult;
 import org.junit.After;
@@ -56,6 +57,7 @@ public class BootstrapServiceTest {
   private static BootstrapConfig bootstrapConfig;
   private static BootstrapService bootstrapService;
   private static BootstrapStore bootstrapStore;
+  private static SystemAppManagementService systemAppManagementService;
 
   @BeforeClass
   public static void setupClass() {
@@ -72,7 +74,9 @@ public class BootstrapServiceTest {
     BootstrapConfigProvider bootstrapConfigProvider = new InMemoryBootstrapConfigProvider(bootstrapConfig);
 
     bootstrapStore = AppFabricTestHelper.getInjector().getInstance(BootstrapStore.class);
-    bootstrapService = new BootstrapService(bootstrapConfigProvider, bootstrapStore, executors);
+    systemAppManagementService = AppFabricTestHelper.getInjector().getInstance(SystemAppManagementService.class);
+    bootstrapService = new BootstrapService(bootstrapConfigProvider, bootstrapStore, executors,
+                                            systemAppManagementService);
     bootstrapService.reload();
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
@@ -27,13 +27,12 @@ import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
-import org.iq80.leveldb.util.FileUtils;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -99,21 +98,21 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
   }
 
   /**
-   * Tests SystemAppManagementService end to end by running below scenario:
-   * 1. Creates a system app config for an application into corresponding directory.
+   * Tests SystemAppManagementService's upgrade method end to end by running this scenario:
+   * 1. Creates a system app config for an application into corresponding directory with artifact version VERSION1.
    * 2. Successfully read and load the config.
    * 3. Runs all steps to enable a system app , tests SystemAppEnableExecutor.
-   * 4. Deploys the app.
-   * 5. Runs all programs corresponding to the app.
-   * 6. Checks status of a continuously running program, i.e a service program.
-   * @throws Exception
+   * 4. Deploys the VERSION1 app and runs all programs corresponding to the app.
+   * 5. Checks status of a continuously running program, i.e a service program.
+   * 6. Updates system app config with app version upgraded to VERSION2.
+   * 7. On restart of SystemAppManagementService, app should kill old running programs and start program again.
    */
   @Test
   public void testSystemAppManagementServiceE2E() throws Exception {
-    systemConfigDir = TEMPORARY_FOLDER.newFolder("demo-sys-app-config-dir");
+    systemConfigDir = tmpFolder.newFolder("demo-sys-app-config-dir");
     cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
     systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
-                                                                programLifecycleService);
+        programLifecycleService);
     Id.Artifact artifactId1 = Id.Artifact.from(Id.Namespace.DEFAULT, "App", VERSION1);
     addAppArtifact(artifactId1, AllProgramsApp.class);
     createEnableSysAppConfigFile(artifactId1, "demo.json");
@@ -122,5 +121,19 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
     ProgramId serviceId1 = appId1.program(ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME);
     waitState(serviceId1, RUNNING);
     Assert.assertEquals(RUNNING, getProgramStatus(serviceId1));
+    // Program shouldn't be killed first time it is started.
+    assertProgramRuns(serviceId1, ProgramRunStatus.KILLED, 0);
+    systemAppManagementService.shutDown();
+
+    // New system app config with newer artifact version.
+    Id.Artifact artifactId2 = Id.Artifact.from(Id.Namespace.DEFAULT, "App", VERSION2);
+    addAppArtifact(artifactId2, AllProgramsApp.class);
+    createEnableSysAppConfigFile(artifactId2, "demo.json");
+    // SystemAppManagement restarts again.
+    systemAppManagementService.startUp();
+    // Program ID still stays the same.
+    waitState(serviceId1, RUNNING);
+    Assert.assertEquals(RUNNING, getProgramStatus(serviceId1));
+    assertProgramRuns(serviceId1, ProgramRunStatus.KILLED, 1);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
@@ -54,7 +54,6 @@ import java.util.List;
  */
 public class SystemAppManagementServiceTest extends AppFabricTestBase {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SystemAppManagementServiceTest.class);
   private static final Gson GSON = new Gson();
 
   private static ProgramLifecycleService programLifecycleService;
@@ -70,7 +69,7 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
 
 
   @BeforeClass
-  public static void setup() throws IOException {
+  public static void setup() {
     Injector injector = getInjector();
     programLifecycleService = injector.getInstance(ProgramLifecycleService.class);
     applicationLifecycleService = injector.getInstance(ApplicationLifecycleService.class);
@@ -109,7 +108,7 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
    */
   @Test
   public void testSystemAppManagementServiceE2E() throws Exception {
-    systemConfigDir = tmpFolder.newFolder("demo-sys-app-config-dir");
+    systemConfigDir = TEMPORARY_FOLDER.newFolder("demo-sys-app-config-dir");
     cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
     systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
         programLifecycleService);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/sysapp/SystemAppManagementServiceTest.java
@@ -111,7 +111,7 @@ public class SystemAppManagementServiceTest extends AppFabricTestBase {
     systemConfigDir = TEMPORARY_FOLDER.newFolder("demo-sys-app-config-dir");
     cConf.set(Constants.SYSTEM_APP_CONFIG_DIR, systemConfigDir.getAbsolutePath());
     systemAppManagementService = new SystemAppManagementService(cConf, applicationLifecycleService,
-        programLifecycleService);
+                                                                programLifecycleService);
     Id.Artifact artifactId1 = Id.Artifact.from(Id.Namespace.DEFAULT, "App", VERSION1);
     addAppArtifact(artifactId1, AllProgramsApp.class);
     createEnableSysAppConfigFile(artifactId1, "demo.json");


### PR DESCRIPTION
Changes includes:

Start SystemAppManagementService only after BootStrap steps are run due to dependency on metadata and load system artifacts steps.

Force restart programs running for a system app when ENABLE_ step is run for it to make sure programs are running with latest system artifacts and arguments. This is safe to do as system apps are stateless and we already restart them while upgrading an instance of CDAP.

TESTS: Tested using unit tests.
BUILD: https://builds.cask.co/browse/CDAP-DUT7141-2

Retrying again, previous revert https://github.com/cdapio/cdap/pull/11942