### PR TITLE
Fixed GSON parsing error when using configuration string

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -391,7 +391,6 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    * ]
    * }
    * </pre>
-   * <p>
    * The response will be an array of {@link BatchApplicationDetail} object, which either indicates a success (200) or
    * failure for each of the requested application in the same order as the request.
    */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -175,7 +175,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @HeaderParam(ARCHIVE_NAME_HEADER) final String archiveName,
                              @HeaderParam(APP_CONFIG_HEADER) String configString,
                              @HeaderParam(PRINCIPAL_HEADER) String ownerPrincipal,
-                             @DefaultValue("true") @HeaderParam(SCHEDULES_HEADER) boolean  updateSchedules)
+                             @DefaultValue("true") @HeaderParam(SCHEDULES_HEADER) boolean updateSchedules)
     throws BadRequestException, NamespaceNotFoundException {
 
     NamespaceId namespace = validateNamespace(namespaceId);
@@ -195,14 +195,14 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps/{app-id}/versions/{version-id}/create")
   @AuditPolicy(AuditDetail.REQUEST_BODY)
   public BodyConsumer createAppVersion(HttpRequest request, HttpResponder responder,
-                                         @PathParam("namespace-id") final String namespaceId,
-                                         @PathParam("app-id") final String appId,
-                                         @PathParam("version-id") final String versionId)
+                                       @PathParam("namespace-id") final String namespaceId,
+                                       @PathParam("app-id") final String appId,
+                                       @PathParam("version-id") final String versionId)
     throws Exception {
 
     ApplicationId applicationId = validateApplicationVersionId(namespaceId, appId, versionId);
 
-    if (!applicationLifecycleService.updateAppAllowed(applicationId))  {
+    if (!applicationLifecycleService.updateAppAllowed(applicationId)) {
       responder.sendString(HttpResponseStatus.CONFLICT,
                            String.format("Cannot update the application because version %s already exists", versionId));
     }
@@ -306,8 +306,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @DELETE
   @Path("/apps/{app-id}")
   public void deleteApp(HttpRequest request, HttpResponder responder,
-                               @PathParam("namespace-id") String namespaceId,
-                               @PathParam("app-id") final String appId) throws Exception {
+                        @PathParam("namespace-id") String namespaceId,
+                        @PathParam("app-id") final String appId) throws Exception {
     ApplicationId id = validateApplicationId(namespaceId, appId);
     applicationLifecycleService.removeApplication(id);
     responder.sendStatus(HttpResponseStatus.OK);
@@ -319,9 +319,9 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @DELETE
   @Path("/apps/{app-id}/versions/{version-id}")
   public void deleteAppVersion(HttpRequest request, HttpResponder responder,
-                        @PathParam("namespace-id") final String namespaceId,
-                        @PathParam("app-id") final String appId,
-                        @PathParam("version-id") final String versionId) throws Exception {
+                               @PathParam("namespace-id") final String namespaceId,
+                               @PathParam("app-id") final String appId,
+                               @PathParam("version-id") final String versionId) throws Exception {
     ApplicationId id = validateApplicationVersionId(namespaceId, appId, versionId);
     applicationLifecycleService.removeApplication(id);
     responder.sendStatus(HttpResponseStatus.OK);
@@ -391,7 +391,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    * ]
    * }
    * </pre>
-   *
+   * <p>
    * The response will be an array of {@link BatchApplicationDetail} object, which either indicates a success (200) or
    * failure for each of the requested application in the same order as the request.
    */
@@ -469,7 +469,9 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
             appRequest.getOwnerPrincipal() == null ? null : new KerberosPrincipalId(appRequest.getOwnerPrincipal());
 
           // if we don't null check, it gets serialized to "null"
-          String configString = appRequest.getConfig() == null ? null : GSON.toJson(appRequest.getConfig());
+          Object config = appRequest.getConfig();
+          String configString = config == null ? null :
+            config instanceof String ? (String) config : GSON.toJson(config);
 
           try {
             applicationLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -530,7 +530,7 @@ public abstract class AppFabricTestBase {
   }
 
   protected HttpResponse deploy(Id.Application appId,
-                                AppRequest<? extends Config> appRequest) throws Exception {
+                                AppRequest<?> appRequest) throws Exception {
     String deployPath = getVersionedAPIPath("apps/" + appId.getId(), appId.getNamespaceId());
     return executeDeploy(HttpRequest.put(getEndPoint(deployPath).toURL()), appRequest);
   }
@@ -543,7 +543,7 @@ public abstract class AppFabricTestBase {
   }
 
   private HttpResponse executeDeploy(HttpRequest.Builder requestBuilder,
-                                     AppRequest<? extends Config> appRequest) throws Exception {
+                                     AppRequest<?> appRequest) throws Exception {
     requestBuilder.addHeader(Constants.Gateway.API_KEY, "api-key-example");
     requestBuilder.addHeader(HttpHeaderNames.CONTENT_TYPE.toString(), MediaType.APPLICATION_JSON);
     requestBuilder.withBody(GSON.toJson(appRequest));

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -116,6 +116,43 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
   }
 
   @Test
+  public void testAppWithConfigurationString() throws Exception {
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp");
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    HttpResponse response = addAppArtifact(artifactId, ConfigTestApp.class);
+    Assert.assertEquals(200, response.getResponseCode());
+
+    ConfigTestApp.ConfigClass configuration = new ConfigTestApp.ConfigClass("abc", "def");
+    String configurationString = GSON.toJson(configuration);
+    response = deploy(appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), null,null,null,null,
+                                              configurationString));
+    Assert.assertEquals(200, response.getResponseCode());
+    JsonObject appDetails = getAppDetails(Id.Namespace.DEFAULT.getId(), "ConfigApp");
+    Assert.assertEquals(GSON.toJson(configuration), appDetails.get("configuration").getAsString());
+
+    deleteApp(appId, 200);
+    deleteArtifact(artifactId, 200);
+  }
+
+  @Test
+  public void testAppWithConfiguration() throws Exception {
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp");
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    HttpResponse response = addAppArtifact(artifactId, ConfigTestApp.class);
+    Assert.assertEquals(200, response.getResponseCode());
+
+    ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("abc", "def");
+    response = deploy(appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), null,null,null,null,
+                                              config));
+    Assert.assertEquals(200, response.getResponseCode());
+    JsonObject appDetails = getAppDetails(Id.Namespace.DEFAULT.getId(), "ConfigApp");
+    Assert.assertEquals(GSON.toJson(config), appDetails.get("configuration").getAsString());
+
+    deleteApp(appId, 200);
+    deleteArtifact(artifactId, 200);
+  }
+
+  @Test
   public void testDeployUsingNonexistantArtifact404() throws Exception {
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "badapp");
     AppRequest<Config> appRequest =

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -124,7 +124,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     ConfigTestApp.ConfigClass configuration = new ConfigTestApp.ConfigClass("abc", "def");
     String configurationString = GSON.toJson(configuration);
-    response = deploy(appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), null,null,null,null,
+    response = deploy(appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), null, null, null, null,
                                               configurationString));
     Assert.assertEquals(200, response.getResponseCode());
     JsonObject appDetails = getAppDetails(Id.Namespace.DEFAULT.getId(), "ConfigApp");
@@ -141,12 +141,12 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     HttpResponse response = addAppArtifact(artifactId, ConfigTestApp.class);
     Assert.assertEquals(200, response.getResponseCode());
 
-    ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("abc", "def");
-    response = deploy(appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), null,null,null,null,
-                                              config));
+    ConfigTestApp.ConfigClass configuration = new ConfigTestApp.ConfigClass("abc", "def");
+    response = deploy(appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), null, null, null, null,
+                                              configuration));
     Assert.assertEquals(200, response.getResponseCode());
     JsonObject appDetails = getAppDetails(Id.Namespace.DEFAULT.getId(), "ConfigApp");
-    Assert.assertEquals(GSON.toJson(config), appDetails.get("configuration").getAsString());
+    Assert.assertEquals(GSON.toJson(configuration), appDetails.get("configuration").getAsString());
 
     deleteApp(appId, 200);
     deleteArtifact(artifactId, 200);

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/AppRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/AppRequest.java
@@ -56,14 +56,17 @@ public class AppRequest<T> {
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable PreviewConfig preview,
                     @Nullable String ownerPrincipal, @Nullable Boolean updateSchedules) {
+    this(artifact, config, preview, ownerPrincipal, updateSchedules, null);
+  }
+
+  public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable PreviewConfig preview,
+                    @Nullable String ownerPrincipal, @Nullable Boolean updateSchedules, @Nullable T configuration) {
     this.artifact = artifact;
     this.config = config;
     this.preview = preview;
     this.ownerPrincipal = ownerPrincipal;
     this.updateSchedules = updateSchedules;
-
-    // This should never be set programmatically, this is added as a workaround for JIRA issue CDAP-16211
-    this.configuration = null;
+    this.configuration = configuration;
   }
 
   public ArtifactSummary getArtifact() {


### PR DESCRIPTION
Fix for [CDAP-16211](https://issues.cask.co/browse/CDAP-16211) was incomplete and it would result in a GSON error when attempting to deploy using a json string in the `configuration` field