### PR TITLE
(CDAP-16353) Support preview using local level DB when storage is NOSQL.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -100,7 +100,9 @@ import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
 import io.cdap.cdap.internal.profile.ProfileService;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
+import io.cdap.cdap.metadata.LocalPreferencesFetcherInternal;
 import io.cdap.cdap.metadata.MetadataServiceModule;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
@@ -318,6 +320,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
         }
       });
       bind(ProfileService.class).in(Scopes.SINGLETON);
+      bind(PreferencesFetcher.class).to(LocalPreferencesFetcherInternal.class).in(Scopes.SINGLETON);
 
       Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
         binder(), HttpHandler.class, Names.named(Constants.AppFabric.HANDLERS_BINDING));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/PreferencesHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/PreferencesHttpHandlerInternal.java
@@ -19,16 +19,12 @@ package io.cdap.cdap.gateway.handlers;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.BadRequestException;
-import io.cdap.cdap.common.NamespaceNotFoundException;
-import io.cdap.cdap.common.ProgramNotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.config.PreferencesService;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
-import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.PreferencesDetail;
-import io.cdap.cdap.proto.ProgramRecord;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -37,7 +33,6 @@ import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
-import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -77,9 +72,7 @@ public class PreferencesHttpHandlerInternal extends AbstractAppFabricHttpHandler
                                       @PathParam("namespace-id") String namespace,
                                       @QueryParam("resolved") boolean resolved) throws Exception {
     NamespaceId namespaceId = new NamespaceId(namespace);
-    if (!namespaceQueryAdmin.exists(namespaceId)) {
-      throw new NamespaceNotFoundException(namespaceId);
-    }
+    // No need to check if namespace exists. PreferencesService returns an empty PreferencesDetail when that happens.
     PreferencesDetail detail;
     if (resolved) {
       detail = preferencesService.getResolvedPreferences(namespaceId);
@@ -96,7 +89,7 @@ public class PreferencesHttpHandlerInternal extends AbstractAppFabricHttpHandler
                                         @PathParam("application-id") String appId,
                                         @QueryParam("resolved") boolean resolved) throws Exception {
     ApplicationId applicationId = new ApplicationId(namespace, appId);
-    applicationLifecycleService.getAppDetail(applicationId);
+    // No need to check if application exists. PreferencesService returns an empty PreferencesDetail when that happens.
     PreferencesDetail detail;
     if (resolved) {
       detail = preferencesService.getResolvedPreferences(applicationId);
@@ -115,10 +108,7 @@ public class PreferencesHttpHandlerInternal extends AbstractAppFabricHttpHandler
                                     @PathParam("program-id") String programId,
                                     @QueryParam("resolved") boolean resolved) throws Exception {
     ProgramId program = new ProgramId(namespace, appId, getProgramType(programType), programId);
-    ApplicationDetail applicationDetail = applicationLifecycleService.getAppDetail(program.getParent());
-    if (!programExists(applicationDetail, program)) {
-      throw new ProgramNotFoundException(program);
-    }
+    // No need to check if program exists. PreferencesService returns an empty PreferencesDetail when that happens.
     PreferencesDetail detail;
     if (resolved) {
       detail = preferencesService.getResolvedPreferences(program);
@@ -140,20 +130,5 @@ public class PreferencesHttpHandlerInternal extends AbstractAppFabricHttpHandler
     } catch (Exception e) {
       throw new BadRequestException(String.format("Invalid program type '%s'", programType), e);
     }
-  }
-
-  /**
-   * Returns true if the given program id exists in the {@code applicationDetail}
-   */
-  private boolean programExists(ApplicationDetail applicationDetail, ProgramId programId) {
-    List<ProgramRecord> programs = applicationDetail.getPrograms();
-    for (ProgramRecord program : programs) {
-      if (program.getApp().equals(programId.getApplication()) &&
-          program.getName().equals(programId.getProgram()) &&
-          program.getType().equals(programId.getType())) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -23,14 +23,11 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.name.Named;
-import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import io.cdap.cdap.api.security.store.SecureStore;
-import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewRequest;
@@ -56,12 +53,6 @@ import io.cdap.cdap.data.runtime.preview.PreviewDataModules;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.data2.metadata.writer.NoOpMetadataServiceClient;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
-import io.cdap.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
-import io.cdap.cdap.internal.app.runtime.artifact.LocalArtifactRepositoryReader;
-import io.cdap.cdap.internal.app.runtime.artifact.LocalPluginFinder;
-import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
 import io.cdap.cdap.logging.read.FileLogReader;
@@ -350,24 +341,9 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
         }
       }),
       new ProvisionerModule(),
-      new PrivateModule() {
-        @Override
-        protected void configure() {
-          // ArtifactRepositoryReader is required by DefaultArtifactRepository.
-          // Keep ArtifactRepositoryReader private to minimize the scope of the binding visibility.
-          bind(ArtifactRepositoryReader.class).to(LocalArtifactRepositoryReader.class).in(Scopes.SINGLETON);
-          bind(ArtifactRepository.class)
-            .annotatedWith(Names.named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO))
-            .to(DefaultArtifactRepository.class)
-            .in(Scopes.SINGLETON);
-          expose(ArtifactRepository.class)
-            .annotatedWith(Names.named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO));
-        }
-      },
       new AbstractModule() {
         @Override
         protected void configure() {
-          bind(PluginFinder.class).to(LocalPluginFinder.class);
           bind(LogReader.class).to(FileLogReader.class).in(Scopes.SINGLETON);
         }
         @Provides

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/PropertiesResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2017 Cask Data, Inc.
+ * Copyright © 2015-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,40 +20,48 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import io.cdap.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.id.Id;
-import io.cdap.cdap.config.PreferencesService;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.metadata.PreferencesFetcher;
+import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.security.impersonation.ImpersonationInfo;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Used to provide default user and system properties that can be used while starting a Program.
  */
 public class PropertiesResolver {
-
-  private final PreferencesService prefStore;
+  private static final Logger LOG = LoggerFactory.getLogger(PropertiesResolver.class);
+  private final PreferencesFetcher preferencesFetcher;
   private final CConfiguration cConf;
   private final OwnerAdmin ownerAdmin;
   private final SchedulerQueueResolver queueResolver;
 
+
   @Inject
-  PropertiesResolver(PreferencesService prefStore, CConfiguration cConf,
+  PropertiesResolver(PreferencesFetcher preferencesFetcher, CConfiguration cConf,
                      OwnerAdmin ownerAdmin,
                      SchedulerQueueResolver schedulerQueueResolver) {
-    this.prefStore = prefStore;
+    this.preferencesFetcher = preferencesFetcher;
     this.cConf = cConf;
     this.ownerAdmin = ownerAdmin;
     this.queueResolver = schedulerQueueResolver;
   }
 
-  public Map<String, String> getUserProperties(Id.Program id) {
-    Map<String, String> userArgs = prefStore.getResolvedProperties(id.toEntityId());
+  public Map<String, String> getUserProperties(Id.Program id) throws IOException, NotFoundException {
+    PreferencesDetail preferencesDetail = null;
+    preferencesDetail = preferencesFetcher.get(id.toEntityId(), true);
+    Map<String, String> userArgs = new HashMap<String, String>(preferencesDetail.getProperties());
     userArgs.put(ProgramOptionConstants.LOGICAL_START_TIME, Long.toString(System.currentTimeMillis()));
     return userArgs;
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalPreferencesFetcherInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalPreferencesFetcherInternal.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.config.PreferencesService;
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramId;
+
+/**
+ * Fetch preferences locally via {@link PreferencesService}
+ */
+public class LocalPreferencesFetcherInternal implements PreferencesFetcher {
+
+  private final PreferencesService preferencesService;
+
+  @Inject
+  public LocalPreferencesFetcherInternal(PreferencesService preferencesService) {
+    this.preferencesService = preferencesService;
+  }
+
+  /**
+   * Get preferences for the given identify
+   */
+  public PreferencesDetail get(EntityId entityId, boolean resolved) {
+    final PreferencesService service = preferencesService;
+    PreferencesDetail detail = null;
+    switch (entityId.getEntityType()) {
+      case INSTANCE:
+        detail = resolved ? service.getResolvedPreferences() : service.getPreferences();
+        break;
+      case NAMESPACE:
+        NamespaceId namespaceId = (NamespaceId) entityId;
+        detail = resolved ? service.getResolvedPreferences(namespaceId) : service.getPreferences(namespaceId);
+        break;
+      case APPLICATION:
+        ApplicationId appId = (ApplicationId) entityId;
+        detail = resolved ? service.getResolvedPreferences(appId) : service.getPreferences(appId);
+        break;
+      case PROGRAM:
+        ProgramId programId = (ProgramId) entityId;
+        detail = resolved ? service.getResolvedPreferences(programId) : service.getPreferences(programId);
+        break;
+      default:
+        throw new UnsupportedOperationException(
+          String.format("Preferences cannot be used on this entity type: %s", entityId.getEntityType()));
+    }
+    return detail;
+  }
+}
+

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewManagerTest.java
@@ -52,7 +52,6 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.TransactionExecutorModule;
 import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactStore;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
@@ -204,13 +203,16 @@ public class PreviewManagerTest {
   private static final class MockPreviewRunnerModule extends DefaultPreviewRunnerModule {
 
     @Inject
-    MockPreviewRunnerModule(ArtifactRepository artifactRepository, ArtifactStore artifactStore,
+    MockPreviewRunnerModule(ArtifactRepositoryReaderProvider readerProvider, ArtifactStore artifactStore,
                             AuthorizerInstantiator authorizerInstantiator, AuthorizationEnforcer authorizationEnforcer,
                             PrivilegesManager privilegesManager, PreferencesService preferencesService,
                             ProgramRuntimeProviderLoader programRuntimeProviderLoader,
+                            PluginFinderProvider pluginFinderProvider,
+                            PreferencesFetcherProvider preferencesFetcherProvider,
                             @Assisted PreviewRequest previewRequest) {
-      super(artifactRepository, artifactStore, authorizerInstantiator, authorizationEnforcer,
-            privilegesManager, preferencesService, programRuntimeProviderLoader, previewRequest);
+      super(readerProvider, artifactStore, authorizerInstantiator, authorizationEnforcer,
+            privilegesManager, preferencesService, programRuntimeProviderLoader, pluginFinderProvider,
+            preferencesFetcherProvider, previewRequest);
     }
 
     @Override

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerInternalTest.java
@@ -206,8 +206,12 @@ public class PreferencesHttpHandlerInternalTest extends AppFabricTestBase {
     Assert.assertTrue(detail1.getSeqId() > 0);
     Assert.assertEquals(detail1, detail2);
 
-    // Get preferences on invalid namespace should fail
-    getPreferencesInternal(getPreferenceURI("invalidNamespace"), true, HttpResponseStatus.NOT_FOUND);
+    // Get preferences on invalid namespace should succeed, but get back a PreferencesDetail with empty property.
+    PreferencesDetail detail = getPreferencesInternal(getPreferenceURI("invalidNamespace"), false,
+                                                      HttpResponseStatus.OK);
+    Assert.assertTrue(detail.getProperties().isEmpty());
+    Assert.assertFalse(detail.getResolved());
+    Assert.assertEquals(0, detail.getSeqId());
   }
 
   @Test
@@ -220,9 +224,12 @@ public class PreferencesHttpHandlerInternalTest extends AppFabricTestBase {
     PreferencesDetail detail;
     Map<String, String> combinedProperties = Maps.newHashMap();
 
-    // Application not created yet, thus get preferences fails with NOT_FOUND
-    getPreferencesInternal(getPreferenceURI(namespace1, "some_non_existing_app"), false,
-                           HttpResponseStatus.NOT_FOUND);
+    // Application not created yet. Get preferences should succeed and get back one with empty properties.
+    detail = getPreferencesInternal(getPreferenceURI(namespace1, "some_non_existing_app"), false,
+                                    HttpResponseStatus.OK);
+    Assert.assertTrue(detail.getProperties().isEmpty());
+    Assert.assertFalse(detail.getResolved());
+    Assert.assertEquals(0, detail.getSeqId());
 
     // Create the app.
     addApplication(namespace1, new AllProgramsApp());
@@ -317,9 +324,13 @@ public class PreferencesHttpHandlerInternalTest extends AppFabricTestBase {
     getPreferencesInternal(getPreferenceURI(
       namespace2, appName, "invalidType", "somename"), false, HttpResponseStatus.BAD_REQUEST);
 
-    // Get preferences on non-existing program id
-    getPreferencesInternal(getPreferenceURI(
-      namespace2, appName, "services", "somename"), false, HttpResponseStatus.NOT_FOUND);
+    // Get preferences on non-existing program id. Should succeed and get back a PreferencesDetail with empty properites
+    detail = getPreferencesInternal(getPreferenceURI(namespace2, appName, "services", "somename"),
+                                    false,
+                                    HttpResponseStatus.OK);
+    Assert.assertTrue(detail.getProperties().isEmpty());
+    Assert.assertFalse(detail.getResolved());
+    Assert.assertEquals(0, detail.getSeqId());
 
     // Set preferences on the program
     programProperties.clear();

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
@@ -18,15 +18,18 @@ package io.cdap.cdap.master.environment.k8s;
 
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-import com.google.inject.Injector;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.app.preview.PreviewStatus;
-import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.app.program.ManifestFields;
 import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.common.test.PluginJarHelper;
 import io.cdap.cdap.common.utils.Tasks;
-import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.master.environment.app.PreviewTestApp;
+import io.cdap.cdap.master.environment.app.PreviewTestAppWithPlugin;
+import io.cdap.cdap.master.environment.plugin.ConstantCallable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.artifact.preview.PreviewConfig;
@@ -39,16 +42,21 @@ import io.cdap.common.http.HttpResponse;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.jar.Manifest;
 
 /**
  * Unit test for {@link AppFabricServiceMain}.
@@ -56,65 +64,201 @@ import java.util.concurrent.TimeUnit;
 public class PreviewServiceMainTest extends MasterServiceMainTestBase {
   private static final Gson GSON = new Gson();
 
-  @Test
-  public void testPreviewService() throws Exception {
+  private static final Type ARTIFACT_SUMMARY_LIST = new TypeToken<List<ArtifactSummary>>() { }.getType();
 
-    // Deploy the app artifact
+  @After
+  public void after() throws IOException {
+    deleteAllArtifact();
+  }
+
+  @Test
+  public void testPreviewSimpleApp() throws Exception {
+    // Build the app
     LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFolder());
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, PreviewTestApp.class);
 
+    // Deploy the app
     String artifactName = PreviewTestApp.class.getSimpleName();
     String artifactVersion = "1.0.0-SNAPSHOT";
+    deployArtifact(appJar, artifactName, artifactVersion);
 
-    HttpRequestConfig requestConfig = new HttpRequestConfig(0, 0, false);
-    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", artifactName)).toURL();
-    HttpResponse response = HttpRequests.execute(
-      HttpRequest.post(url)
-        .withBody((ContentProvider<? extends InputStream>) appJar::getInputStream)
-        .addHeader("Artifact-Version", artifactVersion)
-        .build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    // Start the preview service main, which will use its own local datadir, thus should fetch artifact location
+    // from appFabric when running a preview
+    startService(PreviewServiceMain.class);
 
-    // have to stop AppFabric so that Preview can share the same leveldb table
-    AppFabricServiceMain appFabricServiceMain = getServiceMainInstance(AppFabricServiceMain.class);
-    appFabricServiceMain.stop();
-    Injector injector = appFabricServiceMain.getInjector();
-    injector.getInstance(LevelDBTableService.class).close();
-
-    // start preview service with the same data dir as app-fabric, so that the artifact info is still there.
-    runMain(injector.getInstance(CConfiguration.class), injector.getInstance(SConfiguration.class),
-            PreviewServiceMain.class, AppFabricServiceMain.class.getSimpleName());
-
-    // create a preview run
-    url = getRouterBaseURI().resolve("/v3/namespaces/default/previews").toURL();
+    // Run a preview
     ArtifactSummary artifactSummary = new ArtifactSummary(artifactName, artifactVersion);
     PreviewConfig previewConfig = new PreviewConfig(PreviewTestApp.TestWorkflow.NAME, ProgramType.WORKFLOW,
                                                     Collections.emptyMap(), 2);
     AppRequest appRequest = new AppRequest<>(artifactSummary, null, previewConfig);
-    response = HttpRequests.execute(HttpRequest.post(url).withBody(GSON.toJson(appRequest)).build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
-    ApplicationId previewId = GSON.fromJson(response.getResponseBodyAsString(), ApplicationId.class);
+    ApplicationId previewId = runPreview(appRequest);
 
-    URL statusUrl = getRouterBaseURI()
-      .resolve(String.format("/v3/namespaces/default/previews/%s/status", previewId.getApplication())).toURL();
+    // Wait for preview to complete
+    waitForPreview(previewId);
+
+    // Verify the result of preview run
+    URL url = getRouterBaseURI()
+      .resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
+                             previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
+                                                         new TypeToken<Map<String, List<String>>>() {
+                                                         }.getType());
+    Assert.assertEquals(Collections.singletonMap(PreviewTestApp.TRACER_KEY,
+                                                 Collections.singletonList(PreviewTestApp.TRACER_VAL)),
+                        tracerData);
+
+    // Stop the preview service main to
+    stopService(PreviewServiceMain.class);
+
+    // Clean up
+    deleteArtfiact(artifactName, artifactVersion);
+  }
+
+  @Test
+  public void testPreviewAppWithPlugin() throws Exception {
+    // Build the app
+    LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFolder());
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, PreviewTestAppWithPlugin.class);
+    String appArtifactName = PreviewTestAppWithPlugin.class.getSimpleName() + "_artifact";
+    String artifactVersion = "1.0.0-SNAPSHOT";
+
+    // Deploy the app
+    deployArtifact(appJar, appArtifactName, artifactVersion);
+    HttpResponse response;
+
+    // Build plugin artifact
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, ConstantCallable.class.getPackage().getName());
+    Location pluginJar = PluginJarHelper.createPluginJar(locationFactory, manifest, ConstantCallable.class);
+
+    // Deploy plug artifact
+    String pluginArtifactName = ConstantCallable.class.getSimpleName() + "_artifact";
+    URL pluginArtifactUrl =
+      getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", pluginArtifactName)).toURL();
+    response = HttpRequests.execute(
+      HttpRequest
+        .post(pluginArtifactUrl)
+        .withBody((ContentProvider<? extends InputStream>) pluginJar::getInputStream)
+        .addHeader("Artifact-Extends", String.format("%s[1.0.0-SNAPSHOT,10.0.0]", appArtifactName))
+        .addHeader("Artifact-Version", artifactVersion)
+        .build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+
+    // Start preview service
+    startService(PreviewServiceMain.class);
+
+    // Run a preview
+    String expectedOutput = "output_value";
+    ArtifactId appArtifactId = new ArtifactId(appArtifactName, new ArtifactVersion(artifactVersion),
+                                              ArtifactScope.USER);
+    ArtifactSummary artifactSummary = ArtifactSummary.from(appArtifactId);
+    PreviewConfig previewConfig = new PreviewConfig(PreviewTestAppWithPlugin.TestWorkflow.NAME, ProgramType.WORKFLOW,
+                                                    Collections.emptyMap(), 2);
+    PreviewTestAppWithPlugin.Conf appConf =
+      new PreviewTestAppWithPlugin.Conf(ConstantCallable.NAME,
+                                        Collections.singletonMap("val", expectedOutput));
+    AppRequest appRequest = new AppRequest<>(artifactSummary, appConf, previewConfig);
+    ApplicationId previewId = runPreview(appRequest);
+
+    // Wait for preview to complete
+    waitForPreview(previewId);
+
+    // Verify the result of preview run
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
+                                                       previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
+    response = HttpRequests.execute(HttpRequest.get(url).build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
+                                                         new TypeToken<Map<String, List<String>>>() {
+                                                         }.getType());
+    Assert.assertEquals(Collections.singletonMap(PreviewTestAppWithPlugin.TRACER_KEY,
+                                                 Collections.singletonList(expectedOutput)),
+                        tracerData);
+
+    stopService(PreviewServiceMain.class);
+  }
+
+  /**
+   * Wait for preview to complete with a deadline
+   */
+  private void waitForPreview(ApplicationId previewId) throws MalformedURLException,
+    java.util.concurrent.TimeoutException, InterruptedException, java.util.concurrent.ExecutionException {
+    URL statusUrl = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/previews/%s/status",
+                                                             previewId.getApplication())).toURL();
     Tasks.waitFor(PreviewStatus.Status.COMPLETED, () -> {
-      HttpResponse statusResponse = HttpRequests.execute(HttpRequest.get(statusUrl).build(), requestConfig);
+      HttpResponse statusResponse = HttpRequests.execute(HttpRequest.get(statusUrl).build(), getHttpRequestConfig());
       if (statusResponse.getResponseCode() != 200) {
         return null;
       }
       PreviewStatus previewStatus = GSON.fromJson(statusResponse.getResponseBodyAsString(), PreviewStatus.class);
       return previewStatus.getStatus();
     }, 2, TimeUnit.MINUTES);
-
-    url = getRouterBaseURI()
-      .resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
-                             previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
-    response = HttpRequests.execute(HttpRequest.get(url).build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
-    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
-                                                         new TypeToken<Map<String, List<String>>>() { }.getType());
-    Assert.assertEquals(Collections.singletonMap(PreviewTestApp.TRACER_KEY,
-                                                 Collections.singletonList(PreviewTestApp.TRACER_VAL)),
-                        tracerData);
   }
+
+  /**
+   * Start a preview and return {@link ApplicationId}
+   */
+  private ApplicationId runPreview(AppRequest appRequest) throws IOException {
+    URL url;
+    url = getRouterBaseURI().resolve("/v3/namespaces/default/previews").toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.post(url).withBody(GSON.toJson(appRequest)).build(),
+                                                 getHttpRequestConfig());
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), ApplicationId.class);
+  }
+
+
+  /**
+   * Deploy the given application in default namespace
+   */
+  private void deployArtifact(Location artifactLocation, String artifactName, String artifactVersion)
+    throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", artifactName)).toURL();
+    HttpResponse response = HttpRequests.execute(
+      HttpRequest.post(url)
+        .withBody((ContentProvider<? extends InputStream>) artifactLocation::getInputStream)
+        .addHeader("Artifact-Version", artifactVersion)
+        .build(),
+      requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+  }
+
+  /**
+   * Delete the given artifact from default namespace
+   */
+  private void deleteArtfiact(String artifactName, String artifactVersion) throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s/versions/%s",
+                                                       artifactName, artifactVersion)).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.delete(url).build(), requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+  }
+
+  /**
+   * List all artifacts in the default namespaces and delete all of them.
+   */
+  private void deleteAllArtifact() throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts")).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build(), requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    List<ArtifactSummary> summaryList = GSON.fromJson(response.getResponseBodyAsString(), ARTIFACT_SUMMARY_LIST);
+    for (ArtifactSummary summary : summaryList) {
+      url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s/versions/%s",
+                                                     summary.getName(), summary.getVersion())).toURL();
+      response = HttpRequests.execute(HttpRequest.delete(url).build(), requestConfig);
+      Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    }
+  }
+
+  /**
+   * Return a default {@link HttpRequestConfig} used for making REST calls
+   */
+  private HttpRequestConfig getHttpRequestConfig() {
+    return new HttpRequestConfig(0, 0, false);
+  }
+
 }

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/plugin/ConstantCallable.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/plugin/ConstantCallable.java
@@ -19,16 +19,16 @@ package io.cdap.cdap.master.environment.plugin;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.plugin.PluginConfig;
-import io.cdap.cdap.master.environment.ServiceWithPluginApp;
 
 import java.util.concurrent.Callable;
 
 /**
  * Used to test plugins in apps.
  */
-@Plugin(type = ServiceWithPluginApp.PLUGIN_TYPE)
+@Plugin(type = ConstantCallable.PLUGIN_TYPE)
 @Name(ConstantCallable.NAME)
 public class ConstantCallable implements Callable<String> {
+  public static final String PLUGIN_TYPE = "callable";
   public static final String NAME = "constant";
   private final Conf conf;
 


### PR DESCRIPTION
This change allow preview to run with local levelDB when data storage is NOSQL

Specially this change includes
- Make ProperitesResolver use PreferencesFetcher to get properties
- Bind following interface to local for SQL and remote for NOSQL in preview (
  * ArtifactRepositoryReader
  * PluginFinder
  * PreferencesFetcherProvider

Key changes are in 
- PropertiesResolver.java
- DefaultPreviewRunnerModule.java
