### PR TITLE
[CDAP-16826] fix showing page level error when system services are down

### DIFF
--- a/cdap-ui/app/cdap/components/AppHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/index.tsx
@@ -84,7 +84,8 @@ class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderSta
         }
       },
       (err) => {
-        this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, err);
+        // tslint:disable-next-line: no-console
+        console.log('Error retrieving list of namespaces', err);
       }
     );
     this.nsSubscription = NamespaceStore.subscribe(() => {


### PR DESCRIPTION
We check for list of namespaces in App Header and we throw a page level error whenever there's an error from the namespace list subscription. So when system services are down nodeJS will throw an error and we would surface that as a page level error. This is unnecessary and redundant because we check for namespace validity in other places.

This fix is to not show page level error when namespace list subscription fails. 

JIRA: https://issues.cask.co/browse/CDAP-16826