### PR TITLE
Provide default implementation for getInputStages

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/StageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/StageContext.java
@@ -26,6 +26,8 @@ import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.etl.api.lineage.field.LineageRecorder;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -142,7 +144,9 @@ public interface StageContext extends ServiceDiscoverer, MetadataReader, Metadat
    *
    * @return the list of input stage names
    */
-  List<String> getInputStages();
+  default List<String> getInputStages() {
+    return Collections.emptyList();
+  }
 
   /**
    * Return the output schema of the stage, as set by this stage when the pipeline was deployed. If none was set,


### PR DESCRIPTION
`StageContext.getInputStages` was added in #11948. This seems to have broken clients that implement `StageContext`. 
https://builds.cask.co/browse/CDAP-BUT-2276/log:
```
[ERROR] /var/bamboo/xml-data/build-dir/CDAP-BUT-BMA/app-artifacts/mmds/mmds-app/src/main/java/io/cdap/mmds/manager/WranglerContext.java:[45,8] io.cdap.mmds.manager.WranglerContext is not abstract and does not override abstract method getInputStages() in io.cdap.cdap.etl.api.StageContext
```
The fix is to provide a default implementation of `getInputStages`.