### PR TITLE
[CDAP-16861] Define configuration groups (plugin JSON Creator)

### DIFF
--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
@@ -15,10 +15,9 @@
  */
 
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
-import ToggleSwitchWidget from 'components/AbstractWidget/ToggleSwitchWidget';
-import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
 import Heading, { HeadingTypes } from 'components/Heading';
 import { PluginTypes } from 'components/PluginJSONCreator/constants';
+import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
 import StepButtons from 'components/PluginJSONCreator/Create/Content/StepButtons';
 import {
   CreateContext,
@@ -30,87 +29,11 @@ import * as React from 'react';
 
 const styles = (): StyleRules => {
   return {
-    root: {
-      padding: '30px 40px',
-    },
-    content: {
-      width: '50%',
-      maxWidth: '1000px',
-      minWidth: '600px',
+    basicPluginInput: {
+      marginTop: '30px',
+      marginBottom: '30px',
     },
   };
-};
-
-const PluginTextInput = ({ setValue, value, label }) => {
-  const widget = {
-    label,
-    name: label,
-    'widget-type': 'textbox',
-    'widget-attributes': {
-      placeholder: 'Select a ' + label,
-    },
-  };
-
-  const property = {
-    required: true,
-    name: label,
-  };
-
-  return (
-    <WidgetWrapper
-      widgetProperty={widget}
-      pluginProperty={property}
-      value={value}
-      onChange={setValue}
-    />
-  );
-};
-
-const PluginSelect = ({ setValue, value, label, options }) => {
-  const widget = {
-    label,
-    name: label,
-    'widget-type': 'select',
-    'widget-attributes': {
-      options,
-      default: options[0],
-    },
-  };
-
-  const property = {
-    required: true,
-    name: label,
-  };
-
-  return (
-    <WidgetWrapper
-      widgetProperty={widget}
-      pluginProperty={property}
-      value={value}
-      onChange={setValue}
-    />
-  );
-};
-
-const PluginToggle = ({ setValue, value, label }) => {
-  const widget = {
-    label,
-    name: label,
-    'widget-type': 'toggle',
-    'widget-attributes': {
-      default: value ? 'true' : 'false',
-      on: {
-        value: 'true',
-        label: 'True',
-      },
-      off: {
-        value: 'false',
-        label: 'False',
-      },
-    },
-  };
-
-  return <ToggleSwitchWidget widgetProps={widget} value={value} onChange={setValue} />;
 };
 
 const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
@@ -142,43 +65,52 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
   }
 
   return (
-    <div className={classes.root}>
-      <div className={classes.content}>
-        <Heading type={HeadingTypes.h3} label="Basic Plugin Information" />
-        <br />
-        <PluginTextInput
-          label={'Plugin Name'}
+    <div>
+      <Heading type={HeadingTypes.h3} label="Basic Plugin Information" />
+      <div className={classes.basicPluginInput}>
+        <PluginInput
+          widgetType={'textbox'}
           value={localPluginName}
-          setValue={setLocalPluginName}
+          onChange={setLocalPluginName}
+          label={'Plugin Name'}
+          placeholder={'Select a Plugin Name'}
+          required={true}
         />
-        <br />
-        <br />
-        <PluginSelect
+      </div>
+      <div className={classes.basicPluginInput}>
+        <PluginInput
+          widgetType={'select'}
+          value={localPluginType}
+          onChange={setLocalPluginType}
           label={'Plugin Type'}
           options={PluginTypes}
-          value={localPluginType}
-          setValue={setLocalPluginType}
+          required={true}
         />
-        <br />
-        <br />
-        <PluginTextInput
-          label={'Display Name'}
+      </div>
+      <div className={classes.basicPluginInput}>
+        <PluginInput
+          widgetType={'textbox'}
           value={localDisplayName}
-          setValue={setLocalDisplayName}
+          onChange={setLocalDisplayName}
+          label={'Display Name'}
+          placeholder={'Select a Display Name'}
+          required={true}
         />
-        <br />
-        <Heading type={HeadingTypes.h5} label="Emit Alerts?" />
-        <PluginToggle
+      </div>
+      <div className={classes.basicPluginInput}>
+        <PluginInput
+          widgetType={'toggle'}
+          value={localEmitAlerts ? 'true' : 'false'}
+          onChange={(val) => setLocalEmitAlerts(val === 'true')}
           label={'Emit Alerts?'}
-          value={localEmitAlerts}
-          setValue={setLocalEmitAlerts}
         />
-        <br />
-        <Heading type={HeadingTypes.h5} label="Emit Errors?" />
-        <PluginToggle
+      </div>
+      <div className={classes.basicPluginInput}>
+        <PluginInput
+          widgetType={'toggle'}
+          value={localEmitErrors ? 'true' : 'false'}
+          onChange={(val) => setLocalEmitErrors(val === 'true')}
           label={'Emit Errors?'}
-          value={localEmitErrors}
-          setValue={setLocalEmitErrors}
         />
       </div>
       <StepButtons nextDisabled={!requiredFilledOut} onNext={handleNext} />

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/GroupInfoInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/GroupInfoInput/index.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
+import If from 'components/If';
+import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
+import {
+  CreateContext,
+  createContextConnect,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const styles = (): StyleRules => {
+  return {
+    groupInput: {
+      marginTop: '10px',
+      marginBottom: '10px',
+    },
+    groupInputContainer: {
+      position: 'relative',
+      padding: '7px 10px 5px',
+      margin: '25px',
+    },
+  };
+};
+
+export const GroupInfoInputView = ({ classes, groupID, groupToInfo, setGroupToInfo }) => {
+  function onGroupLabelChange() {
+    return (label) => {
+      setGroupToInfo((prevObjs) => ({
+        ...prevObjs,
+        [groupID]: { ...prevObjs[groupID], label },
+      }));
+    };
+  }
+
+  function onGroupDescriptionChange() {
+    return (description) => {
+      setGroupToInfo((prevObjs) => ({
+        ...prevObjs,
+        [groupID]: { ...prevObjs[groupID], description },
+      }));
+    };
+  }
+
+  const group = groupToInfo ? groupToInfo[groupID] : null;
+
+  return (
+    <If condition={group}>
+      <div className={classes.groupInputContainer} data-cy="widget-wrapper-container">
+        <div className={classes.groupInput}>
+          <PluginInput
+            widgetType={'textbox'}
+            value={group.label}
+            onChange={onGroupLabelChange()}
+            label={'Label'}
+            required={true}
+          />
+        </div>
+        <div className={classes.groupInput}>
+          <PluginInput
+            widgetType={'textarea'}
+            value={group.description}
+            onChange={onGroupDescriptionChange()}
+            label={'Description'}
+            required={false}
+          />
+        </div>
+      </div>
+    </If>
+  );
+};
+
+const StyledGroupInfoInput = withStyles(styles)(GroupInfoInputView);
+const GroupInfoInput = createContextConnect(CreateContext, StyledGroupInfoInput);
+export default GroupInfoInput;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Button from '@material-ui/core/Button';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import IconButton from '@material-ui/core/IconButton';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import Typography from '@material-ui/core/Typography';
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Heading, { HeadingTypes } from 'components/Heading';
+import If from 'components/If';
+import GroupInfoInput from 'components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/GroupInfoInput';
+import StepButtons from 'components/PluginJSONCreator/Create/Content/StepButtons';
+import {
+  CreateContext,
+  createContextConnect,
+  IConfigurationGroupInfo,
+  ICreateContext,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+import uuidV4 from 'uuid/v4';
+
+const styles = (): StyleRules => {
+  return {
+    eachGroup: {
+      display: 'grid',
+      gridTemplateColumns: '5fr 1fr',
+    },
+    groupContent: {
+      display: 'block',
+      padding: '0',
+      width: '100%',
+    },
+  };
+};
+
+const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
+  classes,
+  configurationGroups,
+  setConfigurationGroups,
+  groupToInfo,
+  setGroupToInfo,
+}) => {
+  const [localConfigurationGroups, setLocalConfigurationGroups] = React.useState(
+    configurationGroups
+  );
+  const [activeGroupIndex, setActiveGroupIndex] = React.useState(null);
+  const [localGroupToInfo, setLocalGroupToInfo] = React.useState(groupToInfo);
+
+  function addConfigurationGroup(index: number) {
+    const newGroupID = 'ConfigGroup_' + uuidV4();
+
+    // add a new group's ID at the specified index
+    const newGroups = [...localConfigurationGroups];
+    if (newGroups.length === 0) {
+      newGroups.splice(0, 0, newGroupID);
+    } else {
+      newGroups.splice(index + 1, 0, newGroupID);
+    }
+    setLocalConfigurationGroups(newGroups);
+
+    // set the activeGroupIndex to the new group's index
+    if (newGroups.length <= 1) {
+      setActiveGroupIndex(0);
+    } else {
+      setActiveGroupIndex(index + 1);
+    }
+
+    // set the default label and description of the group
+    setLocalGroupToInfo({
+      ...localGroupToInfo,
+      [newGroupID]: {
+        label: '',
+        description: '',
+      } as IConfigurationGroupInfo,
+    });
+  }
+
+  function deleteConfigurationGroup(index: number) {
+    setActiveGroupIndex(null);
+
+    // delete a group at the specified index
+    const newGroups = [...localConfigurationGroups];
+    const groupToDelete = newGroups[index];
+    newGroups.splice(index, 1);
+    setLocalConfigurationGroups(newGroups);
+
+    // delete the corresponding information of the group
+    const { [groupToDelete]: info, ...restGroupToInfo } = localGroupToInfo;
+    setLocalGroupToInfo(restGroupToInfo);
+  }
+
+  const switchEditConfigurationGroup = (index) => (event, newExpanded) => {
+    if (newExpanded) {
+      setActiveGroupIndex(index);
+    } else {
+      setActiveGroupIndex(null);
+    }
+  };
+
+  function saveAllResults() {
+    setConfigurationGroups(localConfigurationGroups);
+    setGroupToInfo(localGroupToInfo);
+  }
+
+  return (
+    <div>
+      <Heading type={HeadingTypes.h3} label="Configuration Groups" />
+      <br />
+      <If condition={localConfigurationGroups.length === 0}>
+        <Button variant="contained" color="primary" onClick={() => addConfigurationGroup(0)}>
+          Add Configuration Group
+        </Button>
+      </If>
+
+      {localConfigurationGroups.map((groupID, i) => {
+        const configurationGroupExpanded = activeGroupIndex === i;
+        const group = localGroupToInfo[groupID];
+        return (
+          <div key={groupID} className={classes.eachGroup}>
+            <ExpansionPanel
+              expanded={configurationGroupExpanded}
+              onChange={switchEditConfigurationGroup(i)}
+            >
+              <ExpansionPanelSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls="panel1c-content"
+                id="panel1c-header"
+              >
+                <If condition={!configurationGroupExpanded}>
+                  <Typography className={classes.heading}>{group.label}</Typography>
+                </If>
+              </ExpansionPanelSummary>
+              <ExpansionPanelActions className={classes.groupContent}>
+                <GroupInfoInput
+                  classes={classes}
+                  groupID={groupID}
+                  groupToInfo={localGroupToInfo}
+                  setGroupToInfo={setLocalGroupToInfo}
+                />
+              </ExpansionPanelActions>
+            </ExpansionPanel>
+
+            <div className={classes.groupActionButtons}>
+              <IconButton onClick={() => addConfigurationGroup(i)} data-cy="add-row">
+                <AddIcon fontSize="small" />
+              </IconButton>
+              <IconButton
+                onClick={() => deleteConfigurationGroup(i)}
+                color="secondary"
+                data-cy="remove-row"
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </div>
+          </div>
+        );
+      })}
+      <StepButtons nextDisabled={false} onPrevious={saveAllResults} onNext={saveAllResults} />
+    </div>
+  );
+};
+
+const StyledConfigurationGroupsCollectionView = withStyles(styles)(
+  ConfigurationGroupsCollectionView
+);
+const ConfigurationGroupsCollection = createContextConnect(
+  CreateContext,
+  StyledConfigurationGroupsCollectionView
+);
+export default ConfigurationGroupsCollection;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/PluginInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/PluginInput/index.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import * as React from 'react';
+
+const PluginInput = ({
+  widgetType,
+  onChange,
+  value,
+  label,
+  placeholder = '',
+  delimeter = null,
+  options = null,
+  required = true,
+  keyPlaceholder = null,
+  valuePlaceholder = null,
+  kvDelimiter = null,
+}) => {
+  let widgetAttributes;
+  if (widgetType !== 'toggle') {
+    widgetAttributes = {
+      ...(delimeter && { delimeter }),
+      ...(options && { options }),
+      ...(placeholder && { placeholder }),
+      ...(value && { default: value }),
+      ...(keyPlaceholder && { 'key-placeholder': keyPlaceholder }),
+      ...(valuePlaceholder && { 'value-placeholder': valuePlaceholder }),
+      ...(kvDelimiter && { 'kv-delimiter': kvDelimiter }),
+    };
+  } else {
+    widgetAttributes = {
+      on: {
+        value: 'true',
+        label: 'true',
+      },
+      off: {
+        value: 'false',
+        label: 'false',
+      },
+      default: value ? 'true' : 'false',
+    };
+  }
+
+  const widget = {
+    label,
+    name: label,
+    'widget-type': widgetType,
+    'widget-attributes': widgetAttributes,
+  };
+
+  const property = {
+    required,
+    name: label,
+  };
+
+  return (
+    <WidgetWrapper
+      widgetProperty={widget}
+      pluginProperty={property}
+      value={value}
+      onChange={onChange}
+    />
+  );
+};
+
+export default PluginInput;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/StepButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/StepButtons/index.tsx
@@ -42,6 +42,7 @@ interface IStepButtonProps extends WithStyles<typeof styles>, ICreateContext {
   nextDisabled?: boolean;
   onNext?: () => void;
   onComplete?: () => void;
+  onPrevious?: () => void;
   completeLoading?: boolean;
 }
 
@@ -50,9 +51,22 @@ const StepButtonsView: React.FC<IStepButtonProps> = ({
   setActiveStep,
   nextDisabled,
   onNext,
+  onPrevious,
   classes,
   onComplete,
 }) => {
+  function handlePreviousClick() {
+    if (activeStep === 0) {
+      return;
+    }
+
+    if (typeof onNext === 'function') {
+      onPrevious();
+    }
+
+    setActiveStep(activeStep - 1);
+  }
+
   function handleNextClick() {
     if (activeStep === STEPS.length - 1) {
       return;
@@ -68,7 +82,7 @@ const StepButtonsView: React.FC<IStepButtonProps> = ({
   return (
     <div className={classes.root}>
       <If condition={activeStep > 0}>
-        <Button color="primary" onClick={() => setActiveStep(activeStep - 1)}>
+        <Button color="primary" onClick={handlePreviousClick}>
           Previous
         </Button>
       </If>

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/index.tsx
@@ -24,6 +24,14 @@ import * as React from 'react';
 
 const styles = (theme): StyleRules => {
   return {
+    root: {
+      padding: '30px 40px',
+    },
+    content: {
+      width: '50%',
+      maxWidth: '1000px',
+      minWidth: '600px',
+    },
     comp: {
       borderRight: `1px solid ${theme.palette.grey[400]}`,
       width: '60%',
@@ -46,8 +54,10 @@ const ContentView: React.FC<IContentProps & WithStyles<typeof styles>> = ({
 
   const Comp = STEPS[activeStep].component;
   return (
-    <div>
-      <Comp className={classes.comp} />
+    <div className={classes.root}>
+      <div className={classes.content}>
+        <Comp className={classes.comp} />
+      </div>
     </div>
   );
 };

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
@@ -59,16 +59,28 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     });
   };
 
+  public setConfigurationGroups = (configurationGroups: string[]) => {
+    this.setState({ configurationGroups });
+  };
+
+  public setGroupToInfo = (groupToInfo: any) => {
+    this.setState({ groupToInfo });
+  };
+
   public state = {
+    activeStep: 0,
     pluginName: '',
     pluginType: '',
     displayName: '',
-    emitAlerts: true,
-    emitErrors: true,
-    activeStep: 0,
+    emitAlerts: false,
+    emitErrors: false,
+    configurationGroups: [],
+    groupToInfo: {},
 
     setActiveStep: this.setActiveStep,
     setBasicPluginInfo: this.setBasicPluginInfo,
+    setConfigurationGroups: this.setConfigurationGroups,
+    setGroupToInfo: this.setGroupToInfo,
   };
 
   public render() {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/steps.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/steps.tsx
@@ -15,10 +15,15 @@
  */
 
 import BasicPluginInfo from 'components/PluginJSONCreator/Create/Content/BasicPluginInfo';
+import ConfigurationGroupsCollection from 'components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection';
 
 export const STEPS = [
   {
     label: 'Basic Plugin Information',
     component: BasicPluginInfo,
+  },
+  {
+    label: 'Configuration Groups',
+    component: ConfigurationGroupsCollection,
   },
 ];

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
@@ -25,8 +25,13 @@ interface ICreateState {
   displayName: string;
   emitAlerts: boolean;
   emitErrors: boolean;
+  configurationGroups: string[];
+  groupToInfo: any;
+
   setActiveStep: (step: number) => void;
   setBasicPluginInfo: (basicPluginInfo: IBasicPluginInfo) => void;
+  setConfigurationGroups: (groups: string[]) => void;
+  setGroupToInfo: (groupToInfo: any) => void;
 }
 
 export interface IBasicPluginInfo {
@@ -35,6 +40,11 @@ export interface IBasicPluginInfo {
   displayName: string;
   emitAlerts: boolean;
   emitErrors: boolean;
+}
+
+export interface IConfigurationGroupInfo {
+  label: string;
+  description?: string;
 }
 
 export type ICreateContext = Partial<ICreateState>;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16861

Define states within the project, such that users are able to add and define configuration groups for the plugin JSON file.

- Added new page for setting up configuration groups
- Enable user to add/delete configuration group 
- Set the `label` of the configuration group
- Set the `description` of the configuration group
- Added UI experience to navigate between groups easily
- Refactored existing components and CSS from the existing pages

The view of the page

<img width="961" alt="Screen Shot 2020-05-27 at 10 57 59 AM" src="https://user-images.githubusercontent.com/14116152/83036767-ff33f880-a008-11ea-9885-a5fa94ae09f5.png">
