### PR TITLE
[CDAP-16696] Fixes Preview UI to handle INIT status of preview

### DIFF
--- a/cdap-ui/app/cdap/services/PreviewStatus.ts
+++ b/cdap-ui/app/cdap/services/PreviewStatus.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+enum PREVIEW_STATUS {
+  INIT = 'INIT',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  DEPLOY_FAILED = 'DEPLOY_FAILED',
+  RUN_FAILED = 'RUN_FAILED',
+  KILLED = 'KILLED',
+  KILLED_BY_TIMER = 'KILLED_BY_TIMER',
+}
+
+export { PREVIEW_STATUS };

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2019 Cask Data, Inc.
+ * Copyright © 2016-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -118,6 +118,7 @@ var Page404 = require('../cdap/components/404').default;
 var Page500 = require('../cdap/components/500').default;
 var WindowManager = require('../cdap/services/WindowManager').default;
 var { WINDOW_ON_FOCUS, WINDOW_ON_BLUR } = require('../cdap/services/WindowManager');
+var PREVIEW_STATUS = require('../cdap/services/PreviewStatus').PREVIEW_STATUS;
 
 export {
   Store,
@@ -210,4 +211,5 @@ export {
   IsValidNS,
   WINDOW_ON_FOCUS,
   WINDOW_ON_BLUR,
+  PREVIEW_STATUS,
 };

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2017 Cask Data, Inc.
+ * Copyright © 2015-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -108,7 +108,7 @@ class HydratorPlusPlusTopPanelCtrl {
             }
           });
 
-          if (statusRes.status === 'RUNNING') {
+          if (statusRes.status === window.CaskCommon.PREVIEW_STATUS.RUNNING) {
             this.previewRunning = true;
             this.startTimer();
             this.startPollPreviewStatus(this.currentPreviewId);
@@ -642,7 +642,18 @@ class HydratorPlusPlusTopPanelCtrl {
           }
         });
       }
-      if (res.status !== 'RUNNING' && res.status !== 'STARTED') {
+      const {
+        RUNNING,
+        STARTED,
+        INIT,
+        COMPLETED,
+        KILLED_BY_TIMER,
+        KILLED,
+        FAILED,
+        RUN_FAILED,
+        STOPPED,
+      } = window.CaskCommon.PREVIEW_STATUS;
+      if ([RUNNING, STARTED, INIT].indexOf(res.status) === -1) {
         this.stopTimer();
         this.previewRunning = false;
         this.dataSrc.stopPoll(res.__pollId__);
@@ -651,17 +662,17 @@ class HydratorPlusPlusTopPanelCtrl {
         if (pipelineName.length > 0) {
           pipelinePreviewPlaceholder += ` "${pipelineName}"`;
         }
-        if (res.status === 'COMPLETED' || res.status === 'KILLED_BY_TIMER') {
+        if (res.status === COMPLETED || res.status === KILLED_BY_TIMER) {
           this.myAlertOnValium.show({
             type: 'success',
             content: `${pipelinePreviewPlaceholder} has completed successfully.`
           });
-        } else if (res.status === 'STOPPED' || res.status === 'KILLED') {
+        } else if (res.status === STOPPED || res.status === KILLED) {
           this.myAlertOnValium.show({
             type: 'success',
             content: `${pipelinePreviewPlaceholder} was stopped.`
           });
-        } else if (res.status === 'FAILED' || res.status === 'RUN_FAILED') {
+        } else if (res.status === FAILED || res.status === RUN_FAILED) {
           this.myAlertOnValium.show({
             type: 'danger',
             content: `${pipelinePreviewPlaceholder} has failed. Please check the logs for more information.`


### PR DESCRIPTION
**Problem**
- The source of the problem is the introduction of new status in preview
- This status was not handled in UI.
- UI checks for the status of the preview to start/stop timer and to show success/error banner for preview. 
- The following is the map,
  - Running -> poll for preview status
  - !Running -> stop poll and calculate timer based on start and end times for preview run
  - completed, killed-by-timer, stopped, killed -> success message
  - failed, run-failed -> error message 

**Fix**
- Account for INIT status while polling for preview status.

JIRA: https://issues.cask.co/browse/CDAP-16696
Build: ~https://builds.cask.co/browse/CDAP-UDUT595-1~ https://builds.cask.co/browse/CDAP-URUT239