### PR TITLE
(CDAP-16672) Support GCP Dataproc cluster property override via cdap-site.xml

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -374,18 +374,18 @@ final class DataprocClient implements AutoCloseable {
         clusterConfig.setInternalIpOnly(true);
       }
 
-      Map<String, String> dataprocProps = new HashMap<>(conf.getDataprocProperties());
+      Map<String, String> clusterProperties = new HashMap<>(conf.getClusterProperties());
       // The additional property is needed to be able to provision a singlenode cluster on
       // dataproc. Dataproc has an issue that it will treat 0 number of worker
       // nodes as the default number, which means it will always provision a
       // cluster with 2 worker nodes if this property is not set. Refer to
       // https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/single-node-clusters
       // for more information.
-      dataprocProps.put("dataproc:dataproc.allow.zero.workers", "true");
+      clusterProperties.put("dataproc:dataproc.allow.zero.workers", "true");
       // Enable/Disable stackdriver
-      dataprocProps.put("dataproc:dataproc.logging.stackdriver.enable",
+      clusterProperties.put("dataproc:dataproc.logging.stackdriver.enable",
                         Boolean.toString(conf.isStackdriverLoggingEnabled()));
-      dataprocProps.put("dataproc:dataproc.monitoring.stackdriver.enable",
+      clusterProperties.put("dataproc:dataproc.monitoring.stackdriver.enable",
                         Boolean.toString(conf.isStackdriverMonitoringEnabled()));
 
 
@@ -409,7 +409,7 @@ final class DataprocClient implements AutoCloseable {
         .setGceClusterConfig(clusterConfig.build())
         .setSoftwareConfig(SoftwareConfig.newBuilder()
                              .setImageVersion(imageVersion)
-                             .putAllProperties(dataprocProps));
+                             .putAllProperties(clusterProperties));
 
       if (conf.getEncryptionKeyName() != null) {
         builder.setEncryptionConfig(EncryptionConfig.newBuilder()

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -52,7 +52,7 @@ final class DataprocConf {
   static final String STACKDRIVER_MONITORING_ENABLED = "stackdriverMonitoringEnabled";
   static final String IMAGE_VERSION = "imageVersion";
 
-  private static final Pattern CLUSTER_PROPERTIES_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+:");
+  static final Pattern CLUSTER_PROPERTIES_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+:");
 
   private final String accountKey;
   private final String region;
@@ -86,7 +86,7 @@ final class DataprocConf {
   private final boolean stackdriverLoggingEnabled;
   private final boolean stackdriverMonitoringEnabled;
   private final SSHPublicKey publicKey;
-  private final Map<String, String> dataprocProperties;
+  private final Map<String, String> clusterProperties;
 
   DataprocConf(DataprocConf conf, String network, String subnet) {
     this(conf.accountKey, conf.region, conf.zone, conf.projectId, conf.networkHostProjectID, network, subnet,
@@ -95,7 +95,7 @@ final class DataprocConf {
          conf.pollCreateDelay, conf.pollCreateJitter, conf.pollDeleteDelay, conf.pollInterval,
          conf.encryptionKeyName, conf.gcsBucket, conf.serviceAccount,
          conf.preferExternalIP, conf.stackdriverLoggingEnabled, conf.stackdriverMonitoringEnabled,
-         conf.publicKey, conf.imageVersion, conf.dataprocProperties);
+         conf.publicKey, conf.imageVersion, conf.clusterProperties);
   }
 
   private DataprocConf(@Nullable String accountKey, String region, String zone, String projectId,
@@ -106,8 +106,7 @@ final class DataprocConf {
                        @Nullable String encryptionKeyName, @Nullable String gcsBucket,
                        @Nullable String serviceAccount, boolean preferExternalIP, boolean stackdriverLoggingEnabled,
                        boolean stackdriverMonitoringEnabled, @Nullable SSHPublicKey publicKey,
-                       @Nullable String imageVersion,
-                       Map<String, String> dataprocProperties) {
+                       @Nullable String imageVersion, Map<String, String> clusterProperties) {
     this.accountKey = accountKey;
     this.region = region;
     this.zone = zone;
@@ -135,7 +134,7 @@ final class DataprocConf {
     this.stackdriverMonitoringEnabled = stackdriverMonitoringEnabled;
     this.publicKey = publicKey;
     this.imageVersion = imageVersion;
-    this.dataprocProperties = dataprocProperties;
+    this.clusterProperties = clusterProperties;
   }
 
   String getRegion() {
@@ -243,8 +242,8 @@ final class DataprocConf {
     return publicKey;
   }
 
-  Map<String, String> getDataprocProperties() {
-    return dataprocProperties;
+  Map<String, String> getClusterProperties() {
+    return clusterProperties;
   }
 
   /**
@@ -379,7 +378,7 @@ final class DataprocConf {
     boolean stackdriverMonitoringEnabled = Boolean.parseBoolean(properties.getOrDefault(STACKDRIVER_MONITORING_ENABLED,
                                                                                         "true"));
 
-    Map<String, String> dataprocProps = Collections.unmodifiableMap(
+    Map<String, String> clusterProps = Collections.unmodifiableMap(
       properties.entrySet().stream()
         .filter(e -> CLUSTER_PROPERTIES_PATTERN.matcher(e.getKey()).find())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
@@ -395,7 +394,7 @@ final class DataprocConf {
                             workerNumNodes, workerCPUs, workerMemoryGB, workerDiskGB,
                             pollCreateDelay, pollCreateJitter, pollDeleteDelay, pollInterval,
                             gcpCmekKeyName, gcpCmekBucket, serviceAccount, preferExternalIP, stackdriverLoggingEnabled,
-                            stackdriverMonitoringEnabled, publicKey, imageVersion, dataprocProps);
+                            stackdriverMonitoringEnabled, publicKey, imageVersion, clusterProps);
   }
 
   // the UI never sends nulls, it only sends empty strings.

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -340,7 +340,7 @@ public class DataprocProvisioner implements Provisioner {
     }
 
     // Default settings from the system context
-    ArrayList<String> keys = new ArrayList<>(
+    List<String> keys = new ArrayList<>(
       Arrays.asList(DataprocConf.PREFER_EXTERNAL_IP,
                     DataprocConf.NETWORK,
                     DataprocConf.NETWORK_HOST_PROJECT_ID,
@@ -350,13 +350,12 @@ public class DataprocProvisioner implements Provisioner {
                     BUCKET, RUNTIME_JOB_MANAGER)
     );
 
-    // Default cluster properties (i.e. specifying configuration files of the dataproc cluster and the property
-    // key value paris within those files that should be overridden) from the system context.
-    List<String> clusterPropertyKeys = Collections.unmodifiableList(
-      systemContext.getProperties().keySet().stream()
-        .filter(key -> DataprocConf.CLUSTER_PROPERTIES_PATTERN.matcher(key).find())
-        .collect(Collectors.toList()));
-    keys.addAll(clusterPropertyKeys);
+    // Default dataproc cluster property settings from the system context
+    // (i.e. those settings specifying configuration files of the dataproc cluster and the property
+    // key value paris within those files that should be overridden)
+    systemContext.getProperties().keySet().stream()
+      .filter(key -> DataprocConf.CLUSTER_PROPERTIES_PATTERN.matcher(key).find())
+      .collect(Collectors.toCollection(() -> keys));
 
     for (String key : keys) {
       if (!contextProperties.containsKey(key)) {

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2018-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -130,7 +130,7 @@ public class DataprocProvisionerTest {
     Assert.assertEquals(conf.getRegion(), "region1");
     Assert.assertEquals(conf.getZone(), "region1-a");
 
-    Map<String, String> dataprocProps = conf.getDataprocProperties();
+    Map<String, String> dataprocProps = conf.getClusterProperties();
     Assert.assertEquals(3, dataprocProps.size());
 
     Assert.assertEquals("100", dataprocProps.get("spark:spark.reducer.maxSizeInFlight"));
@@ -161,5 +161,25 @@ public class DataprocProvisionerTest {
     props.put("network", "network");
 
     DataprocConf.fromProperties(props);
+  }
+
+  @Test
+  public void testCreateContextProperties() {
+    MockProvisionerSystemContext provisionerSystemContext = new MockProvisionerSystemContext();
+    String resourceMaxPercentKey = "capacity-scheduler:yarn.scheduler.capacity.maximum-am-resource-percent";
+    String resourceMaxPercentVal = "0.5";
+    provisionerSystemContext.addProperty(resourceMaxPercentKey, resourceMaxPercentVal);
+
+    DataprocProvisioner provisioner = new DataprocProvisioner();
+    provisioner.initialize(provisionerSystemContext);
+
+    MockProvisionerContext provisionerContext = new MockProvisionerContext();
+    final String network = "test-network";
+    provisionerContext.addProperty(DataprocConf.NETWORK, network);
+
+    Map<String, String> properties = provisioner.createContextProperties(provisionerContext);
+
+    Assert.assertTrue(properties.get(DataprocConf.NETWORK).equals(network));
+    Assert.assertTrue(properties.get(resourceMaxPercentKey).equals(resourceMaxPercentVal));
   }
 }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
+import io.cdap.cdap.runtime.spi.SparkCompat;
+import io.cdap.cdap.runtime.spi.provisioner.ProgramRun;
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
+import io.cdap.cdap.runtime.spi.ssh.SSHContext;
+import org.apache.twill.filesystem.LocationFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+
+public class MockProvisionerContext implements ProvisionerContext {
+  private Map<String, String> properties;
+
+  public MockProvisionerContext() {
+    properties = new HashMap<>();
+  }
+
+  @Override
+  public ProgramRun getProgramRun() {
+    return null;
+  }
+
+  @Override
+  public ProgramRunInfo getProgramRunInfo() {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public void addProperty(String key, String val) {
+    properties.put(key, val);
+  }
+
+  public void clearProperties() {
+    properties.clear();
+  }
+
+  @Nullable
+  @Override
+  public SSHContext getSSHContext() {
+    return null;
+  }
+
+  @Override
+  public SparkCompat getSparkCompat() {
+    return null;
+  }
+
+  @Override
+  public String getCDAPVersion() {
+    return null;
+  }
+
+  @Override
+  public LocationFactory getLocationFactory() {
+    return null;
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerSystemContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerSystemContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MockProvisionerSystemContext implements ProvisionerSystemContext {
+  Map<String, String> properties;
+
+  public MockProvisionerSystemContext() {
+    properties = new HashMap<>();
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public void addProperty(String key, String val) {
+    properties.put(key, val);
+  }
+
+  public void clearProperties() {
+    properties.clear();
+  }
+
+  @Override
+  public void reloadProperties() {
+  }
+
+  @Override
+  public String getCDAPVersion() {
+    return null;
+  }
+}


### PR DESCRIPTION
Why:
When creating Dataproc cluster, overriding cluster properties
(i.e. property key-val pairs in config files) cannot be done dynamically.
Currently they are hard-coded.

What:
This change gets property overrides from ProvisionerSystemContext and set them
in the context used for dataproc creation, which get passed to Dataproc via
creation API.

Format of property override in cdap-site.xml:
"[prefix].gcp-dataproc.[dataproc config file]:[property key]" : "[property val]"
where "prefix" is "provisioner.system.properties"

E.g.
provisioner.system.properties.gcp-dataproc.capacity-scheduler:yarn.scheduler.capacity.maximum-am-resource-percent: "0.5"

Needs to comply with format
"[prefix].gcp-dataproc.[dataproc config file]:[property key]" : "[property val]"