### PR TITLE
(CDAP-16538) Make sure the plugin properties are immutable

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginProperties.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginProperties.java
@@ -52,7 +52,7 @@ public class PluginProperties implements Serializable {
   }
 
   public Map<String, String> getProperties() {
-    return properties;
+    return Collections.unmodifiableMap(properties);
   }
 
   public Macros getMacros() {


### PR DESCRIPTION
- Even though the builder is building an immutable map, when the properties object is deserialized from JSON, Gson use a modifiable map implementation.
- This lead to bug PLUGIN-128