### PR TITLE
(CDAP-16353) Support preview to run with non-sharing local level DB.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -23,14 +23,11 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.name.Named;
-import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import io.cdap.cdap.api.security.store.SecureStore;
-import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewRequest;
@@ -56,12 +53,6 @@ import io.cdap.cdap.data.runtime.preview.PreviewDataModules;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.data2.metadata.writer.NoOpMetadataServiceClient;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
-import io.cdap.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
-import io.cdap.cdap.internal.app.runtime.artifact.LocalArtifactRepositoryReader;
-import io.cdap.cdap.internal.app.runtime.artifact.LocalPluginFinder;
-import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
 import io.cdap.cdap.logging.read.FileLogReader;
@@ -353,7 +344,6 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
       new AbstractModule() {
         @Override
         protected void configure() {
-          bind(PluginFinder.class).to(LocalPluginFinder.class);
           bind(LogReader.class).to(FileLogReader.class).in(Scopes.SINGLETON);
         }
         @Provides

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewManagerTest.java
@@ -52,8 +52,9 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.TransactionExecutorModule;
 import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReaderProvider;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactStore;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinderProvider;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
@@ -61,6 +62,7 @@ import io.cdap.cdap.logging.guice.LogReaderRuntimeModules;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.MetadataServiceModule;
+import io.cdap.cdap.metadata.PreferencesFetcherProvider;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.query.MetricsQueryHelper;
 import io.cdap.cdap.proto.ProgramType;
@@ -204,13 +206,16 @@ public class PreviewManagerTest {
   private static final class MockPreviewRunnerModule extends DefaultPreviewRunnerModule {
 
     @Inject
-    MockPreviewRunnerModule(ArtifactRepository artifactRepository, ArtifactStore artifactStore,
+    MockPreviewRunnerModule(ArtifactRepositoryReaderProvider readerProvider, ArtifactStore artifactStore,
                             AuthorizerInstantiator authorizerInstantiator, AuthorizationEnforcer authorizationEnforcer,
                             PrivilegesManager privilegesManager, PreferencesService preferencesService,
                             ProgramRuntimeProviderLoader programRuntimeProviderLoader,
+                            PluginFinderProvider pluginFinderProvider,
+                            PreferencesFetcherProvider preferencesFetcherProvider,
                             @Assisted PreviewRequest previewRequest) {
-      super(artifactRepository, artifactStore, authorizerInstantiator, authorizationEnforcer,
-            privilegesManager, preferencesService, programRuntimeProviderLoader, previewRequest);
+      super(readerProvider, artifactStore, authorizerInstantiator, authorizationEnforcer,
+            privilegesManager, preferencesService, programRuntimeProviderLoader, pluginFinderProvider,
+            preferencesFetcherProvider, previewRequest);
     }
 
     @Override

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/app/PreviewTestAppWithPlugin.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/app/PreviewTestAppWithPlugin.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.app;
+
+import io.cdap.cdap.api.Config;
+import io.cdap.cdap.api.app.AbstractApplication;
+import io.cdap.cdap.api.customaction.AbstractCustomAction;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.workflow.AbstractWorkflow;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * An app with a workflow that just writes a single tracer value. Used to test preview.
+ */
+public class PreviewTestAppWithPlugin extends AbstractApplication<PreviewTestAppWithPlugin.Conf> {
+  public static final String TRACER_NAME = "trace";
+  public static final String TRACER_KEY = "k";
+  public static final String PLUGIN_TYPE = "callable";
+  public static final String PLUGIN_ID = "id";
+
+  @Override
+  public void configure() {
+    addWorkflow(new TestWorkflow());
+    Conf conf = getConfig();
+    usePlugin(PLUGIN_TYPE, conf.pluginName, PLUGIN_ID,
+              PluginProperties.builder().addAll(conf.pluginProperties).build());
+  }
+
+  /**
+   * Config for the app
+   */
+  public static class Conf extends Config {
+    private final String pluginName;
+
+    private final Map<String, String> pluginProperties;
+
+    public Conf(String pluginName, Map<String, String> pluginProperties) {
+      this.pluginName = pluginName;
+      this.pluginProperties = pluginProperties;
+    }
+  }
+
+  /**
+   * Workflow that has a single action that writes to a tracer.
+   */
+  public static class TestWorkflow extends AbstractWorkflow {
+    public static final String NAME = TestWorkflow.class.getSimpleName();
+
+    @Override
+    protected void configure() {
+      setName(NAME);
+      addAction(new TracerWriter());
+    }
+  }
+
+  /**
+   * Writes a value to the tracer.
+   */
+  public static class TracerWriter extends AbstractCustomAction {
+
+    @Override
+    public void run() throws Exception {
+      Callable<String> plugin = getContext().newPluginInstance(PLUGIN_ID);
+      getContext().getDataTracer(TRACER_NAME).info(TRACER_KEY, plugin.call());
+    }
+  }
+}

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
@@ -18,15 +18,18 @@ package io.cdap.cdap.master.environment.k8s;
 
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-import com.google.inject.Injector;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.app.preview.PreviewStatus;
-import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.app.program.ManifestFields;
 import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.common.test.PluginJarHelper;
 import io.cdap.cdap.common.utils.Tasks;
-import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.master.environment.app.PreviewTestApp;
+import io.cdap.cdap.master.environment.app.PreviewTestAppWithPlugin;
+import io.cdap.cdap.master.environment.plugin.ConstantCallable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.artifact.preview.PreviewConfig;
@@ -39,16 +42,21 @@ import io.cdap.common.http.HttpResponse;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.jar.Manifest;
 
 /**
  * Unit test for {@link AppFabricServiceMain}.
@@ -56,65 +64,201 @@ import java.util.concurrent.TimeUnit;
 public class PreviewServiceMainTest extends MasterServiceMainTestBase {
   private static final Gson GSON = new Gson();
 
-  @Test
-  public void testPreviewService() throws Exception {
+  private static final Type ARTIFACT_SUMMARY_LIST = new TypeToken<List<ArtifactSummary>>() { }.getType();
 
-    // Deploy the app artifact
+  @After
+  public void after() throws IOException {
+    deleteAllArtifact();
+  }
+
+  @Test
+  public void testPreviewSimpleApp() throws Exception {
+    // Build the app
     LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFolder());
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, PreviewTestApp.class);
 
+    // Deploy the app
     String artifactName = PreviewTestApp.class.getSimpleName();
     String artifactVersion = "1.0.0-SNAPSHOT";
+    deployArtifact(appJar, artifactName, artifactVersion);
 
-    HttpRequestConfig requestConfig = new HttpRequestConfig(0, 0, false);
-    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", artifactName)).toURL();
-    HttpResponse response = HttpRequests.execute(
-      HttpRequest.post(url)
-        .withBody((ContentProvider<? extends InputStream>) appJar::getInputStream)
-        .addHeader("Artifact-Version", artifactVersion)
-        .build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    // Start the preview service main, which will use its own local datadir, thus should fetch artifact location
+    // from appFabric when running a preview
+    startService(PreviewServiceMain.class);
 
-    // have to stop AppFabric so that Preview can share the same leveldb table
-    AppFabricServiceMain appFabricServiceMain = getServiceMainInstance(AppFabricServiceMain.class);
-    appFabricServiceMain.stop();
-    Injector injector = appFabricServiceMain.getInjector();
-    injector.getInstance(LevelDBTableService.class).close();
-
-    // start preview service with the same data dir as app-fabric, so that the artifact info is still there.
-    runMain(injector.getInstance(CConfiguration.class), injector.getInstance(SConfiguration.class),
-            PreviewServiceMain.class, AppFabricServiceMain.class.getSimpleName());
-
-    // create a preview run
-    url = getRouterBaseURI().resolve("/v3/namespaces/default/previews").toURL();
+    // Run a preview
     ArtifactSummary artifactSummary = new ArtifactSummary(artifactName, artifactVersion);
     PreviewConfig previewConfig = new PreviewConfig(PreviewTestApp.TestWorkflow.NAME, ProgramType.WORKFLOW,
                                                     Collections.emptyMap(), 2);
     AppRequest appRequest = new AppRequest<>(artifactSummary, null, previewConfig);
-    response = HttpRequests.execute(HttpRequest.post(url).withBody(GSON.toJson(appRequest)).build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
-    ApplicationId previewId = GSON.fromJson(response.getResponseBodyAsString(), ApplicationId.class);
+    ApplicationId previewId = runPreview(appRequest);
 
-    URL statusUrl = getRouterBaseURI()
-      .resolve(String.format("/v3/namespaces/default/previews/%s/status", previewId.getApplication())).toURL();
+    // Wait for preview to complete
+    waitForPreview(previewId);
+
+    // Verify the result of preview run
+    URL url = getRouterBaseURI()
+      .resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
+                             previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
+                                                         new TypeToken<Map<String, List<String>>>() {
+                                                         }.getType());
+    Assert.assertEquals(Collections.singletonMap(PreviewTestApp.TRACER_KEY,
+                                                 Collections.singletonList(PreviewTestApp.TRACER_VAL)),
+                        tracerData);
+
+    // Stop the preview service main to
+    stopService(PreviewServiceMain.class);
+
+    // Clean up
+    deleteArtfiact(artifactName, artifactVersion);
+  }
+
+  @Test
+  public void testPreviewAppWithPlugin() throws Exception {
+    // Build the app
+    LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFolder());
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, PreviewTestAppWithPlugin.class);
+    String appArtifactName = PreviewTestAppWithPlugin.class.getSimpleName() + "_artifact";
+    String artifactVersion = "1.0.0-SNAPSHOT";
+
+    // Deploy the app
+    deployArtifact(appJar, appArtifactName, artifactVersion);
+    HttpResponse response;
+
+    // Build plugin artifact
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, ConstantCallable.class.getPackage().getName());
+    Location pluginJar = PluginJarHelper.createPluginJar(locationFactory, manifest, ConstantCallable.class);
+
+    // Deploy plug artifact
+    String pluginArtifactName = ConstantCallable.class.getSimpleName() + "_artifact";
+    URL pluginArtifactUrl =
+      getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", pluginArtifactName)).toURL();
+    response = HttpRequests.execute(
+      HttpRequest
+        .post(pluginArtifactUrl)
+        .withBody((ContentProvider<? extends InputStream>) pluginJar::getInputStream)
+        .addHeader("Artifact-Extends", String.format("%s[1.0.0-SNAPSHOT,10.0.0]", appArtifactName))
+        .addHeader("Artifact-Version", artifactVersion)
+        .build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+
+    // Start preview service
+    startService(PreviewServiceMain.class);
+
+    // Run a preview
+    String expectedOutput = "output_value";
+    ArtifactId appArtifactId = new ArtifactId(appArtifactName, new ArtifactVersion(artifactVersion),
+                                              ArtifactScope.USER);
+    ArtifactSummary artifactSummary = ArtifactSummary.from(appArtifactId);
+    PreviewConfig previewConfig = new PreviewConfig(PreviewTestAppWithPlugin.TestWorkflow.NAME, ProgramType.WORKFLOW,
+                                                    Collections.emptyMap(), 2);
+    PreviewTestAppWithPlugin.Conf appConf =
+      new PreviewTestAppWithPlugin.Conf(ConstantCallable.NAME,
+                                        Collections.singletonMap("val", expectedOutput));
+    AppRequest appRequest = new AppRequest<>(artifactSummary, appConf, previewConfig);
+    ApplicationId previewId = runPreview(appRequest);
+
+    // Wait for preview to complete
+    waitForPreview(previewId);
+
+    // Verify the result of preview run
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
+                                                       previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
+    response = HttpRequests.execute(HttpRequest.get(url).build(), getHttpRequestConfig());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
+                                                         new TypeToken<Map<String, List<String>>>() {
+                                                         }.getType());
+    Assert.assertEquals(Collections.singletonMap(PreviewTestAppWithPlugin.TRACER_KEY,
+                                                 Collections.singletonList(expectedOutput)),
+                        tracerData);
+
+    stopService(PreviewServiceMain.class);
+  }
+
+  /**
+   * Wait for preview to complete with a deadline
+   */
+  private void waitForPreview(ApplicationId previewId) throws MalformedURLException,
+    java.util.concurrent.TimeoutException, InterruptedException, java.util.concurrent.ExecutionException {
+    URL statusUrl = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/previews/%s/status",
+                                                             previewId.getApplication())).toURL();
     Tasks.waitFor(PreviewStatus.Status.COMPLETED, () -> {
-      HttpResponse statusResponse = HttpRequests.execute(HttpRequest.get(statusUrl).build(), requestConfig);
+      HttpResponse statusResponse = HttpRequests.execute(HttpRequest.get(statusUrl).build(), getHttpRequestConfig());
       if (statusResponse.getResponseCode() != 200) {
         return null;
       }
       PreviewStatus previewStatus = GSON.fromJson(statusResponse.getResponseBodyAsString(), PreviewStatus.class);
       return previewStatus.getStatus();
     }, 2, TimeUnit.MINUTES);
-
-    url = getRouterBaseURI()
-      .resolve(String.format("/v3/namespaces/default/previews/%s/tracers/%s",
-                             previewId.getApplication(), PreviewTestApp.TRACER_NAME)).toURL();
-    response = HttpRequests.execute(HttpRequest.get(url).build(), requestConfig);
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
-    Map<String, List<String>> tracerData = GSON.fromJson(response.getResponseBodyAsString(),
-                                                         new TypeToken<Map<String, List<String>>>() { }.getType());
-    Assert.assertEquals(Collections.singletonMap(PreviewTestApp.TRACER_KEY,
-                                                 Collections.singletonList(PreviewTestApp.TRACER_VAL)),
-                        tracerData);
   }
+
+  /**
+   * Start a preview and return {@link ApplicationId}
+   */
+  private ApplicationId runPreview(AppRequest appRequest) throws IOException {
+    URL url;
+    url = getRouterBaseURI().resolve("/v3/namespaces/default/previews").toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.post(url).withBody(GSON.toJson(appRequest)).build(),
+                                                 getHttpRequestConfig());
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), ApplicationId.class);
+  }
+
+
+  /**
+   * Deploy the given application in default namespace
+   */
+  private void deployArtifact(Location artifactLocation, String artifactName, String artifactVersion)
+    throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s", artifactName)).toURL();
+    HttpResponse response = HttpRequests.execute(
+      HttpRequest.post(url)
+        .withBody((ContentProvider<? extends InputStream>) artifactLocation::getInputStream)
+        .addHeader("Artifact-Version", artifactVersion)
+        .build(),
+      requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+  }
+
+  /**
+   * Delete the given artifact from default namespace
+   */
+  private void deleteArtfiact(String artifactName, String artifactVersion) throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s/versions/%s",
+                                                       artifactName, artifactVersion)).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.delete(url).build(), requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+  }
+
+  /**
+   * List all artifacts in the default namespaces and delete all of them.
+   */
+  private void deleteAllArtifact() throws IOException {
+    HttpRequestConfig requestConfig = getHttpRequestConfig();
+    URL url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts")).toURL();
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(url).build(), requestConfig);
+    Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    List<ArtifactSummary> summaryList = GSON.fromJson(response.getResponseBodyAsString(), ARTIFACT_SUMMARY_LIST);
+    for (ArtifactSummary summary : summaryList) {
+      url = getRouterBaseURI().resolve(String.format("/v3/namespaces/default/artifacts/%s/versions/%s",
+                                                     summary.getName(), summary.getVersion())).toURL();
+      response = HttpRequests.execute(HttpRequest.delete(url).build(), requestConfig);
+      Assert.assertEquals(response.getResponseBodyAsString(), HttpURLConnection.HTTP_OK, response.getResponseCode());
+    }
+  }
+
+  /**
+   * Return a default {@link HttpRequestConfig} used for making REST calls
+   */
+  private HttpRequestConfig getHttpRequestConfig() {
+    return new HttpRequestConfig(0, 0, false);
+  }
+
 }

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -77,6 +77,7 @@ import io.cdap.cdap.explore.executor.ExploreExecutorService;
 import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.explore.guice.ExploreRuntimeModule;
 import io.cdap.cdap.gateway.handlers.AuthorizationHandler;
+import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.app.services.ProgramNotificationSubscriberService;
 import io.cdap.cdap.internal.profile.ProfileService;
 import io.cdap.cdap.internal.provision.MockProvisionerModule;
@@ -180,7 +181,6 @@ public class TestBase {
   private static int nestedStartCount;
   private static boolean firstInit = true;
   private static MetricsCollectionService metricsCollectionService;
-  private static ProgramNotificationSubscriberService programNotificationSubscriberService;
   private static Scheduler scheduler;
   private static ExploreExecutorService exploreExecutorService;
   private static ExploreClient exploreClient;
@@ -197,13 +197,13 @@ public class TestBase {
   private static Scheduler programScheduler;
   private static MessagingContext messagingContext;
   private static PreviewManager previewManager;
-  private static ProvisioningService provisioningService;
   private static MetadataService metadataService;
   private static MetadataSubscriberService metadataSubscriberService;
   private static MetadataStorage metadataStorage;
   private static MetadataAdmin metadataAdmin;
   private static FieldLineageAdmin fieldLineageAdmin;
   private static LineageAdmin lineageAdmin;
+  private static AppFabricServer appFabricServer;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -309,15 +309,6 @@ public class TestBase {
     datasetService.startAndWait();
     metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
     metricsCollectionService.startAndWait();
-    programNotificationSubscriberService = injector.getInstance(ProgramNotificationSubscriberService.class);
-    programNotificationSubscriberService.startAndWait();
-    scheduler = injector.getInstance(Scheduler.class);
-    if (scheduler instanceof Service) {
-      ((Service) scheduler).startAndWait();
-    }
-    if (scheduler instanceof CoreSchedulerService) {
-      ((CoreSchedulerService) scheduler).waitUntilFunctional(10, TimeUnit.SECONDS);
-    }
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       exploreExecutorService = injector.getInstance(ExploreExecutorService.class);
       exploreExecutorService.startAndWait();
@@ -366,11 +357,19 @@ public class TestBase {
     previewManager = injector.getInstance(PreviewManager.class);
     fieldLineageAdmin = injector.getInstance(FieldLineageAdmin.class);
     lineageAdmin = injector.getInstance(LineageAdmin.class);
-    provisioningService = injector.getInstance(ProvisioningService.class);
-    provisioningService.startAndWait();
     metadataSubscriberService.startAndWait();
     if (previewManager instanceof Service) {
       ((Service) previewManager).startAndWait();
+    }
+    appFabricServer = injector.getInstance(AppFabricServer.class);
+    appFabricServer.startAndWait();
+
+    scheduler = injector.getInstance(Scheduler.class);
+    if (scheduler instanceof Service) {
+      ((Service) scheduler).startAndWait();
+    }
+    if (scheduler instanceof CoreSchedulerService) {
+      ((CoreSchedulerService) scheduler).waitUntilFunctional(10, TimeUnit.SECONDS);
     }
   }
 
@@ -504,6 +503,7 @@ public class TestBase {
       authorizerInstantiator.get().grant(Authorizable.fromEntityId(NamespaceId.DEFAULT),
                                          principal, ImmutableSet.of(Action.ADMIN));
     }
+    appFabricServer.stopAndWait();
     namespaceAdmin.delete(NamespaceId.DEFAULT);
     authorizerInstantiator.close();
 
@@ -511,7 +511,6 @@ public class TestBase {
       ((Service) programScheduler).stopAndWait();
     }
     metricsCollectionService.stopAndWait();
-    programNotificationSubscriberService.stopAndWait();
     if (scheduler instanceof Service) {
       ((Service) scheduler).stopAndWait();
     }
@@ -529,7 +528,6 @@ public class TestBase {
     if (messagingService instanceof Service) {
       ((Service) messagingService).stopAndWait();
     }
-    provisioningService.stopAndWait();
   }
 
   protected MetricsManager getMetricsManager() {


### PR DESCRIPTION
    Why:
    Allow preview to run with its own local levelDB. This allows us to
    deploy cdap in a distributed fashion without shared underlying
    storage when storage impl is NOSQL.

    What:
    This change allow preview to run with local levelDB when data storage
    is NOSQL. It achieves this by binding interface to local vs remote
    implementation dynamically depending on storage implementation config.

    The crux of the change is in DefaultPreviewRunnerModule where we bind
    following interfaces to local impl for SQL and remote for NOSQL
    * ArtifactRepositoryReader
    * PluginFinder
    * PreferencesFetcher

    Changes in tests:
    * Starting AppFabric in TestBase (required by PreviewDataPipelineTest) as
      we use NOSQL in unit tests, therefore bindings use remote impls for
      above interfaces and need to talk to AppFabric
    * PreviewServiceMainTest now no longer needs to workaround the issue of
      non-sharing local levelDB (previously it needs to shutdown AppFabric
      before starting preview so as to have levelDB state updated by AppFabric
      to be visible to preview in order for it to work)
    * Extend PreviewServiceMainTest with a new test case where app has plugin
      (in order to cover plugin finder code path in preview), thus better
      test coverage.