### PR TITLE
(CDAP-16353) Add getOrCreateTable API to StructuredTableContext

### DIFF
--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableContextTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableContextTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.sql;
+
+import com.google.inject.Injector;
+import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableAdmin;
+import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableContext;
+import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableRegistry;
+import io.cdap.cdap.spi.data.nosql.NoSqlTransactionRunner;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+import io.cdap.cdap.spi.data.table.field.FieldType;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Test for {@link NoSqlStructuredTableContext}
+ */
+public class NoSqlStructuredTableContextTest {
+  @ClassRule
+  public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
+
+  private static NoSqlStructuredTableAdmin tableAdmin;
+  private static TransactionRunner transactionRunner;
+
+  public static class TestTable {
+    public static final FieldType FIELD_KEY = Fields.intType("field_int");
+    public static final FieldType FIELD_STRING = Fields.stringType("field_string");
+    public static final FieldType FIELD_LONG = Fields.longType("field_long");
+    public static final StructuredTableId ID = new StructuredTableId("test_table_id");
+    public static final StructuredTableSpecification SPEC = new StructuredTableSpecification.Builder()
+      .withId(ID)
+      .withFields(FIELD_KEY, FIELD_STRING, FIELD_LONG)
+      .withPrimaryKeys(FIELD_KEY.getName())
+      .withIndexes(FIELD_STRING.getName())
+      .build();
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Injector injector = dsFrameworkUtil.getInjector();
+    tableAdmin = injector.getInstance(NoSqlStructuredTableAdmin.class);
+    transactionRunner = dsFrameworkUtil.getInjector().getInstance(NoSqlTransactionRunner.class);
+    NoSqlStructuredTableRegistry registry =
+      dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableRegistry.class);
+    registry.initialize();
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    boolean doCleanup = true;
+    try {
+      TransactionRunners.run(transactionRunner, context -> {
+        context.getTable(TestTable.ID);
+      });
+    } catch (TableNotFoundException e) {
+      doCleanup = false;
+    }
+    if (doCleanup) {
+      tableAdmin.drop(TestTable.ID);
+    }
+  }
+
+  @Test(expected = TableNotFoundException.class)
+  public void testGetTableNotFound() {
+   TransactionRunners.run(transactionRunner, context -> {
+     context.getTable(TestTable.ID);
+    });
+  }
+
+  @Test
+  public void testGetOrCreate() throws Exception {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable tableCreated = context.getOrCreateTable(TestTable.ID, TestTable.SPEC);
+      Assert.assertNotNull(tableCreated);
+      StructuredTable tableGot = context.getTable(TestTable.ID);
+      Assert.assertNotNull(tableGot);
+    });
+  }
+}

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableContextTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableContextTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.sql;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+import io.cdap.cdap.spi.data.table.field.FieldType;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+/**
+ * Test for {@link SqlStructuredTableContext}
+ */
+public class SqlStructuredTableContextTest {
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static EmbeddedPostgres postgres;
+  private static StructuredTableAdmin tableAdmin;
+  private static TransactionRunner transactionRunner;
+
+  public static class TestTable {
+    public static final FieldType FIELD_KEY = Fields.intType("field_int");
+    public static final FieldType FIELD_STRING = Fields.stringType("field_string");
+    public static final FieldType FIELD_LONG = Fields.longType("field_long");
+    public static final StructuredTableId ID = new StructuredTableId("test_table_id");
+    public static final StructuredTableSpecification SPEC = new StructuredTableSpecification.Builder()
+      .withId(ID)
+      .withFields(FIELD_KEY, FIELD_STRING, FIELD_LONG)
+      .withPrimaryKeys(FIELD_KEY.getName())
+      .withIndexes(FIELD_STRING.getName())
+      .build();
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    postgres = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    injector.getInstance(StructuredTableRegistry.class).initialize();
+    tableAdmin = injector.getInstance(StructuredTableAdmin.class);
+    Assert.assertEquals(PostgresSqlStructuredTableAdmin.class, tableAdmin.getClass());
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+    Assert.assertEquals(RetryingSqlTransactionRunner.class, transactionRunner.getClass());
+
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    if (postgres != null) {
+      postgres.close();
+    }
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    boolean doCleanup = true;
+    try {
+      TransactionRunners.run(transactionRunner, context -> {
+        context.getTable(TestTable.ID);
+      });
+    } catch (TableNotFoundException e) {
+      doCleanup = false;
+    }
+    if (doCleanup) {
+      tableAdmin.drop(TestTable.ID);
+    }
+  }
+
+  @Test(expected = TableNotFoundException.class)
+  public void testGetTableNotFound() {
+    TransactionRunners.run(transactionRunner, context -> {
+      context.getTable(TestTable.ID);
+    });
+  }
+
+  @Test
+  public void testGetOrCreate() {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable tableCreated = context.getOrCreateTable(TestTable.ID, TestTable.SPEC);
+      Assert.assertNotNull(tableCreated);
+      StructuredTable tableGot = context.getTable(TestTable.ID);
+      Assert.assertNotNull(tableGot);
+    });
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.k8s.runtime;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.master.environment.k8s.PodInfo;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
@@ -70,11 +71,11 @@ import java.util.stream.Collectors;
 
 /**
  * Kubernetes version of a TwillRunner.
- *
+ * <p>
  * Runs a program in Kubernetes by creating a config-map of the app spec and program options resources that are
  * expected to be found in the local files of the RuntimeSpecification for the TwillRunnable.
  * A deployment is created that mounts the created config-map.
- *
+ * <p>
  * Most of these operations are no-ops as many of these methods and pretty closely coupled to the Hadoop implementation
  * and have no analogy in Kubernetes.
  */
@@ -321,7 +322,21 @@ class KubeTwillPreparer implements TwillPreparer {
     }
   }
 
-  private V1Deployment createDeployment(V1ConfigMap configMap, long startTimeoutMillis) throws ApiException {
+  /**
+   * Return a {@link V1Deployment} object that will be deployed in Kubernetes to run the program
+   */
+  @VisibleForTesting
+  V1Deployment buildDeployment(RunId runid,
+                                      String appSpec,
+                                      String programOptions,
+                                      V1ObjectMeta deploymentMetadata,
+                                      String containerName,
+                                      int vCores,
+                                      int memoryMB,
+                                      Map<String, Map<String, String>> environments,
+                                      V1ConfigMap configMap,
+                                      PodInfo currentPodInfo,
+                                      long startTimeoutMillis) {
     /*
        The deployment will look something like:
        apiVersion: apps/v1
@@ -333,7 +348,6 @@ class KubeTwillPreparer implements TwillPreparer {
        template:
          [template spec]
      */
-    AppsV1Api appsApi = new AppsV1Api(apiClient);
     V1Deployment deployment = new V1Deployment();
 
     /*
@@ -347,8 +361,8 @@ class KubeTwillPreparer implements TwillPreparer {
            cdap.twill.run.id: [twill run id]
      */
     // Copy the meta and add the container label
-    V1ObjectMeta deploymentMeta = new V1ObjectMetaBuilder(resourceMeta).build();
-    deploymentMeta.putLabelsItem(podInfo.getContainerLabelName(), CONTAINER_NAME);
+    V1ObjectMeta deploymentMeta = new V1ObjectMetaBuilder(deploymentMetadata).build();
+    deploymentMeta.putLabelsItem(currentPodInfo.getContainerLabelName(), containerName);
     deploymentMeta.putAnnotationsItem(KubeTwillRunnerService.START_TIMEOUT_ANNOTATION,
                                       Long.toString(startTimeoutMillis));
     deployment.setMetadata(deploymentMeta);
@@ -412,41 +426,41 @@ class KubeTwillPreparer implements TwillPreparer {
     // Define volumes in the pod.
     V1Volume podInfoVolume = getPodInfoVolume();
     V1Volume configVolume = getConfigVolume(configMap);
-    List<V1Volume> volumes = new ArrayList<>(podInfo.getVolumes());
+    List<V1Volume> volumes = new ArrayList<>(currentPodInfo.getVolumes());
     volumes.add(podInfoVolume);
     volumes.add(configVolume);
     podSpec.setVolumes(volumes);
 
     // Set the service for RBAC control for app.
-    podSpec.setServiceAccountName(podInfo.getServiceAccountName());
+    podSpec.setServiceAccountName(currentPodInfo.getServiceAccountName());
 
     // Set the runtime class name to be the same as app-fabric
     // This is for protection against running user code
-    podSpec.setRuntimeClassName(podInfo.getRuntimeClassName());
+    podSpec.setRuntimeClassName(currentPodInfo.getRuntimeClassName());
 
     V1Container container = new V1Container();
-    container.setName(CONTAINER_NAME);
-    container.setImage(podInfo.getContainerImage());
+    container.setName(containerName);
+    container.setImage(currentPodInfo.getContainerImage());
 
     // Add volume mounts to the container. Add those from the current pod for mount cdap and hadoop conf.
-    String configDir = podInfo.getPodInfoDir() + "-app";
-    List<V1VolumeMount> volumeMounts = new ArrayList<>(podInfo.getContainerVolumeMounts());
+    String configDir = currentPodInfo.getPodInfoDir() + "-app";
+    List<V1VolumeMount> volumeMounts = new ArrayList<>(currentPodInfo.getContainerVolumeMounts());
     volumeMounts.add(new V1VolumeMount().name(podInfoVolume.getName())
-                       .mountPath(podInfo.getPodInfoDir()).readOnly(true));
+                       .mountPath(currentPodInfo.getPodInfoDir()).readOnly(true));
     volumeMounts.add(new V1VolumeMount().name(configVolume.getName())
                        .mountPath(configDir).readOnly(true));
     container.setVolumeMounts(volumeMounts);
 
     V1ResourceRequirements resourceRequirements = new V1ResourceRequirements();
     Map<String, Quantity> quantityMap = new HashMap<>();
-    quantityMap.put("cpu", new Quantity(String.valueOf(vcores)));
+    quantityMap.put("cpu", new Quantity(String.valueOf(vCores)));
     // Use slight larger container size
     quantityMap.put("memory", new Quantity(String.format("%dMi", (int) (memoryMB * 1.2f))));
     resourceRequirements.setRequests(quantityMap);
     container.setResources(resourceRequirements);
 
     // Setup the container environment. Inherit everything from the current pod.
-    Map<String, String> environs = podInfo.getContainerEnvironments().stream()
+    Map<String, String> environs = currentPodInfo.getContainerEnvironments().stream()
       .collect(Collectors.toMap(V1EnvVar::getName, V1EnvVar::getValue));
 
     // assumption is there is only a single runnable
@@ -460,16 +474,28 @@ class KubeTwillPreparer implements TwillPreparer {
 
     // when other program types are supported, there will need to be a mapping from program type to main class
     container.setArgs(Arrays.asList("io.cdap.cdap.internal.app.runtime.k8s.UserServiceProgramMain", "--env=k8s",
-                                    String.format("--appSpecPath=%s/%s", configDir, APP_SPEC),
-                                    String.format("--programOptions=%s/%s", configDir, PROGRAM_OPTIONS),
-                                    String.format("--twillRunId=%s", twillRunId.getId())));
+                                    String.format("--appSpecPath=%s/%s", configDir, appSpec),
+                                    String.format("--programOptions=%s/%s", configDir, programOptions),
+                                    String.format("--twillRunId=%s", runid.getId())));
     podSpec.setContainers(Collections.singletonList(container));
 
     templateSpec.setSpec(podSpec);
     spec.setTemplate(templateSpec);
     deployment.setSpec(spec);
 
-    LOG.trace("Creating deployment {} in Kubernetes", resourceMeta.getName());
+    return deployment;
+  }
+
+  /**
+   * Build a {@link V1Deployment} object to run the program and deploy it in kubernete
+   */
+  private V1Deployment createDeployment(V1ConfigMap configMap, long startTimeoutMillis) throws ApiException {
+    AppsV1Api appsApi = new AppsV1Api(apiClient);
+
+    V1Deployment deployment = buildDeployment(twillRunId, APP_SPEC, PROGRAM_OPTIONS, resourceMeta, CONTAINER_NAME,
+                                              vcores, memoryMB, environments, configMap, podInfo,
+                                              startTimeoutMillis);
+
     deployment = appsApi.createNamespacedDeployment(kubeNamespace, deployment, "true", null, null);
     LOG.info("Created deployment {} in Kubernetes", resourceMeta.getName());
     return deployment;

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableContext.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableContext.java
@@ -18,6 +18,9 @@ package io.cdap.cdap.spi.data;
 
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+
+import java.io.IOException;
 
 /**
  * This interface provides methods that instantiate a {@link StructuredTable} during the runtime.
@@ -36,4 +39,18 @@ public interface StructuredTableContext {
    */
   StructuredTable getTable(StructuredTableId tableId)
     throws StructuredTableInstantiationException, TableNotFoundException;
+
+  /**
+   * Get an instance of the specified Dataset. If none exist, create one based on the given
+   * {@link StructuredTableSpecification} first and then returns it.
+   *
+   * @param tableId the table id
+   * @return An instance of the specified table, never null
+   * @throws StructuredTableInstantiationException if the table cannot be instantiated
+   * @throws TableNotFoundException if table was deleted after existence check, therefore leading to table not found
+   * @throws IOException if table creation failed
+   */
+  StructuredTable getOrCreateTable(StructuredTableId tableId, StructuredTableSpecification tableSpec)
+    throws StructuredTableInstantiationException, IOException, TableNotFoundException;
 }
+


### PR DESCRIPTION
    What:
    Adding an API that creates table if doesn't exist. At the moment,
    it is not being used anywhere.

    Why:
    To support all services using their own local levelDB, system apps
    running in their own k8s pods may need to create tables themselves
    instead of depending on appfabric to create those tables.

    For instance, wrangler creates a few tables as part of its application
    configuration, which runs as part of deploying the app in appfabric.
    But wrangler runs in a k8s pod in kubernete. This is fine if all
    services share a SQL database, but problematic when each service
    uses its local levelDB.

    Next step:
    Switch wrangler from getTable() to getOrCreateTable(), therefore
    it can runs with either shared SQL configuration or non-sharing
    local levelDB.
