### PR TITLE
(CDAP-16673) Handle large TMS publish request

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CombineInputStream.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CombineInputStream.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.http;
+
+import com.google.common.io.Closeables;
+import io.cdap.cdap.common.io.FileSeekableInputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import javax.annotation.Nullable;
+
+/**
+ * An {@link InputStream} that reads from an in-memory {@link ByteBuf} and optionally a file.
+ * It is used by the {@link SpillableBodyConsumer} to combine in-memory data with spilled data.
+ */
+final class CombineInputStream extends InputStream {
+
+  private final InputStream bufferStream;
+  private final InputStream spillStream;
+
+  CombineInputStream(ByteBuf buffer, @Nullable Path spillPath) throws IOException {
+    this.bufferStream = new ByteBufInputStream(buffer);
+    this.spillStream = spillPath == null ? null : new FileSeekableInputStream(new FileInputStream(spillPath.toFile()));
+  }
+
+  @Override
+  public int read() throws IOException {
+    int b = bufferStream.read();
+    if (b >= 0 || spillStream == null) {
+      return b;
+    }
+    return spillStream.read();
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    int bytesRead = bufferStream.read(b, off, len);
+    if (spillStream == null || bytesRead == len) {
+      return bytesRead;
+    }
+    if (bytesRead < 0) {
+      bytesRead = 0;
+    }
+
+    return bytesRead + spillStream.read(b, off + bytesRead, len - bytesRead);
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    long skipped = 0;
+    if (bufferStream.available() > 0) {
+      skipped = bufferStream.skip(n);
+    }
+    if (spillStream == null) {
+      return skipped;
+    }
+    return skipped + spillStream.skip(n - skipped);
+  }
+
+  @Override
+  public int available() throws IOException {
+    return bufferStream.available() + (spillStream == null ? 0 : spillStream.available());
+  }
+
+  @Override
+  public void close() throws IOException {
+    Closeables.closeQuietly(bufferStream);
+    if (spillStream != null) {
+      spillStream.close();
+    }
+  }
+
+  @Override
+  public synchronized void mark(int readlimit) {
+    if (!markSupported()) {
+      return;
+    }
+    bufferStream.mark(readlimit);
+    if (spillStream != null) {
+      spillStream.mark(readlimit);
+    }
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    if (!markSupported()) {
+      return;
+    }
+    bufferStream.reset();
+    if (spillStream != null) {
+      spillStream.reset();
+    }
+  }
+
+  @Override
+  public boolean markSupported() {
+    return bufferStream.markSupported() && (spillStream == null || spillStream.markSupported());
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/SpillableBodyConsumer.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/SpillableBodyConsumer.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.http;
+
+import com.google.common.base.Throwables;
+import com.google.common.io.Closeables;
+import io.cdap.http.BodyConsumer;
+import io.cdap.http.HttpResponder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * An abstract base class for implementing a {@link BodyConsumer} that spills data to disk when the request size
+ * exceeded a predetermined in memory buffer size.
+ */
+public abstract class SpillableBodyConsumer extends BodyConsumer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpillableBodyConsumer.class);
+
+  private final CompositeByteBuf buffer;
+  private final Path spillPath;
+  private final int bufferLimit;
+  private OutputStream outputStream;
+
+  protected SpillableBodyConsumer(Path spillPath, int bufferLimit) {
+    this.buffer = Unpooled.compositeBuffer();
+    this.spillPath = spillPath;
+    this.bufferLimit = bufferLimit;
+  }
+
+  /**
+   * This method will be called to process the complete request body.
+   *
+   * @param inputStream the {@link InputStream} to read the request body
+   * @param responder the {@link HttpResponder} for responding to client
+   * @throws IOException if failed to process the given input
+   */
+  protected abstract void processInput(InputStream inputStream, HttpResponder responder) throws Exception;
+
+  @Override
+  public void chunk(ByteBuf request, HttpResponder responder) {
+    if (outputStream == null) {
+      int remaining = bufferLimit - buffer.readableBytes();
+      if (remaining >= request.readableBytes()) {
+        buffer.addComponent(true, request.retain());
+        return;
+      }
+      // Otherwise, add whatever can fit in the buffer
+      if (remaining > 0) {
+        buffer.addComponent(true, request.readRetainedSlice(remaining));
+      }
+    }
+
+    // Spill whatever remaining in the request buffer to disk.
+    try {
+      if (outputStream == null) {
+        outputStream = Files.newOutputStream(spillPath, StandardOpenOption.TRUNCATE_EXISTING);
+      }
+      request.readBytes(outputStream, request.readableBytes());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to write request to spilling output", e);
+    }
+  }
+
+  @Override
+  public void finished(HttpResponder responder) {
+    Closeables.closeQuietly(outputStream);
+
+    try (InputStream is = new CombineInputStream(buffer, outputStream == null ? null : spillPath)) {
+      processInput(is, responder);
+    } catch (Exception e) {
+      Throwables.propagateIfPossible(e);
+      throw new RuntimeException(String.format("Failed to process input from buffer%s",
+                                               outputStream == null ? "" : " and spill path " + spillPath), e);
+    } finally {
+      cleanup();
+    }
+  }
+
+  @Override
+  public void handleError(Throwable cause) {
+    Closeables.closeQuietly(outputStream);
+    cleanup();
+  }
+
+  private void cleanup() {
+    buffer.release();
+    if (spillPath != null) {
+      try {
+        Files.deleteIfExists(spillPath);
+      } catch (IOException e) {
+        LOG.warn("Failed to delete file {}", spillPath, e);
+      }
+    }
+  }
+}

--- a/cdap-common/src/test/java/io/cdap/cdap/common/http/CombineInputStreamTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/http/CombineInputStreamTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.http;
+
+import com.google.common.io.ByteStreams;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Unit tests for the {@link CombineInputStream}.
+ */
+public class CombineInputStreamTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testEmpty() throws IOException {
+    try (InputStream is = new CombineInputStream(Unpooled.EMPTY_BUFFER, null)) {
+      Assert.assertEquals(0, is.available());
+      Assert.assertTrue(is.read() < 0);
+    }
+  }
+
+  @Test
+  public void testBufferOnly() throws IOException {
+    String msg = "Testing message";
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeBytes(StandardCharsets.UTF_8.encode(msg));
+    try (InputStream is = new CombineInputStream(buffer, null)) {
+      testReadAndReset(msg, is);
+    }
+  }
+
+  @Test
+  public void testBufferAndFile() throws IOException {
+    String msg = "Testing message";
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeBytes(StandardCharsets.UTF_8.encode(msg));
+    Path file = TEMP_FOLDER.newFile().toPath();
+    Files.write(file, msg.getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
+
+    try (InputStream is = new CombineInputStream(buffer, file)) {
+      testReadAndReset(msg + msg, is);
+    }
+  }
+
+  private void testReadAndReset(String msg, InputStream is) throws IOException {
+    Assert.assertTrue(is.markSupported());
+    is.mark(Integer.MAX_VALUE);
+
+    // Read the whole stream
+    Assert.assertEquals(msg, new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8));
+
+    // Reset and read one byte at a time
+    is.reset();
+    byte[] bytes = new byte[is.available()];
+    int idx = 0;
+    int b = is.read();
+    while (b >= 0) {
+      bytes[idx++] = (byte) b;
+      b = is.read();
+    }
+    Assert.assertEquals(msg, new String(bytes, StandardCharsets.UTF_8));
+  }
+}

--- a/cdap-common/src/test/java/io/cdap/cdap/common/http/SpillableBodyConsumerTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/http/SpillableBodyConsumerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.http;
+
+import com.google.common.base.Strings;
+import com.google.common.io.ByteStreams;
+import io.cdap.common.http.HttpRequestConfig;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.BodyConsumer;
+import io.cdap.http.HttpResponder;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Unit test for {@link SpillableBodyConsumer}.
+ */
+public class SpillableBodyConsumerTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testSpilling() throws Exception {
+    testPost(Strings.repeat("0123456789", 10), 15);
+  }
+
+  @Test
+  public void testNoSpill() throws Exception {
+    testPost(Strings.repeat("0123456789", 10), 1024);
+  }
+
+  private void testPost(String body, int bufferLimit) throws Exception {
+    NettyHttpService httpService = NettyHttpService.builder("test")
+      .setHttpHandlers(new TestHandler(bufferLimit))
+      .build();
+    httpService.start();
+    try {
+      InetSocketAddress addr = httpService.getBindAddress();
+      URL url = new URL(String.format("http://%s:%d/post", addr.getHostName(), addr.getPort()));
+      HttpResponse response = HttpRequests.execute(io.cdap.common.http.HttpRequest.post(url).withBody(body).build(),
+                                                   new HttpRequestConfig(1000, 10000000));
+
+      Assert.assertEquals(200, response.getResponseCode());
+      Assert.assertEquals(body, response.getResponseBodyAsString());
+    } finally {
+      httpService.stop();
+    }
+  }
+
+  /**
+   * Handler for testing only.
+   */
+  public static final class TestHandler extends AbstractHttpHandler {
+
+    private final int bufferSize;
+
+    public TestHandler(int bufferSize) {
+      this.bufferSize = bufferSize;
+    }
+
+    @POST
+    @Path("/post")
+    public BodyConsumer post(HttpRequest request, HttpResponder responder) throws IOException {
+      return new SpillableBodyConsumer(TEMP_FOLDER.newFile().toPath(), bufferSize) {
+        @Override
+        protected void processInput(InputStream is, HttpResponder responder) throws IOException {
+          responder.sendByteArray(HttpResponseStatus.OK, ByteStreams.toByteArray(is), new DefaultHttpHeaders());
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
The TMS publish by default has a 10MB limit (`messaging.http.server.max.request.size.mb`) per request due to the original TMS assumption that messages are relatively small. However, since then we've extensively using TMS for all metadata transportation, which can result in having large messages in some cases (e.g. Lineage graph). When that happen, it can cause publish failure and hence program execution failure.

This fix is to use a BodyConsumer to buffer the publish request in memory and on disk when the request is too large to fit in memory. This helps relieving the memory pressure of the TMS service, as well as be able to handle relatively large requests without the need of changing CDAP configuration.