### PR TITLE
[CDAP-16578] fixing material styling issue

### DIFF
--- a/cdap-ui/app/cdap/components/Ingestion/PluginList/index.tsx
+++ b/cdap-ui/app/cdap/components/Ingestion/PluginList/index.tsx
@@ -16,7 +16,6 @@
 
 import * as React from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
-import ThemeWrapper from 'components/ThemeWrapper';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import { objectQuery } from 'services/helpers';

--- a/cdap-ui/app/cdap/components/Ingestion/SinkList/index.tsx
+++ b/cdap-ui/app/cdap/components/Ingestion/SinkList/index.tsx
@@ -16,7 +16,6 @@
 
 import * as React from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
-import ThemeWrapper from 'components/ThemeWrapper';
 import Card from '@material-ui/core/Card';
 import { objectQuery } from 'services/helpers';
 import { getIcon } from 'components/Ingestion/helpers';

--- a/cdap-ui/app/cdap/components/Ingestion/SourceSinkConfigurator/index.tsx
+++ b/cdap-ui/app/cdap/components/Ingestion/SourceSinkConfigurator/index.tsx
@@ -17,12 +17,8 @@
 import * as React from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import ThemeWrapper from 'components/ThemeWrapper';
-import Card from '@material-ui/core/Card';
-import { objectQuery } from 'services/helpers';
 import WidgetRenderer from 'components/Ingestion/PluginWidgetRenderer';
 import If from 'components/If';
-import ConfigurationGroup from 'components/ConfigurationGroup';
-import ObjectType from '@storybook/addon-knobs/dist/components/types/Object';
 
 const styles = (theme): StyleRules => {
   return {

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsKeyValuePairWrapper/RuntimeArgsRow.tsx
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsKeyValuePairWrapper/RuntimeArgsRow.tsx
@@ -16,8 +16,7 @@
 
 import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
-import { KeyValueRow } from 'components/AbstractWidget/KeyValueWidget/KeyValueRow';
-import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
 import AbstractRow, {
   IAbstractRowProps,
   AbstractRowStyles,
@@ -30,6 +29,11 @@ const styles = (theme): StyleRules => {
       display: 'grid',
       gridTemplateColumns: '50% 50%',
       gridGap: '10px',
+      // TODO: clean up this additional styling for legend after upgrading bootstrap
+      // and verifying bootstrap does not add additional border-bottom.
+      '& legend': {
+        border: '0px',
+      },
     },
     disabled: {
       '& .Mui-disabled': {


### PR DESCRIPTION
- Styles from bootstrap was adding border-bottom for legend element which is used by material-ui TextField to render label.
- Removed some unused imports.
