### PR TITLE
[CDAP-16500] Resumes polling for individual node metrics if user switches tab and circles back to pipeline detail view

### DIFF
--- a/cdap-ui/app/hydrator/controllers/detail-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail-ctrl.js
@@ -132,7 +132,12 @@ angular.module(PKG.name + '.feature.hydrator')
       }
 
       // let latestRunId = latestRun.runid;
-      if (currentRun && currentRun.runid === latestRun.runid && currentRun.status === latestRun.status) {
+      if (
+        currentRun &&
+        currentRun.runid === latestRun.runid &&
+        currentRun.status === latestRun.status &&
+        currentRun.status !== 'RUNNING'
+      ) {
         return;
       }
 


### PR DESCRIPTION
**Issue:**
To reproduce this issue in latest develop, 
- Deploy a pipeline & run the pipeline
- While the pipeline is running switch tab
- Switch back. 
After switching back to pipeline detail view the metrics stops to update.

**Cause**
This is happening because we stop polling when the tab becomes inactive. When we switch back to the tab again we restart polling runs and runscount. In the runs polling we check if the run has changed, if not we do nothing (meaning not resume polling for metrics).

**Reason for regression**
The regression happened because we didn't stop the polling before so the metrics kept updating while switching tabs. Since we changed this behavior this stopped while the user switched back to the pipeline details tab.

**Fix**
We need to resume polling if the current run is still running. This way when we switch back we resume polling for metrics.

JIRA: https://issues.cask.co/browse/CDAP-16501
Build: https://builds.cask.co/browse/CDAP-UDUT555-2
