### PR TITLE
(CDAP-16353) Refactoring: rename toArtifactId() to apiToProtoArtifactId

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/ProgramDescriptor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/ProgramDescriptor.java
@@ -33,7 +33,7 @@ public class ProgramDescriptor {
   private final ArtifactId artifactId;
 
   public ProgramDescriptor(ProgramId programId, ApplicationSpecification appSpec) {
-    this(programId, appSpec, Artifacts.toArtifactId(programId.getNamespaceId(), appSpec.getArtifactId()));
+    this(programId, appSpec, Artifacts.apiToProtoArtifactId(programId.getNamespaceId(), appSpec.getArtifactId()));
   }
 
   @VisibleForTesting

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -279,7 +279,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
       }
 
       try {
-        ArtifactId artifactId = Artifacts.toArtifactId(programId.getNamespaceId(), plugin.getArtifactId());
+        ArtifactId artifactId = Artifacts.apiToProtoArtifactId(programId.getNamespaceId(), plugin.getArtifactId());
         copyArtifact(artifactId, noAuthArtifactRepository.getArtifact(Id.Artifact.fromEntityId(artifactId)), destFile);
       } catch (ArtifactNotFoundException e) {
         throw new IllegalArgumentException(String.format("Artifact %s could not be found", plugin.getArtifactId()), e);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -55,7 +55,7 @@ public class AppDeploymentInfo {
                            String appClassName, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
                            boolean updateSchedules) {
-    this.artifactId = Artifacts.toArtifactId(namespaceId, artifactDescriptor.getArtifactId());
+    this.artifactId = Artifacts.apiToProtoArtifactId(namespaceId, artifactDescriptor.getArtifactId());
     this.artifactLocation = artifactDescriptor.getLocation();
     this.namespaceId = namespaceId;
     this.appClassName = appClassName;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/Artifacts.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/Artifacts.java
@@ -64,12 +64,12 @@ public final class Artifacts {
   }
 
   /**
-   * Converts a {@link ArtifactId} to {@link io.cdap.cdap.proto.id.ArtifactId}.
+   * Converts a {@link io.cdap.cdap.api.artifact.ArtifactId} to {@link io.cdap.cdap.proto.id.ArtifactId}.
    *
    * @param namespaceId the user namespace to use
    * @param artifactId the artifact id to convert
    */
-  public static io.cdap.cdap.proto.id.ArtifactId toArtifactId(NamespaceId namespaceId, ArtifactId artifactId) {
+  public static io.cdap.cdap.proto.id.ArtifactId apiToProtoArtifactId(NamespaceId namespaceId, ArtifactId artifactId) {
     ArtifactScope scope = artifactId.getScope();
     NamespaceId artifactNamespace = scope == ArtifactScope.SYSTEM ? NamespaceId.SYSTEM : namespaceId;
     return artifactNamespace.artifact(artifactId.getName(), artifactId.getVersion().getVersion());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
@@ -114,7 +114,8 @@ public class RemotePluginFinder implements PluginFinder, ArtifactFinder {
           throw new PluginNotExistsException(pluginNamespaceId, pluginType, pluginName);
         }
 
-        Location artifactLocation = getArtifactLocation(Artifacts.toArtifactId(pluginNamespaceId, selected.getKey()));
+        Location artifactLocation = getArtifactLocation(
+          Artifacts.apiToProtoArtifactId(pluginNamespaceId, selected.getKey()));
         return Maps.immutableEntry(new ArtifactDescriptor(selected.getKey(), artifactLocation), selected.getValue());
       }, retryStrategy);
     } catch (PluginNotExistsException e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -340,7 +340,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     String requestedConfigStr = requestedConfigObj == null ?
       currentSpec.getConfiguration() : new Gson().toJson(requestedConfigObj);
 
-    Id.Artifact artifactId = Id.Artifact.fromEntityId(Artifacts.toArtifactId(appId.getParent(), newArtifactId));
+    Id.Artifact artifactId = Id.Artifact.fromEntityId(Artifacts.apiToProtoArtifactId(appId.getParent(), newArtifactId));
     return deployApp(appId.getParent(), appId.getApplication(), null, artifactId, requestedConfigStr,
                      programTerminator, ownerAdmin.getOwner(appId), appRequest.canUpdateSchedules());
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -281,7 +281,8 @@ public class AppFabricTestHelper {
     ArtifactId artifactId = new ArtifactId(appClass.getSimpleName(), artifactVersion, ArtifactScope.USER);
     ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(artifactId, deployedJar);
     ArtifactRepository artifactRepository = getInjector().getInstance(ArtifactRepository.class);
-    artifactRepository.addArtifact(Id.Artifact.fromEntityId(Artifacts.toArtifactId(namespace.toEntityId(), artifactId)),
+    artifactRepository.addArtifact(Id.Artifact.fromEntityId(Artifacts.apiToProtoArtifactId(namespace.toEntityId(),
+                                                                                           artifactId)),
                                    new File(deployedJar.toURI()));
 
     AppDeploymentInfo info = new AppDeploymentInfo(artifactDescriptor, namespace.toEntityId(),


### PR DESCRIPTION
We have 3 versions of ArtifactId:

io.cdap.cdap.api.artifact.ArtifactId
io.cdap.cdap.proto.id.ArtifactId
io.cdap.cdap.common.id.Artifact

Rename this util function that converts from api.artifact.ArtifactId
to proto.id.ArtifactId to make it clear which version it converts to which.