### PR TITLE
(CDAP-16369) Use twill to launch job on remote Hadoop cluster

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -23,11 +23,9 @@ import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Service;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
-import com.google.inject.util.Modules;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.guice.ClusterMode;
@@ -39,13 +37,11 @@ import io.cdap.cdap.app.runtime.Arguments;
 import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.app.runtime.ProgramRunner;
-import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.logging.LoggingContextAccessor;
 import io.cdap.cdap.common.logging.common.UncaughtExceptionHandler;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
-import io.cdap.cdap.internal.app.program.StateChangeListener;
 import io.cdap.cdap.internal.app.runtime.AbstractListener;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -54,32 +50,20 @@ import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import io.cdap.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
-import io.cdap.cdap.internal.app.runtime.monitor.RuntimeMonitorServer;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.appender.loader.LogAppenderLoaderService;
 import io.cdap.cdap.logging.context.LoggingContextHelper;
-import io.cdap.cdap.messaging.MessagingService;
-import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
-import io.cdap.cdap.messaging.server.MessagingHttpService;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.tephra.TransactionManager;
 import org.apache.twill.api.Command;
-import org.apache.twill.api.ElectionHandler;
-import org.apache.twill.api.RunId;
 import org.apache.twill.api.ServiceAnnouncer;
 import org.apache.twill.api.TwillContext;
 import org.apache.twill.api.TwillRunnable;
 import org.apache.twill.api.TwillRunnableSpecification;
-import org.apache.twill.common.Cancellable;
 import org.apache.twill.common.Threads;
-import org.apache.twill.discovery.ServiceDiscovered;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.internal.Constants;
-import org.apache.twill.internal.EnvKeys;
-import org.apache.twill.internal.TwillRuntimeSpecification;
-import org.apache.twill.internal.json.TwillRuntimeSpecificationAdapter;
 import org.apache.twill.kafka.client.BrokerService;
 import org.apache.twill.kafka.client.KafkaClientService;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -93,8 +77,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.net.Authenticator;
+import java.net.ProxySelector;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
@@ -106,7 +90,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.locks.Lock;
 import javax.annotation.Nullable;
 
 /**
@@ -129,7 +112,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
   private LogAppenderInitializer logAppenderInitializer;
   private ProgramOptions programOptions;
   private Deque<Service> coreServices;
-  private Injector injector;
+  private ProxySelector oldProxySelector;
   private T programRunner;
   private Program program;
   private ProgramRunId programRunId;
@@ -139,46 +122,12 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
   private long maxStopSeconds;
 
   /**
-   * Helper method to get the name of the runnable from the environment.
-   */
-  protected static String getRunnableNameFromEnv() {
-    String runnableName = System.getenv(EnvKeys.TWILL_RUNNABLE_NAME);
-    if (runnableName == null) {
-      throw new IllegalArgumentException("Missing environment variable " + EnvKeys.TWILL_RUNNABLE_NAME);
-    }
-    return runnableName;
-  }
-
-  /**
    * Constructor.
    *
    * @param name Name of the TwillRunnable
    */
   protected AbstractProgramTwillRunnable(String name) {
     this.name = name;
-  }
-
-  protected void doMain() throws Exception {
-    TwillRuntimeSpecification twillRuntimeSpec = TwillRuntimeSpecificationAdapter.create()
-      .fromJson(new File(Constants.Files.RUNTIME_CONFIG_JAR, Constants.Files.TWILL_SPEC));
-    org.apache.twill.internal.Arguments arguments = readJsonFile(new File(Constants.Files.RUNTIME_CONFIG_JAR,
-                                                                          Constants.Files.ARGUMENTS),
-                                                                 org.apache.twill.internal.Arguments.class);
-
-    TwillContext context = new DirectExecutionTwillContext(name, twillRuntimeSpec, arguments);
-    initialize(context);
-    Runtime.getRuntime().addShutdownHook(new Thread(AbstractProgramTwillRunnable.this::stop));
-
-    // Add the program state writer listener when the program controller is available
-    ProgramStateWriter programStateWriter = injector.getInstance(ProgramStateWriter.class);
-    controllerFuture.thenAcceptAsync(
-      c -> c.addListener(new StateChangeListener(c.getProgramRunId(), null,
-                                                 programStateWriter), Threads.SAME_THREAD_EXECUTOR),
-      command -> {
-        Thread t = new Thread(command);
-        t.start();
-      });
-    run();
   }
 
   @Override
@@ -246,12 +195,16 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
     maxStopSeconds = cConf.getLong(io.cdap.cdap.common.conf.Constants.AppFabric.PROGRAM_MAX_STOP_SECONDS);
 
-    if (clusterMode == ClusterMode.ISOLATED) {
-      String hostName = context.getHost().getCanonicalHostName();
-      cConf.set(io.cdap.cdap.common.conf.Constants.Service.MASTER_SERVICES_BIND_ADDRESS, hostName);
-    }
+    Injector injector = Guice.createInjector(createModule(cConf, hConf, programOptions, programRunId));
 
-    injector = Guice.createInjector(createModule(cConf, hConf, programOptions, programRunId));
+    // Setup the proxy selector for in active monitoring mode
+    if (cConf.getBoolean(io.cdap.cdap.common.conf.Constants.RuntimeMonitor.ACTIVE_MONITORING)) {
+      oldProxySelector = ProxySelector.getDefault();
+      if (clusterMode == ClusterMode.ISOLATED) {
+        ProxySelector.setDefault(injector.getInstance(ProxySelector.class));
+        Authenticator.setDefault(injector.getInstance(Authenticator.class));
+      }
+    }
 
     logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
 
@@ -282,24 +235,6 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       // Start the program.
       ProgramController controller = programRunner.run(program, programOptions);
       controller.addListener(new AbstractListener() {
-        @Override
-        public void init(ProgramController.State currentState, @Nullable Throwable cause) {
-          switch (currentState) {
-            case ALIVE:
-              alive();
-              break;
-            case COMPLETED:
-              completed();
-              break;
-            case KILLED:
-              killed();
-              break;
-            case ERROR:
-              error(cause);
-              break;
-          }
-        }
-
         @Override
         public void alive() {
           controllerFuture.complete(controller);
@@ -390,14 +325,14 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
   @Override
   public void destroy() {
-    // no-op
+    ProxySelector.setDefault(oldProxySelector);
   }
 
   /**
    * Returns a set of extra system arguments that will be available through the {@link ProgramOptions#getArguments()}
    * for the program execution.
    */
-  protected Map<String, String> getExtraSystemArguments() {
+  private Map<String, String> getExtraSystemArguments() {
     Map<String, String> args = new HashMap<>();
     args.put(ProgramOptionConstants.INSTANCE_ID, context == null ? "0" : Integer.toString(context.getInstanceId()));
     args.put(ProgramOptionConstants.INSTANCES, context == null ? "1" : Integer.toString(context.getInstanceCount()));
@@ -418,25 +353,8 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
    */
   protected Module createModule(CConfiguration cConf, Configuration hConf,
                                 ProgramOptions programOptions, ProgramRunId programRunId) {
-    Module module = new DistributedProgramContainerModule(cConf, hConf, programRunId,
-                                                          programOptions.getArguments(), getServiceAnnouncer());
-
-    if (ProgramRunners.getClusterMode(programOptions) == ClusterMode.ISOLATED) {
-      // In isolated mode, TMS runs in the "launcher" container.
-      // We don't do this in the DistributedProgramContainerModule
-      // because that module is used in both launcher and task containers
-      module = Modules.override(module).with(
-        new MessagingServerRuntimeModule().getStandaloneModules(),
-        new AbstractModule() {
-          @Override
-          protected void configure() {
-            // Bind a Cancellable for the RuntimeMonitor to stop this program run.
-            bind(Cancellable.class).toInstance(() -> stop());
-          }
-      });
-    }
-
-    return module;
+    return new DistributedProgramContainerModule(cConf, hConf, programRunId,
+                                                 programOptions.getArguments(), getServiceAnnouncer());
   }
 
   /**
@@ -446,13 +364,6 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
   @Nullable
   protected ServiceAnnouncer getServiceAnnouncer() {
     return context;
-  }
-
-  /**
-   * Resolve the scope of the user arguments from the {@link Arguments}
-   */
-  protected Arguments resolveScope(Arguments args) {
-    return args;
   }
 
   /**
@@ -486,7 +397,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
     // Use the name passed in by the constructor as the program name to construct the ProgramId
     return new SimpleProgramOptions(original.getProgramId(), new BasicArguments(arguments),
-                                    resolveScope(original.getUserArguments()), original.isDebug());
+                                    original.getUserArguments(), original.isDebug());
   }
 
   /**
@@ -508,15 +419,8 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
     services.add(metricsCollectionService);
     services.add(injector.getInstance(LogAppenderLoaderService.class));
 
-    switch (ProgramRunners.getClusterMode(programOptions)) {
-      case ON_PREMISE:
-        addOnPremiseServices(injector, programOptions, metricsCollectionService, services);
-        break;
-      case ISOLATED:
-        addIsolatedServices(injector, services);
-        break;
-      default:
-        // This shouldn't happen. Just do nothing.
+    if (ProgramRunners.getClusterMode(programOptions) == ClusterMode.ON_PREMISE) {
+      addOnPremiseServices(injector, programOptions, metricsCollectionService, services);
     }
 
     return services;
@@ -528,16 +432,6 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
     services.add(injector.getInstance(KafkaClientService.class));
     services.add(injector.getInstance(BrokerService.class));
     services.add(new ProgramRunnableResourceReporter(programOptions.getProgramId(), metricsCollectionService, context));
-  }
-
-  private void addIsolatedServices(Injector injector, Collection<Service> services) {
-    MessagingService messagingService = injector.getInstance(MessagingService.class);
-    if (messagingService instanceof Service) {
-      services.add((Service) messagingService);
-    }
-    services.add(injector.getInstance(TransactionManager.class));
-    services.add(injector.getInstance(MessagingHttpService.class));
-    services.add(injector.getInstance(RuntimeMonitorServer.class));
   }
 
   private void startCoreServices() {
@@ -566,106 +460,6 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       }
     }
     logAppenderInitializer.close();
-  }
-
-  /**
-   * A {@link TwillContext} implementation for direct execution from the {@link #doMain()}.
-   */
-  private static final class DirectExecutionTwillContext implements TwillContext {
-
-    private final String runnableName;
-    private final TwillRuntimeSpecification runtimeSpec;
-    private final String[] applicationArgs;
-    private final String[] args;
-
-    private DirectExecutionTwillContext(String runnableName,
-                                        TwillRuntimeSpecification runtimeSpec,
-                                        org.apache.twill.internal.Arguments arguments) {
-      this.runnableName = runnableName;
-      this.runtimeSpec = runtimeSpec;
-      this.applicationArgs = arguments.getArguments().toArray(new String[0]);
-      this.args = arguments.getRunnableArguments().get(runnableName).toArray(new String[0]);
-    }
-
-    @Override
-    public RunId getRunId() {
-      return runtimeSpec.getTwillAppRunId();
-    }
-
-    @Override
-    public RunId getApplicationRunId() {
-      return runtimeSpec.getTwillAppRunId();
-    }
-
-    @Override
-    public int getInstanceCount() {
-      // Only support one instance on direct execution
-      return 1;
-    }
-
-    @Override
-    public InetAddress getHost() {
-      try {
-        return InetAddress.getLocalHost();
-      } catch (UnknownHostException e) {
-        return InetAddress.getLoopbackAddress();
-      }
-    }
-
-    @Override
-    public String[] getArguments() {
-      return args;
-    }
-
-    @Override
-    public String[] getApplicationArguments() {
-      return applicationArgs;
-    }
-
-    @Override
-    public TwillRunnableSpecification getSpecification() {
-      return runtimeSpec.getTwillSpecification().getRunnables().get(runnableName).getRunnableSpecification();
-    }
-
-    @Override
-    public int getInstanceId() {
-      return 0;
-    }
-
-    @Override
-    public int getVirtualCores() {
-      return 0;
-    }
-
-    @Override
-    public int getMaxMemoryMB() {
-      return 0;
-    }
-
-    @Override
-    public ServiceDiscovered discover(String name) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Cancellable electLeader(String name, ElectionHandler participantHandler) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Lock createLock(String name) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Cancellable announce(String serviceName, int port) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Cancellable announce(String serviceName, int port, byte[] payload) {
-      throw new UnsupportedOperationException();
-    }
   }
 }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/MapReduceTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/MapReduceTwillRunnable.java
@@ -22,13 +22,6 @@ import io.cdap.cdap.internal.app.runtime.batch.MapReduceProgramRunner;
  */
 public final class MapReduceTwillRunnable extends AbstractProgramTwillRunnable<MapReduceProgramRunner> {
 
-  /**
-   * Main method for the remote execution mode.
-   */
-  public static void main(String[] args) throws Exception {
-    new MapReduceTwillRunnable(getRunnableNameFromEnv()).doMain();
-  }
-
   public MapReduceTwillRunnable(String name) {
     super(name);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkerTwillRunnable.java
@@ -23,13 +23,6 @@ import io.cdap.cdap.internal.app.runtime.worker.WorkerProgramRunner;
  */
 public class WorkerTwillRunnable extends AbstractProgramTwillRunnable<WorkerProgramRunner> {
 
-  /**
-   * Main method for the remote execution mode.
-   */
-  public static void main(String[] args) throws Exception {
-    new WorkerTwillRunnable(getRunnableNameFromEnv()).doMain();
-  }
-
   protected WorkerTwillRunnable(String name) {
     super(name);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
@@ -48,13 +48,6 @@ import java.util.List;
  */
 public final class WorkflowTwillRunnable extends AbstractProgramTwillRunnable<WorkflowProgramRunner> {
 
-  /**
-   * Main method for the remote execution mode.
-   */
-  public static void main(String[] args) throws Exception {
-    new WorkflowTwillRunnable(getRunnableNameFromEnv()).doMain();
-  }
-
   public WorkflowTwillRunnable(String name) {
     super(name);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionDiscoveryService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionDiscoveryService.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.utils.Networks;
+import io.cdap.cdap.internal.app.runtime.distributed.runtimejob.DefaultRuntimeJob;
 import io.cdap.cdap.internal.app.runtime.monitor.proxy.ServiceSocksProxy;
 import io.cdap.cdap.master.spi.discovery.DefaultServiceDiscovered;
 import io.cdap.cdap.proto.ProgramType;
@@ -43,7 +44,7 @@ import javax.inject.Inject;
  * A discovery service implementation used in remote runtime execution. It has a fixed list of services
  * that will go through {@link ServiceSocksProxy}, hence won't resolve the service name to an actual address.
  * It also use the {@link CConfiguration} as the backing store for service announcements, which is suitable for
- * the current remote runtime that has some "mini" system services running in the runtime process (the driver).
+ * the current remote runtime that has some "mini" system services running in the {@link DefaultRuntimeJob}.
  */
 public class RemoteExecutionDiscoveryService implements DiscoveryServiceClient, DiscoveryService {
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionJobMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionJobMain.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.distributed.remote;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.api.security.store.SecureStoreData;
+import io.cdap.cdap.api.security.store.SecureStoreMetadata;
+import io.cdap.cdap.app.guice.TwillModule;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.DFSLocationModule;
+import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.internal.app.runtime.distributed.runtimejob.DefaultRuntimeJob;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobEnvironment;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
+import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
+import io.cdap.cdap.security.impersonation.UGIProvider;
+import org.apache.twill.api.RunId;
+import org.apache.twill.api.TwillRunner;
+import org.apache.twill.api.TwillRunnerService;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.apache.twill.internal.zookeeper.InMemoryZKServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The main class to setup the {@link RuntimeJobEnvironment} for remote execution.
+ */
+public class RemoteExecutionJobMain {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteExecutionJobMain.class);
+
+  private final DefaultRuntimeJob runtimeJob = new DefaultRuntimeJob();
+
+  private InMemoryZKServer zkServer;
+  private TwillRunnerService twillRunnerService;
+  private LocationFactory locationFactory;
+
+  public static void main(String[] args) throws Exception {
+    new RemoteExecutionJobMain().doMain(args);
+  }
+
+  /**
+   * The main method for the Application. It expects the first argument contains the program run id.
+   *
+   * @param args arguments provided to the application
+   * @throws Exception if failed to the the job
+   */
+  private void doMain(String[] args) throws Exception {
+    if (args.length < 1) {
+      throw new IllegalArgumentException("Missing runId from the first argument");
+    }
+
+    System.setProperty(Constants.Zookeeper.TWILL_ZK_SERVER_LOCALHOST, "false");
+    RunId runId = RunIds.fromString(args[0]);
+    CConfiguration cConf = CConfiguration.create();
+
+    // Namespace the HDFS on the current cluster to segregate multiple runs on the same cluster
+    cConf.set(Constants.CFG_HDFS_NAMESPACE, "/twill-" + runId);
+
+    try {
+      RemoteExecutionRuntimeJobEnvironment jobEnv = initialize(cConf);
+      runtimeJob.run(jobEnv);
+    } finally {
+      destroy();
+    }
+  }
+
+  @VisibleForTesting
+  RemoteExecutionRuntimeJobEnvironment initialize(CConfiguration cConf) throws Exception {
+    zkServer = InMemoryZKServer.builder().build();
+    zkServer.startAndWait();
+
+    InetSocketAddress zkAddr = ResolvingDiscoverable.resolve(zkServer.getLocalAddress());
+    String zkConnectStr = String.format("%s:%d", zkAddr.getHostString(), zkAddr.getPort());
+
+    LOG.debug("In memory ZK started at {}", zkConnectStr);
+
+    cConf.set(Constants.Zookeeper.QUORUM, zkConnectStr);
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new DFSLocationModule(),
+      new InMemoryDiscoveryModule(),
+      new TwillModule(),
+      new AuthenticationContextModules().getProgramContainerModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          // don't need to perform any impersonation from within user programs
+          bind(UGIProvider.class).to(CurrentUGIProvider.class).in(Scopes.SINGLETON);
+
+          // Binds a no-op SecureStore for the TwillModule to setup TokenSecureStoreRenewer.
+          bind(SecureStore.class).toInstance(new SecureStore() {
+            @Override
+            public List<SecureStoreMetadata> list(String namespace) {
+              return Collections.emptyList();
+            }
+
+            @Override
+            public SecureStoreData get(String namespace, String name) throws Exception {
+              throw new NotFoundException("Secure key " + name + " not found in namespace " + namespace);
+            }
+          });
+        }
+      }
+    );
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put(Constants.Zookeeper.QUORUM, zkConnectStr);
+    properties.put(Constants.RuntimeMonitor.ACTIVE_MONITORING, Boolean.TRUE.toString());
+    properties.put(Constants.RuntimeMonitor.SERVER_KEYSTORE_PATH, Constants.RuntimeMonitor.SERVER_KEYSTORE);
+    properties.put(Constants.RuntimeMonitor.CLIENT_KEYSTORE_PATH, Constants.RuntimeMonitor.CLIENT_KEYSTORE);
+
+    locationFactory = injector.getInstance(LocationFactory.class);
+    locationFactory.create("/").mkdirs();
+
+    twillRunnerService = injector.getInstance(TwillRunnerService.class);
+    twillRunnerService.start();
+
+    return new RemoteExecutionRuntimeJobEnvironment(locationFactory, twillRunnerService, properties);
+  }
+
+  @VisibleForTesting
+  void destroy() {
+    if (twillRunnerService != null) {
+      try {
+        twillRunnerService.stop();
+      } catch (Exception e) {
+        LOG.warn("Failed to stop twill runner", e);
+      }
+    }
+
+    if (locationFactory != null) {
+      Location location = locationFactory.create("/");
+      try {
+        location.delete(true);
+      } catch (IOException e) {
+        LOG.warn("Failed to delete location {}", location, e);
+      }
+    }
+
+    if (zkServer != null) {
+      try {
+        zkServer.stopAndWait();
+      } catch (Exception e) {
+        LOG.warn("Failed to stop ZK server", e);
+      }
+    }
+  }
+
+  private static final class RemoteExecutionRuntimeJobEnvironment implements RuntimeJobEnvironment {
+
+    private final LocationFactory locationFactory;
+    private final TwillRunner twillRunner;
+    private final Map<String, String> properties;
+
+    private RemoteExecutionRuntimeJobEnvironment(LocationFactory locationFactory, TwillRunner twillRunner,
+                                                 Map<String, String> properties) {
+      this.locationFactory = locationFactory;
+      this.twillRunner = twillRunner;
+      this.properties = Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public LocationFactory getLocationFactory() {
+      return locationFactory;
+    }
+
+    @Override
+    public TwillRunner getTwillRunner() {
+      return twillRunner;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+      return properties;
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillPreparer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillPreparer.java
@@ -921,11 +921,12 @@ class RemoteExecutionTwillPreparer implements TwillPreparer {
     scriptWriter.println("export HADOOP_CLASSPATH=`hadoop classpath`");
 
     scriptWriter.printf(
-      "nohup java -Djava.io.tmpdir=tmp -Dcdap.runid=%s -cp %s/%s -Xmx%dm %s %s '%s' true >%s/stdout 2>%s/stderr &\n",
+      "nohup java -Djava.io.tmpdir=tmp -Dcdap.runid=%s -cp %s/%s -Xmx%dm %s %s '%s' true %s >%s/stdout 2>%s/stderr &\n",
       programRunId.getRun(), targetPath, Constants.Files.LAUNCHER_JAR, memory,
-      getJvmOptions().getRunnableExtraOptions(runnableName),
+      getJvmOptions().getAMExtraOptions(),
       RemoteLauncher.class.getName(),
-      runtimeSpec.getRunnableSpecification().getClassName(),
+      RemoteExecutionJobMain.class.getName(),
+      programRunId.getRun(),
       logsDir, logsDir);
 
     scriptWriter.flush();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteLauncher.java
@@ -51,7 +51,7 @@ public class RemoteLauncher {
    */
   public static void main(String[] args) throws Exception {
     if (args.length < 2) {
-      System.out.println("Usage: java " + TwillLauncher.class.getName() + " [mainClass] [use_classpath] [args...]");
+      System.out.println("Usage: java " + RemoteLauncher.class.getName() + " [mainClass] [use_classpath] [args...]");
       return;
     }
 
@@ -85,14 +85,8 @@ public class RemoteLauncher {
 
     // For backward compatibility, sort jars from twill and jars from application together
     // With TWILL-179, this will change as the user can have control on how it should be.
-    List<File> libJarFiles = listJarFiles(new File(appJarDir, "lib"), new ArrayList<File>());
-    Collections.sort(listJarFiles(new File(twillJarDir, "lib"), libJarFiles), new Comparator<File>() {
-      @Override
-      public int compare(File file1, File file2) {
-        // order by the file name only. If the name are the same, the one in application jar will prevail.
-        return file1.getName().compareTo(file2.getName());
-      }
-    });
+    List<File> libJarFiles = listJarFiles(new File(appJarDir, "lib"), new ArrayList<>());
+    listJarFiles(new File(twillJarDir, "lib"), libJarFiles).sort(Comparator.comparing(File::getName));
 
     // Add the app jar, resources jar and twill jar directories to the classpath as well
     for (File dir : Arrays.asList(appJarDir, twillJarDir)) {
@@ -115,7 +109,7 @@ public class RemoteLauncher {
     }
 
     addClassPathsToList(urls, new File(Constants.Files.RUNTIME_CONFIG_JAR, Constants.Files.APPLICATION_CLASSPATH));
-    return urls.toArray(new URL[urls.size()]);
+    return urls.toArray(new URL[0]);
   }
 
   /**
@@ -160,7 +154,7 @@ public class RemoteLauncher {
     if (classpath.endsWith("/*")) {
       // Grab all .jar files
       File dir = new File(classpath.substring(0, classpath.length() - 2));
-      List<File> files = listJarFiles(dir, new ArrayList<File>());
+      List<File> files = listJarFiles(dir, new ArrayList<>());
       Collections.sort(files);
       if (files.isEmpty()) {
         return singleItem(dir.toURI().toURL());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -16,17 +16,23 @@
 
 package io.cdap.cdap.internal.app.runtime.distributed.runtimejob;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.Closeables;
+import com.google.common.util.concurrent.Service;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.MapBinder;
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.guice.ClusterMode;
 import io.cdap.cdap.app.guice.DefaultProgramRunnerFactory;
+import io.cdap.cdap.app.guice.RemoteExecutionDiscoveryModule;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.program.Programs;
@@ -39,32 +45,52 @@ import io.cdap.cdap.app.runtime.ProgramRuntimeProvider;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.guice.DFSLocationModule;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.lang.jar.BundleJarUtil;
+import io.cdap.cdap.common.logging.LoggingContextAccessor;
+import io.cdap.cdap.common.logging.common.UncaughtExceptionHandler;
+import io.cdap.cdap.common.namespace.NamespacePathLocator;
+import io.cdap.cdap.common.namespace.NoLookupNamespacePathLocator;
+import io.cdap.cdap.common.security.KeyStores;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.program.MessagingProgramStateWriter;
 import io.cdap.cdap.internal.app.runtime.AbstractListener;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.app.runtime.ProgramRunners;
+import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import io.cdap.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import io.cdap.cdap.internal.app.runtime.distributed.DistributedMapReduceProgramRunner;
+import io.cdap.cdap.internal.app.runtime.distributed.DistributedProgramRunner;
 import io.cdap.cdap.internal.app.runtime.distributed.DistributedWorkerProgramRunner;
 import io.cdap.cdap.internal.app.runtime.distributed.DistributedWorkflowProgramRunner;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.internal.app.runtime.monitor.RuntimeMonitorServer;
+import io.cdap.cdap.logging.appender.LogAppenderInitializer;
+import io.cdap.cdap.logging.context.LoggingContextHelper;
+import io.cdap.cdap.logging.guice.TMSLogAppenderModule;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
+import io.cdap.cdap.messaging.server.MessagingHttpService;
+import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJob;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobEnvironment;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.common.Cancellable;
 import org.apache.twill.common.Threads;
-import org.apache.twill.discovery.DiscoveryService;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.BufferedReader;
 import java.io.Closeable;
@@ -72,7 +98,13 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.net.InetAddress;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -82,69 +114,120 @@ import java.util.concurrent.CompletableFuture;
  * {@link TwillRunner} provided by {@link RuntimeJobEnvironment}.
  */
 public class DefaultRuntimeJob implements RuntimeJob {
-  private static final String PROGRAM_OPTIONS_FILE_NAME = "program.options.json";
-  private static final String CDAP_CONF_FILE_NAME = "cConf.xml";
-  private static final String APP_SPEC_FILE_NAME = "appSpec.json";
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultRuntimeJob.class);
+
   private static final Gson GSON =
     ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
       .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
       .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec()).create();
 
+  private final CompletableFuture<ProgramController> controllerFuture = new CompletableFuture<>();
+
   @Override
   public void run(RuntimeJobEnvironment runtimeJobEnv) throws Exception {
+    // Setup process wide settings
+    Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
+    SLF4JBridgeHandler.removeHandlersForRootLogger();
+    SLF4JBridgeHandler.install();
+
     // Get Program Options
-    ProgramOptions programOptions = readJsonFile(new File(PROGRAM_OPTIONS_FILE_NAME), ProgramOptions.class);
-    ProgramId programId = programOptions.getProgramId();
+    ProgramOptions programOptions = readJsonFile(new File(DistributedProgramRunner.PROGRAM_OPTIONS_FILE_NAME),
+                                                 ProgramOptions.class);
+    ProgramRunId programRunId = programOptions.getProgramId().run(ProgramRunners.getRunId(programOptions));
+    ProgramId programId = programRunId.getParent();
+
+    // Setup logging context for the program
+    Arguments systemArgs = programOptions.getArguments();
+    LoggingContextAccessor.setLoggingContext(LoggingContextHelper.getLoggingContextWithRunId(programRunId,
+                                                                                             systemArgs.asMap()));
+
 
     // Get App spec
-    ApplicationSpecification appSpec = readJsonFile(new File(APP_SPEC_FILE_NAME), ApplicationSpecification.class);
+    ApplicationSpecification appSpec = readJsonFile(new File(DistributedProgramRunner.APP_SPEC_FILE_NAME),
+                                                    ApplicationSpecification.class);
     ProgramDescriptor programDescriptor = new ProgramDescriptor(programId, appSpec);
 
-    // Create cConf with provided properties. These properties can be used to set configs for twill runner such as
-    // connection string for discovery.
-    CConfiguration cConf = createCConf(runtimeJobEnv);
-
     // Create injector and get program runner
-    Injector injector = Guice.createInjector(createmodule(runtimeJobEnv, cConf));
-    ProgramRunner programRunner = injector.getInstance(ProgramRunnerFactory.class).create(programId.getType());
+    Injector injector = Guice.createInjector(createModules(runtimeJobEnv, createCConf(runtimeJobEnv)));
+    LogAppenderInitializer logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
+    Deque<Service> coreServices = createCoreServices(injector);
+    startCoreServices(coreServices, logAppenderInitializer);
 
-    // Create and run the program. The program files should be present in current working directory.
-    try (Program program = createProgram(cConf, programRunner, programDescriptor, programOptions)) {
-      CompletableFuture<ProgramController.State> programCompletion = new CompletableFuture<>();
-      ProgramController controller = programRunner.run(program, programOptions);
-      controller.addListener(new AbstractListener() {
-        @Override
-        public void completed() {
-          programCompletion.complete(ProgramController.State.COMPLETED);
+    try {
+      SystemArguments.setLogLevel(programOptions.getUserArguments(), logAppenderInitializer);
+      CConfiguration cConf = injector.getInstance(CConfiguration.class);
+      ProgramRunner programRunner = injector.getInstance(ProgramRunnerFactory.class).create(programId.getType());
+
+      // Create and run the program. The program files should be present in current working directory.
+      try (Program program = createProgram(cConf, programRunner, programDescriptor, programOptions)) {
+        CompletableFuture<ProgramController.State> programCompletion = new CompletableFuture<>();
+        ProgramController controller = programRunner.run(program, programOptions);
+        controllerFuture.complete(controller);
+
+        controller.addListener(new AbstractListener() {
+          @Override
+          public void completed() {
+            programCompletion.complete(ProgramController.State.COMPLETED);
+          }
+
+          @Override
+          public void killed() {
+            programCompletion.complete(ProgramController.State.KILLED);
+          }
+
+          @Override
+          public void error(Throwable cause) {
+            programCompletion.completeExceptionally(cause);
+          }
+        }, Threads.SAME_THREAD_EXECUTOR);
+
+        // Block on the completion
+        programCompletion.get();
+      } finally {
+        if (programRunner instanceof Closeable) {
+          Closeables.closeQuietly((Closeable) programRunner);
         }
-
-        @Override
-        public void killed() {
-          programCompletion.complete(ProgramController.State.KILLED);
-        }
-
-        @Override
-        public void error(Throwable cause) {
-          programCompletion.completeExceptionally(cause);
-        }
-      }, Threads.SAME_THREAD_EXECUTOR);
-
-      // Block on the completion
-      programCompletion.get();
-    } finally {
-      if (programRunner instanceof Closeable) {
-        ((Closeable) programRunner).close();
       }
+    } catch (Throwable t) {
+      controllerFuture.completeExceptionally(t);
+      throw t;
+    } finally {
+      stopCoreServices(coreServices, logAppenderInitializer);
     }
   }
 
-  private CConfiguration createCConf(RuntimeJobEnvironment runtimeJobEnv) throws Exception {
+  /**
+   * Stops the running program before it completes. It is supposed to be called when user request to stop a run.
+   */
+  private void stop() {
+    try {
+      ProgramController controller = controllerFuture.getNow(null);
+      if (controller == null) {
+        throw new IllegalStateException("Program hasn't been started");
+      }
+      controller.stop();
+    } catch (Exception e) {
+      LOG.warn("Cannot stop a failed program", e);
+    }
+  }
+
+  /**
+   * Create {@link CConfiguration} with the given {@link RuntimeJobEnvironment}.
+   * Properties returned by the {@link RuntimeJobEnvironment#getProperties()} will be set into the returned
+   * {@link CConfiguration} instance.
+   */
+  private CConfiguration createCConf(RuntimeJobEnvironment runtimeJobEnv) throws IOException {
     CConfiguration cConf = CConfiguration.create();
     cConf.clear();
-    cConf.addResource(new File(CDAP_CONF_FILE_NAME).toURI().toURL());
+    cConf.addResource(new File(DistributedProgramRunner.CDAP_CONF_FILE_NAME).toURI().toURL());
     for (Map.Entry<String, String> entry : runtimeJobEnv.getProperties().entrySet()) {
       cConf.set(entry.getKey(), entry.getValue());
     }
+
+    String hostName = InetAddress.getLocalHost().getCanonicalHostName();
+    cConf.set(Constants.Service.MASTER_SERVICES_BIND_ADDRESS, hostName);
+
     return cConf;
   }
 
@@ -186,25 +269,30 @@ public class DefaultRuntimeJob implements RuntimeJob {
   /**
    * Returns list of guice modules used to start the program run.
    */
-  private List<Module> createmodule(RuntimeJobEnvironment runtimeJobEnv, CConfiguration cConf) {
+  @VisibleForTesting
+  List<Module> createModules(RuntimeJobEnvironment runtimeJobEnv, CConfiguration cConf) {
     List<Module> modules = new ArrayList<>();
+    modules.add(new ConfigModule(cConf));
+    modules.add(new IOModule());
+    modules.add(new TMSLogAppenderModule());
+    modules.add(new RemoteExecutionDiscoveryModule());
     modules.add(new AuthenticationContextModules().getProgramContainerModule());
-    modules.add(new MessagingClientModule());
-    modules.add(new DFSLocationModule());
+    modules.add(new MetricsClientRuntimeModule().getDistributedModules());
+    modules.add(new MessagingServerRuntimeModule().getStandaloneModules());
+
     modules.add(new AbstractModule() {
       @Override
       protected void configure() {
         bind(ClusterMode.class).toInstance(ClusterMode.ISOLATED);
-        bind(CConfiguration.class).toInstance(cConf);
         bind(UGIProvider.class).to(CurrentUGIProvider.class).in(Scopes.SINGLETON);
 
-        // get twill runner from environment
+        // In isolated mode, ignore the namespace mapping
+        bind(NamespacePathLocator.class).to(NoLookupNamespacePathLocator.class);
+
+        // Bindings from the environment
         bind(TwillRunner.class).annotatedWith(Constants.AppFabric.ProgramRunner.class)
           .toInstance(runtimeJobEnv.getTwillRunner());
-        // get discovery service from environment
-        bind(DiscoveryService.class).toInstance(runtimeJobEnv.getDiscoveryService());
-        // get discovery service client from environment
-        bind(DiscoveryServiceClient.class).toInstance(runtimeJobEnv.getDiscoveryServiceClient());
+        bind(LocationFactory.class).toInstance(runtimeJobEnv.getLocationFactory());
 
         MapBinder<ProgramType, ProgramRunner> defaultProgramRunnerBinder = MapBinder.newMapBinder(
           binder(), ProgramType.class, ProgramRunner.class);
@@ -221,6 +309,96 @@ public class DefaultRuntimeJob implements RuntimeJob {
       }
     });
 
+    // Active monitoring means we need to start the RuntimeMonitorServer for app-fabric to poll
+    if (cConf.getBoolean(Constants.RuntimeMonitor.ACTIVE_MONITORING)) {
+      modules.add(createRuntimeMonitorServerModule(cConf));
+    }
+
     return modules;
+  }
+
+  /**
+   * Optionally adds {@link RuntimeMonitorServer} binding.
+   */
+  private Module createRuntimeMonitorServerModule(CConfiguration cConf) {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        try {
+          Path keyStorePath = Paths.get(cConf.get(Constants.RuntimeMonitor.SERVER_KEYSTORE_PATH));
+          Path trustStorePath = Paths.get(cConf.get(Constants.RuntimeMonitor.CLIENT_KEYSTORE_PATH));
+
+          KeyStore keyStore = KeyStores.load(Locations.toLocation(keyStorePath), () -> "");
+          KeyStore trustStore = KeyStores.load(Locations.toLocation(trustStorePath), () -> "");
+
+          // Update the cConf as well to store the service proxy password
+          cConf.set(Constants.RuntimeMonitor.SERVICE_PROXY_PASSWORD, KeyStores.hash(keyStore));
+
+          bind(KeyStore.class).annotatedWith(Constants.AppFabric.KeyStore.class).toInstance(keyStore);
+          bind(KeyStore.class).annotatedWith(Constants.AppFabric.TrustStore.class).toInstance(trustStore);
+
+          bind(Cancellable.class).toInstance(() -> stop());
+          bind(RuntimeMonitorServer.class);
+          expose(RuntimeMonitorServer.class);
+
+        } catch (Exception e) {
+          // Just log if failed to load the KeyStores. It will fail when RuntimeMonitorServer is needed.
+          LOG.error("Failed to load key store and/or trust store", e);
+        }
+      }
+    };
+  }
+
+  @VisibleForTesting
+  Deque<Service> createCoreServices(Injector injector) {
+    Deque<Service> services = new LinkedList<>();
+
+    MetricsCollectionService metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
+    services.add(metricsCollectionService);
+
+    // TODO (CDAP-16438): Add the log appender loader
+    // services.add(injector.getInstance(LogAppenderLoaderService.class));
+
+    MessagingService messagingService = injector.getInstance(MessagingService.class);
+    if (messagingService instanceof Service) {
+      services.add((Service) messagingService);
+    }
+    services.add(injector.getInstance(MessagingHttpService.class));
+
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    if (cConf.getBoolean(Constants.RuntimeMonitor.ACTIVE_MONITORING)) {
+      services.add(injector.getInstance(RuntimeMonitorServer.class));
+    }
+
+    return services;
+  }
+
+  private void startCoreServices(Deque<Service> coreServices, LogAppenderInitializer logAppenderInitializer) {
+    // Initialize log appender
+    logAppenderInitializer.initialize();
+
+    try {
+      // Starts the core services
+      for (Service service : coreServices) {
+        LOG.debug("Starting core service {}", service);
+        service.startAndWait();
+      }
+    } catch (Exception e) {
+      logAppenderInitializer.close();
+      throw e;
+    }
+  }
+
+  private void stopCoreServices(Deque<Service> coreServices, LogAppenderInitializer logAppenderInitializer) {
+    // Stop all services. Reverse the order.
+    for (Service service : (Iterable<Service>) coreServices::descendingIterator) {
+      LOG.debug("Stopping core service {}", service);
+      try {
+        service.stopAndWait();
+      } catch (Exception e) {
+        LOG.warn("Exception raised when stopping service {} during program termination.", service, e);
+      }
+    }
+    logAppenderInitializer.close();
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionJobMainTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionJobMainTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.distributed.remote;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobEnvironment;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Map;
+
+/**
+ * Unit test for {@link RemoteExecutionJobMain}.
+ */
+public class RemoteExecutionJobMainTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testJobEnvironment() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.set(Constants.CFG_HDFS_NAMESPACE, TEMP_FOLDER.newFolder().getAbsolutePath());
+
+    RemoteExecutionJobMain runner = new RemoteExecutionJobMain();
+    RuntimeJobEnvironment jobEnv = runner.initialize(cConf);
+    try {
+      Assert.assertNotNull(jobEnv.getLocationFactory());
+      Assert.assertNotNull(jobEnv.getTwillRunner());
+
+      Map<String, String> properties = jobEnv.getProperties();
+      ZKClientService zkClient = ZKClientService.Builder.of(properties.get(Constants.Zookeeper.QUORUM)).build();
+      zkClient.startAndWait();
+      try {
+        Assert.assertNotNull(zkClient.exists("/").get());
+      } finally {
+        zkClient.stopAndWait();
+      }
+    } finally {
+      runner.destroy();
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.distributed.runtimejob;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.security.KeyStores;
+import io.cdap.cdap.common.twill.NoopTwillRunnerService;
+import io.cdap.cdap.logging.appender.LogAppenderInitializer;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobEnvironment;
+import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Unit test for {@link DefaultRuntimeJob}.
+ */
+@RunWith(Parameterized.class)
+public class DefaultRuntimeJobTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Parameterized.Parameters(name = "{index}: DefaultRuntimeJobTest(activeMonitoring = {0})")
+  public static Collection<Object[]> parameters() {
+    return Arrays.asList(new Object[][] {
+      {false},
+      {true}
+    });
+  }
+
+  private final boolean activeMonitoring;
+
+  public DefaultRuntimeJobTest(boolean activeMonitoring) {
+    this.activeMonitoring = activeMonitoring;
+  }
+
+  @Test
+  public void testInjector() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().toString());
+    cConf.setBoolean(Constants.RuntimeMonitor.ACTIVE_MONITORING, activeMonitoring);
+
+    File serverKeyStoreFile = TEMP_FOLDER.newFile();
+    try (OutputStream os = new FileOutputStream(serverKeyStoreFile)) {
+      KeyStores.generatedCertKeyStore(1, "").store(os, "".toCharArray());
+    }
+    cConf.set(Constants.RuntimeMonitor.SERVER_KEYSTORE_PATH, serverKeyStoreFile.getAbsolutePath());
+
+    File clientKeyStoreFile = TEMP_FOLDER.newFile();
+    try (OutputStream os = new FileOutputStream(clientKeyStoreFile)) {
+      KeyStores.generatedCertKeyStore(1, "").store(os, "".toCharArray());
+    }
+    cConf.set(Constants.RuntimeMonitor.CLIENT_KEYSTORE_PATH, clientKeyStoreFile.getAbsolutePath());
+
+    LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFile());
+
+    DefaultRuntimeJob defaultRuntimeJob = new DefaultRuntimeJob();
+    Injector injector = Guice.createInjector(defaultRuntimeJob.createModules(new RuntimeJobEnvironment() {
+
+      @Override
+      public LocationFactory getLocationFactory() {
+        return locationFactory;
+      }
+
+      @Override
+      public TwillRunner getTwillRunner() {
+        return new NoopTwillRunnerService();
+      }
+
+      @Override
+      public Map<String, String> getProperties() {
+        return Collections.emptyMap();
+      }
+    }, cConf));
+
+    injector.getInstance(LogAppenderInitializer.class);
+    defaultRuntimeJob.createCoreServices(injector);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -142,6 +142,9 @@ public final class Constants {
     public static final String CFG_SESSION_TIMEOUT_MILLIS = "zookeeper.session.timeout.millis";
     public static final String CLIENT_STARTUP_TIMEOUT_MILLIS = "zookeeper.client.startup.timeout.millis";
     public static final int DEFAULT_SESSION_TIMEOUT_MILLIS = 40000;
+
+    // System property name to control the InMemoryZKServer to bind to localhost only or not
+    public static final String TWILL_ZK_SERVER_LOCALHOST = "twill.zk.server.localhost";
   }
 
   /**
@@ -862,6 +865,15 @@ public final class Constants {
     public static final String GRACEFUL_SHUTDOWN_MS = "app.program.runtime.monitor.graceful.shutdown.ms";
     public static final String THREADS = "app.program.runtime.monitor.threads";
     public static final String INIT_BATCH_SIZE = "app.program.runtime.monitor.initialize.batch.size";
+
+    /**
+     * Configuration to tell if the runtime monitoring is active
+     * An active monitoring is the app-fabric polling the remote runtime for status
+     * This is temporary until we move the SSH approach to use the RuntimeClient for monitoring.
+     */
+    public static final String ACTIVE_MONITORING = "app.program.runtime.monitor.active.monitoring";
+    public static final String SERVER_KEYSTORE_PATH = "app.program.runtime.monitor.server.keystore.path";
+    public static final String CLIENT_KEYSTORE_PATH = "app.program.runtime.monitor.client.keystore.path";
 
     public static final String BIND_ADDRESS = "app.program.runtime.monitor.server.bind.address";
     public static final String BIND_PORT = "app.program.runtime.monitor.server.bind.port";

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -28,6 +28,7 @@
   <logger name="com.ning" level="WARN"/>
   <logger name="org.apache.spark" level="WARN"/>
   <logger name="org.spark-project" level="WARN"/>
+  <logger name="org.spark_project" level="WARN"/>
   <logger name="org.apache.hadoop" level="WARN"/>
   <logger name="org.apache.hive" level="WARN"/>
   <logger name="org.apache.tephra.distributed.AbstractClientProvider" level="WARN"/>

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -27,6 +27,7 @@
     <logger name="com.ning" level="WARN"/>
     <logger name="org.apache.spark" level="WARN"/>
     <logger name="org.spark-project" level="WARN"/>
+    <logger name="org.spark_project" level="WARN"/>
     <logger name="org.apache.hadoop" level="WARN"/>
     <!--See CDAP-7948-->
     <logger name="org.apache.hadoop.ipc.Client" level="ERROR"/>

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJob.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJob.java
@@ -20,6 +20,7 @@ package io.cdap.cdap.runtime.spi.runtimejob;
  * Represents a job that will be executed on a given runtime environment.
  */
 public interface RuntimeJob {
+
   /**
    * This method will be responsible for submitting the runtime job to underlying runner.
    *

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobEnvironment.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobEnvironment.java
@@ -17,8 +17,7 @@
 package io.cdap.cdap.runtime.spi.runtimejob;
 
 import org.apache.twill.api.TwillRunner;
-import org.apache.twill.discovery.DiscoveryService;
-import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.util.Map;
 
@@ -26,15 +25,11 @@ import java.util.Map;
  * Represents runtime job environment that provides information that is needed by the {@link RuntimeJob} to run the job.
  */
 public interface RuntimeJobEnvironment {
-  /**
-   * Returns a {@link DiscoveryService} for service announcement purpose.
-   */
-  DiscoveryService getDiscoveryService();
 
   /**
-   * Returns a {@link DiscoveryServiceClient} for service discovery purpose.
+   * Returns a {@link LocationFactory} for location access.
    */
-  DiscoveryServiceClient getDiscoveryServiceClient();
+  LocationFactory getLocationFactory();
 
   /**
    * Returns a {@link TwillRunner}.

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkTwillRunnable.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkTwillRunnable.java
@@ -42,13 +42,6 @@ import org.apache.twill.api.TwillRunnable;
  */
 public class SparkTwillRunnable extends AbstractProgramTwillRunnable<ProgramRunner> {
 
-  /**
-   * Main method for the remote execution mode.
-   */
-  public static void main(String[] args) throws Exception {
-    new SparkTwillRunnable(getRunnableNameFromEnv()).doMain();
-  }
-
   SparkTwillRunnable(String name) {
     super(name);
   }

--- a/cdap-standalone/src/main/resources/logback-container.xml
+++ b/cdap-standalone/src/main/resources/logback-container.xml
@@ -28,6 +28,7 @@
   <logger name="com.ning" level="WARN"/>
   <logger name="org.apache.spark" level="WARN"/>
   <logger name="org.spark-project" level="WARN"/>
+  <logger name="org.spark_project" level="WARN"/>
   <logger name="org.apache.hadoop" level="WARN"/>
   <logger name="org.apache.hive" level="WARN"/>
   <logger name="org.apache.tephra.distributed.AbstractClientProvider" level="WARN"/>

--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -31,6 +31,7 @@
   <logger name="com.ning" level="WARN"/>
   <logger name="org.apache.spark" level="WARN"/>
   <logger name="org.spark-project" level="WARN"/>
+  <logger name="org.spark_project" level="WARN"/>
   <logger name="org.apache.hadoop" level="WARN"/>
   <logger name="org.apache.hive" level="WARN"/>
   <!-- TODO Remove suppressing of Tephra logs once CDAP-8806 is fixed. -->


### PR DESCRIPTION
- This change is to move services that are used to run in AbstractProgramTwillRunnable
  into DefaultRuntimeJob. It provides a unified way of running job in any hadoop cluster,
  regardless of how the DefaultRuntimeJob is being started.