### PR TITLE
Handle backward compatibility for inputStages.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/spec/StageSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/spec/StageSpec.java
@@ -133,7 +133,7 @@ public class StageSpec implements Serializable {
     return Objects.equals(name, that.name) &&
       Objects.equals(plugin, that.plugin) &&
       Objects.equals(inputSchemas, that.inputSchemas) &&
-      Objects.equals(new HashSet<>(inputStages), new HashSet<>(that.inputStages)) &&
+      Objects.equals(new HashSet<>(getInputStages()), new HashSet<>(that.getInputStages())) &&
       Objects.equals(outputPorts, that.outputPorts) &&
       Objects.equals(outputSchema, that.outputSchema) &&
       Objects.equals(errorSchema, that.errorSchema) &&
@@ -143,7 +143,7 @@ public class StageSpec implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, plugin, inputSchemas, new HashSet<>(inputStages),
+    return Objects.hash(name, plugin, inputSchemas, new HashSet<>(getInputStages()),
                         outputSchema, errorSchema, stageLoggingEnabled, processTimingEnabled, maxPreviewRecords);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/test/java/io/cdap/cdap/etl/proto/v2/spec/StageSpecTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/test/java/io/cdap/cdap/etl/proto/v2/spec/StageSpecTest.java
@@ -53,15 +53,15 @@ public class StageSpecTest {
                 new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", ImmutableMap.of(), ARTIFACT_ID))
                 .addInputSchema("source1", SCHEMA_A)
                 .addInputSchema("source2", SCHEMA_B)
-                .addInputStages(ImmutableList.of("a", "b"))
+                .addInputStages(ImmutableList.of("source1", "source2"))
                 .build();
 
         StageSpec spec2 = StageSpec.builder("sink",
                 new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", ImmutableMap.of(), ARTIFACT_ID))
                 .addInputSchema("source1", SCHEMA_A)
                 .addInputSchema("source2", SCHEMA_B)
-                .addInputStage("b")
-                .addInputStage("a")
+                .addInputStage("source2")
+                .addInputStage("source1")
                 .build();
 
         Assert.assertEquals(spec1, spec2);
@@ -72,18 +72,55 @@ public class StageSpecTest {
         StageSpec spec1 = StageSpec.builder("sink",
                 new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", ImmutableMap.of(), ARTIFACT_ID))
                 .addInputSchemas(ImmutableMap.of("source1", SCHEMA_A, "source2", SCHEMA_B))
-                .addInputStage("b")
-                .addInputStage("a")
+                .addInputStage("source1")
+                .addInputStage("source2")
                 .build();
 
         StageSpec spec2 = StageSpec.builder("sink",
                 new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", ImmutableMap.of(), ARTIFACT_ID))
                 .addInputSchema("source1", SCHEMA_A)
                 .addInputSchema("source2", SCHEMA_B)
-                .addInputStages(ImmutableList.of("a", "b"))
+                .addInputStages(ImmutableList.of("source2", "source1"))
                 .build();
 
         Assert.assertEquals(spec1.hashCode(), spec2.hashCode());
+    }
+
+    @Test
+    public void testHashCodeWithoutInputStages() {
+        // This can happen if JSON generated with old code is deserialized with newer code.
+        StageSpec spec1 = StageSpec.builder("sink",
+            new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", ImmutableMap.of(), ARTIFACT_ID))
+            .addInputSchemas(ImmutableMap.of("source1", SCHEMA_A, "source2", SCHEMA_B))
+            .build();
+
+        StageSpec spec2 = StageSpec.builder("sink",
+            new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", ImmutableMap.of(), ARTIFACT_ID))
+            .addInputSchema("source1", SCHEMA_A)
+            .addInputSchema("source2", SCHEMA_B)
+            .addInputStages(ImmutableList.of("source1", "source2"))
+            .build();
+
+        Assert.assertEquals(spec1.hashCode(), spec2.hashCode());
+    }
+
+    @Test
+    public void testEqualityWithoutInputStages() {
+        StageSpec spec1 = StageSpec.builder("sink",
+            new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", ImmutableMap.of(), ARTIFACT_ID))
+            .addInputSchema("source1", SCHEMA_A)
+            .addInputSchema("source2", SCHEMA_B)
+            .addInputStages(ImmutableList.of("source1", "source2"))
+            .build();
+
+        // This can happen if JSON generated with old code is deserialized with newer code.
+        StageSpec spec2 = StageSpec.builder("sink",
+            new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", ImmutableMap.of(), ARTIFACT_ID))
+            .addInputSchema("source1", SCHEMA_A)
+            .addInputSchema("source2", SCHEMA_B)
+            .build();
+
+        Assert.assertEquals(spec1, spec2);
     }
 
 }


### PR DESCRIPTION
Pipelines created with older code will not have inputStages in serialized JSON. In these cases we should derive inputStages from keys of inputSchemas.