### PR TITLE
(CDAP-16353) Support preview using local level DB when storage is NOSQL.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerModule.java
@@ -24,8 +24,10 @@ import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
 import io.cdap.cdap.app.deploy.Manager;
 import io.cdap.cdap.app.deploy.ManagerFactory;
+import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.app.store.preview.PreviewStore;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
@@ -45,16 +47,21 @@ import io.cdap.cdap.internal.app.preview.DefaultDataTracerFactory;
 import io.cdap.cdap.internal.app.preview.DefaultPreviewRunner;
 import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReaderProvider;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactStore;
+import io.cdap.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinderProvider;
 import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowStateWriter;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowStateWriter;
 import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.internal.app.store.preview.DefaultPreviewStore;
 import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
 import io.cdap.cdap.metadata.DefaultMetadataAdmin;
-import io.cdap.cdap.metadata.LocalPreferencesFetcherInternal;
 import io.cdap.cdap.metadata.MetadataAdmin;
 import io.cdap.cdap.metadata.PreferencesFetcher;
+import io.cdap.cdap.metadata.PreferencesFetcherProvider;
 import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.NoOpScheduler;
 import io.cdap.cdap.scheduler.Scheduler;
@@ -74,7 +81,6 @@ import io.cdap.cdap.store.DefaultOwnerStore;
  */
 public class DefaultPreviewRunnerModule extends PrivateModule implements PreviewRunnerModule {
 
-  private final ArtifactRepository artifactRepository;
   private final ArtifactStore artifactStore;
   private final AuthorizerInstantiator authorizerInstantiator;
   private final AuthorizationEnforcer authorizationEnforcer;
@@ -82,16 +88,21 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
   private final PreferencesService preferencesService;
   private final ProgramRuntimeProviderLoader programRuntimeProviderLoader;
   private final PreviewRequest previewRequest;
+  private final ArtifactRepositoryReaderProvider artifactRepositoryReaderProvider;
+  private final PluginFinderProvider pluginFinderProvider;
+  private final PreferencesFetcherProvider preferencesFetcherProvider;
 
   @VisibleForTesting
   @Inject
-  public DefaultPreviewRunnerModule(ArtifactRepository artifactRepository, ArtifactStore artifactStore,
+  public DefaultPreviewRunnerModule(ArtifactRepositoryReaderProvider readerProvider, ArtifactStore artifactStore,
                                     AuthorizerInstantiator authorizerInstantiator,
                                     AuthorizationEnforcer authorizationEnforcer,
                                     PrivilegesManager privilegesManager, PreferencesService preferencesService,
                                     ProgramRuntimeProviderLoader programRuntimeProviderLoader,
+                                    PluginFinderProvider pluginFinderProvider,
+                                    PreferencesFetcherProvider preferencesFetcherProvider,
                                     @Assisted PreviewRequest previewRequest) {
-    this.artifactRepository = artifactRepository;
+    this.artifactRepositoryReaderProvider = readerProvider;
     this.artifactStore = artifactStore;
     this.authorizerInstantiator = authorizerInstantiator;
     this.authorizationEnforcer = authorizationEnforcer;
@@ -99,12 +110,23 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
     this.preferencesService = preferencesService;
     this.programRuntimeProviderLoader = programRuntimeProviderLoader;
     this.previewRequest = previewRequest;
+    this.pluginFinderProvider = pluginFinderProvider;
+    this.preferencesFetcherProvider = preferencesFetcherProvider;
   }
 
   @Override
   protected void configure() {
-    bind(ArtifactRepository.class).toInstance(artifactRepository);
+    bind(ArtifactRepositoryReader.class).toProvider(artifactRepositoryReaderProvider);
+
+    bind(ArtifactRepository.class).to(DefaultArtifactRepository.class);
     expose(ArtifactRepository.class);
+
+    bind(ArtifactRepository.class)
+      .annotatedWith(Names.named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO))
+      .to(DefaultArtifactRepository.class)
+      .in(Scopes.SINGLETON);
+    expose(ArtifactRepository.class).annotatedWith(Names.named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO));
+
     bind(ArtifactStore.class).toInstance(artifactStore);
     expose(ArtifactStore.class);
     bind(AuthorizerInstantiator.class).toInstance(authorizerInstantiator);
@@ -125,9 +147,12 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
 
     install(
       new FactoryModuleBuilder()
-        .implement(new TypeLiteral<Manager<AppDeploymentInfo, ApplicationWithPrograms>>() { },
-                   new TypeLiteral<PreviewApplicationManager<AppDeploymentInfo, ApplicationWithPrograms>>() { })
-        .build(new TypeLiteral<ManagerFactory<AppDeploymentInfo, ApplicationWithPrograms>>() { })
+        .implement(new TypeLiteral<Manager<AppDeploymentInfo, ApplicationWithPrograms>>() {
+                   },
+                   new TypeLiteral<PreviewApplicationManager<AppDeploymentInfo, ApplicationWithPrograms>>() {
+                   })
+        .build(new TypeLiteral<ManagerFactory<AppDeploymentInfo, ApplicationWithPrograms>>() {
+        })
     );
 
     bind(Store.class).to(DefaultStore.class);
@@ -165,7 +190,11 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
 
     bind(PreviewRequest.class).toInstance(previewRequest);
 
-    bind(PreferencesFetcher.class).to(LocalPreferencesFetcherInternal.class).in(Scopes.SINGLETON);
+    bind(PluginFinder.class).toProvider(pluginFinderProvider);
+    expose(PluginFinder.class);
+
+    bind(PreferencesFetcher.class).toProvider(preferencesFetcherProvider);
+    expose(PreferencesFetcher.class);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -23,14 +23,11 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.name.Named;
-import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import io.cdap.cdap.api.security.store.SecureStore;
-import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewRequest;
@@ -56,12 +53,6 @@ import io.cdap.cdap.data.runtime.preview.PreviewDataModules;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.data2.metadata.writer.NoOpMetadataServiceClient;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
-import io.cdap.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
-import io.cdap.cdap.internal.app.runtime.artifact.LocalArtifactRepositoryReader;
-import io.cdap.cdap.internal.app.runtime.artifact.LocalPluginFinder;
-import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
 import io.cdap.cdap.logging.read.FileLogReader;
@@ -350,24 +341,9 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
         }
       }),
       new ProvisionerModule(),
-      new PrivateModule() {
-        @Override
-        protected void configure() {
-          // ArtifactRepositoryReader is required by DefaultArtifactRepository.
-          // Keep ArtifactRepositoryReader private to minimize the scope of the binding visibility.
-          bind(ArtifactRepositoryReader.class).to(LocalArtifactRepositoryReader.class).in(Scopes.SINGLETON);
-          bind(ArtifactRepository.class)
-            .annotatedWith(Names.named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO))
-            .to(DefaultArtifactRepository.class)
-            .in(Scopes.SINGLETON);
-          expose(ArtifactRepository.class)
-            .annotatedWith(Names.named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO));
-        }
-      },
       new AbstractModule() {
         @Override
         protected void configure() {
-          bind(PluginFinder.class).to(LocalPluginFinder.class);
           bind(LogReader.class).to(FileLogReader.class).in(Scopes.SINGLETON);
         }
         @Provides

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryReaderProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryReaderProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.artifact;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+
+/**
+ * Provider for {@link ArtifactRepositoryReader}.
+ * Use {@link LocalArtifactRepositoryReader} if storage is {@link Constants.Dataset#DATA_STORAGE_SQL}.
+ * Use {@link RemoteArtifactRepositoryReader} if storage is {@link Constants.Dataset#DATA_STORAGE_NOSQL}.
+ */
+public final class ArtifactRepositoryReaderProvider implements Provider<ArtifactRepositoryReader> {
+
+  private final CConfiguration cConf;
+  private final Injector injector;
+
+  @Inject
+  ArtifactRepositoryReaderProvider(CConfiguration cConf, Injector injector) {
+    this.cConf = cConf;
+    this.injector = injector;
+  }
+
+  @Override
+  public ArtifactRepositoryReader get() {
+    String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
+    if (storageImpl == null) {
+      throw new IllegalStateException(
+        "No storage implementation is specified in the configuration file");
+    }
+
+    storageImpl = storageImpl.toLowerCase();
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+      return injector.getInstance(RemoteArtifactRepositoryReader.class);
+    }
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      return injector.getInstance(LocalArtifactRepositoryReader.class);
+    }
+    throw new UnsupportedOperationException(
+      String.format(
+        "%s is not a supported storage implementation, the supported ones are %s and %s",
+        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/PluginFinderProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/PluginFinderProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.artifact;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+
+
+/**
+ * Provider for {@link PluginFinder}.
+ * Use {@link LocalPluginFinder} if storage implication is {@link Constants.Dataset#DATA_STORAGE_SQL}.
+ * Use {@link RemotePluginFinder} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL}.
+ */
+public class PluginFinderProvider implements Provider<PluginFinder> {
+
+  private final CConfiguration cConf;
+  private final Injector injector;
+
+  @Inject
+  PluginFinderProvider(CConfiguration cConf, Injector injector) {
+    this.cConf = cConf;
+    this.injector = injector;
+  }
+
+  @Override
+  public PluginFinder get() {
+    String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
+    if (storageImpl == null) {
+      throw new IllegalStateException(
+        "No storage implementation is specified in the configuration file");
+    }
+
+    storageImpl = storageImpl.toLowerCase();
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+      return injector.getInstance(RemotePluginFinder.class);
+    }
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      return injector.getInstance(LocalPluginFinder.class);
+    }
+    throw new UnsupportedOperationException(
+      String.format(
+        "%s is not a supported storage implementation, the supported ones are %s and %s",
+        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/PreferencesFetcherProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/PreferencesFetcherProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+
+/**
+ * Provider for {@link PreferencesFetcher}.
+ * Use {@link LocalPreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_SQL}.
+ * Use {@link RemotePreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL}
+ */
+public class PreferencesFetcherProvider implements Provider<PreferencesFetcher> {
+
+  private final CConfiguration cConf;
+  private final Injector injector;
+
+  @Inject
+  PreferencesFetcherProvider(CConfiguration cConf, Injector injector) {
+    this.cConf = cConf;
+    this.injector = injector;
+  }
+
+  @Override
+  public PreferencesFetcher get() {
+    String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
+    if (storageImpl == null) {
+      throw new IllegalStateException(
+        "No storage implementation is specified in the configuration file");
+    }
+
+    storageImpl = storageImpl.toLowerCase();
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+      return injector.getInstance(RemotePreferencesFetcherInternal.class);
+    }
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      return injector.getInstance(LocalPreferencesFetcherInternal.class);
+    }
+    throw new UnsupportedOperationException(
+      String.format(
+        "%s is not a supported storage implementation, the supported ones are %s and %s",
+        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  }
+}
+

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewManagerTest.java
@@ -52,8 +52,9 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.TransactionExecutorModule;
 import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReaderProvider;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactStore;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinderProvider;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
@@ -61,6 +62,7 @@ import io.cdap.cdap.logging.guice.LogReaderRuntimeModules;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.MetadataServiceModule;
+import io.cdap.cdap.metadata.PreferencesFetcherProvider;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.query.MetricsQueryHelper;
 import io.cdap.cdap.proto.ProgramType;
@@ -204,13 +206,16 @@ public class PreviewManagerTest {
   private static final class MockPreviewRunnerModule extends DefaultPreviewRunnerModule {
 
     @Inject
-    MockPreviewRunnerModule(ArtifactRepository artifactRepository, ArtifactStore artifactStore,
+    MockPreviewRunnerModule(ArtifactRepositoryReaderProvider readerProvider, ArtifactStore artifactStore,
                             AuthorizerInstantiator authorizerInstantiator, AuthorizationEnforcer authorizationEnforcer,
                             PrivilegesManager privilegesManager, PreferencesService preferencesService,
                             ProgramRuntimeProviderLoader programRuntimeProviderLoader,
+                            PluginFinderProvider pluginFinderProvider,
+                            PreferencesFetcherProvider preferencesFetcherProvider,
                             @Assisted PreviewRequest previewRequest) {
-      super(artifactRepository, artifactStore, authorizerInstantiator, authorizationEnforcer,
-            privilegesManager, preferencesService, programRuntimeProviderLoader, previewRequest);
+      super(readerProvider, artifactStore, authorizerInstantiator, authorizationEnforcer,
+            privilegesManager, preferencesService, programRuntimeProviderLoader, pluginFinderProvider,
+            preferencesFetcherProvider, previewRequest);
     }
 
     @Override

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
@@ -18,15 +18,18 @@ package io.cdap.cdap.master.environment.k8s;
 
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-import com.google.inject.Injector;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.app.preview.PreviewStatus;
-import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.app.program.ManifestFields;
 import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.common.test.PluginJarHelper;
 import io.cdap.cdap.common.utils.Tasks;
-import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.master.environment.app.PreviewTestApp;
+import io.cdap.cdap.master.environment.app.PreviewTestAppWithPlugin;
+import io.cdap.cdap.master.environment.plugin.ConstantCallable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.artifact.preview.PreviewConfig;
@@ -39,16 +42,21 @@ import io.cdap.common.http.HttpResponse;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.jar.Manifest;
 
 /**
  * Unit test for {@link AppFabricServiceMain}.
@@ -56,65 +64,201 @@ import java.util.concurrent.TimeUnit;
 public class PreviewServiceMainTest extends MasterServiceMainTestBase {
   private static final Gson GSON = new Gson();
 
-  @Test
-  public void testPreviewService() throws Exception {
+  private static final Type ARTIFACT_SUMMARY_LIST = new TypeToken<List<ArtifactSummary>>() { }.getType();
 
-    // Deploy the app artifact
+  @After
+  public void after() throws IOException {
+    deleteAllArtifact();
+  }
+
+  @Test
+  public void testPreviewSimpleApp() throws Exception {
+    // Build the app
     LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFolder());
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, PreviewTestApp.class);
 
+    // Deploy the app
     String artifactName = PreviewTestApp.class.getSimpleName();
     String artifactVersion = "1.0.0-SNAPSHOT";
+    deployArtifact(appJar, artifactName, artifactVersion);
 
-    HttpRequestConfig requestConfig = new HttpRequestConfig(0, 0, false);
-    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", artifactName)).toURL();
-    HttpResponse response = HttpRequests.execute(
-      HttpRequest.post(url)
-        .withBody((ContentProvider<? extends InputStream>) appJar::getInputStream)
-        .addHeader("Artifact-Version", artifactVersion)
-        .build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    // Start the preview service main, which will use its own local datadir, thus should fetch artifact location
+    // from appFabric when running a preview
+    startService(PreviewServiceMain.class);
 
-    // have to stop AppFabric so that Preview can share the same leveldb table
-    AppFabricServiceMain appFabricServiceMain = getServiceMainInstance(AppFabricServiceMain.class);
-    appFabricServiceMain.stop();
-    Injector injector = appFabricServiceMain.getInjector();
-    injector.getInstance(LevelDBTableService.class).close();
-
-    // start preview service with the same data dir as app-fabric, so that the artifact info is still there.
-    runMain(injector.getInstance(CConfiguration.class), injector.getInstance(SConfiguration.class),
-            PreviewServiceMain.class, AppFabricServiceMain.class.getSimpleName());
-
-    // create a preview run
-    url = getRouterBaseURI().resolve("/v3/namespaces/default/previews").toURL();
+    // Run a preview
     ArtifactSummary artifactSummary = new ArtifactSummary(artifactName, artifactVersion);
     PreviewConfig previewConfig = new PreviewConfig(PreviewTestApp.TestWorkflow.NAME, ProgramType.WORKFLOW,
                                                     Collections.emptyMap(), 2);
     AppRequest appRequest = new AppRequest<>(artifactSummary, null, previewConfig);
-    response = HttpRequests.execute(HttpRequest.post(url).withBody(GSON.toJson(appRequest)).build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
-    ApplicationId previewId = GSON.fromJson(response.getResponseBodyAsString(), ApplicationId.class);
+    ApplicationId previewId = runPreview(appRequest);
 
-    URL statusUrl = getRouterBaseURI()
-      .resolve(String.format("/v3/namespaces/default/previews/%s/status", previewId.getApplication())).toURL();
+    // Wait for preview to complete
+    waitForPreview(previewId);
+
+    // Verify the result of preview run
+    URL url = getRouterBaseURI()
+      .resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
+                             previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
+                                                         new TypeToken<Map<String, List<String>>>() {
+                                                         }.getType());
+    Assert.assertEquals(Collections.singletonMap(PreviewTestApp.TRACER_KEY,
+                                                 Collections.singletonList(PreviewTestApp.TRACER_VAL)),
+                        tracerData);
+
+    // Stop the preview service main to
+    stopService(PreviewServiceMain.class);
+
+    // Clean up
+    deleteArtfiact(artifactName, artifactVersion);
+  }
+
+  @Test
+  public void testPreviewAppWithPlugin() throws Exception {
+    // Build the app
+    LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFolder());
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, PreviewTestAppWithPlugin.class);
+    String appArtifactName = PreviewTestAppWithPlugin.class.getSimpleName() + "_artifact";
+    String artifactVersion = "1.0.0-SNAPSHOT";
+
+    // Deploy the app
+    deployArtifact(appJar, appArtifactName, artifactVersion);
+    HttpResponse response;
+
+    // Build plugin artifact
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, ConstantCallable.class.getPackage().getName());
+    Location pluginJar = PluginJarHelper.createPluginJar(locationFactory, manifest, ConstantCallable.class);
+
+    // Deploy plug artifact
+    String pluginArtifactName = ConstantCallable.class.getSimpleName() + "_artifact";
+    URL pluginArtifactUrl =
+      getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", pluginArtifactName)).toURL();
+    response = HttpRequests.execute(
+      HttpRequest
+        .post(pluginArtifactUrl)
+        .withBody((ContentProvider<? extends InputStream>) pluginJar::getInputStream)
+        .addHeader("Artifact-Extends", String.format("%s[1.0.0-SNAPSHOT,10.0.0]", appArtifactName))
+        .addHeader("Artifact-Version", artifactVersion)
+        .build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+
+    // Start preview service
+    startService(PreviewServiceMain.class);
+
+    // Run a preview
+    String expectedOutput = "output_value";
+    ArtifactId appArtifactId = new ArtifactId(appArtifactName, new ArtifactVersion(artifactVersion),
+                                              ArtifactScope.USER);
+    ArtifactSummary artifactSummary = ArtifactSummary.from(appArtifactId);
+    PreviewConfig previewConfig = new PreviewConfig(PreviewTestAppWithPlugin.TestWorkflow.NAME, ProgramType.WORKFLOW,
+                                                    Collections.emptyMap(), 2);
+    PreviewTestAppWithPlugin.Conf appConf =
+      new PreviewTestAppWithPlugin.Conf(ConstantCallable.NAME,
+                                        Collections.singletonMap("val", expectedOutput));
+    AppRequest appRequest = new AppRequest<>(artifactSummary, appConf, previewConfig);
+    ApplicationId previewId = runPreview(appRequest);
+
+    // Wait for preview to complete
+    waitForPreview(previewId);
+
+    // Verify the result of preview run
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
+                                                       previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
+    response = HttpRequests.execute(HttpRequest.get(url).build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
+                                                         new TypeToken<Map<String, List<String>>>() {
+                                                         }.getType());
+    Assert.assertEquals(Collections.singletonMap(PreviewTestAppWithPlugin.TRACER_KEY,
+                                                 Collections.singletonList(expectedOutput)),
+                        tracerData);
+
+    stopService(PreviewServiceMain.class);
+  }
+
+  /**
+   * Wait for preview to complete with a deadline
+   */
+  private void waitForPreview(ApplicationId previewId) throws MalformedURLException,
+    java.util.concurrent.TimeoutException, InterruptedException, java.util.concurrent.ExecutionException {
+    URL statusUrl = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/previews/%s/status",
+                                                             previewId.getApplication())).toURL();
     Tasks.waitFor(PreviewStatus.Status.COMPLETED, () -> {
-      HttpResponse statusResponse = HttpRequests.execute(HttpRequest.get(statusUrl).build(), requestConfig);
+      HttpResponse statusResponse = HttpRequests.execute(HttpRequest.get(statusUrl).build(), getHttpRequestConfig());
       if (statusResponse.getResponseCode() != 200) {
         return null;
       }
       PreviewStatus previewStatus = GSON.fromJson(statusResponse.getResponseBodyAsString(), PreviewStatus.class);
       return previewStatus.getStatus();
     }, 2, TimeUnit.MINUTES);
-
-    url = getRouterBaseURI()
-      .resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
-                             previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
-    response = HttpRequests.execute(HttpRequest.get(url).build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
-    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
-                                                         new TypeToken<Map<String, List<String>>>() { }.getType());
-    Assert.assertEquals(Collections.singletonMap(PreviewTestApp.TRACER_KEY,
-                                                 Collections.singletonList(PreviewTestApp.TRACER_VAL)),
-                        tracerData);
   }
+
+  /**
+   * Start a preview and return {@link ApplicationId}
+   */
+  private ApplicationId runPreview(AppRequest appRequest) throws IOException {
+    URL url;
+    url = getRouterBaseURI().resolve("/v3/namespaces/default/previews").toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.post(url).withBody(GSON.toJson(appRequest)).build(),
+                                                 getHttpRequestConfig());
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), ApplicationId.class);
+  }
+
+
+  /**
+   * Deploy the given application in default namespace
+   */
+  private void deployArtifact(Location artifactLocation, String artifactName, String artifactVersion)
+    throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", artifactName)).toURL();
+    HttpResponse response = HttpRequests.execute(
+      HttpRequest.post(url)
+        .withBody((ContentProvider<? extends InputStream>) artifactLocation::getInputStream)
+        .addHeader("Artifact-Version", artifactVersion)
+        .build(),
+      requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+  }
+
+  /**
+   * Delete the given artifact from default namespace
+   */
+  private void deleteArtfiact(String artifactName, String artifactVersion) throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s/versions/%s",
+                                                       artifactName, artifactVersion)).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.delete(url).build(), requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+  }
+
+  /**
+   * List all artifacts in the default namespaces and delete all of them.
+   */
+  private void deleteAllArtifact() throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts")).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build(), requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    List<ArtifactSummary> summaryList = GSON.fromJson(response.getResponseBodyAsString(), ARTIFACT_SUMMARY_LIST);
+    for (ArtifactSummary summary : summaryList) {
+      url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s/versions/%s",
+                                                     summary.getName(), summary.getVersion())).toURL();
+      response = HttpRequests.execute(HttpRequest.delete(url).build(), requestConfig);
+      Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    }
+  }
+
+  /**
+   * Return a default {@link HttpRequestConfig} used for making REST calls
+   */
+  private HttpRequestConfig getHttpRequestConfig() {
+    return new HttpRequestConfig(0, 0, false);
+  }
+
 }

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/plugin/ConstantCallable.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/plugin/ConstantCallable.java
@@ -19,16 +19,16 @@ package io.cdap.cdap.master.environment.plugin;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.plugin.PluginConfig;
-import io.cdap.cdap.master.environment.ServiceWithPluginApp;
 
 import java.util.concurrent.Callable;
 
 /**
  * Used to test plugins in apps.
  */
-@Plugin(type = ServiceWithPluginApp.PLUGIN_TYPE)
+@Plugin(type = ConstantCallable.PLUGIN_TYPE)
 @Name(ConstantCallable.NAME)
 public class ConstantCallable implements Callable<String> {
+  public static final String PLUGIN_TYPE = "callable";
   public static final String NAME = "constant";
   private final Conf conf;
 

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -77,6 +77,7 @@ import io.cdap.cdap.explore.executor.ExploreExecutorService;
 import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.explore.guice.ExploreRuntimeModule;
 import io.cdap.cdap.gateway.handlers.AuthorizationHandler;
+import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.app.services.ProgramNotificationSubscriberService;
 import io.cdap.cdap.internal.profile.ProfileService;
 import io.cdap.cdap.internal.provision.MockProvisionerModule;
@@ -204,6 +205,7 @@ public class TestBase {
   private static MetadataAdmin metadataAdmin;
   private static FieldLineageAdmin fieldLineageAdmin;
   private static LineageAdmin lineageAdmin;
+  private static AppFabricServer appFabricServer;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -369,6 +371,8 @@ public class TestBase {
     provisioningService = injector.getInstance(ProvisioningService.class);
     provisioningService.startAndWait();
     metadataSubscriberService.startAndWait();
+    appFabricServer = injector.getInstance(AppFabricServer.class);
+    appFabricServer.startAndWait();
     if (previewManager instanceof Service) {
       ((Service) previewManager).startAndWait();
     }
@@ -504,6 +508,7 @@ public class TestBase {
       authorizerInstantiator.get().grant(Authorizable.fromEntityId(NamespaceId.DEFAULT),
                                          principal, ImmutableSet.of(Action.ADMIN));
     }
+    appFabricServer.stopAndWait();
     namespaceAdmin.delete(NamespaceId.DEFAULT);
     authorizerInstantiator.close();
 


### PR DESCRIPTION
This change allow preview to run with local levelDB when data storage is NOSQL

Specially
major change is (in DefaultPreviewRunnerModule.java)
- Bind following interfaces to local for SQL and remote for NOSQL in preview
  * ArtifactRepositoryReader
  * PluginFinder
  * PreferencesFetcher

Minor testing related changes are
- Starting AppFabric in TestBase (required by PreviewDataPipelineTest) as
  we use NOSQL in unit tests
- PreviewServiceMainTest now no longer needs to workaround the issue of
  non-sharing local levelDB (by shutting down appfabric before starting preview), 
  so existing test case serves as a good unit test for per-service local private level DB
- Extend PreviewServiceMainTest with a new test case where app has plugin (in order
  to cover plugin finder code path in preview), thus better test coverage.