### PR TITLE
CDAP-16744 bump memory for unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1553,7 +1553,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.19.1</version>
           <configuration>
-            <argLine>-Xmx4096m -Djava.awt.headless=true -XX:+UseG1GC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError</argLine>
+            <argLine>-Xmx8192m -Djava.awt.headless=true -XX:+UseG1GC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <forkCount>3</forkCount>


### PR DESCRIPTION
bump memory for unit test, the app fabric test is flaky and failing from time to time with VM crash.

Try to bump the memory, have 10+ successful runs from bamboo. 
https://builds.cask.co/browse/CDAP-RUT1768