### PR TITLE
[CDAP-16649] Support authentication and TLS to Elastic metadata storage

### DIFF
--- a/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/Config.java
+++ b/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/Config.java
@@ -24,6 +24,8 @@ public final class Config {
 
   static final String CONF_ELASTIC_HOSTS = "metadata.elasticsearch.cluster.hosts";
   static final String CONF_ELASTIC_TLS_VERIFY = "metadata.elasticsearch.tls.verify";
+  static final String CONF_ELASTIC_USERNAME = "metadata.elasticsearch.credentials.username";
+  static final String CONF_ELASTIC_PASSWORD = "metadata.elasticsearch.credentials.password";
   static final String CONF_ELASTIC_INDEX_NAME = "metadata.elasticsearch.index.name";
   static final String CONF_ELASTIC_SCROLL_TIMEOUT = "metadata.elasticsearch.scroll.timeout";
   static final String CONF_ELASTIC_NUM_SHARDS = "metadata.elasticsearch.num.shards";

--- a/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/Config.java
+++ b/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/Config.java
@@ -23,6 +23,7 @@ public final class Config {
   private Config() { }
 
   static final String CONF_ELASTIC_HOSTS = "metadata.elasticsearch.cluster.hosts";
+  static final String CONF_ELASTIC_TLS_VERIFY = "metadata.elasticsearch.tls.verify";
   static final String CONF_ELASTIC_INDEX_NAME = "metadata.elasticsearch.index.name";
   static final String CONF_ELASTIC_SCROLL_TIMEOUT = "metadata.elasticsearch.scroll.timeout";
   static final String CONF_ELASTIC_NUM_SHARDS = "metadata.elasticsearch.num.shards";
@@ -37,6 +38,7 @@ public final class Config {
   static final int DEFAULT_ELASTIC_CONFLICT_NUM_RETRIES = 50;
   static final int DEFAULT_ELASTIC_CONFLICT_RETRY_SLEEP_MS = 100;
   static final int DEFAULT_MAX_RESULT_WINDOW = 10000; // this is hardcoded in Elasticsearch
+  static final boolean DEFAULT_ELASTIC_TLS_VERIFY = true;
 
   // index.mappings.json will have a mapping: "cdap_version": "CDAP_VERSION".
   // the latter (placeholder) is replaced with the current CDAP version at index creation

--- a/cdap-elastic/src/test/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorageTest.java
+++ b/cdap-elastic/src/test/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorageTest.java
@@ -22,6 +22,7 @@ import com.google.common.io.Closeables;
 import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.metadata.Cursor;
 import io.cdap.cdap.spi.metadata.Metadata;
 import io.cdap.cdap.spi.metadata.MetadataKind;
@@ -75,7 +76,8 @@ public class ElasticsearchMetadataStorageTest extends MetadataStorageTest {
       LOG.info("Elasticsearch port is {}", elasticPort);
       cConf.set(Config.CONF_ELASTIC_HOSTS, "localhost:" + elasticPort);
     }
-    elasticStore = new ElasticsearchMetadataStorage(cConf);
+    SConfiguration sConf = SConfiguration.create();
+    elasticStore = new ElasticsearchMetadataStorage(cConf, sConf);
     elasticStore.createIndex();
   }
 


### PR DESCRIPTION
Adds following support for Elastic metadata storage:
 - Connect to Elastic over TLS

This is done by allowing the `metadata.elasticsearch.cluster.hosts` config to contain a scheme (`http` or `https`). If no scheme is specified, it defaults to `http` (the legacy behavior)

 - Allow TLS verification to be disabled

Adds the `metadata.elasticsearch.tls.verify` config, allowing TLS to be used without the certificate being verified. Useful in development/testing scenarios when self signed certificates are in use.

 - Allow configuration of username/password for Elastic in cdap-security.xml

Adds `metadata.elasticsearch.credentials.username` and `metadata.elasticsearch.credentials.password` in the `cdap-security.xml` file. Allows for HTTP basic authentication to Elastic cluster (with or without TLS).