### PR TITLE
[CDAP-16786] Fix spotlight search modal to link to pipelines correctly

### DIFF
--- a/cdap-ui/app/cdap/components/NavLinkWrapper/index.js
+++ b/cdap-ui/app/cdap/components/NavLinkWrapper/index.js
@@ -15,11 +15,14 @@
  */
 
 import PropTypes from 'prop-types';
-
 import React from 'react';
+import isEmpty from 'lodash/isEmpty';
 import { NavLink } from 'react-router-dom';
 
 const NavLinkWrapper = ({ children, to, isNativeLink, ...attributes }) => {
+  if (isEmpty(to)) {
+    return <a {...attributes}>{children}</a>;
+  }
   if (isNativeLink) {
     return (
       <a href={to} {...attributes}>


### PR DESCRIPTION
- We removed references to application detailed view from UI
- Since we constructed the url dynamically from the metadata response, the spotlight search modal was left out. 
- Fixes the search modal to link to pipelines only.

JIRA: https://issues.cask.co/browse/CDAP-16788
Build: https://builds.cask.co/browse/CDAP-URUT250-1