### PR TITLE
[CDAP-15894] Navigate to cause/impact lineage from table header

### DIFF
--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContext.tsx
@@ -19,7 +19,8 @@ import { objectQuery, parseQueryString } from 'services/helpers';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import {
   IField,
-  ITableFields,
+  ITableInfo,
+  ITablesList,
   ITimeParams,
   getTableId,
   getTimeRange,
@@ -38,7 +39,7 @@ import {
 
 const defaultContext: IContextState = {
   target: '',
-  targetFields: [],
+  targetFields: {},
   links: getDefaultLinks(),
   causeSets: {},
   impactSets: {},
@@ -58,10 +59,10 @@ type ITimeType = number | string | null;
 
 export interface IContextState {
   target: string;
-  targetFields: IField[];
+  targetFields: ITableInfo;
   links: ILinkSet;
-  causeSets: ITableFields;
-  impactSets: ITableFields;
+  causeSets: ITablesList;
+  impactSets: ITablesList;
   showingOneField: boolean;
   start: ITimeType;
   end: ITimeType;
@@ -76,8 +77,8 @@ export interface IContextState {
   handleViewCauseImpact?: () => void;
   handleReset?: () => void;
   activeField?: IField;
-  activeCauseSets?: ITableFields;
-  activeImpactSets?: ITableFields;
+  activeCauseSets?: ITablesList;
+  activeImpactSets?: ITablesList;
   activeLinks?: ILinkSet;
   numTables?: number;
   firstCause?: number;
@@ -158,14 +159,18 @@ export class Provider extends React.Component<{ children }, IContextState> {
 
         if (nonTargetFd.type === 'cause') {
           if (!(tableId in activeCauseSets)) {
-            activeCauseSets[tableId] = [];
+            activeCauseSets[tableId] = {
+              fields: [],
+            };
           }
-          activeCauseSets[tableId].push(nonTargetFd);
+          activeCauseSets[tableId].fields.push(nonTargetFd);
         } else {
           if (!(tableId in activeImpactSets)) {
-            activeImpactSets[tableId] = [];
+            activeImpactSets[tableId] = {
+              fields: [],
+            };
           }
-          activeImpactSets[tableId].push(nonTargetFd);
+          activeImpactSets[tableId].fields.push(nonTargetFd);
         }
       });
     }
@@ -188,10 +193,10 @@ export class Provider extends React.Component<{ children }, IContextState> {
     const namespace = getCurrentNamespace();
     const updateState = (newState: IContextState) => {
       // If no field selected, grab the first field with lineage
-      if (!newState.activeField.id && newState.targetFields.length > 0) {
+      if (!newState.activeField.id && newState.targetFields.fields.length > 0) {
         newState.activeField = {
-          id: newState.targetFields[0].id,
-          name: newState.targetFields[0].name,
+          id: newState.targetFields.fields[0].id,
+          name: newState.targetFields.fields[0].name,
         };
       }
 
@@ -290,7 +295,7 @@ export class Provider extends React.Component<{ children }, IContextState> {
 
   public state = {
     target: '',
-    targetFields: [],
+    targetFields: {},
     links: getDefaultLinks(),
     causeSets: {},
     impactSets: {},

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContextHelper.ts
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/Context/FllContextHelper.ts
@@ -25,7 +25,7 @@ import { IContextState } from 'components/FieldLevelLineage/v2/Context/FllContex
 // types for backend response
 interface IFllEntity {
   entityId?: IEntityId;
-  relations?: IRelation[];
+  relations?: IResLink[];
 }
 
 interface IEntityId {
@@ -34,7 +34,8 @@ interface IEntityId {
   entity?: string;
 }
 
-export interface IRelation {
+// Info we get from backend about lineage connection
+export interface IResLink {
   source?: string;
   destination?: string;
 }
@@ -46,8 +47,11 @@ export interface IField {
   type?: string;
   dataset?: string;
   namespace?: string;
+  hasIncomingOps?: boolean;
+  hasOutgoingOps?: boolean;
 }
 
+// IResLink plus extra info for rendering connections
 export interface ILink {
   source: IField;
   destination: IField;
@@ -58,8 +62,15 @@ export interface ILinkSet {
   outgoing: ILink[];
 }
 
-export interface ITableFields {
-  [tablename: string]: IField[];
+// Field count and field name info for all incoming or outgoing datsets
+export interface ITablesList {
+  [tablename: string]: ITableInfo;
+}
+
+export interface ITableInfo {
+  fields?: IField[];
+  namespace?: string;
+  dataset?: string;
 }
 
 export interface ITimeParams {
@@ -112,23 +123,42 @@ export const getDefaultLinks = () => {
  * namespace and target are the target namespace and dataset name
  */
 
-export function parseRelations(
+export function getLinks(
   namespace: string,
   target: string,
   ents: IFllEntity[],
   isCause: boolean = true
 ) {
-  const tables: ITableFields = {};
-  const relLinks: ILink[] = [];
-  ents.map((ent) => {
+  const tables: ITablesList = {};
+  const links: ILink[] = [];
+  const targetFieldsWithOps = new Set(); // Keep track of all target fields with operations/lineage
+
+  ents.forEach((ent) => {
     // Assumes that all tableNames are unique within a namespace
+
+    // Check if entity should not be rendered (i.e. from dropped or added field)
+    if (!ent.hasOwnProperty('entityId')) {
+      // Just mark the target field(s) as having operations, for the dangling links
+      ent.relations.map((rel) => {
+        const targetField = isCause ? rel.destination : rel.source; // Grab the target field
+        targetFieldsWithOps.add(targetField);
+      });
+      return;
+    }
 
     const type = isCause ? 'cause' : 'impact';
     const tableId = getTableId(ent.entityId.dataset, ent.entityId.namespace, type);
-    // tables keeps track of fields for each incoming or outgoing dataset.
-    tables[tableId] = [];
-    // fieldIds keeps track of fields, since a single field can have multiple connections
+
+    // tables keeps track of datasets and fields that need to be rendered.
+    tables[tableId] = {
+      fields: [],
+      dataset: ent.entityId.dataset,
+      namespace: ent.entityId.namespace,
+    };
+    // fieldIds keeps track of fields to prevent duplication, since a single field can have multiple connections
     const fieldIds = new Map();
+
+    // Go through all the entity's relations to grab fields to be rendered and the target fields (which have ops)
     ent.relations.map((rel) => {
       /** backend response assumes connection goes from left to right
        * i.e. an incoming connection's destination = target field,
@@ -139,19 +169,23 @@ export function parseRelations(
       let id = fieldIds.get(fieldName);
       const field: IField = {
         id,
-        type: isCause ? 'cause' : 'impact',
+        type,
         name: fieldName,
         dataset: ent.entityId.dataset,
         namespace: ent.entityId.namespace,
       };
+      // if we haven't seen this field yet, add it to the table's list of fields
       if (!fieldIds.has(fieldName)) {
         id = getFieldId(fieldName, ent.entityId.dataset, ent.entityId.namespace, type);
         field.id = id;
         fieldIds.set(fieldName, id);
-        tables[tableId].push(field);
+        tables[tableId].fields.push(field);
       }
 
       const targetName = isCause ? rel.destination : rel.source;
+
+      targetFieldsWithOps.add(targetName);
+
       const targetField: IField = {
         id: getFieldId(targetName, target, namespace, 'target'),
         type: 'target',
@@ -163,34 +197,46 @@ export function parseRelations(
         source: isCause ? field : targetField,
         destination: isCause ? targetField : field,
       };
-      relLinks.push(link);
+      links.push(link);
     });
   });
-  return { tables, relLinks };
+  return { tables, links, targetFieldsWithOps };
 }
 
 export function getFieldsAndLinks(d) {
-  const incoming = parseRelations(d.entityId.namespace, d.entityId.dataset, d.incoming);
-  const outgoing = parseRelations(d.entityId.namespace, d.entityId.dataset, d.outgoing, false);
-  const causeTables = incoming.tables;
-  const impactTables = outgoing.tables;
-  const links: ILinkSet = { incoming: incoming.relLinks, outgoing: outgoing.relLinks };
-  return { causeTables, impactTables, links };
+  const incomingLineage = getLinks(d.entityId.namespace, d.entityId.dataset, d.incoming);
+  const outgoingLineage = getLinks(d.entityId.namespace, d.entityId.dataset, d.outgoing, false);
+  const causeTables = incomingLineage.tables;
+  const impactTables = outgoingLineage.tables;
+  const targetFieldsWithOps = {
+    incoming: incomingLineage.targetFieldsWithOps,
+    outgoing: outgoingLineage.targetFieldsWithOps,
+  };
+  const links: ILinkSet = { incoming: incomingLineage.links, outgoing: outgoingLineage.links };
+  return { causeTables, impactTables, links, targetFieldsWithOps };
 }
 
-export function makeTargetFields({ namespace, dataset }: IEntityId, fields: string[]) {
+export function makeTargetFields(
+  { namespace, dataset }: IEntityId,
+  fields: string[],
+  fieldsWithOps
+) {
   const targetFields = fields.map((fieldname) => {
     const id = `target_ns-${namespace}_ds-${dataset}_fd-${fieldname}`;
+    const hasIncomingOps = fieldsWithOps.incoming.has(fieldname);
+    const hasOutgoingOps = fieldsWithOps.outgoing.has(fieldname);
     const field: IField = {
       id,
       type: 'target',
       name: fieldname,
       dataset,
       namespace,
+      hasIncomingOps,
+      hasOutgoingOps,
     };
     return field;
   });
-  return targetFields;
+  return { fields: targetFields };
 }
 
 export function getFieldId(fieldname, dataset, namespace, type) {
@@ -253,7 +299,7 @@ export function getFieldLineage(
     const parsedRes = getFieldsAndLinks(res);
     const targetInfo: IContextState = {
       target: res.entityId.dataset,
-      targetFields: makeTargetFields(res.entityId, res.fields),
+      targetFields: makeTargetFields(res.entityId, res.fields, parsedRes.targetFieldsWithOps),
       links: parsedRes.links,
       causeSets: parsedRes.causeTables,
       impactSets: parsedRes.impactTables,

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllField.tsx
@@ -100,7 +100,7 @@ function FllField({ field, isActive, classes }: IFieldProps) {
         </span>
       </If>
       <If condition={activeField.id && field.id === activeField.id && isTarget && !showingOneField}>
-        <FllMenu />
+        <FllMenu hasIncomingOps={field.hasIncomingOps} hasOutgoingOps={field.hasOutgoingOps} />
       </If>
       <If condition={activeField.id && field.id === activeField.id && isTarget && showingOneField}>
         <span className={classes.targetView} onClick={handleReset} data-cy="reset-lineage">

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllMenu/index.tsx
@@ -15,7 +15,7 @@
 */
 
 import React, { useState, useContext } from 'react';
-import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
@@ -52,11 +52,14 @@ const styles = (theme): StyleRules => {
   };
 };
 
-function FllMenu({ classes }) {
+interface IFllMenuProps extends WithStyles<typeof styles> {
+  hasIncomingOps?: boolean;
+  hasOutgoingOps?: boolean;
+}
+
+function FllMenu({ hasIncomingOps, hasOutgoingOps, classes }: IFllMenuProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const { handleViewCauseImpact, toggleOperations, activeCauseSets, activeImpactSets } = useContext<
-    IContextState
-  >(FllContext);
+  const { handleViewCauseImpact, toggleOperations } = useContext<IContextState>(FllContext);
 
   function handleViewClick(e: React.MouseEvent<HTMLButtonElement>) {
     setAnchorEl(e.currentTarget);
@@ -71,8 +74,6 @@ function FllMenu({ classes }) {
     handleCloseMenu();
   }
 
-  const hasIncomingOps = Object.keys(activeCauseSets).length !== 0;
-  const hasOutgoingOps = Object.keys(activeImpactSets).length !== 0;
   return (
     <span className={classes.root}>
       <Button onClick={handleViewClick} className={classes.targetView} data-cy="fll-view-dropdown">

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllTableHeader.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/FllTable/FllTableHeader.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useState, useContext } from 'react';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import classnames from 'classnames';
+import {
+  IField,
+  getTimeQueryParams,
+  ITableInfo,
+} from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
+import { Link } from 'react-router-dom';
+import T from 'i18n-react';
+import If from 'components/If';
+import { FllContext, IContextState } from 'components/FieldLevelLineage/v2/Context/FllContext';
+
+const styles = (theme): StyleRules => {
+  return {
+    tableHeader: {
+      borderBottom: `2px solid ${theme.palette.grey[300]}`,
+      height: '40px',
+      paddingLeft: '10px',
+      fontWeight: 'bold',
+      fontSize: '1rem',
+      overflow: 'hidden',
+      ' & .table-name': {
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+      },
+      ' &.hovering': {
+        backgroundColor: theme.palette.grey[700],
+      },
+    },
+    tableSubheader: {
+      color: theme.palette.grey[100],
+      fontWeight: 'normal',
+    },
+  };
+};
+
+interface ITableHeaderProps extends WithStyles<typeof styles> {
+  tableInfo: ITableInfo;
+  fields: IField[];
+  isTarget: boolean;
+  isExpanded: boolean;
+}
+
+function FllTableHeader({
+  tableInfo,
+  fields,
+  isTarget,
+  isExpanded = false,
+  classes,
+}: ITableHeaderProps) {
+  const [isHovering, setHoverState] = useState<boolean>(false);
+  const { selection, start, end } = useContext<IContextState>(FllContext);
+
+  const timeParams = getTimeQueryParams(selection, start, end);
+  const toggleHoverState = (nextState) => {
+    setHoverState(nextState);
+  };
+  const count: number = fields.length;
+  const tableName = fields[0].dataset;
+  const i18nOptions = { context: count };
+  const linkPath = `/ns/${tableInfo.namespace}/datasets/${tableInfo.dataset}/fields${timeParams}`;
+  return (
+    <div
+      className={classnames(classes.tableHeader, { hovering: isHovering && !isTarget })}
+      onMouseEnter={toggleHoverState.bind(this, true)}
+      onMouseLeave={toggleHoverState.bind(this, false)}
+    >
+      <div className="table-name">{tableName}</div>
+
+      <If condition={!isHovering || isTarget}>
+        <div className={classes.tableSubheader}>
+          {isTarget || isExpanded
+            ? T.translate('features.FieldLevelLineage.v2.FllTable.fieldsCount', i18nOptions)
+            : T.translate('features.FieldLevelLineage.v2.FllTable.relatedFieldsCount', i18nOptions)}
+        </div>
+      </If>
+      <If condition={isHovering}>
+        <span data-cy="view-lineage" className={classes.tableSubheader}>
+          <Link to={linkPath} className={classes.hoverText} title={tableName}>
+            {T.translate('features.FieldLevelLineage.v2.FllTable.FllTableHeader.viewLineage')}
+          </Link>
+        </span>
+      </If>
+    </div>
+  );
+}
+
+const StyledTableHeader = withStyles(styles)(FllTableHeader);
+
+export default StyledTableHeader;

--- a/cdap-ui/app/cdap/components/FieldLevelLineage/v2/LineageSummary/index.tsx
+++ b/cdap-ui/app/cdap/components/FieldLevelLineage/v2/LineageSummary/index.tsx
@@ -20,7 +20,7 @@ import FllHeader from 'components/FieldLevelLineage/v2/FllHeader';
 import FllTable from 'components/FieldLevelLineage/v2/FllTable';
 import OperationsModal from 'components/FieldLevelLineage/v2/OperationsModal';
 import {
-  ITableFields,
+  ITablesList,
   IField,
   ILinkSet,
 } from 'components/FieldLevelLineage/v2/Context/FllContextHelper';
@@ -67,8 +67,8 @@ const styles = (theme): StyleRules => {
 
 interface ILineageState {
   activeField: IField;
-  activeCauseSets: ITableFields;
-  activeImpactSets: ITableFields;
+  activeCauseSets: ITablesList;
+  activeImpactSets: ITablesList;
   activeLinks: ILinkSet;
 }
 
@@ -269,13 +269,13 @@ class LineageSummary extends React.Component<{ classes }, ILineageState> {
                     <If condition={Object.keys(visibleCauseSets).length === 0}>
                       <FllTable type="cause" />
                     </If>
-                    {Object.entries(visibleCauseSets).map(([tableId, fields]) => {
+                    {Object.entries(visibleCauseSets).map(([tableId, tableInfo]) => {
                       const isActive = tableId in activeCauseSets;
                       return (
                         <FllTable
                           key={tableId}
                           tableId={tableId}
-                          fields={fields}
+                          tableInfo={tableInfo}
                           type="cause"
                           isActive={isActive}
                         />
@@ -284,20 +284,20 @@ class LineageSummary extends React.Component<{ classes }, ILineageState> {
                   </div>
                   <div data-cy="target-fields" className={this.props.classes.summaryCol}>
                     <FllHeader type="target" total={Object.keys(targetFields).length} />
-                    <FllTable tableId={target} fields={targetFields} type="target" />
+                    <FllTable tableId={target} tableInfo={targetFields} type="target" />
                   </div>
                   <div data-cy="impact-fields" className={this.props.classes.summaryCol}>
                     <FllHeader type="impact" total={Object.keys(visibleImpactSets).length} />
                     <If condition={Object.keys(visibleImpactSets).length === 0}>
                       <FllTable type="impact" />
                     </If>
-                    {Object.entries(visibleImpactSets).map(([tableId, fields]) => {
+                    {Object.entries(visibleImpactSets).map(([tableId, tableInfo]) => {
                       const isActive = tableId in activeImpactSets;
                       return (
                         <FllTable
                           key={tableId}
                           tableId={tableId}
-                          fields={fields}
+                          tableInfo={tableInfo}
                           type="impact"
                           isActive={isActive}
                         />

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -1553,6 +1553,8 @@ features:
           causeImpact: "Pin field"
           viewIncoming: "View cause"
           viewOutgoing: "View impact"
+        FllTableHeader:
+          viewLineage: "View lineage"
         noRelatedTables: "There is no {type} for {target}"
         relatedFieldsCount:
           1: "{context} related field"


### PR DESCRIPTION
Build: https://builds.cask.co/browse/CDAP-URUT218

Cherry-picking two changes:

- Allows user to change target dataset in field level lineage UI by hovering over and selecting dataset header (https://issues.cask.co/browse/CDAP-15894)
- Modify context to allow for additional dataset properties (related to https://github.com/cdapio/cdap/pull/11869, except without the fieldcount since API changes aren't in this branch)