### PR TITLE
CDAP-16708 add API for autojoiner

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchAutoJoiner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchAutoJoiner.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.batch;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.etl.api.MultiInputPipelineConfigurable;
+import io.cdap.cdap.etl.api.MultiInputPipelineConfigurer;
+import io.cdap.cdap.etl.api.join.AutoJoiner;
+
+/**
+ * Joins input data, leaving implementation details up to the application.
+ */
+@Beta
+public abstract class BatchAutoJoiner extends MultiInputBatchConfigurable<BatchJoinerContext>
+  implements AutoJoiner, MultiInputPipelineConfigurable {
+  public static final String PLUGIN_TYPE = BatchJoiner.PLUGIN_TYPE;
+
+  /**
+   * Configure the pipeline. This is run once when the pipeline is being published.
+   * This is where you perform any static logic, like creating required datasets, performing schema validation,
+   * setting output schema, and things of that nature.
+   *
+   * @param multiInputPipelineConfigurer the configurer used to add required datasets and streams
+   */
+  @Override
+  public void configurePipeline(MultiInputPipelineConfigurer multiInputPipelineConfigurer) {
+    // no-op
+  }
+
+  /**
+   * Prepare a pipeline run. This is run every time before a pipeline runs in order to help set up the run.
+   * This is where you would set things like the number of partitions to use when joining, and setting the
+   * join key class if they are not known at compile time.
+   *
+   * @param context batch execution context
+   * @throws Exception
+   */
+  @Override
+  public void prepareRun(BatchJoinerContext context) throws Exception {
+    //no-op
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchJoiner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchJoiner.java
@@ -35,7 +35,6 @@ import io.cdap.cdap.etl.api.StageLifecycle;
  * If the joiner is being used in spark, both the join key and input record must implement the
  * {@link java.io.Serializable} interface.
  *
- *
  * @param <JOIN_KEY> type of join key. Must be a supported type
  * @param <INPUT_RECORD> type of input record. Must be a supported type
  * @param <OUT> type of output object

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/AutoJoiner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/AutoJoiner.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+import io.cdap.cdap.api.annotation.Beta;
+
+import javax.annotation.Nullable;
+
+/**
+ * Joins data from two or more input stages together.
+ *
+ * For example, the following represents a left outer join on 'purchases'.'user_id' = 'users'.'id':
+ *
+ * <pre>
+ *   {@code
+ *     JoinDefinition define(AutoJoinerContext context) {
+ *       JoinStage purchases = JoinStage.builder(context.getInputStages().get("purchases"))
+ *         .isRequired()
+ *         .build();
+ *       JoinStage users = JoinStage.builder(context.getInputStages().get("users"))
+ *         .isOptional()
+ *         .build();
+ *
+ *       JoinCondition condition = JoinCondition.onKeys()
+ *         .addKey(new JoinKey("users", Arrays.asList("id")))
+ *         .addKey(new JoinKey("purchases", Arrays.asList("user_id")))
+ *         .build();
+ *
+ *       return JoinDefinition.builder()
+ *         // stage name, field name, optional alias
+ *         .select(new Field("purchases", "id", "purchase_id"),
+ *                 new Field("purchases", "user_id"),
+ *                 new Field("users", "email"))
+ *         .from(purchases, users)
+ *         .on(condition)
+ *         .build()
+ *     }
+ *   }
+ * </pre>
+ */
+@Beta
+public interface AutoJoiner {
+
+  /**
+   * @return definition about what type of join to execute, or null if the definition cannot be created due to
+   *   macro values not being evaluated yet.
+   */
+  @Nullable
+  JoinDefinition define(AutoJoinerContext context);
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/AutoJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/AutoJoinerContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+import java.util.Map;
+
+/**
+ * Context for an AutoJoin.
+ */
+public interface AutoJoinerContext {
+
+  /**
+   * @return all input stages
+   */
+  Map<String, JoinStage> getInputStages();
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/Field.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/Field.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+import io.cdap.cdap.api.annotation.Beta;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * The name of a field and an optional alias to rename it to.
+ */
+@Beta
+public class Field {
+  private final String stageName;
+  private final String fieldName;
+  private final String alias;
+
+  public Field(String stageName, String fieldName) {
+    this(stageName, fieldName, null);
+  }
+
+  public Field(String stageName, String fieldName, @Nullable String alias) {
+    this.stageName = stageName;
+    this.fieldName = fieldName;
+    this.alias = alias;
+  }
+
+  public String getStageName() {
+    return stageName;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  @Nullable
+  public String getAlias() {
+    return alias;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Field field1 = (Field) o;
+    return Objects.equals(stageName, field1.stageName) &&
+      Objects.equals(fieldName, field1.fieldName) &&
+      Objects.equals(alias, field1.alias);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stageName, fieldName, alias);
+  }
+
+  @Override
+  public String toString() {
+    return "Field{" +
+      "stage='" + stageName + '\'' +
+      ", field='" + fieldName + '\'' +
+      ", alias='" + alias + '\'' +
+      '}';
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/InvalidJoinConditionException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/InvalidJoinConditionException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+/**
+ * Thrown when the join condition is invalid.
+ */
+public class InvalidJoinConditionException extends InvalidJoinException {
+
+  public InvalidJoinConditionException(String message) {
+    super(message);
+  }
+
+  public InvalidJoinConditionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/InvalidJoinException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/InvalidJoinException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+/**
+ * Thrown when a join definition is invalid.
+ */
+public class InvalidJoinException extends RuntimeException {
+
+  public InvalidJoinException(String message) {
+    super(message);
+  }
+
+  public InvalidJoinException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+import io.cdap.cdap.api.data.schema.Schema;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A condition to join on.
+ *
+ * Currently joins can only be performed on equality on a set of fields from each stage.
+ */
+public class JoinCondition {
+  private final Op op;
+
+  private JoinCondition(Op op) {
+    this.op = op;
+  }
+
+  public Op getOp() {
+    return op;
+  }
+
+  /**
+   * Validate that is condition is valid to use when joining the given stages.
+   *
+   * @param joinStages the stages that will be joined on this condition
+   * @throws InvalidJoinConditionException if the condition is invalid
+   */
+  public void validate(List<JoinStage> joinStages) {
+    // no-op
+  }
+
+  /**
+   * Condition operation.
+   */
+  public enum Op {
+    EQUAL_TO
+  }
+
+  public static OnKeys.Builder onKeys() {
+    return new OnKeys.Builder();
+  }
+
+  /**
+   * Join on multiple keys from each stage.
+   */
+  public static class OnKeys extends JoinCondition {
+    private final Set<JoinKey> keys;
+    private final boolean dropNullKeys;
+
+    private OnKeys(Set<JoinKey> keys, boolean dropNullKeys) {
+      super(Op.EQUAL_TO);
+      this.keys = Collections.unmodifiableSet(new HashSet<>(keys));
+      this.dropNullKeys = dropNullKeys;
+    }
+
+    public Set<JoinKey> getKeys() {
+      return keys;
+    }
+
+    public boolean isDropNullKeys() {
+      return dropNullKeys;
+    }
+
+    @Override
+    public void validate(List<JoinStage> joinStages) {
+      super.validate(joinStages);
+
+      Map<String, JoinStage> stageMap = joinStages.stream()
+        .collect(Collectors.toMap(JoinStage::getStageName, s -> s));
+
+      for (JoinKey joinKey : keys) {
+        String joinStageName = joinKey.getStageName();
+        JoinStage joinStage = stageMap.get(joinStageName);
+        // check that the stage for each key is in the list of stages
+        if (joinStage == null) {
+          throw new InvalidJoinConditionException(String.format(
+            "Join key for stage '%s' is invalid. Stage '%s' is not a join input.",
+            joinStageName, joinStageName));
+        }
+        // this happens if the schema for that stage is unknown.
+        // for example, because of macros could not be evaluated yet.
+        if (joinStage.getSchema() == null) {
+          continue;
+        }
+        Set<String> fields = joinStage.getSchema().getFields().stream()
+          .map(Schema.Field::getName)
+          .collect(Collectors.toSet());
+
+        // check that the key fields for each key is in fields for that stage
+        // for example, when joining on A.id = B.uid, check that 'id' is in the fields for stage A and 'uid' for stage B
+        Set<String> keysCopy = new HashSet<>(joinKey.getFields());
+        keysCopy.removeAll(fields);
+        if (keysCopy.size() == 1) {
+          throw new InvalidJoinConditionException(String.format(
+            "Join key for stage '%s' is invalid. Field '%s' does not exist in the stage.",
+            joinStageName, keysCopy.iterator().next()));
+        }
+        if (keysCopy.size() > 1) {
+          throw new InvalidJoinConditionException(String.format(
+            "Join key for stage '%s' is invalid. Fields %s do not exist in the stage.",
+            joinStageName, String.join(", ", keysCopy)));
+        }
+      }
+
+      // check that the keys have the same type.
+
+      Iterator<JoinKey> keyIter = keys.iterator();
+      JoinKey key1 = keyIter.next();
+      // stage is guaranteed to be exist because of above validation
+      Schema schema1 = stageMap.get(key1.getStageName()).getSchema();
+      if (schema1 == null) {
+        return;
+      }
+      while (keyIter.hasNext()) {
+        JoinKey otherKey = keyIter.next();
+        Schema otherSchema = stageMap.get(otherKey.getStageName()).getSchema();
+        if (otherSchema == null) {
+          continue;
+        }
+        Iterator<String> fieldIter = otherKey.getFields().iterator();
+        for (String key1Field : key1.getFields()) {
+          Schema key1Schema = getNonNullableFieldSchema(schema1, key1Field);
+
+          // don't need to check hasNext() because already verified they are all the same length
+          String otherField = fieldIter.next();
+          Schema otherFieldSchema = getNonNullableFieldSchema(otherSchema, otherField);
+
+          if (key1Schema.getType() != otherFieldSchema.getType()) {
+            throw new InvalidJoinConditionException(String.format(
+              "Type mismatch on join keys. '%s'.'%s' is of type '%s' while '%s'.'%s' is of type '%s'.",
+              key1.getStageName(), key1Field, key1Schema.getDisplayName(),
+              otherKey.getStageName(), otherField, otherFieldSchema.getDisplayName()));
+          }
+        }
+      }
+    }
+
+    private Schema getNonNullableFieldSchema(Schema schema, String field) {
+      Schema fieldSchema = schema.getField(field).getSchema();
+      return fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
+    }
+
+    /**
+     * Builds an OnKeys condition.
+     */
+    public static class Builder {
+      private final Set<JoinKey> keys;
+      private boolean dropNullKeys;
+
+      private Builder() {
+        this.keys = new HashSet<>();
+        this.dropNullKeys = false;
+      }
+
+      public Builder addKey(JoinKey key) {
+        this.keys.add(key);
+        return this;
+      }
+
+      public Builder setKeys(Collection<JoinKey> keys) {
+        this.keys.clear();
+        this.keys.addAll(keys);
+        return this;
+      }
+
+      public Builder setDropNullKeys(boolean dropNullKeys) {
+        this.dropNullKeys = dropNullKeys;
+        return this;
+      }
+
+      public OnKeys build() {
+        if (keys.size() < 2) {
+          throw new InvalidJoinConditionException("Must specify a join key for each input stage.");
+        }
+        Map<Integer, Set<String>> numFieldsToStages = new HashMap<>();
+        for (JoinKey joinKey : keys) {
+          int numFields = joinKey.getFields().size();
+          Set<String> stages = numFieldsToStages.computeIfAbsent(numFields, k -> new HashSet<>());
+          stages.add(joinKey.getStageName());
+        }
+        // this means there are stages with different number of fields.
+        // it's the equivalent of trying to join on A.id = B.id and A.name = [null]
+        if (numFieldsToStages.size() > 1) {
+          StringBuilder message = new StringBuilder("Must join on the same number of fields for each stage. ");
+          for (Map.Entry<Integer, Set<String>> entry : numFieldsToStages.entrySet()) {
+            int numFields = entry.getKey();
+            String fieldsStr = String.format("%d join field%s", numFields, numFields == 1 ? "" : "s");
+            Set<String> stages = entry.getValue();
+            if (stages.size() == 1) {
+              message.append(String.format("Stage '%s' has %s. ", stages.iterator().next(), fieldsStr));
+            } else {
+              message.append(String.format("Stages %s have %s. ", String.join(", ", stages), fieldsStr));
+            }
+          }
+          throw new InvalidJoinConditionException(message.toString());
+        }
+        return new OnKeys(keys, dropNullKeys);
+      }
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinDefinition.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.api.data.schema.Schema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Specifies how a join should be executed.
+ */
+@Beta
+public class JoinDefinition {
+  private final List<Field> selectedFields;
+  private final List<JoinStage> stages;
+  private final JoinCondition condition;
+  private final Schema outputSchema;
+
+  private JoinDefinition(List<Field> selectedFields, List<JoinStage> stages,
+                         JoinCondition condition, Schema outputSchema) {
+    this.stages = Collections.unmodifiableList(stages);
+    this.selectedFields = Collections.unmodifiableList(new ArrayList<>(selectedFields));
+    this.condition = condition;
+    this.outputSchema = outputSchema;
+  }
+
+  public List<Field> getSelectedFields() {
+    return selectedFields;
+  }
+
+  public List<JoinStage> getStages() {
+    return stages;
+  }
+
+  public JoinCondition getCondition() {
+    return condition;
+  }
+
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+
+  /**
+   * @return a Builder to create a JoinSpecification.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builds a JoinSpecification.
+   */
+  public static class Builder {
+    private final List<JoinStage> stages;
+    private final List<Field> selectedFields;
+    private JoinCondition condition;
+    private String schemaName;
+
+    private Builder() {
+      stages = new ArrayList<>();
+      selectedFields = new ArrayList<>();
+      schemaName = null;
+      condition = null;
+    }
+
+    public Builder select(List<Field> selectedFields) {
+      this.selectedFields.clear();
+      this.selectedFields.addAll(selectedFields);
+      return this;
+    }
+
+    public Builder select(Field... fields) {
+      return select(Arrays.asList(fields));
+    }
+
+    public Builder from(Collection<JoinStage> stages) {
+      this.stages.clear();
+      this.stages.addAll(stages);
+      return this;
+    }
+
+    public Builder from(JoinStage... stages) {
+      return from(Arrays.asList(stages));
+    }
+
+    public Builder on(JoinCondition condition) {
+      this.condition = condition;
+      return this;
+    }
+
+    public Builder setOutputSchemaName(@Nullable String name) {
+      schemaName = name;
+      return this;
+    }
+
+    /**
+     * @return a valid JoinDefinition
+     *
+     * @throws InvalidJoinException if the join is invalid
+     */
+    public JoinDefinition build() {
+      if (selectedFields.isEmpty()) {
+        throw new InvalidJoinException("At least one field must be selected.");
+      }
+
+      // validate the join stages
+      if (stages.size() < 2) {
+        throw new InvalidJoinException("At least two stages must be specified.");
+      }
+
+      // validate the join condition
+      if (condition == null) {
+        throw new InvalidJoinException("A join condition must be specified.");
+      }
+      condition.validate(stages);
+
+      return new JoinDefinition(selectedFields, stages, condition, getOutputSchema());
+    }
+
+    @Nullable
+    private Schema getOutputSchema() {
+      Set<String> outputFieldNames = new HashSet<>();
+      List<Schema.Field> outputFields = new ArrayList<>(selectedFields.size());
+      Map<String, JoinStage> stageMap = stages.stream()
+        .collect(Collectors.toMap(JoinStage::getStageName, s -> s));
+
+      for (Field field : selectedFields) {
+        JoinStage joinStage = stageMap.get(field.getStageName());
+        if (joinStage == null) {
+          throw new InvalidJoinException(String.format(
+            "Selected field '%s'.'%s' is invalid because stage '%s' is not part of the join.",
+            field.getStageName(), field.getFieldName(), field.getStageName()));
+        }
+        Schema stageSchema = joinStage.getSchema();
+        // schema is null if the schema is unknown
+        // for example, when the pipeline is being deployed, the schema might not yet be known due to
+        // macros not being evaluated yet.
+        if (stageSchema == null) {
+          return null;
+        }
+        Schema.Field schemaField = stageSchema.getField(field.getFieldName());
+        if (schemaField == null) {
+          throw new InvalidJoinException(String.format(
+            "Selected field '%s'.'%s' is invalid because stage '%s' does not contain field '%s'.",
+            field.getStageName(), field.getFieldName(), field.getStageName(), field.getFieldName()));
+        }
+
+        String outputFieldName = field.getAlias() == null ? field.getFieldName() : field.getAlias();
+        if (!outputFieldNames.add(outputFieldName)) {
+          throw new InvalidJoinException(String.format(
+            "Field '%s' from stage '%s' is a duplicate. Set an alias to make it unique.",
+            outputFieldName, field.getStageName()));
+        }
+        Schema outputFieldSchema = schemaField.getSchema();
+        if (!joinStage.isRequired() && !outputFieldSchema.isNullable()) {
+          outputFieldSchema = Schema.nullableOf(outputFieldSchema);
+        }
+        outputFields.add(Schema.Field.of(outputFieldName, outputFieldSchema));
+      }
+
+      return Schema.recordOf(schemaName == null ? "joined" : schemaName, outputFields);
+    }
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinKey.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinKey.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+import io.cdap.cdap.api.annotation.Beta;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A list of fields from a given stage.
+ */
+@Beta
+public class JoinKey {
+  private final String stageName;
+  private final List<String> fields;
+
+  public JoinKey(String stageName, List<String> fields) {
+    this.stageName = stageName;
+    this.fields = Collections.unmodifiableList(new ArrayList<>(fields));
+  }
+
+  public String getStageName() {
+    return stageName;
+  }
+
+  public List<String> getFields() {
+    return fields;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    JoinKey that = (JoinKey) o;
+    return Objects.equals(stageName, that.stageName) &&
+      Objects.equals(fields, that.fields);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stageName, fields);
+  }
+
+  @Override
+  public String toString() {
+    return "JoinKey{" +
+      "stageName='" + stageName + '\'' +
+      ", fields=" + fields +
+      '}';
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinStage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinStage.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+import io.cdap.cdap.api.data.schema.Schema;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents an input stage to the auto join.
+ */
+public class JoinStage {
+  private final String stageName;
+  private final Schema schema;
+  private final boolean required;
+  private final boolean broadcast;
+
+  private JoinStage(String stageName, Schema schema, boolean required, boolean broadcast) {
+    this.stageName = stageName;
+    this.schema = schema;
+    this.required = required;
+    this.broadcast = broadcast;
+  }
+
+  public String getStageName() {
+    return stageName;
+  }
+
+  @Nullable
+  public Schema getSchema() {
+    return schema;
+  }
+
+  public boolean isRequired() {
+    return required;
+  }
+
+  public boolean isBroadcast() {
+    return broadcast;
+  }
+
+  public static Builder builder(String stageName, @Nullable Schema schema) {
+    return new Builder(stageName, schema);
+  }
+
+  public static Builder builder(JoinStage existing) {
+    return new Builder(existing.stageName, existing.schema)
+      .setBroadcast(existing.broadcast)
+      .setRequired(existing.required);
+  }
+
+  /**
+   * Builds a JoinStage.
+   */
+  public static class Builder {
+    private final String stageName;
+    private final Schema schema;
+    private boolean required;
+    private boolean broadcast;
+
+    private Builder(String stageName, Schema schema) {
+      this.stageName = stageName;
+      this.schema = schema;
+      this.required = true;
+      this.broadcast = false;
+    }
+
+    public Builder isRequired() {
+      return setRequired(true);
+    }
+
+    public Builder isOptional() {
+      return setRequired(false);
+    }
+
+    /**
+     * Set whether the stage is required. Joining two required stages is an inner join. Joining a required stage
+     * with an optional stage is a left outer join. Joining two optional stages is an outer join.
+     */
+    public Builder setRequired(boolean required) {
+      this.required = required;
+      return this;
+    }
+
+    /**
+     * Set whether the stage data should be broadcast during the join. In order to be broadcast, the stage data must
+     * be below 8gb and fit entirely in memory. You cannot broadcast both sides of a join.
+     */
+    public Builder setBroadcast(boolean broadcast) {
+      this.broadcast = broadcast;
+      return this;
+    }
+
+    /**
+     * @return a valid JoinStage
+     */
+    public JoinStage build() {
+      return new JoinStage(stageName, schema, required, broadcast);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidationException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidationException.java
@@ -35,7 +35,7 @@ public class ValidationException extends RuntimeException {
    * @param failures list of validation failures
    */
   public ValidationException(List<ValidationFailure> failures) {
-    super("Errors were encountered during validation.");
+    super(generateMessage(failures));
     this.failures = Collections.unmodifiableList(new ArrayList<>(failures));
   }
 
@@ -44,5 +44,10 @@ public class ValidationException extends RuntimeException {
    */
   public List<ValidationFailure> getFailures() {
     return failures;
+  }
+
+  private static String generateMessage(List<ValidationFailure> failures) {
+    return String.format("Errors were encountered during validation. %s",
+                         failures.isEmpty() ? "" : failures.iterator().next().getMessage());
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/join/JoinDefinitionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/join/JoinDefinitionTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Tests for {@link JoinDefinition} and related builders.
+ */
+public class JoinDefinitionTest {
+  private static final Schema USER_SCHEMA = Schema.recordOf(
+    "user",
+    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("email", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+    Schema.Field.of("age", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("bday", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))));
+  private static final Schema PURCHASE_SCHEMA = Schema.recordOf(
+    "purchase",
+    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+    Schema.Field.of("user_id", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+    Schema.Field.of("ts", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+    Schema.Field.of("coupon", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))));
+
+  @Test
+  public void testInnerJoinSchema() {
+    Schema expected = Schema.recordOf(
+      "userPurchase",
+      Schema.Field.of("purchase_id", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("user_id", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("ts", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+      Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+      Schema.Field.of("coupon", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("email", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("age", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("bday", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))));
+
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA)
+      .isRequired()
+      .build();
+
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA)
+      .isRequired()
+      .build();
+
+    testUserPurchaseSchema(purchases, users, expected);
+  }
+
+  @Test
+  public void testLeftOuterJoinSchema() {
+    Schema expected = Schema.recordOf(
+      "userPurchase",
+      Schema.Field.of("purchase_id", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("user_id", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+      Schema.Field.of("ts", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+      Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+      Schema.Field.of("coupon", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
+      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("email", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("age", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+      Schema.Field.of("bday", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))));
+
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA)
+      .isRequired()
+      .build();
+
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA)
+      .isOptional()
+      .build();
+
+    testUserPurchaseSchema(purchases, users, expected);
+  }
+
+  @Test
+  public void testOuterJoinSchema() {
+    Schema expected = Schema.recordOf(
+      "userPurchase",
+      Schema.Field.of("purchase_id", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+      Schema.Field.of("user_id", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+      Schema.Field.of("ts", Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))),
+      Schema.Field.of("price", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+      Schema.Field.of("coupon", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
+      Schema.Field.of("name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("email", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("age", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+      Schema.Field.of("bday", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))));
+
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA)
+      .isOptional()
+      .build();
+
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA)
+      .isOptional()
+      .build();
+
+    testUserPurchaseSchema(purchases, users, expected);
+  }
+
+  @Test
+  public void testUnknownSchema() {
+    JoinStage purchases = JoinStage.builder("purchases", null).build();
+
+    JoinStage users = JoinStage.builder("users", null).build();
+
+    JoinDefinition definition = JoinDefinition.builder()
+      .select(new Field("purchases", "id", "purchase_id"),
+              new Field("users", "id", "user_id"),
+              new Field("users", "name"))
+      .from(purchases, users)
+      .on(JoinCondition.onKeys()
+            .addKey(new JoinKey("purchases", Collections.singletonList("user_id")))
+            .addKey(new JoinKey("users", Collections.singletonList("id")))
+            .build())
+      .build();
+
+    Assert.assertNull(definition.getOutputSchema());
+  }
+
+  @Test
+  public void testSelectMissingFieldThrowsException() {
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA).build();
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA).build();
+
+    try {
+      JoinDefinition.builder()
+        .select(new Field("purchases", "id", "purchase_id"),
+                new Field("users", "abcdef"))
+        .from(purchases, users)
+        .on(JoinCondition.onKeys()
+              .addKey(new JoinKey("purchases", Collections.singletonList("user_id")))
+              .addKey(new JoinKey("users", Collections.singletonList("id")))
+              .build())
+        .build();
+      Assert.fail("Select missing field did not fail as expected");
+    } catch (InvalidJoinException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testSelectMissingStageThrowsException() {
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA).build();
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA).build();
+
+    try {
+      JoinDefinition.builder()
+        .select(new Field("purchases", "id", "purchase_id"),
+                new Field("users2", "id"))
+        .from(purchases, users)
+        .on(JoinCondition.onKeys()
+              .addKey(new JoinKey("purchases", Collections.singletonList("user_id")))
+              .addKey(new JoinKey("users", Collections.singletonList("id")))
+              .build())
+        .build();
+      Assert.fail("Select missing stage did not fail as expected");
+    } catch (InvalidJoinException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testDuplicateOutputFieldsThrowsException() {
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA).build();
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA).build();
+
+    try {
+      JoinDefinition.builder()
+        .select(new Field("purchases", "user_id"),
+                new Field("users", "id", "user_id"))
+        .from(purchases, users)
+        .on(JoinCondition.onKeys()
+              .addKey(new JoinKey("purchases", Collections.singletonList("user_id")))
+              .addKey(new JoinKey("users", Collections.singletonList("id")))
+              .build())
+        .build();
+      Assert.fail("Duplicate fields did not fail as expected");
+    } catch (InvalidJoinException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testWrongJoinKeyStageThrowsException() {
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA).build();
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA).build();
+
+    try {
+      JoinDefinition.builder()
+        .select(new Field("purchases", "id"),
+                new Field("users", "id", "user_id"))
+        .from(purchases, users)
+        .on(JoinCondition.onKeys()
+              .addKey(new JoinKey("abc", Collections.singletonList("user_id")))
+              .addKey(new JoinKey("users", Collections.singletonList("id")))
+              .build())
+        .build();
+      Assert.fail("Invalid join condition did not fail as expected");
+    } catch (InvalidJoinConditionException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testJoinKeyMissingFieldThrowsException() {
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA).build();
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA).build();
+
+    try {
+      JoinDefinition.builder()
+        .select(new Field("purchases", "id"),
+                new Field("users", "id", "user_id"))
+        .from(purchases, users)
+        .on(JoinCondition.onKeys()
+              .addKey(new JoinKey("purchases", Collections.singletonList("abc")))
+              .addKey(new JoinKey("users", Collections.singletonList("email")))
+              .build())
+        .build();
+      Assert.fail("Invalid join condition did not fail as expected");
+    } catch (InvalidJoinConditionException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testJoinKeyMismatchedNumFieldsThrowsException() {
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA).build();
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA).build();
+
+    try {
+      JoinDefinition.builder()
+        .select(new Field("purchases", "id"),
+                new Field("users", "id", "user_id"))
+        .from(purchases, users)
+        .on(JoinCondition.onKeys()
+              .addKey(new JoinKey("purchases", Arrays.asList("id", "user_id")))
+              .addKey(new JoinKey("users", Collections.singletonList("id")))
+              .build())
+        .build();
+      Assert.fail("Invalid join condition did not fail as expected");
+    } catch (InvalidJoinConditionException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testJoinKeyMismatchedFieldTypeThrowsException() {
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA).build();
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA).build();
+
+    try {
+      JoinDefinition.builder()
+        .select(new Field("purchases", "id"),
+                new Field("users", "id", "user_id"))
+        .from(purchases, users)
+        .on(JoinCondition.onKeys()
+              .addKey(new JoinKey("purchases", Arrays.asList("id")))
+              .addKey(new JoinKey("users", Collections.singletonList("email")))
+              .build())
+        .build();
+      Assert.fail("Invalid join condition did not fail as expected");
+    } catch (InvalidJoinConditionException e) {
+      // expected
+    }
+  }
+
+  private void testUserPurchaseSchema(JoinStage purchases, JoinStage users, Schema expected) {
+    JoinDefinition definition = JoinDefinition.builder()
+      .select(new Field("purchases", "id", "purchase_id"),
+              new Field("users", "id", "user_id"),
+              new Field("purchases", "ts"),
+              new Field("purchases", "price"),
+              new Field("purchases", "coupon"),
+              new Field("users", "name"),
+              new Field("users", "email"),
+              new Field("users", "age"),
+              new Field("users", "bday"))
+      .from(purchases, users)
+      .on(JoinCondition.onKeys()
+            .addKey(new JoinKey("purchases", Collections.singletonList("user_id")))
+            .addKey(new JoinKey("users", Collections.singletonList("id")))
+            .build())
+      .setOutputSchemaName(expected.getRecordName())
+      .build();
+
+    Assert.assertEquals(expected, definition.getOutputSchema());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultAutoJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultAutoJoinerContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinStage;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Default implementation of AutoJoinerContext.
+ */
+public class DefaultAutoJoinerContext implements AutoJoinerContext {
+  private final Map<String, JoinStage> inputStages;
+
+  public DefaultAutoJoinerContext(Map<String, Schema> inputStages) {
+    Map<String, JoinStage> stageMap = new HashMap<>();
+    for (Map.Entry<String, Schema> e : inputStages.entrySet()) {
+      stageMap.put(e.getKey(), JoinStage.builder(e.getKey(), e.getValue()).build());
+    }
+    this.inputStages = Collections.unmodifiableMap(stageMap);
+  }
+
+  @Override
+  public Map<String, JoinStage> getInputStages() {
+    return inputStages;
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultStageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultStageConfigurer.java
@@ -69,7 +69,6 @@ public class DefaultStageConfigurer implements StageConfigurer, MultiInputStageC
     outputPortSchemas.putAll(outputSchemas);
   }
 
-  @Nullable
   @Override
   public Map<String, Schema> getInputSchemas() {
     return inputSchemas;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -32,10 +32,17 @@ import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.SplitterTransform;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.action.Action;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.condition.Condition;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.Field;
+import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinKey;
+import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.batch.BatchPipelineSpec;
 import io.cdap.cdap.etl.batch.BatchPipelineSpecGenerator;
@@ -51,6 +58,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -62,18 +70,25 @@ import javax.annotation.Nullable;
 public class PipelineSpecGeneratorTest {
   private static final Schema SCHEMA_A = Schema.recordOf("a", Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
   private static final Schema SCHEMA_B = Schema.recordOf("b", Schema.Field.of("b", Schema.of(Schema.Type.STRING)));
+  private static final Schema SCHEMA_ABC = Schema.recordOf("abc",
+                                                           Schema.Field.of("a", Schema.of(Schema.Type.STRING)),
+                                                           Schema.Field.of("b", Schema.of(Schema.Type.STRING)),
+                                                           Schema.Field.of("c", Schema.of(Schema.Type.INT)));
   private static final Map<String, String> EMPTY_MAP = ImmutableMap.of();
   private static final ETLPlugin MOCK_SOURCE = new ETLPlugin("mocksource", BatchSource.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_TRANSFORM_A = new ETLPlugin("mockA", Transform.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_TRANSFORM_B = new ETLPlugin("mockB", Transform.PLUGIN_TYPE, EMPTY_MAP);
+  private static final ETLPlugin MOCK_TRANSFORM_ABC = new ETLPlugin("mockABC", Transform.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_SINK = new ETLPlugin("mocksink", BatchSink.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_JOINER = new ETLPlugin("mockjoiner", BatchJoiner.PLUGIN_TYPE, EMPTY_MAP);
+  private static final ETLPlugin MOCK_AUTO_JOINER = new ETLPlugin("mockautojoiner", BatchJoiner.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_ERROR = new ETLPlugin("mockerror", ErrorTransform.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_ACTION = new ETLPlugin("mockaction", Action.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_CONDITION = new ETLPlugin("mockcondition", Condition.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_SPLITTER = new ETLPlugin("mocksplit", SplitterTransform.PLUGIN_TYPE, EMPTY_MAP);
   private static final ArtifactId ARTIFACT_ID =
     new ArtifactId("plugins", new ArtifactVersion("1.0.0"), ArtifactScope.USER);
+  private static JoinDefinition joinDefinition;
   private static BatchPipelineSpecGenerator specGenerator;
 
   @BeforeClass
@@ -88,6 +103,8 @@ public class PipelineSpecGeneratorTest {
                                    artifactIds);
     pluginConfigurer.addMockPlugin(Transform.PLUGIN_TYPE, "mockB",
                                    MockPlugin.builder().setOutputSchema(SCHEMA_B).build(), artifactIds);
+    pluginConfigurer.addMockPlugin(Transform.PLUGIN_TYPE, "mockABC",
+                                   MockPlugin.builder().setOutputSchema(SCHEMA_ABC).build(), artifactIds);
     pluginConfigurer.addMockPlugin(BatchSink.PLUGIN_TYPE, "mocksink", MockPlugin.builder().build(), artifactIds);
     pluginConfigurer.addMockPlugin(Action.PLUGIN_TYPE, "mockaction", MockPlugin.builder().build(), artifactIds);
     pluginConfigurer.addMockPlugin(Condition.PLUGIN_TYPE, "mockcondition", MockPlugin.builder().build(), artifactIds);
@@ -96,7 +113,7 @@ public class PipelineSpecGeneratorTest {
     pluginConfigurer.addMockPlugin(SplitterTransform.PLUGIN_TYPE, "mocksplit",
                                    new MockSplitter(ImmutableMap.of("portA", SCHEMA_A, "portB", SCHEMA_B)),
                                    artifactIds);
-
+    pluginConfigurer.addMockPlugin(BatchJoiner.PLUGIN_TYPE, "mockautojoiner", new MockAutoJoin(), artifactIds);
 
     specGenerator = new BatchPipelineSpecGenerator(pluginConfigurer,
                                                    ImmutableSet.of(BatchSource.PLUGIN_TYPE),
@@ -396,6 +413,7 @@ public class PipelineSpecGeneratorTest {
       .setNumOfRecordsPreview(100)
       .build();
 
+    Map<String, String> emptyMap = Collections.emptyMap();
     PipelineSpec expected = BatchPipelineSpec.builder()
       .addStage(
         StageSpec.builder("source", new PluginSpec(BatchSource.PLUGIN_TYPE, "mocksource", EMPTY_MAP, ARTIFACT_ID))
@@ -432,6 +450,89 @@ public class PipelineSpecGeneratorTest {
       .build();
 
     PipelineSpec actual = specGenerator.generateSpec(config);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testAutoJoin() {
+    /*
+     *           ---- transformA --------|
+     *           |                       |
+     * source ---|                       |-- autojoin --- sink
+     *           |                       |
+     *           ---- transformABC ------|
+     */
+    ETLBatchConfig config = ETLBatchConfig.builder()
+      .setTimeSchedule("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("tA", MOCK_TRANSFORM_A))
+      .addStage(new ETLStage("tABC", MOCK_TRANSFORM_ABC))
+      .addStage(new ETLStage("autojoin", MOCK_AUTO_JOINER))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addConnection("source", "tA")
+      .addConnection("source", "tABC")
+      .addConnection("tA", "autojoin")
+      .addConnection("tABC", "autojoin")
+      .addConnection("autojoin", "sink")
+      .setNumOfRecordsPreview(100)
+      .build();
+
+    joinDefinition = JoinDefinition.builder()
+      .select(new Field("tA", "a"), new Field("tABC", "b"), new Field("tABC", "c"))
+      .from(JoinStage.builder("tA", SCHEMA_A).isRequired().build(),
+            JoinStage.builder("tABC", SCHEMA_ABC).isOptional().build())
+      .on(JoinCondition.onKeys()
+            .addKey(new JoinKey("tA", Collections.singletonList("a")))
+            .addKey(new JoinKey("tABC", Collections.singletonList("a")))
+            .build())
+      .setOutputSchemaName("abc.joined")
+      .build();
+    Schema joinSchema = Schema.recordOf("abc.joined",
+                                        Schema.Field.of("a", Schema.of(Schema.Type.STRING)),
+                                        Schema.Field.of("b", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+                                        Schema.Field.of("c", Schema.nullableOf(Schema.of(Schema.Type.INT))));
+
+    Map<String, String> emptyMap = new HashMap<>();
+    PipelineSpec expected = BatchPipelineSpec.builder()
+      .addStage(
+        StageSpec.builder("source", new PluginSpec(BatchSource.PLUGIN_TYPE, "mocksource", emptyMap, ARTIFACT_ID))
+          .addOutput(SCHEMA_A, "tA", "tABC")
+          .build())
+      .addStage(
+        StageSpec.builder("tA", new PluginSpec(Transform.PLUGIN_TYPE, "mockA", emptyMap, ARTIFACT_ID))
+          .addInputSchema("source", SCHEMA_A)
+          .addOutput(SCHEMA_A, "autojoin")
+          .setErrorSchema(SCHEMA_B)
+          .build())
+      .addStage(
+        StageSpec.builder("tABC", new PluginSpec(Transform.PLUGIN_TYPE, "mockABC", emptyMap, ARTIFACT_ID))
+          .addInputSchema("source", SCHEMA_A)
+          .addOutput(SCHEMA_ABC, "autojoin")
+          .setErrorSchema(SCHEMA_A)
+          .build())
+      .addStage(
+        StageSpec.builder("autojoin",
+                          new PluginSpec(BatchJoiner.PLUGIN_TYPE, "mockautojoiner", emptyMap, ARTIFACT_ID))
+          .addInputSchema("tA", SCHEMA_A)
+          .addInputSchema("tABC", SCHEMA_ABC)
+          .addOutput(joinSchema, "sink")
+          .setErrorSchema(SCHEMA_ABC)
+          .build())
+      .addStage(
+        StageSpec.builder("sink", new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", emptyMap, ARTIFACT_ID))
+          .addInputSchema("autojoin", joinSchema)
+          .setErrorSchema(joinSchema)
+          .build())
+      .addConnections(config.getConnections())
+      .setResources(config.getResources())
+      .setDriverResources(config.getDriverResources())
+      .setClientResources(config.getClientResources())
+      .setStageLoggingEnabled(config.isStageLoggingEnabled())
+      .setNumOfRecordsPreview(config.getNumOfRecordsPreview())
+      .build();
+
+    PipelineSpec actual = specGenerator.generateSpec(config);
+
     Assert.assertEquals(expected, actual);
   }
 
@@ -880,6 +981,15 @@ public class PipelineSpecGeneratorTest {
     @Override
     public void configurePipeline(MultiOutputPipelineConfigurer multiOutputPipelineConfigurer) {
       multiOutputPipelineConfigurer.getMultiOutputStageConfigurer().setOutputSchemas(outputSchemas);
+    }
+  }
+
+  private static class MockAutoJoin extends BatchAutoJoiner {
+
+    @Nullable
+    @Override
+    public JoinDefinition define(AutoJoinerContext context) {
+      return joinDefinition;
     }
   }
 


### PR DESCRIPTION
Add a new set of classes for AutoJoiner, which can be used instead
of the current Joiner interface. This new API leaves all of the
implementation details up to the application, which will allow the
app to perform the join in better ways. For example, in the Spark
program, it will allow using broadcast joins.

Plugin developers are responsible for returning a JoinDefinition
based on information about incoming stages.

This change includes the JoinDefinition as well as all the classes
required to create a definition. It also includes validation logic
to make sure the plugin cannot create a definition that tries to
join on a field that doesn't exist, or tries to join on fields
that have mismatched types, or any other type of error.