### PR TITLE
Renames all occurence of github org 'caskdata' to 'cdapio' in cdap docs

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -438,7 +438,7 @@ function set_and_display_version() {
 
 function get_cdap_pipelines_version() {
   # $1 Branch of Hydrator to use
-  CDAP_PIPELINES_VERSION=$(curl --silent "https://raw.githubusercontent.com/caskdata/hydrator-plugins/${1}/pom.xml" | grep "<version>")
+  CDAP_PIPELINES_VERSION=$(curl --silent "https://raw.githubusercontent.com/cdapio/hydrator-plugins/${1}/pom.xml" | grep "<version>")
   CDAP_PIPELINES_VERSION=${CDAP_PIPELINES_VERSION#*<version>}
   CDAP_PIPELINES_VERSION=${CDAP_PIPELINES_VERSION%%</version>*}
   export CDAP_PIPELINES_VERSION
@@ -446,7 +446,7 @@ function get_cdap_pipelines_version() {
 
 function get_cdap_metadata_management_version() {
   # $1 Branch of Tracker to use
-  CDAP_METADATA_MANAGEMENT_VERSION=$(curl --silent "https://raw.githubusercontent.com/caskdata/cask-tracker/${1}/pom.xml" | grep "<version>")
+  CDAP_METADATA_MANAGEMENT_VERSION=$(curl --silent "https://raw.githubusercontent.com/cdapio/cask-tracker/${1}/pom.xml" | grep "<version>")
   CDAP_METADATA_MANAGEMENT_VERSION=${CDAP_METADATA_MANAGEMENT_VERSION#*<version>}
   CDAP_METADATA_MANAGEMENT_VERSION=${CDAP_METADATA_MANAGEMENT_VERSION%%</version>*}
   if [[ -z ${CDAP_METADATA_MANAGEMENT_VERSION} ]]; then

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -221,13 +221,13 @@ git_build_vars = get_git_build_vars()
 # use %% to preserve substitution
 GIT_BRANCH_PARENT = 'GIT_BRANCH_PARENT'
 if git_build_vars.has_key(GIT_BRANCH_PARENT):
-    cdap_java_source_github_pattern = "https://github.com/caskdata/cdap/blob/%s/%%s" % git_build_vars[GIT_BRANCH_PARENT]
+    cdap_java_source_github_pattern = "https://github.com/cdapio/cdap/blob/%s/%%s" % git_build_vars[GIT_BRANCH_PARENT]
 else:
     cdap_java_source_github_pattern = ''
 
 GIT_BRANCH_CDAP_SECURITY_EXTN = 'GIT_BRANCH_CDAP_SECURITY_EXTN'
 if git_build_vars.has_key(GIT_BRANCH_CDAP_SECURITY_EXTN):
-    cdap_security_extn_github_pattern = "https://github.com/caskdata/cdap-security-extn/blob/%s/%%s" % \
+    cdap_security_extn_github_pattern = "https://github.com/cdapio/cdap-security-extn/blob/%s/%%s" % \
         git_build_vars[GIT_BRANCH_CDAP_SECURITY_EXTN]
 else:
     cdap_security_extn_github_pattern = ''
@@ -241,7 +241,7 @@ else:
 
 GIT_BRANCH_HYDRATOR_PLUGINS = 'GIT_BRANCH_HYDRATOR_PLUGINS'
 if git_build_vars.has_key(GIT_BRANCH_HYDRATOR_PLUGINS):
-    hydrator_plugins_github_pattern = "https://github.com/caskdata/hydrator-plugins/blob/%s/%%s" % \
+    hydrator_plugins_github_pattern = "https://github.com/cdapio/hydrator-plugins/blob/%s/%%s" % \
         git_build_vars[GIT_BRANCH_HYDRATOR_PLUGINS]
 else:
     hydrator_plugins_github_pattern = ''
@@ -390,9 +390,9 @@ if release and version:
     else:
         source_link = "v%s" % release
     rst_epilog += """
-.. |git-clone-command| replace:: ``$ git clone -b %(source_link)s https://github.com/caskdata/cdap.git``
-.. |source-link| replace:: `GitHub <https://github.com/caskdata/cdap/archive/%(source_link)s.zip>`__
-.. |ui-read-me| replace:: `CDAP UI README <https://github.com/caskdata/cdap/blob/%(source_link)s/cdap-ui/README.rst>`__
+.. |git-clone-command| replace:: ``$ git clone -b %(source_link)s https://github.com/cdapio/cdap.git``
+.. |source-link| replace:: `GitHub <https://github.com/cdapio/cdap/archive/%(source_link)s.zip>`__
+.. |ui-read-me| replace:: `CDAP UI README <https://github.com/cdapio/cdap/blob/%(source_link)s/cdap-ui/README.rst>`__
 .. |release-range| replace:: %(release_range)s
 """ % {'source_link': source_link, 'release_range': release_range}
 
@@ -406,7 +406,7 @@ if copyright:
 .. |copyright| replace:: %(copyright)s
 """ % {'copyright': copyright}
 
-# cdap_apps_version is for https://github.com/caskdata/cdap-apps repo
+# cdap_apps_version is for https://github.com/cdapio/cdap-apps repo
 cdap_apps_version = git_build_vars["GIT_VERSION_CDAP_APPS"]
 cdap_apps_compatibile_version = git_build_vars["GIT_BRANCH_CDAP_APPS"]
 

--- a/cdap-docs/admin-manual/source/operations/logging.rst
+++ b/cdap-docs/admin-manual/source/operations/logging.rst
@@ -668,7 +668,7 @@ Monitoring Utilities
 ====================
 CDAP can be monitored using external systems such as `Nagios <https://www.nagios.org/>`__;
 a Nagios-style plugin `is available
-<https://github.com/caskdata/cdap-monitoring-tools/blob/develop/nagios/README.rst>`__ for
+<https://github.com/cdapio/cdap-ops-tools/blob/develop/nagios/README.rst>`__ for
 checking the status of CDAP applications, programs, and the CDAP instance itself.
 
 

--- a/cdap-docs/admin-manual/source/security/authorization.rst
+++ b/cdap-docs/admin-manual/source/security/authorization.rst
@@ -54,7 +54,7 @@ require additional properties to be configured. Please see the documentation on
 individual extensions for configuring properties specific to that extension:
 
 - :ref:`Integrations: Apache Sentry <apache-sentry>`
-- `Integrations: Apache Ranger <https://github.com/caskdata/cdap-security-extn/wiki/CDAP-Ranger-Extension>`_
+- `Integrations: Apache Ranger <https://github.com/cdapio/cdap-security-extn/wiki/CDAP-Ranger-Extension>`_
 
 :ref:`Security extension properties <appendix-cdap-default-security>`, which are specified
 in ``cdap-site.xml``, begin with the prefix ``security.authorization.extension.config``.

--- a/cdap-docs/developer-manual/build-pipelines.sh
+++ b/cdap-docs/developer-manual/build-pipelines.sh
@@ -202,8 +202,8 @@ function pipelines_download_includes() {
     local base_source="file://${PROJECT_PATH}/../${pipelines_plugins}"
     CDAP_PIPELINES_SOURCE="${base_source}"
   else
-    echo_red_bold "Downloading Markdown doc file includes from GitHub repo caskdata/${pipelines_plugins}..."
-    local base_source="https://raw.githubusercontent.com/caskdata/${pipelines_plugins}"
+    echo_red_bold "Downloading Markdown doc file includes from GitHub repo cdapio/${pipelines_plugins}..."
+    local base_source="https://raw.githubusercontent.com/cdapio/${pipelines_plugins}"
     if [ "x${GIT_BRANCH_TYPE:0:7}" == "xdevelop" ]; then
       local pipelines_branch="develop"
     else

--- a/cdap-docs/developer-manual/build.sh
+++ b/cdap-docs/developer-manual/build.sh
@@ -46,7 +46,7 @@ function download_includes() {
   pipelines_download_includes ${1}
 
   echo "Downloading source files to be included from GitHub..."
-  local github_url="https://raw.githubusercontent.com/caskdata"
+  local github_url="https://raw.githubusercontent.com/cdapio"
   local includes_dir=${1}
   set_version
 
@@ -60,14 +60,14 @@ function download_includes() {
   fi
 
 # cdap-clients
-# https://raw.githubusercontent.com/caskdata/cdap-clients/develop/cdap-authentication-clients/java/README.rst
+# https://raw.githubusercontent.com/cdapio/cdap-clients/develop/cdap-authentication-clients/java/README.rst
   local clients_url="${github_url}/cdap-clients/${clients_branch}"
 
   download_readme_file_and_test ${includes_dir} ${clients_url} 9bdc7d9ab874bfb6ec044964d3df804e cdap-authentication-clients/java
   download_readme_file_and_test ${includes_dir} ${clients_url} 6f937cbf71ed2312a4893cba27e6145f cdap-authentication-clients/python
 
 # cdap-ingest
-# https://raw.githubusercontent.com/caskdata/cdap-ingest/develop/cdap-file-drop-zone/README.rst
+# https://raw.githubusercontent.com/cdapio/cdap-ingest/develop/cdap-file-drop-zone/README.rst
   local ingest_url="${github_url}/cdap-ingest/${ingest_branch}"
 
   download_readme_file_and_test ${includes_dir} ${ingest_url} cf2d8cac45b4be267adbb0e8ecdc88a4 cdap-flume

--- a/cdap-docs/developer-manual/source/ingesting-tools/cdap-flume.rst
+++ b/cdap-docs/developer-manual/source/ingesting-tools/cdap-flume.rst
@@ -9,4 +9,4 @@
 Source Code Repository
 ======================
 Source code (and other resources) for this page are available at the 
-`CDAP Ingest Project GitHub repository <https://github.com/caskdata/cdap-ingest>`__.
+`CDAP Ingest Project GitHub repository <https://github.com/cdapio/cdap-ingest>`__.

--- a/cdap-docs/developer-manual/source/ingesting-tools/cdap-stream-clients-java.rst
+++ b/cdap-docs/developer-manual/source/ingesting-tools/cdap-stream-clients-java.rst
@@ -9,4 +9,4 @@
 Source Code Repository
 ======================
 Source code (and other resources) for this page are available at the 
-`CDAP Ingest Project GitHub repository <https://github.com/caskdata/cdap-ingest>`__.
+`CDAP Ingest Project GitHub repository <https://github.com/cdapio/cdap-ingest>`__.

--- a/cdap-docs/developer-manual/source/ingesting-tools/cdap-stream-clients-python.rst
+++ b/cdap-docs/developer-manual/source/ingesting-tools/cdap-stream-clients-python.rst
@@ -9,4 +9,4 @@
 Source Code Repository
 ======================
 Source code (and other resources) for this page are available at the 
-`CDAP Ingest Project GitHub repository <https://github.com/caskdata/cdap-ingest>`__.
+`CDAP Ingest Project GitHub repository <https://github.com/cdapio/cdap-ingest>`__.

--- a/cdap-docs/developer-manual/source/ingesting-tools/cdap-stream-clients-ruby.rst
+++ b/cdap-docs/developer-manual/source/ingesting-tools/cdap-stream-clients-ruby.rst
@@ -9,4 +9,4 @@
 Source Code Repository
 ======================
 Source code (and other resources) for this page are available at the 
-`CDAP Ingest Project GitHub repository <https://github.com/caskdata/cdap-ingest>`__.
+`CDAP Ingest Project GitHub repository <https://github.com/cdapio/cdap-ingest>`__.

--- a/cdap-docs/developer-manual/source/metadata/audit-logging.rst
+++ b/cdap-docs/developer-manual/source/metadata/audit-logging.rst
@@ -80,7 +80,7 @@ When audit publishing is :ref:`enabled <audit-logging-configuring-audit-publishi
 
 The contents of the message are a JSON representation of
 the `AuditMessage
-<https://github.com/caskdata/cdap/blob/develop/cdap-proto/src/main/java/co/cask/cdap/proto/audit/AuditMessage.java>`__
+<https://github.com/cdapio/cdap/blob/develop/cdap-proto/src/main/java/io/cdap/cdap/proto/audit/AuditMessage.java>`__
 class.
 
 Here are some example JSON messages, pretty-printed:
@@ -179,5 +179,5 @@ Here are some example JSON messages, pretty-printed:
   }
 
 CDAP also provides an `adapter class 
-<https://github.com/caskdata/cdap/blob/develop/cdap-proto/src/main/java/co/cask/cdap/proto/codec/AuditMessageTypeAdapter.java>`__
+<https://github.com/cdapio/cdap/blob/develop/cdap-proto/src/main/java/io/cdap/cdap/proto/codec/AuditMessageTypeAdapter.java>`__
 to enable deserializing of the audit messages using the `GSON <https://github.com/google/gson>`__ library.

--- a/cdap-docs/developer-manual/source/security/custom-authentication.rst
+++ b/cdap-docs/developer-manual/source/security/custom-authentication.rst
@@ -34,7 +34,7 @@ extending ``AbstractAuthenticationHandler`` and implementing its abstract method
 
 An example of an ``AuthenticationHandler`` can be found in the CDAP source code for
 `LDAPAuthenticationHandler.java
-<https://github.com/caskdata/cdap/blob/develop/cdap-security/src/main/java/co/cask/cdap/security/server/LDAPAuthenticationHandler.java>`__.
+<https://github.com/cdapio/cdap/blob/develop/cdap-security/src/main/java/io/cdap/cdap/security/server/LDAPAuthenticationHandler.java>`__.
 
 To configure the custom authentication handler, see the Administration Manual’s
 :ref:`installation-custom-authentication` section.

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -84,7 +84,7 @@ function download_includes() {
   local includes_wise="${includes}/tutorial-wise"
   local project_version=${PROJECT_SHORT_VERSION}
 
-  local source1="https://raw.githubusercontent.com/caskdata/cdap-apps"
+  local source1="https://raw.githubusercontent.com/cdapio/cdap-apps"
   if [ "x${GIT_BRANCH_CDAP_APPS}" != "x" ]; then
     local source2="${GIT_BRANCH_CDAP_APPS}"
   elif [ "x${GIT_BRANCH_TYPE:0:7}" == "xdevelop" ]; then

--- a/cdap-docs/examples-manual/source/_includes/apps-packs.txt
+++ b/cdap-docs/examples-manual/source/_includes/apps-packs.txt
@@ -12,51 +12,51 @@ CDAP Applications Repository
 ----------------------------
 
 .. |cdap-apps-repository| replace:: **CDAP Apps Repository**
-.. _cdap-apps-repository: https://github.com/caskdata/cdap-apps
+.. _cdap-apps-repository: https://github.com/cdapio/cdap-apps
 
 The |cdap-apps-repository|_ contains data applications built using CDAP:
 
 
 .. |wise| replace:: **WISE,** *Web Analytics:*
-.. _wise: https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/Wise
+.. _wise: https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/Wise
 
 - |wise|_ Web Insights Engine analyzes the behavior of users of a website by processing
   Apache web logs.
   This application is also the basis for the online tutorial of the same name,
   :ref:`WISE: Web Analytics <cdap-tutorial-wise>`;
   refer to it for step-by-step instructions on creating the application from scratch.
-  Download the source or clone the app at `GitHub <https://github.com/caskdata/cdap-apps/tree/<placeholder-version>>`__.
+  Download the source or clone the app at `GitHub <https://github.com/cdapio/cdap-apps/tree/<placeholder-version>>`__.
 
 .. |netlens| replace:: **Netlens,** *Network Analytics:*
-.. _netlens: https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/Netlens
+.. _netlens: https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/Netlens
 
 - |netlens|_ The app analyzes network packets to provide insights on traffic statistics
   and detects anomalies in the traffic patterns. 
-  Download the source or clone the app at `GitHub <https://github.com/caskdata/cdap-apps/tree/<placeholder-version>>`__.
+  Download the source or clone the app at `GitHub <https://github.com/cdapio/cdap-apps/tree/<placeholder-version>>`__.
 
 
 .. |twittersentiment| replace:: **TwitterSentiment,** *Social Analytics:*
-.. _twittersentiment: https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/TwitterSentiment
+.. _twittersentiment: https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/TwitterSentiment
 
 - |twittersentiment|_ The application performs sentiment analysis on Twitter data to
   understand consumer feelings and attitudes towards brands or topics in online
   conversations. 
-  Download the source or clone the app at `GitHub <https://github.com/caskdata/cdap-apps/tree/<placeholder-version>>`__.
+  Download the source or clone the app at `GitHub <https://github.com/cdapio/cdap-apps/tree/<placeholder-version>>`__.
 
 
 .. |movierecommender| replace:: **MovieRecommender,** *a Recommender System:*
-.. _movierecommender: https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/MovieRecommender
+.. _movierecommender: https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/MovieRecommender
 
 - |movierecommender|_ The application uses a collaborative filtering algorithm to provide
   movie recommendations for users.
-  Download the source or clone the app at `GitHub <https://github.com/caskdata/cdap-apps/tree/<placeholder-version>>`__.
+  Download the source or clone the app at `GitHub <https://github.com/cdapio/cdap-apps/tree/<placeholder-version>>`__.
 
 
 CDAP Packs Repository
 ---------------------
 
 .. |cdap-packs-repository| replace:: **CDAP Packs Repository**
-.. _cdap-packs-repository: https://github.com/caskdata/cdap-packs
+.. _cdap-packs-repository: https://github.com/cdapio/cdap-packs
 
 The |cdap-packs-repository|_ is a collection of useful and reusable building blocks for
 your data applications. They are libraries of common data patterns and other programs
@@ -64,11 +64,11 @@ useful when building big data applications:
 
 
 .. |twitter-pack| replace:: **Twitter-pack** *for Twitter Integration:*
-.. _twitter-pack: https://github.com/caskdata/cdap-packs/blob/<placeholder-version>/cdap-twitter-pack
+.. _twitter-pack: https://github.com/cdapio/cdap-packs/blob/<placeholder-version>/cdap-twitter-pack
 
 - |twitter-pack|_ The Twitter-pack library is designed to ease the CDAP apps development
   tasks that require integration with Twitter, such as pulling a tweets stream. Download the source or
-  clone the library at `GitHub <https://github.com/caskdata/cdap-packs/tree/<placeholder-version>>`__.
+  clone the library at `GitHub <https://github.com/cdapio/cdap-packs/tree/<placeholder-version>>`__.
 
 
 .. |kafka-flow-pack| replace:: **Kafka-Flow-pack** *for Kafka Flow Integration:*

--- a/cdap-docs/examples-manual/source/_includes/tutorials-index.txt
+++ b/cdap-docs/examples-manual/source/_includes/tutorials-index.txt
@@ -15,9 +15,9 @@ Tutorials
    :titlesonly:
 
    WISE: Web Analytics <wise>
-   Netlens: Network Analytics <https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/Netlens>
-   TwitterSentiment: Social Analytics <https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/TwitterSentiment>
-   MovieRecommender: Recommender System <https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/MovieRecommender>
+   Netlens: Network Analytics <https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/Netlens>
+   TwitterSentiment: Social Analytics <https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/TwitterSentiment>
+   MovieRecommender: Recommender System <https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/MovieRecommender>
 
 Designed to be completed in an hour or more, these tutorials provide deeper, in-context explorations of 
 big data application development topics, leaving you ready to implement real-world solutions.
@@ -29,21 +29,21 @@ big data application development topics, leaving you ready to implement real-wor
 
 
 .. |netlens| replace:: **Netlens: Network Analytics:**
-.. _netlens: https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/Netlens
+.. _netlens: https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/Netlens
 
 - |netlens|_ Learn how to build a CDAP application to analyze network packets to provide traffic stats 
   and detect anomalies in the traffic patterns in real time.
 
 
 .. |twittersentiment| replace:: **TwitterSentiment: Social Analytics:**
-.. _twittersentiment: https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/TwitterSentiment
+.. _twittersentiment: https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/TwitterSentiment
 
 - |twittersentiment|_ Learn how build a CDAP application to perform sentiment analysis on Twitter data to 
   understand consumer feelings and attitudes towards brands or topics in online conversations.
 
 
 .. |movierecommender| replace:: **MovieRecommender: Recommender System:**
-.. _movierecommender: https://github.com/caskdata/cdap-apps/tree/<placeholder-version>/MovieRecommender
+.. _movierecommender: https://github.com/cdapio/cdap-apps/tree/<placeholder-version>/MovieRecommender
 
 - |movierecommender|_ Learn how to build a CDAP application that uses collaborative filtering to provide movie 
   recommendations for users.

--- a/cdap-docs/examples-manual/source/tutorials/wise.rst
+++ b/cdap-docs/examples-manual/source/tutorials/wise.rst
@@ -91,7 +91,7 @@ CDAP Sandbox, and download the WISE source code:
 .. tabbed-parsed-literal::
 
   $ cd <CDAP-HOME>/examples
-  $ curl -w"\n" -X GET "https://codeload.github.com/caskdata/cdap-apps/zip/release/cdap-|short-version|-compatible" \
+  $ curl -w"\n" -X GET "https://codeload.github.com/cdapio/cdap-apps/zip/release/cdap-|short-version|-compatible" \
   --output cdap-apps-release-cdap-|short-version|-compatible.zip
 
 Unzip the directory and change to the source directory:

--- a/cdap-docs/integrations/build.sh
+++ b/cdap-docs/integrations/build.sh
@@ -28,8 +28,8 @@ function download_includes() {
     echo_red_bold "Copying local copy of Apache Sentry and Ranger File..."
     local base_source="file://${PROJECT_PATH}/../cdap-security-extn/"
   else
-    echo_red_bold "Downloading Apache Sentry and Ranger File from GitHub repo caskdata/cdap-security-extn..."
-    local base_source="https://raw.githubusercontent.com/caskdata/cdap-security-extn/"
+    echo_red_bold "Downloading Apache Sentry and Ranger File from GitHub repo cdapio/cdap-security-extn..."
+    local base_source="https://raw.githubusercontent.com/cdapio/cdap-security-extn/"
     if [ "x${GIT_BRANCH_TYPE:0:7}" == "xdevelop" ]; then
       local branch="develop/"
     else

--- a/cdap-docs/reference-manual/licenses-pdf/cdap-ui-dependencies.pdf
+++ b/cdap-docs/reference-manual/licenses-pdf/cdap-ui-dependencies.pdf
@@ -1,5 +1,5 @@
 %PDF-1.4
-%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+%ï¿½ï¿½ï¿½ï¿½ ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
 <<
 /F1 2 0 R /F2 3 0 R /F3 5 0 R
@@ -510,14 +510,14 @@ endobj
 73 0 obj
 <<
 /A <<
-/S /URI /Type /Action /URI (https://raw.githubusercontent.com/caskdata/ui-schema-parser/develop/LICENSE)
+/S /URI /Type /Action /URI (https://raw.githubusercontent.com/cdapio/ui-schema-parser/develop/LICENSE)
 >> /Border [ 0 0 0 ] /Rect [ 362.4 645.75 549.71 657.75 ] /Subtype /Link /Type /Annot
 >>
 endobj
 74 0 obj
 <<
 /A <<
-/S /URI /Type /Action /URI (https://raw.githubusercontent.com/caskdata/ui-schema-parser/develop/LICENSE)
+/S /URI /Type /Action /URI (https://raw.githubusercontent.com/cdapio/ui-schema-parser/develop/LICENSE)
 >> /Border [ 0 0 0 ] /Rect [ 362.4 633.75 531.9 645.75 ] /Subtype /Link /Type /Annot
 >>
 endobj
@@ -3055,7 +3055,7 @@ q
 q
 0 0 .501961 rg
 0 0 .501961 RG
-BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (https://raw.githubusercontent.com/caskdat) Tj T* (a/ui-schema-parser/develop/LICENSE) Tj T* ET
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL (https://raw.githubusercontent.com/cdapio) Tj T* (a/ui-schema-parser/develop/LICENSE) Tj T* ET
 Q
 Q
 q

--- a/cdap-docs/reference-manual/source/java-client-api.rst
+++ b/cdap-docs/reference-manual/source/java-client-api.rst
@@ -76,7 +76,7 @@ Then, instantiate as follows::
   AuthenticationClient authenticationClient = new BasicAuthenticationClient();
   authenticationClient.setConnectionInfo("example.com", 11015, sslEnabled);
   // Configure the AuthenticationClient as documented in
-  // https://github.com/caskdata/cdap-clients/blob/develop/cdap-authentication-clients/java
+  // https://github.com/cdapio/cdap-clients/blob/develop/cdap-authentication-clients/java
   AccessToken accessToken = authenticationClient.getAccessToken();
 
   // Interact with the secure CDAP instance located at example.com, port 11015, with the provided accessToken

--- a/cdap-docs/reference-manual/source/licenses/cdap-ui-dependencies.rst
+++ b/cdap-docs/reference-manual/source/licenses/cdap-ui-dependencies.rst
@@ -45,7 +45,7 @@ Cask Data Application Platform UI Dependencies
    "body-parser","1.14.2","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://github.com/expressjs/body-parser"
    "bootstrap","4.0.0-alpha.5","bower","`MIT License <http://opensource.org/licenses/MIT>`__","http://getbootstrap.com"
    "c3","0.4.10","bower","`MIT License <http://opensource.org/licenses/MIT>`__","https://github.com/masayuki0812/c3"
-   "cdap-avsc","4.1.12","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://raw.githubusercontent.com/caskdata/ui-schema-parser/develop/LICENSE"
+   "cdap-avsc","4.1.12","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://raw.githubusercontent.com/cdapio/ui-schema-parser/develop/LICENSE"
    "chart.js","2.3.0","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://raw.githubusercontent.com/chartjs/Chart.js/master/LICENSE.md"
    "classnames","2.2.5","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://raw.githubusercontent.com/JedWatson/classnames/master/LICENSE"
    "compression","1.6.1","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://github.com/expressjs/compression"

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -5916,7 +5916,7 @@ Improvements
 **Tools**
 
 - Added a tool (`HBaseQueueDebugger
-  <https://github.com/caskdata/cdap/blob/release/3.0/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java>`__)
+  <https://github.com/cdapio/cdap/blob/release/3.0/cdap-master/src/main/java/io/cdap/cdap/data/tools/HBaseQueueDebugger.java>`__)
   that counts consumed and unconsumed entries in a flowlet queue
   (`CDAP-2105 <https://issues.cask.co/browse/CDAP-2105>`__).
 
@@ -6275,7 +6275,7 @@ New Features
   programs, and applications, and vice-versa
   (`CDAP-2214 <https://issues.cask.co/browse/CDAP-2214>`__).
 
-- Created a `queue introspection tool <https://github.com/caskdata/cdap/pull/2290>`__,
+- Created a `queue introspection tool <https://github.com/cdapio/cdap/pull/2290>`__,
   for counting processed and unprocessed entries in a
   flowlet queue (`CDAP-2105 <https://issues.cask.co/browse/CDAP-2105>`__).
 

--- a/cdap-docs/tools/cdap-default/cdap-xml-sdl-files.txt
+++ b/cdap-docs/tools/cdap-default/cdap-xml-sdl-files.txt
@@ -9,9 +9,9 @@ cdap-standalone/src/main/resources/cdap-site.xml
 ../cdap-ambari-service/configuration/cdap-site.xml
 - app.program.spark.yarn.client.rewrite.enabled
 - stream.container.instances
-  https://raw.githubusercontent.com/caskdata/cdap-ambari-service/develop/configuration/cdap-site.xml
-  https://raw.githubusercontent.com/caskdata/cdap-ambari-service/release/3.3/configuration/cdap-site.xml
+  https://raw.githubusercontent.com/cdapio/cdap-ambari-service/develop/configuration/cdap-site.xml
+  https://raw.githubusercontent.com/cdapio/cdap-ambari-service/release/3.3/configuration/cdap-site.xml
 
 ../cm_csd/src/descriptor/service.sdl
-  https://raw.githubusercontent.com/caskdata/cm_csd/develop/src/descriptor/service.sdl
-  https://raw.githubusercontent.com/caskdata/cm_csd/release/3.3/src/descriptor/service.sdl
+  https://raw.githubusercontent.com/cdapio/cm_csd/develop/src/descriptor/service.sdl
+  https://raw.githubusercontent.com/cdapio/cm_csd/release/3.3/src/descriptor/service.sdl

--- a/cdap-docs/tools/licenses/cdap-dependencies-master.csv
+++ b/cdap-docs/tools/licenses/cdap-dependencies-master.csv
@@ -42,7 +42,7 @@
 # dependency,version,type,license,license_url,homepage,license_page
 "babel-polyfill","6.16.0","npm","MIT License","http://opensource.org/licenses/MIT","https://babeljs.io/","https://raw.githubusercontent.com/babel/babel/master/LICENSE"
 "body-parser","1.14.2","npm","MIT License","http://opensource.org/licenses/MIT","https://github.com/expressjs/body-parser",""
-"cdap-avsc","4.1.12","npm","MIT License","http://opensource.org/licenses/MIT","https://github.com/caskdata/ui-schema-parser","https://raw.githubusercontent.com/caskdata/ui-schema-parser/develop/LICENSE"
+"cdap-avsc","4.1.12","npm","MIT License","http://opensource.org/licenses/MIT","https://github.com/cdapio/ui-schema-parser","https://raw.githubusercontent.com/cdapio/ui-schema-parser/develop/LICENSE"
 "chart.js","2.3.0","npm","MIT License","http://opensource.org/licenses/MIT","http://www.chartjs.org","https://raw.githubusercontent.com/chartjs/Chart.js/master/LICENSE.md"
 "classnames","2.2.5","npm","MIT License","http://opensource.org/licenses/MIT","https://github.com/JedWatson/classnames#readme","https://raw.githubusercontent.com/JedWatson/classnames/master/LICENSE"
 "compression","1.6.1","npm","MIT License","http://opensource.org/licenses/MIT","https://github.com/expressjs/compression",""

--- a/cdap-docs/tools/licenses/cdap-ui-dependencies.rst
+++ b/cdap-docs/tools/licenses/cdap-ui-dependencies.rst
@@ -45,7 +45,7 @@ Cask Data Application Platform UI Dependencies
    "body-parser","1.14.2","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://github.com/expressjs/body-parser"
    "bootstrap","4.0.0-alpha.5","bower","`MIT License <http://opensource.org/licenses/MIT>`__","http://getbootstrap.com"
    "c3","0.4.10","bower","`MIT License <http://opensource.org/licenses/MIT>`__","https://github.com/masayuki0812/c3"
-   "cdap-avsc","4.1.12","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://raw.githubusercontent.com/caskdata/ui-schema-parser/develop/LICENSE"
+   "cdap-avsc","4.1.12","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://raw.githubusercontent.com/cdapio/ui-schema-parser/develop/LICENSE"
    "classnames","2.2.5","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://raw.githubusercontent.com/JedWatson/classnames/master/LICENSE"
    "compression","1.6.1","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://github.com/expressjs/compression"
    "cookie-parser","1.4.1","npm","`MIT License <http://opensource.org/licenses/MIT>`__","https://github.com/expressjs/cookie-parser"

--- a/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
+++ b/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
@@ -24,7 +24,7 @@
   <packaging>pom</packaging>
   <name>Hydrator Plugin Collection</name>
   <description>A collection of plugins for Cask Hydrator.</description>
-  <url>https://github.com/caskdata/hydrator-plugins</url>
+  <url>https://github.com/cdapio/hydrator-plugins</url>
 
   <modules>
     <module>hydrator-common</module>
@@ -63,9 +63,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:https://github.com/caskdata/hydrator-plugins.git</connection>
-    <developerConnection>scm:git:git@github.com:caskdata/hydrator-plugins.git</developerConnection>
-    <url>https://github.com/caskdata/hydrator-plugins.git</url>
+    <connection>scm:git:https://github.com/cdapio/hydrator-plugins.git</connection>
+    <developerConnection>scm:git:git@github.com:cdapio/hydrator-plugins.git</developerConnection>
+    <url>https://github.com/cdapio/hydrator-plugins.git</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -60,7 +60,7 @@ GIT_BRANCH_CDAP_APPS="release/cdap-4.3-compatible"
 GIT_VERSION_CDAP_APPS="0.8.0"
 
 # Used for pipelines documentation in developer-manual
-# From https://github.com/caskdata/hydrator-plugins
+# From https://github.com/cdapio/hydrator-plugins
 GIT_BRANCH_CDAP_PIPELINES="release/1.8"
 GIT_BRANCH_HYDRATOR_PLUGINS="release/1.8"
 


### PR DESCRIPTION
backporting security fix https://github.com/cdapio/cdap/pull/11337 to old doc branches