### PR TITLE
[CDAP-16621] Remove export modal when exporting pipeline JSON

### DIFF
--- a/cdap-ui/app/cdap/components/ActionsPopover/index.tsx
+++ b/cdap-ui/app/cdap/components/ActionsPopover/index.tsx
@@ -32,6 +32,8 @@ export interface IAction {
 interface IActionsPopoverProps {
   actions: IAction[];
   targetElem?: (props) => React.ReactElement;
+  showPopover?: boolean;
+  togglePopover?: () => void;
 }
 
 const POPPER_MODIFIERS = {
@@ -43,9 +45,19 @@ const POPPER_MODIFIERS = {
   },
 };
 
-const ActionsPopover: React.SFC<IActionsPopoverProps> = ({ actions, targetElem }) => {
+const ActionsPopover: React.SFC<IActionsPopoverProps> = ({
+  actions,
+  targetElem,
+  showPopover,
+  togglePopover,
+}) => {
   let target = (props) => (
-    <IconSVG name="icon-cog-empty" {...props} className={`default-target ${props.className}`} />
+    <IconSVG
+      name="icon-cog-empty"
+      {...props}
+      className={`default-target ${props.className}`}
+      onClick={togglePopover}
+    />
   );
   if (targetElem) {
     target = targetElem;
@@ -59,6 +71,7 @@ const ActionsPopover: React.SFC<IActionsPopoverProps> = ({ actions, targetElem }
       bubbleEvent={false}
       enableInteractionInPopover={true}
       modifiers={POPPER_MODIFIERS}
+      showPopover={showPopover}
     >
       <ul>
         {actions.map((action, i) => {

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -27,6 +27,7 @@ import T from 'i18n-react';
 import classnames from 'classnames';
 import { duplicatePipeline } from 'services/PipelineUtils';
 import cloneDeep from 'lodash/cloneDeep';
+import downloadFile from 'services/download-file';
 require('./PipelineDetailsActionsButton.scss');
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
@@ -129,6 +130,18 @@ export default class PipelineDetailsActionsButton extends Component {
     );
   };
 
+  handlePipelineExport = () => {
+    if (window.Cypress) {
+      this.showExportModal();
+      return;
+    }
+    // Unless we are running an e2e test, just export the pipeline JSON
+    const closePopoverCb = () => {
+      this.setState({ showPopover: false });
+    };
+    downloadFile(this.pipelineConfig, closePopoverCb);
+  };
+
   toggleExportModal = () => {
     this.setState({ showExportModal: !this.state.showExportModal });
   };
@@ -151,6 +164,7 @@ export default class PipelineDetailsActionsButton extends Component {
         isOpen={this.state.showExportModal}
         onClose={this.toggleExportModal}
         pipelineConfig={sanitizeConfig(this.pipelineConfig)}
+        onExport={this.handlePipelineExport}
       />
     );
   }
@@ -242,7 +256,7 @@ export default class PipelineDetailsActionsButton extends Component {
         >
           <ul>
             <li onClick={this.duplicateConfigAndNavigate}>{T.translate(`${PREFIX}.duplicate`)}</li>
-            <li onClick={this.toggleExportModal}>{T.translate(`${PREFIX}.export`)}</li>
+            <li onClick={this.handlePipelineExport}>{T.translate(`${PREFIX}.export`)}</li>
             <hr />
             <li
               onClick={this.toggleDeleteConfirmationModal}

--- a/cdap-ui/app/cdap/components/PipelineExportModal/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineExportModal/index.tsx
@@ -26,30 +26,10 @@ interface IProps {
   isOpen: boolean;
   onClose: () => void;
   pipelineConfig: any;
+  onExport: (config: any) => void;
 }
 
-const PipelineExportModal: React.SFC<IProps> = ({ isOpen, onClose, pipelineConfig }) => {
-  const exportPipeline = () => {
-    const blob = new Blob([JSON.stringify(pipelineConfig, null, 4)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const exportFileName =
-      (pipelineConfig.name ? pipelineConfig.name : 'noname') + '-' + pipelineConfig.artifact.name;
-
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${exportFileName}.json`;
-
-    const clickHandler = (event) => {
-      event.stopPropagation();
-      setTimeout(() => {
-        onClose();
-      }, 300);
-    };
-
-    a.addEventListener('click', clickHandler, false);
-    a.click();
-  };
-
+const PipelineExportModal: React.SFC<IProps> = ({ isOpen, onClose, pipelineConfig, onExport }) => {
   return (
     <Modal
       isOpen={isOpen}
@@ -80,7 +60,7 @@ const PipelineExportModal: React.SFC<IProps> = ({ isOpen, onClose, pipelineConfi
         </fieldset>
       </ModalBody>
       <ModalFooter>
-        <div className="btn btn-primary" onClick={exportPipeline}>
+        <div className="btn btn-primary" onClick={onExport.bind(null, pipelineConfig)}>
           {T.translate(`${PREFIX}.export`)}
         </div>
         <div className="btn btn-secondary close-button" onClick={onClose}>

--- a/cdap-ui/app/cdap/services/download-file.js
+++ b/cdap-ui/app/cdap/services/download-file.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ function DownloadFile(fileConfig, postExportCb) {
+  const blob = new Blob([JSON.stringify(fileConfig, null, 4)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const exportFileName = `${fileConfig.name ? fileConfig.name : 'noname'}-${
+    fileConfig.artifact.name
+  }`;
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${exportFileName}.json`;
+
+  const clickHandler = (event) => {
+    event.stopPropagation();
+    setTimeout(() => {
+      typeof postExportCb === 'function' && postExportCb()
+    }, 300);
+  };
+
+  a.addEventListener('click', clickHandler, false);
+  a.click();
+};
+
+export default DownloadFile;

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -119,6 +119,7 @@ var Page500 = require('../cdap/components/500').default;
 var WindowManager = require('../cdap/services/WindowManager').default;
 var { WINDOW_ON_FOCUS, WINDOW_ON_BLUR } = require('../cdap/services/WindowManager');
 var PREVIEW_STATUS = require('../cdap/services/PreviewStatus').PREVIEW_STATUS;
+var DownloadFile = require('../cdap/services/download-file').default;
 
 export {
   Store,
@@ -212,4 +213,5 @@ export {
   WINDOW_ON_FOCUS,
   WINDOW_ON_BLUR,
   PREVIEW_STATUS,
+  DownloadFile,
 };

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -244,7 +244,12 @@ class HydratorPlusPlusTopPanelCtrl {
     let config = angular.copy(this.HydratorPlusPlusConfigStore.getDisplayConfig());
     let exportConfig = this.HydratorPlusPlusConfigStore.getConfigForExport();
     delete exportConfig.__ui__;
-    this.myPipelineExportModalService.show(config, exportConfig);
+    // Only show export modal with pipeline JSON when running e2e tests
+    if (window.Cypress) {
+      this.myPipelineExportModalService.show(config, exportConfig);
+    } else {
+      window.CaskCommon.DownloadFile(exportConfig);
+    }
   }
   onSaveDraft() {
     this.HydratorPlusPlusConfigActions.saveAsDraft();

--- a/cdap-ui/cypress/integration/pipeline.canvas.actions.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.canvas.actions.spec.ts
@@ -14,19 +14,7 @@
  * the License.
  */
 
-import {
-  loginIfRequired,
-  getGenericEndpoint,
-  getConditionNodeEndpoint,
-  getArtifactsPoll,
-} from '../helpers';
-import {
-  DEFAULT_GCP_PROJECTID,
-  DEFAULT_GCP_SERVICEACCOUNT_PATH,
-  DEFAULT_BIGQUERY_DATASET,
-  DEFAULT_BIGQUERY_TABLE,
-} from '../support/constants';
-import { INodeInfo, INodeIdentifier } from '../typings';
+import { loginIfRequired, getArtifactsPoll } from '../helpers';
 let headers = {};
 
 describe('Pipeline Canvas actions', () => {
@@ -42,10 +30,22 @@ describe('Pipeline Canvas actions', () => {
         };
       });
     });
+    cy.visit('/cdap', {
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear();
+        win.sessionStorage.setItem('pipelineConfigTesting', 'true');
+      },
+    });
   });
 
   beforeEach(() => {
     getArtifactsPoll(headers);
+  });
+
+  after(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.removeItem('pipelineConfigTesting');
+    });
   });
 
   it('Should correctly undo/redo actions done by the user', () => {

--- a/cdap-ui/cypress/integration/pipeline.contextmenu.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.contextmenu.spec.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import * as Helpers from '../helpers';
 let headers = {};
@@ -27,6 +27,18 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
           Authorization: 'Bearer ' + cookie.value,
         };
       });
+    });
+    cy.visit('/cdap', {
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear();
+        win.sessionStorage.setItem('pipelineConfigTesting', 'true');
+      },
+    });
+  });
+
+  after(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.removeItem('pipelineConfigTesting');
     });
   });
 
@@ -46,13 +58,15 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
       cy.select_from_to(sourceNodeId, sinkNodeId);
       cy.get(Helpers.getNodeSelectorFromNodeIndentifier(sourceNodeId)).rightclick();
       cy.get('li[role="menuitem"]').contains('Copy Plugins');
-      cy.get('li[role="menuitem"]').contains('Delete Plugins').click();
+      cy.get('li[role="menuitem"]')
+        .contains('Delete Plugins')
+        .click();
       cy.get('[data-cy="pipeline-export-btn"]').should('have.attr', 'disabled', 'disabled');
       const undoSelector = '[data-cy="pipeline-undo-action-btn"]';
       cy.get(undoSelector).click();
       cy.get(undoSelector).click();
       cy.get(undoSelector).click();
-      cy.get_pipeline_json().then(pipelineConfig => {
+      cy.get_pipeline_json().then((pipelineConfig) => {
         const connections = pipelineConfig.config.connections;
         const stages = pipelineConfig.config.stages;
         expect(connections.length).eq(2);
@@ -75,57 +89,54 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
   });
 
   it('Should work on clicking zoom-in/out actions', () => {
-    cy.get('#dag-container').then(el => {
+    cy.get('#dag-container').then((el) => {
       // matrix(1,0,0,1,0,0) is the default value for transform
       // with scalex & y(zoom) to be 1 and dx & dy to be 0
       expect(el).to.have.css('transform', 'matrix(1, 0, 0, 1, 0, 0)');
     });
     cy.get('#dag-container').rightclick({ force: true });
     cy.get('[data-cy="menu-item-zoom-in"]').click();
-    cy.get('#dag-container').then(el => {
+    cy.get('#dag-container').then((el) => {
       expect(el).to.have.css('transform', 'matrix(1.1, 0, 0, 1.1, 0, 0)');
     });
     cy.get('#dag-container').rightclick({ force: true });
     cy.get('[data-cy="menu-item-zoom-in"]').click();
-    cy.get('#dag-container').then(el => {
+    cy.get('#dag-container').then((el) => {
       expect(el).to.have.css('transform', 'matrix(1.2, 0, 0, 1.2, 0, 0)');
     });
     cy.get('#dag-container').rightclick({ force: true });
     cy.get('[data-cy="menu-item-zoom-out"]').click();
     cy.get('#dag-container').rightclick({ force: true });
     cy.get('[data-cy="menu-item-zoom-out"]').click();
-    cy.get('#dag-container').then(el => {
+    cy.get('#dag-container').then((el) => {
       expect(el).to.have.css('transform', 'matrix(1, 0, 0, 1, 0, 0)');
     });
   });
 
   it('Should work on clicking fit-to-screen', () => {
     cy.visit('/pipelines/ns/default/studio');
-    cy.create_complex_pipeline().then(({
-      sourceNodeId1,
-      sourceNodeId2,
-      sinkNodeId1,
-      sinkNodeId2
-    }) => {
-      cy.get_node(sourceNodeId1).should('be.visible');
-      cy.get_node(sourceNodeId2).should('be.visible');
-      cy.get_node(sinkNodeId1).should('be.visible');
-      cy.get_node(sinkNodeId2).should('be.visible');
-      cy.get('[data-cy="pipeline-zoom-in-control"]').click();
-      cy.get('[data-cy="pipeline-zoom-in-control"]').click();
-      cy.get('[data-cy="pipeline-zoom-in-control"]').click();
-      cy.get('[data-cy="pipeline-zoom-in-control"]').click();
-      cy.get_node(sourceNodeId1).should('not.be.visible');
-      cy.get_node(sourceNodeId2).should('not.be.visible');
-      cy.get_node(sinkNodeId1).should('not.be.visible');
-      cy.get_node(sinkNodeId2).should('not.be.visible');
-      cy.get('#dag-container').rightclick({ force: true });
-      cy.get('[data-cy="menu-item-fit-to-screen"]').click();
-      cy.get_node(sourceNodeId1).should('be.visible');
-      cy.get_node(sourceNodeId2).should('be.visible');
-      cy.get_node(sinkNodeId1).should('be.visible');
-      cy.get_node(sinkNodeId2).should('be.visible');
-    });
+    cy.create_complex_pipeline().then(
+      ({ sourceNodeId1, sourceNodeId2, sinkNodeId1, sinkNodeId2 }) => {
+        cy.get_node(sourceNodeId1).should('be.visible');
+        cy.get_node(sourceNodeId2).should('be.visible');
+        cy.get_node(sinkNodeId1).should('be.visible');
+        cy.get_node(sinkNodeId2).should('be.visible');
+        cy.get('[data-cy="pipeline-zoom-in-control"]').click();
+        cy.get('[data-cy="pipeline-zoom-in-control"]').click();
+        cy.get('[data-cy="pipeline-zoom-in-control"]').click();
+        cy.get('[data-cy="pipeline-zoom-in-control"]').click();
+        cy.get_node(sourceNodeId1).should('not.be.visible');
+        cy.get_node(sourceNodeId2).should('not.be.visible');
+        cy.get_node(sinkNodeId1).should('not.be.visible');
+        cy.get_node(sinkNodeId2).should('not.be.visible');
+        cy.get('#dag-container').rightclick({ force: true });
+        cy.get('[data-cy="menu-item-fit-to-screen"]').click();
+        cy.get_node(sourceNodeId1).should('be.visible');
+        cy.get_node(sourceNodeId2).should('be.visible');
+        cy.get_node(sinkNodeId1).should('be.visible');
+        cy.get_node(sinkNodeId2).should('be.visible');
+      }
+    );
   });
 
   it('Should be enabled/disabled if clipboard has valid pipeline object', () => {
@@ -134,9 +145,9 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
     }
     cy.visit('/pipelines/ns/default/studio');
     cy.create_simple_pipeline().then(({ sourceNodeId, sinkNodeId }) => {
-      cy.window().then(window => window.CaskCommon.Clipboard.copyToClipBoard(''));
+      cy.window().then((window) => window.CaskCommon.Clipboard.copyToClipBoard(''));
       cy.get('#dag-container').rightclick({ force: true });
-      cy.get('[data-cy="menu-item-pipeline-node-paste"]').then(el => {
+      cy.get('[data-cy="menu-item-pipeline-node-paste"]').then((el) => {
         expect(el[0].getAttribute('aria-disabled')).to.eq('true');
       });
       cy.get('body').type('{esc}', { release: true });
@@ -144,7 +155,7 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
       cy.get(Helpers.getNodeSelectorFromNodeIndentifier(sourceNodeId)).rightclick();
       cy.get('[data-cy="menu-item-plugin copy"]:visible').click();
       cy.get('#dag-container').rightclick({ force: true });
-      cy.get('[data-cy="menu-item-pipeline-node-paste"]').then(el => {
+      cy.get('[data-cy="menu-item-pipeline-node-paste"]').then((el) => {
         expect(el[0].getAttribute('aria-disabled')).to.eq('false');
       });
     });
@@ -161,7 +172,7 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
       cy.get('[data-cy="menu-item-plugin copy"]:visible').click();
       cy.get('#dag-container').rightclick({ force: true });
       cy.get('[data-cy="menu-item-pipeline-node-paste"]').click();
-      cy.get_pipeline_json().then(pipelineConfig => {
+      cy.get_pipeline_json().then((pipelineConfig) => {
         const { stages, connections } = pipelineConfig.config;
         expect(stages.length).to.eq(6);
         expect(connections.length).to.eq(4);
@@ -181,18 +192,17 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
       cy.get(`[data-cy="${hamburgerSelector}-copy"]`).click();
       cy.get('#dag-container').rightclick({ force: true });
       cy.get(`[data-cy="menu-item-pipeline-node-paste"]`).click();
-      cy.get_pipeline_json().then(pipelineConfig => {
+      cy.get_pipeline_json().then((pipelineConfig) => {
         const { stages } = pipelineConfig.config;
         expect(stages.length).to.eq(4);
       });
       const newAddedSourceName = `BigQueryTable-batchsource-3`;
       cy.get(`[data-cy="hamburgermenu-${newAddedSourceName}-toggle"]`).click();
       cy.get(`[data-cy="hamburgermenu-${newAddedSourceName}-delete"]`).click();
-      cy.get_pipeline_json().then(pipelineConfig => {
+      cy.get_pipeline_json().then((pipelineConfig) => {
         const { stages } = pipelineConfig.config;
         expect(stages.length).to.eq(3);
       });
     });
   });
-
 });

--- a/cdap-ui/cypress/integration/pipeline.multiselect.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.multiselect.spec.ts
@@ -28,6 +28,18 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
         };
       });
     });
+    cy.visit('/cdap', {
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear();
+        win.sessionStorage.setItem('pipelineConfigTesting', 'true');
+      },
+    });
+  });
+
+  after(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.removeItem('pipelineConfigTesting');
+    });
   });
 
   it('Should select node(s)', () => {

--- a/cdap-ui/cypress/integration/pipeline.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.spec.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import * as Helpers from '../helpers';
 
@@ -35,6 +35,12 @@ describe('Creating a pipeline', () => {
           Authorization: 'Bearer ' + cookie.value,
         };
       });
+      cy.visit('/cdap', {
+        onBeforeLoad: (win) => {
+          win.sessionStorage.clear();
+          win.sessionStorage.setItem('pipelineConfigTesting', 'true');
+        },
+      });
     });
   });
 
@@ -45,6 +51,12 @@ describe('Creating a pipeline', () => {
   afterEach(() => {
     // Delete the pipeline to clean up
     cy.cleanup_pipelines(headers, TEST_PIPELINE_NAME);
+  });
+
+  after(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.removeItem('pipelineConfigTesting');
+    });
   });
 
   it('is configured correctly', () => {

--- a/cdap-ui/cypress/integration/widgets.CSVWidget.spec.ts
+++ b/cdap-ui/cypress/integration/widgets.CSVWidget.spec.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import { loginIfRequired, getArtifactsPoll } from '../helpers';
 import { INodeInfo, INodeIdentifier } from '../typings';
@@ -32,6 +32,18 @@ describe('CSV Widgets', () => {
           Authorization: 'Bearer ' + cookie.value,
         };
       });
+    });
+    cy.visit('/cdap', {
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear();
+        win.sessionStorage.setItem('pipelineConfigTesting', 'true');
+      },
+    });
+  });
+
+  after(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.removeItem('pipelineConfigTesting');
     });
   });
 

--- a/cdap-ui/cypress/integration/widgets.KeyValueDropdownWidget.spec.ts
+++ b/cdap-ui/cypress/integration/widgets.KeyValueDropdownWidget.spec.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import { loginIfRequired, getArtifactsPoll, dataCy } from '../helpers';
 import { INodeInfo, INodeIdentifier } from '../typings';
@@ -39,11 +39,23 @@ describe('KeyValueDropdown Widgets', () => {
           Authorization: 'Bearer ' + cookie.value,
         };
       });
+      cy.visit('/cdap', {
+        onBeforeLoad: (win) => {
+          win.sessionStorage.clear();
+          win.sessionStorage.setItem('pipelineConfigTesting', 'true');
+        },
+      });
     });
   });
 
   beforeEach(() => {
     getArtifactsPoll(headers);
+  });
+
+  after(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.removeItem('pipelineConfigTesting');
+    });
   });
 
   it('Should render KeyValueDropdown row', () => {

--- a/cdap-ui/cypress/integration/widgets.KeyValueWidget.spec.ts
+++ b/cdap-ui/cypress/integration/widgets.KeyValueWidget.spec.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import { loginIfRequired, getArtifactsPoll, dataCy } from '../helpers';
 import { INodeInfo, INodeIdentifier } from '../typings';
@@ -40,10 +40,22 @@ describe('KeyValue Widgets', () => {
         };
       });
     });
+    cy.visit('/cdap', {
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear();
+        win.sessionStorage.setItem('pipelineConfigTesting', 'true');
+      },
+    });
   });
 
   beforeEach(() => {
     getArtifactsPoll(headers);
+  });
+
+  after(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.removeItem('pipelineConfigTesting');
+    });
   });
 
   it('Should render KeyValue row', () => {

--- a/cdap-ui/cypress/support/commands.ts
+++ b/cdap-ui/cypress/support/commands.ts
@@ -338,6 +338,8 @@ Cypress.Commands.add('move_node', (node: INodeIdentifier | string, toX: number, 
 Cypress.Commands.add('select_from_to', (from: INodeIdentifier, to: INodeIdentifier) => {
   let fromNodeElement;
   let toNodeElement;
+  // Make sure nodes are aligned  so that correct nodes are selected
+  cy.get('[data-cy="pipeline-clean-up-graph-control"]').click();
   cy.get_node(from).then((sElement) => {
     fromNodeElement = sElement;
     cy.get_node(to).then((tElement) => {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16621
Build: https://builds.cask.co/browse/CDAP-UDUT590

Removes export modal from listview (draft and deployed pipelines), pipeline details page, and Studio.

We currently need to show the pipeline JSON for some of the pipeline integration tests, so I've added a token that's set when we're running the integration tests (for pipeline studio and also the widgets). Also modified the cypress helper function that clicks and drags to select nodes to make it less flaky. 