### PR TITLE
Fix complex schema e2e test

### DIFF
--- a/cdap-ui/cypress/integration/pipeline.complexschema.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.complexschema.spec.ts
@@ -206,6 +206,9 @@ describe('Output Schema', () => {
       cy.get('[data-testid="deploy-pipeline"]').click();
       cy.url({ timeout: 60000 }).should('include', `/view/${PIPELINE_NAME}`);
 
+      // Wait to allow pipeline to finish rendering before checking node properties
+      cy.wait(500);
+
       cy.open_node_property(sourceNodeId);
       cy.get('#macro-input-schema').should('have.value', '${source_output_schema}');
       cy.close_node_property();


### PR DESCRIPTION
The complex schema e2e test was failing on bamboo because we were opening multiple properties modals for the source node (which caused the test to fail when it found multiple elements when we were assuming there was only one). This seemed to be happening because the click started before the entire pipeline was rendered. I added a a check for the rendering of the transform node before clicking on the properties modal, to ensure the click didn't happen until the entire pipeline was rendered. 

<img width="404" alt="Screen Shot 2020-05-14 at 11 53 52 AM" src="https://user-images.githubusercontent.com/16228294/81974033-d7d93680-95d9-11ea-82e1-1f7e58c1674f.png">
