### PR TITLE
(CDAP-16730) Set correct -xmx for pods in k8s to run programs

### DIFF
--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -76,6 +76,16 @@
       <artifactId>logback-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.twill</groupId>
+      <artifactId>twill-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
Bug:
We have introduced a multiplier to determine the actual CPU and RAM
to request for creating the pod to run a program. But we fail to
set the correct -xmx based on the RAM requested for the pod.

This change
- Set memory requested to be memory * multiplier
- Set xmx to be memory * multiplier * 0.8
where memory is the requested memroy by the program, we may allocate
more or less depending on the setting of multplier which depends on
the k8s cluster size.