### PR TITLE
Fix docs build for release 6.1.2

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -304,6 +304,7 @@ function download_file() {
 
   echo "Downloading using curl ${file_name}"
   echo "from ${source_dir}"
+  echo "curl --silent ${source_dir}/${file_name} --output ${target}"
   curl --silent ${source_dir}/${file_name} --output ${target}
   test_an_include ${md5_hash} ${target}
 }

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="1f3344e3e560107d888f2986d24b8adc"
+DEFAULT_XML_MD5_HASH="d803ed1e5d44b04598cb262cd46e0e30"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/integrations/build.sh
+++ b/cdap-docs/integrations/build.sh
@@ -36,11 +36,11 @@ function download_includes() {
       local branch="${GIT_BRANCH_CDAP_SECURITY_EXTN}/"
     fi
   fi
-  local file_source="${base_source}${branch}cdap-sentry/cdap-sentry-extension/"
+  local file_source="${base_source}${branch}cdap-sentry/cdap-sentry-extension"
   # Download Apache Sentry File
   download_file ${target_includes_dir} ${file_source} README.rst dd94634ab6e0b2729e53c3fdf11c8743 cdap-sentry-extension-readme.txt
   # Download Apache Ranger File
-  local file_source="${base_source}${branch}cdap-ranger/"
+  local file_source="${base_source}${branch}cdap-ranger"
   download_file ${target_includes_dir} ${file_source} README.rst 62a4384022002e1f3f45f1fab5205e42 cdap-ranger-extension-readme.txt
 }
 


### PR DESCRIPTION
- Fixed the way we fetch and create hash for cdap-sentry-extensions & cdap-ranger README.rst files
- Updates cdap-default.xml file hash

Build: https://builds.cask.co/browse/CDAP-DBT45-5
