### PR TITLE
CDAP-16816 fix schedule properties to override preferences

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
@@ -21,10 +21,10 @@ import com.google.inject.Inject;
 import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.proto.NamespaceConfig;
 import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -62,13 +62,13 @@ public class SchedulerQueueResolver {
    * @return schedule queue at namespace level or default queue.
    */
   @Nullable
-  public String getQueue(Id.Namespace namespaceId) throws IOException, NamespaceNotFoundException {
-    if (namespaceId.equals(Id.Namespace.SYSTEM)) {
+  public String getQueue(NamespaceId namespaceId) throws IOException, NamespaceNotFoundException {
+    if (namespaceId.equals(NamespaceId.SYSTEM)) {
       return systemQueue;
     }
     NamespaceMeta meta;
     try {
-      meta = namespaceQueryAdmin.get(namespaceId.toEntityId());
+      meta = namespaceQueryAdmin.get(namespaceId);
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -437,8 +437,8 @@ public class ProgramLifecycleService {
     authorizationEnforcer.enforce(programId, authenticationContext.getPrincipal(), Action.EXECUTE);
     checkConcurrentExecution(programId);
 
-    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(Id.Program.fromEntityId(programId));
-    Map<String, String> userArgs = propertiesResolver.getUserProperties(Id.Program.fromEntityId(programId));
+    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId);
+    Map<String, String> userArgs = propertiesResolver.getUserProperties(programId);
     if (overrides != null) {
       userArgs.putAll(overrides);
     }
@@ -574,10 +574,10 @@ public class ProgramLifecycleService {
     authorizationEnforcer.enforce(programId, authenticationContext.getPrincipal(), Action.EXECUTE);
     checkConcurrentExecution(programId);
 
-    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(Id.Program.fromEntityId(programId));
+    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId);
     sysArgs.put(ProgramOptionConstants.SKIP_PROVISIONING, "true");
     sysArgs.put(SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
-    Map<String, String> userArgs = propertiesResolver.getUserProperties(Id.Program.fromEntityId(programId));
+    Map<String, String> userArgs = propertiesResolver.getUserProperties(programId);
     if (overrides != null) {
       userArgs.putAll(overrides);
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleTaskRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleTaskRunnerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.schedule;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
+import io.cdap.cdap.common.namespace.NamespaceAdmin;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
+import io.cdap.cdap.internal.app.services.PropertiesResolver;
+import io.cdap.cdap.metadata.PreferencesFetcher;
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.impersonation.NoOpOwnerAdmin;
+import io.cdap.cdap.security.impersonation.OwnerAdmin;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Tests {@link ScheduleTaskRunner}.
+ */
+public class ScheduleTaskRunnerTest {
+
+  @Test
+  public void testRuntimeArgumentResolution() throws Exception {
+    Injector injector = Guice.createInjector(
+      new ConfigModule(),
+      binder -> {
+        binder.bind(OwnerAdmin.class).to(NoOpOwnerAdmin.class);
+        binder.bind(NamespaceAdmin.class).to(InMemoryNamespaceAdmin.class);
+        binder.bind(NamespaceQueryAdmin.class).to(InMemoryNamespaceAdmin.class);
+        binder.bind(PreferencesFetcher.class)
+          .toInstance(new FakePreferencesFetcher(Collections.singletonMap("key", "should-be-overridden")));
+      });
+
+    PropertiesResolver propertiesResolver = injector.getInstance(PropertiesResolver.class);
+
+    ApplicationId appId = NamespaceId.DEFAULT.app("app");
+    ProgramSchedule programSchedule = new ProgramSchedule(
+      "schedule", "desc", appId.workflow("wf2"),
+      Collections.singletonMap("key", "val"), new ProgramStatusTrigger(appId.workflow("wf1")),
+      Collections.emptyList());
+    Map<String, String> userArgs = ScheduleTaskRunner.getUserArgs(programSchedule, propertiesResolver);
+    Assert.assertEquals("val", userArgs.get("key"));
+  }
+
+  /**
+   * Fake preferences that just returns whatever it is configured to return.
+   */
+  private static class FakePreferencesFetcher implements PreferencesFetcher {
+    private final Map<String, String> properties;
+
+    private FakePreferencesFetcher(Map<String, String> properties) {
+      this.properties = properties;
+    }
+
+    @Override
+    public PreferencesDetail get(EntityId entityId, boolean resolved) {
+      return new PreferencesDetail(properties, 0L, resolved);
+    }
+  }
+}

--- a/cdap-explore/src/main/java/io/cdap/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/io/cdap/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -36,7 +36,6 @@ import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.ConfigurationUtil;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.utils.FileUtils;
 import io.cdap.cdap.data.dataset.SystemDatasetInstantiatorFactory;
@@ -1291,7 +1290,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     QueryHandle queryHandle = QueryHandle.generate();
     sessionConf.put(Constants.Explore.QUERY_ID, queryHandle.getHandle());
 
-    String schedulerQueue = namespace != null ? schedulerQueueResolver.getQueue(Id.Namespace.fromEntityId(namespace))
+    String schedulerQueue = namespace != null ? schedulerQueueResolver.getQueue(namespace)
                                               : schedulerQueueResolver.getDefaultQueue();
 
     if (schedulerQueue != null && !schedulerQueue.isEmpty()) {


### PR DESCRIPTION
Fix so that the schedule properties will override program
preferences. This also a bug where the profile set for a
schedule is ignored for the profile set on the program.

Also some general cleanup to avoid unnecessary id conversions.