### PR TITLE
[CDAP-16749] Fix selecting connections in pipeline studio

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -706,6 +706,7 @@ angular.module(PKG.name + '.commons')
         }
 
         if (connObj.source && connObj.target) {
+          connObj.cssClass = `connection-id-${conn.from}-${conn.to}`;
           let newConn = vm.instance.connect(connObj);
           if (
             targetNode.type === 'condition' ||
@@ -749,6 +750,7 @@ angular.module(PKG.name + '.commons')
       let defaultConnectorSettings = vm.defaultDagSettings.Connector;
       connObj.connector = [defaultConnectorSettings[0], Object.assign({}, defaultConnectorSettings[1], { midpoint: 0 })];
 
+      connObj.cssClass = `connection-id-${conn.from}-${conn.to}`;
       vm.instance.connect(connObj);
     };
 
@@ -816,6 +818,7 @@ angular.module(PKG.name + '.commons')
       const source = newConnObj.source.getAttribute('data-nodetype');
       const fromNodeId = newConnObj.source.getAttribute('data-nodeid');
       connection.from = fromNodeId;
+      newConnObj.connection.connector.canvas.classList.add(`connection-id-${connection.from}-${connection.to}`);
 
       if (source === 'splitter') {
         connection.port = newConnObj.source.getAttribute('data-portname');
@@ -877,6 +880,11 @@ angular.module(PKG.name + '.commons')
       if (vm.isDisabled) { return; }
 
       vm.clearSelectedNodes();
+      if (event) {
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        event.preventDefault();
+      }
 
       // is connection
       if (selectedObj.sourceId && selectedObj.targetId) {
@@ -915,11 +923,6 @@ angular.module(PKG.name + '.commons')
           connection.removeClass('selected-connector');
           connection.removeType('selected');
         });
-      }
-      if (event) {
-        event.stopPropagation();
-        event.stopImmediatePropagation();
-        event.preventDefault();
       }
     }
 

--- a/cdap-ui/cypress/integration/pipeline.multiselect.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.multiselect.spec.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import * as Helpers from '../helpers';
 let headers = {};
@@ -30,7 +30,7 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
     });
   });
 
-  it('Should select multiple nodes', () => {
+  it('Should select node(s)', () => {
     cy.visit('/pipelines/ns/default/studio');
     cy.create_simple_pipeline().then(({ sourceNodeId, transformNodeId, sinkNodeId }) => {
       cy.select_from_to(sourceNodeId, transformNodeId);
@@ -40,6 +40,23 @@ describe('Pipeline multi-select nodes + context menu for plugins & canvas', () =
       cy.get('.box.selected').should('have.length', 3);
       cy.get('#dag-container').click({ force: true });
       cy.get('.box.selected').should('have.length', 0);
+    });
+  });
+
+  it.only('Should select connection(s)', () => {
+    cy.visit('/pipelines/ns/default/studio');
+    cy.create_simple_pipeline().then(({ sourceNodeId, transformNodeId, sinkNodeId }) => {
+      cy.select_connection(sourceNodeId, transformNodeId).then((element) => {
+        expect(element[0].children[1].getAttribute('stroke')).to.eq('#58b7f6');
+      });
+      cy.select_connection(transformNodeId, sinkNodeId).then((element) => {
+        expect(element[0].children[1].getAttribute('stroke')).to.eq('#58b7f6');
+      });
+      cy.get('body').type('{del}');
+      cy.get_pipeline_json().then((pipelineConfig) => {
+        const connections = pipelineConfig.config.connections;
+        expect(connections.length).eq(0);
+      });
     });
   });
 

--- a/cdap-ui/cypress/support/commands.ts
+++ b/cdap-ui/cypress/support/commands.ts
@@ -367,6 +367,27 @@ Cypress.Commands.add('select_from_to', (from: INodeIdentifier, to: INodeIdentifi
   });
 });
 
+Cypress.Commands.add('select_connection', (from: INodeIdentifier, to: INodeIdentifier) => {
+  let fromNodeElement;
+  let toNodeElement;
+  cy.get_node(from).then((sElement) => {
+    fromNodeElement = sElement;
+    cy.get_node(to).then((tElement) => {
+      toNodeElement = tElement;
+      const sourceName = fromNodeElement[0].getAttribute('id');
+      const targetName = toNodeElement[0].getAttribute('id');
+      const connectionSelector = `.jsplumb-connector.connection-id-${sourceName}-${targetName}`;
+      cy.get(connectionSelector).then((connElement) => {
+        (connElement[0] as any)._jsPlumb._jsPlumb.instance.fire(
+          'click',
+          (connElement[0] as any)._jsPlumb
+        );
+        return cy.wrap(connElement[0]);
+      });
+    });
+  });
+});
+
 Cypress.Commands.add(
   'connect_two_nodes',
   (

--- a/cdap-ui/cypress/typings/index.d.ts
+++ b/cdap-ui/cypress/typings/index.d.ts
@@ -74,6 +74,10 @@ declare global {
       select_from_to: (from: INodeIdentifier, to: INodeIdentifier) => Chainable<any>;
 
       /**
+       * Select a specific connection give source and target node
+       */
+      select_connection: (from: INodeIdentifier, to: INodeIdentifier) => Chainable<JQuery<any>>;
+      /**
        * Creates a simple BQ source -> Wrangler Transform -> BQ Sink pipeline.
        *
        * This is a dumb command to be reused whenever we want to create a basic pipeline


### PR DESCRIPTION
**Context**
 - We introduced the option of clicking and dragging across the canvas to select multiple nodes.
 - As part of it users can now click and select an area and all the nodes within that area will be selected
  - We used to have the functionality where clicking on the canvas clears all the nodes and connections selection

**Problem**
 - This meant we can now click and this event gets bubbled to canvas.
 - We check in the bubbling phase if the user is currently selecting any nodes. If yes let them select and prevent bubbling to happen
 - We missed preventing bubbling the event when a connection is clicked.
 - This is now considered as a click on the canvas which clears all the selections (nodes & connections)

**Fix**
- Properly prevent the bubbling while clicking on the connections.
- Add test to validate selection of connections

Build: https://builds.cask.co/browse/CDAP-URUT246-1
JIRA: https://issues.cask.co/browse/CDAP-16749