### PR TITLE
(CDAP-16593) Restricts max network tags to 64.

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -17,7 +17,9 @@
 package io.cdap.cdap.runtime.spi.common;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -54,7 +56,15 @@ public final class DataprocUtils {
     return map;
   }
 
+  /**
+   * Parses the given list of IP CIDR blocks into list of {@link IPRange}.
+   */
+  public static List<IPRange> parseIPRanges(List<String> ranges) {
+    return ranges.stream().map(IPRange::new).collect(Collectors.toList());
+  }
+
   private DataprocUtils() {
     // no-op
   }
+
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/IPRange.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/IPRange.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.common;
+
+import com.google.common.net.InetAddresses;
+
+import java.net.InetAddress;
+
+/**
+ * Represents an IP range with a lower and upper bound.
+ */
+public final class IPRange {
+
+  private final InetAddress lower;
+  private final InetAddress upper;
+
+  IPRange(String cidrBlock) {
+    String[] parts = cidrBlock.split("/");
+    int size = parts.length == 1 ? 0 : Integer.parseInt(parts[1]);
+    this.lower = InetAddresses.forString(parts[0]);
+    this.upper = InetAddresses.fromInteger(InetAddresses.coerceToInteger(lower) + (1 << (32 - size)) - 1);
+  }
+
+  /**
+   * Returns {@code true} if the given {@link IPRange} overlaps with this IP range.
+   */
+  public boolean isOverlap(IPRange range) {
+    int ourLower = InetAddresses.coerceToInteger(lower);
+    int ourUpper = InetAddresses.coerceToInteger(upper);
+    int theirLower = InetAddresses.coerceToInteger(range.lower);
+    int theirUpper = InetAddresses.coerceToInteger(range.upper);
+
+    return ourLower <= theirUpper && theirLower <= ourUpper;
+  }
+
+  @Override
+  public String toString() {
+    return "IPRange{" +
+      "lower=" + lower +
+      ", upper=" + upper +
+      '}';
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -54,6 +54,8 @@ import com.google.common.base.Strings;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
 import com.google.rpc.Status;
+import io.cdap.cdap.runtime.spi.common.DataprocUtils;
+import io.cdap.cdap.runtime.spi.common.IPRange;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
@@ -67,6 +69,7 @@ import java.security.GeneralSecurityException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -87,7 +90,9 @@ final class DataprocClient implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(DataprocClient.class);
   // something like 2018-04-16T12:09:03.943-07:00
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSSX");
-
+  private static final List<IPRange> PRIVATE_IP_RANGES = DataprocUtils.parseIPRanges(Arrays.asList("10.0.0.0/8",
+                                                                                                   "172.16.0.0/12",
+                                                                                                   "192.168.0.0/16"));
   private final DataprocConf conf;
   private final ClusterControllerClient client;
   private final Compute compute;
@@ -363,11 +368,16 @@ final class DataprocClient implements AutoCloseable {
                                                   conf.getNetwork()));
       }
 
-      for (String targetTag : getFirewallTargetTags()) {
-        clusterConfig.addTags(targetTag);
-      }
       //Add any defined Network Tags
       clusterConfig.addAllTags(conf.getNetworkTags());
+
+      // Add firewall rules for SSH
+      int maxTags = Math.max(0, DataprocConf.MAX_NETWORK_TAGS - clusterConfig.getTagsCount());
+      List<String> tags = getFirewallTargetTags(useInternalIP);
+      if (tags.size() > maxTags) {
+        LOG.warn("No more than 64 tags can be added. Firewall tags ignored: {}", tags.subList(maxTags, tags.size()));
+      }
+      tags.stream().limit(maxTags).forEach(clusterConfig::addTags);
 
       // if internal ip is prefered then create dataproc cluster without external ip for better security
       if (useInternalIP) {
@@ -594,7 +604,7 @@ final class DataprocClient implements AutoCloseable {
    * @return a {@link Collection} of tags that need to be added to the VM to have those firewall rules applies
    * @throws IOException If failed to discover those firewall rules
    */
-  private Collection<String> getFirewallTargetTags() throws IOException {
+  private List<String> getFirewallTargetTags(boolean useInternalIP) throws IOException {
     FirewallList firewalls = compute.firewalls().list(networkHostProjectId).execute();
     List<String> tags = new ArrayList<>();
     Set<FirewallPort> requiredPorts = EnumSet.allOf(FirewallPort.class);
@@ -612,6 +622,28 @@ final class DataprocClient implements AutoCloseable {
       String direction = firewall.getDirection();
       if (!"INGRESS".equals(direction) || firewall.getAllowed() == null) {
         continue;
+      }
+
+      if (useInternalIP) {
+        // If the Dataproc cluster is using internal IP only, we are only interested in firewall rule that has source
+        // IP range overlap with one of the private IP block or doesn't have source IP at all.
+        // This is because if Dataproc cluster is using internal IP, the CDAP itself must be running inside one of the
+        // private IP blocks in order to be able to communicate with Dataproc.
+        try {
+          List<IPRange> sourceRanges = Optional.ofNullable(firewall.getSourceRanges())
+            .map(DataprocUtils::parseIPRanges)
+            .orElse(Collections.emptyList());
+
+          if (!sourceRanges.isEmpty()) {
+            boolean isPrivate = PRIVATE_IP_RANGES.stream()
+              .anyMatch(privateRange -> sourceRanges.stream().anyMatch(privateRange::isOverlap));
+            if (!isPrivate) {
+              continue;
+            }
+          }
+        } catch (Exception e) {
+          LOG.warn("Failed to parse source ranges from firewall rule {}", firewall.getName(), e);
+        }
       }
 
       for (Firewall.Allowed allowed : firewall.getAllowed()) {


### PR DESCRIPTION
- Also only include private IP tags if Dataproc is running with private IP only.

It is a cherry-pick from the release/6.2 branch with conflicts resolved.