### PR TITLE
[CDAP-16236] Reverts the change to remove check for macros before running preview

### DIFF
--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config.html
@@ -289,7 +289,7 @@
             <span ng-if="BatchPipelineConfigCtrl.startingPipeline" class="fa fa-spinner fa-spin"></span>
           </button>
           <button
-            data-cy="run-preview-btn"
+            data-cy="preview-configure-run-btn"
             class="btn btn-primary apply-action"
             ng-if="BatchPipelineConfigCtrl.showPreviewConfig"
             ng-disabled="BatchPipelineConfigCtrl.buttonsAreDisabled()"

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -205,7 +205,8 @@
           tooltip-placement="bottom"
           tooltip-class="toppanel-tooltip"
           tooltip-enable="!HydratorPlusPlusTopPanelCtrl.hasNodes"
-          ng-disabled="HydratorPlusPlusTopPanelCtrl.previewLoading || !HydratorPlusPlusTopPanelCtrl.hasNodes">
+          ng-disabled="HydratorPlusPlusTopPanelCtrl.previewLoading || !HydratorPlusPlusTopPanelCtrl.hasNodes"
+          data-cy="preview-top-run-btn">
       <div class="btn-container">
         <span class="fa fa-play text-success"></span>
         <div class="button-label">Run</div>
@@ -262,7 +263,7 @@
     runtime-arguments="HydratorPlusPlusTopPanelCtrl.runtimeArguments"
     apply-runtime-arguments="HydratorPlusPlusTopPanelCtrl.applyRuntimeArguments()"
     resolved-macros="HydratorPlusPlusTopPanelCtrl.resolvedMacros"
-    run-pipeline="HydratorPlusPlusTopPanelCtrl.startOrStopPreview()"
+    run-pipeline="HydratorPlusPlusTopPanelCtrl.doStartOrStopPreview()"
     pipeline-name="{{HydratorPlusPlusTopPanelCtrl.state.metadata['name']}}"
     pipeline-action="Run"
     on-close="HydratorPlusPlusTopPanelCtrl.viewConfig = false"

--- a/cdap-ui/cypress/support/commands.ts
+++ b/cdap-ui/cypress/support/commands.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import { ConnectionType } from '../../app/cdap/components/DataPrepConnections/ConnectionType';
 import {
@@ -20,14 +20,14 @@ import {
   DEFAULT_GCP_SERVICEACCOUNT_PATH,
   RUNTIME_ARGS_DEPLOYED_SELECTOR,
   RUNTIME_ARGS_KEY_SELECTOR,
-  RUNTIME_ARGS_VALUE_SELECTOR
-} from "../support/constants";
+  RUNTIME_ARGS_VALUE_SELECTOR,
+} from '../support/constants';
 import { INodeIdentifier, INodeInfo, IgetNodeIDOptions } from '../typings';
 import {
   getGenericEndpoint,
   getConditionNodeEndpoint,
   getNodeSelectorFromNodeIndentifier,
-  dataCy
+  dataCy,
 } from '../helpers';
 /**
  * Uploads a pipeline json from fixtures to input file element.
@@ -377,8 +377,8 @@ Cypress.Commands.add(
   ) => {
     cy.get_node(sourceNode).then((sourceEl) => {
       cy.get_node(targetNode).then((targetEl) => {
-        let sourceCoOrdinates = sourceEl[0].getBoundingClientRect();
-        let targetCoOrdinates = targetEl[0].getBoundingClientRect();
+        const sourceCoOrdinates = sourceEl[0].getBoundingClientRect();
+        const targetCoOrdinates = targetEl[0].getBoundingClientRect();
         // connect from source endpoint to midway between the target node
         cy.move_node(
           sourceEndpoint(options, sourceEl[0].id),
@@ -391,7 +391,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('get_node', (element: INodeIdentifier) => {
-  let elementId = getNodeSelectorFromNodeIndentifier(element);
+  const elementId = getNodeSelectorFromNodeIndentifier(element);
   return cy.get(elementId).then((e) => cy.wrap(e));
 });
 
@@ -535,65 +535,104 @@ Cypress.Commands.add('close_node_property', () => {
 /**
  * row - row index for the runtime argument key value pair.
  */
-Cypress.Commands.add('add_runtime_args_row_with_value', (row: number, key: string, value: string) => {
-  // clicking add on previous row.
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row - 1)} ${
-    dataCy('add-row')}`)
-    .click();
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_KEY_SELECTOR)}`)
-    .should('exist');
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_KEY_SELECTOR)} input`)
-    .type(key);
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_VALUE_SELECTOR)} input`)
-    .type(value);
-});
-
+Cypress.Commands.add(
+  'add_runtime_args_row_with_value',
+  (row: number, key: string, value: string) => {
+    // clicking add on previous row.
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row - 1)} ${dataCy('add-row')}`
+    ).click();
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_KEY_SELECTOR
+      )}`
+    ).should('exist');
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_KEY_SELECTOR
+      )} input`
+    ).type(key);
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_VALUE_SELECTOR
+      )} input`
+    ).type(value);
+  }
+);
 
 /**
  * row - row index for the runtime argument key value pair.
  */
-Cypress.Commands.add('update_runtime_args_row', (row: number, key: string, value: string, macro: boolean = false) => {
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_KEY_SELECTOR)}`)
-    .should('exist');
-  if (!macro) {
-    cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-      dataCy(RUNTIME_ARGS_KEY_SELECTOR)} input`).clear();
-    cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-      dataCy(RUNTIME_ARGS_KEY_SELECTOR)}`)
-      .type(key);
+Cypress.Commands.add(
+  'update_runtime_args_row',
+  (row: number, key: string, value: string, macro: boolean = false) => {
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_KEY_SELECTOR
+      )}`
+    ).should('exist');
+    if (!macro) {
+      cy.get(
+        `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+          RUNTIME_ARGS_KEY_SELECTOR
+        )} input`
+      ).clear();
+      cy.get(
+        `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+          RUNTIME_ARGS_KEY_SELECTOR
+        )}`
+      ).type(key);
+    }
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_VALUE_SELECTOR
+      )} input`
+    ).should('exist');
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_VALUE_SELECTOR
+      )} input`
+    ).clear();
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_VALUE_SELECTOR
+      )}`
+    ).type(value);
   }
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_VALUE_SELECTOR)} input`).should('exist');
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_VALUE_SELECTOR)} input`).clear();
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_VALUE_SELECTOR)}`)
-    .type(value);
-});
+);
 
 /**
  * row - row index for the runtime argument key value pair.
  */
-Cypress.Commands.add('assert_runtime_args_row', (row: number, key: string, value: string, macro: boolean = false) => {
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_KEY_SELECTOR)}`)
-    .should('exist');
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_KEY_SELECTOR)} input`)
-    .should('have.value', key);
-  if (macro) {
-    cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-      dataCy(RUNTIME_ARGS_KEY_SELECTOR)} input`)
-      .should('be.disabled');
+Cypress.Commands.add(
+  'assert_runtime_args_row',
+  (row: number, key: string, value: string, macro: boolean = false) => {
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_KEY_SELECTOR
+      )}`
+    ).should('exist');
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_KEY_SELECTOR
+      )} input`
+    ).should('have.value', key);
+    if (macro) {
+      cy.get(
+        `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+          RUNTIME_ARGS_KEY_SELECTOR
+        )} input`
+      ).should('be.disabled');
+    }
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_VALUE_SELECTOR
+      )}`
+    ).should('exist');
+    cy.get(
+      `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${dataCy(
+        RUNTIME_ARGS_VALUE_SELECTOR
+      )} input`
+    ).should('have.value', value);
   }
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_VALUE_SELECTOR)}`)
-    .should('exist');
-  cy.get(`${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(row)} ${
-    dataCy(RUNTIME_ARGS_VALUE_SELECTOR)} input`)
-    .should('have.value', value);
-});
+);

--- a/cdap-ui/cypress/typings/index.d.ts
+++ b/cdap-ui/cypress/typings/index.d.ts
@@ -183,6 +183,21 @@ declare global {
        * Creates a SPANNER connection
        */
       create_SPANNER_connection: (connectionId: string, projectId?: string, serviceAccountPath?: string) => void;
+
+      /**
+       * Utility to add runtime arguments at specific key
+       */
+      add_runtime_args_row_with_value: (row: number, key: string, value: string) => void;
+
+      /**
+       * Utility to add runtime arguments for existing key-value in runtime arguments
+       */
+      update_runtime_args_row: (row: number, key: string, value: string, macro?: boolean) => void;
+
+      /**
+       * Assertion to validate a runtime argument row
+       */
+      assert_runtime_args_row: (row: number, key: string, value: string, macro?: boolean) => void;
       compareSnapshot: (s: string) => any;
     }
     // tslint:disable-next-line: interface-name
@@ -191,6 +206,7 @@ declare global {
       DataTransfer: any;
       sessionStorage: any;
       onbeforeunload: any;
+      CDAP_CONFIG: any;
     }
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16236
Build: https://builds.cask.co/browse/CDAP-UDUT579-1
E2E tests: https://builds.cask.co/browse/IT-UPD2141-1

**Problem:** 
- We accidentally removed the check for macros before running preview. This shouldn't have been merged.
- This was not caught by e2e tests (even though we had one) because is disabled in e2e testing environment

**Fix:**
- Revert the change
- Make tests run locally but skip in distributed environments.
- _Note_: The majority of change in this PR is in test and not in actual code.

**TODO:**
- Make preview enabled in e2e environments