### PR TITLE
[CDAP-16500] Resumes polling for individual node metrics if user switches tab and circles back to pipeline detail view

### DIFF
--- a/cdap-ui/app/hydrator/controllers/detail-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail-ctrl.js
@@ -119,7 +119,12 @@ angular.module(PKG.name + '.feature.hydrator')
       }
 
       // let latestRunId = latestRun.runid;
-      if (currentRun && currentRun.runid === latestRun.runid && currentRun.status === latestRun.status) {
+      if (
+        currentRun &&
+        currentRun.runid === latestRun.runid &&
+        currentRun.status === latestRun.status &&
+        currentRun.status !== 'RUNNING'
+      ) {
         return;
       }
 


### PR DESCRIPTION
Cherry-picking changes from 6.2 https://github.com/cdapio/cdap/pull/12011

Build: https://builds.cask.co/browse/CDAP-UDUT560-1