### PR TITLE
[CDAP-16384] Improve handling of 404 when last completed preview is missing

### DIFF
--- a/cdap-ui/app/cdap/services/datasource/index.js
+++ b/cdap-ui/app/cdap/services/datasource/index.js
@@ -89,7 +89,7 @@ export default class Datasource {
         delete this.bindings[hash];
       } else {
         if (this.bindings[hash] && this.bindings[hash].type === 'POLL') {
-          this.bindings[hash].resource.interval = this.startClientPoll(hash, this.bindings[hash].resource.intervalTime);
+          this.bindings[hash].resource.interval = this.startClientPoll(hash);
         }
       }
     });
@@ -249,7 +249,8 @@ export default class Datasource {
     return observable;
   }
 
-  startClientPoll = (resourceId, interval) => {
+  startClientPoll = (resourceId) => {
+    const interval = objectQuery(this.bindings, resourceId, 'resource', 'intervalTime' );
     const intervalTimer = setTimeout(() => {
       const resource = objectQuery(this.bindings, resourceId, 'resource');
       if (!resource || !ifvisible.now('active')) {
@@ -289,7 +290,7 @@ export default class Datasource {
     Object.keys(this.bindings)
       .filter(subscriptionID => this.bindings[subscriptionID].type === 'POLL')
       .forEach(subscriptionID => {
-        this.bindings[subscriptionID].resource.interval = this.startClientPoll(subscriptionID, this.bindings[subscriptionID].resource.intervalTime);
+        this.bindings[subscriptionID].resource.interval = this.startClientPoll(subscriptionID);
       });
   }
 

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
@@ -232,13 +232,17 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
         },
         (statusErr) => {
           console.log('ERROR: ', statusErr);
+          let errorMsg = `Error getting preview logs: ${statusErr.data}`
 
           if (statusErr.statusCode === 404) {
-            myAlertOnValium.show({
-              type: 'danger',
-              content: statusErr.data
-            });
-          }
+            errorMsg = 'Logs for this preview run are not available. Please try re-running preview.'
+            vm.loading = false;
+          };
+
+          myAlertOnValium.show({
+            type: 'danger',
+            content: errorMsg
+          });
         });
     } else {
       vm.loading = false;

--- a/cdap-ui/app/services/cask-angular-socket-datasource/datasource.js
+++ b/cdap-ui/app/services/cask-angular-socket-datasource/datasource.js
@@ -211,7 +211,7 @@ var socketDataSource = angular.module(PKG.name+'.services');
         Object.keys(bindings)
           .filter(resourceId => bindings[resourceId].type === 'POLL')
           .forEach(resourceId => {
-            bindings[resourceId].resource.interval = startClientPoll(resourceId, bindings[resourceId].resource);
+            bindings[resourceId].resource.interval = startClientPoll(resourceId, bindings, bindings[resourceId].resource);
           });
       }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16384
Build: https://builds.cask.co/browse/CDAP-URUT221

Improving error message for 404 received when user checks logs for preview run when preview data is missing. 

To replicate: Update preview.exec.threads to be 1 in cdap-site.xml, run (and complete) a preview run for a pipeline. Switch to another tab and start another preview run, which will purge the latest completed preview. This causes the backend to send a 404 when user checks logs for the original (first and already completed) preview run. 

Also fixed JS errors that appeared when polling was resumed after switching tabs. 