### PR TITLE
(CDAP-16369) Collections of provisioner improvement

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeInfo.java
@@ -17,7 +17,7 @@
 package io.cdap.cdap.internal.app.runtime.distributed.runtimejob;
 
 import io.cdap.cdap.proto.id.ProgramRunId;
-import io.cdap.cdap.runtime.spi.runtimejob.ProgramRunInfo;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobInfo;
 import org.apache.twill.api.LocalFile;
 
@@ -38,7 +38,7 @@ public class DefaultRuntimeInfo implements RuntimeJobInfo {
       .setNamespace(programRunId.getNamespace())
       .setApplication(programRunId.getApplication())
       .setVersion(programRunId.getVersion())
-      .setProgramType(programRunId.getType().getPrettyName())
+      .setProgramType(programRunId.getType().name())
       .setProgram(programRunId.getProgram())
       .setRun(programRunId.getRun()).build();
     this.files = Collections.unmodifiableCollection(new ArrayList<>(files));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/RuntimeJobTwillController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/RuntimeJobTwillController.java
@@ -20,7 +20,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import io.cdap.cdap.internal.app.runtime.ThrowingRunnable;
 import io.cdap.cdap.internal.app.runtime.distributed.AbstractRuntimeTwillController;
 import io.cdap.cdap.proto.id.ProgramRunId;
-import io.cdap.cdap.runtime.spi.runtimejob.ProgramRunInfo;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
 import org.apache.twill.api.ServiceController;
 import org.apache.twill.api.TwillController;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/RuntimeJobTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/RuntimeJobTwillRunnerService.java
@@ -35,7 +35,7 @@ import io.cdap.cdap.internal.provision.ProvisioningService;
 import io.cdap.cdap.logging.context.LoggingContextHelper;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
-import io.cdap.cdap.runtime.spi.runtimejob.ProgramRunInfo;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.ResourceSpecification;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.runtime.spi.provisioner.ProgramRun;
 import io.cdap.cdap.runtime.spi.provisioner.Provisioner;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,9 +42,10 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   private final SSHContext sshContext;
   private final SparkCompat sparkCompat;
   private final String cdapVersion;
+  private final LocationFactory locationFactory;
 
   DefaultProvisionerContext(ProgramRunId programRunId, Map<String, String> properties,
-                            SparkCompat sparkCompat, @Nullable SSHContext sshContext) {
+                            SparkCompat sparkCompat, @Nullable SSHContext sshContext, LocationFactory locationFactory) {
     this.programRun = new ProgramRun(programRunId.getNamespace(), programRunId.getApplication(),
                                      programRunId.getProgram(), programRunId.getRun());
     this.programRunInfo = new ProgramRunInfo.Builder()
@@ -57,6 +59,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.sshContext = sshContext;
     this.sparkCompat = sparkCompat;
+    this.locationFactory = locationFactory;
     this.cdapVersion = ProjectInfo.getVersion().toString();
   }
 
@@ -89,5 +92,10 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   @Override
   public String getCDAPVersion() {
     return cdapVersion;
+  }
+
+  @Override
+  public LocationFactory getLocationFactory() {
+    return locationFactory;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.provision;
 
 import io.cdap.cdap.common.utils.ProjectInfo;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.runtime.spi.provisioner.ProgramRun;
 import io.cdap.cdap.runtime.spi.provisioner.Provisioner;
@@ -33,16 +34,26 @@ import javax.annotation.Nullable;
  * Context for a {@link Provisioner} extension
  */
 public class DefaultProvisionerContext implements ProvisionerContext {
+
   private final ProgramRun programRun;
+  private final ProgramRunInfo programRunInfo;
   private final Map<String, String> properties;
   private final SSHContext sshContext;
   private final SparkCompat sparkCompat;
   private final String cdapVersion;
 
-  public DefaultProvisionerContext(ProgramRunId programRunId, Map<String, String> properties,
-                                   SparkCompat sparkCompat, @Nullable SSHContext sshContext) {
+  DefaultProvisionerContext(ProgramRunId programRunId, Map<String, String> properties,
+                            SparkCompat sparkCompat, @Nullable SSHContext sshContext) {
     this.programRun = new ProgramRun(programRunId.getNamespace(), programRunId.getApplication(),
                                      programRunId.getProgram(), programRunId.getRun());
+    this.programRunInfo = new ProgramRunInfo.Builder()
+      .setNamespace(programRunId.getNamespace())
+      .setApplication(programRunId.getApplication())
+      .setVersion(programRunId.getVersion())
+      .setProgramType(programRunId.getType().name())
+      .setProgram(programRunId.getProgram())
+      .setRun(programRunId.getRun())
+      .build();
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.sshContext = sshContext;
     this.sparkCompat = sparkCompat;
@@ -52,6 +63,11 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   @Override
   public ProgramRun getProgramRun() {
     return programRun;
+  }
+
+  @Override
+  public ProgramRunInfo getProgramRunInfo() {
+    return programRunInfo;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/NativeProvisioner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/NativeProvisioner.java
@@ -70,7 +70,7 @@ public class NativeProvisioner implements Provisioner {
 
   @Override
   public Cluster createCluster(ProvisionerContext context) {
-    return new Cluster(context.getProgramRun().getRun(), ClusterStatus.RUNNING,
+    return new Cluster(context.getProgramRunInfo().getRun(), ClusterStatus.RUNNING,
                        Collections.emptyList(), Collections.emptyMap());
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
@@ -151,7 +151,8 @@ public class ProvisioningService extends AbstractIdleService {
     LOG.info("Starting {}", getClass().getSimpleName());
     initializeProvisioners();
     this.taskExecutor = new KeyedExecutor<>(Executors.newScheduledThreadPool(
-      0, Threads.createDaemonThreadFactory("provisioning-service-%d")));
+      cConf.getInt(Constants.Provisioner.EXECUTOR_THREADS),
+      Threads.createDaemonThreadFactory("provisioning-service-%d")));
     resumeTasks(taskStateCleanup);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
@@ -734,7 +734,7 @@ public class ProvisioningService extends AbstractIdleService {
   private ProvisionerContext createContext(ProgramRunId programRunId, String userId, Map<String, String> properties,
                                            @Nullable SSHContext sshContext) {
     Map<String, String> evaluated = evaluateMacros(secureStore, userId, programRunId.getNamespace(), properties);
-    return new DefaultProvisionerContext(programRunId, evaluated, sparkCompat, sshContext);
+    return new DefaultProvisionerContext(programRunId, evaluated, sparkCompat, sshContext, locationFactory);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/task/ClusterDeleteSubtask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/task/ClusterDeleteSubtask.java
@@ -39,8 +39,8 @@ public class ClusterDeleteSubtask extends ProvisioningSubtask {
 
   @Override
   public Cluster execute(Cluster cluster) throws Exception {
-    provisioner.deleteCluster(provisionerContext, cluster);
-    return new Cluster(cluster == null ? null : cluster.getName(), ClusterStatus.DELETING,
+    ClusterStatus clusterStatus = provisioner.deleteClusterWithStatus(provisionerContext, cluster);
+    return new Cluster(cluster == null ? null : cluster.getName(), clusterStatus,
                        cluster == null ? Collections.emptyList() : cluster.getNodes(),
                        cluster == null ? Collections.emptyMap() : cluster.getProperties());
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/provision/MockProvisioner.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/provision/MockProvisioner.java
@@ -20,12 +20,12 @@ import com.google.inject.Singleton;
 import io.cdap.cdap.proto.profile.Profile;
 import io.cdap.cdap.proto.provisioner.ProvisionerInfo;
 import io.cdap.cdap.proto.provisioner.ProvisionerPropertyValue;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategies;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategy;
-import io.cdap.cdap.runtime.spi.provisioner.ProgramRun;
 import io.cdap.cdap.runtime.spi.provisioner.Provisioner;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
@@ -57,7 +57,7 @@ public class MockProvisioner implements Provisioner {
   private static final ProvisionerSpecification SPEC = new ProvisionerSpecification(
     NAME, "Native", "Runs programs on the CDAP master cluster. Does not provision any resources.");
   private final AtomicInteger callCount;
-  private final Set<ProgramRun> seenRuns;
+  private final Set<ProgramRunInfo> seenRuns;
 
   public MockProvisioner() {
     this.callCount = new AtomicInteger(0);
@@ -79,7 +79,7 @@ public class MockProvisioner implements Provisioner {
     failIfConfigured(context, FAIL_CREATE);
     failRetryablyEveryN(context);
     waitIfConfigured(context, WAIT_CREATE_MS);
-    return new Cluster(context.getProgramRun().getRun(), ClusterStatus.CREATING,
+    return new Cluster(context.getProgramRunInfo().getRun(), ClusterStatus.CREATING,
                        Collections.emptyList(), Collections.emptyMap());
   }
 
@@ -96,7 +96,7 @@ public class MockProvisioner implements Provisioner {
     ClusterStatus status = cluster.getStatus();
     ClusterStatus newStatus;
     String firstClusterStatus = context.getProperties().get(FIRST_CLUSTER_STATUS);
-    if (seenRuns.add(context.getProgramRun()) && firstClusterStatus != null) {
+    if (seenRuns.add(context.getProgramRunInfo()) && firstClusterStatus != null) {
       newStatus = ClusterStatus.valueOf(firstClusterStatus);
     } else {
       switch (status) {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1408,6 +1408,7 @@ public final class Constants {
   public static final class Provisioner {
     public static final String EXTENSIONS_DIR = "runtime.extensions.dir";
     public static final String SYSTEM_PROPERTY_PREFIX = "provisioner.system.properties.";
+    public static final String EXECUTOR_THREADS = "provisioner.executor.threads";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2640,6 +2640,15 @@
     </description>
   </property>
 
+  <!-- Provisioner Configuration -->
+  <property>
+    <name>provisioner.executor.threads</name>
+    <value>10</value>
+    <description>
+      Thread pool size for the executor in the provisioning service
+    </description>
+  </property>
+
 
   <!-- Runtime Monitor Configuration -->
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.dataproc.v1.ClusterOperationMetadata;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
@@ -373,20 +372,17 @@ public class DataprocProvisioner implements Provisioner {
     String clusterName = getClusterName(context.getProgramRunInfo());
     String projectId = conf.getProjectId();
     String region = conf.getRegion();
-    String sparkCompat = context.getSparkCompat().getCompat();
     String bucket = getBucket(systemProperties, conf);
     Map<String, String> systemLabels = getSystemLabels(systemContext);
-    GoogleCredentials dataprocCredentials;
     try {
-      dataprocCredentials = conf.getDataprocCredentials();
+      return Optional.of(
+        new DataprocRuntimeJobManager(new DataprocClusterInfo(context, clusterName, conf.getDataprocCredentials(),
+                                                              DataprocClient.DATAPROC_GOOGLEAPIS_COM_443,
+                                                              projectId, region, bucket, systemLabels)));
     } catch (Exception e) {
       throw new RuntimeException("Error while getting credentials for dataproc. ", e);
     }
 
-    return Optional.of(
-      new DataprocRuntimeJobManager(new DataprocClusterInfo(clusterName, dataprocCredentials,
-                                                            DataprocClient.DATAPROC_GOOGLEAPIS_COM_443,
-                                                            projectId, region, bucket, systemLabels, sparkCompat)));
   }
 
   private String getBucket(Map<String, String> systemProperties, DataprocConf conf) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocClusterInfo.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocClusterInfo.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.runtime.spi.runtimejob;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,6 +27,8 @@ import java.util.Map;
  * Class to carry information about dataproc cluster. Instance of this class will be created by provisioner.
  */
 public class DataprocClusterInfo {
+
+  private final ProvisionerContext provisionerContext;
   private final String clusterName;
   private final String endpoint;
   private final GoogleCredentials credentials;
@@ -33,10 +36,11 @@ public class DataprocClusterInfo {
   private final String region;
   private final String bucket;
   private final Map<String, String> labels;
-  private final String sparkCompat;
 
-  public DataprocClusterInfo(String clusterName, GoogleCredentials credentials, String endpoint, String projectId,
-                             String region, String bucket, Map<String, String> labels, String sparkCompat) {
+  public DataprocClusterInfo(ProvisionerContext provisionerContext,
+                             String clusterName, GoogleCredentials credentials, String endpoint, String projectId,
+                             String region, String bucket, Map<String, String> labels) {
+    this.provisionerContext = provisionerContext;
     this.clusterName = clusterName;
     this.endpoint = endpoint;
     this.credentials = credentials;
@@ -44,7 +48,10 @@ public class DataprocClusterInfo {
     this.region = region;
     this.bucket = bucket;
     this.labels = Collections.unmodifiableMap(new HashMap<>(labels));
-    this.sparkCompat = sparkCompat;
+  }
+
+  ProvisionerContext getProvisionerContext() {
+    return provisionerContext;
   }
 
   String getClusterName() {
@@ -73,9 +80,5 @@ public class DataprocClusterInfo {
 
   Map<String, String> getLabels() {
     return labels;
-  }
-
-  String getSparkCompat() {
-    return sparkCompat;
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJarUtil.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJarUtil.java
@@ -93,7 +93,7 @@ final class DataprocJarUtil {
     return createLocalFile(location, false);
   }
 
-  static LocalFile createLocalFile(Location location, boolean archive) throws IOException {
+  private static LocalFile createLocalFile(Location location, boolean archive) throws IOException {
     return new DefaultLocalFile(location.getName(), location.toURI(),
                                 location.lastModified(), location.length(), archive, null);
   }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -43,13 +43,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import org.apache.twill.api.LocalFile;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.LocationFactory;
+import org.apache.twill.internal.DefaultLocalFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -85,6 +86,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
   private static final String CDAP_RUNTIME_RUNID = "cdap.runtime.runid";
   private static final Pattern DATAPROC_JOB_ID_PATTERN = Pattern.compile("[a-zA-Z0-9_-]{0,100}$");
 
+  private final ProvisionerContext provisionerContext;
   private final String clusterName;
   private final GoogleCredentials credentials;
   private final String endpoint;
@@ -92,7 +94,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
   private final String region;
   private final String bucket;
   private final Map<String, String> labels;
-  private final String sparkCompat;
 
   private Storage storageClient;
   private JobControllerClient jobControllerClient;
@@ -103,6 +104,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
    * @param clusterInfo dataproc cluster information
    */
   public DataprocRuntimeJobManager(DataprocClusterInfo clusterInfo) {
+    this.provisionerContext = clusterInfo.getProvisionerContext();
     this.clusterName = clusterInfo.getClusterName();
     this.credentials = clusterInfo.getCredentials();
     this.endpoint = clusterInfo.getEndpoint();
@@ -110,7 +112,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
     this.region = clusterInfo.getRegion();
     this.bucket = clusterInfo.getBucket();
     this.labels = clusterInfo.getLabels();
-    this.sparkCompat = clusterInfo.getSparkCompat();
   }
 
   @Override
@@ -128,6 +129,8 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
 
   @Override
   public void launch(RuntimeJobInfo runtimeJobInfo) throws Exception {
+    String bucket = DataprocUtils.getBucketName(this.bucket);
+
     ProgramRunInfo runInfo = runtimeJobInfo.getProgramRunInfo();
     LOG.info("Launching run {} with following configurations: cluster {}, project {}, region {}, bucket {}.",
              runInfo.getRun(), clusterName, projectId, region, bucket);
@@ -142,15 +145,15 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
       List<LocalFile> localFiles = getRuntimeLocalFiles(runtimeJobInfo.getLocalizeFiles(), tempDir);
 
       // step 2: upload all the necessary files to gcs so that those files are available to dataproc job
+      List<LocalFile> uploadedFiles = new ArrayList<>();
       for (LocalFile fileToUpload : localFiles) {
         String targetFilePath = getPath(runRootPath, fileToUpload.getName());
-        LOG.debug("Uploading file {} to gcs bucket {}.", targetFilePath, bucket);
-        uploadFile(targetFilePath, fileToUpload);
-        LOG.debug("Uploaded file {} to gcs bucket {}.", targetFilePath, bucket);
+        uploadedFiles.add(uploadFile(bucket, targetFilePath, fileToUpload));
+        LOG.debug("Uploaded file from {} to gs://{}/{}.", fileToUpload.getURI(), bucket, targetFilePath);
       }
 
       // step 3: build the hadoop job request to be submitted to dataproc
-      SubmitJobRequest request = getSubmitJobRequest(runtimeJobInfo.getRuntimeJobClassname(), runInfo, localFiles);
+      SubmitJobRequest request = getSubmitJobRequest(runtimeJobInfo.getRuntimeJobClassname(), runInfo, uploadedFiles);
 
       // step 4: submit hadoop job to dataproc
       LOG.info("Submitting hadoop job {} to cluster {}.", request.getJob().getReference().getJobId(), clusterName);
@@ -255,27 +258,40 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
   /**
    * Uploads files to gcs.
    */
-  private void uploadFile(String targetFilePath, LocalFile localFile) throws IOException, StorageException {
-    String bucket = DataprocUtils.getBucketName(this.bucket);
+  private LocalFile uploadFile(String bucket, String targetFilePath,
+                               LocalFile localFile) throws IOException, StorageException {
     BlobId blobId = BlobId.of(bucket, targetFilePath);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("application/octet-stream").build();
 
-    URI fileURI = localFile.getURI();
-    if (fileURI.getScheme().startsWith("file")) {
-      try (InputStream inputStream = fileURI.toURL().openStream()) {
-        try (WriteChannel writer = storageClient.writer(blobInfo)) {
-          ByteStreams.copy(inputStream, Channels.newOutputStream(writer));
-        }
-      }
-    } else {
-      BlobId sourceBlobId = BlobId.of(fileURI.getAuthority(), fileURI.getPath().substring(1));
-      Storage client = StorageOptions.getDefaultInstance().getService();
-      try (InputStream inputStream = new ByteArrayInputStream(client.get(sourceBlobId).getContent())) {
-        try (WriteChannel writer = storageClient.writer(blobInfo)) {
-          ByteStreams.copy(inputStream, Channels.newOutputStream(writer));
-        }
-      }
+    try (InputStream inputStream = openStream(localFile.getURI());
+         WriteChannel writer = storageClient.writer(blobInfo)) {
+      ByteStreams.copy(inputStream, Channels.newOutputStream(writer));
     }
+
+    return new DefaultLocalFile(localFile.getName(), URI.create(String.format("gs://%s/%s", bucket, targetFilePath)),
+                                localFile.getLastModified(), localFile.getSize(),
+                                localFile.isArchive(), localFile.getPattern());
+  }
+
+  /**
+   * Opens an {@link InputStream} to read from the given URI.
+   */
+  private InputStream openStream(URI uri) throws IOException {
+    if ("file".equals(uri.getScheme())) {
+      return Files.newInputStream(new File(uri).toPath());
+    }
+    LocationFactory locationFactory = provisionerContext.getLocationFactory();
+    if (locationFactory.getHomeLocation().toURI().getScheme().equals(uri.getScheme())) {
+      return locationFactory.create(uri).getInputStream();
+    }
+    if ("gs".equals(uri.getScheme())) {
+      BlobId blobId = BlobId.of(uri.getAuthority(), uri.getPath().substring(1));
+      Storage client = StorageOptions.getDefaultInstance().getService();
+      return Channels.newInputStream(client.get(blobId).reader());
+    }
+
+    // Default to Java URL stream implementation.
+    return uri.toURL().openStream();
   }
 
   /**
@@ -287,9 +303,8 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
 
     // The DataprocJobMain argument is <class-name> <spark-compat> <list of archive files...>
     List<String> arguments = Stream.concat(
-      Stream.of(jobMainClassName, sparkCompat),
-      localFiles.stream()
-        .filter(LocalFile::isArchive).map(LocalFile::getName)
+      Stream.of(jobMainClassName, provisionerContext.getSparkCompat().getCompat()),
+      localFiles.stream().filter(LocalFile::isArchive).map(LocalFile::getName)
     ).collect(Collectors.toList());
 
     Map<String, String> properties = new LinkedHashMap<>();
@@ -308,17 +323,12 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
       .putAllProperties(properties);
 
     for (LocalFile localFile : localFiles) {
-      String localFileName = localFile.getName();
-      String fileName = getPath(bucket, DataprocUtils.CDAP_GCS_ROOT, runId, localFileName);
-
       // add jar file
+      URI uri = localFile.getURI();
       if (localFile.getName().endsWith("jar")) {
-        LOG.info("Adding {} as jar.", localFileName);
-        hadoopJobBuilder.addJarFileUris(fileName);
+        hadoopJobBuilder.addJarFileUris(uri.toString());
       } else {
-        // add all the other files as file
-        LOG.info("Adding {} as file.", localFileName);
-        hadoopJobBuilder.addFileUris(fileName);
+        hadoopJobBuilder.addFileUris(uri.toString());
       }
     }
 
@@ -355,8 +365,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
    */
   private RuntimeJobStatus getRuntimeJobStatus(Job job) {
     JobStatus.State state = job.getStatus().getState();
-    LOG.debug("Dataproc job {} is in state {}.", job.getReference().getJobId(), state);
-
     RuntimeJobStatus runtimeJobStatus;
     switch (state) {
       case STATE_UNSPECIFIED:

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -41,6 +41,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import org.apache.twill.api.LocalFile;
 import org.apache.twill.filesystem.LocalLocationFactory;

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
-import io.cdap.cdap.runtime.spi.provisioner.ProgramRun;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,12 +32,27 @@ public class DataprocProvisionerTest {
   @Test
   public void testClusterName() {
     // test basic
-    ProgramRun programRun = new ProgramRun("ns", "app", "program", UUID.randomUUID().toString());
-    Assert.assertEquals("cdap-app-" + programRun.getRun(), DataprocProvisioner.getClusterName(programRun));
+    ProgramRunInfo programRunInfo = new ProgramRunInfo.Builder()
+      .setNamespace("ns")
+      .setApplication("app")
+      .setVersion("1.0")
+      .setProgramType("workflow")
+      .setProgram("program")
+      .setRun(UUID.randomUUID().toString())
+      .build();
+    Assert.assertEquals("cdap-app-" + programRunInfo.getRun(), DataprocProvisioner.getClusterName(programRunInfo));
 
     // test lowercasing, stripping of invalid characters, and truncation
-    programRun = new ProgramRun("ns", "My@Appl!cation", "program", UUID.randomUUID().toString());
-    Assert.assertEquals("cdap-myapplcat-" + programRun.getRun(), DataprocProvisioner.getClusterName(programRun));
+    programRunInfo = new ProgramRunInfo.Builder()
+      .setNamespace("ns")
+      .setApplication("My@Appl!cation")
+      .setVersion("1.0")
+      .setProgramType("workflow")
+      .setProgram("program")
+      .setRun(UUID.randomUUID().toString())
+      .build();
+    Assert.assertEquals("cdap-myapplcat-" + programRunInfo.getRun(),
+                        DataprocProvisioner.getClusterName(programRunInfo));
   }
 
   @Test

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRuntimeJobManagerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRuntimeJobManagerTest.java
@@ -16,8 +16,8 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager;
-import io.cdap.cdap.runtime.spi.runtimejob.ProgramRunInfo;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/cdap-runtime-ext-emr/src/test/java/io/cdap/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisionerTest.java
+++ b/cdap-runtime-ext-emr/src/test/java/io/cdap/cdap/runtime/spi/provisioner/emr/ElasticMapReduceProvisionerTest.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.emr;
 
-import io.cdap.cdap.runtime.spi.provisioner.ProgramRun;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,12 +30,27 @@ public class ElasticMapReduceProvisionerTest {
   @Test
   public void testClusterName() {
     // test basic
-    ProgramRun programRun = new ProgramRun("ns", "app", "program", UUID.randomUUID().toString());
-    Assert.assertEquals("cdap-app-" + programRun.getRun(), ElasticMapReduceProvisioner.getClusterName(programRun));
+    ProgramRunInfo programRunInfo = new ProgramRunInfo.Builder()
+      .setNamespace("ns")
+      .setApplication("app")
+      .setVersion("1.0")
+      .setProgramType("workflow")
+      .setProgram("program")
+      .setRun(UUID.randomUUID().toString())
+      .build();
+    Assert.assertEquals("cdap-app-" + programRunInfo.getRun(),
+                        ElasticMapReduceProvisioner.getClusterName(programRunInfo));
 
     // test lowercasing, stripping of invalid characters, and truncation
-    programRun = new ProgramRun("ns", "My@Appl!cation", "program", UUID.randomUUID().toString());
-    Assert.assertEquals("cdap-myapplcat-" + programRun.getRun(),
-            ElasticMapReduceProvisioner.getClusterName(programRun));
+    programRunInfo = new ProgramRunInfo.Builder()
+      .setNamespace("ns")
+      .setApplication("My@Appl!cation")
+      .setVersion("1.0")
+      .setProgramType("workflow")
+      .setProgram("program")
+      .setRun(UUID.randomUUID().toString())
+      .build();
+    Assert.assertEquals("cdap-myapplcat-" + programRunInfo.getRun(),
+                        ElasticMapReduceProvisioner.getClusterName(programRunInfo));
   }
 }

--- a/cdap-runtime-ext-remote-hadoop/src/main/java/io/cdap/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
+++ b/cdap-runtime-ext-remote-hadoop/src/main/java/io/cdap/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
@@ -127,8 +127,8 @@ public class RemoteHadoopProvisioner implements Provisioner {
   public void deleteCluster(ProvisionerContext context, Cluster cluster) {
     // delete jars copied over by CDAP
     // TODO: (CDAP-13795) move this logic into the platform
-    String programName = context.getProgramRun().getProgram();
-    String runId = context.getProgramRun().getRun();
+    String programName = context.getProgramRunInfo().getProgram();
+    String runId = context.getProgramRunInfo().getRun();
     String remoteIP = getMasterExternalIp(cluster);
     try (SSHSession session = createSSHSession(context, remoteIP)) {
       LOG.debug("Cleaning up remote cluster resources for program {} run {}", programName, runId);

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/ProgramRunInfo.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/ProgramRunInfo.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.runtime.spi.runtimejob;
+package io.cdap.cdap.runtime.spi;
 
 import java.util.Objects;
 
@@ -154,12 +154,12 @@ public class ProgramRunInfo {
     return version;
   }
 
-  public String getProgram() {
-    return program;
-  }
-
   public String getProgramType() {
     return programType;
+  }
+
+  public String getProgram() {
+    return program;
   }
 
   public String getRun() {

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProgramRun.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProgramRun.java
@@ -16,11 +16,16 @@
 
 package io.cdap.cdap.runtime.spi.provisioner;
 
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
+
 import java.util.Objects;
 
 /**
  * A program run.
+ *
+ * @deprecated Since 6.2.0. Use {@link ProgramRunInfo} instead.
  */
+@Deprecated
 public class ProgramRun {
   private final String namespace;
   private final String application;

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/Provisioner.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/Provisioner.java
@@ -123,8 +123,25 @@ public interface Provisioner {
    * @param cluster the cluster to delete
    * @throws RetryableProvisionException if the operation failed, but may succeed on a retry
    * @throws Exception if the operation failed in a non-retryable fashion
+   * @deprecated Since 6.2.0. Implements the {@link #deleteClusterWithStatus(ProvisionerContext, Cluster)} as well.
    */
+  @Deprecated
   void deleteCluster(ProvisionerContext context, Cluster cluster) throws Exception;
+
+  /**
+   * Request to delete a cluster. The cluster does not have to be deleted before the method returns, but it must
+   * at least be in the process of being deleted. Must be implemented in an idempotent way.
+   *
+   * @param context provisioner context
+   * @param cluster the cluster to delete
+   * @return the {@link ClusterStatus} after the delete cluster operation
+   * @throws RetryableProvisionException if the operation failed, but may succeed on a retry
+   * @throws Exception if the operation failed in a non-retryable fashion
+   */
+  default ClusterStatus deleteClusterWithStatus(ProvisionerContext context, Cluster cluster) throws Exception {
+    deleteCluster(context, cluster);
+    return ClusterStatus.DELETING;
+  }
 
   /**
    * Get the {@link PollingStrategy} to use when polling for cluster creation or deletion. The cluster status is

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.runtime.spi.provisioner;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -67,4 +68,9 @@ public interface ProvisionerContext {
    * @return the CDAP version
    */
   String getCDAPVersion();
+
+  /**
+   * Returns the {@link LocationFactory} used by the CDAP system.
+   */
+  LocationFactory getLocationFactory();
 }

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.runtime.spi.provisioner;
 
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 
@@ -29,8 +30,15 @@ public interface ProvisionerContext {
 
   /**
    * @return the program run
+   * @deprecated Use {@link #getProgramRunInfo()} instead
    */
+  @Deprecated
   ProgramRun getProgramRun();
+
+  /**
+   * @return the program run information
+   */
+  ProgramRunInfo getProgramRunInfo();
 
   /**
    * Get the provisioner properties for this program run. These properties will start off as the provisioner properties

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobDetail.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobDetail.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.runtime.spi.runtimejob;
 
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
+
 import java.util.Objects;
 
 /**

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobInfo.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobInfo.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.runtime.spi.runtimejob;
 
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import org.apache.twill.api.LocalFile;
 
 import java.util.Collection;

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobManager.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobManager.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.runtime.spi.runtimejob;
 
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
+
 import java.util.List;
 import java.util.Optional;
 

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobStatus.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobStatus.java
@@ -20,10 +20,23 @@ package io.cdap.cdap.runtime.spi.runtimejob;
  * Status for a runtime job.
  */
 public enum RuntimeJobStatus {
-  STARTING,
-  RUNNING,
-  STOPPING,
-  STOPPED,
-  COMPLETED,
-  FAILED
+  STARTING(false),
+  RUNNING(false),
+  STOPPING(false),
+  STOPPED(true),
+  COMPLETED(true),
+  FAILED(true);
+
+  private final boolean terminated;
+
+  RuntimeJobStatus(boolean terminated) {
+    this.terminated = terminated;
+  }
+
+  /**
+   * Returns true if this status represents a terminated state.
+   */
+  public boolean isTerminated() {
+    return terminated;
+  }
 }


### PR DESCRIPTION
Changes are organized by commits:

1. (CDAP-16369) Enhance provisioner delete cluster to allow returning cluster status
   - The gives more control to the provision deletion implementation on the deletion state transition
      - The deprovisioning can make sure jobs are completed before deleting the cluster
      - It can relies on the state transition from the provisioning service to perform retry/polling logic
1. (CDAP-16369) Add isTerminated to RuntimJobStatus
   - This helps simplify logic on determining if a job is terminated or not
1. (CDAP-16369) Improve and fix Dataproc job files upload
   - Enhance the file upload logic to use LocationFactory from CDAP
   - This automatically enables the local caching in distributed mode
   - Fix the bucket name settings in Dataproc provisioner such that it works with or without gs:// prefix
1. (CDAP-16369) Expose LocationFactory to ProvisionerContext
   - This allows provisioner to have access to locations as used by CDAP
1. (CDAP-16369) Deprecate ProgramRun in favor of ProgramRunInfo
   - The ProgramRunInfo is a super set of ProgramRun
1. (CDAP-16369) Make provisioner executor size configurable
   - This is a small bug fix
   - ScheduledExecutor size shouldn't be 0