### PR TITLE
(CDAP-16353) Add binding providers to allow local vs remote bindings

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryReaderProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryReaderProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.artifact;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+
+/**
+ * Provider for {@link ArtifactRepositoryReader}.
+ * Use {@link LocalArtifactRepositoryReader} if storage implementation is {@link Constants.Dataset#DATA_STORAGE_SQL}.
+ * Use {@link RemoteArtifactRepositoryReader} if storage implementation is {@link Constants.Dataset#DATA_STORAGE_NOSQL}.
+ */
+public final class ArtifactRepositoryReaderProvider implements Provider<ArtifactRepositoryReader> {
+
+  private final CConfiguration cConf;
+  private final Injector injector;
+
+  @Inject
+  ArtifactRepositoryReaderProvider(CConfiguration cConf, Injector injector) {
+    this.cConf = cConf;
+    this.injector = injector;
+  }
+
+  @Override
+  public ArtifactRepositoryReader get() {
+    String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
+    if (storageImpl == null) {
+      throw new IllegalStateException(
+        "No storage implementation is specified in the configuration file");
+    }
+
+    storageImpl = storageImpl.toLowerCase();
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+      return injector.getInstance(RemoteArtifactRepositoryReader.class);
+    }
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      return injector.getInstance(LocalArtifactRepositoryReader.class);
+    }
+    throw new UnsupportedOperationException(
+      String.format(
+        "%s is not a supported storage implementation, the supported ones are %s and %s",
+        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/PluginFinderProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/PluginFinderProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.artifact;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+
+/**
+ * Provider for {@link PluginFinder}.
+ * Use {@link LocalPluginFinder} if storage implication is {@link Constants.Dataset#DATA_STORAGE_SQL}.
+ * Use {@link RemotePluginFinder} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL}.
+ */
+public class PluginFinderProvider implements Provider<PluginFinder> {
+
+  private final CConfiguration cConf;
+  private final Injector injector;
+
+  @Inject
+  PluginFinderProvider(CConfiguration cConf, Injector injector) {
+    this.cConf = cConf;
+    this.injector = injector;
+  }
+
+  @Override
+  public PluginFinder get() {
+    String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
+    if (storageImpl == null) {
+      throw new IllegalStateException(
+        "No storage implementation is specified in the configuration file");
+    }
+
+    storageImpl = storageImpl.toLowerCase();
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+      return injector.getInstance(RemotePluginFinder.class);
+    }
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      return injector.getInstance(LocalPluginFinder.class);
+    }
+    throw new UnsupportedOperationException(
+      String.format(
+        "%s is not a supported storage implementation, the supported ones are %s and %s",
+        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcherProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcherProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+
+/**
+ * Provider for {@link PreferencesFetcher}.
+ * Use {@link LocalPreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_SQL}
+ * Use {@link RemotePreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL}
+ */
+public class ApplicationDetailFetcherProvider implements Provider<ApplicationDetailFetcher> {
+  private final CConfiguration cConf;
+  private final Injector injector;
+
+  @Inject
+  ApplicationDetailFetcherProvider(CConfiguration cConf, Injector injector) {
+    this.cConf = cConf;
+    this.injector = injector;
+  }
+
+  @Override
+  public ApplicationDetailFetcher get() {
+    String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
+    if (storageImpl == null) {
+      throw new IllegalStateException("No storage implementation is specified in the configuration file");
+    }
+
+    storageImpl = storageImpl.toLowerCase();
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+      return injector.getInstance(RemoteApplicationDetailFetcher.class);
+    }
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      return injector.getInstance(LocalApplicationDetailFetcher.class);
+    }
+    throw new UnsupportedOperationException(
+      String.format("%s is not a supported storage implementation, the supported implementations are %s and %s",
+                    storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/PreferencesFetcherProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/PreferencesFetcherProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+
+/**
+ * Provider for {@link PreferencesFetcher}.
+ * Use {@link LocalPreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_SQL}.
+ * Use {@link RemotePreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL}
+ */
+public class PreferencesFetcherProvider implements Provider<PreferencesFetcher> {
+
+  private final CConfiguration cConf;
+  private final Injector injector;
+
+  @Inject
+  PreferencesFetcherProvider(CConfiguration cConf, Injector injector) {
+    this.cConf = cConf;
+    this.injector = injector;
+  }
+
+  @Override
+  public PreferencesFetcher get() {
+    String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
+    if (storageImpl == null) {
+      throw new IllegalStateException(
+        "No storage implementation is specified in the configuration file");
+    }
+
+    storageImpl = storageImpl.toLowerCase();
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
+      return injector.getInstance(RemotePreferencesFetcherInternal.class);
+    }
+    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      return injector.getInstance(LocalPreferencesFetcherInternal.class);
+    }
+    throw new UnsupportedOperationException(
+      String.format(
+        "%s is not a supported storage implementation, the supported ones are %s and %s",
+        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  }
+}
+


### PR DESCRIPTION
Motivation:
We have local vs remote implications for
* ApplicationDetailFetcher
* ArtifactRepositoryReader
* PluginFinder
* PreferencesFetcher

This change introduces providers for each of them to bind interface
to local impl for SQL and remote for NOSQL