### PR TITLE
[CDAP-16420] Make job management through ssh optional

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Context for a {@link Provisioner} extension
@@ -39,7 +40,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   private final String cdapVersion;
 
   public DefaultProvisionerContext(ProgramRunId programRunId, Map<String, String> properties,
-                                   SparkCompat sparkCompat, SSHContext sshContext) {
+                                   SparkCompat sparkCompat, @Nullable SSHContext sshContext) {
     this.programRun = new ProgramRun(programRunId.getNamespace(), programRunId.getApplication(),
                                      programRunId.getProgram(), programRunId.getRun());
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
@@ -64,6 +65,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   }
 
   @Override
+  @Nullable
   public SSHContext getSSHContext() {
     return sshContext;
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -891,6 +891,14 @@ public final class Constants {
   }
 
   /**
+   * RuntimeJob constants.
+   */
+  public static final class RuntimeJob {
+    public static final String RUNTIME_JOB_MANAGER = "runtime.job.manager";
+    public static final String CLOUD_PROVIDER = "cloud-provider";
+  }
+
+  /**
    * Logging constants.
    */
   public static final class Logging {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
+import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,17 +151,21 @@ public class DataprocProvisioner implements Provisioner {
     // Generates and set the ssh key if it does not have one.
     // Since invocation of this method can come from a retry, we don't need to keep regenerating the keys
     SSHContext sshContext = context.getSSHContext();
-    SSHKeyPair sshKeyPair = sshContext.getSSHKeyPair().orElse(null);
-    if (sshKeyPair == null) {
-      sshKeyPair = sshContext.generate("cdap");
-      sshContext.setSSHKeyPair(sshKeyPair);
+    SSHPublicKey sshPublicKey = null;
+    if (sshContext != null) {
+      SSHKeyPair sshKeyPair = sshContext.getSSHKeyPair().orElse(null);
+      if (sshKeyPair == null) {
+        sshKeyPair = sshContext.generate("cdap");
+        sshContext.setSSHKeyPair(sshKeyPair);
+      }
+      sshPublicKey = sshKeyPair.getPublicKey();
     }
 
     // Reload system context properties and get system labels
     systemContext.reloadProperties();
     Map<String, String> systemLabels = getSystemLabels(systemContext);
 
-    DataprocConf conf = DataprocConf.create(createContextProperties(context), sshKeyPair.getPublicKey());
+    DataprocConf conf = DataprocConf.create(createContextProperties(context), sshPublicKey);
     String clusterName = getClusterName(context.getProgramRun());
 
     try (DataprocClient client =

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Context for provisioner operations.
@@ -45,6 +46,7 @@ public interface ProvisionerContext {
   /**
    * Returns the {@link SSHContext} for performing ssh operations.
    */
+  @Nullable
   SSHContext getSSHContext();
 
   /**


### PR DESCRIPTION
With this change ssh-key is not added to cluster metadata when job needs to be submitted using cloud provider apis.

![image](https://user-images.githubusercontent.com/14131070/76799965-d7feb680-678f-11ea-9b90-6ebc0e3ba12d.png)
