### PR TITLE
[CDAP-16860] Create Routing & Basic Plugin Information page (plugin JSON)

### DIFF
--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -114,6 +114,10 @@ const Ingestion = Loadable({
   loader: () => import(/* webpackChunkMame: "Ingestion" */ 'components/Ingestion'),
   loading: LoadingSVGCentered,
 });
+const PluginJSONCreator = Loadable({
+  loader: () => import(/* webpackChunkMame: "PluginJSONCreator" */ 'components/PluginJSONCreator'),
+  loading: LoadingSVGCentered,
+});
 
 export default class Home extends Component {
   constructor(props) {
@@ -214,6 +218,7 @@ export default class Home extends Component {
               );
             }}
           />
+          <Route path="/ns/:namespace/plugincreation" component={PluginJSONCreator} />
           <Route component={Page404} />
         </Switch>
       </div>

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import ToggleSwitchWidget from 'components/AbstractWidget/ToggleSwitchWidget';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import Heading, { HeadingTypes } from 'components/Heading';
+import { PluginTypes } from 'components/PluginJSONCreator/constants';
+import StepButtons from 'components/PluginJSONCreator/Create/Content/StepButtons';
+import {
+  CreateContext,
+  createContextConnect,
+  IBasicPluginInfo,
+  ICreateContext,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const styles = (): StyleRules => {
+  return {
+    root: {
+      padding: '30px 40px',
+    },
+    content: {
+      width: '50%',
+      maxWidth: '1000px',
+      minWidth: '600px',
+    },
+  };
+};
+
+const PluginTextInput = ({ setValue, value, label }) => {
+  const widget = {
+    label,
+    name: label,
+    'widget-type': 'textbox',
+    'widget-attributes': {
+      placeholder: 'Select a ' + label,
+    },
+  };
+
+  const property = {
+    required: true,
+    name: label,
+  };
+
+  return (
+    <WidgetWrapper
+      widgetProperty={widget}
+      pluginProperty={property}
+      value={value}
+      onChange={setValue}
+    />
+  );
+};
+
+const PluginSelect = ({ setValue, value, label, options }) => {
+  const widget = {
+    label,
+    name: label,
+    'widget-type': 'select',
+    'widget-attributes': {
+      options,
+      default: options[0],
+    },
+  };
+
+  const property = {
+    required: true,
+    name: label,
+  };
+
+  return (
+    <WidgetWrapper
+      widgetProperty={widget}
+      pluginProperty={property}
+      value={value}
+      onChange={setValue}
+    />
+  );
+};
+
+const PluginToggle = ({ setValue, value, label }) => {
+  const widget = {
+    label,
+    name: label,
+    'widget-type': 'toggle',
+    'widget-attributes': {
+      default: value ? 'true' : 'false',
+      on: {
+        value: 'true',
+        label: 'True',
+      },
+      off: {
+        value: 'false',
+        label: 'False',
+      },
+    },
+  };
+
+  return <ToggleSwitchWidget widgetProps={widget} value={value} onChange={setValue} />;
+};
+
+const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
+  classes,
+  pluginName,
+  pluginType,
+  displayName,
+  emitAlerts,
+  emitErrors,
+  setBasicPluginInfo,
+}) => {
+  const [localPluginName, setLocalPluginName] = React.useState(pluginName);
+  const [localPluginType, setLocalPluginType] = React.useState(pluginType);
+  const [localDisplayName, setLocalDisplayName] = React.useState(displayName);
+  const [localEmitAlerts, setLocalEmitAlerts] = React.useState(emitAlerts);
+  const [localEmitErrors, setLocalEmitErrors] = React.useState(emitErrors);
+
+  const requiredFilledOut =
+    localPluginName.length > 0 && localPluginType.length > 0 && localDisplayName.length > 0;
+
+  function handleNext() {
+    setBasicPluginInfo({
+      pluginName: localPluginName,
+      pluginType: localPluginType,
+      displayName: localDisplayName,
+      emitAlerts: localEmitAlerts,
+      emitErrors: localEmitErrors,
+    } as IBasicPluginInfo);
+  }
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.content}>
+        <Heading type={HeadingTypes.h3} label="Basic Plugin Information" />
+        <br />
+        <PluginTextInput
+          label={'Plugin Name'}
+          value={localPluginName}
+          setValue={setLocalPluginName}
+        />
+        <br />
+        <br />
+        <PluginSelect
+          label={'Plugin Type'}
+          options={PluginTypes}
+          value={localPluginType}
+          setValue={setLocalPluginType}
+        />
+        <br />
+        <br />
+        <PluginTextInput
+          label={'Display Name'}
+          value={localDisplayName}
+          setValue={setLocalDisplayName}
+        />
+        <br />
+        <Heading type={HeadingTypes.h5} label="Emit Alerts?" />
+        <PluginToggle
+          label={'Emit Alerts?'}
+          value={localEmitAlerts}
+          setValue={setLocalEmitAlerts}
+        />
+        <br />
+        <Heading type={HeadingTypes.h5} label="Emit Errors?" />
+        <PluginToggle
+          label={'Emit Errors?'}
+          value={localEmitErrors}
+          setValue={setLocalEmitErrors}
+        />
+      </div>
+      <StepButtons nextDisabled={!requiredFilledOut} onNext={handleNext} />
+    </div>
+  );
+};
+
+const StyledBasicPluginInfoView = withStyles(styles)(BasicPluginInfoView);
+const BasicPluginInfo = createContextConnect(CreateContext, StyledBasicPluginInfoView);
+export default BasicPluginInfo;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/StepButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/StepButtons/index.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Button from '@material-ui/core/Button';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import If from 'components/If';
+import { STEPS } from 'components/PluginJSONCreator/Create/steps';
+import {
+  CreateContext,
+  createContextConnect,
+  ICreateContext,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const styles = (theme): StyleRules => {
+  return {
+    root: {
+      marginTop: '50px',
+      borderTop: `1px solid ${theme.palette.grey[300]}`,
+      paddingTop: '25px',
+      '& button': {
+        marginRight: '50px',
+      },
+    },
+  };
+};
+
+interface IStepButtonProps extends WithStyles<typeof styles>, ICreateContext {
+  nextDisabled?: boolean;
+  onNext?: () => void;
+  onComplete?: () => void;
+  completeLoading?: boolean;
+}
+
+const StepButtonsView: React.FC<IStepButtonProps> = ({
+  activeStep,
+  setActiveStep,
+  nextDisabled,
+  onNext,
+  classes,
+  onComplete,
+}) => {
+  function handleNextClick() {
+    if (activeStep === STEPS.length - 1) {
+      return;
+    }
+
+    if (typeof onNext === 'function') {
+      onNext();
+    }
+
+    setActiveStep(activeStep + 1);
+  }
+
+  return (
+    <div className={classes.root}>
+      <If condition={activeStep > 0}>
+        <Button color="primary" onClick={() => setActiveStep(activeStep - 1)}>
+          Previous
+        </Button>
+      </If>
+      <If condition={typeof onComplete !== 'function'}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleNextClick}
+          disabled={nextDisabled}
+        >
+          Next
+        </Button>
+      </If>
+    </div>
+  );
+};
+
+const StyledStepButtons = withStyles(styles)(StepButtonsView);
+const StepButtons = createContextConnect(CreateContext, StyledStepButtons);
+export default StepButtons;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/index.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import { STEPS } from 'components/PluginJSONCreator/Create/steps';
+import {
+  CreateContext,
+  createContextConnect,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const styles = (theme): StyleRules => {
+  return {
+    comp: {
+      borderRight: `1px solid ${theme.palette.grey[400]}`,
+      width: '60%',
+      color: `${theme.palette.grey[400]}`,
+    },
+  };
+};
+
+interface IContentProps {
+  activeStep: number;
+}
+
+const ContentView: React.FC<IContentProps & WithStyles<typeof styles>> = ({
+  classes,
+  activeStep,
+}) => {
+  if (!STEPS[activeStep] || !STEPS[activeStep].component) {
+    return null;
+  }
+
+  const Comp = STEPS[activeStep].component;
+  return (
+    <div>
+      <Comp className={classes.comp} />
+    </div>
+  );
+};
+
+const StyledContentView = withStyles(styles)(ContentView);
+const Content = createContextConnect(CreateContext, StyledContentView);
+export default Content;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/WizardGuideline/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/WizardGuideline/index.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Chip from '@material-ui/core/Chip';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import Check from '@material-ui/icons/Check';
+import classnames from 'classnames';
+import { STEPS } from 'components/PluginJSONCreator/Create/steps';
+import {
+  CreateContext,
+  createContextConnect,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const styles = (theme): StyleRules => {
+  return {
+    root: {
+      borderRight: `1px solid ${theme.palette.grey[300]}`,
+    },
+    row: {
+      padding: '15px',
+      lineHeight: '24px',
+    },
+    finishedRow: {
+      cursor: 'pointer',
+
+      '&:hover': {
+        backgroundColor: theme.palette.grey[700],
+      },
+
+      '& $chip': {
+        backgroundColor: theme.palette.blue[100],
+      },
+    },
+    active: {
+      backgroundColor: theme.palette.grey[700],
+    },
+    chip: {
+      marginRight: '10px',
+      color: theme.palette.white[50],
+      backgroundColor: theme.palette.grey[200],
+      minWidth: '24px',
+      height: '24px',
+
+      '& span': {
+        paddingLeft: '5px',
+        paddingRight: '5px',
+      },
+    },
+    checkIcon: {
+      fontSize: '14px',
+    },
+  };
+};
+
+interface IWizardGuidelineProps extends WithStyles<typeof styles> {
+  activeStep: number;
+  setActiveStep: (step: number) => void;
+}
+
+const WizardGuidelineView: React.FC<IWizardGuidelineProps> = ({
+  classes,
+  setActiveStep,
+  activeStep,
+}) => {
+  function handleStepClick(step) {
+    if (step >= activeStep) {
+      return;
+    }
+
+    setActiveStep(step);
+  }
+
+  return (
+    <div className={classes.root}>
+      {STEPS.map((step, i) => {
+        const chipContent = i < activeStep ? <Check className={classes.checkIcon} /> : i + 1;
+
+        return (
+          <div
+            key={step.label}
+            className={classnames(classes.row, {
+              [classes.finishedRow]: i <= activeStep,
+              [classes.active]: i === activeStep,
+            })}
+            onClick={handleStepClick.bind(null, i)}
+          >
+            <Chip label={chipContent} className={classes.chip} />
+            <span>{step.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const StyledWizardGuideline = withStyles(styles)(WizardGuidelineView);
+const WizardGuideline = createContextConnect(CreateContext, StyledWizardGuideline);
+export default WizardGuideline;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import Content from 'components/PluginJSONCreator/Create/Content';
+import WizardGuideline from 'components/PluginJSONCreator/Create/WizardGuideline';
+import {
+  CreateContext,
+  IBasicPluginInfo,
+  ICreateContext,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+export const LEFT_PANEL_WIDTH = 250;
+
+const styles = (): StyleRules => {
+  return {
+    root: {
+      height: '100%',
+    },
+    content: {
+      height: 'calc(100% - 50px)',
+      display: 'grid',
+      gridTemplateColumns: `${LEFT_PANEL_WIDTH}px 1fr`,
+
+      '& > div': {
+        overflowY: 'auto',
+      },
+    },
+  };
+};
+
+class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof styles>> {
+  public setActiveStep = (activeStep: number) => {
+    this.setState({ activeStep });
+  };
+
+  public setBasicPluginInfo = (basicPluginInfo: IBasicPluginInfo) => {
+    const { pluginName, pluginType, displayName, emitAlerts, emitErrors } = basicPluginInfo;
+    this.setState({
+      pluginName,
+      pluginType,
+      displayName,
+      emitAlerts,
+      emitErrors,
+    });
+  };
+
+  public state = {
+    pluginName: '',
+    pluginType: '',
+    displayName: '',
+    emitAlerts: true,
+    emitErrors: true,
+    activeStep: 0,
+
+    setActiveStep: this.setActiveStep,
+    setBasicPluginInfo: this.setBasicPluginInfo,
+  };
+
+  public render() {
+    return (
+      <CreateContext.Provider value={this.state}>
+        <div className={this.props.classes.root}>
+          <div className={this.props.classes.content}>
+            <WizardGuideline />
+            <Content />
+          </div>
+        </div>
+      </CreateContext.Provider>
+    );
+  }
+}
+
+const Create = withStyles(styles)(CreateView);
+export default Create;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/steps.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/steps.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import BasicPluginInfo from 'components/PluginJSONCreator/Create/Content/BasicPluginInfo';
+
+export const STEPS = [
+  {
+    label: 'Basic Plugin Information',
+    component: BasicPluginInfo,
+  },
+];

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+
+export const CreateContext = React.createContext({});
+
+interface ICreateState {
+  activeStep: number;
+  pluginName: string;
+  pluginType: string;
+  displayName: string;
+  emitAlerts: boolean;
+  emitErrors: boolean;
+  setActiveStep: (step: number) => void;
+  setBasicPluginInfo: (basicPluginInfo: IBasicPluginInfo) => void;
+}
+
+export interface IBasicPluginInfo {
+  pluginName: string;
+  pluginType: string;
+  displayName: string;
+  emitAlerts: boolean;
+  emitErrors: boolean;
+}
+
+export type ICreateContext = Partial<ICreateState>;
+
+export function createContextConnect(Context, Component) {
+  return (extraProps) => {
+    return (
+      <Context.Consumer>
+        {(props) => {
+          const finalProps = {
+            ...props,
+            ...extraProps,
+          };
+
+          return <Component {...finalProps} />;
+        }}
+      </Context.Consumer>
+    );
+  };
+}

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { GLOBALS } from 'services/global-constants';
+
+export const PluginTypes = Object.keys(GLOBALS.pluginTypeToLabel).filter(
+  (t) => t !== 'sqljoiner' && t !== 'batchjoiner' && t !== 'errortransform'
+);

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/index.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { Redirect, Route, Switch } from 'react-router-dom';
+import Helmet from 'react-helmet';
+import Create from 'components/PluginJSONCreator/Create';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+import { Theme } from 'services/ThemeHelper';
+
+export const basepath = '/ns/:namespace/plugincreation';
+
+const PluginJSONCreator: React.FC = () => {
+  const pageTitle = `${Theme.productName} | Plugin JSON`;
+
+  return (
+    <React.Fragment>
+      <Helmet title={pageTitle} />
+      <Switch>
+        <Route path={basepath} component={Create} />
+        <Route
+          render={() => {
+            return <Redirect to={`/ns/${getCurrentNamespace()}/plugincreation`} />;
+          }}
+        />
+      </Switch>
+    </React.Fragment>
+  );
+};
+
+export default PluginJSONCreator;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16860

- set up basic routing http://localhost:11011/cdap/ns/default/plugincreation
- add Wizard UI experience on the page (huge thanks to the existing replication page!)
- 1st page consists of input fields where users can set the basic information of the JSON plugin

Users can set the basic information (such as `display name`, `plugin name`, `plugin type`, `emit alerts` , and `emit errors`).

**The view of the page**

<img width="1792" alt="Screen Shot 2020-05-26 at 11 05 34 AM" src="https://user-images.githubusercontent.com/14116152/82917078-eb24c400-9f40-11ea-888c-f4667b9af3a7.png">

**When user fills in all the required fields, they can move to the next page**

<img width="1792" alt="Screen Shot 2020-05-26 at 11 05 54 AM" src="https://user-images.githubusercontent.com/14116152/82917143-055ea200-9f41-11ea-9e0a-b37396c947c7.png">
