### PR TITLE
[CDAP-16602] Fix search by tags modal in UI to fetch results from correct property in response.

### DIFF
--- a/cdap-ui/app/cdap/components/Pagination/PaginationDropdown.js
+++ b/cdap-ui/app/cdap/components/Pagination/PaginationDropdown.js
@@ -50,6 +50,9 @@ export default class PaginationDropdown extends Component {
         </div>
       );
     }
+    if (this.props.numberOfPages === 1) {
+      return null;
+    }
 
     return (
       <Dropdown

--- a/cdap-ui/app/cdap/components/Pagination/PaginationDropdown.scss
+++ b/cdap-ui/app/cdap/components/Pagination/PaginationDropdown.scss
@@ -16,6 +16,15 @@
 .pagination-dropdown {
   cursor: pointer;
   &.dropdown {
+    &.show {
+      /*
+      * We have important here because the 'show' css class added by reactstrap
+      * has important while showing the dropdown. Because of the display being
+      * set as block by reactstrap dropdown overflows out and screws up the display
+      * FIXME: CDAP-16605
+      */
+      display: inline-block !important;
+    }
     .dropdown-menu {
       .dropdown-item {
         cursor: pointer;

--- a/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModal.scss
+++ b/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModal.scss
@@ -34,8 +34,6 @@ $highlight-color: $grey-06;
     border-radius: 0;
 
     .close-section {
-      width: 325px;
-
       .dropdown {
         display: inline-block;
         margin-right: 26px;
@@ -70,10 +68,18 @@ $highlight-color: $grey-06;
         }
       }
     }
+    .tag-title {
+      width: 100%;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
     .modal-title {
       font-size: 14px;
       font-weight: 500;
       width: 100%;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(auto, auto));
 
       .search-results-total {
         color: $light-grey;

--- a/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModalHeader.js
+++ b/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/SpotlightModalHeader.js
@@ -41,12 +41,12 @@ export default class SpotlightModalHeader extends Component {
   render() {
     return (
       <ModalHeader>
-        <span className="float-left">
+        <span className="tag-title">
           {T.translate('features.SpotlightSearch.SpotlightModal.headerTagResults', {
             tag: this.props.tag,
           })}
         </span>
-        <div className="close-section float-right text-right">
+        <div className="close-section text-right">
           <span className="search-results-total">
             {this.props.total === 1
               ? T.translate('features.SpotlightSearch.SpotlightModal.numResult', {
@@ -56,13 +56,11 @@ export default class SpotlightModalHeader extends Component {
                   total: this.props.total,
                 })}
           </span>
-          <span>
-            <PaginationDropdown
-              numberOfPages={this.props.numPages}
-              currentPage={this.props.currentPage}
-              onPageChange={this.props.handleSearch.bind(this)}
-            />
-          </span>
+          <PaginationDropdown
+            numberOfPages={this.props.numPages}
+            currentPage={this.props.currentPage}
+            onPageChange={this.props.handleSearch.bind(this)}
+          />
           <span className="fa fa-times" onClick={this.props.toggle} />
         </div>
       </ModalHeader>

--- a/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/index.js
+++ b/cdap-ui/app/cdap/components/SpotlightSearch/SpotlightModal/index.js
@@ -126,7 +126,7 @@ export default class SpotlightModal extends Component {
       this.setState({
         searchResults: res,
         currentPage: page,
-        numPages: Math.ceil(res.total / PAGE_SIZE),
+        numPages: Math.ceil(res.totalResults / PAGE_SIZE),
         focusIndex: 0,
       });
     });

--- a/cdap-ui/app/cdap/components/Tags/Tag/Tag.scss
+++ b/cdap-ui/app/cdap/components/Tags/Tag/Tag.scss
@@ -24,6 +24,7 @@
       .tag-content {
         display: flex;
         align-items: center;
+        white-space: nowrap;
       }
 
       .icon-close {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16602
Build: https://builds.cask.co/browse/CDAP-UDUT577-1

**Problem:**
- The backend API response seem to have changed from 'total' to 'totalResults' to get total results of the search.
- UI was still using the old property which made it pagination useless in UI
- On top of it we had regressions with css which caused an empty dropdown to showup

**Fix:**
- Get total results from right property
- Don't show a dropdown if there is only one page
- Show the pagination dropdown properly if there is more than one page.