### PR TITLE
[CDAP-16645] Avoid unnecessarily re-rendering preferences in UI

### DIFF
--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -81,12 +81,6 @@ export default class SetPreferenceModal extends Component {
           this.setPreferencesApi = MyPreferenceApi.setProgramPreferences;
         }
       }
-
-      this.subscription = NamespaceStore.subscribe(() => {
-        this.params.namespace = NamespaceStore.getState().selectedNamespace;
-        this.getSpecifiedPreferences();
-        this.getInheritedPreferences();
-      });
     }
 
     this.apiSubscriptions = [];
@@ -426,7 +420,7 @@ export default class SetPreferenceModal extends Component {
         className="confirmation-modal set-preference-modal cdap-modal"
         size="lg"
         backdrop="static"
-        zIndex="1201"
+        zIndex="1601"
       >
         <ModalHeader className="modal-header">
           <div className="float-left">


### PR DESCRIPTION
- We modified the way we poll for system health (namespaces and system services) to be on the client. 
- This means we poll for the data every 10 seconds from the browser.
- This caused react to re-render since we were updating the store no matter whether there was a change.
- This causes user to lose their existing preference that they have just typed in to be saved.
- This didn't happen before because we had our polling logic in nodejs server and nodejs server sends an update only when there is a change in the response.

JIRA: https://issues.cask.co/browse/CDAP-16645
Build: https://builds.cask.co/browse/CDAP-UDUT588-1