### PR TITLE
(CDAP-16353) Cleanup: remove MetadataServiceModule from AppFabricServiceRuntimeModule

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -233,7 +233,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
                            new AuthenticationContextModules().getMasterModule(),
-                           new MetadataServiceModule(),
                            new ProvisionerModule(),
                            BootstrapModules.getFileBasedModule(),
                            new AbstractModule() {


### PR DESCRIPTION
Reason:
AppFabric doesn't need MetadataServiceModule module.

MetadataServiceModule contains metadata and lineage http handler bindings and
a binding for MetadataAdmin.  All these are specific to metadata service and are
not needed by AppFabric.