### PR TITLE
(CDAP-16353) Move get artifact details for range into ArtifactRepositoryReader

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -108,15 +108,6 @@ public interface ArtifactRepository extends ArtifactRepositoryReader {
    */
   List<ArtifactSummary> getArtifactSummaries(ArtifactRange range, int limit,
                                              ArtifactSortOrder order) throws Exception;
-  /**
-   * Get all artifact details that match artifacts in the given ranges.
-   *
-   * @param range the range to match artifacts in
-   * @param limit the limit number of the result
-   * @param order the order of the result
-   * @return an unmodifiable list of all artifacts that match the given ranges. If none exist, an empty list is returned
-   */
-  List<ArtifactDetail> getArtifactDetails(ArtifactRange range, int limit, ArtifactSortOrder order) throws Exception;
 
   /**
    * Get all application classes in the given namespace, optionally including classes from system artifacts as well.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryReader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryReader.java
@@ -16,10 +16,13 @@
 
 package io.cdap.cdap.internal.app.runtime.artifact;
 
+import io.cdap.cdap.api.artifact.ArtifactRange;
 import io.cdap.cdap.common.ArtifactNotFoundException;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.proto.artifact.ArtifactSortOrder;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  *  Interface to fetch artifact metadata
@@ -35,4 +38,14 @@ public interface ArtifactRepositoryReader {
    * @throws ArtifactNotFoundException if the given artifact does not exist
    */
   ArtifactDetail getArtifact(Id.Artifact artifactId) throws Exception;
+
+  /**
+   * Get all artifact details that match artifacts in the given ranges.
+   *
+   * @param range the range to match artifacts in
+   * @param limit the limit number of the result
+   * @param order the order of the result
+   * @return an unmodifiable list of all artifacts that match the given ranges. If none exist, an empty list is returned
+   */
+  List<ArtifactDetail> getArtifactDetails(ArtifactRange range, int limit, ArtifactSortOrder order) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactRepository.java
@@ -180,7 +180,7 @@ public class DefaultArtifactRepository implements ArtifactRepository {
   @Override
   public List<ArtifactDetail> getArtifactDetails(final ArtifactRange range, int limit,
                                                  ArtifactSortOrder order) throws Exception {
-    return artifactStore.getArtifacts(range, limit, order);
+    return artifactRepositoryReader.getArtifactDetails(range, limit, order);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/LocalArtifactRepositoryReader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/LocalArtifactRepositoryReader.java
@@ -17,7 +17,11 @@
 package io.cdap.cdap.internal.app.runtime.artifact;
 
 import com.google.inject.Inject;
+import io.cdap.cdap.api.artifact.ArtifactRange;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.proto.artifact.ArtifactSortOrder;
+
+import java.util.List;
 
 /**
  * Implementation for {@link ArtifactRepositoryReader} to fetch artifact metadata directly from local
@@ -34,5 +38,10 @@ public class LocalArtifactRepositoryReader implements ArtifactRepositoryReader {
   @Override
   public ArtifactDetail getArtifact(Id.Artifact artifactId) throws Exception {
     return artifactStore.getArtifact(artifactId);
+  }
+
+  @Override
+  public List<ArtifactDetail> getArtifactDetails(ArtifactRange range, int limit, ArtifactSortOrder order) {
+    return artifactStore.getArtifacts(range, limit, order);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerInternalTest.java
@@ -17,16 +17,20 @@
 package io.cdap.cdap.internal.app.services.http.handlers;
 
 import io.cdap.cdap.api.artifact.ArtifactInfo;
+import io.cdap.cdap.api.artifact.ArtifactRange;
 import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReader;
+import io.cdap.cdap.proto.artifact.ArtifactSortOrder;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ArtifactHttpHandlerInternalTest extends ArtifactHttpHandlerTestBase {
@@ -96,20 +100,103 @@ public class ArtifactHttpHandlerInternalTest extends ArtifactHttpHandlerTestBase
   }
 
   /**
-   * Test {@link RemoteArtifactRepositoryReader}
+   * Test {@link RemoteArtifactRepositoryReader#getArtifact}
    */
   @Test
-  public void testRemoteArtifactRepositoryReader() throws Exception {
+  public void testRemoteArtifactRepositoryReaderGetArtifact() throws Exception {
     // Add a system artifact
     String systemArtfiactName = "sysApp";
     String systemArtifactVeresion = "1.0.0";
     ArtifactId systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, systemArtifactVeresion);
     addAppAsSystemArtifacts(systemArtifactId);
 
+    // Fetch ArtifactDetail using RemoteArtifactRepositoryReader and verify
     ArtifactRepositoryReader remoteReader = getInjector().getInstance(RemoteArtifactRepositoryReader.class);
     ArtifactDetail detail = remoteReader.getArtifact(Id.Artifact.fromEntityId(systemArtifactId));
     Assert.assertNotNull(detail);
     ArtifactDetail expectedDetail = getArtifactDetailFromRepository(Id.Artifact.fromEntityId(systemArtifactId));
     Assert.assertTrue(detail.equals(expectedDetail));
+
+    wipeData();
+  }
+
+  /**
+   * Test {@link RemoteArtifactRepositoryReader#getArtifactDetails}
+   */
+  @Test
+  public void testRemoteArtifactRepositoryReaderGetArtifactDetails() throws Exception {
+    // Add an artifact with a number of versions
+    String systemArtfiactName = "sysApp3";
+    final int numVersions = 10;
+    List<ArtifactId> artifactIds = new ArrayList<>();
+    for (int i = 1; i <= numVersions; i++) {
+      String version = String.format("%d.0.0", i);
+      ArtifactId systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, version);
+      addAppAsSystemArtifacts(systemArtifactId);
+      artifactIds.add(systemArtifactId);
+    }
+    ArtifactRepositoryReader remoteReader = getInjector().getInstance(RemoteArtifactRepositoryReader.class);
+
+    ArtifactRange range = null;
+    List<ArtifactDetail> details = null;
+    ArtifactId systemArtifactId = null;
+    ArtifactDetail expectedDetail = null;
+    int numLimits = 0;
+
+
+    range = new ArtifactRange(NamespaceId.SYSTEM.getNamespace(),
+                                            systemArtfiactName,
+                                            new ArtifactVersion("1.0.0"),
+                                            new ArtifactVersion(String.format("%d.0.0", numVersions)));
+    // Fetch artifacts with the version in range [1.0.0, numVersions.0.0], but limit == 1 in desc order
+    numLimits = 1;
+    details = remoteReader.getArtifactDetails(range, numLimits, ArtifactSortOrder.DESC);
+    Assert.assertEquals(numLimits, details.size());
+    systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, String.format("%d.0.0", numVersions));
+    expectedDetail = getArtifactDetailFromRepository(Id.Artifact.fromEntityId(systemArtifactId));
+    Assert.assertTrue(details.get(numLimits - 1).equals(expectedDetail));
+
+    // Fetch artifacts with the version in range [1.0.0, numVersions.0.0], but limit == 3 in desc order
+    numLimits = 3;
+    details = remoteReader.getArtifactDetails(range, numLimits, ArtifactSortOrder.DESC);
+    Assert.assertEquals(numLimits, details.size());
+    for (int i = 0; i < numLimits; i++) {
+      systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, String.format("%d.0.0", numVersions - i));
+      expectedDetail = getArtifactDetailFromRepository(Id.Artifact.fromEntityId(systemArtifactId));
+      Assert.assertTrue(details.get(i).equals(expectedDetail));
+    }
+
+    // Fetch artifacts with the version in range [1.0.0, numVersions.0.0], but limit == 1 in asec order
+    details = remoteReader.getArtifactDetails(range, 1, ArtifactSortOrder.ASC);
+    Assert.assertEquals(1, details.size());
+    systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, "1.0.0");
+    expectedDetail = getArtifactDetailFromRepository(Id.Artifact.fromEntityId(systemArtifactId));
+    Assert.assertTrue(details.get(0).equals(expectedDetail));
+
+    // Fetch artifacts with the version in range [1.0.0, numVersions.0.0], but limit == 5 in asec order
+    numLimits = 5;
+    details = remoteReader.getArtifactDetails(range, numLimits, ArtifactSortOrder.ASC);
+    Assert.assertEquals(numLimits, details.size());
+    for (int i = 0; i < numLimits; i++) {
+      systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, String.format("%d.0.0", i + 1));
+      expectedDetail = getArtifactDetailFromRepository(Id.Artifact.fromEntityId(systemArtifactId));
+      Assert.assertTrue(details.get(i).equals(expectedDetail));
+    }
+
+    int versionLow = 1;
+    int versionHigh = numVersions / 2;
+    range = new ArtifactRange(NamespaceId.SYSTEM.getNamespace(),
+                                            systemArtfiactName,
+                                            new ArtifactVersion(String.format("%d.0.0", versionLow)),
+                                            new ArtifactVersion(String.format("%d.0.0", versionHigh)));
+    // Fetch artifacts with the version in range [1.0.0, <numVersions/2>.0.0], but limit == numVersions in desc order
+    numLimits = numVersions;
+    details = remoteReader.getArtifactDetails(range, numLimits, ArtifactSortOrder.DESC);
+    Assert.assertEquals(versionHigh - versionLow + 1, details.size());
+    for (int i = 0; i < versionHigh - versionLow + 1; i++) {
+      systemArtifactId = NamespaceId.SYSTEM.artifact(systemArtfiactName, String.format("%d.0.0", versionHigh - i));
+      expectedDetail = getArtifactDetailFromRepository(Id.Artifact.fromEntityId(systemArtifactId));
+      Assert.assertTrue(details.get(i).equals(expectedDetail));
+    }
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTestBase.java
@@ -21,6 +21,7 @@ import com.google.gson.GsonBuilder;
 import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.api.artifact.ArtifactInfo;
 import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.client.config.ClientConfig;
@@ -43,6 +44,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
+import org.apache.commons.io.FileUtils;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.junit.After;
@@ -95,6 +97,9 @@ public abstract class ArtifactHttpHandlerTestBase extends AppFabricTestBase {
   public void wipeData() throws Exception {
     artifactRepository.clear(NamespaceId.DEFAULT);
     artifactRepository.clear(NamespaceId.SYSTEM);
+    // Clean up system artifact dir as well so they don't get auto reloaded by system artifact loader
+    // which scans system artifact directory.
+    FileUtils.cleanDirectory(new File(systemArtifactsDir));
   }
 
   /**


### PR DESCRIPTION
Motivation:
AppLifecycleDeployment use getArtifactDetails to find the artifact detail
for deploymnet. Moving this method into ArtifactRepositoryReader allows us
to have remote vs local implication used by preview (when configured with
local levelDB) and appfabric respectively.

Add implementation for this method in both LocalArtifactRepositoryReader
and RemoteArtifactRepositoryReader. But the latter is not being used
anywhere at the moment. A follow-up change will make preview to use
RemoteArtifactRepositoryReader when configured with local levelDB.