### PR TITLE
(CDAP-16353) Refactoring: move artifact http internal endpoints to a separate handler

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.data.security.DefaultSecretStore;
 import io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandlerInternal;
 import io.cdap.cdap.gateway.handlers.ArtifactHttpHandler;
+import io.cdap.cdap.gateway.handlers.ArtifactHttpHandlerInternal;
 import io.cdap.cdap.gateway.handlers.AuthorizationHandler;
 import io.cdap.cdap.gateway.handlers.BootstrapHttpHandler;
 import io.cdap.cdap.gateway.handlers.CommonHandlers;
@@ -320,6 +321,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(TransactionHttpHandler.class);
       handlerBinder.addBinding().to(WorkflowHttpHandler.class);
       handlerBinder.addBinding().to(ArtifactHttpHandler.class);
+      handlerBinder.addBinding().to(ArtifactHttpHandlerInternal.class);
       handlerBinder.addBinding().to(WorkflowStatsSLAHttpHandler.class);
       handlerBinder.addBinding().to(AuthorizationHandler.class);
       handlerBinder.addBinding().to(SecureStoreHandler.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/ProgramDescriptor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/ProgramDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2019 Cask Data, Inc.
+ * Copyright © 2016-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -33,7 +33,7 @@ public class ProgramDescriptor {
   private final ArtifactId artifactId;
 
   public ProgramDescriptor(ProgramId programId, ApplicationSpecification appSpec) {
-    this(programId, appSpec, Artifacts.apiToProtoArtifactId(programId.getNamespaceId(), appSpec.getArtifactId()));
+    this(programId, appSpec, Artifacts.toProtoArtifactId(programId.getNamespaceId(), appSpec.getArtifactId()));
   }
 
   @VisibleForTesting

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2018 Cask Data, Inc.
+ * Copyright © 2014-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -279,7 +279,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
       }
 
       try {
-        ArtifactId artifactId = Artifacts.apiToProtoArtifactId(programId.getNamespaceId(), plugin.getArtifactId());
+        ArtifactId artifactId = Artifacts.toProtoArtifactId(programId.getNamespaceId(), plugin.getArtifactId());
         copyArtifact(artifactId, noAuthArtifactRepository.getArtifact(Id.Artifact.fromEntityId(artifactId)), destFile);
       } catch (ArtifactNotFoundException e) {
         throw new IllegalArgumentException(String.format("Artifact %s could not be found", plugin.getArtifactId()), e);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -734,39 +734,6 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  // the following endpoints with path "artifact-internals" are only called by CDAP programs, not exposed via router.
-  @GET
-  @Path("/namespaces/{namespace-id}/artifact-internals/artifacts")
-  public void listArtifactsInternal(HttpRequest request, HttpResponder responder,
-                                    @PathParam("namespace-id") String namespaceId) {
-    try {
-      List<ArtifactInfo> artifactInfoList = new ArrayList<>();
-      artifactInfoList.addAll(artifactRepository.getArtifactsInfo(new NamespaceId(namespaceId)));
-      artifactInfoList.addAll(artifactRepository.getArtifactsInfo(NamespaceId.SYSTEM));
-      responder.sendJson(HttpResponseStatus.OK, GSON.toJson(artifactInfoList, ARTIFACT_INFO_LIST_TYPE));
-    } catch (Exception e) {
-      LOG.warn("Exception reading artifact metadata for namespace {} from the store.", namespaceId, e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error reading artifact metadata from the store.");
-    }
-  }
-
-  @GET
-  @Path("/namespaces/{namespace-id}/artifact-internals/artifacts/{artifact-name}/versions/{artifact-version}/location")
-  public void getArtifactLocation(HttpRequest request, HttpResponder responder,
-                                  @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("artifact-name") String artifactName,
-                                  @PathParam("artifact-version") String artifactVersion) {
-    try {
-      ArtifactDetail artifactDetail = artifactRepository.getArtifact(
-        Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersion));
-      responder.sendString(HttpResponseStatus.OK, artifactDetail.getDescriptor().getLocation().toURI().getPath());
-    } catch (Exception e) {
-      LOG.warn("Exception reading artifact metadata for namespace {} from the store.", namespaceId, e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                           "Error reading artifact metadata from the store.");
-    }
-  }
-
   private ArtifactScope validateScope(String scope) throws BadRequestException {
     try {
       return ArtifactScope.valueOf(scope.toUpperCase());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandlerInternal.java
@@ -53,8 +53,7 @@ public class ArtifactHttpHandlerInternal extends AbstractHttpHandler {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
-  private static final Type ARTIFACT_INFO_LIST_TYPE = new TypeToken<List<ArtifactInfo>>() {
-  }.getType();
+  private static final Type ARTIFACT_INFO_LIST_TYPE = new TypeToken<List<ArtifactInfo>>() { }.getType();
 
   private final ArtifactRepository artifactRepository;
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandlerInternal.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.api.artifact.ArtifactInfo;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDetail;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * Internal {@link io.cdap.http.HttpHandler} for managing artifacts.
+ */
+@Singleton
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3)
+public class ArtifactHttpHandlerInternal extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(ArtifactHttpHandlerInternal.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .create();
+  private static final Type ARTIFACT_INFO_LIST_TYPE = new TypeToken<List<ArtifactInfo>>() {
+  }.getType();
+
+  private final ArtifactRepository artifactRepository;
+
+  @Inject
+  ArtifactHttpHandlerInternal(ArtifactRepository artifactRepository) {
+    this.artifactRepository = artifactRepository;
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/artifacts")
+  public void listArtifacts(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId) {
+    try {
+      List<ArtifactInfo> artifactInfoList = new ArrayList<>();
+      artifactInfoList.addAll(artifactRepository.getArtifactsInfo(new NamespaceId(namespaceId)));
+      artifactInfoList.addAll(artifactRepository.getArtifactsInfo(NamespaceId.SYSTEM));
+      responder.sendJson(HttpResponseStatus.OK, GSON.toJson(artifactInfoList, ARTIFACT_INFO_LIST_TYPE));
+    } catch (Exception e) {
+      LOG.warn("Exception reading artifact metadata for namespace {} from the store.", namespaceId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error reading artifact metadata from the store.");
+    }
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/location")
+  public void getArtifactLocationPath(HttpRequest request, HttpResponder responder,
+                                      @PathParam("namespace-id") String namespaceId,
+                                      @PathParam("artifact-name") String artifactName,
+                                      @PathParam("artifact-version") String artifactVersion) {
+    try {
+      ArtifactDetail artifactDetail = artifactRepository.getArtifact(
+        Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersion));
+      responder.sendString(HttpResponseStatus.OK, artifactDetail.getDescriptor().getLocation().toURI().getPath());
+    } catch (Exception e) {
+      LOG.warn("Exception reading artifact metadata for namespace {} from the store.", namespaceId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error reading artifact metadata from the store.");
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2017 Cask Data, Inc.
+ * Copyright © 2015-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,7 +55,7 @@ public class AppDeploymentInfo {
                            String appClassName, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
                            boolean updateSchedules) {
-    this.artifactId = Artifacts.apiToProtoArtifactId(namespaceId, artifactDescriptor.getArtifactId());
+    this.artifactId = Artifacts.toProtoArtifactId(namespaceId, artifactDescriptor.getArtifactId());
     this.artifactLocation = artifactDescriptor.getLocation();
     this.namespaceId = namespaceId;
     this.appClassName = appClassName;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/Artifacts.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/Artifacts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.Config;
 import io.cdap.cdap.api.app.Application;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.internal.lang.Reflections;
 import io.cdap.cdap.proto.id.NamespaceId;
 
@@ -64,12 +65,12 @@ public final class Artifacts {
   }
 
   /**
-   * Converts a {@link io.cdap.cdap.api.artifact.ArtifactId} to {@link io.cdap.cdap.proto.id.ArtifactId}.
+   * Converts a {@link ArtifactId} to {@link io.cdap.cdap.proto.id.ArtifactId}.
    *
    * @param namespaceId the user namespace to use
    * @param artifactId the artifact id to convert
    */
-  public static io.cdap.cdap.proto.id.ArtifactId apiToProtoArtifactId(NamespaceId namespaceId, ArtifactId artifactId) {
+  public static io.cdap.cdap.proto.id.ArtifactId toProtoArtifactId(NamespaceId namespaceId, ArtifactId artifactId) {
     ArtifactScope scope = artifactId.getScope();
     NamespaceId artifactNamespace = scope == ArtifactScope.SYSTEM ? NamespaceId.SYSTEM : namespaceId;
     return artifactNamespace.artifact(artifactId.getName(), artifactId.getVersion().getVersion());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactManager.java
@@ -61,7 +61,7 @@ public final class RemoteArtifactManager extends AbstractArtifactManager {
   private final NamespaceId namespaceId;
   private final RetryStrategy retryStrategy;
   private final boolean authorizationEnabled;
-  private final RemoteClient remoteClient;
+  private final RemoteClient remoteClientInternal;
 
   @Inject
   RemoteArtifactManager(CConfiguration cConf, DiscoveryServiceClient discoveryServiceClient,
@@ -73,9 +73,9 @@ public final class RemoteArtifactManager extends AbstractArtifactManager {
     this.namespaceId = namespaceId;
     this.retryStrategy = retryStrategy;
     this.authorizationEnabled = cConf.getBoolean(Constants.Security.Authorization.ENABLED);
-    this.remoteClient = new RemoteClient(discoveryServiceClient, Constants.Service.APP_FABRIC_HTTP,
-                                         new DefaultHttpRequestConfig(false),
-                                         String.format("%s", Constants.Gateway.API_VERSION_3));
+    this.remoteClientInternal = new RemoteClient(discoveryServiceClient, Constants.Service.APP_FABRIC_HTTP,
+                                                 new DefaultHttpRequestConfig(false),
+                                                 String.format("%s", Constants.Gateway.INTERNAL_API_VERSION_3));
   }
 
   /**
@@ -105,8 +105,8 @@ public final class RemoteArtifactManager extends AbstractArtifactManager {
   public List<ArtifactInfo> listArtifacts(String namespace) throws IOException {
     return Retries.callWithRetries(() -> {
       HttpRequest.Builder requestBuilder =
-        remoteClient.requestBuilder(HttpMethod.GET,
-                                    String.format("namespaces/%s/artifact-internals/artifacts", namespace));
+        remoteClientInternal.requestBuilder(HttpMethod.GET,
+                                            String.format("namespaces/%s/artifacts", namespace));
       // add header if auth is enabled
       if (authorizationEnabled) {
         requestBuilder.addHeader(Constants.Security.Headers.USER_ID, authenticationContext.getPrincipal().getName());
@@ -116,7 +116,7 @@ public final class RemoteArtifactManager extends AbstractArtifactManager {
   }
 
   private List<ArtifactInfo> getArtifactsList(HttpRequest httpRequest) throws IOException {
-    HttpResponse httpResponse = remoteClient.execute(httpRequest);
+    HttpResponse httpResponse = remoteClientInternal.execute(httpRequest);
 
     if (httpResponse.getResponseCode() == HttpResponseStatus.NOT_FOUND.code()) {
       throw new IOException("Could not list artifacts, endpoint not found");
@@ -142,15 +142,15 @@ public final class RemoteArtifactManager extends AbstractArtifactManager {
     }
 
     HttpRequest.Builder requestBuilder =
-      remoteClient.requestBuilder(
-        HttpMethod.GET, String.format("namespaces/%s/artifact-internals/artifacts/%s/versions/%s/location",
+      remoteClientInternal.requestBuilder(
+        HttpMethod.GET, String.format("namespaces/%s/artifacts/%s/versions/%s/location",
                                       namespace, artifactInfo.getName(), artifactInfo.getVersion()));
     // add header if auth is enabled
     if (authorizationEnabled) {
       requestBuilder.addHeader(Constants.Security.Headers.USER_ID, authenticationContext.getPrincipal().getName());
     }
 
-    HttpResponse httpResponse = remoteClient.execute(requestBuilder.build());
+    HttpResponse httpResponse = remoteClientInternal.execute(requestBuilder.build());
 
     if (httpResponse.getResponseCode() == HttpResponseStatus.NOT_FOUND.code()) {
       throw new IOException("Could not get artifact detail, endpoint not found");

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactManager.java
@@ -49,7 +49,8 @@ import javax.annotation.Nullable;
 
 /**
  * Implementation for {@link io.cdap.cdap.api.artifact.ArtifactManager}
- * communicating with {@link io.cdap.cdap.gateway.handlers.ArtifactHttpHandler} and returning artifact info.
+ * communicating with internal REST endpoints {@link io.cdap.cdap.gateway.handlers.ArtifactHttpHandlerInternal}
+ * and returning artifact info.
  */
 public final class RemoteArtifactManager extends AbstractArtifactManager {
   private static final Gson GSON = new GsonBuilder()

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
@@ -65,6 +65,7 @@ public class RemotePluginFinder implements PluginFinder, ArtifactFinder {
   private static final Type PLUGIN_INFO_LIST_TYPE = new TypeToken<List<PluginInfo>>() { }.getType();
 
   private final RemoteClient remoteClient;
+  private final RemoteClient remoteClientInternal;
   private final boolean authorizationEnabled;
   private final AuthenticationContext authenticationContext;
   private final LocationFactory locationFactory;
@@ -77,6 +78,9 @@ public class RemotePluginFinder implements PluginFinder, ArtifactFinder {
     this.remoteClient = new RemoteClient(discoveryServiceClient, Constants.Service.APP_FABRIC_HTTP,
                                          new DefaultHttpRequestConfig(false),
                                          String.format("%s", Constants.Gateway.API_VERSION_3));
+    this.remoteClientInternal = new RemoteClient(discoveryServiceClient, Constants.Service.APP_FABRIC_HTTP,
+                                                 new DefaultHttpRequestConfig(false),
+                                                 String.format("%s", Constants.Gateway.INTERNAL_API_VERSION_3));
     this.authorizationEnabled = cConf.getBoolean(Constants.Security.Authorization.ENABLED);
     this.authenticationContext = authenticationContext;
     this.locationFactory = locationFactory;
@@ -114,8 +118,8 @@ public class RemotePluginFinder implements PluginFinder, ArtifactFinder {
           throw new PluginNotExistsException(pluginNamespaceId, pluginType, pluginName);
         }
 
-        Location artifactLocation = getArtifactLocation(
-          Artifacts.apiToProtoArtifactId(pluginNamespaceId, selected.getKey()));
+        Location artifactLocation = getArtifactLocation(Artifacts.toProtoArtifactId(pluginNamespaceId,
+                                                                                    selected.getKey()));
         return Maps.immutableEntry(new ArtifactDescriptor(selected.getKey(), artifactLocation), selected.getValue());
       }, retryStrategy);
     } catch (PluginNotExistsException e) {
@@ -181,15 +185,15 @@ public class RemotePluginFinder implements PluginFinder, ArtifactFinder {
   @Override
   public Location getArtifactLocation(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
     HttpRequest.Builder requestBuilder =
-      remoteClient.requestBuilder(
-        HttpMethod.GET, String.format("namespaces/%s/artifact-internals/artifacts/%s/versions/%s/location",
+      remoteClientInternal.requestBuilder(
+        HttpMethod.GET, String.format("namespaces/%s/artifacts/%s/versions/%s/location",
                                       artifactId.getNamespace(), artifactId.getArtifact(), artifactId.getVersion()));
     // add header if auth is enabled
     if (authorizationEnabled) {
       requestBuilder.addHeader(Constants.Security.Headers.USER_ID, authenticationContext.getPrincipal().getName());
     }
 
-    HttpResponse response = remoteClient.execute(requestBuilder.build());
+    HttpResponse response = remoteClientInternal.execute(requestBuilder.build());
 
     if (response.getResponseCode() == HttpResponseStatus.NOT_FOUND.code()) {
       throw new ArtifactNotFoundException(artifactId);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -340,7 +340,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     String requestedConfigStr = requestedConfigObj == null ?
       currentSpec.getConfiguration() : new Gson().toJson(requestedConfigObj);
 
-    Id.Artifact artifactId = Id.Artifact.fromEntityId(Artifacts.apiToProtoArtifactId(appId.getParent(), newArtifactId));
+    Id.Artifact artifactId = Id.Artifact.fromEntityId(Artifacts.toProtoArtifactId(appId.getParent(), newArtifactId));
     return deployApp(appId.getParent(), appId.getApplication(), null, artifactId, requestedConfigStr,
                      programTerminator, ownerAdmin.getOwner(appId), appRequest.canUpdateSchedules());
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2019 Cask Data, Inc.
+ * Copyright © 2014-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -281,8 +281,8 @@ public class AppFabricTestHelper {
     ArtifactId artifactId = new ArtifactId(appClass.getSimpleName(), artifactVersion, ArtifactScope.USER);
     ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(artifactId, deployedJar);
     ArtifactRepository artifactRepository = getInjector().getInstance(ArtifactRepository.class);
-    artifactRepository.addArtifact(Id.Artifact.fromEntityId(Artifacts.apiToProtoArtifactId(namespace.toEntityId(),
-                                                                                           artifactId)),
+    artifactRepository.addArtifact(Id.Artifact.fromEntityId(Artifacts.toProtoArtifactId(namespace.toEntityId(),
+                                                                                        artifactId)),
                                    new File(deployedJar.toURI()));
 
     AppDeploymentInfo info = new AppDeploymentInfo(artifactDescriptor, namespace.toEntityId(),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerInternalTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services.http.handlers;
+
+import io.cdap.cdap.api.artifact.ArtifactInfo;
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDetail;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ArtifactHttpHandlerInternalTest extends ArtifactHttpHandlerTestBase {
+  @Test
+  public void testListArtifacts() throws Exception {
+    List<ArtifactInfo> artifactInfoList = null;
+    ArtifactInfo artifactInfo = null;
+
+    // Add a system artifact
+    String systemArtfiactName = "sysApp";
+    String systemArtifactVeresion = "1.0.0";
+    ArtifactId systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, systemArtifactVeresion);
+    addAppAsSystemArtifacts(systemArtifactId);
+
+    // Listing all artifacts in default namespace, should include system artifacts
+    artifactInfoList = listArtifactsInternal(NamespaceId.DEFAULT.getNamespace());
+    Assert.assertEquals(1, artifactInfoList.size());
+    artifactInfo = artifactInfoList.stream().filter(info -> info.getScope().equals(ArtifactScope.SYSTEM))
+      .findAny().orElse(null);
+    Assert.assertNotNull(artifactInfo);
+    Assert.assertEquals(ArtifactScope.SYSTEM, artifactInfo.getScope());
+    Assert.assertEquals(systemArtfiactName, artifactInfo.getName());
+    Assert.assertEquals(systemArtifactVeresion, artifactInfo.getVersion());
+    Assert.assertTrue(artifactInfo.getClasses().getApps().size() > 0);
+
+    // Add a user artifact, in addition to the above system artifact
+    String userArtifactName = "userApp";
+    String userArtifactVersion = "2.0.0";
+    ArtifactId userArtifactId = NamespaceId.DEFAULT.artifact(userArtifactName, userArtifactVersion);
+    addAppAsUserArtifacts(userArtifactId);
+
+    // Listing all artifacts in default namespace, should include both user and system artifacts
+    artifactInfoList = listArtifactsInternal(NamespaceId.DEFAULT.getNamespace());
+    Assert.assertEquals(2, artifactInfoList.size());
+
+    artifactInfo = artifactInfoList.stream().filter(info -> info.getScope().equals(ArtifactScope.USER))
+      .findAny().orElse(null);
+    Assert.assertNotNull(artifactInfo);
+    Assert.assertEquals(ArtifactScope.USER, artifactInfo.getScope());
+    Assert.assertEquals(userArtifactName, artifactInfo.getName());
+    Assert.assertEquals(userArtifactVersion, artifactInfo.getVersion());
+    Assert.assertTrue(artifactInfo.getClasses().getApps().size() > 0);
+
+    artifactInfo = artifactInfoList.stream().filter(info -> info.getScope().equals(ArtifactScope.SYSTEM))
+      .findAny().orElse(null);
+    Assert.assertNotNull(artifactInfo);
+    Assert.assertEquals(ArtifactScope.SYSTEM, artifactInfo.getScope());
+    Assert.assertEquals(systemArtfiactName, artifactInfo.getName());
+    Assert.assertEquals(systemArtifactVeresion, artifactInfo.getVersion());
+    Assert.assertTrue(artifactInfo.getClasses().getApps().size() > 0);
+  }
+
+  @Test
+  public void testGetArtifactLocation() throws Exception {
+    // Add a system artifact
+    String systemArtfiactName = "sysApp";
+    String systemArtifactVeresion = "1.0.0";
+    ArtifactId systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, systemArtifactVeresion);
+    addAppAsSystemArtifacts(systemArtifactId);
+
+    String locationPath = getArtifactLocationPath(systemArtifactId);
+    Assert.assertNotNull(locationPath);
+
+    ArtifactDetail expectedArtifactDetail = getArtifactDetailFromRepository(Id.Artifact.fromEntityId(systemArtifactId));
+    Assert.assertEquals(expectedArtifactDetail.getDescriptor().getLocation().toURI().getPath(),
+                        locationPath);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTestBase.java
@@ -158,7 +158,7 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
   }
 
   /**
-   * Return {@link ArtifactInfo} of the given artifactId
+   * @return {@link ArtifactInfo} of the given artifactId
    */
   protected ArtifactInfo getArtifactInfo(ArtifactId artifactId) throws IOException {
     // get /artifacts/{name}/versions/{version}
@@ -166,7 +166,7 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
   }
 
   /**
-   * Return {@link ArtifactInfo} of the given artifactId in the given scope
+   * @return {@link ArtifactInfo} of the given artifactId in the given scope
    */
   protected ArtifactInfo getArtifactInfo(ArtifactId artifactId, ArtifactScope scope) throws IOException {
     // get /artifacts/{name}/versions/{version}?scope={scope}
@@ -179,7 +179,7 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
   }
 
   /**
-   * Return the contents from doing a get on the given url as the given type, or null if a 404 is returned
+   * @return the contents from doing a get on the given url as the given type, or null if a 404 is returned
    */
   @Nullable
   <T> T getResults(URL endpoint, Type type) throws IOException {
@@ -196,7 +196,7 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
   }
 
   /**
-   * Return the given scope as a query parameter string or empty string if the scope is null
+   * @return the given scope as a query parameter string or empty string if the scope is null
    */
   String getScopeQuery(ArtifactScope scope) {
     return (scope == null) ? ("") : ("?scope=" + scope.name());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,22 +15,26 @@
  */
 package io.cdap.cdap.internal.app.services.http.handlers;
 
+import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.api.artifact.ArtifactInfo;
 import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.client.config.ClientConfig;
 import io.cdap.cdap.client.config.ConnectionConfig;
+import io.cdap.cdap.common.ArtifactNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
 import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
-import io.cdap.cdap.common.utils.DirUtils;
+import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.gateway.handlers.ArtifactHttpHandler;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
@@ -49,8 +53,8 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
-import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
 import javax.annotation.Nullable;
@@ -64,6 +68,7 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
     .create();
   private static String systemArtifactsDir;
   private static ArtifactRepository artifactRepository;
+  private static final Type ARTIFACT_INFO_LIST_TYPE = new TypeToken<List<ArtifactInfo>>() { }.getType();
 
   @BeforeClass
   public static void setup() {
@@ -93,27 +98,77 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
   }
 
   /**
-   * Adds {@link AllProgramsApp} as system artifact which can be used as parent artifact for testing purpose
-   * @throws Exception
+   * Add {@link AllProgramsApp} as system artifact with the given {@link ArtifactId}
+   * which can be used as parent artifact for testing purpose
    */
-  void addAppAsSystemArtifacts() throws Exception {
-    File destination = new File(systemArtifactsDir + "/app-1.0.0.jar");
+  protected void addAppAsSystemArtifacts(ArtifactId artifactId) throws Exception {
+    File destination = new File(String.format("%s/%s-%s.jar",
+                                              systemArtifactsDir, artifactId.getArtifact(), artifactId.getVersion()));
     buildAppArtifact(AllProgramsApp.class, new Manifest(), destination);
     artifactRepository.addSystemArtifacts();
   }
 
   /**
-   * @return {@link ArtifactInfo} of the given artifactId
+   * Add {@link AllProgramsApp} as user artifact with the given {@link ArtifactId}
    */
-  ArtifactInfo getArtifact(ArtifactId artifactId) throws URISyntaxException, IOException {
-    // get /artifacts/{name}/versions/{version}
-    return getArtifact(artifactId, null);
+  protected void addAppAsUserArtifacts(ArtifactId artifactId) throws Exception {
+    CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
+    File localDataDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR));
+    String namespaceDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
+    File namespaceBase = new File(localDataDir, namespaceDir);
+    File destination = new File(new File(namespaceBase, artifactId.getNamespace()),
+                                String.format("%s-%s.jar", artifactId.getArtifact(), artifactId.getVersion()));
+    buildAppArtifact(AllProgramsApp.class, new Manifest(), destination);
+    artifactRepository.addArtifact(new Id.Artifact(
+                                     new Id.Namespace(artifactId.getNamespace()),
+                                     artifactId.getArtifact(),
+                                     new ArtifactVersion(artifactId.getVersion())),
+                                   destination);
+  }
+
+
+  /**
+   * Get {@link ArtifactInfo} of all artifacts in the given namespace. Artifacts from system namespace should be
+   * included.
+   */
+  List<ArtifactInfo> listArtifactsInternal(String namespace) throws IOException {
+    URL endpoint = getEndPoint(String.format("%s/namespaces/%s/artifacts",
+                                             Constants.Gateway.INTERNAL_API_VERSION_3, namespace)).toURL();
+    return getResults(endpoint, ARTIFACT_INFO_LIST_TYPE);
   }
 
   /**
-   * @return {@link ArtifactInfo} of the given artifactId in the given scope
+   * Get the location path of the given artifact.
    */
-  ArtifactInfo getArtifact(ArtifactId artifactId, ArtifactScope scope) throws URISyntaxException, IOException {
+  String getArtifactLocationPath(ArtifactId artifactId) throws ArtifactNotFoundException, IOException {
+    URL endpoint = getEndPoint(String.format("%s/namespaces/%s/artifacts/%s/versions/%s/location",
+                                             Constants.Gateway.INTERNAL_API_VERSION_3,
+                                             artifactId.getNamespace(),
+                                             artifactId.getArtifact(),
+                                             artifactId.getVersion())).toURL();
+    HttpResponse httpResponse = HttpRequests.execute(HttpRequest.get(endpoint).build(),
+                                                 new DefaultHttpRequestConfig(false));
+
+    int responseCode = httpResponse.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new ArtifactNotFoundException(artifactId);
+    }
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, responseCode);
+    return httpResponse.getResponseBodyAsString();
+  }
+
+  /**
+   * Return {@link ArtifactInfo} of the given artifactId
+   */
+  protected ArtifactInfo getArtifactInfo(ArtifactId artifactId) throws IOException {
+    // get /artifacts/{name}/versions/{version}
+    return getArtifactInfo(artifactId, null);
+  }
+
+  /**
+   * Return {@link ArtifactInfo} of the given artifactId in the given scope
+   */
+  protected ArtifactInfo getArtifactInfo(ArtifactId artifactId, ArtifactScope scope) throws IOException {
     // get /artifacts/{name}/versions/{version}?scope={scope}
     URL endpoint = getEndPoint(String.format("%s/namespaces/%s/artifacts/%s/versions/%s%s",
                                              Constants.Gateway.API_VERSION_3, artifactId.getNamespace(),
@@ -124,7 +179,7 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
   }
 
   /**
-   * @return the contents from doing a get on the given url as the given type, or null if a 404 is returned
+   * Return the contents from doing a get on the given url as the given type, or null if a 404 is returned
    */
   @Nullable
   <T> T getResults(URL endpoint, Type type) throws IOException {
@@ -141,19 +196,17 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
   }
 
   /**
-   * @return the given scope as a query parameter string or empty string if the scope is null
+   * Return the given scope as a query parameter string or empty string if the scope is null
    */
   String getScopeQuery(ArtifactScope scope) {
     return (scope == null) ? ("") : ("?scope=" + scope.name());
   }
 
   /**
-   * Deletes all the jar in the systemArtifactDir
+   * Get the {@link ArtifactDetail} of the given artifact directly from {@link ArtifactRepository}. This is typically
+   * used as expected value to verify the info fetched via REST API calls.
    */
-  void cleanupSystemArtifactsDirectory() {
-    File dir = new File(systemArtifactsDir);
-    for (File jarFile : DirUtils.listFiles(dir, "jar")) {
-      jarFile.delete();
-    }
+  ArtifactDetail getArtifactDetailFromRepository(Id.Artifact artifactId) throws Exception {
+    return artifactRepository.getArtifact(artifactId);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PluginExclusionTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PluginExclusionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -44,6 +44,7 @@ public class PluginExclusionTest extends ArtifactHttpHandlerTestBase {
   @ClassRule
   public static final ExternalResource RESOURCE = new ExternalResource() {
     private String previousRequirementBlacklist;
+
     @Override
     protected void before() {
       // store the previous value
@@ -65,13 +66,14 @@ public class PluginExclusionTest extends ArtifactHttpHandlerTestBase {
 
   @Test
   public void testPluginRequirements() throws Exception {
-    // add a system artifact
-    ArtifactId systemId = NamespaceId.SYSTEM.artifact("app", "1.0.0");
-    addAppAsSystemArtifacts();
+    // Add a system artifact
+    ArtifactId systemArtifactId = NamespaceId.SYSTEM.artifact("app", "1.0.0");
+    addAppAsSystemArtifacts(systemArtifactId);
 
     Set<ArtifactRange> parents = Sets.newHashSet(new ArtifactRange(
-      systemId.getNamespace(), systemId.getArtifact(),
-      new ArtifactVersion(systemId.getVersion()), true, new ArtifactVersion(systemId.getVersion()), true));
+      systemArtifactId.getNamespace(), systemArtifactId.getArtifact(),
+      new ArtifactVersion(systemArtifactId.getVersion()), true,
+      new ArtifactVersion(systemArtifactId.getVersion()), true));
 
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, InspectionApp.class.getPackage().getName());
@@ -79,7 +81,7 @@ public class PluginExclusionTest extends ArtifactHttpHandlerTestBase {
     Assert.assertEquals(HttpResponseStatus.OK.code(),
                         addPluginArtifact(Id.Artifact.fromEntityId(artifactId), InspectionApp.class, manifest, parents)
                           .getResponseCode());
-    Set<PluginClass> plugins = getArtifact(artifactId).getClasses().getPlugins();
+    Set<PluginClass> plugins = getArtifactInfo(artifactId).getClasses().getPlugins();
     // Only four plugins which does not have transactions as requirement should be visible.
     Assert.assertEquals(4, plugins.size());
     Set<String> actualPluginClassNames = plugins.stream().map(PluginClass::getClassName).collect(Collectors.toSet());

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
@@ -185,11 +185,6 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       // /v3/namespaces/{namespace-id}/data/datasets/{name}/properties
       // /v3/namespaces/{namespace-id}/data/datasets/{name}/admin/{method}
       return DATASET_MANAGER;
-    } else if ((uriParts.length >= 4) && uriParts[3].equals("artifact-internals")) {
-      // we don't want to expose endpoints in artifact handler that are internal and can only by called by programs
-      // /v3/namespaces/{namespace-id}/artifact-internals/list/artifacts
-      // /v3/namespaces/{namespace-id}/artifact-internals/artifact/{artifact-name}
-      return DONT_ROUTE;
     } else if ((uriParts.length == 3) && uriParts[1].equals("metadata-internals")) {
       // we don't want to expose endpoints for direct metadata mutation from CDAP master
       // /v3/metadata-internals/{mutation-type}

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
@@ -370,13 +370,6 @@ public class RouterPathLookupTest {
   }
 
   @Test
-  public void testArtifactInternalsPaths() {
-    assertRouting("/v3/namespaces/default/artifact-internals/artifacts", RouterPathLookup.DONT_ROUTE);
-    assertRouting("/v3/namespaces/default/artifact-internals/artifact/jdbc", RouterPathLookup.DONT_ROUTE);
-    assertRouting("/v3/namespaces/default/previews/artifact-internals/status", RouterPathLookup.PREVIEW_HTTP);
-  }
-
-  @Test
   public void testMetadataInternalsPaths() {
     assertRouting("/v3/metadata-internals/create", RouterPathLookup.DONT_ROUTE);
     assertRouting("/v3/metadata-internals/drop", RouterPathLookup.DONT_ROUTE);


### PR DESCRIPTION
Move 2 artifact http internal endpoints (e.g. ../artifact-internals/...) to a separate internal http handler.

This is in preparation of introducing more internal endpoint for fetching artifact details,
which is needed by preview to run with local levelDB.

(this is re-sending out an earlier PR that was discarded due to me messing up the change when resolving conflicts)