### PR TITLE
(CDAP-16353) Replace ArtifactRepository param with PluginFinder for AbstractConfigurer…

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -76,6 +76,8 @@ import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactStore;
 import io.cdap.cdap.internal.app.runtime.artifact.AuthorizationArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.LocalPluginFinder;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.schedule.DistributedTimeSchedulerService;
 import io.cdap.cdap.internal.app.runtime.schedule.ExecutorThreadPool;
 import io.cdap.cdap.internal.app.runtime.schedule.LocalTimeSchedulerService;
@@ -271,6 +273,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
     protected void configure() {
       bind(PipelineFactory.class).to(SynchronousPipelineFactory.class);
 
+      bind(PluginFinder.class).to(LocalPluginFinder.class);
       install(
         new FactoryModuleBuilder()
           .implement(new TypeLiteral<Manager<AppDeploymentInfo, ApplicationWithPrograms>>() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/InMemoryProgramRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/InMemoryProgramRunnerModule.java
@@ -34,7 +34,6 @@ import io.cdap.cdap.internal.app.runtime.artifact.ArtifactFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.LocalArtifactManager;
 import io.cdap.cdap.internal.app.runtime.artifact.LocalPluginFinder;
-import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.batch.MapReduceProgramRunner;
 import io.cdap.cdap.internal.app.runtime.service.InMemoryProgramRuntimeService;
 import io.cdap.cdap.internal.app.runtime.service.InMemoryServiceProgramRunner;
@@ -72,9 +71,7 @@ final class InMemoryProgramRunnerModule extends PrivateModule {
               .build(ArtifactManagerFactory.class));
     expose(ArtifactManagerFactory.class);
 
-    bind(PluginFinder.class).to(LocalPluginFinder.class);
     bind(ArtifactFinder.class).to(LocalPluginFinder.class);
-    expose(PluginFinder.class);
     expose(ArtifactFinder.class);
 
     // Bind ProgramRunner

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewApplicationManager.java
@@ -32,6 +32,7 @@ import io.cdap.cdap.internal.app.deploy.pipeline.DeploymentCleanupStage;
 import io.cdap.cdap.internal.app.deploy.pipeline.LocalArtifactLoaderStage;
 import io.cdap.cdap.internal.app.deploy.pipeline.ProgramGenerationStage;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.pipeline.Pipeline;
 import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.security.impersonation.Impersonator;
@@ -58,6 +59,7 @@ public class PreviewApplicationManager<I, O> implements Manager<I, O> {
   private final Impersonator impersonator;
   private final AuthenticationContext authenticationContext;
   private final AuthorizationEnforcer authorizationEnforcer;
+  private final PluginFinder pluginFinder;
 
   @Inject
   PreviewApplicationManager(CConfiguration configuration, PipelineFactory pipelineFactory,
@@ -65,7 +67,7 @@ public class PreviewApplicationManager<I, O> implements Manager<I, O> {
                             @Named("datasetMDS") DatasetFramework inMemoryDatasetFramework,
                             UsageRegistry usageRegistry, ArtifactRepository artifactRepository,
                             AuthenticationContext authenticationContext, Impersonator impersonator,
-                            AuthorizationEnforcer authorizationEnforcer) {
+                            AuthorizationEnforcer authorizationEnforcer, PluginFinder pluginFinder) {
     this.cConf = configuration;
     this.pipelineFactory = pipelineFactory;
     this.store = store;
@@ -77,13 +79,14 @@ public class PreviewApplicationManager<I, O> implements Manager<I, O> {
     this.authenticationContext = authenticationContext;
     this.ownerAdmin = ownerAdmin;
     this.authorizationEnforcer = authorizationEnforcer;
+    this.pluginFinder = pluginFinder;
   }
 
   @Override
   public ListenableFuture<O> deploy(I input) throws Exception {
     Pipeline<O> pipeline = pipelineFactory.getPipeline();
     pipeline.addLast(new LocalArtifactLoaderStage(cConf, store, artifactRepository, impersonator,
-                                                  authorizationEnforcer, authenticationContext));
+                                                  authorizationEnforcer, authenticationContext, pluginFinder));
     pipeline.addLast(new ApplicationVerificationStage(store, datasetFramework, ownerAdmin, authenticationContext));
     pipeline.addLast(new DeployDatasetModulesStage(cConf, datasetFramework, inMemoryDatasetFramework,
                                                    ownerAdmin, authenticationContext));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/AbstractConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/AbstractConfigurer.java
@@ -25,8 +25,7 @@ import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.api.plugin.PluginSelector;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.api.DefaultDatasetConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
-import io.cdap.cdap.internal.app.runtime.artifact.LocalPluginFinder;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 
 import java.util.HashMap;
@@ -46,12 +45,12 @@ public abstract class AbstractConfigurer extends DefaultDatasetConfigurer implem
   protected final Id.Namespace deployNamespace;
 
   protected AbstractConfigurer(Id.Namespace deployNamespace, Id.Artifact artifactId,
-                               ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
+                               PluginFinder pluginFinder, PluginInstantiator pluginInstantiator) {
     this.deployNamespace = deployNamespace;
     this.extraPlugins = new HashMap<>();
     this.pluginConfigurer = new DefaultPluginConfigurer(artifactId.toEntityId(),
                                                         deployNamespace.toEntityId(), pluginInstantiator,
-                                                        new LocalPluginFinder(artifactRepository));
+                                                        pluginFinder);
   }
 
   public Map<String, Plugin> getPlugins() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/customaction/DefaultCustomActionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/customaction/DefaultCustomActionConfigurer.java
@@ -22,7 +22,7 @@ import io.cdap.cdap.api.customaction.CustomActionConfigurer;
 import io.cdap.cdap.api.customaction.CustomActionSpecification;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.AbstractConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.customaction.DefaultCustomActionSpecification;
 import io.cdap.cdap.internal.lang.Reflections;
@@ -46,8 +46,8 @@ public final class DefaultCustomActionConfigurer extends AbstractConfigurer impl
   private Map<String, String> properties;
 
   private DefaultCustomActionConfigurer(CustomAction customAction, Id.Namespace deployNamespace, Id.Artifact artifactId,
-                                       ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
-    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
+                                        PluginFinder pluginFinder, PluginInstantiator pluginInstantiator) {
+    super(deployNamespace, artifactId, pluginFinder , pluginInstantiator);
     this.customAction = customAction;
     this.name = customAction.getClass().getSimpleName();
     this.description = "";
@@ -81,10 +81,10 @@ public final class DefaultCustomActionConfigurer extends AbstractConfigurer impl
   }
 
   public static CustomActionSpecification configureAction(CustomAction action, Id.Namespace deployNamespace,
-                                                          Id.Artifact artifactId, ArtifactRepository artifactRepository,
+                                                          Id.Artifact artifactId, PluginFinder pluginFinder,
                                                           PluginInstantiator pluginInstantiator) {
     DefaultCustomActionConfigurer configurer = new DefaultCustomActionConfigurer(action, deployNamespace, artifactId,
-                                                                                 artifactRepository,
+                                                                                 pluginFinder,
                                                                                  pluginInstantiator);
     action.configure(configurer);
     return configurer.createSpecification();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -42,6 +42,7 @@ import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppSpecInfo;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,13 +71,13 @@ public final class InMemoryConfigurator implements Configurator {
   // if the artifact is a system artifact, the namespace will be the system namespace.
   private final Id.Namespace appNamespace;
 
-  private final ArtifactRepository artifactRepository;
+  private final PluginFinder pluginFinder;
   private final ClassLoader artifactClassLoader;
   private final String appClassName;
   private final Id.Artifact artifactId;
 
   public InMemoryConfigurator(CConfiguration cConf, Id.Namespace appNamespace, Id.Artifact artifactId,
-                              String appClassName, ArtifactRepository artifactRepository,
+                              String appClassName, PluginFinder pluginFinder,
                               ClassLoader artifactClassLoader,
                               @Nullable String applicationName, @Nullable String applicationVersion,
                               @Nullable String configString) {
@@ -87,7 +88,7 @@ public final class InMemoryConfigurator implements Configurator {
     this.applicationName = applicationName;
     this.applicationVersion = applicationVersion;
     this.configString = configString == null ? "" : configString;
-    this.artifactRepository = artifactRepository;
+    this.pluginFinder = pluginFinder;
     this.artifactClassLoader = artifactClassLoader;
     this.baseUnpackDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                                   cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
@@ -134,7 +135,7 @@ public final class InMemoryConfigurator implements Configurator {
       PluginInstantiator pluginInstantiator = new PluginInstantiator(cConf, app.getClass().getClassLoader(), tempDir)
     ) {
       configurer = new DefaultAppConfigurer(appNamespace, artifactId, app,
-                                            configString, artifactRepository, pluginInstantiator);
+                                            configString, pluginFinder, pluginInstantiator);
       T appConfig;
       Type configType = Artifacts.getConfigType(app.getClass());
       if (configString.isEmpty()) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.deploy.InMemoryConfigurator;
 import io.cdap.cdap.internal.app.deploy.LocalApplicationManager;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.pipeline.AbstractStage;
 import io.cdap.cdap.pipeline.Context;
 import io.cdap.cdap.pipeline.Pipeline;
@@ -62,13 +63,14 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
   private final Impersonator impersonator;
   private final AuthorizationEnforcer authorizationEnforcer;
   private final AuthenticationContext authenticationContext;
+  private final PluginFinder pluginFinder;
 
   /**
    * Constructor with hit for handling type.
    */
   public LocalArtifactLoaderStage(CConfiguration cConf, Store store, ArtifactRepository artifactRepository,
                                   Impersonator impersonator, AuthorizationEnforcer authorizationEnforcer,
-                                  AuthenticationContext authenticationContext) {
+                                  AuthenticationContext authenticationContext, PluginFinder pluginFinder) {
     super(TypeToken.of(AppDeploymentInfo.class));
     this.cConf = cConf;
     this.store = store;
@@ -76,6 +78,7 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
     this.impersonator = impersonator;
     this.authorizationEnforcer = authorizationEnforcer;
     this.authenticationContext = authenticationContext;
+    this.pluginFinder = pluginFinder;
   }
 
   /**
@@ -102,7 +105,7 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
     InMemoryConfigurator inMemoryConfigurator = new InMemoryConfigurator(
       cConf, Id.Namespace.fromEntityId(deploymentInfo.getNamespaceId()),
       Id.Artifact.fromEntityId(artifactId), appClassName,
-      artifactRepository, artifactClassLoader,
+      pluginFinder, artifactClassLoader,
       deploymentInfo.getApplicationName(),
       deploymentInfo.getApplicationVersion(),
       configString);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
@@ -22,7 +22,7 @@ import io.cdap.cdap.api.mapreduce.MapReduceConfigurer;
 import io.cdap.cdap.api.mapreduce.MapReduceSpecification;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.AbstractConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.lang.Reflections;
 import io.cdap.cdap.internal.specification.DataSetFieldExtractor;
@@ -49,9 +49,9 @@ public final class DefaultMapReduceConfigurer extends AbstractConfigurer impleme
   private Resources reducerResources;
 
   public DefaultMapReduceConfigurer(MapReduce mapReduce, Id.Namespace deployNamespace, Id.Artifact artifactId,
-                                    ArtifactRepository artifactRepository,
+                                    PluginFinder pluginFinder,
                                     PluginInstantiator pluginInstantiator) {
-    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
+    super(deployNamespace, artifactId, pluginFinder, pluginInstantiator);
     this.mapReduce = mapReduce;
     this.name = mapReduce.getClass().getSimpleName();
     this.description = "";

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -57,6 +57,8 @@ import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.data2.metadata.writer.NoOpMetadataServiceClient;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.LocalPluginFinder;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
 import io.cdap.cdap.logging.read.FileLogReader;
@@ -353,6 +355,8 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
             .to(DefaultArtifactRepository.class)
             .in(Scopes.SINGLETON);
           bind(LogReader.class).to(FileLogReader.class).in(Scopes.SINGLETON);
+
+          bind(PluginFinder.class).to(LocalPluginFinder.class);
         }
 
         @Provides

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
@@ -24,7 +24,7 @@ import io.cdap.cdap.api.service.http.ServiceHttpEndpoint;
 import io.cdap.cdap.api.service.http.SystemHttpServiceConfigurer;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.AbstractConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.lang.Reflections;
 import io.cdap.cdap.internal.specification.DataSetFieldExtractor;
@@ -54,14 +54,15 @@ public class DefaultHttpServiceHandlerConfigurer extends AbstractConfigurer impl
    * The properties and description are set to empty values and the name is the handler class name.
    *
    * @param handler the handler for the service
+   * @param pluginFinder
    */
   public DefaultHttpServiceHandlerConfigurer(HttpServiceHandler handler,
                                              Id.Namespace deployNamespace,
                                              Id.Artifact artifactId,
-                                             ArtifactRepository artifactRepository,
+                                             PluginFinder pluginFinder,
                                              PluginInstantiator pluginInstantiator,
                                              SystemTableConfigurer systemTableConfigurer) {
-    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
+    super(deployNamespace, artifactId, pluginFinder, pluginInstantiator);
     this.handler = handler;
     this.name = handler.getClass().getSimpleName();
     this.properties = new HashMap<>();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/DefaultServiceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/DefaultServiceConfigurer.java
@@ -34,7 +34,7 @@ import io.cdap.cdap.api.service.http.SystemHttpServiceConfigurer;
 import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.AbstractConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.app.runtime.service.http.HttpHandlerFactory;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -50,7 +50,7 @@ public class DefaultServiceConfigurer extends AbstractConfigurer implements Syst
 
   private final String className;
   private final Id.Artifact artifactId;
-  private final ArtifactRepository artifactRepository;
+  private final PluginFinder pluginFinder;
   private final PluginInstantiator pluginInstantiator;
   private final SystemTableConfigurer systemTableConfigurer;
 
@@ -64,9 +64,9 @@ public class DefaultServiceConfigurer extends AbstractConfigurer implements Syst
    * Create an instance of {@link DefaultServiceConfigurer}
    */
   public DefaultServiceConfigurer(Service service, Id.Namespace namespace, Id.Artifact artifactId,
-                                  ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator,
+                                  PluginFinder pluginFinder, PluginInstantiator pluginInstantiator,
                                   DefaultSystemTableConfigurer systemTableConfigurer) {
-    super(namespace, artifactId, artifactRepository, pluginInstantiator);
+    super(namespace, artifactId, pluginFinder, pluginInstantiator);
     this.className = service.getClass().getName();
     this.name = service.getClass().getSimpleName();
     this.description = "";
@@ -74,7 +74,7 @@ public class DefaultServiceConfigurer extends AbstractConfigurer implements Syst
     this.resources = new Resources();
     this.instances = 1;
     this.artifactId = artifactId;
-    this.artifactRepository = artifactRepository;
+    this.pluginFinder = pluginFinder;
     this.pluginInstantiator = pluginInstantiator;
     this.systemTableConfigurer = systemTableConfigurer;
   }
@@ -120,7 +120,7 @@ public class DefaultServiceConfigurer extends AbstractConfigurer implements Syst
     Map<String, HttpServiceHandlerSpecification> handleSpecs = Maps.newHashMap();
     for (HttpServiceHandler handler : handlers) {
       DefaultHttpServiceHandlerConfigurer configurer = new DefaultHttpServiceHandlerConfigurer(
-        handler, deployNamespace, artifactId, artifactRepository, pluginInstantiator, systemTableConfigurer);
+        handler, deployNamespace, artifactId, pluginFinder, pluginInstantiator, systemTableConfigurer);
       handler.configure(configurer);
       HttpServiceHandlerSpecification spec = configurer.createSpecification();
       Preconditions.checkArgument(!handleSpecs.containsKey(spec.getName()),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/DefaultSparkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/DefaultSparkConfigurer.java
@@ -24,7 +24,7 @@ import io.cdap.cdap.api.spark.SparkHttpServiceHandlerSpecification;
 import io.cdap.cdap.api.spark.SparkSpecification;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.AbstractConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.lang.Reflections;
 import io.cdap.cdap.internal.specification.DataSetFieldExtractor;
@@ -52,8 +52,8 @@ public class DefaultSparkConfigurer extends AbstractConfigurer implements SparkC
   private Resources executorResources;
 
   public DefaultSparkConfigurer(Spark spark, Id.Namespace deployNamespace, Id.Artifact artifactId,
-                                ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
-    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
+                                PluginFinder pluginFinder, PluginInstantiator pluginInstantiator) {
+    super(deployNamespace, artifactId, pluginFinder, pluginInstantiator);
     this.spark = spark;
     this.name = spark.getClass().getSimpleName();
     this.description = "";

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/DefaultWorkerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/DefaultWorkerConfigurer.java
@@ -24,7 +24,7 @@ import io.cdap.cdap.api.worker.WorkerConfigurer;
 import io.cdap.cdap.api.worker.WorkerSpecification;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.AbstractConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.lang.Reflections;
 import io.cdap.cdap.internal.specification.PropertyFieldExtractor;
@@ -47,9 +47,9 @@ public class DefaultWorkerConfigurer extends AbstractConfigurer implements Worke
   private Set<String> datasets;
 
   public DefaultWorkerConfigurer(Worker worker, Id.Namespace deployNamespace, Id.Artifact artifactId,
-                                 ArtifactRepository artifactRepository,
+                                 PluginFinder pluginFinder,
                                  PluginInstantiator pluginInstantiator) {
-    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
+    super(deployNamespace, artifactId, pluginFinder, pluginInstantiator);
     this.worker = worker;
     this.name = worker.getClass().getSimpleName();
     this.description = "";

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/workflow/DefaultWorkflowForkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/workflow/DefaultWorkflowForkConfigurer.java
@@ -30,7 +30,7 @@ import io.cdap.cdap.api.workflow.WorkflowForkConfigurer;
 import io.cdap.cdap.api.workflow.WorkflowForkNode;
 import io.cdap.cdap.api.workflow.WorkflowNode;
 import io.cdap.cdap.common.id.Id;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.app.workflow.condition.DefaultConditionConfigurer;
 import io.cdap.cdap.internal.workflow.condition.DefaultConditionSpecification;
@@ -50,18 +50,18 @@ public class DefaultWorkflowForkConfigurer<T extends WorkflowForkJoiner & Workfl
   private final List<List<WorkflowNode>> branches = Lists.newArrayList();
   private final Id.Namespace deployNamespace;
   private final Id.Artifact artifactId;
-  private final ArtifactRepository artifactRepository;
+  private final PluginFinder pluginFinder;
   private final PluginInstantiator pluginInstantiator;
 
   private List<WorkflowNode> currentBranch;
 
   public DefaultWorkflowForkConfigurer(T parentForkConfigurer, Id.Namespace deployNamespace, Id.Artifact artifactId,
-                                       ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
+                                       PluginFinder pluginFinder, PluginInstantiator pluginInstantiator) {
     this.parentForkConfigurer = parentForkConfigurer;
     currentBranch = Lists.newArrayList();
     this.deployNamespace = deployNamespace;
     this.artifactId = artifactId;
-    this.artifactRepository = artifactRepository;
+    this.pluginFinder = pluginFinder;
     this.pluginInstantiator = pluginInstantiator;
   }
 
@@ -80,27 +80,27 @@ public class DefaultWorkflowForkConfigurer<T extends WorkflowForkJoiner & Workfl
   @Override
   public WorkflowForkConfigurer<T> addAction(CustomAction action) {
     currentBranch.add(WorkflowNodeCreator.createWorkflowCustomActionNode(action, deployNamespace, artifactId,
-                                                                         artifactRepository, pluginInstantiator));
+                                                                         pluginFinder, pluginInstantiator));
     return this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public WorkflowForkConfigurer<? extends WorkflowForkConfigurer<T>> fork() {
-    return new DefaultWorkflowForkConfigurer<>(this, deployNamespace, artifactId, artifactRepository,
+    return new DefaultWorkflowForkConfigurer<>(this, deployNamespace, artifactId, pluginFinder,
                                                pluginInstantiator);
   }
 
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(
     Predicate<WorkflowContext> predicate) {
-    return new DefaultWorkflowConditionConfigurer<>(predicate, this, deployNamespace, artifactId, artifactRepository,
+    return new DefaultWorkflowConditionConfigurer<>(predicate, this, deployNamespace, artifactId, pluginFinder,
                                                     pluginInstantiator);
   }
 
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(Condition condition) {
-    return new DefaultWorkflowConditionConfigurer<>(condition, this, deployNamespace, artifactId, artifactRepository,
+    return new DefaultWorkflowConditionConfigurer<>(condition, this, deployNamespace, artifactId, pluginFinder,
                                                     pluginInstantiator);
   }
 
@@ -139,7 +139,7 @@ public class DefaultWorkflowForkConfigurer<T extends WorkflowForkJoiner & Workfl
                                        List<WorkflowNode> elseBranch) {
     Preconditions.checkArgument(condition != null, "Condition is null.");
     ConditionSpecification spec = DefaultConditionConfigurer.configureCondition(condition, deployNamespace,
-                                                                                artifactId, artifactRepository,
+                                                                                artifactId, pluginFinder,
                                                                                 pluginInstantiator);
     currentBranch.add(new WorkflowConditionNode(spec.getName(), spec, ifBranch, elseBranch));
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/workflow/WorkflowNodeCreator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/workflow/WorkflowNodeCreator.java
@@ -25,7 +25,7 @@ import io.cdap.cdap.api.workflow.WorkflowActionNode;
 import io.cdap.cdap.api.workflow.WorkflowNode;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.customaction.DefaultCustomActionConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 
 /**
@@ -56,11 +56,11 @@ final class WorkflowNodeCreator {
   }
 
   static WorkflowNode createWorkflowCustomActionNode(CustomAction action, Id.Namespace deployNamespace,
-                                                     Id.Artifact artifactId, ArtifactRepository artifactRepository,
+                                                     Id.Artifact artifactId, PluginFinder pluginFinder,
                                                      PluginInstantiator pluginInstantiator) {
     Preconditions.checkArgument(action != null, "CustomAction is null.");
     CustomActionSpecification spec = DefaultCustomActionConfigurer.configureAction(action, deployNamespace, artifactId,
-                                                                                   artifactRepository,
+                                                                                   pluginFinder,
                                                                                    pluginInstantiator);
     return new WorkflowActionNode(spec.getName(), spec);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/workflow/condition/DefaultConditionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/workflow/condition/DefaultConditionConfigurer.java
@@ -22,7 +22,7 @@ import io.cdap.cdap.api.workflow.ConditionConfigurer;
 import io.cdap.cdap.api.workflow.ConditionSpecification;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.AbstractConfigurer;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.lang.Reflections;
 import io.cdap.cdap.internal.specification.DataSetFieldExtractor;
@@ -44,8 +44,8 @@ public class DefaultConditionConfigurer extends AbstractConfigurer implements Co
   private Map<String, String> properties;
 
   private DefaultConditionConfigurer(Condition condition, Id.Namespace deployNamespace, Id.Artifact artifactId,
-                                     ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
-    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
+                                     PluginFinder pluginFinder, PluginInstantiator pluginInstantiator) {
+    super(deployNamespace, artifactId, pluginFinder, pluginInstantiator);
     this.condition = condition;
     this.name = condition.getClass().getSimpleName();
     this.description = "";
@@ -78,10 +78,10 @@ public class DefaultConditionConfigurer extends AbstractConfigurer implements Co
   }
 
   public static ConditionSpecification configureCondition(Condition condition, Id.Namespace deployNamespace,
-                                                          Id.Artifact artifactId, ArtifactRepository artifactRepository,
+                                                          Id.Artifact artifactId, PluginFinder pluginFinder,
                                                           PluginInstantiator pluginInstantiator) {
     DefaultConditionConfigurer configurer = new DefaultConditionConfigurer(condition, deployNamespace, artifactId,
-                                                                           artifactRepository, pluginInstantiator);
+                                                                           pluginFinder, pluginInstantiator);
 
     condition.configure(configurer);
     return configurer.createSpecification();

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/deploy/spark/AbstractExtendedSparkConfigurer.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/deploy/spark/AbstractExtendedSparkConfigurer.scala
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.spark.service.SparkHttpServiceHandler
 import io.cdap.cdap.app.runtime.spark.dynamic.AbstractSparkCompiler
 import io.cdap.cdap.common.id.Id
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator
 import io.cdap.cdap.internal.app.runtime.service.http.HttpHandlerFactory
 import io.cdap.cdap.internal.app.services.ServiceEndpointExtractor
@@ -47,9 +48,9 @@ import scala.tools.nsc.Settings
 abstract class AbstractExtendedSparkConfigurer(spark: Spark,
                                                deployNamespace: Id.Namespace,
                                                artifactId: Id.Artifact,
-                                               artifactRepository: ArtifactRepository,
+                                               pluginFinder: PluginFinder,
                                                pluginInstantiator: PluginInstantiator)
-  extends DefaultSparkConfigurer(spark, deployNamespace, artifactId, artifactRepository, pluginInstantiator)
+  extends DefaultSparkConfigurer(spark, deployNamespace, artifactId, pluginFinder, pluginInstantiator)
   with ExtendedSparkConfigurer {
 
   private val handlers = new mutable.ArrayBuffer[SparkHttpServiceHandler]()

--- a/cdap-spark-core/src/main/scala/io/cdap/cdap/app/deploy/spark/DefaultExtendedSparkConfigurer.scala
+++ b/cdap-spark-core/src/main/scala/io/cdap/cdap/app/deploy/spark/DefaultExtendedSparkConfigurer.scala
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.spark.dynamic.SparkCompiler
 import io.cdap.cdap.app.runtime.spark.dynamic.{DefaultSparkCompiler, URLAdder}
 import io.cdap.cdap.common.id.Id
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator
 
 import scala.reflect.io.VirtualDirectory
@@ -34,9 +35,9 @@ import scala.tools.nsc.Settings
 class DefaultExtendedSparkConfigurer(spark: Spark,
                                      deployNamespace: Id.Namespace,
                                      artifactId: Id.Artifact,
-                                     artifactRepository: ArtifactRepository,
+                                     pluginFinder: PluginFinder,
                                      pluginInstantiator: PluginInstantiator)
-  extends AbstractExtendedSparkConfigurer(spark, deployNamespace, artifactId, artifactRepository, pluginInstantiator) {
+  extends AbstractExtendedSparkConfigurer(spark, deployNamespace, artifactId, pluginFinder, pluginInstantiator) {
 
   override def createSparkCompiler(settings: Settings): SparkCompiler = {
     // Creates an in-memory compiler

--- a/cdap-spark-core2_2.11/src/main/scala/io/cdap/cdap/app/deploy/spark/DefaultExtendedSparkConfigurer.scala
+++ b/cdap-spark-core2_2.11/src/main/scala/io/cdap/cdap/app/deploy/spark/DefaultExtendedSparkConfigurer.scala
@@ -22,6 +22,7 @@ import io.cdap.cdap.app.runtime.spark.dynamic.DefaultSparkCompiler
 import io.cdap.cdap.app.runtime.spark.dynamic.URLAdder
 import io.cdap.cdap.common.id.Id
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator
 
 import java.net.URL
@@ -34,9 +35,9 @@ import scala.tools.nsc.Settings
 class DefaultExtendedSparkConfigurer(spark: Spark,
                                      deployNamespace: Id.Namespace,
                                      artifactId: Id.Artifact,
-                                     artifactRepository: ArtifactRepository,
+                                     pluginFinder: PluginFinder,
                                      pluginInstantiator: PluginInstantiator)
-  extends AbstractExtendedSparkConfigurer(spark, deployNamespace, artifactId, artifactRepository, pluginInstantiator) {
+  extends AbstractExtendedSparkConfigurer(spark, deployNamespace, artifactId, pluginFinder, pluginInstantiator) {
 
   override def createSparkCompiler(settings: Settings): SparkCompiler = {
     return new DefaultSparkCompiler(settings, new URLAdder {


### PR DESCRIPTION
(CDAP-16353) Replace ArtifactRepository param with PluginFinder for AbstractConfigurer

 Motivation:
AbstractConfigurer uses ArtifactRepository just to find the artifact for a given plugin,
this functionality is already provided by PluginFinder which has local and remote implementations,
thereby allowing us to use local impl when having shared SQL and remote version for non-shared
per service local levelDB. 