### PR TITLE
(CDAP-16055) Fix logs

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceTaskContextProvider.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.internal.app.runtime.batch.distributed;
 
+import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -81,6 +82,9 @@ public final class DistributedMapReduceTaskContextProvider extends MapReduceTask
     super.startUp();
     ProgramOptions programOptions = mapReduceContextConfig.getProgramOptions();
     try {
+      logAppenderInitializer.initialize();
+      SystemArguments.setLogLevel(programOptions.getUserArguments(), logAppenderInitializer);
+
       oldProxySelector = ProxySelector.getDefault();
       if (clusterMode == ClusterMode.ISOLATED) {
         RuntimeMonitors.setupMonitoring(getInjector(), programOptions);
@@ -89,8 +93,6 @@ public final class DistributedMapReduceTaskContextProvider extends MapReduceTask
       for (Service service : coreServices) {
         service.startAndWait();
       }
-      logAppenderInitializer.initialize();
-      SystemArguments.setLogLevel(programOptions.getUserArguments(), logAppenderInitializer);
     } catch (Exception e) {
       // Try our best to stop services. Chain stop guarantees it will stop everything, even some of them failed.
       try {
@@ -105,12 +107,9 @@ public final class DistributedMapReduceTaskContextProvider extends MapReduceTask
   @Override
   protected void shutDown() throws Exception {
     super.shutDown();
+    Closeables.closeQuietly(logAppenderInitializer);
+
     Exception failure = null;
-    try {
-      logAppenderInitializer.close();
-    } catch (Exception e) {
-      failure = e;
-    }
     for (Service service : (Iterable<Service>) coreServices::descendingIterator) {
       try {
         service.stopAndWait();

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -191,7 +191,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                                                                    authorizationEnforcer, authenticationContext,
                                                                    messagingService, serviceAnnouncer, pluginFinder,
                                                                    locationFactory, metadataReader, metadataPublisher,
-                                                                   namespaceQueryAdmin, fieldLineageWriter);
+                                                                   namespaceQueryAdmin, fieldLineageWriter, () -> { });
       closeables.addFirst(runtimeContext);
 
       Spark spark;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractIdleService;
-import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -85,6 +84,7 @@ import org.apache.twill.zookeeper.ZKClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -99,6 +99,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 /**
@@ -184,8 +185,13 @@ public final class SparkRuntimeContextProvider {
 
       // Create the program
       Program program = createProgram(cConf, contextConfig);
+      ProgramRunId programRunId = program.getId().run(ProgramRunners.getRunId(programOptions));
 
       Injector injector = createInjector(cConf, hConf, contextConfig.getProgramId(), programOptions);
+
+      LogAppenderInitializer logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
+      logAppenderInitializer.initialize();
+      SystemArguments.setLogLevel(programOptions.getUserArguments(), logAppenderInitializer);
 
       ProxySelector oldProxySelector = ProxySelector.getDefault();
       if (clusterMode == ClusterMode.ISOLATED) {
@@ -196,7 +202,6 @@ public final class SparkRuntimeContextProvider {
       SparkServiceAnnouncer serviceAnnouncer = injector.getInstance(SparkServiceAnnouncer.class);
 
       Deque<Service> coreServices = new LinkedList<>();
-      coreServices.add(new LogAppenderService(injector.getInstance(LogAppenderInitializer.class), programOptions));
 
       if (clusterMode == ClusterMode.ON_PREMISE) {
         // Add ZK for discovery and Kafka
@@ -208,32 +213,30 @@ public final class SparkRuntimeContextProvider {
       coreServices.add(metricsCollectionService);
       coreServices.add(serviceAnnouncer);
 
-      // Use the shutdown hook to shutdown services, since this class should only be loaded from System classloader
-      // of the spark executor, hence there should be exactly one instance only.
-      // The problem with not shutting down nicely is that some logs/metrics might be lost
       for (Service coreService : coreServices) {
         coreService.startAndWait();
       }
 
-      Runtime.getRuntime().addShutdownHook(new Thread() {
-        @Override
-        public void run() {
-          // The logger may already been shutdown. Use System.out/err instead
-          System.out.println("Shutting down Spark runtime services");
-
-          // Stop all services. Reverse the order.
-          for (Service service : (Iterable<Service>) coreServices::descendingIterator) {
-            try {
-              service.stopAndWait();
-            } catch (Exception e) {
-              LOG.warn("Exception raised when stopping service {} during program termination.", service, e);
-            }
-          }
-          Authenticator.setDefault(null);
-          ProxySelector.setDefault(oldProxySelector);
-          System.out.println("Spark runtime services shutdown completed");
+      AtomicBoolean closed = new AtomicBoolean();
+      Closeable closeable = () -> {
+        if (!closed.compareAndSet(false, true)) {
+          return;
         }
-      });
+        // Close to flush out all important logs
+        logAppenderInitializer.close();
+
+        // Stop all services. Reverse the order.
+        for (Service service : (Iterable<Service>) coreServices::descendingIterator) {
+          try {
+            service.stopAndWait();
+          } catch (Exception e) {
+            LOG.warn("Exception raised when stopping service {} during program termination.", service, e);
+          }
+        }
+        Authenticator.setDefault(null);
+        ProxySelector.setDefault(oldProxySelector);
+        LOG.debug("Spark runtime services shutdown completed");
+      };
 
       // Constructor the DatasetFramework
       DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
@@ -244,7 +247,6 @@ public final class SparkRuntimeContextProvider {
                                                                  contextConfig.getApplicationSpecification());
       // Setup dataset framework context, if required
       if (programDatasetFramework instanceof ProgramContextAware) {
-        ProgramRunId programRunId = program.getId().run(ProgramRunners.getRunId(programOptions));
         ((ProgramContextAware) programDatasetFramework).setContext(new BasicProgramContext(programRunId));
       }
 
@@ -273,7 +275,8 @@ public final class SparkRuntimeContextProvider {
         injector.getInstance(MetadataReader.class),
         injector.getInstance(MetadataPublisher.class),
         injector.getInstance(NamespaceQueryAdmin.class),
-        injector.getInstance(FieldLineageWriter.class)
+        injector.getInstance(FieldLineageWriter.class),
+        closeable
       );
       LoggingContextAccessor.setLoggingContext(sparkRuntimeContext.getLoggingContext());
       return sparkRuntimeContext;
@@ -350,41 +353,6 @@ public final class SparkRuntimeContextProvider {
       }
     });
     return Guice.createInjector(modules);
-  }
-
-  /**
-   * A guava {@link Service} implementation for starting and stopping {@link LogAppenderInitializer}.
-   */
-  private static final class LogAppenderService extends AbstractService {
-
-    private final ProgramOptions programOptions;
-    private final LogAppenderInitializer initializer;
-
-    private LogAppenderService(LogAppenderInitializer initializer, ProgramOptions programOptions) {
-      this.initializer = initializer;
-      this.programOptions = programOptions;
-    }
-
-    @Override
-    protected void doStart() {
-      try {
-        initializer.initialize();
-        SystemArguments.setLogLevel(programOptions.getUserArguments(), initializer);
-        notifyStarted();
-      } catch (Throwable t) {
-        notifyFailed(t);
-      }
-    }
-
-    @Override
-    protected void doStop() {
-      try {
-        initializer.close();
-        notifyStopped();
-      } catch (Throwable t) {
-        notifyFailed(t);
-      }
-    }
   }
 
   /**

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkRuntimeSecurityManager.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkRuntimeSecurityManager.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.distributed;
+
+import com.google.common.io.Closeables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.security.Permission;
+
+/**
+ * A {@link SecurityManager} for Spark containers (driver and executors) to intercept call to System.exit and to
+ * shutdown system services.
+ */
+final class SparkRuntimeSecurityManager extends SecurityManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkRuntimeSecurityManager.class);
+
+  private final SecurityManager delegate;
+  private final Closeable closeable;
+
+  SparkRuntimeSecurityManager(Closeable closeable) {
+    this.delegate = System.getSecurityManager();
+    this.closeable = closeable;
+  }
+
+  @Override
+  public void checkPermission(Permission perm) {
+    if ("setSecurityManager".equals(perm.getName()) && isFromSpark()) {
+      LOG.warn("Spark program is setting SecurityManager. This can result in logs or metrics not " +
+                 "being collected when the Spark application completed.");
+    }
+    if (delegate != null) {
+      delegate.checkPermission(perm);
+    }
+  }
+
+  @Override
+  public void checkPermission(Permission perm, Object context) {
+    if ("setSecurityManager".equals(perm.getName()) && isFromSpark()) {
+      LOG.warn("Spark program is setting SecurityManager. This can result in logs or metrics not " +
+                 "being collected when the Spark application completed.");
+    }
+    if (delegate != null) {
+      delegate.checkPermission(perm, context);
+    }
+  }
+
+  @Override
+  public void checkExit(int status) {
+    if (delegate != null) {
+      delegate.checkExit(status);
+    }
+    Closeables.closeQuietly(closeable);
+  }
+
+  /**
+   * Returns true if the current class context has spark class.
+   */
+  private boolean isFromSpark() {
+    for (Class<?> c : getClassContext()) {
+      if (c.getName().startsWith("org.apache.spark.")) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/AbstractLogPublisher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/AbstractLogPublisher.java
@@ -76,8 +76,28 @@ public abstract class AbstractLogPublisher<MESSAGE> extends AbstractRetryableSch
   public final void addMessage(LogMessage logMessage) throws InterruptedException {
     // Try to insert new logs, but don't block for longer then a second
     // If it takes too long, start dropping old logs
-    while (!messageQueue.offer(logMessage, 1, TimeUnit.SECONDS)) {
+    while (!offerUninterruptibly(messageQueue, logMessage, 1, TimeUnit.SECONDS)) {
       messageQueue.poll();
+    }
+  }
+
+  /**
+   * Offers an element to the given queue uninterruptibly.
+   */
+  private <E> boolean offerUninterruptibly(BlockingQueue<E> queue, E element, long timeout, TimeUnit timeUnit) {
+    boolean interrupted = false;
+    try {
+      while (true) {
+        try {
+          return queue.offer(element, timeout, timeUnit);
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 
@@ -148,8 +168,7 @@ public abstract class AbstractLogPublisher<MESSAGE> extends AbstractRetryableSch
    * @param blockForMessage whether to block for message
    * @throws InterruptedException if the thread is interrupted
    */
-  private void publishMessages(List<MESSAGE> buffer,
-                               boolean blockForMessage) throws Exception {
+  private void publishMessages(List<MESSAGE> buffer, boolean blockForMessage) throws Exception {
     int maxBufferSize = queueSize;
 
     if (blockForMessage) {
@@ -170,13 +189,14 @@ public abstract class AbstractLogPublisher<MESSAGE> extends AbstractRetryableSch
       }
     }
 
-    while (buffer.size() < maxBufferSize) {
+    while (maxBufferSize > 0) {
       // Poll for more messages
       LogMessage message = messageQueue.poll();
       if (message == null) {
         break;
       }
       buffer.add(createMessage(message));
+      maxBufferSize--;
     }
 
     // Publish all messages

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogAppenderInitializer.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogAppenderInitializer.java
@@ -19,11 +19,13 @@ package io.cdap.cdap.logging.appender;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggerContextListener;
 import ch.qos.logback.core.status.OnConsoleStatusListener;
 import ch.qos.logback.core.status.StatusManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import com.google.inject.Inject;
+import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
@@ -38,12 +40,47 @@ import javax.annotation.Nullable;
  */
 public class LogAppenderInitializer implements Closeable {
   private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LogAppenderInitializer.class);
-  private final Set<String> loggerNames = new HashSet<>();
+  private final Set<String> loggerNames = new ConcurrentHashSet<>();
   private final LogAppender logAppender;
 
   @Inject
   public LogAppenderInitializer(LogAppender logAppender) {
     this.logAppender = logAppender;
+    LoggerContext loggerContext = getLoggerContext();
+    if (loggerContext != null) {
+      // Add a context listener to handle context reset, which happens when the logback configuration changed.
+      loggerContext.addListener(new LoggerContextListener() {
+        @Override
+        public boolean isResetResistant() {
+          return true;
+        }
+
+        @Override
+        public void onStart(LoggerContext context) {
+          // no-op
+        }
+
+        @Override
+        public void onReset(LoggerContext context) {
+          LOG.debug("Resetting logger context");
+          Set<String> names = new HashSet<>(loggerNames);
+          close();
+          for (String name : names) {
+            initialize(name);
+          }
+        }
+
+        @Override
+        public void onStop(LoggerContext context) {
+          // no-op
+        }
+
+        @Override
+        public void onLevelChange(Logger logger, Level level) {
+          // no-op
+        }
+      });
+    }
   }
 
   public void initialize() {
@@ -62,7 +99,10 @@ public class LogAppenderInitializer implements Closeable {
         return;
       }
 
-      logAppender.setContext(loggerContext);
+      if (logAppender.getContext() == null) {
+        logAppender.setContext(loggerContext);
+      }
+
       LOG.info("Initializing log appender {}", logAppender.getName());
 
       // Display any errors during initialization of log appender to console
@@ -70,7 +110,9 @@ public class LogAppenderInitializer implements Closeable {
       OnConsoleStatusListener onConsoleListener = new OnConsoleStatusListener();
       statusManager.add(onConsoleListener);
 
-      logAppender.start();
+      if (!logAppender.isStarted()) {
+        logAppender.start();
+      }
 
       logger.addAppender(logAppender);
     }
@@ -90,21 +132,20 @@ public class LogAppenderInitializer implements Closeable {
   }
 
   @Override
-  public void close() {
-    if (logAppender != null) {
-      LOG.debug("Stopping log appender {}", logAppender.getName());
-      logAppender.stop();
-      LoggerContext loggerContext = getLoggerContext();
-      if (loggerContext != null) {
-        synchronized (this) {
-          for (String loggerName : loggerNames) {
-            loggerContext.getLogger(loggerName).detachAppender(logAppender);
-          }
-        }
+  public synchronized void close() {
+    LOG.debug("Stopping log appender {}", logAppender.getName());
+    LoggerContext loggerContext = getLoggerContext();
+    if (loggerContext != null) {
+      for (String loggerName : loggerNames) {
+        loggerContext.getLogger(loggerName).detachAppender(logAppender);
       }
+      loggerNames.clear();
+    }
+    if (logAppender.isStarted()) {
+      logAppender.stop();
     }
   }
-  
+
   /**
    * Helper function to get the {@link LoggerContext}
    * @return the {@link LoggerContext} or null if {@link LoggerFactory} is not a logback LoggerContext.

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/TMSLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/TMSLogAppender.java
@@ -40,6 +40,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Log appender that publishes log messages to TMS.
@@ -48,27 +50,32 @@ public final class TMSLogAppender extends LogAppender {
 
   private static final String APPENDER_NAME = "TMSLogAppender";
 
-  private final TMSLogPublisher tmsLogPublisher;
+  private final CConfiguration cConf;
+  private final MessagingService messagingService;
+  private final AtomicReference<TMSLogPublisher> tmsLogPublisher;
 
   @Inject
   TMSLogAppender(CConfiguration cConf, MessagingService messagingService) {
     setName(APPENDER_NAME);
-    int queueSize = cConf.getInt(Constants.Logging.APPENDER_QUEUE_SIZE);
-    this.tmsLogPublisher = new TMSLogPublisher(cConf, messagingService, queueSize);
+    this.cConf = cConf;
+    this.messagingService = messagingService;
+    this.tmsLogPublisher = new AtomicReference<>();
   }
 
   @Override
   public void start() {
-    tmsLogPublisher.startAndWait();
+    TMSLogPublisher publisher = new TMSLogPublisher(cConf, messagingService);
+    Optional.ofNullable(tmsLogPublisher.getAndSet(publisher)).ifPresent(TMSLogPublisher::stopAndWait);
+    publisher.startAndWait();
     addInfo("Successfully started " + APPENDER_NAME);
     super.start();
   }
 
   @Override
   public void stop() {
-    tmsLogPublisher.stopAndWait();
-    addInfo("Successfully stopped " + APPENDER_NAME);
     super.stop();
+    Optional.ofNullable(tmsLogPublisher.getAndSet(null)).ifPresent(TMSLogPublisher::stopAndWait);
+    addInfo("Successfully stopped " + APPENDER_NAME);
   }
 
   @Override
@@ -77,7 +84,7 @@ public final class TMSLogAppender extends LogAppender {
     logMessage.getCallerData();
 
     try {
-      tmsLogPublisher.addMessage(logMessage);
+      tmsLogPublisher.get().addMessage(logMessage);
     } catch (InterruptedException e) {
       addInfo("Interrupted when adding log message to queue: " + logMessage.getFormattedMessage());
     }
@@ -101,8 +108,9 @@ public final class TMSLogAppender extends LogAppender {
     private final MessagingContext messagingContext;
     private final LogPartitionType logPartitionType;
 
-    private TMSLogPublisher(CConfiguration cConf, MessagingService messagingService, int queueSize) {
-      super(queueSize, RetryStrategies.fromConfiguration(cConf, "system.log.process."));
+    private TMSLogPublisher(CConfiguration cConf, MessagingService messagingService) {
+      super(cConf.getInt(Constants.Logging.APPENDER_QUEUE_SIZE, 512),
+            RetryStrategies.fromConfiguration(cConf, "system.log.process."));
       this.topicPrefix = cConf.get(Constants.Logging.TMS_TOPIC_PREFIX);
       this.numPartitions = cConf.getInt(Constants.Logging.NUM_PARTITIONS);
       this.loggingEventSerializer = new LoggingEventSerializer();

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/LogAppenderInitializerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/LogAppenderInitializerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.appender;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import com.google.common.io.LineProcessor;
+import com.google.common.io.Resources;
+import io.cdap.cdap.common.logging.LoggingContextAccessor;
+import io.cdap.cdap.common.logging.logback.TestLoggingContext;
+import io.cdap.cdap.common.utils.Tasks;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+public class LogAppenderInitializerTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Test (timeout = 10000L)
+  public void testConfigUpdate() throws Exception {
+    File logbackFile = createLogbackFile(new File(TEMP_FOLDER.newFolder(), "logback.xml"), "");
+
+    // Create a logger context from the generated logback.xml file
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    loggerContext.reset();
+
+    JoranConfigurator configurator = new JoranConfigurator();
+    configurator.setContext(loggerContext);
+    configurator.doConfigure(logbackFile);
+
+    TestLogAppender testAppender = new TestLogAppender();
+    testAppender.setName("TestAppender");
+    LogAppenderInitializer initializer = new LogAppenderInitializer(testAppender);
+    initializer.initialize();
+
+    LoggingContextAccessor.setLoggingContext(new TestLoggingContext("ns", "app", "run", "instance"));
+
+    Logger logger = loggerContext.getLogger(LogAppenderInitializerTest.class);
+    logger.info("Testing");
+
+    Assert.assertEquals("Testing", testAppender.getLastMessage());
+
+    // Update the logback file
+    createLogbackFile(logbackFile, "<logger name=\"io.cdap.cdap\" level=\"INFO\" />");
+
+    // Wait till the test appender stop() is called. This will happen when logback detected the changes.
+    while (!testAppender.isStoppedOnce()) {
+      // We need to keep logging because there is some internal thresold in logback implementation to trigger the
+      // config reload thread.
+      logger.info("Waiting stop");
+      TimeUnit.MILLISECONDS.sleep(150);
+      // Update the last modified time of the logback file to make sure logback can pick it with.
+      logbackFile.setLastModified(System.currentTimeMillis());
+    }
+
+    // The appender should get automatically started again
+    Tasks.waitFor(true, testAppender::isStarted, 5, TimeUnit.SECONDS);
+    logger.info("Reattached");
+
+    Assert.assertEquals("Reattached", testAppender.getLastMessage());
+    loggerContext.stop();
+  }
+
+  private File createLogbackFile(File file, String template) throws IOException {
+    Path tmpFile = Files.createTempFile(file.getParentFile().toPath(), "logback", ".xml");
+    URL url = getClass().getClassLoader().getResource("test-appender.xml");
+
+    // Read in the logback xml and replace ${TEMPLATE} with the given template string.
+    String content = Resources.readLines(url, StandardCharsets.UTF_8, new LineProcessor<String>() {
+
+      private final StringBuilder builder = new StringBuilder();
+
+      @Override
+      public boolean processLine(String line) {
+        builder.append(line.replace("${TEMPLATE}", template));
+        return true;
+      }
+
+      @Override
+      public String getResult() {
+        return builder.toString();
+      }
+    });
+
+    Files.delete(tmpFile);
+    try (BufferedWriter writer = Files.newBufferedWriter(tmpFile, StandardCharsets.UTF_8)) {
+      writer.write(content);
+    }
+    Files.move(tmpFile, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    return file;
+  }
+
+
+  private static final class TestLogAppender extends LogAppender {
+
+    private volatile String lastMessage;
+    private volatile boolean stoppedOnce;
+
+    @Override
+    protected void appendEvent(LogMessage logMessage) {
+      lastMessage = logMessage.getFormattedMessage();
+    }
+
+    @Override
+    public void stop() {
+      super.stop();
+      this.stoppedOnce = true;
+    }
+
+    boolean isStoppedOnce() {
+      return stoppedOnce;
+    }
+
+    String getLastMessage() {
+      return lastMessage;
+    }
+  }
+}

--- a/cdap-watchdog/src/test/resources/test-appender.xml
+++ b/cdap-watchdog/src/test/resources/test-appender.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright © 2020 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<configuration scan="true" scanPeriod="2 seconds">
+
+  ${TEMPLATE}
+
+  <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>Test appender - %d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="Console"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
This PR includes two changes related to log

1. Makes all log appender resilient to LoggerContext reset, which will happen when the logback configuration change.
2. Ignore interrupt in log appender when offering new message into the internal blocking queue