### PR TITLE
(CDAP-16369) Introduce new runtime service

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DefaultProgramRunnerFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DefaultProgramRunnerFactory.java
@@ -70,7 +70,7 @@ public final class DefaultProgramRunnerFactory implements ProgramRunnerFactory {
     ProgramRunner runner;
 
     if (provider != null) {
-      LOG.debug("Using runtime provider {} for program type {}", provider, programType);
+      LOG.trace("Using runtime provider {} for program type {}", provider, programType);
       runner = provider.createProgramRunner(programType, mode, injector);
     } else {
       Provider<ProgramRunner> defaultProvider = defaultRunnerProviders.get(programType);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/RuntimeServerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/RuntimeServerModule.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.guice;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.PrivateModule;
+import com.google.inject.Provider;
+import com.google.inject.Scopes;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.runtime.monitor.DirectRuntimeRequestValidator;
+import io.cdap.cdap.internal.app.runtime.monitor.LogAppenderLogProcessor;
+import io.cdap.cdap.internal.app.runtime.monitor.RemoteExecutionLogProcessor;
+import io.cdap.cdap.internal.app.runtime.monitor.RuntimeRequestValidator;
+import io.cdap.cdap.internal.app.runtime.monitor.RuntimeServer;
+import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
+
+/**
+ * A Guice module for exposing {@link RuntimeServer} for runtime monitoring.
+ */
+public class RuntimeServerModule extends PrivateModule {
+
+  @Override
+  protected void configure() {
+    bind(RuntimeRequestValidator.class).to(DirectRuntimeRequestValidator.class).in(Scopes.SINGLETON);
+    bind(RemoteExecutionLogProcessor.class).to(LogAppenderLogProcessor.class).in(Scopes.SINGLETON);
+    bind(ProgramRunRecordFetcher.class).toProvider(ProgramRunRecordFetcherProvider.class);
+
+    bind(RuntimeServer.class).in(Scopes.SINGLETON);
+    expose(RuntimeServer.class);
+  }
+
+  /**
+   * Provider for {@link ProgramRunRecordFetcher}. Implementation returned is based on CDAP configuration.
+   */
+  private static final class ProgramRunRecordFetcherProvider implements Provider<ProgramRunRecordFetcher> {
+
+    private final Injector injector;
+    private final Class<? extends ProgramRunRecordFetcher> fetcherClass;
+
+    @Inject
+    ProgramRunRecordFetcherProvider(Injector injector, CConfiguration cConf) {
+      this.injector = injector;
+      this.fetcherClass = cConf.getClass(Constants.RuntimeMonitor.RUN_RECORD_FETCHER_CLASS, null,
+                                         ProgramRunRecordFetcher.class);
+      if (fetcherClass == null) {
+        throw new IllegalStateException("Missing configuration " + Constants.RuntimeMonitor.RUN_RECORD_FETCHER_CLASS);
+      }
+    }
+
+    @Override
+    public ProgramRunRecordFetcher get() {
+      return injector.getInstance(fetcherClass);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStatePublisher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStatePublisher.java
@@ -51,7 +51,8 @@ public class MessagingProgramStatePublisher implements ProgramStatePublisher {
   private final TopicId topicId;
   private final RetryStrategy retryStrategy;
 
-  MessagingProgramStatePublisher(MessagingService messagingService, TopicId topicId, RetryStrategy retryStrategy) {
+  public MessagingProgramStatePublisher(MessagingService messagingService,
+                                        TopicId topicId, RetryStrategy retryStrategy) {
     this.messagingService = messagingService;
     this.topicId = topicId;
     this.retryStrategy = retryStrategy;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStateWriter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStateWriter.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.internal.app.program;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -36,8 +37,6 @@ import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -46,7 +45,7 @@ import javax.inject.Inject;
  * An implementation of ProgramStateWriter that publishes program status events to TMS
  */
 public final class MessagingProgramStateWriter implements ProgramStateWriter {
-  private static final Logger LOG = LoggerFactory.getLogger(MessagingProgramStateWriter.class);
+
   private static final Gson GSON =
     ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
       .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
@@ -57,11 +56,15 @@ public final class MessagingProgramStateWriter implements ProgramStateWriter {
 
   @Inject
   public MessagingProgramStateWriter(CConfiguration cConf, MessagingService messagingService) {
-    this.programStatePublisher =
-      new MessagingProgramStatePublisher(messagingService,
-                                         NamespaceId.SYSTEM.topic(cConf.get(
-                                           Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)),
-                                         RetryStrategies.fromConfiguration(cConf, "system.program.state."));
+    this(new MessagingProgramStatePublisher(messagingService,
+                                            NamespaceId.SYSTEM.topic(cConf.get(
+                                              Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)),
+                                            RetryStrategies.fromConfiguration(cConf, "system.program.state.")));
+  }
+
+  @VisibleForTesting
+  public MessagingProgramStateWriter(ProgramStatePublisher programStatePublisher) {
+    this.programStatePublisher = programStatePublisher;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.ServiceUnavailableException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.runtime.distributed.remote.RemoteRuntimeTable;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.netty.handler.codec.http.HttpRequest;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link RuntimeRequestValidator} implementation that reads from the runtime table directly.
+ */
+final class DirectRuntimeRequestValidator implements RuntimeRequestValidator {
+
+  private final TransactionRunner transactionRunner;
+  private final LoadingCache<ProgramRunId, Boolean> programRunsCache;
+
+  DirectRuntimeRequestValidator(CConfiguration cConf, TransactionRunner transactionRunner) {
+    this.transactionRunner = transactionRunner;
+
+    // Configure the cache with expiry the poll time.
+    // This helps reducing the actual lookup for a burst of requests within one poll interval,
+    // but not to keep it too long so that data becomes stale.
+    long pollTimeMillis = cConf.getLong(Constants.RuntimeMonitor.POLL_TIME_MS);
+    this.programRunsCache = CacheBuilder.newBuilder()
+      .expireAfterWrite(pollTimeMillis, TimeUnit.MILLISECONDS)
+      .build(new CacheLoader<ProgramRunId, Boolean>() {
+        @Override
+        public Boolean load(ProgramRunId programRunId) throws IOException {
+          return isValid(programRunId);
+        }
+      });
+  }
+
+  @Override
+  public void validate(ProgramRunId programRunId, HttpRequest request) throws BadRequestException {
+    boolean exists;
+    try {
+      exists = programRunsCache.get(programRunId);
+    } catch (Exception e) {
+      throw new ServiceUnavailableException(Constants.Service.RUNTIME, e);
+    }
+    if (!exists) {
+      throw new BadRequestException("Program run " + programRunId + " is not valid");
+    }
+  }
+
+  /**
+   * Checks if the given {@link ProgramRunId} is valid.
+   */
+  private boolean isValid(ProgramRunId programRunId) throws IOException {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return RemoteRuntimeTable.create(context).exists(programRunId);
+    }, IOException.class);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.AbstractIterator;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.messaging.MessagingContext;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.logging.LogSamplers;
+import io.cdap.cdap.common.logging.Loggers;
+import io.cdap.cdap.common.service.AbstractRetryableScheduledService;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.data.MessageId;
+import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.TopicId;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterators;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * A service that periodically relay messages from local TMS to the runtime server.
+ * This service runs in the remote runtime.
+ */
+public class RuntimeClientService extends AbstractRetryableScheduledService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RuntimeClientService.class);
+  private static final Logger PROGRESS_LOG = Loggers.sampling(LOG,
+                                                              LogSamplers.limitRate(TimeUnit.SECONDS.toMillis(30)));
+  private static final Gson GSON = new Gson();
+
+  private final Map<String, TopicRelayer> topicRelayers;
+  private final MessagingContext messagingContext;
+  private final long pollTimeMillis;
+  private final long gracefulShutdownMillis;
+  private final ProgramRunId programRunId;
+  private final RuntimeClient runtimeClient;
+  private final int fetchLimit;
+  private long programFinishTime;
+
+  @Inject
+  RuntimeClientService(CConfiguration cConf, MessagingService messagingService,
+                       DiscoveryServiceClient discoveryServiceClient, ProgramRunId programRunId) {
+    super(RetryStrategies.fromConfiguration(cConf, "system.runtime.monitor."));
+    this.messagingContext = new MultiThreadMessagingContext(messagingService);
+    this.pollTimeMillis = cConf.getLong(Constants.RuntimeMonitor.POLL_TIME_MS);
+    this.gracefulShutdownMillis = cConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS);
+    this.programRunId = programRunId;
+    this.runtimeClient = new RuntimeClient(discoveryServiceClient);
+    this.fetchLimit = cConf.getInt(Constants.RuntimeMonitor.BATCH_SIZE);
+    this.programFinishTime = -1L;
+    this.topicRelayers = RuntimeMonitors.createTopicConfigs(cConf).entrySet().stream()
+      .collect(Collectors.toMap(Map.Entry::getKey, e -> createTopicRelayer(cConf, e.getValue())));
+  }
+
+  @Override
+  protected long runTask() throws Exception {
+    long nextPollDelay = pollTimeMillis;
+    for (Map.Entry<String, TopicRelayer> entry : topicRelayers.entrySet()) {
+      TopicRelayer topicRelayer = entry.getValue();
+      nextPollDelay = Math.min(nextPollDelay, topicRelayer.publishMessages());
+    }
+
+    // If we got the program finished state, determine when to shutdown
+    if (programFinishTime > 0) {
+      // Gives half the time of the graceful shutdown time to allow empty fetches
+      // Essentially is the wait time for any unpublished events on the remote runtime to publish
+      // E.g. Metrics from the remote runtime process might have some delay after the program state changed,
+      // even though we explicitly flush the metrics on program completion.
+      // If the nextPollDelay returned by all topicRelays equals to the pollTimeMillis,
+      // that means all of them fetched till the end of the corresponding topic in the latest fetch.
+      long now = System.currentTimeMillis();
+      if ((nextPollDelay == pollTimeMillis && now - (gracefulShutdownMillis >> 1) > programFinishTime)
+          || (now - gracefulShutdownMillis > programFinishTime)) {
+        stop();
+      }
+    }
+
+    return nextPollDelay;
+  }
+
+  @Override
+  protected boolean shouldRetry(Exception e) {
+    LOG.warn("Failed to send runtime status. Will be retried.", e);
+    return true;
+  }
+
+  @Override
+  protected void doShutdown() throws Exception {
+    // Close all the TopicRelay, which will flush out all pending messages
+    for (TopicRelayer topicRelayer : topicRelayers.values()) {
+      Retries.callWithRetries((Retries.Callable<Void, IOException>) () -> {
+        topicRelayer.close();
+        return null;
+      }, getRetryStrategy(), t -> t instanceof IOException || t instanceof RetryableException);
+    }
+  }
+
+  @VisibleForTesting
+  long getProgramFinishTime() {
+    return programFinishTime;
+  }
+
+  /**
+   * Creates an instance of {@link TopicRelayer} based on the topic.
+   */
+  private TopicRelayer createTopicRelayer(CConfiguration cConf, String topic) {
+    TopicId topicId = NamespaceId.SYSTEM.topic(topic);
+
+    String programStatusTopic = cConf.get(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC);
+    if (programStatusTopic.equals(topic)) {
+      return new ProgramStatusTopicRelayer(topicId);
+    }
+    return new TopicRelayer(topicId);
+  }
+
+  /**
+   * Helper class to fetch and publish messages from one topic.
+   */
+  private class TopicRelayer implements Closeable {
+
+    private final TopicId topicId;
+    private String lastMessageId;
+    private long nextPublishTimeMillis;
+
+    TopicRelayer(TopicId topicId) {
+      this.topicId = topicId;
+    }
+
+    /**
+     * Fetches messages from the {@link MessagingContext} and publish them using {@link RuntimeClient}.
+     *
+     * @return delay in milliseconds till the next poll
+     * @throws TopicNotFoundException if the TMS topic to fetch from does not exist
+     * @throws IOException if failed to read from TMS or write to RuntimeClient
+     */
+    long publishMessages() throws TopicNotFoundException, IOException {
+      long currentTimeMillis = System.currentTimeMillis();
+
+      // Not too publish more than necessary in one topic.
+      // This method might get called more than once even before the next publish time is hit.
+      if (currentTimeMillis < nextPublishTimeMillis) {
+        return nextPublishTimeMillis - currentTimeMillis;
+      }
+
+      try (CloseableIterator<Message> iterator = messagingContext.getMessageFetcher().fetch(topicId.getNamespace(),
+                                                                                            topicId.getTopic(),
+                                                                                            fetchLimit,
+                                                                                            lastMessageId)) {
+        AtomicInteger messageCount = new AtomicInteger();
+        if (iterator.hasNext()) {
+          String[] messageId = new String[1];
+          processMessages(new AbstractIterator<Message>() {
+            @Override
+            protected Message computeNext() {
+              if (!iterator.hasNext()) {
+                return endOfData();
+              }
+              Message message = iterator.next();
+              messageId[0] = message.getId();
+              messageCount.incrementAndGet();
+              return message;
+            }
+          });
+
+          // Update the lastMessageId if sendMessages succeeded
+          lastMessageId = messageId[0] == null ? lastMessageId : messageId[0];
+          PROGRESS_LOG.debug("Processed {} messages on topic {}", messageCount.get(), topicId);
+        }
+
+        // If we fetched all messages, then delay the next poll by pollTimeMillis.
+        // Otherwise, try to poll again immediately.
+        nextPublishTimeMillis = System.currentTimeMillis();
+        if (messageCount.get() >= fetchLimit) {
+          return 0L;
+        }
+        nextPublishTimeMillis += pollTimeMillis;
+        return pollTimeMillis;
+      }
+    }
+
+    /**
+     * Processes the give list of {@link Message}. By default it sends them through the {@link RuntimeClient}.
+     */
+    protected void processMessages(Iterator<Message> iterator) throws IOException {
+      runtimeClient.sendMessages(programRunId, topicId, iterator);
+    }
+
+    @Override
+    public void close() throws IOException {
+      // no-op
+    }
+  }
+
+  /**
+   * A {@link TopicRelayer} specifically for handling program state events.
+   * We need special handling for program state to delay the relaying of terminal program status
+   * to give a grace period for messages in other topics to send out.
+   */
+  private class ProgramStatusTopicRelayer extends TopicRelayer {
+
+    private final List<Message> lastProgramStateMessages;
+
+    ProgramStatusTopicRelayer(TopicId topicId) {
+      super(topicId);
+      this.lastProgramStateMessages = new LinkedList<>();
+    }
+
+    @Override
+    protected void processMessages(Iterator<Message> iterator) throws IOException {
+      List<Message> message = StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false)
+        .collect(Collectors.toList());
+
+      if (programFinishTime < 0) {
+        programFinishTime = findProgramFinishTime(message);
+      }
+      if (programFinishTime >= 0) {
+        // Buffer the program state messages and don't publish them until the end
+        // Otherwise, once we publish, the deprovisioner will kick in and delete the cluster
+        // which could result in losing the last set of messages for some topics.
+        // Since we already consumed the incoming Iterator, the next fetch offset is being updated.
+        // This is to avoid fetching duplicate messages.
+        lastProgramStateMessages.addAll(message);
+
+        // Send an empty iterator to serve as the heartbeat.
+        super.processMessages(Collections.emptyIterator());
+      } else {
+        // If the program is not yet finished, just publish the messages
+        super.processMessages(message.iterator());
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (!lastProgramStateMessages.isEmpty()) {
+        super.processMessages(lastProgramStateMessages.iterator());
+        lastProgramStateMessages.clear();
+      }
+    }
+
+    /**
+     * Returns the time where the program finished, meaning it reaches one of the terminal states. If the given
+     * list of {@link Message} doesn't contain such information, {@code -1L} is returned.
+     */
+    private long findProgramFinishTime(List<Message> messages) {
+      for (Message message : messages) {
+        Notification notification = GSON.fromJson(message.getPayloadAsString(), Notification.class);
+        if (notification.getNotificationType() != Notification.Type.PROGRAM_STATUS) {
+          continue;
+        }
+
+        Map<String, String> properties = notification.getProperties();
+        String programRun = properties.get(ProgramOptionConstants.PROGRAM_RUN_ID);
+        String programStatus = properties.get(ProgramOptionConstants.PROGRAM_STATUS);
+
+        if (programRun == null || programStatus == null) {
+          continue;
+        }
+
+        // Only match the program state change for the program run it is monitoring
+        // For Workflow case, there could be multiple state changes for programs running inside the workflow.
+        ProgramRunId messageRunId = GSON.fromJson(programRun, ProgramRunId.class);
+        if (!programRunId.equals(messageRunId)) {
+          continue;
+        }
+
+        if (ProgramRunStatus.isEndState(programStatus)) {
+          try {
+            return Long.parseLong(properties.get(ProgramOptionConstants.END_TIME));
+          } catch (Exception e) {
+            // END_TIME should be a valid long. In case there is any problem, use the timestamp in the message ID
+            return new MessageId(Bytes.fromHexString(message.getId())).getPublishTimestamp();
+          }
+        }
+      }
+
+      return -1L;
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeHandler.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.messaging.MessagingContext;
 import io.cdap.cdap.api.messaging.TopicNotFoundException;
 import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
@@ -49,6 +50,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import javax.ws.rs.POST;
@@ -64,10 +66,15 @@ public class RuntimeHandler extends AbstractHttpHandler {
 
   private final MessagingContext messagingContext;
   private final RuntimeRequestValidator requestValidator;
+  private final RemoteExecutionLogProcessor logProcessor;
+  private final String logsTopicPrefix;
 
-  RuntimeHandler(MessagingContext messagingContext, RuntimeRequestValidator requestValidator) {
+  RuntimeHandler(CConfiguration cConf, MessagingContext messagingContext,
+                 RemoteExecutionLogProcessor logProcessor, RuntimeRequestValidator requestValidator) {
     this.requestValidator = requestValidator;
+    this.logProcessor = logProcessor;
     this.messagingContext = messagingContext;
+    this.logsTopicPrefix = cConf.get(Constants.Logging.TMS_TOPIC_PREFIX);
   }
 
   @Override
@@ -108,7 +115,20 @@ public class RuntimeHandler extends AbstractHttpHandler {
                                                  ProgramType.valueOfCategoryName(programType, BadRequestException::new),
                                                  program, run);
     requestValidator.validate(programRunId, request);
-    return new MessageBodyConsumer(messagingContext, NamespaceId.SYSTEM.topic(topic));
+
+    TopicId topicId = NamespaceId.SYSTEM.topic(topic);
+    if (topic.startsWith(logsTopicPrefix)) {
+      return new MessageBodyConsumer(topicId, logProcessor::process);
+    }
+
+    return new MessageBodyConsumer(topicId, payloads -> {
+      try {
+        messagingContext.getDirectMessagePublisher().publish(topicId.getNamespace(),
+                                                             topicId.getTopic(), payloads);
+      } catch (TopicNotFoundException e) {
+        throw new BadRequestException(e);
+      }
+    });
   }
 
   /**
@@ -119,8 +139,8 @@ public class RuntimeHandler extends AbstractHttpHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageBodyConsumer.class);
 
-    private final MessagingContext messagingContext;
     private final TopicId topicId;
+    private final PayloadProcessor payloadProcessor;
     private final CompositeByteBuf buffer;
     private final DelegatingInputStream inputStream;
     private final Decoder decoder;
@@ -128,9 +148,9 @@ public class RuntimeHandler extends AbstractHttpHandler {
     private ByteBuffer payload;
     private long items;
 
-    MessageBodyConsumer(MessagingContext messagingContext, TopicId topicId) {
-      this.messagingContext = messagingContext;
+    MessageBodyConsumer(TopicId topicId, PayloadProcessor payloadProcessor) {
       this.topicId = topicId;
+      this.payloadProcessor = payloadProcessor;
       this.buffer = Unpooled.compositeBuffer();
       this.inputStream = new DelegatingInputStream(new ByteBufInputStream(buffer));
       this.decoder = DecoderFactory.get().directBinaryDecoder(inputStream, null);
@@ -161,12 +181,11 @@ public class RuntimeHandler extends AbstractHttpHandler {
 
           if (!payloads.isEmpty()) {
             try {
-              messagingContext.getDirectMessagePublisher().publish(topicId.getNamespace(),
-                                                                   topicId.getTopic(), payloads.iterator());
+              payloadProcessor.process(payloads.iterator());
               payloads.clear();
             } catch (IOException e) {
-              // If we cannot publish, just continue to keep buffering messages and retry at the next/finished called.
-              LOG.debug("Failed to publish message to {}. Will be retried", topicId, e);
+              // If we cannot process, just continue to keep buffering messages and retry at the next/finished called.
+              LOG.debug("Failed to process payload for topic {}. Will be retried", topicId, e);
             }
           }
 
@@ -176,7 +195,7 @@ public class RuntimeHandler extends AbstractHttpHandler {
         } catch (EOFException e) {
           inputStream.reset();
         }
-      } catch (TopicNotFoundException | IOException e) {
+      } catch (IOException | BadRequestException e) {
         responder.sendString(HttpResponseStatus.BAD_REQUEST,
                              "Failed to process request due to exception " + e.getMessage());
         throw new RuntimeException(e);
@@ -191,14 +210,13 @@ public class RuntimeHandler extends AbstractHttpHandler {
           return;
         }
         try {
-          messagingContext.getDirectMessagePublisher().publish(topicId.getNamespace(),
-                                                               topicId.getTopic(), payloads.iterator());
+          payloadProcessor.process(payloads.iterator());
           responder.sendStatus(HttpResponseStatus.OK);
-        } catch (TopicNotFoundException e) {
-          responder.sendString(HttpResponseStatus.BAD_REQUEST, "Topic not found " + topicId);
+        } catch (BadRequestException e) {
+          responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
         } catch (IOException e) {
           responder.sendString(HttpResponseStatus.SERVICE_UNAVAILABLE,
-                               "Failed to publish all messages due to " + e.getMessage());
+                               "Failed to process all messages due to " + e.getMessage());
         }
       } finally {
         Closeables.closeQuietly(inputStream);
@@ -224,5 +242,21 @@ public class RuntimeHandler extends AbstractHttpHandler {
       Closeables.closeQuietly(in);
       in = delegate;
     }
+  }
+
+  /**
+   * An internal interface for processing payloads received from the
+   * {@link #writeMessages(HttpRequest, HttpResponder, String, String, String, String, String, String, String)}
+   * call.
+   */
+  private interface PayloadProcessor {
+
+    /**
+     * Process the given payload.
+     *
+     * @throws IOException if there is error when processing the payload
+     * @throws BadRequestException if the request is invalid
+     */
+    void process(Iterator<byte[]> payloads) throws IOException, BadRequestException;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeMonitors.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeMonitors.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.collect.Maps;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Utility class for runtime monitor.
+ */
+public final class RuntimeMonitors {
+
+  /**
+   * Creates a map from topic configuration name to the actual TMS topic based on the list of topic configuration names
+   * specified by the {@link Constants.RuntimeMonitor#TOPICS_CONFIGS} key.
+   */
+  public static Map<String, String> createTopicConfigs(CConfiguration cConf) {
+    return cConf.getTrimmedStringCollection(Constants.RuntimeMonitor.TOPICS_CONFIGS).stream().flatMap(key -> {
+      int idx = key.lastIndexOf(':');
+      if (idx < 0) {
+        return Stream.of(Maps.immutableEntry(key, cConf.get(key)));
+      }
+
+      try {
+        int totalTopicCount = Integer.parseInt(key.substring(idx + 1));
+        if (totalTopicCount <= 0) {
+          throw new IllegalArgumentException("Total topic number must be positive for system topic config '" +
+                                               key + "'.");
+        }
+        // For metrics, We make an assumption that number of metrics topics on runtime are not different than
+        // cdap system. So, we will add same number of topic configs as number of metrics topics so that we can
+        // keep track of different offsets for each metrics topic.
+        // TODO: CDAP-13303 - Handle different number of metrics topics between runtime and cdap system
+        String topicPrefix = key.substring(0, idx);
+        return IntStream
+          .range(0, totalTopicCount)
+          .mapToObj(i -> Maps.immutableEntry(topicPrefix + ":" + i, cConf.get(topicPrefix) + i));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Total topic number must be a positive number for system topic config'"
+                                             + key + "'.", e);
+      }
+    }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private RuntimeMonitors() {
+    // no-op
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeProgramStatusSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeProgramStatusSubscriberService.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.app.program.ProgramDescriptor;
+import io.cdap.cdap.app.runtime.ProgramOptions;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.utils.ImmutablePair;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.app.services.AbstractNotificationSubscriberService;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * A TMS subscriber service to replicate program status from the
+ * {@link Constants.AppFabric#PROGRAM_STATUS_RECORD_EVENT_TOPIC} to a local storage.
+ * It is for the {@link DirectRuntimeRequestValidator} to validate incoming requests that it is coming from
+ * a running program.
+ */
+public class RuntimeProgramStatusSubscriberService extends AbstractNotificationSubscriberService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RuntimeProgramStatusSubscriberService.class);
+  private static final Gson GSON = new Gson();
+
+  @Inject
+  RuntimeProgramStatusSubscriberService(CConfiguration cConf, MessagingService messagingService,
+                                        MetricsCollectionService metricsCollectionService,
+                                        TransactionRunner transactionRunner) {
+    super("runtime.program.status", cConf,
+          cConf.get(Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC),
+          cConf.getInt(Constants.AppFabric.STATUS_EVENT_FETCH_SIZE),
+          cConf.getLong(Constants.AppFabric.STATUS_EVENT_POLL_DELAY_MILLIS),
+          messagingService, metricsCollectionService, transactionRunner);
+  }
+
+  @Nullable
+  @Override
+  protected String loadMessageId(StructuredTableContext context) throws IOException {
+    return getAppMetadataStore(context).retrieveSubscriberState(getTopicId().getTopic(), "runtime");
+  }
+
+  @Override
+  protected void storeMessageId(StructuredTableContext context, String messageId) throws IOException {
+    getAppMetadataStore(context).persistSubscriberState(getTopicId().getTopic(), "runtime", messageId);
+  }
+
+  @Override
+  protected void processMessages(StructuredTableContext context,
+                                 Iterator<ImmutablePair<String, Notification>> messages) throws Exception {
+    while (messages.hasNext()) {
+      ImmutablePair<String, Notification> pair = messages.next();
+      Notification notification = pair.getSecond();
+      if (notification.getNotificationType() != Notification.Type.PROGRAM_STATUS) {
+        continue;
+      }
+      processNotification(pair.getFirst().getBytes(StandardCharsets.UTF_8), notification, getAppMetadataStore(context));
+    }
+  }
+
+  /**
+   * Processes a given {@link Notification} from TMS and updates the {@link AppMetadataStore}.
+   *
+   * @param sourceId the message id in TMS
+   * @param notification the {@link Notification} to process
+   * @param store the {@link AppMetadataStore} to write to
+   * @throws IOException if failed to write to the store
+   */
+  private void processNotification(byte[] sourceId, Notification notification,
+                                   AppMetadataStore store) throws IOException {
+    Map<String, String> properties = notification.getProperties();
+
+    ProgramRunId programRunId;
+    ProgramRunStatus programRunStatus;
+    try {
+      programRunId = GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_RUN_ID),
+                                                ProgramRunId.class);
+      if (programRunId == null) {
+        throw new IllegalArgumentException("Missing program run id from notification");
+      }
+      programRunStatus = ProgramRunStatus.valueOf(properties.get(ProgramOptionConstants.PROGRAM_STATUS));
+    } catch (Exception e) {
+      // This shouldn't happen. If it does, we can only log and ignore the event.
+      LOG.warn("Ignore notification due to unable to get program run id and program run status from notification {}",
+               notification, e);
+      return;
+    }
+
+    // Runtime server only needs the programRunId and status. We use the AppMetadataStore to record to help
+    // handling state transition correctly, but we omit certain fields when calling those record* methods since
+    // they are not used by the runtime server.
+    LOG.debug("Received program {} of status {} {}", programRunId, programRunStatus, Bytes.toString(sourceId));
+    switch (programRunStatus) {
+      case STARTING: {
+        ProgramOptions programOptions = ProgramOptions.fromNotification(notification, GSON);
+        store.recordProgramProvisioning(programRunId, programOptions.getUserArguments().asMap(),
+                                        programOptions.getArguments().asMap(), sourceId, null);
+        store.recordProgramProvisioned(programRunId, 0, sourceId);
+        store.recordProgramStart(programRunId, null, programOptions.getArguments().asMap(), sourceId);
+        break;
+      }
+      case RUNNING:
+        store.recordProgramRunning(programRunId,
+                                   Optional.ofNullable(properties.get(ProgramOptionConstants.LOGICAL_START_TIME))
+                                     .map(Long::parseLong).orElse(System.currentTimeMillis()),
+                                   null, sourceId);
+        break;
+      case SUSPENDED:
+        store.recordProgramSuspend(programRunId, sourceId,
+                                   Optional.ofNullable(properties.get(ProgramOptionConstants.SUSPEND_TIME))
+                                     .map(Long::parseLong).orElse(System.currentTimeMillis()));
+        break;
+      case RESUMING:
+        store.recordProgramResumed(programRunId, sourceId,
+                                   Optional.ofNullable(properties.get(ProgramOptionConstants.RESUME_TIME))
+                                     .map(Long::parseLong).orElse(System.currentTimeMillis()));
+        break;
+      case COMPLETED:
+      case FAILED:
+      case KILLED:
+        store.recordProgramStop(programRunId,
+                                Optional.ofNullable(properties.get(ProgramOptionConstants.END_TIME))
+                                  .map(Long::parseLong).orElse(System.currentTimeMillis()),
+                                programRunStatus, null, sourceId);
+        // We don't need to retain records for terminated programs, hence just delete it
+        store.deleteRunIfTerminated(programRunId, sourceId);
+        break;
+      case REJECTED: {
+        ProgramOptions programOptions = ProgramOptions.fromNotification(notification, GSON);
+        ProgramDescriptor programDescriptor =
+          GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_DESCRIPTOR), ProgramDescriptor.class);
+
+        store.recordProgramRejected(programRunId, programOptions.getUserArguments().asMap(),
+                                    programOptions.getArguments().asMap(), sourceId,
+                                    programDescriptor.getArtifactId().toApiArtifactId());
+        // We don't need to retain records for terminated programs, hence just delete it
+        store.deleteRunIfTerminated(programRunId,  sourceId);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Returns an instance of {@link AppMetadataStore}.
+   */
+  private AppMetadataStore getAppMetadataStore(StructuredTableContext context) {
+    return AppMetadataStore.create(context);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServer.java
@@ -53,10 +53,12 @@ public class RuntimeServer extends AbstractIdleService {
   @Inject
   RuntimeServer(CConfiguration cConf, RuntimeRequestValidator requestValidator,
                 DiscoveryService discoveryService, DiscoveryServiceClient discoveryServiceClient,
-                MessagingService messagingService, MetricsCollectionService metricsCollectionService) {
+                MessagingService messagingService, MetricsCollectionService metricsCollectionService,
+                RemoteExecutionLogProcessor logProcessor) {
     this.httpService = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.RUNTIME)
       .setHttpHandlers(new PingHandler(),
-                       new RuntimeHandler(new MultiThreadMessagingContext(messagingService), requestValidator),
+                       new RuntimeHandler(cConf, new MultiThreadMessagingContext(messagingService),
+                                          logProcessor, requestValidator),
                        new RuntimeServiceRoutingHandler(discoveryServiceClient, requestValidator))
       .setExceptionHandler(new HttpExceptionHandler())
       .setHandlerHooks(Collections.singleton(new MetricsReporterHook(metricsCollectionService,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -173,12 +173,12 @@ public class DefaultStore implements Store {
     Preconditions.checkArgument(runStatus != null, "Run state of program run should be defined");
     TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore metaStore = getAppMetadataStore(context);
-      WorkflowTable workflowTable = getWorkflowTable(context);
       metaStore.recordProgramStop(id, endTime, runStatus, failureCause, sourceId);
 
       // This block has been added so that completed workflow runs can be logged to the workflow dataset
       WorkflowId workflowId = new WorkflowId(id.getParent().getParent(), id.getProgram());
       if (id.getType() == ProgramType.WORKFLOW && runStatus == ProgramRunStatus.COMPLETED) {
+        WorkflowTable workflowTable = getWorkflowTable(context);
         recordCompletedWorkflow(metaStore, workflowTable, workflowId, id.getRun());
       }
       // todo: delete old history data

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/StoreProgramRunRecordFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/StoreProgramRunRecordFetcher.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * A {@link ProgramRunRecordFetcher} that uses {@link AppMetadataStore} for fetching run records directly.
+ */
+public class StoreProgramRunRecordFetcher implements ProgramRunRecordFetcher {
+
+  private final TransactionRunner txRunner;
+
+  @Inject
+  StoreProgramRunRecordFetcher(TransactionRunner txRunner) {
+    this.txRunner = txRunner;
+  }
+
+  @Override
+  public RunRecordDetail getRunRecordMeta(ProgramRunId runId) throws IOException, NotFoundException {
+    return Optional.ofNullable(TransactionRunners.run(txRunner, context -> {
+      return AppMetadataStore.create(context).getRun(runId);
+    }, IOException.class)).orElseThrow(() -> new NotFoundException(runId));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
@@ -140,6 +140,7 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
       cConf.addResource(new File(options.getExtraConfPath(), "cdap-site.xml").toURI().toURL());
       sConf.addResource(new File(options.getExtraConfPath(), "cdap-security.xml").toURI().toURL());
     }
+    cConf = updateCConf(cConf);
 
     Configuration hConf = new Configuration();
 
@@ -272,6 +273,16 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
    */
   protected Module getLogAppenderModule() {
     return new RemoteLogAppenderModule();
+  }
+
+  /**
+   * Updates the given {@link CConfiguration}.
+   *
+   * @param cConf the {@link CConfiguration} to be updated
+   * @return the updated configuration
+   */
+  protected CConfiguration updateCConf(CConfiguration cConf) {
+    return cConf;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
@@ -25,7 +25,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Provider;
-import com.google.inject.util.Modules;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.app.MainClassLoader;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -40,7 +39,8 @@ import io.cdap.cdap.common.options.OptionsParser;
 import io.cdap.cdap.common.runtime.DaemonMain;
 import io.cdap.cdap.common.utils.ProjectInfo;
 import io.cdap.cdap.data.runtime.ConstantTransactionSystemClient;
-import io.cdap.cdap.data.runtime.DataFabricModules;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.TransactionExecutorModule;
 import io.cdap.cdap.data2.transaction.DelegatingTransactionSystemClientService;
 import io.cdap.cdap.data2.transaction.TransactionSystemClientService;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
@@ -241,17 +241,19 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
    * Returns the Guice module for data-fabric bindings.
    */
   protected final Module getDataFabricModule() {
-    return Modules.override(
-      new DataFabricModules("master").getDistributedModules()).with(new AbstractModule() {
+    return new AbstractModule() {
       @Override
       protected void configure() {
+        install(new StorageModule());
+        install(new TransactionExecutorModule());
+
         // Bind transaction system to a constant one, basically no transaction, with every write become
         // visible immediately.
         // TODO: Ideally we shouldn't need this at all. However, it is needed now to satisfy dependencies
         bind(TransactionSystemClientService.class).to(DelegatingTransactionSystemClientService.class);
         bind(TransactionSystemClient.class).to(ConstantTransactionSystemClient.class);
       }
-    });
+    };
   }
 
   protected void initializeDataSourceConnection(CConfiguration cConf) throws SQLException {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.AuthorizationException;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.NamespaceAdminTestModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.ConstantTransactionSystemClient;
+import io.cdap.cdap.data.runtime.DataSetsModules;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.data2.dataset2.lib.table.inmemory.InMemoryTableService;
+import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
+import io.cdap.cdap.internal.app.runtime.distributed.remote.RemoteRuntimeTable;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
+import io.cdap.cdap.security.spi.authorization.AuthorizationEnforcer;
+import io.cdap.cdap.security.spi.authorization.NoOpAuthorizer;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.TableAlreadyExistsException;
+import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.cdap.store.StoreDefinition;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.apache.tephra.TransactionSystemClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+/**
+ * Unit test for {@link DirectRuntimeRequestValidator}.
+ */
+public class DirectRuntimeRequestValidatorTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private CConfiguration cConf;
+  private TransactionRunner transactionRunner;
+
+  @Before
+  public void setup() throws IOException, TableAlreadyExistsException {
+    cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().toString());
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new DataSetsModules().getInMemoryModules(),
+      new NamespaceAdminTestModule(),
+      new StorageModule(),
+      new AuthenticationContextModules().getNoOpModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+          bind(AuthorizationEnforcer.class).to(NoOpAuthorizer.class);
+          bind(TransactionSystemClient.class).to(ConstantTransactionSystemClient.class);
+        }
+      }
+    );
+
+    // Create runtime store definition
+    injector.getInstance(StructuredTableRegistry.class).initialize();
+    StoreDefinition.RemoteRuntimeStore.createTables(injector.getInstance(StructuredTableAdmin.class), true);
+
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+  }
+
+  @After
+  public void cleanup() {
+    // This clears the StructuredTableRegistry that is backed by InMemoryTableService, which is a singleton per JVM.
+    InMemoryTableService.reset();
+  }
+
+  @Test
+  public void testValid() throws BadRequestException, AuthorizationException {
+    ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
+
+    // Insert the run id
+    TransactionRunners.run(transactionRunner, context -> {
+      RemoteRuntimeTable.create(context).write(programRunId, new SimpleProgramOptions(programRunId.getParent()));
+    });
+
+    // Validation should pass
+    RuntimeRequestValidator validator = new DirectRuntimeRequestValidator(cConf, transactionRunner);
+    validator.validate(programRunId, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
+  }
+
+  @Test (expected = BadRequestException.class)
+  public void testInvalid() throws BadRequestException, AuthorizationException {
+    ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
+
+    // Validation should fail
+    RuntimeRequestValidator validator = new DirectRuntimeRequestValidator(cConf, transactionRunner);
+    validator.validate(programRunId, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.util.concurrent.Service;
+import com.google.gson.Gson;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.messaging.MessageFetcher;
+import io.cdap.cdap.api.messaging.MessagePublisher;
+import io.cdap.cdap.api.messaging.MessagingContext;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.app.runtime.ProgramStateWriter;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.common.utils.Tasks;
+import io.cdap.cdap.internal.app.program.MessagingProgramStateWriter;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
+import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterators;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
+
+/**
+ * Unit test for {@link RuntimeClientService}.
+ */
+public class RuntimeClientServiceTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  // The cConf value for the runtime monitor topic configs to have two topics, and one has to be program status event
+  // This is for testing the RuntimeClientService handling of program status correctly
+  private static final String TOPIC_CONFIGS_VALUE =
+    Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC
+      + "," + Constants.Metadata.MESSAGING_TOPIC
+      + "," + Constants.Audit.TOPIC;
+
+  private static final ProgramRunId PROGRAM_RUN_ID =
+    NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
+  private static final Gson GSON = new Gson();
+
+  private Map<String, String> topicConfigs;
+
+  // Services for the runtime server side
+  private MessagingService messagingService;
+  private RuntimeServer runtimeServer;
+
+  // Services for the runtime client side
+  private CConfiguration clientCConf;
+  private MessagingService clientMessagingService;
+  private RuntimeClientService runtimeClientService;
+
+  @Before
+  public void beforeTest() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS, TOPIC_CONFIGS_VALUE);
+    cConf.setInt(Constants.RuntimeMonitor.BIND_PORT, 0);
+
+    topicConfigs = RuntimeMonitors.createTopicConfigs(cConf);
+
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
+
+    // Injector for the server side
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new MessagingServerRuntimeModule().getInMemoryModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+          bind(RuntimeRequestValidator.class).toInstance((programRunId, request) -> { });
+          bind(RemoteExecutionLogProcessor.class).toInstance(payloads -> { });
+          bind(DiscoveryService.class).toInstance(discoveryService);
+          bind(DiscoveryServiceClient.class).toInstance(discoveryService);
+        }
+      }
+    );
+
+    messagingService = injector.getInstance(MessagingService.class);
+    if (messagingService instanceof Service) {
+      ((Service) messagingService).startAndWait();
+    }
+
+    runtimeServer = injector.getInstance(RuntimeServer.class);
+    runtimeServer.startAndWait();
+
+    // Injector for the client side
+    clientCConf = CConfiguration.create();
+    clientCConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    clientCConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS, TOPIC_CONFIGS_VALUE);
+
+    // Shorten the poll delay and grace period to speed up testing of program terminate state handling
+    clientCConf.setLong(Constants.RuntimeMonitor.POLL_TIME_MS, 200);
+    clientCConf.setLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS, 3000);
+    // Use smaller batch size so that fetches is broken into multiple fetches
+    clientCConf.setInt(Constants.RuntimeMonitor.BATCH_SIZE, 1);
+
+    injector = Guice.createInjector(
+      new ConfigModule(clientCConf),
+      new MessagingServerRuntimeModule().getInMemoryModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+          bind(DiscoveryService.class).toInstance(discoveryService);
+          bind(DiscoveryServiceClient.class).toInstance(discoveryService);
+          bind(ProgramRunId.class).toInstance(PROGRAM_RUN_ID);
+        }
+      }
+    );
+
+    clientMessagingService = injector.getInstance(MessagingService.class);
+    if (clientMessagingService instanceof Service) {
+      ((Service) clientMessagingService).startAndWait();
+    }
+    runtimeClientService = injector.getInstance(RuntimeClientService.class);
+    runtimeClientService.startAndWait();
+  }
+
+  @After
+  public void afterTest() {
+    runtimeClientService.stopAndWait();
+    if (clientMessagingService instanceof Service) {
+      ((Service) clientMessagingService).stopAndWait();
+    }
+
+    runtimeServer.stopAndWait();
+    if (messagingService instanceof Service) {
+      ((Service) messagingService).stopAndWait();
+    }
+  }
+
+  @Test
+  public void testBasicRelay() throws Exception {
+    // Send some messages to multiple topics in the client side TMS, they should get replicated to the server side TMS.
+    MessagingContext messagingContext = new MultiThreadMessagingContext(clientMessagingService);
+    MessagePublisher messagePublisher = messagingContext.getDirectMessagePublisher();
+    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(clientCConf, clientMessagingService);
+
+    for (Map.Entry<String, String> entry : topicConfigs.entrySet()) {
+      // For program status event topic, we need to send valid program status event because
+      // the RuntimeClientService will decode it to watch for program termination
+      if (entry.getKey().equals(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)) {
+        // Write a non-terminal state to test basic relaying
+        programStateWriter.running(PROGRAM_RUN_ID, null);
+      } else {
+        messagePublisher.publish(NamespaceId.SYSTEM.getNamespace(), entry.getValue(), entry.getKey(), entry.getKey());
+      }
+    }
+
+    MessagingContext serverMessagingContext = new MultiThreadMessagingContext(messagingService);
+    for (Map.Entry<String, String> entry : topicConfigs.entrySet()) {
+      if (entry.getKey().equals(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)) {
+        // Extract the program run status from the Notification
+        Tasks.waitFor(Collections.singletonList(ProgramRunStatus.RUNNING),
+                      () -> fetchMessages(serverMessagingContext, entry.getValue(), 10, null).stream()
+                        .map(Message::getPayloadAsString)
+                        .map(s -> GSON.fromJson(s, Notification.class))
+                        .map(n -> n.getProperties().get(ProgramOptionConstants.PROGRAM_STATUS))
+                        .map(ProgramRunStatus::valueOf)
+                        .collect(Collectors.toList()), 5, TimeUnit.SECONDS);
+      } else {
+        Tasks.waitFor(Arrays.asList(entry.getKey(), entry.getKey()),
+                      () -> fetchMessages(serverMessagingContext, entry.getValue(), 10, null)
+                        .stream().map(Message::getPayloadAsString).collect(Collectors.toList()),
+                      5, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  @Test
+  public void testProgramTerminate() throws Exception {
+    MessagingContext messagingContext = new MultiThreadMessagingContext(clientMessagingService);
+    MessagePublisher messagePublisher = messagingContext.getDirectMessagePublisher();
+
+    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(clientCConf, clientMessagingService);
+
+    // Send a terminate program state first, wait for the service sees the state change,
+    // then publish messages to other topics.
+    programStateWriter.completed(PROGRAM_RUN_ID);
+    Tasks.waitFor(true, () -> runtimeClientService.getProgramFinishTime() >= 0, 2, TimeUnit.SECONDS);
+
+    for (Map.Entry<String, String> entry : topicConfigs.entrySet()) {
+      // For program status event topic, we need to send valid program status event because
+      // the RuntimeClientService will decode it to watch for program termination
+      if (!entry.getKey().equals(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)) {
+        List<String> payloads = Arrays.asList(entry.getKey(), entry.getKey(), entry.getKey());
+        messagePublisher.publish(NamespaceId.SYSTEM.getNamespace(), entry.getValue(),
+                                 StandardCharsets.UTF_8, payloads.iterator());
+      }
+    }
+
+    // The client service should get stopped by itself.
+    Tasks.waitFor(Service.State.TERMINATED, () -> runtimeClientService.state(),
+                  clientCConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS), TimeUnit.MILLISECONDS);
+
+    // All messages should be sent after the runtime client service stopped
+    MessagingContext serverMessagingContext = new MultiThreadMessagingContext(messagingService);
+    for (Map.Entry<String, String> entry : topicConfigs.entrySet()) {
+      if (entry.getKey().equals(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)) {
+        // Extract the program run status from the Notification
+        Tasks.waitFor(Collections.singletonList(ProgramRunStatus.COMPLETED),
+                      () -> fetchMessages(serverMessagingContext, entry.getValue(), 10, null).stream()
+                        .map(Message::getPayloadAsString)
+                        .map(s -> GSON.fromJson(s, Notification.class))
+                        .map(n -> n.getProperties().get(ProgramOptionConstants.PROGRAM_STATUS))
+                        .map(ProgramRunStatus::valueOf)
+                        .collect(Collectors.toList()), 5, TimeUnit.SECONDS);
+      } else {
+        Tasks.waitFor(Arrays.asList(entry.getKey(), entry.getKey(), entry.getKey()),
+                      () -> fetchMessages(serverMessagingContext, entry.getValue(), 10, null)
+                        .stream().map(Message::getPayloadAsString).collect(Collectors.toList()),
+                      5, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  private List<Message> fetchMessages(MessagingContext messagingContext, String topic, int limit,
+                                      @Nullable String lastMessageId) throws TopicNotFoundException, IOException {
+    MessageFetcher messageFetcher = messagingContext.getMessageFetcher();
+    try (CloseableIterator<Message> iterator = messageFetcher.fetch(NamespaceId.SYSTEM.getNamespace(),
+                                                                    topic, limit, lastMessageId)) {
+      return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false).collect(Collectors.toList());
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
@@ -239,7 +239,7 @@ public class RuntimeClientServiceTest {
 
     // The client service should get stopped by itself.
     Tasks.waitFor(Service.State.TERMINATED, () -> runtimeClientService.state(),
-                  clientCConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS), TimeUnit.MILLISECONDS);
+                  clientCConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS) + 2000, TimeUnit.MILLISECONDS);
 
     // All messages should be sent after the runtime client service stopped
     MessagingContext serverMessagingContext = new MultiThreadMessagingContext(messagingService);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
@@ -103,6 +103,7 @@ public class RuntimeServiceRoutingTest {
         @Override
         protected void configure() {
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+          bind(RemoteExecutionLogProcessor.class).toInstance(bytes -> { });
           bind(RuntimeRequestValidator.class).toInstance((programRunId, request) -> {
             String authHeader = request.headers().get(HttpHeaderNames.AUTHORIZATION);
             String expected = "test " + Base64.getEncoder().encodeToString(

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -24,7 +24,6 @@ import com.google.gson.reflect.TypeToken;
 import io.cdap.cdap.AppForUnrecoverableResetTest;
 import io.cdap.cdap.AppWithDataset;
 import io.cdap.cdap.AppWithServices;
-import io.cdap.cdap.client.config.ConnectionConfig;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -865,6 +865,7 @@ public final class Constants {
     public static final String GRACEFUL_SHUTDOWN_MS = "app.program.runtime.monitor.graceful.shutdown.ms";
     public static final String THREADS = "app.program.runtime.monitor.threads";
     public static final String INIT_BATCH_SIZE = "app.program.runtime.monitor.initialize.batch.size";
+    public static final String RUN_RECORD_FETCHER_CLASS = "app.program.runtime.monitor.run.record.fetch.class";
 
     /**
      * Configuration to tell if the runtime monitoring is active

--- a/cdap-common/src/main/java/io/cdap/cdap/internal/app/store/RunRecordDetail.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/internal/app/store/RunRecordDetail.java
@@ -201,7 +201,7 @@ public final class RunRecordDetail extends RunRecord {
       return this;
     }
 
-    public Builder setTwillRunId(String twillRunId) {
+    public Builder setTwillRunId(@Nullable String twillRunId) {
       this.twillRunId = twillRunId;
       return this;
     }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2686,6 +2686,15 @@
   </property>
 
   <property>
+    <name>app.program.runtime.monitor.run.record.fetch.class</name>
+    <value>io.cdap.cdap.internal.app.store.StoreProgramRunRecordFetcher</value>
+    <description>
+      Class name of the ProgramRunRecordFetcher used by the runtime monitoring system.
+      This value controls the run record fetching mechanism depending on the CDAP setup.
+    </description>
+  </property>
+
+  <property>
     <name>app.program.runtime.monitor.server.bind.address</name>
     <value>0.0.0.0</value>
     <description>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2673,6 +2673,7 @@
     <value>5000</value>
     <description>
       Number of milliseconds to wait for the runtime to shutdown after a program execution completed in that runtime.
+      This value should be larger than the value of the "app.program.runtime.monitor.polltime.ms" property
     </description>
   </property>
 

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/AbstractWatcherThread.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/AbstractWatcherThread.java
@@ -221,7 +221,7 @@ public abstract class AbstractWatcherThread<T> extends Thread implements AutoClo
       // There is only single thread (the run thread) that will call this method,
       // hence if the watch was null outside of this sync block, it will stay as null here.
       String labelSelector = getSelector();
-      LOG.debug("Creating watch with label selector {}", labelSelector);
+      LOG.trace("Creating watch with label selector {}", labelSelector);
       Call call = createCall(namespace, labelSelector);
 
       this.watch = watch = Watch.createWatch(getApiClient(), call, watchResponseType);

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/discovery/DefaultServiceDiscovered.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/discovery/DefaultServiceDiscovered.java
@@ -65,7 +65,7 @@ public final class DefaultServiceDiscovered implements ServiceDiscovered {
       return;
     }
 
-    LOG.debug("Discoverables for service {} changed from {} to {}", name, oldDiscoverables, newDiscoverables);
+    LOG.trace("Discoverables for service {} changed from {} to {}", name, oldDiscoverables, newDiscoverables);
 
     // Collect all listeners with a read lock to the listener list.
     List<ListenerCaller> callers = new ArrayList<>();

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
@@ -32,7 +32,6 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.LocalLocationModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
-import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.gateway.handlers.CommonHandlers;
@@ -77,7 +76,6 @@ public class LogsServiceMain extends AbstractServiceMain<EnvironmentOptions> {
   @Override
   protected List<Module> getServiceModules(MasterEnvironment masterEnv, EnvironmentOptions options) {
     return Arrays.asList(
-      new NamespaceQueryAdminModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
       new AuthenticationContextModules().getMasterModule(),
       new MessagingClientModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
@@ -33,10 +33,8 @@ import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.data2.audit.AuditModule;
-import io.cdap.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
 import io.cdap.cdap.data2.metadata.writer.MessagingMetadataPublisher;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
-import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
@@ -47,7 +45,6 @@ import io.cdap.cdap.metadata.MetadataSubscriberService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -82,11 +79,9 @@ public class MetadataServiceMain extends AbstractServiceMain<EnvironmentOptions>
       // In K8s, there won't be HBase and the cdap-site should be set to use SQL store for StructuredTable.
       new SystemDatasetRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
-      new ExploreClientModule(),
       new MetadataServiceModule(),
       new AuditModule(),
       new EntityVerifierModule(),
-      new SecureStoreClientModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
       new AuthenticationContextModules().getMasterModule(),
       new DFSLocationModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.cdap.cdap.app.guice.RuntimeServerModule;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.logging.LoggingContext;
+import io.cdap.cdap.common.logging.ServiceLoggingContext;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.internal.app.runtime.monitor.RuntimeProgramStatusSubscriberService;
+import io.cdap.cdap.internal.app.runtime.monitor.RuntimeServer;
+import io.cdap.cdap.master.spi.environment.MasterEnvironment;
+import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
+import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.TableAlreadyExistsException;
+import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
+import io.cdap.cdap.store.StoreDefinition;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * The main class to run the runtime service for program runtime monitoring.
+ */
+public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> {
+
+  /**
+   * Main entry point
+   */
+  public static void main(String[] args) throws Exception {
+    main(RuntimeServiceMain.class, args);
+  }
+
+  @Override
+  protected List<Module> getServiceModules(MasterEnvironment masterEnv, EnvironmentOptions options) {
+    return Arrays.asList(
+      new MessagingClientModule(),
+      new SystemDatasetRuntimeModule().getStandaloneModules(),
+      getDataFabricModule(),
+      new RuntimeServerModule()
+    );
+  }
+
+  @Override
+  protected CConfiguration updateCConf(CConfiguration cConf) {
+    // Runtime service always maintain a storage locally for replicating program states from TMS.
+    cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
+    return cConf;
+  }
+
+  @Override
+  protected void addServices(Injector injector, List<? super Service> services,
+                             List<? super AutoCloseable> closeableResources,
+                             MasterEnvironment masterEnv, MasterEnvironmentContext masterEnvContext,
+                             EnvironmentOptions options) {
+    services.add(new AbstractIdleService() {
+      @Override
+      protected void startUp() throws Exception {
+        try {
+          StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
+                                          injector.getInstance(StructuredTableRegistry.class));
+        } catch (TableAlreadyExistsException e) {
+          // ignore
+        }
+      }
+
+      @Override
+      protected void shutDown() {
+        // no-op
+      }
+    });
+    services.add(injector.getInstance(RuntimeProgramStatusSubscriberService.class));
+    services.add(injector.getInstance(RuntimeServer.class));
+  }
+
+  @Nullable
+  @Override
+  protected LoggingContext getLoggingContext(EnvironmentOptions options) {
+    return new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
+                                     Constants.Logging.COMPONENT_NAME,
+                                     Constants.Service.RUNTIME);
+  }
+}

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
@@ -23,6 +23,8 @@ import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.security.KeyStores;
 import io.cdap.cdap.common.security.KeyStoresTest;
 import io.cdap.cdap.gateway.router.NettyRouter;
+import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
+import io.cdap.cdap.logging.gateway.handlers.RemoteProgramRunRecordFetcher;
 import org.apache.twill.common.Cancellable;
 import org.apache.twill.internal.zookeeper.InMemoryZKServer;
 import org.junit.AfterClass;
@@ -53,7 +55,8 @@ public class MasterServiceMainTestBase {
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   private static InMemoryZKServer zkServer;
-  private static Map<Class<?>, ServiceMainManager<?>> serviceManagers = new LinkedHashMap<>();
+  private static final Map<Class<? extends AbstractServiceMain>, ServiceMainManager<?>> SERVICE_MANAGERS =
+    new LinkedHashMap<>();
   protected static String[] initArgs;
 
   protected static CConfiguration cConf;
@@ -99,6 +102,13 @@ public class MasterServiceMainTestBase {
     cConf.setInt(Constants.Router.ROUTER_PORT, 0);
     cConf.setInt(Constants.Router.ROUTER_SSL_PORT, 0);
 
+    // Set runtime server to bind to random port
+    cConf.setInt(Constants.RuntimeMonitor.BIND_PORT, 0);
+
+    // Use remote fetcher for runtime server
+    cConf.setClass(Constants.RuntimeMonitor.RUN_RECORD_FETCHER_CLASS,
+                   RemoteProgramRunRecordFetcher.class, ProgramRunRecordFetcher.class);
+
     // Starting all master service mains
     List<Class<? extends AbstractServiceMain<EnvironmentOptions>>> serviceMainClasses =
       Arrays.asList(RouterServiceMain.class,
@@ -106,6 +116,7 @@ public class MasterServiceMainTestBase {
                     MetricsServiceMain.class,
                     LogsServiceMain.class,
                     MetadataServiceMain.class,
+                    RuntimeServiceMain.class,
                     AppFabricServiceMain.class);
     for (Class<? extends AbstractServiceMain> serviceMainClass : serviceMainClasses) {
       startService(serviceMainClass);
@@ -115,10 +126,7 @@ public class MasterServiceMainTestBase {
   @AfterClass
   public static void finish() {
     // Reverse stop services
-    Lists.reverse(new ArrayList<>(serviceManagers.keySet())).forEach(
-      (serviceMainClass) -> {
-        stopService((Class<? extends AbstractServiceMain>) serviceMainClass);
-      });
+    Lists.reverse(new ArrayList<>(SERVICE_MANAGERS.keySet())).forEach(MasterServiceMainTestBase::stopService);
     zkServer.stopAndWait();
   }
 
@@ -131,7 +139,7 @@ public class MasterServiceMainTestBase {
    * @throws Exception if failed to start service main
    */
   protected static <T extends AbstractServiceMain> void startService(Class<T> serviceMainClass) throws Exception {
-    serviceManagers.put(serviceMainClass, runMain(cConf, sConf, serviceMainClass));
+    SERVICE_MANAGERS.put(serviceMainClass, runMain(cConf, sConf, serviceMainClass));
   }
 
   /**
@@ -142,7 +150,7 @@ public class MasterServiceMainTestBase {
    * @param <T> the type of service main class (e.g. {@link AppFabricServiceMain})
    */
   protected static <T extends AbstractServiceMain> void stopService(Class<T> serviceMainClass) {
-    final ServiceMainManager<?> serviceMainManager = serviceManagers.remove(serviceMainClass);
+    final ServiceMainManager<?> serviceMainManager = SERVICE_MANAGERS.remove(serviceMainClass);
     serviceMainManager.cancel();
   }
 
@@ -159,7 +167,7 @@ public class MasterServiceMainTestBase {
    * Gets the instance of master main service of the given class.
    */
   static <T extends AbstractServiceMain> T getServiceMainInstance(Class<T> serviceMainClass) {
-    ServiceMainManager<?> manager = serviceManagers.get(serviceMainClass);
+    ServiceMainManager<?> manager = SERVICE_MANAGERS.get(serviceMainClass);
     AbstractServiceMain instance = manager.getInstance();
     if (!serviceMainClass.isInstance(instance)) {
       throw new IllegalArgumentException("Mismatch manager class." + serviceMainClass + " != " + instance);

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMainTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.inject.Injector;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.app.program.ProgramDescriptor;
+import io.cdap.cdap.app.runtime.ProgramOptions;
+import io.cdap.cdap.app.runtime.ProgramStateWriter;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.service.RetryStrategy;
+import io.cdap.cdap.common.utils.Tasks;
+import io.cdap.cdap.internal.app.program.MessagingProgramStatePublisher;
+import io.cdap.cdap.internal.app.program.MessagingProgramStateWriter;
+import io.cdap.cdap.internal.app.program.ProgramStatePublisher;
+import io.cdap.cdap.internal.app.runtime.BasicArguments;
+import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
+import io.cdap.cdap.internal.app.runtime.SystemArguments;
+import io.cdap.cdap.internal.app.runtime.monitor.RuntimeClient;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.internal.app.store.RunRecordDetail;
+import io.cdap.cdap.internal.provision.NativeProvisioner;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.data.MessageId;
+import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit test for {@link RuntimeServiceMain}.
+ */
+public class RuntimeServiceMainTest extends MasterServiceMainTestBase {
+
+  private static final Gson GSON = new Gson();
+
+  @Test
+  public void testRuntimeService() throws Exception {
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("test", "1.0");
+    ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").worker("worker").run(RunIds.generate());
+
+    Map<String, String> systemArgs = ImmutableMap.of(
+      SystemArguments.PROFILE_PROVISIONER, NativeProvisioner.SPEC.getName(),
+      SystemArguments.PROFILE_NAME, "default"
+    );
+
+    ProgramOptions programOptions = new SimpleProgramOptions(programRunId.getParent(), new BasicArguments(systemArgs),
+                                                             new BasicArguments());
+    ProgramDescriptor programDescriptor = new ProgramDescriptor(programRunId.getParent(), null, artifactId);
+
+    // Write out program state events to simulate program start
+    Injector appFabricInjector = getServiceMainInstance(AppFabricServiceMain.class).getInjector();
+    CConfiguration cConf = appFabricInjector.getInstance(CConfiguration.class);
+    ProgramStatePublisher programStatePublisher = new MessagingProgramStatePublisher(
+      appFabricInjector.getInstance(MessagingService.class),
+      NamespaceId.SYSTEM.topic(cConf.get(Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC)),
+      RetryStrategies.fromConfiguration(cConf, "system.program.state.")
+    );
+    new MessagingProgramStateWriter(programStatePublisher).start(programRunId, programOptions, null,
+                                                                 programDescriptor);
+
+    Injector injector = getServiceMainInstance(RuntimeServiceMain.class).getInjector();
+    TransactionRunner txRunner = injector.getInstance(TransactionRunner.class);
+
+    // Should see a STARTING record in the runtime store
+    Tasks.waitFor(ProgramRunStatus.STARTING, () -> {
+      RunRecordDetail detail = TransactionRunners.run(txRunner, context -> {
+        return AppMetadataStore.create(context).getRun(programRunId);
+      });
+      return detail == null ? null : detail.getStatus();
+    }, 5, TimeUnit.SECONDS);
+
+    ProgramStateWriter programStateWriter = createProgramStateWriter(injector, programRunId);
+
+
+    // Write a running state. We should see a RUNNING record in the runtime store
+    programStateWriter.running(programRunId, null);
+    Tasks.waitFor(ProgramRunStatus.RUNNING, () -> {
+      RunRecordDetail detail = TransactionRunners.run(txRunner, context -> {
+        return AppMetadataStore.create(context).getRun(programRunId);
+      });
+      return detail == null ? null : detail.getStatus();
+    }, 5, TimeUnit.SECONDS);
+
+    // Write a complete state. The run record should be removed in the runtime store
+    programStateWriter.completed(programRunId);
+    Tasks.waitFor(true, () -> TransactionRunners.run(
+      txRunner, context -> AppMetadataStore.create(context).getRun(programRunId) == null), 5, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Creates a {@link ProgramStateWriter} that writes to {@link RuntimeClient} directly.
+   *
+   * @param injector the injector for creating the {@link RuntimeClient}
+   * @param programRunId the {@link ProgramRunId} for the program state change
+   * @return a {@link ProgramStateWriter}
+   */
+  private ProgramStateWriter createProgramStateWriter(Injector injector, ProgramRunId programRunId) {
+    RuntimeClient runtimeClient = injector.getInstance(RuntimeClient.class);
+
+    // We write to the record event directly to skip the app-fabric to process it
+    // This is because we don't follow the normal event flow here for testing
+    TopicId topicId = NamespaceId.SYSTEM.topic(
+      injector.getInstance(CConfiguration.class).get(Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC));
+    RetryStrategy retryStrategy = RetryStrategies.timeLimit(5, TimeUnit.SECONDS,
+                                                            RetryStrategies.fixDelay(200, TimeUnit.MILLISECONDS));
+
+    return new MessagingProgramStateWriter((notificationType, properties) -> {
+      Notification notification = new Notification(notificationType, properties);
+      try {
+        Retries.callWithRetries((Retries.Callable<Void, Exception>) () -> {
+          runtimeClient.sendMessages(programRunId, topicId,
+                                     Collections.singleton(createMessage(notification)).iterator());
+          return null;
+        }, retryStrategy, t -> t instanceof IOException || t instanceof RetryableException);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  private Message createMessage(Notification notification) {
+    byte[] payload = GSON.toJson(notification).getBytes(StandardCharsets.UTF_8);
+    return new Message() {
+      @Override
+      public String getId() {
+        byte[] id = new byte[MessageId.RAW_ID_SIZE];
+        MessageId.putRawId(System.currentTimeMillis(), (short) 0, 0, (short) 0, id, 0);
+        return Bytes.toHexString(id);
+      }
+
+      @Override
+      public byte[] getPayload() {
+        return payload;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Introduced a new RuntimeService to prepare for taking runtime monitoring calls from the remote runtime. It contains two main components, namely the server and client.

**Server**
- Runs in the CDAP side
- Designed to be executed as an isolated process
- This code change doesn't include running the server in standalone mode (TBD)
- It validates requests from client by checking it is a valid running program based on the request validator.
- It listen to program status events to maintain a replicated view of program status for request validation

**Client**
- Runs in the remote runtime. Should be run in DefaultRuntimeJob (not part of this PR)
- Periodically poll local TMS and replicates them to the Runtime Server
