### PR TITLE
(CDAP-16353) parameterize preference fetcher test to ensure same behavior for local vs remote

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/config/PreferencesServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/config/PreferencesServiceTest.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.common.ProfileConflictException;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.internal.profile.ProfileService;
+import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.EntityId;
@@ -60,6 +61,12 @@ public class PreferencesServiceTest extends AppFabricTestBase {
     store.deleteProperties();
     store.deleteProperties(NamespaceId.DEFAULT);
     store.deleteProperties(new ProgramId("a", "x", ProgramType.WORKFLOW, "z"));
+
+    // Get instance level PreferencesDetail. None has been set, so seqId should be 0 and it should monotonically
+    // increasing as preferences are mutated (i.e. set or deleted) for the entity.
+    PreferencesDetail detail = store.getPreferences();
+    Assert.assertEquals(emptyMap, detail.getProperties());
+    Assert.assertEquals(0, detail.getSeqId());
   }
 
   @Test


### PR DESCRIPTION
Motivation:
To ensure that local and remote implementations for PreferencesFetcher have
consistent behavior. Parameterizing the test to run exact same set of tests
for both implementations.

(This is a follow-up from a previous PR regarding ensuring local vs remote behaving consistently) 