### PR TITLE
[CDAP -16581] Fix parse as JSON (and other directives) in Wrangler

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/Bulkset/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/Bulkset/index.js
@@ -46,11 +46,7 @@ export default class Bulkset extends Component {
     this.onColumnNamesChange = this.onColumnNamesChange.bind(this);
     this.handleKeyPress = this.handleKeyPress.bind(this);
   }
-  componentDidMount() {
-    if (this.textarea) {
-      this.textarea.focus();
-    }
-  }
+
   applyDirective() {
     let columns = this.state.columnNames.toString();
     let directive = `set columns ${columns}`;
@@ -136,6 +132,7 @@ export default class Bulkset extends Component {
         backdrop="static"
         zIndex="1061"
         className="bulkset-columnactions-modal cdap-modal"
+        autoFocus={false}
       >
         <ModalHeader>
           <span>{T.translate(`${PREFIX}.modalTitle`)}</span>
@@ -154,7 +151,7 @@ export default class Bulkset extends Component {
               value={this.state.columnNames}
               onChange={this.onColumnNamesChange}
               onKeyPress={this.handleKeyPress}
-              ref={(ref) => (this.textarea = ref)}
+              autoFocus
             />
             <div className="text-danger">{this.state.error}</div>
           </fieldset>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/ReplaceColumns/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/ColumnActions/ReplaceColumns/index.js
@@ -51,9 +51,6 @@ export default class ReplaceColumns extends Component {
   }
 
   componentDidMount() {
-    if (this.patternInputRef) {
-      this.patternInputRef.focus();
-    }
     MouseTrap.bind('enter', this.applyDirective);
   }
 
@@ -150,8 +147,7 @@ export default class ReplaceColumns extends Component {
             value={this.state.sourcePattern}
             onChange={this.handleChange.bind(this, 'sourcePattern')}
             placeholder={placeholder}
-            autoFocus={true}
-            ref={(ref) => (this.patternInputRef = ref)}
+            autoFocus
           />
         </div>
       </div>
@@ -188,6 +184,7 @@ export default class ReplaceColumns extends Component {
         backdrop="static"
         zIndex="1061"
         className="changecolumns-columnactions-modal cdap-modal"
+        autoFocus={false}
       >
         <ModalHeader>
           <span>{T.translate(`${PREFIX}.modalTitle`)}</span>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/ExcelModal.js
@@ -34,7 +34,6 @@ export default class ExcelModal extends Component {
       sheetNumber: 0,
       firstRowHeader: false,
     };
-    this.numberTextBox = null;
     this.onSheetNumberChange = this.onSheetNumberChange.bind(this);
     this.onSheetNameChange = this.onSheetNameChange.bind(this);
     this.onSheetSourceChange = this.onSheetSourceChange.bind(this);
@@ -45,9 +44,6 @@ export default class ExcelModal extends Component {
 
   componentDidMount() {
     MouseTrap.bind('enter', this.applyDirective);
-    if (this.numberTextBox) {
-      this.numberTextBox.focus();
-    }
   }
 
   componentWillUnmount() {
@@ -115,6 +111,7 @@ export default class ExcelModal extends Component {
         backdrop="static"
         zIndex="1061"
         className="dataprep-parse-modal parse-as-excel cdap-modal"
+        autoFocus={false}
       >
         <ModalHeader>
           <span>
@@ -144,12 +141,7 @@ export default class ExcelModal extends Component {
                 className="form-control mousetrap"
                 value={this.state.sheetNumber}
                 onChange={this.onSheetNumberChange}
-                ref={(ref) => {
-                  if (ref) {
-                    this.numberTextBox = ref;
-                    ref.focus();
-                  }
-                }}
+                autoFocus
               />
             ) : null}
           </FormGroup>
@@ -170,11 +162,7 @@ export default class ExcelModal extends Component {
                 value={this.state.sheetName}
                 onChange={this.onSheetNameChange}
                 placeholder={T.translate(`${PREFIX}.modal.sheetNameInputPlaceholder`)}
-                ref={(ref) => {
-                  if (ref) {
-                    ref.focus();
-                  }
-                }}
+                autoFocus
               />
             ) : null}
           </FormGroup>

--- a/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/Directives/Parse/Modals/SingleFieldModal.js
@@ -38,7 +38,6 @@ export default class SingleFieldModal extends Component {
 
   componentDidMount() {
     MouseTrap.bind('enter', this.apply);
-    this.inputRef.focus();
   }
 
   componentWillUnmount() {
@@ -104,6 +103,7 @@ export default class SingleFieldModal extends Component {
         backdrop="static"
         zIndex="1061"
         className="dataprep-parse-modal cdap-modal"
+        autoFocus={false}
       >
         <ModalHeader>
           <span>{T.translate(`${SUFFIX}.modalTitle`, { parser: parserTitle })}</span>
@@ -122,8 +122,8 @@ export default class SingleFieldModal extends Component {
               className="form-control mousetrap"
               placeholder={T.translate(`${SUFFIX}.Parsers.${parser}.placeholder`)}
               value={this.state.text}
-              ref={(ref) => (this.inputRef = ref)}
               onChange={this.onTextChange}
+              autoFocus
             />
           </div>
 

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -600,7 +600,7 @@ features:
           description: Enter column names in order starting from the first column
           modalTitle: Bulk set column names
           setBtnLabel: Set Columns
-          textareaplaceholder: "Enter column names seperated by comma. Special characters (eg., @ - #) are not allowed"
+          textareaplaceholder: "Enter column names separated by commas. Special characters (eg., @ - #) are not allowed"
         ReplaceColumns:
           applyButton: Replace
           ignoreCase: Ignore case


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16581
Build: https://builds.cask.co/browse/CDAP-UDUT569

Bug in reactstrap (due to upgrade) caused issues in several directives where we were setting focus in componentDidMount with a ref (see details here: https://github.com/reactstrap/reactstrap/issues/1598).  

This caused parse as JSON to be completely broken in the Wrangler UI, and also made it so that the correct element wasn't getting the focus in parse as Excel, replace columns, and bulkset column names.  The bug was addressed by using the autofocus attribute instead.