### PR TITLE
[CDAP-16621] Remove export modal when exporting pipeline JSON

### DIFF
--- a/cdap-ui/app/cdap/components/ActionsPopover/index.tsx
+++ b/cdap-ui/app/cdap/components/ActionsPopover/index.tsx
@@ -31,6 +31,9 @@ export interface IAction {
 
 interface IActionsPopoverProps {
   actions: IAction[];
+  targetElem?: (props) => React.ReactElement;
+  showPopover?: boolean;
+  togglePopover?: () => void;
 }
 
 const POPPER_MODIFIERS = {
@@ -42,7 +45,24 @@ const POPPER_MODIFIERS = {
   },
 };
 
-const ActionsPopover: React.SFC<IActionsPopoverProps> = ({ actions }) => {
+const ActionsPopover: React.SFC<IActionsPopoverProps> = ({
+  actions,
+  targetElem,
+  showPopover,
+  togglePopover,
+}) => {
+  let target = (props) => (
+    <IconSVG
+      name="icon-cog-empty"
+      {...props}
+      className={`default-target ${props.className}`}
+      onClick={togglePopover}
+    />
+  );
+  if (targetElem) {
+    target = targetElem;
+  }
+
   return (
     <Popover
       target={(props) => <IconSVG name="icon-cog-empty" {...props} />}
@@ -51,6 +71,7 @@ const ActionsPopover: React.SFC<IActionsPopoverProps> = ({ actions }) => {
       bubbleEvent={false}
       enableInteractionInPopover={true}
       modifiers={POPPER_MODIFIERS}
+      showPopover={showPopover}
     >
       <ul>
         {actions.map((action, i) => {

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -27,6 +27,7 @@ import T from 'i18n-react';
 import classnames from 'classnames';
 import { duplicatePipeline } from 'services/PipelineUtils';
 import cloneDeep from 'lodash/cloneDeep';
+import downloadFile from 'services/download-file';
 require('./PipelineDetailsActionsButton.scss');
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
@@ -118,6 +119,18 @@ export default class PipelineDetailsActionsButton extends Component {
     );
   };
 
+  handlePipelineExport = () => {
+    if (window.Cypress) {
+      this.showExportModal();
+      return;
+    }
+    // Unless we are running an e2e test, just export the pipeline JSON
+    const closePopoverCb = () => {
+      this.setState({ showPopover: false });
+    };
+    downloadFile(this.pipelineConfig, closePopoverCb);
+  };
+
   toggleExportModal = () => {
     this.setState({ showExportModal: !this.state.showExportModal });
   };
@@ -140,6 +153,7 @@ export default class PipelineDetailsActionsButton extends Component {
         isOpen={this.state.showExportModal}
         onClose={this.toggleExportModal}
         pipelineConfig={sanitizeConfig(this.pipelineConfig)}
+        onExport={this.handlePipelineExport}
       />
     );
   }
@@ -231,7 +245,7 @@ export default class PipelineDetailsActionsButton extends Component {
         >
           <ul>
             <li onClick={this.duplicateConfigAndNavigate}>{T.translate(`${PREFIX}.duplicate`)}</li>
-            <li onClick={this.toggleExportModal}>{T.translate(`${PREFIX}.export`)}</li>
+            <li onClick={this.handlePipelineExport}>{T.translate(`${PREFIX}.export`)}</li>
             <hr />
             <li
               onClick={this.toggleDeleteConfirmationModal}

--- a/cdap-ui/app/cdap/components/PipelineExportModal/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineExportModal/index.tsx
@@ -26,30 +26,10 @@ interface IProps {
   isOpen: boolean;
   onClose: () => void;
   pipelineConfig: any;
+  onExport: (config: any) => void;
 }
 
-const PipelineExportModal: React.SFC<IProps> = ({ isOpen, onClose, pipelineConfig }) => {
-  const exportPipeline = () => {
-    const blob = new Blob([JSON.stringify(pipelineConfig, null, 4)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const exportFileName =
-      (pipelineConfig.name ? pipelineConfig.name : 'noname') + '-' + pipelineConfig.artifact.name;
-
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${exportFileName}.json`;
-
-    const clickHandler = (event) => {
-      event.stopPropagation();
-      setTimeout(() => {
-        onClose();
-      }, 300);
-    };
-
-    a.addEventListener('click', clickHandler, false);
-    a.click();
-  };
-
+const PipelineExportModal: React.SFC<IProps> = ({ isOpen, onClose, pipelineConfig, onExport }) => {
   return (
     <Modal
       isOpen={isOpen}
@@ -80,7 +60,7 @@ const PipelineExportModal: React.SFC<IProps> = ({ isOpen, onClose, pipelineConfi
         </fieldset>
       </ModalBody>
       <ModalFooter>
-        <div className="btn btn-primary" onClick={exportPipeline}>
+        <div className="btn btn-primary" onClick={onExport.bind(null, pipelineConfig)}>
           {T.translate(`${PREFIX}.export`)}
         </div>
         <div className="btn btn-secondary close-button" onClick={onClose}>

--- a/cdap-ui/app/cdap/services/download-file.js
+++ b/cdap-ui/app/cdap/services/download-file.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ function DownloadFile(fileConfig, postExportCb) {
+  const blob = new Blob([JSON.stringify(fileConfig, null, 4)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const exportFileName = `${fileConfig.name ? fileConfig.name : 'noname'}-${
+    fileConfig.artifact.name
+  }`;
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${exportFileName}.json`;
+
+  const clickHandler = (event) => {
+    event.stopPropagation();
+    setTimeout(() => {
+      typeof postExportCb === 'function' && postExportCb()
+    }, 300);
+  };
+
+  a.addEventListener('click', clickHandler, false);
+  a.click();
+};
+
+export default DownloadFile;

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -105,6 +105,7 @@ var ConfigurationGroupUtilities = require('../cdap/components/ConfigurationGroup
 var DynamicFiltersUtilities = require('../cdap/components/ConfigurationGroup/utilities/DynamicPluginFilters');
 var LoadingSVG = require('../cdap/components/LoadingSVG').default;
 var WindowManager = require('../cdap/services/WindowManager').default;
+var DownloadFile = require('../cdap/services/download-file').default;
 
 export {
   Store,
@@ -184,4 +185,5 @@ export {
   DynamicFiltersUtilities,
   LoadingSVG,
   WindowManager,
+  DownloadFile,
 };

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -244,7 +244,12 @@ class HydratorPlusPlusTopPanelCtrl {
     let config = angular.copy(this.HydratorPlusPlusConfigStore.getDisplayConfig());
     let exportConfig = this.HydratorPlusPlusConfigStore.getConfigForExport();
     delete exportConfig.__ui__;
-    this.myPipelineExportModalService.show(config, exportConfig);
+    // Only show export modal with pipeline JSON when running e2e tests
+    if (window.Cypress) {
+      this.myPipelineExportModalService.show(config, exportConfig);
+    } else {
+      window.CaskCommon.DownloadFile(exportConfig);
+    }
   }
   onSaveDraft() {
     this.HydratorPlusPlusConfigActions.saveAsDraft();

--- a/cdap-ui/cypress/integration/pipeline.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.spec.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import * as Helpers from '../helpers';
 
@@ -31,6 +31,12 @@ describe('Creating a pipeline', () => {
           Authorization: 'Bearer ' + cookie.value,
         };
       });
+      cy.visit('/cdap', {
+        onBeforeLoad: (win) => {
+          win.sessionStorage.clear();
+          win.sessionStorage.setItem('pipelineConfigTesting', 'true');
+        },
+      });
     });
   });
 
@@ -41,6 +47,12 @@ describe('Creating a pipeline', () => {
   afterEach(() => {
     // Delete the pipeline to clean up
     cy.cleanup_pipelines(headers, TEST_PIPELINE_NAME);
+  });
+
+  after(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.removeItem('pipelineConfigTesting');
+    });
   });
 
   it('is configured correctly', () => {

--- a/cdap-ui/cypress/support/commands.ts
+++ b/cdap-ui/cypress/support/commands.ts
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
+ */
 
 import { ConnectionType } from '../../app/cdap/components/DataPrepConnections/ConnectionType';
 import { DEFAULT_GCP_PROJECTID, DEFAULT_GCP_SERVICEACCOUNT_PATH } from '../support/constants';


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16621
Build: https://builds.cask.co/browse/CDAP-URUT253

Cherry-pick https://github.com/cdapio/cdap/pull/12113 for 6.1

Remove pipeline JSON modal when exporting pipelines from deployed/draft list views, Studio,  and pipeline detail page. 