### PR TITLE
CDAP-16709 batch spark auto-join implementation

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
@@ -58,7 +58,7 @@ public class JoinCondition {
    * Condition operation.
    */
   public enum Op {
-    EQUAL_TO
+    KEY_EQUALITY
   }
 
   public static OnKeys.Builder onKeys() {
@@ -73,7 +73,7 @@ public class JoinCondition {
     private final boolean dropNullKeys;
 
     private OnKeys(Set<JoinKey> keys, boolean dropNullKeys) {
-      super(Op.EQUAL_TO);
+      super(Op.KEY_EQUALITY);
       this.keys = Collections.unmodifiableSet(new HashSet<>(keys));
       this.dropNullKeys = dropNullKeys;
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReducePreparer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReducePreparer.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.etl.api.SplitterTransform;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchConfigurable;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
@@ -213,6 +214,12 @@ public class MapReducePreparer extends PipelinePhasePreparer {
       job.setMapOutputValueClass(TaggedWritable.class);
       stageOperations.put(stageName, joinerContext.getFieldOperations());
     });
+  }
+
+  @Override
+  protected SubmitterPlugin createAutoJoiner(BatchAutoJoiner batchJoiner, StageSpec stageSpec) {
+    // TODO: (CDAP-16709) implement auto-join for mapreduce
+    throw new UnsupportedOperationException("");
   }
 
   private Class<?> getOutputKeyClass(String reducerName, Class<?> outputKeyClass) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultAutoJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultAutoJoinerContext.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.etl.common;
 
-import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinStage;
 
@@ -30,12 +29,8 @@ import java.util.Map;
 public class DefaultAutoJoinerContext implements AutoJoinerContext {
   private final Map<String, JoinStage> inputStages;
 
-  public DefaultAutoJoinerContext(Map<String, Schema> inputStages) {
-    Map<String, JoinStage> stageMap = new HashMap<>();
-    for (Map.Entry<String, Schema> e : inputStages.entrySet()) {
-      stageMap.put(e.getKey(), JoinStage.builder(e.getKey(), e.getValue()).build());
-    }
-    this.inputStages = Collections.unmodifiableMap(stageMap);
+  public DefaultAutoJoinerContext(Map<String, JoinStage> inputStages) {
+    this.inputStages = Collections.unmodifiableMap(new HashMap<>(inputStages));
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/submit/PipelinePhasePreparer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/submit/PipelinePhasePreparer.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.etl.api.ErrorTransform;
 import io.cdap.cdap.etl.api.SplitterTransform;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchConfigurable;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchSink;
@@ -105,8 +106,17 @@ public abstract class PipelinePhasePreparer {
         BatchAggregator<?, ?, ?> aggregator = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
         submitterPlugin = createAggregator(aggregator, stageSpec);
       } else if (BatchJoiner.PLUGIN_TYPE.equals(pluginType)) {
-        BatchJoiner<?, ?, ?> batchJoiner = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
-        submitterPlugin = createJoiner(batchJoiner, stageSpec);
+        Object plugin = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
+        if (plugin instanceof BatchJoiner) {
+          BatchJoiner<?, ?, ?> batchJoiner = (BatchJoiner<?, ?, ?>) plugin;
+          submitterPlugin = createJoiner(batchJoiner, stageSpec);
+        } else if (plugin instanceof BatchAutoJoiner) {
+          BatchAutoJoiner batchJoiner = (BatchAutoJoiner) plugin;
+          submitterPlugin = createAutoJoiner(batchJoiner, stageSpec);
+        } else {
+          throw new IllegalStateException(String.format("Join stage '%s' is of an unsupported class '%s'.",
+                                                        stageSpec.getName(), plugin.getClass().getName()));
+        }
       } else if (SplitterTransform.PLUGIN_TYPE.equals(pluginType)) {
         SplitterTransform<?, ?> splitterTransform = pluginInstantiator.newPluginInstance(stageName, macroEvaluator);
         submitterPlugin = createSplitterTransform(splitterTransform, stageSpec);
@@ -143,5 +153,7 @@ public abstract class PipelinePhasePreparer {
   protected abstract SubmitterPlugin createAggregator(BatchAggregator<?, ?, ?> aggregator, StageSpec stageSpec);
 
   protected abstract SubmitterPlugin createJoiner(BatchJoiner<?, ?, ?> batchJoiner, StageSpec stageSpec);
+
+  protected abstract SubmitterPlugin createAutoJoiner(BatchAutoJoiner batchJoiner, StageSpec stageSpec);
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -46,6 +46,7 @@ import io.cdap.cdap.etl.api.condition.Condition;
 import io.cdap.cdap.etl.api.join.AutoJoiner;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.cdap.etl.api.validation.ValidationException;
@@ -65,6 +66,7 @@ import io.cdap.cdap.etl.proto.v2.spec.PluginSpec;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -290,7 +292,12 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
         // This is because we want to allow a Joiner plugin to switch from using the BatchJoiner interface
         // to the BatchAutoJoiner while preserving backwards compatibility in the pipeline config.
         if (plugin instanceof AutoJoiner) {
-          AutoJoinerContext autoContext = new DefaultAutoJoinerContext(stageConfigurer.getInputSchemas());
+          Map<String, JoinStage> stageMap = new HashMap<>();
+          for (Map.Entry<String, Schema> e : stageConfigurer.getInputSchemas().entrySet()) {
+            stageMap.put(e.getKey(), JoinStage.builder(e.getKey(), e.getValue()).build());
+          }
+
+          AutoJoinerContext autoContext = new DefaultAutoJoinerContext(stageMap);
           joinDefinition = ((AutoJoiner) plugin).define(autoContext);
           if (joinDefinition != null) {
             stageConfigurer.setOutputSchema(joinDefinition.getOutputSchema());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkPreparer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkPreparer.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.plugin.PluginContext;
 import io.cdap.cdap.etl.api.SplitterTransform;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchConfigurable;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
@@ -146,6 +147,17 @@ public abstract class AbstractSparkPreparer extends PipelinePhasePreparer {
 
   @Override
   protected SubmitterPlugin createJoiner(BatchJoiner<?, ?, ?> batchJoiner, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultJoinerContext> contextProvider =
+      new JoinerContextProvider(pipelineRuntime, stageSpec, admin);
+    return new SubmitterPlugin<>(stageName, transactional, batchJoiner, contextProvider, sparkJoinerContext -> {
+      stagePartitions.put(stageName, sparkJoinerContext.getNumPartitions());
+      stageOperations.put(stageName, sparkJoinerContext.getFieldOperations());
+    });
+  }
+
+  @Override
+  protected SubmitterPlugin createAutoJoiner(BatchAutoJoiner batchJoiner, StageSpec stageSpec) {
     String stageName = stageSpec.getName();
     ContextProvider<DefaultJoinerContext> contextProvider =
       new JoinerContextProvider(pipelineRuntime, stageSpec, admin);

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
@@ -16,15 +16,19 @@
 
 package io.cdap.cdap.etl.spark;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
 import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -65,4 +69,6 @@ public interface SparkCollection<T> {
   void publishAlerts(StageSpec stageSpec, StageStatisticsCollector collector) throws Exception;
 
   SparkCollection<T> window(StageSpec stageSpec, Windower windower);
+
+  SparkCollection<T> join(JoinRequest joinRequest);
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.etl.spark;
 
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.plugin.PluginContext;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
@@ -34,9 +35,16 @@ import io.cdap.cdap.etl.api.batch.BatchJoinerRuntimeContext;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.join.AutoJoiner;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinKey;
+import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.common.BasicArguments;
 import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.DefaultAutoJoinerContext;
 import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
 import io.cdap.cdap.etl.common.NoopStageStatisticsCollector;
 import io.cdap.cdap.etl.common.PipelinePhase;
@@ -53,6 +61,8 @@ import io.cdap.cdap.etl.spark.function.LeftJoinFlattenFunction;
 import io.cdap.cdap.etl.spark.function.OuterJoinFlattenFunction;
 import io.cdap.cdap.etl.spark.function.OutputPassFilter;
 import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
+import io.cdap.cdap.etl.spark.join.JoinCollection;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +78,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 /**
  * Base Spark program to run a Hydrator pipeline.
@@ -247,68 +258,35 @@ public abstract class SparkPipelineRunner {
 
       } else if (BatchJoiner.PLUGIN_TYPE.equals(pluginType)) {
 
-        BatchJoiner<Object, Object, Object> joiner = pluginContext.newPluginInstance(stageName, macroEvaluator);
-        BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createBatchRuntimeContext();
-        joiner.initialize(joinerRuntimeContext);
+        Object plugin = pluginContext.newPluginInstance(stageName, macroEvaluator);
+        if (plugin instanceof BatchJoiner) {
+          BatchJoiner<Object, Object, Object> joiner = (BatchJoiner<Object, Object, Object>) plugin;
+          BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createBatchRuntimeContext();
+          joiner.initialize(joinerRuntimeContext);
 
-        Map<String, SparkPairCollection<Object, Object>> preJoinStreams = new HashMap<>();
-        for (Map.Entry<String, SparkCollection<Object>> inputStreamEntry : inputDataCollections.entrySet()) {
-          String inputStage = inputStreamEntry.getKey();
-          SparkCollection<Object> inputStream = inputStreamEntry.getValue();
-          preJoinStreams.put(inputStage, addJoinKey(stageSpec, inputStage, inputStream, collector));
-        }
+          Integer numPartitions = stagePartitions.get(stageName);
 
-        Set<String> remainingInputs = new HashSet<>();
-        remainingInputs.addAll(inputDataCollections.keySet());
-
-        Integer numPartitions = stagePartitions.get(stageName);
-
-        SparkPairCollection<Object, List<JoinElement<Object>>> joinedInputs = null;
-        // inner join on required inputs
-        for (final String inputStageName : joiner.getJoinConfig().getRequiredInputs()) {
-          SparkPairCollection<Object, Object> preJoinCollection = preJoinStreams.get(inputStageName);
-
-          if (joinedInputs == null) {
-            joinedInputs = preJoinCollection.mapValues(new InitialJoinFunction<>(inputStageName));
-          } else {
-            JoinFlattenFunction<Object> joinFlattenFunction = new JoinFlattenFunction<>(inputStageName);
-            joinedInputs = numPartitions == null ?
-              joinedInputs.join(preJoinCollection).mapValues(joinFlattenFunction) :
-              joinedInputs.join(preJoinCollection, numPartitions).mapValues(joinFlattenFunction);
+          SparkCollection<Object> joined = handleJoin(joiner, inputDataCollections,
+                                                      stageSpec, numPartitions, collector);
+          emittedBuilder = emittedBuilder.setOutput(joined.cache());
+        } else if (plugin instanceof AutoJoiner) {
+          AutoJoiner autoJoiner = (AutoJoiner) plugin;
+          Map<String, JoinStage> inputStages = new HashMap<>();
+          for (String inputStageName : pipelinePhase.getStageInputs(stageName)) {
+            StageSpec inputStageSpec = pipelinePhase.getStage(inputStageName);
+            inputStages.put(inputStageName,
+                            JoinStage.builder(inputStageName, inputStageSpec.getOutputSchema()).build());
           }
-          remainingInputs.remove(inputStageName);
+          AutoJoinerContext autoJoinerContext = new DefaultAutoJoinerContext(inputStages);
+
+          emittedBuilder = emittedBuilder.setOutput(handleAutoJoin(autoJoiner, autoJoinerContext,
+                                                                   inputDataCollections));
+
+        } else {
+          // should never happen unless there is a bug in the code. should have failed during deployment
+          throw new IllegalStateException(String.format("Stage '%s' is an unknown joiner type %s",
+                                                        stageName, plugin.getClass().getName()));
         }
-
-        // outer join on non-required inputs
-        boolean isFullOuter = joinedInputs == null;
-        for (final String inputStageName : remainingInputs) {
-          SparkPairCollection<Object, Object> preJoinStream = preJoinStreams.get(inputStageName);
-
-          if (joinedInputs == null) {
-            joinedInputs = preJoinStream.mapValues(new InitialJoinFunction<>(inputStageName));
-          } else {
-            if (isFullOuter) {
-              OuterJoinFlattenFunction<Object> flattenFunction = new OuterJoinFlattenFunction<>(inputStageName);
-
-              joinedInputs = numPartitions == null ?
-                joinedInputs.fullOuterJoin(preJoinStream).mapValues(flattenFunction) :
-                joinedInputs.fullOuterJoin(preJoinStream, numPartitions).mapValues(flattenFunction);
-            } else {
-              LeftJoinFlattenFunction<Object> flattenFunction = new LeftJoinFlattenFunction<>(inputStageName);
-
-              joinedInputs = numPartitions == null ?
-                joinedInputs.leftOuterJoin(preJoinStream).mapValues(flattenFunction) :
-                joinedInputs.leftOuterJoin(preJoinStream, numPartitions).mapValues(flattenFunction);
-            }
-          }
-        }
-
-        // should never happen, but removes warnings
-        if (joinedInputs == null) {
-          throw new IllegalStateException("There are no inputs into join stage " + stageName);
-        }
-
-        emittedBuilder = emittedBuilder.setOutput(mergeJoinResults(stageSpec, joinedInputs, collector).cache());
 
       } else if (Windower.PLUGIN_TYPE.equals(pluginType)) {
 
@@ -376,6 +354,114 @@ public abstract class SparkPipelineRunner {
     if (error != null) {
       Throwables.propagate(error);
     }
+  }
+
+  /**
+   * The purpose of this method is to collect various pieces of information together into a JoinRequest.
+   * This amounts to gathering the SparkCollection, schema, join key, and join type for each stage involved in the join.
+   */
+  private SparkCollection<Object> handleAutoJoin(AutoJoiner autoJoiner, AutoJoinerContext autoJoinerContext,
+                                                 Map<String, SparkCollection<Object>> inputDataCollections) {
+    JoinDefinition joinDefinition = autoJoiner.define(autoJoinerContext);
+
+    Iterator<JoinStage> stageIter = joinDefinition.getStages().iterator();
+    JoinStage left = stageIter.next();
+    SparkCollection<Object> leftCollection = inputDataCollections.get(left.getStageName());
+    Schema leftSchema = left.getSchema();
+
+    JoinCondition condition = joinDefinition.getCondition();
+    // currently this is the only operation, but check this for future changes
+    if (condition.getOp() != JoinCondition.Op.KEY_EQUALITY) {
+      throw new IllegalStateException("Unsupport join condition operation " + condition.getOp());
+    }
+    JoinCondition.OnKeys onKeys = (JoinCondition.OnKeys) condition;
+
+    // If this is a join on A.x = B.y = C.z and A.k = B.k = C.k, then stageKeys will look like:
+    // A -> [x, k]
+    // B -> [y, k]
+    // C -> [z, k]
+    Map<String, List<String>> stageKeys = onKeys.getKeys().stream()
+      .collect(Collectors.toMap(JoinKey::getStageName, JoinKey::getFields));
+
+    List<JoinCollection> toJoin = new ArrayList<>();
+    while (stageIter.hasNext()) {
+      // in this loop, information for each stage to be joined is gathered together into a JoinCollection
+      JoinStage right = stageIter.next();
+      String rightName = right.getStageName();
+      // JoinCollection contains the stage name,  SparkCollection, schema, joinkey,
+      // whether it's required, and whether to broadcast
+      toJoin.add(new JoinCollection(rightName, inputDataCollections.get(rightName),
+                                    right.getSchema(), stageKeys.get(rightName),
+                                    right.isRequired(), right.isBroadcast()));
+    }
+
+    // JoinRequest contains the left side of the join, plus 1 or more other stages to join to.
+    JoinRequest joinRequest = new JoinRequest(left.getStageName(), stageKeys.get(left.getStageName()), leftSchema,
+                                              left.isRequired(), joinDefinition.getSelectedFields(),
+                                              joinDefinition.getOutputSchema(), toJoin);
+    return leftCollection.join(joinRequest);
+  }
+
+  private SparkCollection<Object> handleJoin(BatchJoiner<Object, Object, Object> joiner,
+                                             Map<String, SparkCollection<Object>> inputDataCollections,
+                                             StageSpec stageSpec, Integer numPartitions,
+                                             StageStatisticsCollector collector) throws Exception {
+    Map<String, SparkPairCollection<Object, Object>> preJoinStreams = new HashMap<>();
+    for (Map.Entry<String, SparkCollection<Object>> inputStreamEntry : inputDataCollections.entrySet()) {
+      String inputStage = inputStreamEntry.getKey();
+      SparkCollection<Object> inputStream = inputStreamEntry.getValue();
+      preJoinStreams.put(inputStage, addJoinKey(stageSpec, inputStage, inputStream, collector));
+    }
+
+    Set<String> remainingInputs = new HashSet<>();
+    remainingInputs.addAll(inputDataCollections.keySet());
+
+    SparkPairCollection<Object, List<JoinElement<Object>>> joinedInputs = null;
+    // inner join on required inputs
+    for (final String inputStageName : joiner.getJoinConfig().getRequiredInputs()) {
+      SparkPairCollection<Object, Object> preJoinCollection = preJoinStreams.get(inputStageName);
+
+      if (joinedInputs == null) {
+        joinedInputs = preJoinCollection.mapValues(new InitialJoinFunction<>(inputStageName));
+      } else {
+        JoinFlattenFunction<Object> joinFlattenFunction = new JoinFlattenFunction<>(inputStageName);
+        joinedInputs = numPartitions == null ?
+          joinedInputs.join(preJoinCollection).mapValues(joinFlattenFunction) :
+          joinedInputs.join(preJoinCollection, numPartitions).mapValues(joinFlattenFunction);
+      }
+      remainingInputs.remove(inputStageName);
+    }
+
+    // outer join on non-required inputs
+    boolean isFullOuter = joinedInputs == null;
+    for (final String inputStageName : remainingInputs) {
+      SparkPairCollection<Object, Object> preJoinStream = preJoinStreams.get(inputStageName);
+
+      if (joinedInputs == null) {
+        joinedInputs = preJoinStream.mapValues(new InitialJoinFunction<>(inputStageName));
+      } else {
+        if (isFullOuter) {
+          OuterJoinFlattenFunction<Object> flattenFunction = new OuterJoinFlattenFunction<>(inputStageName);
+
+          joinedInputs = numPartitions == null ?
+            joinedInputs.fullOuterJoin(preJoinStream).mapValues(flattenFunction) :
+            joinedInputs.fullOuterJoin(preJoinStream, numPartitions).mapValues(flattenFunction);
+        } else {
+          LeftJoinFlattenFunction<Object> flattenFunction = new LeftJoinFlattenFunction<>(inputStageName);
+
+          joinedInputs = numPartitions == null ?
+            joinedInputs.leftOuterJoin(preJoinStream).mapValues(flattenFunction) :
+            joinedInputs.leftOuterJoin(preJoinStream, numPartitions).mapValues(flattenFunction);
+        }
+      }
+    }
+
+    // should never happen, but removes warnings
+    if (joinedInputs == null) {
+      throw new IllegalStateException("There are no inputs into join stage " + stageSpec.getName());
+    }
+
+    return mergeJoinResults(stageSpec, joinedInputs, collector);
   }
 
   // return whether this stage should be cached to avoid recomputation

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
@@ -54,6 +54,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.sql.SQLContext;
 import org.apache.spark.storage.StorageLevel;
 import scala.Tuple2;
 
@@ -61,22 +62,27 @@ import javax.annotation.Nullable;
 
 
 /**
- * Implementation of {@link SparkCollection} that is backed by a JavaRDD.
+ * Implementation of {@link SparkCollection} that is backed by a JavaRDD. Spark1 and Spark2 implementations need to be
+ * separate because DataFrames are not compatible between Spark1 and Spark2. In Spark2, DataFrame is just a
+ * Dataset of Row. In Spark1, DataFrame is its own class. Spark1 and Spark2 also have different methods that they
+ * support on a DataFrame/Dataset.
  *
  * @param <T> type of object in the collection
  */
-public class RDDCollection<T> implements SparkCollection<T> {
+public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
   private static final Gson GSON = new Gson();
-  private final JavaSparkExecutionContext sec;
-  private final JavaSparkContext jsc;
-  private final DatasetContext datasetContext;
-  private final SparkBatchSinkFactory sinkFactory;
-  private final JavaRDD<T> rdd;
+  protected final JavaSparkExecutionContext sec;
+  protected final JavaSparkContext jsc;
+  protected final SQLContext sqlContext;
+  protected final DatasetContext datasetContext;
+  protected final SparkBatchSinkFactory sinkFactory;
+  protected final JavaRDD<T> rdd;
 
-  public RDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc,
-                       DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
+  protected BaseRDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
+                              DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
     this.sec = sec;
     this.jsc = jsc;
+    this.sqlContext = sqlContext;
     this.datasetContext = datasetContext;
     this.sinkFactory = sinkFactory;
     this.rdd = rdd;
@@ -147,7 +153,7 @@ public class RDDCollection<T> implements SparkCollection<T> {
 
   @Override
   public <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function) {
-    return new PairRDDCollection<>(sec, jsc, datasetContext, sinkFactory, rdd.flatMapToPair(function));
+    return new PairRDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd.flatMapToPair(function));
   }
 
   @Override
@@ -227,8 +233,7 @@ public class RDDCollection<T> implements SparkCollection<T> {
     throw new UnsupportedOperationException("Windowing is not supported on RDDs.");
   }
 
-  private <U> RDDCollection<U> wrap(JavaRDD<U> rdd) {
-    return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory, rdd);
+  protected <U> RDDCollection<U> wrap(JavaRDD<U> rdd) {
+    return new RDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
   }
-
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -50,6 +50,7 @@ import io.cdap.cdap.etl.spark.function.JoinOnFunction;
 import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SQLContext;
 
 import java.io.BufferedReader;
 import java.nio.charset.StandardCharsets;
@@ -82,7 +83,7 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
   @Override
   protected SparkCollection<RecordInfo<Object>> getSource(StageSpec stageSpec, StageStatisticsCollector collector) {
     PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageSpec, sec, collector);
-    return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory,
+    return new RDDCollection<>(sec, jsc, new SQLContext(jsc), datasetContext, sinkFactory,
                                sourceFactory.createRDD(sec, jsc, stageSpec.getName(), Object.class, Object.class)
                                  .flatMap(Compat.convert(new BatchSourceFunction(pluginFunctionContext))));
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/PairRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/PairRDDCollection.java
@@ -26,6 +26,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.SQLContext;
 import scala.Tuple2;
 
 /**
@@ -37,14 +38,17 @@ import scala.Tuple2;
 public class PairRDDCollection<K, V> implements SparkPairCollection<K, V> {
   private final JavaSparkExecutionContext sec;
   private final JavaSparkContext jsc;
+  private final SQLContext sqlContext;
   private final DatasetContext datasetContext;
   private final SparkBatchSinkFactory sinkFactory;
   private final JavaPairRDD<K, V> pairRDD;
 
-  public PairRDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, DatasetContext datasetContext,
-                           SparkBatchSinkFactory sinkFactory, JavaPairRDD<K, V> pairRDD) {
+  public PairRDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
+                           DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory,
+                           JavaPairRDD<K, V> pairRDD) {
     this.sec = sec;
     this.jsc = jsc;
+    this.sqlContext = sqlContext;
     this.datasetContext = datasetContext;
     this.sinkFactory = sinkFactory;
     this.pairRDD = pairRDD;
@@ -58,7 +62,7 @@ public class PairRDDCollection<K, V> implements SparkPairCollection<K, V> {
 
   @Override
   public <T> SparkCollection<T> flatMap(FlatMapFunction<Tuple2<K, V>, T> function) {
-    return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory, pairRDD.flatMap(function));
+    return new RDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, pairRDD.flatMap(function));
   }
 
   @Override
@@ -105,6 +109,6 @@ public class PairRDDCollection<K, V> implements SparkPairCollection<K, V> {
   }
 
   private <X, Y> SparkPairCollection<X, Y> wrap(JavaPairRDD<X, Y> javaPairRDD) {
-    return new PairRDDCollection<>(sec, jsc, datasetContext, sinkFactory, javaPairRDD);
+    return new PairRDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, javaPairRDD);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinCollection.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.join;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.spark.SparkCollection;
+
+import java.util.List;
+
+/**
+ * Data to join.
+ */
+public class JoinCollection {
+  private final String stage;
+  private final SparkCollection<?> data;
+  private final Schema schema;
+  private final List<String> key;
+  private final boolean required;
+  private final boolean broadcast;
+
+  public JoinCollection(String stage, SparkCollection<?> data, Schema schema,
+                        List<String> key, boolean required, boolean broadcast) {
+    this.stage = stage;
+    this.data = data;
+    this.schema = schema;
+    this.key = key;
+    this.required = required;
+    this.broadcast = broadcast;
+  }
+
+  public String getStage() {
+    return stage;
+  }
+
+  public SparkCollection<?> getData() {
+    return data;
+  }
+
+  public Schema getSchema() {
+    return schema;
+  }
+
+  public List<String> getKey() {
+    return key;
+  }
+
+  public boolean isRequired() {
+    return required;
+  }
+
+  /**
+   * @return whether the data in this collection should be broadcast when performing the join.
+   *   A broadcast join will load all the data in this collection into memory on the Spark driver, then broadcast it
+   *   to every executor in memory, where an in-memory join can then be performed. This avoids shuffling data,
+   *   and leads to much better performance when a large dataset is joined to a small one.
+   */
+  public boolean isBroadcast() {
+    return broadcast;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinRequest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.join;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.join.JoinField;
+
+import java.util.List;
+
+/**
+ * Request to join some collection to another collection.
+ */
+public class JoinRequest {
+  private final String leftStage;
+  private final List<String> leftKey;
+  private final Schema leftSchema;
+  private final boolean leftRequired;
+  private final List<JoinField> fields;
+  private final Schema outputSchema;
+  private final List<JoinCollection> toJoin;
+
+  public JoinRequest(String leftStage, List<String> leftKey, Schema leftSchema, boolean leftRequired,
+                     List<JoinField> fields, Schema outputSchema, List<JoinCollection> toJoin) {
+    this.leftStage = leftStage;
+    this.leftKey = leftKey;
+    this.leftRequired = leftRequired;
+    this.fields = fields;
+    this.leftSchema = leftSchema;
+    this.outputSchema = outputSchema;
+    this.toJoin = toJoin;
+  }
+
+  public String getLeftStage() {
+    return leftStage;
+  }
+
+  public Schema getLeftSchema() {
+    return leftSchema;
+  }
+
+  public List<String> getLeftKey() {
+    return leftKey;
+  }
+
+  public boolean isLeftRequired() {
+    return leftRequired;
+  }
+
+  public List<JoinField> getFields() {
+    return fields;
+  }
+
+  public List<JoinCollection> getToJoin() {
+    return toJoin;
+  }
+
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -36,6 +36,7 @@ import io.cdap.cdap.etl.spark.SparkCollection;
 import io.cdap.cdap.etl.spark.SparkPairCollection;
 import io.cdap.cdap.etl.spark.SparkPipelineRuntime;
 import io.cdap.cdap.etl.spark.batch.BasicSparkExecutionPluginContext;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
 import io.cdap.cdap.etl.spark.streaming.function.ComputeTransformFunction;
 import io.cdap.cdap.etl.spark.streaming.function.CountingTransformFunction;
 import io.cdap.cdap.etl.spark.streaming.function.DynamicAggregatorAggregate;
@@ -182,6 +183,12 @@ public class DStreamCollection<T> implements SparkCollection<T> {
                   .window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval()))
                   .transform(new CountingTransformFunction<T>(stageName, sec.getMetrics(), "records.out",
                                                              sec.getDataTracer(stageName))));
+  }
+
+  @Override
+  public SparkCollection<T> join(JoinRequest joinRequest) {
+    // TODO: (CDAP-16709) implement
+    throw new UnsupportedOperationException("auto join not supported");
   }
 
   private <U> SparkCollection<U> wrap(JavaDStream<U> stream) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>spark-streaming_2.10</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.10</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.api.spark.sql.DataFrames;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.join.JoinCollection;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.types.StructType;
+import scala.collection.JavaConversions;
+import scala.collection.Seq;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Spark1 RDD collection.
+ *
+ * @param <T> type of object in the collection
+ */
+public class RDDCollection<T> extends BaseRDDCollection<T> {
+
+  public RDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
+                       DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
+    super(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SparkCollection<T> join(JoinRequest joinRequest) {
+    Map<String, DataFrame> collections = new HashMap<>();
+    DataFrame left = toDataFrame((JavaRDD<StructuredRecord>) rdd, joinRequest.getLeftSchema());
+    collections.put(joinRequest.getLeftStage(), left);
+
+    List<Column> leftJoinColumns = joinRequest.getLeftKey().stream()
+      .map(left::col)
+      .collect(Collectors.toList());
+
+    /*
+        This flag keeps track of whether there is at least one required stage in the join.
+        This is needed in case there is a join like:
+
+        A (optional), B (required), C (optional), D (required)
+
+        The correct thing to do here is:
+
+        1. A right outer join B as TMP1
+        2. TMP1 left outer join C as TMP2
+        3. TMP2 inner join D
+
+        Join #1 is a straightforward join between 2 sides.
+        Join #2 is a left outer because TMP1 becomes 'required', since it uses required input B.
+        Join #3 is an inner join because even though it contains 2 optional datasets, because 'B' is still required.
+     */
+    boolean seenRequired = joinRequest.isLeftRequired();
+    DataFrame joined = left;
+    for (JoinCollection toJoin : joinRequest.getToJoin()) {
+      RDDCollection<StructuredRecord> data = (RDDCollection<StructuredRecord>) toJoin.getData();
+      DataFrame right = toDataFrame(data.rdd, toJoin.getSchema());
+      collections.put(toJoin.getStage(), right);
+
+      List<Column> rightJoinColumns = toJoin.getKey().stream()
+        .map(right::col)
+        .collect(Collectors.toList());
+
+      Iterator<Column> leftIter = leftJoinColumns.iterator();
+      Iterator<Column> rightIter = rightJoinColumns.iterator();
+      Column joinOn = leftIter.next().equalTo(rightIter.next());
+      while (leftIter.hasNext()) {
+        joinOn = joinOn.and(leftIter.next().equalTo(rightIter.next()));
+      }
+
+      String joinType;
+      if (seenRequired && toJoin.isRequired()) {
+        joinType = "inner";
+      } else if (seenRequired && !toJoin.isRequired()) {
+        joinType = "leftouter";
+      } else if (!seenRequired && toJoin.isRequired()) {
+        joinType = "rightouter";
+      } else {
+        joinType = "outer";
+      }
+      seenRequired = seenRequired || toJoin.isRequired();
+
+      joined = joined.join(right, joinOn, joinType);
+
+      /*
+           Consider stages A, B, C:
+
+           A (id, email) = (2, charles@example.com)
+           B (id, name) = (0, alice), (1, bob)
+           C (id, age) = (0, 25)
+
+           where A, B, C are joined on A.id = B.id = C.id, where B and C are required and A is optional.
+           This RDDCollection is the data for stage A.
+
+           this is implemented as a join of (A right outer join B on A.id = B.id) as TMP1
+           followed by (TMP1 inner join C on TMP1.B.id = C.id) as OUT
+
+           TMP1 looks like:
+           TMP1 (A.id, A.name, B.id, B.email) = (null, null, 0, alice), (null, null, 1, bob)
+
+           and the final output looks like:
+           OUT (A.id, A.name, B.id, B.email, C.id, C.age) = (null, null, 0, alice, 0, 25)
+
+           It's important to join on B.id = C.id and not on A.id = C.id, because joining on A.id = C.id will result
+           in an empty output, as A.id is always null in the TMP1 dataset. In general, the principle is to join on the
+           required fields and not on the optional fields when possible.
+       */
+      if (toJoin.isRequired()) {
+        leftJoinColumns = rightJoinColumns;
+      }
+    }
+
+    // select and alias fields in the expected order
+    List<Column> outputColumns = new ArrayList<>(joinRequest.getFields().size());
+    for (JoinField field : joinRequest.getFields()) {
+      Column column = collections.get(field.getStageName()).col(field.getFieldName());
+      if (field.getAlias() != null) {
+        column = column.alias(field.getAlias());
+      }
+
+      outputColumns.add(column);
+    }
+    Seq<Column> outputColumnSeq = JavaConversions.asScalaBuffer(outputColumns).toSeq();
+    joined = joined.select(outputColumnSeq);
+
+    Schema outputSchema = joinRequest.getOutputSchema();
+    JavaRDD<StructuredRecord> output = joined.javaRDD().map(r -> DataFrames.fromRow(r, outputSchema));
+    return (SparkCollection<T>) wrap(output);
+  }
+
+  private DataFrame toDataFrame(JavaRDD<StructuredRecord> rdd, Schema schema) {
+    StructType sparkSchema = DataFrames.toDataType(schema);
+    JavaRDD<Row> rowRDD = rdd.map(record -> DataFrames.toRow(record, sparkSchema));
+    return sqlContext.createDataFrame(rowRDD.rdd(), sparkSchema);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>spark-streaming_2.11</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.api.spark.sql.DataFrames;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.join.JoinCollection;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.types.StructType;
+import scala.collection.JavaConversions;
+import scala.collection.Seq;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Spark2 RDD collection.
+ *
+ * @param <T> type of object in the collection
+ */
+public class RDDCollection<T> extends BaseRDDCollection<T> {
+
+  public RDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
+                       DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
+    super(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
+  }
+
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SparkCollection<T> join(JoinRequest joinRequest) {
+    Map<String, Dataset> collections = new HashMap<>();
+    Dataset<Row> left = toDataset((JavaRDD<StructuredRecord>) rdd, joinRequest.getLeftSchema());
+    collections.put(joinRequest.getLeftStage(), left);
+
+    List<Column> leftJoinColumns = joinRequest.getLeftKey().stream()
+      .map(left::col)
+      .collect(Collectors.toList());
+
+    /*
+        This flag keeps track of whether there is at least one required stage in the join.
+        This is needed in case there is a join like:
+
+        A (optional), B (required), C (optional), D (required)
+
+        The correct thing to do here is:
+
+        1. A right outer join B as TMP1
+        2. TMP1 left outer join C as TMP2
+        3. TMP2 inner join D
+
+        Join #1 is a straightforward join between 2 sides.
+        Join #2 is a left outer because TMP1 becomes 'required', since it uses required input B.
+        Join #3 is an inner join because even though it contains 2 optional datasets, because 'B' is still required.
+     */
+    boolean seenRequired = joinRequest.isLeftRequired();
+    Dataset<Row> joined = left;
+    for (JoinCollection toJoin : joinRequest.getToJoin()) {
+      RDDCollection<StructuredRecord> data = (RDDCollection<StructuredRecord>) toJoin.getData();
+      Dataset<Row> right = toDataset(data.rdd, toJoin.getSchema());
+      collections.put(toJoin.getStage(), right);
+
+      List<Column> rightJoinColumns = toJoin.getKey().stream()
+        .map(right::col)
+        .collect(Collectors.toList());
+
+      Iterator<Column> leftIter = leftJoinColumns.iterator();
+      Iterator<Column> rightIter = rightJoinColumns.iterator();
+      Column joinOn = leftIter.next().equalTo(rightIter.next());
+      while (leftIter.hasNext()) {
+        joinOn = joinOn.and(leftIter.next().equalTo(rightIter.next()));
+      }
+
+      String joinType;
+      if (seenRequired && toJoin.isRequired()) {
+        joinType = "inner";
+      } else if (seenRequired && !toJoin.isRequired()) {
+        joinType = "leftouter";
+      } else if (!seenRequired && toJoin.isRequired()) {
+        joinType = "rightouter";
+      } else {
+        joinType = "outer";
+      }
+      seenRequired = seenRequired || toJoin.isRequired();
+      
+      joined = joined.join(right, joinOn, joinType);
+
+      /*
+           Consider stages A, B, C:
+
+           A (id, email) = (2, charles@example.com)
+           B (id, name) = (0, alice), (1, bob)
+           C (id, age) = (0, 25)
+
+           where A, B, C are joined on A.id = B.id = C.id, where B and C are required and A is optional.
+           This RDDCollection is the data for stage A.
+
+           this is implemented as a join of (A right outer join B on A.id = B.id) as TMP1
+           followed by (TMP1 inner join C on TMP1.B.id = C.id) as OUT
+
+           TMP1 looks like:
+           TMP1 (A.id, A.name, B.id, B.email) = (null, null, 0, alice), (null, null, 1, bob)
+
+           and the final output looks like:
+           OUT (A.id, A.name, B.id, B.email, C.id, C.age) = (null, null, 0, alice, 0, 25)
+
+           It's important to join on B.id = C.id and not on A.id = C.id, because joining on A.id = C.id will result
+           in an empty output, as A.id is always null in the TMP1 dataset. In general, the principle is to join on the
+           required fields and not on the optional fields when possible.
+       */
+      if (toJoin.isRequired()) {
+        leftJoinColumns = rightJoinColumns;
+      }
+    }
+
+    // select and alias fields in the expected order
+    List<Column> outputColumns = new ArrayList<>(joinRequest.getFields().size());
+    for (JoinField field : joinRequest.getFields()) {
+      Column column = collections.get(field.getStageName()).col(field.getFieldName());
+      if (field.getAlias() != null) {
+        column = column.alias(field.getAlias());
+      }
+
+      outputColumns.add(column);
+    }
+
+    Seq<Column> outputColumnSeq = JavaConversions.asScalaBuffer(outputColumns).toSeq();
+    joined = joined.select(outputColumnSeq);
+
+    Schema outputSchema = joinRequest.getOutputSchema();
+    JavaRDD<StructuredRecord> output = joined.javaRDD().map(r -> DataFrames.fromRow(r, outputSchema));
+    return (SparkCollection<T>) wrap(output);
+  }
+
+  private Dataset<Row> toDataset(JavaRDD<StructuredRecord> rdd, Schema schema) {
+    StructType sparkSchema = DataFrames.toDataType(schema);
+    JavaRDD<Row> rowRDD = rdd.map(record -> DataFrames.toRow(record, sparkSchema));
+    return sqlContext.createDataset(rowRDD.rdd(), RowEncoder.apply(sparkSchema));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/joiner/MockAutoJoiner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/joiner/MockAutoJoiner.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.mock.batch.joiner;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
+import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinKey;
+import io.cdap.cdap.etl.api.join.JoinStage;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+import io.cdap.cdap.internal.guava.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Mock auto-joiner. Performs inner, leftouter, or outer joins. Assumes join keys are named the same on both the
+ * left and right sides.
+ */
+@Plugin(type = BatchJoiner.PLUGIN_TYPE)
+@Name(MockAutoJoiner.NAME)
+public class MockAutoJoiner extends BatchAutoJoiner {
+  public static final String NAME = "MockAutoJoiner";
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private static final Type LIST = new TypeToken<List<String>>() { }.getType();
+  private static final Gson GSON = new Gson();
+  private final Conf conf;
+
+  @SuppressWarnings("unused")
+  public MockAutoJoiner(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Nullable
+  @Override
+  public JoinDefinition define(AutoJoinerContext context) {
+    Map<String, JoinStage> inputStages = context.getInputStages();
+    List<JoinStage> from = new ArrayList<>(inputStages.size());
+    Set<String> required = new HashSet<>(conf.getRequired());
+    List<JoinField> selectedFields = new ArrayList<>();
+    JoinCondition.OnKeys.Builder condition = JoinCondition.onKeys();
+    for (String stageName : conf.getStages()) {
+      JoinStage stage = inputStages.get(stageName);
+      if (!required.contains(stageName)) {
+        stage = JoinStage.builder(stage).isOptional().build();
+      }
+      from.add(stage);
+
+      condition.addKey(new JoinKey(stageName, conf.getKey()));
+
+      for (Schema.Field field : stage.getSchema().getFields()) {
+        // alias everything to stage_field
+        selectedFields.add(new JoinField(stageName, field.getName(),
+                                         String.format("%s_%s", stageName, field.getName())));
+      }
+    }
+
+    JoinDefinition.Builder builder = JoinDefinition.builder()
+      .select(selectedFields)
+      .on(condition.build())
+      .from(from)
+      .setOutputSchemaName(String.join(".", conf.getStages()));
+    return builder.build();
+  }
+
+  /**
+   * Auto Join config.
+   */
+  @SuppressWarnings("unused")
+  public static class Conf extends PluginConfig {
+    private String stages;
+
+    private String key;
+
+    @Nullable
+    private String required;
+
+
+    List<String> getKey() {
+      return GSON.fromJson(key, LIST);
+    }
+
+    List<String> getStages() {
+      return GSON.fromJson(stages, LIST);
+    }
+
+    List<String> getRequired() {
+      return required == null ? Collections.emptyList() : GSON.fromJson(required, LIST);
+    }
+  }
+
+  public static ETLPlugin getPlugin(List<String> stages, List<String> key, List<String> required) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("stages", GSON.toJson(stages));
+    properties.put("required", GSON.toJson(required));
+    properties.put("key", GSON.toJson(key));
+    return new ETLPlugin(NAME, BatchJoiner.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("stages", new PluginPropertyField("left", "", "string", true, false));
+    properties.put("required", new PluginPropertyField("right", "", "string", false, false));
+    properties.put("key", new PluginPropertyField("type", "", "string", true, false));
+    return new PluginClass(BatchJoiner.PLUGIN_TYPE, NAME, "", MockAutoJoiner.class.getName(), "conf", properties);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.condition.Condition;
+import io.cdap.cdap.etl.api.join.AutoJoiner;
 import io.cdap.cdap.etl.api.lineage.AccessType;
 import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
@@ -48,6 +49,7 @@ import io.cdap.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
 import io.cdap.cdap.etl.mock.batch.aggregator.GroupFilterAggregator;
 import io.cdap.cdap.etl.mock.batch.aggregator.IdentityAggregator;
 import io.cdap.cdap.etl.mock.batch.joiner.DupeFlagger;
+import io.cdap.cdap.etl.mock.batch.joiner.MockAutoJoiner;
 import io.cdap.cdap.etl.mock.batch.joiner.MockJoiner;
 import io.cdap.cdap.etl.mock.condition.MockCondition;
 import io.cdap.cdap.etl.mock.spark.Window;
@@ -79,7 +81,7 @@ public class HydratorTestBase extends TestBase {
   // To work around, we'll just explicitly specify each plugin.
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, GroupFilterAggregator.PLUGIN_CLASS,
-    MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
+    MockJoiner.PLUGIN_CLASS, MockAutoJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     MockRuntimeDatasetSink.PLUGIN_CLASS, MockRuntimeDatasetSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, AllErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
@@ -98,7 +100,7 @@ public class HydratorTestBase extends TestBase {
     IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS, DropNullTransform.PLUGIN_CLASS,
     FilterTransform.PLUGIN_CLASS,
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
-    GroupFilterAggregator.PLUGIN_CLASS, MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
+    GroupFilterAggregator.PLUGIN_CLASS, MockJoiner.PLUGIN_CLASS, MockAutoJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     StringValueFilterCompute.PLUGIN_CLASS, Window.PLUGIN_CLASS,
     FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,
     NullFieldSplitterTransform.PLUGIN_CLASS, TMSAlertPublisher.PLUGIN_CLASS, NullAlertTransform.PLUGIN_CLASS
@@ -114,6 +116,7 @@ public class HydratorTestBase extends TestBase {
     addAppArtifact(artifactId, appClass,
                    BatchSource.class.getPackage().getName(),
                    Action.class.getPackage().getName(),
+                   AutoJoiner.class.getPackage().getName(),
                    Condition.class.getPackage().getName(),
                    PipelineConfigurable.class.getPackage().getName(),
                    AccessType.class.getPackage().getName(),
@@ -141,6 +144,7 @@ public class HydratorTestBase extends TestBase {
     addAppArtifact(artifactId, appClass,
                    StreamingSource.class.getPackage().getName(),
                    Transform.class.getPackage().getName(),
+                   AutoJoiner.class.getPackage().getName(),
                    SparkCompute.class.getPackage().getName(),
                    InvalidStageException.class.getPackage().getName(),
                    PipelineConfigurable.class.getPackage().getName(),


### PR DESCRIPTION
Implemented auto join for batch spark pipelines.

Added a join method to SparkCollection that takes in the list of
other SparkCollections that it should be joined to.
RDDCollection converts RDDs into Datasets and uses the Dataset
join method to implement the join. This allows Spark to broadcast
small datasets automatically, and to use sort merge join instead
of shuffle hash join, which has better memory characteristics.

As part of this, added a separate RDDCollection implementation for
Spark1 and Spark2, since the Spark API for joins is not compatible.