### PR TITLE
(CDAP-16639) Move hive-exec to the bottom of the class path

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/twill/HadoopClassExcluder.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/twill/HadoopClassExcluder.java
@@ -40,6 +40,9 @@ public class HadoopClassExcluder extends ClassAcceptor {
         return false;
       }
     }
-    return true;
+    // We don't use the snappy library from org.iq80. We use the one from org.xerial.snappy.
+    // This is an optional dependency from org.iq80.leveldb, hence it is not included in CDAP
+    // However, the hive-exec contains it, which can mess up other dependency if we include it.
+    return !className.startsWith("org.iq80.snappy.");
   }
 }


### PR DESCRIPTION
- Also exclude the org.iq80.snappy classes are they are not used, but will pull in hive-exec if we accept it during dependency tracing.

Cherry-pick https://github.com/cdapio/cdap/pull/12109