### PR TITLE
(CDAP-16672) Bump up Application Master resource limit to 50%

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -359,6 +359,12 @@ public class DataprocProvisioner implements Provisioner {
     contextProperties.put("yarn:yarn.nodemanager.pmem-check-enabled", "false");
     contextProperties.put("yarn:yarn.nodemanager.vmem-check-enabled", "false");
 
+    // Allow Application Master (AM) to use up to 50% of the all resources to avoid unschedulable issue due to
+    // limited resource for AM.
+    // By default this is either 10% or 25% depending on the hadoop version, which may not be sufficient.
+    // (e.g. insufficient RAM to run 2 AMs for workflow and mapreduce/spark in a single-node cluster)
+    contextProperties.put("capacity-scheduler:yarn.scheduler.capacity.maximum-am-resource-percent", "0.5");
+
     return contextProperties;
   }
 


### PR DESCRIPTION
Why:
Default setting of 10% or 25% depending on hadoop version may not be
sufficient. For instance, we need to run 2 Application Masters for
workflow and mapreduce/spark.