### PR TITLE
[CDAP-16751] Fix schema editor to properly check for logical type precision and scale values

### DIFF
--- a/cdap-ui/app/cdap/services/cdapavscwrapper/DecimalLogicalType.ts
+++ b/cdap-ui/app/cdap/services/cdapavscwrapper/DecimalLogicalType.ts
@@ -17,6 +17,7 @@
 import AbstractLogicalType, { IJsonResponse } from 'services/cdapavscwrapper/AbstractLogicalType';
 import { LogicalTypes } from 'services/cdapavscwrapper/LogicalTypes';
 import cdapavsc from 'cdap-avsc';
+import isNil from 'lodash/isNil';
 
 const UNDERLYING_TYPE = 'bytes';
 interface IDecimalJsonResponse extends IJsonResponse {
@@ -30,10 +31,10 @@ const JSON_FORMAT: IDecimalJsonResponse = {
 
 export default class DecimalLogicalType extends AbstractLogicalType {
   constructor(attrs, opts) {
-    if (attrs.precision) {
+    if (!isNil(attrs.precision)) {
       JSON_FORMAT.precision = attrs.precision;
     }
-    if (attrs.scale) {
+    if (!isNil(attrs.scale)) {
       JSON_FORMAT.scale = attrs.scale;
     }
     super(attrs, opts, [cdapavsc.types.LongType], JSON_FORMAT);


### PR DESCRIPTION
- Since 0 is a falsy value we exclude setting precision or scale if the value is 0
- Rightly check for empty values instead of false'y values for scale and precision

JIRA: https://issues.cask.co/browse/CDAP-16751
Build: https://builds.cask.co/browse/CDAP-URUT245-1