### PR TITLE
CDAP-16121 set better spark defaults

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -97,6 +97,8 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     }
 
     SparkConf sparkConf = new SparkConf();
+    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
+    sparkConf.set("spark.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
     sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
     for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -94,6 +94,8 @@ public class ETLSpark extends AbstractSpark {
     SparkClientContext context = getContext();
 
     SparkConf sparkConf = new SparkConf();
+    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
+    sparkConf.set("spark.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
     sparkConf.set("spark.speculation", "false");
     context.setSparkConf(sparkConf);
 


### PR DESCRIPTION
Set some values in SparkConf by default to use Kryo serialization
and to set a max frame setting that can cause issues in large joins.