### PR TITLE
(CDAP-16353) fixing test breakage due to appfabric being stopped too soon

### DIFF
--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -503,7 +503,7 @@ public class TestBase {
       authorizerInstantiator.get().grant(Authorizable.fromEntityId(NamespaceId.DEFAULT),
                                          principal, ImmutableSet.of(Action.ADMIN));
     }
-    appFabricServer.stopAndWait();
+    
     namespaceAdmin.delete(NamespaceId.DEFAULT);
     authorizerInstantiator.close();
 
@@ -524,10 +524,10 @@ public class TestBase {
     metadataSubscriberService.stopAndWait();
     Closeables.closeQuietly(metadataStorage);
     txService.stopAndWait();
-
     if (messagingService instanceof Service) {
       ((Service) messagingService).stopAndWait();
     }
+    appFabricServer.stopAndWait();
   }
 
   protected MetricsManager getMetricsManager() {


### PR DESCRIPTION
Why:
Hydrator tests failing
...
	at io.cdap.cdap.spi.data.transaction.TransactionRunners.run(TransactionRunners.java:165)
	at io.cdap.cdap.scheduler.CoreSchedulerService.execute(CoreSchedulerService.java:652)
	at io.cdap.cdap.scheduler.CoreSchedulerService.deleteSchedules(CoreSchedulerService.java:407)
	at io.cdap.cdap.internal.app.services.ApplicationLifecycleService.deleteApp(ApplicationLifecycleService.java:705)
	at io.cdap.cdap.internal.app.services.ApplicationLifecycleService.removeAppInternal(ApplicationLifecycleService.java:552)
	at io.cdap.cdap.internal.app.services.ApplicationLifecycleService.removeAll(ApplicationLifecycleService.java:521)
	at io.cdap.cdap.internal.app.namespace.DefaultNamespaceResourceDeleter.deleteResources(DefaultNamespaceResourceDeleter.java:88)
	at io.cdap.cdap.internal.app.namespace.DefaultNamespaceAdmin.delete(DefaultNamespaceAdmin.java:270)
	at io.cdap.cdap.test.TestBase.finish(TestBase.java:507)
...

What:
Shutdown appfabric server after namespace deletion.
Move the appfabric all the way to the end in case other services still need it to be up