### PR TITLE
CDAP-16855 aggregator spark impl

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/ReduceAggregatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/ReduceAggregatorTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.dataset.table.Table;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.etl.api.Engine;
+import io.cdap.cdap.etl.mock.batch.MockSink;
+import io.cdap.cdap.etl.mock.batch.MockSource;
+import io.cdap.cdap.etl.mock.batch.reduceaggregator.DistinctReduceAggregator;
+import io.cdap.cdap.etl.mock.batch.reduceaggregator.FieldCountReduceAggregator;
+import io.cdap.cdap.etl.mock.test.HydratorTestBase;
+import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
+import io.cdap.cdap.etl.proto.v2.ETLStage;
+import io.cdap.cdap.etl.spark.Compat;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.test.ApplicationManager;
+import io.cdap.cdap.test.DataSetManager;
+import io.cdap.cdap.test.TestConfiguration;
+import io.cdap.cdap.test.WorkflowManager;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Tests for BatchReduceAggregator plugins.
+ */
+public class ReduceAggregatorTest extends HydratorTestBase {
+  private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("app", "1.0.0");
+  private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
+
+  private static int startCount = 0;
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
+                                                                       Constants.Security.Store.PROVIDER, "file",
+                                                                       Constants.AppFabric.SPARK_COMPAT,
+                                                                       Compat.SPARK_COMPAT);
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    if (startCount++ > 0) {
+      return;
+    }
+    setupBatchArtifacts(APP_ARTIFACT_ID, DataPipelineApp.class);
+  }
+
+
+  @Test
+  public void testSimpleAggregator() throws Exception {
+    Schema inputSchema = Schema.recordOf(
+      "input",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("used_name", Schema.of(Schema.Type.STRING)));
+    String userInput = "inputSource";
+    String output = "outputSink";
+    ETLBatchConfig config = ETLBatchConfig.builder()
+      .addStage(new ETLStage("users", MockSource.getPlugin(userInput, inputSchema)))
+      .addStage(new ETLStage("aggregator", DistinctReduceAggregator.getPlugin("id,name")))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(output)))
+      .addConnection("users", "aggregator")
+      .addConnection("aggregator", "sink")
+      .setEngine(Engine.SPARK)
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
+    ApplicationId appId = NamespaceId.DEFAULT.app(UUID.randomUUID().toString());
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    List<StructuredRecord> userData = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      StructuredRecord record1 = StructuredRecord.builder(inputSchema)
+        .set("id", 1).set("name", "test").set("used_name", "test" + i).build();
+      StructuredRecord record2 = StructuredRecord.builder(inputSchema)
+        .set("id", 2).set("name", "test2").set("used_name", "test2" + i).build();
+      userData.add(record1);
+      userData.add(record2);
+    }
+
+    // write input data
+    DataSetManager<Table> inputManager = getDataset(userInput);
+    MockSource.writeInput(inputManager, userData);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset(output);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
+
+    Schema expectedSchema = Schema.recordOf(
+      "record",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    Set<StructuredRecord> expected = ImmutableSet.of(
+      StructuredRecord.builder(expectedSchema).set("id", 1).set("name", "test").build(),
+      StructuredRecord.builder(expectedSchema).set("id", 2).set("name", "test2").build()
+    );
+    Assert.assertEquals(expected, new HashSet<>(outputRecords));
+  }
+
+  @Test
+  public void testFieldCountAgg() throws Exception {
+    Engine engine = Engine.SPARK;
+    String source1Name = "pAggInput1-" + engine.name();
+    String source2Name = "pAggInput2-" + engine.name();
+    String sink1Name = "pAggOutput1-" + engine.name();
+    String sink2Name = "pAggOutput2-" + engine.name();
+    Schema inputSchema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item", Schema.of(Schema.Type.LONG))
+    );
+    /*
+       source1 --|--> agg1 --> sink1
+                 |
+       source2 --|--> agg2 --> sink2
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
+      .setEngine(engine)
+      .addStage(new ETLStage("source1", MockSource.getPlugin(source1Name, inputSchema)))
+      .addStage(new ETLStage("source2", MockSource.getPlugin(source2Name, inputSchema)))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin(sink1Name)))
+      .addStage(new ETLStage("sink2", MockSink.getPlugin(sink2Name)))
+      .addStage(new ETLStage("agg1", FieldCountReduceAggregator.getPlugin("user", "string")))
+      .addStage(new ETLStage("agg2", FieldCountReduceAggregator.getPlugin("item", "long")))
+      .addConnection("source1", "agg1")
+      .addConnection("source1", "agg2")
+      .addConnection("source2", "agg1")
+      .addConnection("source2", "agg2")
+      .addConnection("agg1", "sink1")
+      .addConnection("agg2", "sink2")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("ParallelAggApp-" + engine);
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // write few records to each source
+    DataSetManager<Table> inputManager = getDataset(NamespaceId.DEFAULT.dataset(source1Name));
+    MockSource.writeInput(inputManager, ImmutableList.of(
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 1L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 2L).build()));
+
+    inputManager = getDataset(NamespaceId.DEFAULT.dataset(source2Name));
+    MockSource.writeInput(inputManager, ImmutableList.of(
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 3L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "john").set("item", 4L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "john").set("item", 3L).build()));
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    Schema outputSchema1 = Schema.recordOf(
+      "user.count",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("ct", Schema.of(Schema.Type.LONG))
+    );
+    Schema outputSchema2 = Schema.recordOf(
+      "item.count",
+      Schema.Field.of("item", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("ct", Schema.of(Schema.Type.LONG))
+    );
+
+    // check output
+    DataSetManager<Table> sinkManager = getDataset(sink1Name);
+    Set<StructuredRecord> expected = ImmutableSet.of(
+      StructuredRecord.builder(outputSchema1).set("user", "all").set("ct", 5L).build(),
+      StructuredRecord.builder(outputSchema1).set("user", "samuel").set("ct", 3L).build(),
+      StructuredRecord.builder(outputSchema1).set("user", "john").set("ct", 2L).build());
+    Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+
+    sinkManager = getDataset(sink2Name);
+    expected = ImmutableSet.of(
+      StructuredRecord.builder(outputSchema2).set("item", 0L).set("ct", 5L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 1L).set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 2L).set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 3L).set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 4L).set("ct", 1L).build());
+    actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+
+    validateMetric(2, appId, "source1.records.out");
+    validateMetric(3, appId, "source2.records.out");
+    validateMetric(5, appId, "agg1.records.in");
+    // 2 users, but FieldCountReduceAggregator always emits an 'all' group
+    validateMetric(3, appId, "agg1.aggregator.groups");
+    validateMetric(3, appId, "agg1.records.out");
+    validateMetric(5, appId, "agg2.records.in");
+    // 4 items, but FieldCountReduceAggregator always emits an 'all' group
+    validateMetric(5, appId, "agg2.aggregator.groups");
+    validateMetric(5, appId, "agg2.records.out");
+    validateMetric(3, appId, "sink1.records.in");
+    validateMetric(5, appId, "sink2.records.in");
+  }
+
+  private void validateMetric(long expected, ApplicationId appId,
+                              String metric) throws TimeoutException, InterruptedException {
+    Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, appId.getNamespace(),
+                                               Constants.Metrics.Tag.APP, appId.getEntityName(),
+                                               Constants.Metrics.Tag.WORKFLOW, SmartWorkflow.NAME);
+    getMetricsManager().waitForTotalMetricCount(tags, "user." + metric, expected, 20, TimeUnit.SECONDS);
+    // wait for won't throw an exception if the metric count is greater than expected
+    Assert.assertEquals(expected, getMetricsManager().getTotalMetric(tags, "user." + metric));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/Aggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/Aggregator.java
@@ -43,9 +43,12 @@ public interface Aggregator<GROUP_KEY, GROUP_VALUE, OUT> {
 
   /**
    * Aggregate all objects in the same group into zero or more output objects.
+   * If this aggregator does not implement {@link Reducer}, the group values will contain all input objects with
+   * same group key. If it does, the group value will only contain one value which contains the aggregated stats for
+   * all the values, this method can use this stat to compute the desired result, i.e, average, standard deviation
    *
    * @param groupKey the key for the group
-   * @param groupValues an iterator over all input objects that have the same group key
+   * @param groupValues an iterator contains the group values associated with the group key
    * @param emitter the emitter to emit aggregate values for the group
    * @throws Exception if there is some error aggregating
    */

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/Reducer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/Reducer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api;
+
+import io.cdap.cdap.api.annotation.Beta;
+
+/**
+ * This class can be implemented by an {@link Aggregator} to reduce the number of group values in each split before
+ * grouping all the values for the group key to achieve better performance.
+ *
+ * @param <GROUP_VALUE> Type of values to group
+ */
+@Beta
+public interface Reducer<GROUP_VALUE> {
+
+  /**
+   * Reduce the given values to a single value.
+   * For example, to compute the sum, the returned value will be the sum of two given values.
+   * To compute average, the returned value will contain the sum and count for the two given values. Later, the
+   * aggregate function can be used to compute the average.
+   *
+   * @param value1 the value to reduce
+   * @param value2 the value to reduce
+   * @return the aggregated value of two given values
+   */
+  GROUP_VALUE reduce(GROUP_VALUE value1, GROUP_VALUE value2) throws Exception;
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchReduceAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchReduceAggregator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.batch;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.etl.api.Aggregator;
+import io.cdap.cdap.etl.api.Reducer;
+
+/**
+ * An {@link Aggregator} used in batch programs. It implements the {@link Reducer} to achieve better performance.
+ *
+ * @param <GROUP_KEY> group key type. Must be a supported type
+ * @param <GROUP_VALUE> group value type. Must be a supported type
+ * @param <OUT> output object type
+ */
+@Beta
+public abstract class BatchReduceAggregator<GROUP_KEY, GROUP_VALUE, OUT>
+  extends BatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> implements Reducer<GROUP_VALUE> {
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
@@ -58,7 +58,7 @@ public class JoinCondition {
    * Condition operation.
    */
   public enum Op {
-    EQUAL_TO
+    KEY_EQUALITY
   }
 
   public static OnKeys.Builder onKeys() {
@@ -73,7 +73,7 @@ public class JoinCondition {
     private final boolean dropNullKeys;
 
     private OnKeys(Set<JoinKey> keys, boolean dropNullKeys) {
-      super(Op.EQUAL_TO);
+      super(Op.KEY_EQUALITY);
       this.keys = Collections.unmodifiableSet(new HashSet<>(keys));
       this.dropNullKeys = dropNullKeys;
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReducePreparer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReducePreparer.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.etl.api.SplitterTransform;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchConfigurable;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
@@ -213,6 +214,12 @@ public class MapReducePreparer extends PipelinePhasePreparer {
       job.setMapOutputValueClass(TaggedWritable.class);
       stageOperations.put(stageName, joinerContext.getFieldOperations());
     });
+  }
+
+  @Override
+  protected SubmitterPlugin createAutoJoiner(BatchAutoJoiner batchJoiner, StageSpec stageSpec) {
+    // TODO: (CDAP-16709) implement auto-join for mapreduce
+    throw new UnsupportedOperationException("");
   }
 
   private Class<?> getOutputKeyClass(String reducerName, Class<?> outputKeyClass) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultAutoJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultAutoJoinerContext.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.etl.common;
 
-import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinStage;
 
@@ -30,12 +29,8 @@ import java.util.Map;
 public class DefaultAutoJoinerContext implements AutoJoinerContext {
   private final Map<String, JoinStage> inputStages;
 
-  public DefaultAutoJoinerContext(Map<String, Schema> inputStages) {
-    Map<String, JoinStage> stageMap = new HashMap<>();
-    for (Map.Entry<String, Schema> e : inputStages.entrySet()) {
-      stageMap.put(e.getKey(), JoinStage.builder(e.getKey(), e.getValue()).build());
-    }
-    this.inputStages = Collections.unmodifiableMap(stageMap);
+  public DefaultAutoJoinerContext(Map<String, JoinStage> inputStages) {
+    this.inputStages = Collections.unmodifiableMap(new HashMap<>(inputStages));
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/PipelinePluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/PipelinePluginContext.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.batch.BatchReduceAggregator;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.PostAction;
@@ -94,6 +95,8 @@ public class PipelinePluginContext implements PluginContext {
       return new WrappedErrorTransform<>((ErrorTransform) plugin, caller, operationTimer);
     } else if (plugin instanceof Transform) {
       return new WrappedTransform<>((Transform) plugin, caller, operationTimer);
+    } else if (plugin instanceof BatchReduceAggregator) {
+      return new WrappedReduceAggregator<>((BatchReduceAggregator) plugin, caller, operationTimer);
     } else if (plugin instanceof BatchAggregator) {
       return new WrappedBatchAggregator<>((BatchAggregator) plugin, caller, operationTimer);
     } else if (plugin instanceof BatchJoiner) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedReduceAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedReduceAggregator.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common.plugin;
+
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.batch.BatchAggregatorContext;
+import io.cdap.cdap.etl.api.batch.BatchReduceAggregator;
+import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
+import io.cdap.cdap.etl.common.TypeChecker;
+
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+
+/**
+ * Wrapper around {@link BatchReduceAggregator} that makes sure logging, classloading, and other pipeline capabilities
+ * are setup correctly.
+ *
+ * @param <GROUP_KEY> group key type. Must be a supported type
+ * @param <GROUP_VALUE> group value type. Must be a supported type
+ * @param <OUT> output object type
+ */
+public class WrappedReduceAggregator<GROUP_KEY, GROUP_VALUE, OUT>
+  extends BatchReduceAggregator<GROUP_KEY, GROUP_VALUE, OUT>  {
+  private final BatchReduceAggregator<GROUP_KEY, GROUP_VALUE, OUT> aggregator;
+  private final Caller caller;
+  private final OperationTimer operationTimer;
+
+  public WrappedReduceAggregator(BatchReduceAggregator<GROUP_KEY, GROUP_VALUE, OUT> aggregator, Caller caller,
+                                 OperationTimer operationTimer) {
+    this.aggregator = aggregator;
+    this.caller = caller;
+    this.operationTimer = operationTimer;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    caller.callUnchecked((Callable<Void>) () -> {
+      aggregator.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    caller.call((Callable<Void>) () -> {
+      aggregator.initialize(context);
+      return null;
+    });
+  }
+
+  @Override
+  public void destroy() {
+    caller.callUnchecked((Callable<Void>) () -> {
+      aggregator.destroy();
+      return null;
+    });
+  }
+
+  @Override
+  public void prepareRun(BatchAggregatorContext context) throws Exception {
+    context.setGroupKeyClass(TypeChecker.getGroupKeyClass(aggregator));
+    context.setGroupValueClass(TypeChecker.getGroupValueClass(aggregator));
+    caller.call((Callable<Void>) () -> {
+      aggregator.prepareRun(context);
+      return null;
+    });
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, BatchAggregatorContext context) {
+    caller.callUnchecked((Callable<Void>) () -> {
+      aggregator.onRunFinish(succeeded, context);
+      return null;
+    });
+  }
+
+  @Override
+  public void groupBy(GROUP_VALUE groupValue, Emitter<GROUP_KEY> emitter) throws Exception {
+    operationTimer.start();
+    try {
+      caller.call((Callable<Void>) () -> {
+        aggregator.groupBy(groupValue, new UntimedEmitter<>(emitter, operationTimer));
+        return null;
+      });
+    } finally {
+      operationTimer.reset();
+    }
+  }
+
+  @Override
+  public void aggregate(GROUP_KEY groupKey, Iterator<GROUP_VALUE> groupValues,
+                        Emitter<OUT> emitter) throws Exception {
+    operationTimer.start();
+    try {
+      caller.call((Callable<Void>) () -> {
+        aggregator.aggregate(groupKey, groupValues, new UntimedEmitter<>(emitter, operationTimer));
+        return null;
+      });
+    } finally {
+      operationTimer.reset();
+    }
+  }
+
+  @Override
+  public GROUP_VALUE reduce(GROUP_VALUE value1, GROUP_VALUE value2) throws Exception {
+    return caller.call(() -> aggregator.reduce(value1, value2));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -46,6 +46,7 @@ import io.cdap.cdap.etl.api.condition.Condition;
 import io.cdap.cdap.etl.api.join.AutoJoiner;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.cdap.etl.api.validation.ValidationException;
@@ -65,6 +66,7 @@ import io.cdap.cdap.etl.proto.v2.spec.PluginSpec;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -290,7 +292,12 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
         // This is because we want to allow a Joiner plugin to switch from using the BatchJoiner interface
         // to the BatchAutoJoiner while preserving backwards compatibility in the pipeline config.
         if (plugin instanceof AutoJoiner) {
-          AutoJoinerContext autoContext = new DefaultAutoJoinerContext(stageConfigurer.getInputSchemas());
+          Map<String, JoinStage> stageMap = new HashMap<>();
+          for (Map.Entry<String, Schema> e : stageConfigurer.getInputSchemas().entrySet()) {
+            stageMap.put(e.getKey(), JoinStage.builder(e.getKey(), e.getValue()).build());
+          }
+
+          AutoJoinerContext autoContext = new DefaultAutoJoinerContext(stageMap);
           joinDefinition = ((AutoJoiner) plugin).define(autoContext);
           if (joinDefinition != null) {
             stageConfigurer.setOutputSchema(joinDefinition.getOutputSchema());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkPreparer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkPreparer.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.plugin.PluginContext;
 import io.cdap.cdap.etl.api.SplitterTransform;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchConfigurable;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
@@ -146,6 +147,17 @@ public abstract class AbstractSparkPreparer extends PipelinePhasePreparer {
 
   @Override
   protected SubmitterPlugin createJoiner(BatchJoiner<?, ?, ?> batchJoiner, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultJoinerContext> contextProvider =
+      new JoinerContextProvider(pipelineRuntime, stageSpec, admin);
+    return new SubmitterPlugin<>(stageName, transactional, batchJoiner, contextProvider, sparkJoinerContext -> {
+      stagePartitions.put(stageName, sparkJoinerContext.getNumPartitions());
+      stageOperations.put(stageName, sparkJoinerContext.getFieldOperations());
+    });
+  }
+
+  @Override
+  protected SubmitterPlugin createAutoJoiner(BatchAutoJoiner batchJoiner, StageSpec stageSpec) {
     String stageName = stageSpec.getName();
     ContextProvider<DefaultJoinerContext> contextProvider =
       new JoinerContextProvider(pipelineRuntime, stageSpec, admin);

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
@@ -16,15 +16,19 @@
 
 package io.cdap.cdap.etl.spark;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
 import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -65,4 +69,6 @@ public interface SparkCollection<T> {
   void publishAlerts(StageSpec stageSpec, StageStatisticsCollector collector) throws Exception;
 
   SparkCollection<T> window(StageSpec stageSpec, Windower windower);
+
+  SparkCollection<T> join(JoinRequest joinRequest);
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
@@ -58,6 +58,9 @@ public interface SparkCollection<T> {
   SparkCollection<RecordInfo<Object>> aggregate(StageSpec stageSpec, @Nullable Integer partitions,
                                                 StageStatisticsCollector collector);
 
+  SparkCollection<RecordInfo<Object>> reduceAggregate(StageSpec stageSpec, @Nullable Integer partitions,
+                                                      StageStatisticsCollector collector);
+
   <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function);
 
   <U> SparkCollection<U> compute(StageSpec stageSpec, SparkCompute<T, U> compute) throws Exception;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.etl.spark;
 
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.plugin.PluginContext;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
@@ -34,9 +35,16 @@ import io.cdap.cdap.etl.api.batch.BatchJoinerRuntimeContext;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.join.AutoJoiner;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.common.BasicArguments;
 import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.DefaultAutoJoinerContext;
 import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
 import io.cdap.cdap.etl.common.NoopStageStatisticsCollector;
 import io.cdap.cdap.etl.common.PipelinePhase;
@@ -53,6 +61,8 @@ import io.cdap.cdap.etl.spark.function.LeftJoinFlattenFunction;
 import io.cdap.cdap.etl.spark.function.OuterJoinFlattenFunction;
 import io.cdap.cdap.etl.spark.function.OutputPassFilter;
 import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
+import io.cdap.cdap.etl.spark.join.JoinCollection;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +78,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 /**
  * Base Spark program to run a Hydrator pipeline.
@@ -247,68 +258,35 @@ public abstract class SparkPipelineRunner {
 
       } else if (BatchJoiner.PLUGIN_TYPE.equals(pluginType)) {
 
-        BatchJoiner<Object, Object, Object> joiner = pluginContext.newPluginInstance(stageName, macroEvaluator);
-        BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createBatchRuntimeContext();
-        joiner.initialize(joinerRuntimeContext);
+        Object plugin = pluginContext.newPluginInstance(stageName, macroEvaluator);
+        if (plugin instanceof BatchJoiner) {
+          BatchJoiner<Object, Object, Object> joiner = (BatchJoiner<Object, Object, Object>) plugin;
+          BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createBatchRuntimeContext();
+          joiner.initialize(joinerRuntimeContext);
 
-        Map<String, SparkPairCollection<Object, Object>> preJoinStreams = new HashMap<>();
-        for (Map.Entry<String, SparkCollection<Object>> inputStreamEntry : inputDataCollections.entrySet()) {
-          String inputStage = inputStreamEntry.getKey();
-          SparkCollection<Object> inputStream = inputStreamEntry.getValue();
-          preJoinStreams.put(inputStage, addJoinKey(stageSpec, inputStage, inputStream, collector));
-        }
+          Integer numPartitions = stagePartitions.get(stageName);
 
-        Set<String> remainingInputs = new HashSet<>();
-        remainingInputs.addAll(inputDataCollections.keySet());
-
-        Integer numPartitions = stagePartitions.get(stageName);
-
-        SparkPairCollection<Object, List<JoinElement<Object>>> joinedInputs = null;
-        // inner join on required inputs
-        for (final String inputStageName : joiner.getJoinConfig().getRequiredInputs()) {
-          SparkPairCollection<Object, Object> preJoinCollection = preJoinStreams.get(inputStageName);
-
-          if (joinedInputs == null) {
-            joinedInputs = preJoinCollection.mapValues(new InitialJoinFunction<>(inputStageName));
-          } else {
-            JoinFlattenFunction<Object> joinFlattenFunction = new JoinFlattenFunction<>(inputStageName);
-            joinedInputs = numPartitions == null ?
-              joinedInputs.join(preJoinCollection).mapValues(joinFlattenFunction) :
-              joinedInputs.join(preJoinCollection, numPartitions).mapValues(joinFlattenFunction);
+          SparkCollection<Object> joined = handleJoin(joiner, inputDataCollections,
+                                                      stageSpec, numPartitions, collector);
+          emittedBuilder = emittedBuilder.setOutput(joined.cache());
+        } else if (plugin instanceof AutoJoiner) {
+          AutoJoiner autoJoiner = (AutoJoiner) plugin;
+          Map<String, JoinStage> inputStages = new HashMap<>();
+          for (String inputStageName : pipelinePhase.getStageInputs(stageName)) {
+            StageSpec inputStageSpec = pipelinePhase.getStage(inputStageName);
+            inputStages.put(inputStageName,
+                            JoinStage.builder(inputStageName, inputStageSpec.getOutputSchema()).build());
           }
-          remainingInputs.remove(inputStageName);
+          AutoJoinerContext autoJoinerContext = new DefaultAutoJoinerContext(inputStages);
+
+          emittedBuilder = emittedBuilder.setOutput(handleAutoJoin(autoJoiner, autoJoinerContext,
+                                                                   inputDataCollections));
+
+        } else {
+          // should never happen unless there is a bug in the code. should have failed during deployment
+          throw new IllegalStateException(String.format("Stage '%s' is an unknown joiner type %s",
+                                                        stageName, plugin.getClass().getName()));
         }
-
-        // outer join on non-required inputs
-        boolean isFullOuter = joinedInputs == null;
-        for (final String inputStageName : remainingInputs) {
-          SparkPairCollection<Object, Object> preJoinStream = preJoinStreams.get(inputStageName);
-
-          if (joinedInputs == null) {
-            joinedInputs = preJoinStream.mapValues(new InitialJoinFunction<>(inputStageName));
-          } else {
-            if (isFullOuter) {
-              OuterJoinFlattenFunction<Object> flattenFunction = new OuterJoinFlattenFunction<>(inputStageName);
-
-              joinedInputs = numPartitions == null ?
-                joinedInputs.fullOuterJoin(preJoinStream).mapValues(flattenFunction) :
-                joinedInputs.fullOuterJoin(preJoinStream, numPartitions).mapValues(flattenFunction);
-            } else {
-              LeftJoinFlattenFunction<Object> flattenFunction = new LeftJoinFlattenFunction<>(inputStageName);
-
-              joinedInputs = numPartitions == null ?
-                joinedInputs.leftOuterJoin(preJoinStream).mapValues(flattenFunction) :
-                joinedInputs.leftOuterJoin(preJoinStream, numPartitions).mapValues(flattenFunction);
-            }
-          }
-        }
-
-        // should never happen, but removes warnings
-        if (joinedInputs == null) {
-          throw new IllegalStateException("There are no inputs into join stage " + stageName);
-        }
-
-        emittedBuilder = emittedBuilder.setOutput(mergeJoinResults(stageSpec, joinedInputs, collector).cache());
 
       } else if (Windower.PLUGIN_TYPE.equals(pluginType)) {
 
@@ -376,6 +354,123 @@ public abstract class SparkPipelineRunner {
     if (error != null) {
       Throwables.propagate(error);
     }
+  }
+
+  private SparkCollection<Object> handleAutoJoin(AutoJoiner autoJoiner, AutoJoinerContext autoJoinerContext,
+                                                 Map<String, SparkCollection<Object>> inputDataCollections) {
+    JoinDefinition joinDefinition = autoJoiner.define(autoJoinerContext);
+
+    // join required stages first to cut down the data as much as possible
+    List<JoinStage> requiredStages = joinDefinition.getStages().stream()
+      .filter(s -> s.isRequired())
+      .collect(Collectors.toList());
+    List<JoinStage> optionalStages = joinDefinition.getStages().stream()
+      .filter(s -> !s.isRequired())
+      .collect(Collectors.toList());
+    List<JoinStage> orderedStages = new ArrayList<>(requiredStages.size() + optionalStages.size());
+    orderedStages.addAll(requiredStages);
+    orderedStages.addAll(optionalStages);
+
+    Iterator<JoinStage> stageIter = orderedStages.iterator();
+    JoinStage left = stageIter.next();
+    SparkCollection<Object> leftCollection = inputDataCollections.get(left.getStageName());
+    Schema leftSchema = left.getSchema();
+
+    JoinCondition condition = joinDefinition.getCondition();
+    // currently this is the only operation, but check this for future changes
+    if (condition.getOp() != JoinCondition.Op.KEY_EQUALITY) {
+      throw new IllegalStateException("Unsupport join condition operation " + condition.getOp());
+    }
+    JoinCondition.OnKeys onKeys = (JoinCondition.OnKeys) condition;
+    Map<String, List<String>> stageKeys = onKeys.getKeys().stream()
+      .collect(Collectors.toMap(j -> j.getStageName(), j -> j.getFields()));
+
+
+    List<JoinCollection> toJoin = new ArrayList<>();
+    while (stageIter.hasNext()) {
+      JoinStage right = stageIter.next();
+      String type;
+      if (left.isRequired() && right.isRequired()) {
+        type = "inner";
+      } else if (left.isRequired() && !right.isRequired()) {
+        type = "leftouter";
+      } else if (!left.isRequired() && right.isRequired()) {
+        type = "rightouter";
+      } else {
+        type = "outer";
+      }
+      String rightName = right.getStageName();
+      toJoin.add(new JoinCollection(rightName, type, inputDataCollections.get(rightName),
+                                    right.getSchema(), stageKeys.get(rightName),
+                                    right.isBroadcast()));
+    }
+
+    JoinRequest joinRequest = new JoinRequest(left.getStageName(), stageKeys.get(left.getStageName()), leftSchema,
+                                              joinDefinition.getSelectedFields(), joinDefinition.getOutputSchema(),
+                                              toJoin);
+    return leftCollection.join(joinRequest);
+  }
+
+  private SparkCollection<Object> handleJoin(BatchJoiner<Object, Object, Object> joiner,
+                                             Map<String, SparkCollection<Object>> inputDataCollections,
+                                             StageSpec stageSpec, Integer numPartitions,
+                                             StageStatisticsCollector collector) throws Exception {
+    Map<String, SparkPairCollection<Object, Object>> preJoinStreams = new HashMap<>();
+    for (Map.Entry<String, SparkCollection<Object>> inputStreamEntry : inputDataCollections.entrySet()) {
+      String inputStage = inputStreamEntry.getKey();
+      SparkCollection<Object> inputStream = inputStreamEntry.getValue();
+      preJoinStreams.put(inputStage, addJoinKey(stageSpec, inputStage, inputStream, collector));
+    }
+
+    Set<String> remainingInputs = new HashSet<>();
+    remainingInputs.addAll(inputDataCollections.keySet());
+
+    SparkPairCollection<Object, List<JoinElement<Object>>> joinedInputs = null;
+    // inner join on required inputs
+    for (final String inputStageName : joiner.getJoinConfig().getRequiredInputs()) {
+      SparkPairCollection<Object, Object> preJoinCollection = preJoinStreams.get(inputStageName);
+
+      if (joinedInputs == null) {
+        joinedInputs = preJoinCollection.mapValues(new InitialJoinFunction<>(inputStageName));
+      } else {
+        JoinFlattenFunction<Object> joinFlattenFunction = new JoinFlattenFunction<>(inputStageName);
+        joinedInputs = numPartitions == null ?
+          joinedInputs.join(preJoinCollection).mapValues(joinFlattenFunction) :
+          joinedInputs.join(preJoinCollection, numPartitions).mapValues(joinFlattenFunction);
+      }
+      remainingInputs.remove(inputStageName);
+    }
+
+    // outer join on non-required inputs
+    boolean isFullOuter = joinedInputs == null;
+    for (final String inputStageName : remainingInputs) {
+      SparkPairCollection<Object, Object> preJoinStream = preJoinStreams.get(inputStageName);
+
+      if (joinedInputs == null) {
+        joinedInputs = preJoinStream.mapValues(new InitialJoinFunction<>(inputStageName));
+      } else {
+        if (isFullOuter) {
+          OuterJoinFlattenFunction<Object> flattenFunction = new OuterJoinFlattenFunction<>(inputStageName);
+
+          joinedInputs = numPartitions == null ?
+            joinedInputs.fullOuterJoin(preJoinStream).mapValues(flattenFunction) :
+            joinedInputs.fullOuterJoin(preJoinStream, numPartitions).mapValues(flattenFunction);
+        } else {
+          LeftJoinFlattenFunction<Object> flattenFunction = new LeftJoinFlattenFunction<>(inputStageName);
+
+          joinedInputs = numPartitions == null ?
+            joinedInputs.leftOuterJoin(preJoinStream).mapValues(flattenFunction) :
+            joinedInputs.leftOuterJoin(preJoinStream, numPartitions).mapValues(flattenFunction);
+        }
+      }
+    }
+
+    // should never happen, but removes warnings
+    if (joinedInputs == null) {
+      throw new IllegalStateException("There are no inputs into join stage " + stageSpec.getName());
+    }
+
+    return mergeJoinResults(stageSpec, joinedInputs, collector);
   }
 
   // return whether this stage should be cached to avoid recomputation

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -50,6 +50,7 @@ import io.cdap.cdap.etl.spark.function.JoinOnFunction;
 import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SQLContext;
 
 import java.io.BufferedReader;
 import java.nio.charset.StandardCharsets;
@@ -82,7 +83,7 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
   @Override
   protected SparkCollection<RecordInfo<Object>> getSource(StageSpec stageSpec, StageStatisticsCollector collector) {
     PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageSpec, sec, collector);
-    return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory,
+    return new RDDCollection<>(sec, jsc, new SQLContext(jsc), datasetContext, sinkFactory,
                                sourceFactory.createRDD(sec, jsc, stageSpec.getName(), Object.class, Object.class)
                                  .flatMap(Compat.convert(new BatchSourceFunction(pluginFunctionContext))));
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/PairRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/PairRDDCollection.java
@@ -26,6 +26,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.SQLContext;
 import scala.Tuple2;
 
 /**
@@ -37,14 +38,17 @@ import scala.Tuple2;
 public class PairRDDCollection<K, V> implements SparkPairCollection<K, V> {
   private final JavaSparkExecutionContext sec;
   private final JavaSparkContext jsc;
+  private final SQLContext sqlContext;
   private final DatasetContext datasetContext;
   private final SparkBatchSinkFactory sinkFactory;
   private final JavaPairRDD<K, V> pairRDD;
 
-  public PairRDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, DatasetContext datasetContext,
-                           SparkBatchSinkFactory sinkFactory, JavaPairRDD<K, V> pairRDD) {
+  public PairRDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
+                           DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory,
+                           JavaPairRDD<K, V> pairRDD) {
     this.sec = sec;
     this.jsc = jsc;
+    this.sqlContext = sqlContext;
     this.datasetContext = datasetContext;
     this.sinkFactory = sinkFactory;
     this.pairRDD = pairRDD;
@@ -58,7 +62,7 @@ public class PairRDDCollection<K, V> implements SparkPairCollection<K, V> {
 
   @Override
   public <T> SparkCollection<T> flatMap(FlatMapFunction<Tuple2<K, V>, T> function) {
-    return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory, pairRDD.flatMap(function));
+    return new RDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, pairRDD.flatMap(function));
   }
 
   @Override
@@ -105,6 +109,6 @@ public class PairRDDCollection<K, V> implements SparkPairCollection<K, V> {
   }
 
   private <X, Y> SparkPairCollection<X, Y> wrap(JavaPairRDD<X, Y> javaPairRDD) {
-    return new PairRDDCollection<>(sec, jsc, datasetContext, sinkFactory, javaPairRDD);
+    return new PairRDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, javaPairRDD);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorPostReduceFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorPostReduceFunction.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.Transformation;
+import io.cdap.cdap.etl.api.batch.BatchAggregator;
+import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.TrackedTransform;
+import io.cdap.cdap.etl.spark.CombinedEmitter;
+import scala.Tuple2;
+
+import java.util.Collections;
+
+/**
+ * Function that uses a BatchReduceAggregator to perform the aggregate part of the aggregator.
+ * Non-serializable fields are lazily created since this is used in a Spark closure.
+ *
+ * @param <GROUP_KEY> type of group key
+ * @param <GROUP_VAL> type of group value
+ * @param <OUT> type of aggregate output
+ */
+public class AggregatorPostReduceFunction<GROUP_KEY, GROUP_VAL, OUT>
+  implements FlatMapFunc<Tuple2<GROUP_KEY, GROUP_VAL>, RecordInfo<Object>> {
+  private final PluginFunctionContext pluginFunctionContext;
+  private transient TrackedTransform<Tuple2<GROUP_KEY, GROUP_VAL>, OUT> aggregateTransform;
+  private transient CombinedEmitter<OUT> emitter;
+
+  public AggregatorPostReduceFunction(PluginFunctionContext pluginFunctionContext) {
+    this.pluginFunctionContext = pluginFunctionContext;
+  }
+
+  @Override
+  public Iterable<RecordInfo<Object>> call(Tuple2<GROUP_KEY, GROUP_VAL> input) throws Exception {
+    if (aggregateTransform == null) {
+      BatchAggregator<GROUP_KEY, GROUP_VAL, OUT> aggregator = pluginFunctionContext.createPlugin();
+      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      aggregateTransform = new TrackedTransform<>(new AggregateTransform<>(aggregator),
+                                                  pluginFunctionContext.createStageMetrics(),
+                                                  Constants.Metrics.AGG_GROUPS,
+                                                  Constants.Metrics.RECORDS_OUT, pluginFunctionContext.getDataTracer(),
+                                                  pluginFunctionContext.getStageStatisticsCollector());
+      emitter = new CombinedEmitter<>(pluginFunctionContext.getStageName());
+    }
+    emitter.reset();
+    aggregateTransform.transform(input, emitter);
+    return emitter.getEmitted();
+  }
+
+  private static class AggregateTransform<GROUP_KEY, GROUP_VAL, OUT_VAL>
+    implements Transformation<Tuple2<GROUP_KEY, GROUP_VAL>, OUT_VAL> {
+    private final BatchAggregator<GROUP_KEY, GROUP_VAL, OUT_VAL> aggregator;
+
+    AggregateTransform(BatchAggregator<GROUP_KEY, GROUP_VAL, OUT_VAL> aggregator) {
+      this.aggregator = aggregator;
+    }
+
+    @Override
+    public void transform(Tuple2<GROUP_KEY, GROUP_VAL> input, Emitter<OUT_VAL> emitter) throws Exception {
+      aggregator.aggregate(input._1(), Collections.singleton(input._2).iterator(), emitter);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorReduceFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorReduceFunction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.batch.BatchReduceAggregator;
+import org.apache.spark.api.java.function.Function2;
+
+/**
+ * Function that uses a BatchReduceAggregator to perform the reduce part of the aggregator.
+ * Non-serializable fields are lazily created since this is used in a Spark closure.
+ *
+ * @param <GROUP_VALUE> type of group value
+ */
+public class AggregatorReduceFunction<GROUP_VALUE> implements Function2<GROUP_VALUE, GROUP_VALUE, GROUP_VALUE> {
+  private final PluginFunctionContext pluginFunctionContext;
+  private transient BatchReduceAggregator<?, GROUP_VALUE, ?> aggregator;
+
+  public AggregatorReduceFunction(PluginFunctionContext pluginFunctionContext) {
+    this.pluginFunctionContext = pluginFunctionContext;
+  }
+
+  @Override
+  public GROUP_VALUE call(GROUP_VALUE v1, GROUP_VALUE v2) throws Exception {
+    if (aggregator == null) {
+      aggregator = pluginFunctionContext.createPlugin();
+      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+    }
+    return aggregator.reduce(v1, v2);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinCollection.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.join;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.spark.SparkCollection;
+
+import java.util.List;
+
+/**
+ * Data to join.
+ */
+public class JoinCollection {
+  private final String stage;
+  private final String type;
+  private final SparkCollection<?> data;
+  private final Schema schema;
+  private final List<String> key;
+  private final boolean broadcast;
+
+  public JoinCollection(String stage, String type, SparkCollection<?> data, Schema schema,
+                        List<String> key, boolean broadcast) {
+    this.stage = stage;
+    this.type = type;
+    this.data = data;
+    this.schema = schema;
+    this.key = key;
+    this.broadcast = broadcast;
+  }
+
+  public String getStage() {
+    return stage;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public SparkCollection<?> getData() {
+    return data;
+  }
+
+  public Schema getSchema() {
+    return schema;
+  }
+
+  public List<String> getKey() {
+    return key;
+  }
+
+  public boolean isBroadcast() {
+    return broadcast;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinRequest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinRequest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.join;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.join.JoinField;
+
+import java.util.List;
+
+/**
+ * Request to join some collection to another collection.
+ */
+public class JoinRequest {
+  private final String leftStage;
+  private final List<String> leftKey;
+  private final Schema leftSchema;
+  private final List<JoinField> fields;
+  private final Schema outputSchema;
+  private final List<JoinCollection> toJoin;
+
+  public JoinRequest(String leftStage, List<String> leftKey, Schema leftSchema, List<JoinField> fields,
+                     Schema outputSchema, List<JoinCollection> toJoin) {
+    this.leftStage = leftStage;
+    this.leftKey = leftKey;
+    this.fields = fields;
+    this.leftSchema = leftSchema;
+    this.outputSchema = outputSchema;
+    this.toJoin = toJoin;
+  }
+
+  public String getLeftStage() {
+    return leftStage;
+  }
+
+  public Schema getLeftSchema() {
+    return leftSchema;
+  }
+
+  public List<String> getLeftKey() {
+    return leftKey;
+  }
+
+  public List<JoinField> getFields() {
+    return fields;
+  }
+
+  public List<JoinCollection> getToJoin() {
+    return toJoin;
+  }
+
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -36,6 +36,7 @@ import io.cdap.cdap.etl.spark.SparkCollection;
 import io.cdap.cdap.etl.spark.SparkPairCollection;
 import io.cdap.cdap.etl.spark.SparkPipelineRuntime;
 import io.cdap.cdap.etl.spark.batch.BasicSparkExecutionPluginContext;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
 import io.cdap.cdap.etl.spark.streaming.function.ComputeTransformFunction;
 import io.cdap.cdap.etl.spark.streaming.function.CountingTransformFunction;
 import io.cdap.cdap.etl.spark.streaming.function.DynamicAggregatorAggregate;
@@ -182,6 +183,12 @@ public class DStreamCollection<T> implements SparkCollection<T> {
                   .window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval()))
                   .transform(new CountingTransformFunction<T>(stageName, sec.getMetrics(), "records.out",
                                                              sec.getDataTracer(stageName))));
+  }
+
+  @Override
+  public SparkCollection<T> join(JoinRequest joinRequest) {
+    // TODO: (CDAP-16709) implement
+    throw new UnsupportedOperationException("auto join not supported");
   }
 
   private <U> SparkCollection<U> wrap(JavaDStream<U> stream) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -132,6 +132,14 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   @Override
+  public SparkCollection<RecordInfo<Object>> reduceAggregate(StageSpec stageSpec, @Nullable Integer partitions,
+                                                             StageStatisticsCollector collector) {
+    // TODO: implement
+    throw new UnsupportedOperationException("auto join not supported");
+  }
+
+
+  @Override
   public <U> SparkCollection<U> compute(final StageSpec stageSpec, SparkCompute<T, U> compute) throws Exception {
     final SparkCompute<T, U> wrappedCompute =
       new DynamicSparkCompute<>(new DynamicDriverContext(stageSpec, sec, new NoopStageStatisticsCollector()), compute);

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>spark-streaming_2.10</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.10</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.api.spark.sql.DataFrames;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.join.JoinCollection;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.types.StructType;
+import scala.collection.JavaConversions;
+import scala.collection.Seq;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Spark1 RDD collection.
+ *
+ * @param <T> type of object in the collection
+ */
+public class RDDCollection<T> extends BaseRDDCollection<T> {
+
+  public RDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
+                       DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
+    super(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SparkCollection<T> join(JoinRequest joinRequest) {
+    Map<String, DataFrame> collections = new HashMap<>();
+    DataFrame left = toDataFrame((JavaRDD<StructuredRecord>) rdd, joinRequest.getLeftSchema());
+    collections.put(joinRequest.getLeftStage(), left);
+
+    List<Column> leftJoinColumns = joinRequest.getLeftKey().stream()
+      .map(left::col)
+      .collect(Collectors.toList());
+
+    DataFrame joined = left;
+    for (JoinCollection toJoin : joinRequest.getToJoin()) {
+      RDDCollection<StructuredRecord> data = (RDDCollection<StructuredRecord>) toJoin.getData();
+      DataFrame right = toDataFrame(data.rdd, toJoin.getSchema());
+      collections.put(toJoin.getStage(), right);
+
+      List<Column> rightJoinColumns = toJoin.getKey().stream()
+        .map(right::col)
+        .collect(Collectors.toList());
+
+      Iterator<Column> leftIter = leftJoinColumns.iterator();
+      Iterator<Column> rightIter = rightJoinColumns.iterator();
+      Column joinOn = leftIter.next().equalTo(rightIter.next());
+      while (leftIter.hasNext()) {
+        joinOn = joinOn.and(leftIter.next().equalTo(rightIter.next()));
+      }
+
+      String joinType = toJoin.getType();
+      joined = joined.join(right, joinOn, joinType);
+    }
+
+    // select and alias fields in the expected order
+    List<Column> outputColumns = new ArrayList<>(joinRequest.getFields().size());
+    for (JoinField field : joinRequest.getFields()) {
+      Column column = collections.get(field.getStageName()).col(field.getFieldName());
+      if (field.getAlias() != null) {
+        column = column.alias(field.getAlias());
+      }
+
+      outputColumns.add(column);
+    }
+    Seq<Column> outputColumnSeq = JavaConversions.asScalaBuffer(outputColumns).toSeq();
+    joined = joined.select(outputColumnSeq);
+
+    Schema outputSchema = joinRequest.getOutputSchema();
+    JavaRDD<StructuredRecord> output = joined.javaRDD().map(r -> DataFrames.fromRow(r, outputSchema));
+    return (SparkCollection<T>) wrap(output);
+  }
+
+  private DataFrame toDataFrame(JavaRDD<StructuredRecord> rdd, Schema schema) {
+    StructType sparkSchema = DataFrames.toDataType(schema);
+    JavaRDD<Row> rowRDD = rdd.map(record -> DataFrames.toRow(record, sparkSchema));
+    return sqlContext.createDataFrame(rowRDD.rdd(), sparkSchema);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>spark-streaming_2.11</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.api.spark.sql.DataFrames;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.join.JoinCollection;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.types.StructType;
+import scala.collection.JavaConversions;
+import scala.collection.Seq;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Spark2 RDD collection.
+ *
+ * @param <T> type of object in the collection
+ */
+public class RDDCollection<T> extends BaseRDDCollection<T> {
+
+  public RDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
+                       DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
+    super(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
+  }
+
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SparkCollection<T> join(JoinRequest joinRequest) {
+    Map<String, Dataset> collections = new HashMap<>();
+    Dataset<Row> left = toDataset((JavaRDD<StructuredRecord>) rdd, joinRequest.getLeftSchema());
+    collections.put(joinRequest.getLeftStage(), left);
+
+    List<Column> leftJoinColumns = joinRequest.getLeftKey().stream()
+      .map(left::col)
+      .collect(Collectors.toList());
+
+    Dataset<Row> joined = left;
+    for (JoinCollection toJoin : joinRequest.getToJoin()) {
+      RDDCollection<StructuredRecord> data = (RDDCollection<StructuredRecord>) toJoin.getData();
+      Dataset<Row> right = toDataset(data.rdd, toJoin.getSchema());
+      collections.put(toJoin.getStage(), right);
+
+      List<Column> rightJoinColumns = toJoin.getKey().stream()
+        .map(right::col)
+        .collect(Collectors.toList());
+
+      Iterator<Column> leftIter = leftJoinColumns.iterator();
+      Iterator<Column> rightIter = rightJoinColumns.iterator();
+      Column joinOn = leftIter.next().equalTo(rightIter.next());
+      while (leftIter.hasNext()) {
+        joinOn = joinOn.and(leftIter.next().equalTo(rightIter.next()));
+      }
+
+      joined = joined.join(right, joinOn, toJoin.getType());
+    }
+
+    // select and alias fields in the expected order
+    List<Column> outputColumns = new ArrayList<>(joinRequest.getFields().size());
+    for (JoinField field : joinRequest.getFields()) {
+      Column column = collections.get(field.getStageName()).col(field.getFieldName());
+      if (field.getAlias() != null) {
+        column = column.alias(field.getAlias());
+      }
+
+      outputColumns.add(column);
+    }
+
+    Seq<Column> outputColumnSeq = JavaConversions.asScalaBuffer(outputColumns).toSeq();
+    joined = joined.select(outputColumnSeq);
+
+    Schema outputSchema = joinRequest.getOutputSchema();
+    JavaRDD<StructuredRecord> output = joined.javaRDD().map(r -> DataFrames.fromRow(r, outputSchema));
+    return (SparkCollection<T>) wrap(output);
+  }
+
+  private Dataset<Row> toDataset(JavaRDD<StructuredRecord> rdd, Schema schema) {
+    StructType sparkSchema = DataFrames.toDataType(schema);
+    JavaRDD<Row> rowRDD = rdd.map(record -> DataFrames.toRow(record, sparkSchema));
+    return sqlContext.createDataset(rowRDD.rdd(), RowEncoder.apply(sparkSchema));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/joiner/MockAutoJoiner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/joiner/MockAutoJoiner.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.mock.batch.joiner;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
+import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinKey;
+import io.cdap.cdap.etl.api.join.JoinStage;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+import io.cdap.cdap.internal.guava.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Mock auto-joiner. Performs inner, leftouter, or outer joins. Assumes join keys are named the same on both the
+ * left and right sides.
+ */
+@Plugin(type = BatchJoiner.PLUGIN_TYPE)
+@Name(MockAutoJoiner.NAME)
+public class MockAutoJoiner extends BatchAutoJoiner {
+  public static final String NAME = "MockAutoJoiner";
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private static final Type LIST = new TypeToken<List<String>>() { }.getType();
+  private static final Gson GSON = new Gson();
+  private final Conf conf;
+
+  @SuppressWarnings("unused")
+  public MockAutoJoiner(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Nullable
+  @Override
+  public JoinDefinition define(AutoJoinerContext context) {
+    Map<String, JoinStage> inputStages = context.getInputStages();
+    List<JoinStage> from = new ArrayList<>(inputStages.size());
+    Set<String> required = new HashSet<>(conf.getRequired());
+    List<JoinField> selectedFields = new ArrayList<>();
+    JoinCondition.OnKeys.Builder condition = JoinCondition.onKeys();
+    for (String stageName : conf.getStages()) {
+      JoinStage stage = inputStages.get(stageName);
+      if (!required.contains(stageName)) {
+        stage = JoinStage.builder(stage).isOptional().build();
+      }
+      from.add(stage);
+
+      condition.addKey(new JoinKey(stageName, conf.getKey()));
+
+      for (Schema.Field field : stage.getSchema().getFields()) {
+        // alias everything to stage_field
+        selectedFields.add(new JoinField(stageName, field.getName(),
+                                         String.format("%s_%s", stageName, field.getName())));
+      }
+    }
+
+    JoinDefinition.Builder builder = JoinDefinition.builder()
+      .select(selectedFields)
+      .on(condition.build())
+      .from(from)
+      .setOutputSchemaName(String.join(".", conf.getStages()));
+    return builder.build();
+  }
+
+  /**
+   * Auto Join config.
+   */
+  @SuppressWarnings("unused")
+  public static class Conf extends PluginConfig {
+    private String stages;
+
+    private String key;
+
+    @Nullable
+    private String required;
+
+
+    List<String> getKey() {
+      return GSON.fromJson(key, LIST);
+    }
+
+    List<String> getStages() {
+      return GSON.fromJson(stages, LIST);
+    }
+
+    List<String> getRequired() {
+      return required == null ? Collections.emptyList() : GSON.fromJson(required, LIST);
+    }
+  }
+
+  public static ETLPlugin getPlugin(List<String> stages, List<String> key, List<String> required) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("stages", GSON.toJson(stages));
+    properties.put("required", GSON.toJson(required));
+    properties.put("key", GSON.toJson(key));
+    return new ETLPlugin(NAME, BatchJoiner.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("stages", new PluginPropertyField("left", "", "string", true, false));
+    properties.put("required", new PluginPropertyField("right", "", "string", false, false));
+    properties.put("key", new PluginPropertyField("type", "", "string", true, false));
+    return new PluginClass(BatchJoiner.PLUGIN_TYPE, NAME, "", MockAutoJoiner.class.getName(), "conf", properties);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/reduceaggregator/FieldCountReduceAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/reduceaggregator/FieldCountReduceAggregator.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.mock.batch.reduceaggregator;
+
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.StageConfigurer;
+import io.cdap.cdap.etl.api.batch.BatchAggregator;
+import io.cdap.cdap.etl.api.batch.BatchAggregatorContext;
+import io.cdap.cdap.etl.api.batch.BatchReduceAggregator;
+import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
+import io.cdap.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Groups on a specific field and adds count field. Used to test that the right values are going to the
+ * right groups, to test multiple group keys for the same value, and to test setting the group key class
+ * at runtime, and to test setting a supported non-writable class.
+ * TODO: CDAP-16856 remove and use the existing {@link FieldCountAggregator} once mapreduce implementation is done
+ */
+@Plugin(type = BatchAggregator.PLUGIN_TYPE)
+@Name(FieldCountReduceAggregator.NAME)
+public class FieldCountReduceAggregator extends BatchReduceAggregator<Object, StructuredRecord, StructuredRecord> {
+  public static final String NAME = "FieldCount Aggregator";
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private static final Schema REDUCE_SCHEMA =
+    Schema.recordOf("record", Schema.Field.of("fc", Schema.of(Schema.Type.LONG)));
+  private final Config config;
+  private Schema schema;
+
+  public FieldCountReduceAggregator(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    if (!config.containsMacro("fieldType") && !config.containsMacro("fieldName")) {
+      stageConfigurer.setOutputSchema(config.getSchema());
+    }
+  }
+
+  @Override
+  public void prepareRun(BatchAggregatorContext context) throws Exception {
+    if ("long".equalsIgnoreCase(config.fieldType)) {
+      context.setGroupKeyClass(Long.class);
+    } else {
+      context.setGroupKeyClass(String.class);
+    }
+  }
+
+  @Override
+  public void groupBy(StructuredRecord input, Emitter<Object> emitter) throws Exception {
+    if ("long".equalsIgnoreCase(config.fieldType)) {
+      emitter.emit(input.get(config.fieldName));
+      emitter.emit(0L);
+    } else {
+      emitter.emit(input.get(config.fieldName).toString());
+      emitter.emit("all");
+    }
+  }
+
+  @Override
+  public StructuredRecord reduce(StructuredRecord value1, StructuredRecord value2) throws Exception {
+    Object v1Ct = value1.get("fc");
+    Object v2Ct = value2.get("fc");
+    long count = (v1Ct == null ? 1L : (Long) v1Ct) + (v2Ct == null ? 1L : (Long) v2Ct);
+    return StructuredRecord.builder(REDUCE_SCHEMA).set("fc", count).build();
+  }
+
+  @Override
+  public void aggregate(Object groupKey, Iterator<StructuredRecord> groupValues,
+                        Emitter<StructuredRecord> emitter) throws Exception {
+    StructuredRecord record = groupValues.next();
+    emitter.emit(StructuredRecord.builder(schema)
+                   .set(config.fieldName, groupKey)
+                   .set("ct", record.get("fc") == null ? 1L : record.get("fc"))
+                   .build());
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    schema = config.getSchema();
+    // should never happen, just done to test App correctness in unit tests
+    if (context.getOutputSchema() != null && !schema.equals(context.getOutputSchema())) {
+      throw new IllegalStateException("Output schema does not match what was set at configure time.");
+    }
+  }
+
+  /**
+   * Conf for the aggregator.
+   */
+  public static class Config extends PluginConfig {
+    @Macro
+    private final String fieldName;
+
+    @Macro
+    private final String fieldType;
+
+    public Config() {
+      this.fieldName = "field";
+      this.fieldType = "string";
+    }
+
+    private Schema getSchema() {
+      Schema.Field fieldSchema;
+      if ("string".equalsIgnoreCase(fieldType)) {
+        fieldSchema = Schema.Field.of(fieldName, Schema.of(Schema.Type.STRING));
+      } else if ("long".equalsIgnoreCase(fieldType)) {
+        fieldSchema = Schema.Field.of(fieldName, Schema.of(Schema.Type.LONG));
+      } else {
+        throw new IllegalArgumentException("Unsupported field type " + fieldType);
+      }
+
+      return Schema.recordOf(
+        fieldName + ".count",
+        fieldSchema,
+        Schema.Field.of("ct", Schema.of(Schema.Type.LONG)));
+    }
+  }
+
+  public static ETLPlugin getPlugin(String fieldName, String fieldType) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("fieldName", fieldName);
+    properties.put("fieldType", fieldType);
+    return new ETLPlugin(NAME, BatchReduceAggregator.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("fieldName", new PluginPropertyField("fieldName", "", "string", true, true));
+    properties.put("fieldType", new PluginPropertyField("fieldType", "", "string", true, true));
+    return new PluginClass(BatchReduceAggregator.PLUGIN_TYPE, NAME, "",
+                           FieldCountReduceAggregator.class.getName(), "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.condition.Condition;
+import io.cdap.cdap.etl.api.join.AutoJoiner;
 import io.cdap.cdap.etl.api.lineage.AccessType;
 import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
@@ -48,6 +49,7 @@ import io.cdap.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
 import io.cdap.cdap.etl.mock.batch.aggregator.GroupFilterAggregator;
 import io.cdap.cdap.etl.mock.batch.aggregator.IdentityAggregator;
 import io.cdap.cdap.etl.mock.batch.joiner.DupeFlagger;
+import io.cdap.cdap.etl.mock.batch.joiner.MockAutoJoiner;
 import io.cdap.cdap.etl.mock.batch.joiner.MockJoiner;
 import io.cdap.cdap.etl.mock.condition.MockCondition;
 import io.cdap.cdap.etl.mock.spark.Window;
@@ -79,7 +81,7 @@ public class HydratorTestBase extends TestBase {
   // To work around, we'll just explicitly specify each plugin.
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, GroupFilterAggregator.PLUGIN_CLASS,
-    MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
+    MockJoiner.PLUGIN_CLASS, MockAutoJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     MockRuntimeDatasetSink.PLUGIN_CLASS, MockRuntimeDatasetSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, AllErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
@@ -98,7 +100,7 @@ public class HydratorTestBase extends TestBase {
     IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS, DropNullTransform.PLUGIN_CLASS,
     FilterTransform.PLUGIN_CLASS,
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
-    GroupFilterAggregator.PLUGIN_CLASS, MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
+    GroupFilterAggregator.PLUGIN_CLASS, MockJoiner.PLUGIN_CLASS, MockAutoJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     StringValueFilterCompute.PLUGIN_CLASS, Window.PLUGIN_CLASS,
     FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,
     NullFieldSplitterTransform.PLUGIN_CLASS, TMSAlertPublisher.PLUGIN_CLASS, NullAlertTransform.PLUGIN_CLASS
@@ -114,6 +116,7 @@ public class HydratorTestBase extends TestBase {
     addAppArtifact(artifactId, appClass,
                    BatchSource.class.getPackage().getName(),
                    Action.class.getPackage().getName(),
+                   AutoJoiner.class.getPackage().getName(),
                    Condition.class.getPackage().getName(),
                    PipelineConfigurable.class.getPackage().getName(),
                    AccessType.class.getPackage().getName(),
@@ -141,6 +144,7 @@ public class HydratorTestBase extends TestBase {
     addAppArtifact(artifactId, appClass,
                    StreamingSource.class.getPackage().getName(),
                    Transform.class.getPackage().getName(),
+                   AutoJoiner.class.getPackage().getName(),
                    SparkCompute.class.getPackage().getName(),
                    InvalidStageException.class.getPackage().getName(),
                    PipelineConfigurable.class.getPackage().getName(),

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -51,6 +51,8 @@ import io.cdap.cdap.etl.mock.batch.aggregator.IdentityAggregator;
 import io.cdap.cdap.etl.mock.batch.joiner.DupeFlagger;
 import io.cdap.cdap.etl.mock.batch.joiner.MockAutoJoiner;
 import io.cdap.cdap.etl.mock.batch.joiner.MockJoiner;
+import io.cdap.cdap.etl.mock.batch.reduceaggregator.DistinctReduceAggregator;
+import io.cdap.cdap.etl.mock.batch.reduceaggregator.FieldCountReduceAggregator;
 import io.cdap.cdap.etl.mock.condition.MockCondition;
 import io.cdap.cdap.etl.mock.spark.Window;
 import io.cdap.cdap.etl.mock.spark.compute.StringValueFilterCompute;
@@ -90,7 +92,8 @@ public class HydratorTestBase extends TestBase {
     MockAction.PLUGIN_CLASS, FileMoveAction.PLUGIN_CLASS, FieldLineageAction.PLUGIN_CLASS,
     StringValueFilterCompute.PLUGIN_CLASS, FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,
     NullFieldSplitterTransform.PLUGIN_CLASS, TMSAlertPublisher.PLUGIN_CLASS, NullAlertTransform.PLUGIN_CLASS,
-    MockCondition.PLUGIN_CLASS, MockSource.PLUGIN_CLASS, MockSink.PLUGIN_CLASS
+    MockCondition.PLUGIN_CLASS, MockSource.PLUGIN_CLASS, MockSink.PLUGIN_CLASS, DistinctReduceAggregator.PLUGIN_CLASS,
+    FieldCountReduceAggregator.PLUGIN_CLASS
   );
   private static final Set<PluginClass> STREAMING_MOCK_PLUGINS = ImmutableSet.of(
     io.cdap.cdap.etl.mock.spark.streaming.MockSource.PLUGIN_CLASS,


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16855
build: https://builds.cask.co/browse/CDAP-RUT1785-1

Implemented reducer as aggregator improvement for batch spark pipelines. This changes the use of `groupByKey` to `reduceByKey` which will do a map side reduce before do the aggregation. A reduce function will need to be provided to achieve this