### PR TITLE
[CDAP-14945] Remove table headers on empty pipeline list view

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/PipelineTable/index.tsx
@@ -23,6 +23,7 @@ import EmptyList, { VIEW_TYPES } from 'components/PipelineList/EmptyList';
 import { Actions } from 'components/PipelineList/DeployedPipelineView/store';
 import EmptyMessageContainer from 'components/EmptyMessageContainer';
 import SortableHeader from 'components/PipelineList/DeployedPipelineView/PipelineTable/SortableHeader';
+import If from 'components/If';
 import './PipelineTable.scss';
 
 interface IProps {
@@ -76,19 +77,20 @@ const PipelineTableView: React.SFC<IProps> = ({
   return (
     <div className="grid-wrapper pipeline-list-table">
       <div className="grid grid-container">
-        <div className="grid-header">
-          <div className="grid-row">
-            <SortableHeader columnName="name" />
-            <strong>{T.translate(`${PREFIX}.type`)}</strong>
-            <strong>{T.translate(`${PREFIX}.status`)}</strong>
-            <strong>{T.translate(`${PREFIX}.lastStartTime`)}</strong>
-            <strong>{T.translate(`${PREFIX}.nextRun`)}</strong>
-            <strong>{T.translate(`${PREFIX}.runs`)}</strong>
-            <strong>{T.translate(`${PREFIX}.tags`)}</strong>
-            <strong />
+        <If condition={pipelines && filteredList && filteredList.length > 0}>
+          <div className="grid-header">
+            <div className="grid-row">
+              <SortableHeader columnName="name" />
+              <strong>{T.translate(`${PREFIX}.type`)}</strong>
+              <strong>{T.translate(`${PREFIX}.status`)}</strong>
+              <strong>{T.translate(`${PREFIX}.lastStartTime`)}</strong>
+              <strong>{T.translate(`${PREFIX}.nextRun`)}</strong>
+              <strong>{T.translate(`${PREFIX}.runs`)}</strong>
+              <strong>{T.translate(`${PREFIX}.tags`)}</strong>
+              <strong />
+            </div>
           </div>
-        </div>
-
+        </If>
         {renderBody()}
       </div>
     </div>

--- a/cdap-ui/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DraftPipelineView/DraftTable/index.tsx
@@ -20,6 +20,7 @@ import { connect } from 'react-redux';
 import { IDraft } from 'components/PipelineList/DraftPipelineView/types';
 import EmptyList, { VIEW_TYPES } from 'components/PipelineList/EmptyList';
 import SortableHeader from 'components/PipelineList/DraftPipelineView/DraftTable/SortableHeader';
+import If from 'components/If';
 
 interface IProps {
   drafts: IDraft[];
@@ -51,15 +52,16 @@ const DraftTableView: React.SFC<IProps> = ({ drafts, currentPage, pageLimit }) =
   return (
     <div className="draft-table grid-wrapper">
       <div className="grid grid-container">
-        <div className="grid-header">
-          <div className="grid-row">
-            <SortableHeader columnName="name" />
-            <SortableHeader columnName="type" />
-            <SortableHeader columnName="lastSaved" />
-            <strong />
+        <If condition={drafts && drafts.length > 0}>
+          <div className="grid-header">
+            <div className="grid-row">
+              <SortableHeader columnName="name" />
+              <SortableHeader columnName="type" />
+              <SortableHeader columnName="lastSaved" />
+              <strong />
+            </div>
           </div>
-        </div>
-
+        </If>
         {renderBody()}
       </div>
     </div>


### PR DESCRIPTION
Fixes:
- Remove table headers on empty pipeline list view.
- This includes the case when the "search results" of pipeline is empty in the deployed view.

JIRA:
https://issues.cask.co/browse/CDAP-14945

Build:
https://builds.cask.co/browse/CDAP-UDUT604

Screenshots:
1. When there are pipelines
<img width="1440" alt="deployed-when-there-are-pipelines" src="https://user-images.githubusercontent.com/14116152/82105468-6b4d5d00-96e9-11ea-8e49-52d1ce220d54.png">

<img width="1440" alt="drafts-when-there-are-pipelines" src="https://user-images.githubusercontent.com/14116152/82105426-3fca7280-96e9-11ea-9311-a890a493726d.png">

2. When there are no pipelines
<img width="1439" alt="deployed-when-there-are-no-pipelines" src="https://user-images.githubusercontent.com/14116152/82105443-5375d900-96e9-11ea-8f22-571c04a5d65c.png">
<img width="1440" alt="drafts-when-there-are-no-pipelines" src="https://user-images.githubusercontent.com/14116152/82105447-57096000-96e9-11ea-880e-bee8d382476d.png">

2. When there are filtered results
<img width="1440" alt="deployed-when-there-are-matching-search-results" src="https://user-images.githubusercontent.com/14116152/82105377-05f96c00-96e9-11ea-98db-2a42685e6491.png">

3. When there are no filtered results
<img width="1440" alt="deployed-when-there-are-pipeliens-but-no-matching-search-results" src="https://user-images.githubusercontent.com/14116152/82105410-33deb080-96e9-11ea-8194-348e7cf768ed.png">
