### PR TITLE
[CDAP-16493] Fix Joiner dropdown overflow issue

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/SqlConditionsWidget/Rule.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SqlConditionsWidget/Rule.tsx
@@ -138,7 +138,7 @@ const Rule: React.FC<IRuleProps> = ({
           {rule.map((stage, i) => (
             <div key={`${i}-${stage.stageName}`} className={classes.stageRow}>
               <div className={classes.tableCell}>{stage.stageName}</div>
-              <div className={classes.tableCell}>
+              <div>
                 <OutlinedSelect
                   options={inputSchema[stage.stageName]}
                   disabled={disabled}

--- a/cdap-ui/app/cdap/components/OutlinedSelect/index.tsx
+++ b/cdap-ui/app/cdap/components/OutlinedSelect/index.tsx
@@ -72,6 +72,7 @@ const OutlinedSelect: React.FC<IOutlinedSelectProps> = ({ options, value, onChan
       onChange={handleOnChange}
       disabled={disabled}
       input={<CustomizedInput />}
+      title={value}
     >
       {dropdownOptions.map((opt) => {
         return (


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16493
Build: https://builds.cask.co/browse/CDAP-UDUT557

Modify styes for Rule component (which is only used in SqlConditionsWidget) to prevent overflow when field names are long. See JIRA for screenshot of component with bugfiix. 