### PR TITLE
CDAP-16816 fix schedule properties to override preferences

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
@@ -21,10 +21,10 @@ import com.google.inject.Inject;
 import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.proto.NamespaceConfig;
 import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -62,13 +62,13 @@ public class SchedulerQueueResolver {
    * @return schedule queue at namespace level or default queue.
    */
   @Nullable
-  public String getQueue(Id.Namespace namespaceId) throws IOException, NamespaceNotFoundException {
-    if (namespaceId.equals(Id.Namespace.SYSTEM)) {
+  public String getQueue(NamespaceId namespaceId) throws IOException, NamespaceNotFoundException {
+    if (namespaceId.equals(NamespaceId.SYSTEM)) {
       return systemQueue;
     }
     NamespaceMeta meta;
     try {
-      meta = namespaceQueryAdmin.get(namespaceId.toEntityId());
+      meta = namespaceQueryAdmin.get(namespaceId);
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -432,8 +432,8 @@ public class ProgramLifecycleService {
     authorizationEnforcer.enforce(programId, authenticationContext.getPrincipal(), Action.EXECUTE);
     checkConcurrentExecution(programId);
 
-    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(Id.Program.fromEntityId(programId));
-    Map<String, String> userArgs = propertiesResolver.getUserProperties(Id.Program.fromEntityId(programId));
+    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId);
+    Map<String, String> userArgs = propertiesResolver.getUserProperties(programId);
     if (overrides != null) {
       userArgs.putAll(overrides);
     }
@@ -569,10 +569,10 @@ public class ProgramLifecycleService {
     authorizationEnforcer.enforce(programId, authenticationContext.getPrincipal(), Action.EXECUTE);
     checkConcurrentExecution(programId);
 
-    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(Id.Program.fromEntityId(programId));
+    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId);
     sysArgs.put(ProgramOptionConstants.SKIP_PROVISIONING, "true");
     sysArgs.put(SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
-    Map<String, String> userArgs = propertiesResolver.getUserProperties(Id.Program.fromEntityId(programId));
+    Map<String, String> userArgs = propertiesResolver.getUserProperties(programId);
     if (overrides != null) {
       userArgs.putAll(overrides);
     }

--- a/cdap-explore/src/main/java/io/cdap/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/io/cdap/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -36,7 +36,6 @@ import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.ConfigurationUtil;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.utils.FileUtils;
 import io.cdap.cdap.data.dataset.SystemDatasetInstantiatorFactory;
@@ -1291,7 +1290,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     QueryHandle queryHandle = QueryHandle.generate();
     sessionConf.put(Constants.Explore.QUERY_ID, queryHandle.getHandle());
 
-    String schedulerQueue = namespace != null ? schedulerQueueResolver.getQueue(Id.Namespace.fromEntityId(namespace))
+    String schedulerQueue = namespace != null ? schedulerQueueResolver.getQueue(namespace)
                                               : schedulerQueueResolver.getDefaultQueue();
 
     if (schedulerQueue != null && !schedulerQueue.isEmpty()) {


### PR DESCRIPTION
Fix so that the schedule properties will override program
preferences. This also a bug where the profile set for a
schedule is ignored for the profile set on the program.

Also some general cleanup to avoid unnecessary id conversions.