### PR TITLE
(CDAP-16353) Make ProperitesResolver use PreferencesFetcher to get properties

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -100,7 +100,9 @@ import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
 import io.cdap.cdap.internal.profile.ProfileService;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
+import io.cdap.cdap.metadata.LocalPreferencesFetcherInternal;
 import io.cdap.cdap.metadata.MetadataServiceModule;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
@@ -318,6 +320,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
         }
       });
       bind(ProfileService.class).in(Scopes.SINGLETON);
+      bind(PreferencesFetcher.class).to(LocalPreferencesFetcherInternal.class).in(Scopes.SINGLETON);
 
       Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
         binder(), HttpHandler.class, Names.named(Constants.AppFabric.HANDLERS_BINDING));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerModule.java
@@ -52,7 +52,9 @@ import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.internal.app.store.preview.DefaultPreviewStore;
 import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
 import io.cdap.cdap.metadata.DefaultMetadataAdmin;
+import io.cdap.cdap.metadata.LocalPreferencesFetcherInternal;
 import io.cdap.cdap.metadata.MetadataAdmin;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.NoOpScheduler;
 import io.cdap.cdap.scheduler.Scheduler;
@@ -162,6 +164,8 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
     expose(OwnerAdmin.class);
 
     bind(PreviewRequest.class).toInstance(previewRequest);
+
+    bind(PreferencesFetcher.class).to(LocalPreferencesFetcherInternal.class).in(Scopes.SINGLETON);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalPreferencesFetcherInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalPreferencesFetcherInternal.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.config.PreferencesService;
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramId;
+
+/**
+ * Fetch preferences locally via {@link PreferencesService}
+ */
+public class LocalPreferencesFetcherInternal implements PreferencesFetcher {
+
+  private final PreferencesService preferencesService;
+
+  @Inject
+  public LocalPreferencesFetcherInternal(PreferencesService preferencesService) {
+    this.preferencesService = preferencesService;
+  }
+
+  /**
+   * Get preferences for the given identify
+   */
+  public PreferencesDetail get(EntityId entityId, boolean resolved) {
+    final PreferencesService service = preferencesService;
+    PreferencesDetail detail = null;
+    switch (entityId.getEntityType()) {
+      case INSTANCE:
+        detail = resolved ? service.getResolvedPreferences() : service.getPreferences();
+        break;
+      case NAMESPACE:
+        NamespaceId namespaceId = (NamespaceId) entityId;
+        detail = resolved ? service.getResolvedPreferences(namespaceId) : service.getPreferences(namespaceId);
+        break;
+      case APPLICATION:
+        ApplicationId appId = (ApplicationId) entityId;
+        detail = resolved ? service.getResolvedPreferences(appId) : service.getPreferences(appId);
+        break;
+      case PROGRAM:
+        ProgramId programId = (ProgramId) entityId;
+        detail = resolved ? service.getResolvedPreferences(programId) : service.getPreferences(programId);
+        break;
+      default:
+        throw new UnsupportedOperationException(
+          String.format("Preferences cannot be used on this entity type: %s", entityId.getEntityType()));
+    }
+    return detail;
+  }
+}
+

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerInternalTest.java
@@ -206,8 +206,12 @@ public class PreferencesHttpHandlerInternalTest extends AppFabricTestBase {
     Assert.assertTrue(detail1.getSeqId() > 0);
     Assert.assertEquals(detail1, detail2);
 
-    // Get preferences on invalid namespace should fail
-    getPreferencesInternal(getPreferenceURI("invalidNamespace"), true, HttpResponseStatus.NOT_FOUND);
+    // Get preferences on invalid namespace should succeed, but get back a PreferencesDetail with empty property.
+    PreferencesDetail detail = getPreferencesInternal(getPreferenceURI("invalidNamespace"), false,
+                                                      HttpResponseStatus.OK);
+    Assert.assertTrue(detail.getProperties().isEmpty());
+    Assert.assertFalse(detail.getResolved());
+    Assert.assertEquals(0, detail.getSeqId());
   }
 
   @Test
@@ -220,9 +224,12 @@ public class PreferencesHttpHandlerInternalTest extends AppFabricTestBase {
     PreferencesDetail detail;
     Map<String, String> combinedProperties = Maps.newHashMap();
 
-    // Application not created yet, thus get preferences fails with NOT_FOUND
-    getPreferencesInternal(getPreferenceURI(namespace1, "some_non_existing_app"), false,
-                           HttpResponseStatus.NOT_FOUND);
+    // Application not created yet. Get preferences should succeed and get back one with empty properties.
+    detail = getPreferencesInternal(getPreferenceURI(namespace1, "some_non_existing_app"), false,
+                                    HttpResponseStatus.OK);
+    Assert.assertTrue(detail.getProperties().isEmpty());
+    Assert.assertFalse(detail.getResolved());
+    Assert.assertEquals(0, detail.getSeqId());
 
     // Create the app.
     addApplication(namespace1, new AllProgramsApp());
@@ -317,9 +324,13 @@ public class PreferencesHttpHandlerInternalTest extends AppFabricTestBase {
     getPreferencesInternal(getPreferenceURI(
       namespace2, appName, "invalidType", "somename"), false, HttpResponseStatus.BAD_REQUEST);
 
-    // Get preferences on non-existing program id
-    getPreferencesInternal(getPreferenceURI(
-      namespace2, appName, "services", "somename"), false, HttpResponseStatus.NOT_FOUND);
+    // Get preferences on non-existing program id. Should succeed and get back a PreferencesDetail with empty properites
+    detail = getPreferencesInternal(getPreferenceURI(namespace2, appName, "services", "somename"),
+                                    false,
+                                    HttpResponseStatus.OK);
+    Assert.assertTrue(detail.getProperties().isEmpty());
+    Assert.assertFalse(detail.getResolved());
+    Assert.assertEquals(0, detail.getSeqId());
 
     // Set preferences on the program
     programProperties.clear();


### PR DESCRIPTION
Motivation:
At the moment, ProperitesResolver directly accesses local preferences store.
Change that to use PreferencesFetcher allows us to fetch properties either from
local storage or from a remote service via REST calls. This paves the path for
support per service local level DB.

Additional changes:
- Make PreferencesHttpHandler to return empty properties instead of fail if the
  requested entity (e.g. program, or application) doesn't exist, for 2 reasons
  1) consistent with the behavior of preferences store
  2) user may request resolved properties for a program, which will include
     properties from parents (e.g. application, namespace and instance). Even
     through the program doesn't exist, it would be good to return resolved
     properties from its parent and above.