### PR TITLE
Update pipeline versions for e2e tests

### DIFF
--- a/cdap-ui/cypress/fixtures/fll_airport_pipeline2.json
+++ b/cdap-ui/cypress/fixtures/fll_airport_pipeline2.json
@@ -3,7 +3,7 @@
     "description": "without wrangler",
     "artifact": {
         "name": "cdap-data-pipeline",
-        "version": "[6.1.0-SNAPSHOT, 6.2.0-SNAPSHOT]",
+        "version": "[6.1.0-SNAPSHOT, 6.3.0-SNAPSHOT]",
         "scope": "SYSTEM"
     },
     "config": {

--- a/cdap-ui/cypress/fixtures/null_splitter_pipeline-cdap-data-pipeline.json
+++ b/cdap-ui/cypress/fixtures/null_splitter_pipeline-cdap-data-pipeline.json
@@ -1,7 +1,7 @@
 {
     "artifact": {
         "name": "cdap-data-pipeline",
-        "version": "[6.1.0-SNAPSHOT, 6.2.0-SNAPSHOT]",
+        "version": "[6.1.0-SNAPSHOT, 6.3.0-SNAPSHOT]",
         "scope": "SYSTEM",
         "label": "Data Pipeline - Batch"
     },

--- a/cdap-ui/cypress/fixtures/union_condition_splitter_pipeline_v1-cdap-data-pipeline.json
+++ b/cdap-ui/cypress/fixtures/union_condition_splitter_pipeline_v1-cdap-data-pipeline.json
@@ -1,7 +1,7 @@
 {
     "artifact": {
         "name": "cdap-data-pipeline",
-        "version": "[6.1.0-SNAPSHOT, 6.2.0-SNAPSHOT]",
+        "version": "[6.1.0-SNAPSHOT, 6.3.0-SNAPSHOT]",
         "scope": "SYSTEM",
         "label": "Data Pipeline - Batch"
     },


### PR DESCRIPTION
To fix integration tests for 6.3.0-SNAPSHOT

Build: https://builds.cask.co/browse/CDAP-UDUT582