### PR TITLE
(CDAP-16353) cleanup of test: move plugin type definition from app to …

### DIFF
--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/ServiceWithPluginApp.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/ServiceWithPluginApp.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.service.AbstractService;
 import io.cdap.cdap.api.service.http.AbstractHttpServiceHandler;
 import io.cdap.cdap.api.service.http.HttpServiceRequest;
 import io.cdap.cdap.api.service.http.HttpServiceResponder;
+import io.cdap.cdap.master.environment.plugin.ConstantCallable;
 
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -34,7 +35,7 @@ import javax.ws.rs.Path;
  */
 public class ServiceWithPluginApp extends AbstractApplication<ServiceWithPluginApp.Conf> {
   public static final String NAME = ServiceWithPluginApp.class.getSimpleName();
-  public static final String PLUGIN_TYPE = "callable";
+  public static final String PLUGIN_TYPE = ConstantCallable.PLUGIN_TYPE;
   public static final String PLUGIN_ID = "id";
 
   @Override

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/plugin/ConstantCallable.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/plugin/ConstantCallable.java
@@ -19,16 +19,16 @@ package io.cdap.cdap.master.environment.plugin;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.plugin.PluginConfig;
-import io.cdap.cdap.master.environment.ServiceWithPluginApp;
 
 import java.util.concurrent.Callable;
 
 /**
  * Used to test plugins in apps.
  */
-@Plugin(type = ServiceWithPluginApp.PLUGIN_TYPE)
+@Plugin(type = ConstantCallable.PLUGIN_TYPE)
 @Name(ConstantCallable.NAME)
 public class ConstantCallable implements Callable<String> {
+  public static final String PLUGIN_TYPE = "callable";
   public static final String NAME = "constant";
   private final Conf conf;
 


### PR DESCRIPTION
Why:
It seems more reasonable to define plugin type in the plugin instead of
in the application that uses the plugin.